### PR TITLE
fix: remove hardcoded version from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,6 @@ Add elevator-core to your project:
 cargo add elevator-core
 ```
 
-Or add it manually to your `Cargo.toml`:
-
-```toml
-[dependencies]
-elevator-core = "0.1"
-```
-
 From there, the typical workflow is:
 
 1. **Configure stops** -- define the building layout with named stops at arbitrary positions.


### PR DESCRIPTION
## Summary

- Remove the `elevator-core = "0.1"` manual Cargo.toml snippet from Getting Started — it goes stale on every release. `cargo add elevator-core` is sufficient.

## Test plan

- [ ] Verify README renders correctly on GitHub