### PR TITLE
docs: add mdBook guide, showcase example, and enhanced rustdoc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,46 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docs/**
+      - .github/workflows/docs.yml
+  workflow_dispatch:
+
+permissions:
+  pages: write
+  id-token: write
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: latest
+
+      - name: Build book
+        run: mdbook build docs
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/book
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/crates/elevator-core/examples/showcase.rs
+++ b/crates/elevator-core/examples/showcase.rs
@@ -1,0 +1,463 @@
+//! # elevator-core Showcase
+//!
+//! A comprehensive example demonstrating the major features of elevator-core.
+//! Run with: `cargo run --example showcase -p elevator-core`
+
+// Examples are standalone binaries — suppress lint noise that doesn't apply.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::missing_docs_in_private_items,
+    missing_docs,
+    clippy::must_use_candidate
+)]
+
+use elevator_core::config::{
+    BuildingConfig, ElevatorConfig, PassengerSpawnConfig, SimConfig, SimulationParams,
+};
+use elevator_core::dispatch::etd::EtdDispatch;
+use elevator_core::prelude::*;
+use elevator_core::stop::StopConfig;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn main() {
+    part1_basic_simulation();
+    part2_custom_dispatch();
+    part3_extensions();
+    part4_lifecycle_hooks();
+    part5_metrics_deep_dive();
+    part6_configuration();
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Part 1: Basic Simulation
+// ────────────────────────────────────────────────────────────────────────────
+
+fn part1_basic_simulation() {
+    println!("=== Part 1: Basic Simulation ===\n");
+
+    // Build a simple 3-stop building with one elevator.
+    // `stops()` replaces the builder's default stops entirely.
+    let mut sim = SimulationBuilder::new()
+        .stops(vec![
+            StopConfig {
+                id: StopId(0),
+                name: "Ground".into(),
+                position: 0.0,
+            },
+            StopConfig {
+                id: StopId(1),
+                name: "Floor 2".into(),
+                position: 4.0,
+            },
+            StopConfig {
+                id: StopId(2),
+                name: "Floor 3".into(),
+                position: 8.0,
+            },
+        ])
+        .build()
+        .unwrap();
+
+    // Spawn a rider at Ground heading to Floor 3, weighing 75 kg.
+    let rider_id = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
+        .unwrap();
+    println!("Spawned rider: {rider_id:?}");
+
+    // Step the simulation until the rider is delivered (or a safety cap).
+    for _ in 0..600 {
+        sim.step();
+    }
+
+    // Drain all events that occurred during the run.
+    let events = sim.drain_events();
+    println!("Total events emitted: {}", events.len());
+
+    // Show a few interesting ones.
+    for event in &events {
+        match event {
+            Event::RiderBoarded {
+                rider, elevator, ..
+            } => {
+                println!("  Rider {rider:?} boarded elevator {elevator:?}");
+            }
+            Event::RiderAlighted {
+                rider,
+                elevator,
+                stop,
+                ..
+            } => {
+                println!("  Rider {rider:?} alighted elevator {elevator:?} at stop {stop:?}");
+            }
+            Event::ElevatorArrived {
+                elevator, at_stop, ..
+            } => {
+                println!("  Elevator {elevator:?} arrived at stop {at_stop:?}");
+            }
+            _ => {}
+        }
+    }
+
+    // Query aggregate metrics.
+    let m = sim.metrics();
+    println!("\nMetrics after {} ticks:", sim.current_tick());
+    println!("  Total spawned:   {}", m.total_spawned());
+    println!("  Total delivered: {}", m.total_delivered());
+    println!("  Avg wait time:   {:.1} ticks", m.avg_wait_time());
+    println!("  Avg ride time:   {:.1} ticks", m.avg_ride_time());
+    println!("  Max wait time:   {} ticks", m.max_wait_time());
+    println!("  Throughput:      {}", m.throughput());
+    println!();
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Part 2: Custom Dispatch
+// ────────────────────────────────────────────────────────────────────────────
+
+fn part2_custom_dispatch() {
+    println!("=== Part 2: Custom Dispatch (ETD) ===\n");
+
+    // The ETD (Estimated Time to Destination) algorithm minimizes the total
+    // cost of serving new riders while considering delay to existing ones.
+    let mut sim = SimulationBuilder::new()
+        .stops(vec![
+            StopConfig {
+                id: StopId(0),
+                name: "Lobby".into(),
+                position: 0.0,
+            },
+            StopConfig {
+                id: StopId(1),
+                name: "Sky Lobby".into(),
+                position: 5.0,
+            },
+            StopConfig {
+                id: StopId(2),
+                name: "Penthouse".into(),
+                position: 10.0,
+            },
+        ])
+        .dispatch(EtdDispatch::with_delay_weight(1.5))
+        .build()
+        .unwrap();
+
+    // Spawn several riders to see ETD in action.
+    let _ = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    let _ = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(1), 80.0)
+        .unwrap();
+    let _ = sim
+        .spawn_rider_by_stop_id(StopId(2), StopId(0), 65.0)
+        .unwrap();
+
+    // Run for enough ticks for the elevator to make full round trips.
+    for _ in 0..900 {
+        sim.step();
+    }
+
+    let events = sim.drain_events();
+
+    // Count event types to see dispatch decisions at work.
+    let assigned_count = events
+        .iter()
+        .filter(|e| matches!(e, Event::ElevatorAssigned { .. }))
+        .count();
+    let boarded_count = events
+        .iter()
+        .filter(|e| matches!(e, Event::RiderBoarded { .. }))
+        .count();
+    let delivered_count = events
+        .iter()
+        .filter(|e| matches!(e, Event::RiderAlighted { .. }))
+        .count();
+
+    println!("ETD dispatch results over {} ticks:", sim.current_tick());
+    println!("  Elevator assignments: {assigned_count}");
+    println!("  Riders boarded:       {boarded_count}");
+    println!("  Riders delivered:     {delivered_count}");
+    println!(
+        "  Avg wait time:        {:.1} ticks",
+        sim.metrics().avg_wait_time()
+    );
+    println!();
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Part 3: Extensions
+// ────────────────────────────────────────────────────────────────────────────
+
+/// A custom extension component: marks a rider as VIP.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct VipTag {
+    /// VIP priority level (higher = more important).
+    level: u32,
+}
+
+fn part3_extensions() {
+    println!("=== Part 3: Extensions ===\n");
+
+    // Register the extension type at build time for snapshot support.
+    let mut sim = SimulationBuilder::new()
+        .stops(vec![
+            StopConfig {
+                id: StopId(0),
+                name: "Ground".into(),
+                position: 0.0,
+            },
+            StopConfig {
+                id: StopId(1),
+                name: "Executive".into(),
+                position: 12.0,
+            },
+        ])
+        .with_ext::<VipTag>("vip_tag")
+        .build()
+        .unwrap();
+
+    // Spawn a rider and attach the VIP extension.
+    let rider = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
+        .unwrap();
+    sim.world_mut()
+        .insert_ext::<VipTag>(rider, VipTag { level: 3 }, "vip_tag");
+
+    // Read the extension back.
+    let vip: Option<VipTag> = sim.world().get_ext::<VipTag>(rider);
+    println!("Rider {rider:?} VIP tag: {vip:?}");
+
+    // Extensions are arbitrary typed data — useful for game-specific components
+    // like priority tiers, cargo manifests, or NPC traits without modifying
+    // the core library.
+    println!();
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Part 4: Lifecycle Hooks
+// ────────────────────────────────────────────────────────────────────────────
+
+fn part4_lifecycle_hooks() {
+    println!("=== Part 4: Lifecycle Hooks ===\n");
+
+    // Hooks run before or after simulation phases. They receive &mut World,
+    // letting you inspect or modify entity state each tick.
+    //
+    // Here we add an after-loading hook that prints whenever a rider finishes
+    // boarding (transitions to Riding phase).
+    let boarding_count = Arc::new(AtomicU64::new(0));
+    let boarding_count_hook = Arc::clone(&boarding_count);
+
+    let mut sim = SimulationBuilder::new()
+        .stops(vec![
+            StopConfig {
+                id: StopId(0),
+                name: "Ground".into(),
+                position: 0.0,
+            },
+            StopConfig {
+                id: StopId(1),
+                name: "Upper".into(),
+                position: 5.0,
+            },
+        ])
+        .after(Phase::Loading, move |world| {
+            // Count how many riders are currently in Riding phase.
+            let riding = world
+                .iter_riders()
+                .filter(|(_, r)| matches!(r.phase, RiderPhase::Riding(_)))
+                .count();
+            if riding > 0 {
+                boarding_count_hook.fetch_add(1, Ordering::Relaxed);
+            }
+        })
+        .build()
+        .unwrap();
+
+    let _ = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(1), 60.0)
+        .unwrap();
+
+    for _ in 0..300 {
+        sim.step();
+    }
+
+    println!(
+        "After-loading hook fired with riding riders {} times",
+        boarding_count.load(Ordering::Relaxed)
+    );
+    println!("Delivered: {}", sim.metrics().total_delivered());
+    println!();
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Part 5: Metrics Deep Dive
+// ────────────────────────────────────────────────────────────────────────────
+
+fn part5_metrics_deep_dive() {
+    println!("=== Part 5: Metrics Deep Dive (Tags) ===\n");
+
+    let mut sim = SimulationBuilder::new()
+        .stops(vec![
+            StopConfig {
+                id: StopId(0),
+                name: "Lobby".into(),
+                position: 0.0,
+            },
+            StopConfig {
+                id: StopId(1),
+                name: "Office".into(),
+                position: 4.0,
+            },
+            StopConfig {
+                id: StopId(2),
+                name: "Rooftop".into(),
+                position: 10.0,
+            },
+        ])
+        .build()
+        .unwrap();
+
+    // Tag the lobby stop — riders spawned there inherit the tag automatically.
+    let lobby_entity = sim.stop_entity(StopId(0)).unwrap();
+    sim.tag_entity(lobby_entity, "zone:lobby");
+
+    // Spawn riders from the tagged lobby.
+    for _ in 0..5 {
+        let _ = sim
+            .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+            .unwrap();
+    }
+
+    // Tag a rider individually for a different dimension.
+    let special = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(1), 60.0)
+        .unwrap();
+    sim.tag_entity(special, "priority:express");
+
+    // Run enough ticks for deliveries.
+    for _ in 0..600 {
+        sim.step();
+    }
+
+    // Query per-tag metrics.
+    if let Some(lobby_metrics) = sim.metrics_for_tag("zone:lobby") {
+        println!("zone:lobby metrics:");
+        println!("  Spawned:    {}", lobby_metrics.total_spawned());
+        println!("  Delivered:  {}", lobby_metrics.total_delivered());
+        println!("  Avg wait:   {:.1} ticks", lobby_metrics.avg_wait_time());
+        println!("  Max wait:   {} ticks", lobby_metrics.max_wait_time());
+    }
+
+    if let Some(express_metrics) = sim.metrics_for_tag("priority:express") {
+        println!("priority:express metrics:");
+        println!("  Spawned:    {}", express_metrics.total_spawned());
+        println!("  Delivered:  {}", express_metrics.total_delivered());
+        println!("  Avg wait:   {:.1} ticks", express_metrics.avg_wait_time());
+    }
+
+    // List all registered tags.
+    println!("\nAll registered tags: {:?}", sim.all_tags());
+    println!();
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Part 6: Configuration
+// ────────────────────────────────────────────────────────────────────────────
+
+fn part6_configuration() {
+    println!("=== Part 6: Programmatic Configuration ===\n");
+
+    // Build a SimConfig entirely in code (no RON file needed).
+    let config = SimConfig {
+        building: BuildingConfig {
+            name: "Space Needle".into(),
+            stops: vec![
+                StopConfig {
+                    id: StopId(0),
+                    name: "Ground Level".into(),
+                    position: 0.0,
+                },
+                StopConfig {
+                    id: StopId(1),
+                    name: "Restaurant".into(),
+                    position: 15.0,
+                },
+                StopConfig {
+                    id: StopId(2),
+                    name: "Observation Deck".into(),
+                    position: 20.0,
+                },
+            ],
+        },
+        elevators: vec![
+            ElevatorConfig {
+                id: 0,
+                name: "Express A".into(),
+                max_speed: 5.0,
+                acceleration: 2.5,
+                deceleration: 3.0,
+                weight_capacity: 1200.0,
+                starting_stop: StopId(0),
+                door_open_ticks: 15,
+                door_transition_ticks: 8,
+            },
+            ElevatorConfig {
+                id: 1,
+                name: "Express B".into(),
+                max_speed: 5.0,
+                acceleration: 2.5,
+                deceleration: 3.0,
+                weight_capacity: 1200.0,
+                starting_stop: StopId(0),
+                door_open_ticks: 15,
+                door_transition_ticks: 8,
+            },
+        ],
+        simulation: SimulationParams {
+            ticks_per_second: 60.0,
+        },
+        passenger_spawning: PassengerSpawnConfig {
+            mean_interval_ticks: 90,
+            weight_range: (50.0, 100.0),
+        },
+    };
+
+    println!("Building: {}", config.building.name);
+    println!("Stops:    {}", config.building.stops.len());
+    println!("Elevators:{}", config.elevators.len());
+    println!("TPS:      {}", config.simulation.ticks_per_second);
+
+    // Construct simulation from the config, using ETD dispatch.
+    let mut sim = SimulationBuilder::from_config(config)
+        .dispatch(EtdDispatch::new())
+        .build()
+        .unwrap();
+
+    // Spawn riders and simulate.
+    let _ = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(1), 80.0)
+        .unwrap();
+    let _ = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 65.0)
+        .unwrap();
+
+    for _ in 0..1800 {
+        sim.step();
+    }
+
+    let m = sim.metrics();
+    println!(
+        "\nAfter {} ticks ({:.1}s simulated):",
+        sim.current_tick(),
+        sim.current_tick() as f64 / 60.0
+    );
+    println!("  Delivered:     {}", m.total_delivered());
+    println!("  Avg wait:      {:.1} ticks", m.avg_wait_time());
+    println!("  Avg ride:      {:.1} ticks", m.avg_ride_time());
+    println!("  Total distance:{:.1} units", m.total_distance());
+    println!();
+}

--- a/crates/elevator-core/src/builder.rs
+++ b/crates/elevator-core/src/builder.rs
@@ -50,6 +50,17 @@ impl Default for SimulationBuilder {
 
 impl SimulationBuilder {
     /// Create a builder with a minimal valid default configuration.
+    ///
+    /// The default gives you two stops (Ground at 0.0, Top at 10.0) and one
+    /// elevator with SCAN dispatch. Override any part with the fluent methods
+    /// before calling [`build`](Self::build).
+    ///
+    /// ```
+    /// use elevator_core::prelude::*;
+    ///
+    /// let sim = SimulationBuilder::new().build().unwrap();
+    /// assert_eq!(sim.current_tick(), 0);
+    /// ```
     #[must_use]
     pub fn new() -> Self {
         let config = SimConfig {
@@ -260,6 +271,29 @@ impl SimulationBuilder {
     /// # Errors
     ///
     /// Returns [`SimError::InvalidConfig`] if the assembled configuration is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use elevator_core::prelude::*;
+    /// use elevator_core::stop::StopConfig;
+    ///
+    /// let mut sim = SimulationBuilder::new()
+    ///     .stops(vec![
+    ///         StopConfig { id: StopId(0), name: "Lobby".into(), position: 0.0 },
+    ///         StopConfig { id: StopId(1), name: "Roof".into(), position: 20.0 },
+    ///     ])
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 75.0).unwrap();
+    ///
+    /// for _ in 0..1000 {
+    ///     sim.step();
+    /// }
+    ///
+    /// assert!(sim.metrics().total_delivered() > 0);
+    /// ```
     pub fn build(self) -> Result<Simulation, SimError> {
         let default_dispatch = self
             .dispatchers

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -1,7 +1,73 @@
-//! Engine-agnostic elevator simulation library.
+//! # elevator-core
 //!
-//! Provides a tick-based simulation with pluggable dispatch strategies,
-//! trapezoidal velocity profiles, and a typed event bus for UI/metrics consumers.
+//! Engine-agnostic, tick-based elevator simulation library for Rust.
+//!
+//! This crate provides the building blocks for modeling vertical transportation
+//! systems — from a 3-story office building to an orbital space elevator.
+//! Stops sit at arbitrary positions rather than uniform floors, and the
+//! simulation is driven by a deterministic 6-phase tick loop.
+//!
+//! ## Key capabilities
+//!
+//! - **Pluggable dispatch** — four built-in algorithms ([`dispatch::scan::ScanDispatch`],
+//!   [`dispatch::look::LookDispatch`], [`dispatch::nearest_car::NearestCarDispatch`],
+//!   [`dispatch::etd::EtdDispatch`]) plus the [`dispatch::DispatchStrategy`] trait
+//!   for custom implementations.
+//! - **Trapezoidal motion profiles** — realistic acceleration, cruise, and
+//!   deceleration computed per-tick in the [`movement`] module.
+//! - **Extension components** — attach arbitrary `Serialize + DeserializeOwned`
+//!   data to any entity via [`world::World::insert_ext`] without modifying the
+//!   library.
+//! - **Lifecycle hooks** — inject logic before or after any of the six
+//!   simulation phases. See [`hooks::Phase`].
+//! - **Metrics and events** — query aggregate wait/ride times through
+//!   [`metrics::Metrics`] and react to fine-grained tick events via
+//!   [`events::Event`].
+//! - **Snapshot save/load** — capture and restore full simulation state with
+//!   [`snapshot::WorldSnapshot`].
+//! - **Zero `unsafe` code** — enforced by `#![forbid(unsafe_code)]`.
+//!
+//! ## Quick start
+//!
+//! ```rust
+//! use elevator_core::prelude::*;
+//! use elevator_core::stop::StopConfig;
+//!
+//! let mut sim = SimulationBuilder::new()
+//!     .stops(vec![
+//!         StopConfig { id: StopId(0), name: "Ground".into(), position: 0.0 },
+//!         StopConfig { id: StopId(1), name: "Floor 2".into(), position: 4.0 },
+//!         StopConfig { id: StopId(2), name: "Floor 3".into(), position: 8.0 },
+//!     ])
+//!     .build()
+//!     .unwrap();
+//!
+//! sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0).unwrap();
+//!
+//! for _ in 0..1000 {
+//!     sim.step();
+//! }
+//!
+//! assert!(sim.metrics().total_delivered() > 0);
+//! ```
+//!
+//! ## Crate layout
+//!
+//! | Module | Purpose |
+//! |--------|---------|
+//! | [`builder`] | Fluent [`SimulationBuilder`](builder::SimulationBuilder) API |
+//! | [`sim`] | Top-level [`Simulation`](sim::Simulation) runner and tick loop |
+//! | [`dispatch`] | Dispatch strategies and the [`DispatchStrategy`](dispatch::DispatchStrategy) trait |
+//! | [`world`] | ECS-style [`World`](world::World) with typed component storage |
+//! | [`components`] | Data types: [`Elevator`](components::Elevator), [`Rider`](components::Rider), [`Stop`](components::Stop), etc. |
+//! | [`events`] | [`Event`](events::Event) variants and the [`EventBus`](events::EventBus) |
+//! | [`metrics`] | Aggregate [`Metrics`](metrics::Metrics) (wait time, throughput, etc.) |
+//! | [`config`] | RON-deserializable [`SimConfig`](config::SimConfig) |
+//! | [`hooks`] | Lifecycle hook registration by [`Phase`](hooks::Phase) |
+//! | [`query`] | Entity query builder for filtering by component composition |
+//!
+//! For narrative guides, tutorials, and architecture walkthroughs, see the
+//! [mdBook documentation](https://andymai.github.io/elevator-core/).
 
 #![forbid(unsafe_code)]
 #![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)]

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -480,6 +480,17 @@ impl Simulation {
     ///
     /// Returns [`SimError::StopNotFound`] if the origin or destination stop ID
     /// is not in the building configuration.
+    ///
+    /// ```
+    /// use elevator_core::prelude::*;
+    ///
+    /// // Default builder has StopId(0) and StopId(1).
+    /// let mut sim = SimulationBuilder::new().build().unwrap();
+    ///
+    /// let rider = sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 80.0).unwrap();
+    /// sim.step(); // metrics are updated during the tick
+    /// assert_eq!(sim.metrics().total_spawned(), 1);
+    /// ```
     pub fn spawn_rider_by_stop_id(
         &mut self,
         origin: StopId,
@@ -505,6 +516,18 @@ impl Simulation {
     /// and made available here after `advance_tick()` is called.
     /// Events emitted outside the tick loop (e.g., `spawn_rider`, `disable`)
     /// are also included.
+    ///
+    /// ```
+    /// use elevator_core::prelude::*;
+    ///
+    /// let mut sim = SimulationBuilder::new().build().unwrap();
+    ///
+    /// sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0).unwrap();
+    /// sim.step();
+    ///
+    /// let events = sim.drain_events();
+    /// assert!(!events.is_empty());
+    /// ```
     pub fn drain_events(&mut self) -> Vec<Event> {
         // Flush any events still in the bus (from spawn_rider, disable, etc.)
         self.pending_output.extend(self.events.drain());
@@ -1090,6 +1113,14 @@ impl Simulation {
     /// Events from this tick are buffered internally and available via
     /// `drain_events()`. The metrics system only processes events from
     /// the current tick, regardless of whether the consumer drains them.
+    ///
+    /// ```
+    /// use elevator_core::prelude::*;
+    ///
+    /// let mut sim = SimulationBuilder::new().build().unwrap();
+    /// sim.step();
+    /// assert_eq!(sim.current_tick(), 1);
+    /// ```
     pub fn step(&mut self) {
         self.run_advance_transient();
         self.run_dispatch();

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,15 @@
+[book]
+title = "elevator-core"
+authors = ["Andy Aragon"]
+language = "en"
+src = "src"
+
+[build]
+build-dir = "../target/book"
+
+[output.html]
+default-theme = "light"
+preferred-dark-theme = "navy"
+git-repository-url = "https://github.com/andymai/elevator-core"
+edit-url-template = "https://github.com/andymai/elevator-core/edit/main/docs/src/{path}"
+additional-css = ["theme/custom.css"]

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,13 @@
+# Summary
+
+[Introduction](introduction.md)
+
+---
+
+- [Getting Started](getting-started.md)
+- [Core Concepts](core-concepts.md)
+- [Dispatch Strategies](dispatch.md)
+- [Extensions and Hooks](extensions-and-hooks.md)
+- [Configuration](configuration.md)
+- [Metrics and Events](metrics-and-events.md)
+- [Bevy Integration](bevy-integration.md)

--- a/docs/src/bevy-integration.md
+++ b/docs/src/bevy-integration.md
@@ -1,0 +1,163 @@
+# Bevy Integration
+
+The `elevator-bevy` crate is a Bevy 0.18 binary that wraps the core simulation with 2D rendering, a HUD, AI passengers, and keyboard controls. It serves as both a visual debugger for testing dispatch strategies and a reference implementation for integrating elevator-core into a game engine.
+
+## Running the Bevy app
+
+With the default config:
+
+```bash
+cargo run
+```
+
+With a custom config:
+
+```bash
+cargo run -- assets/config/space_elevator.ron
+```
+
+The app reads a RON config file, creates a `Simulation`, and renders the building in a 2D view with elevator cars, rider dots, and a metrics HUD.
+
+## Plugin architecture
+
+The integration is built around a single Bevy plugin:
+
+```rust,ignore
+pub struct ElevatorSimPlugin;
+```
+
+When you add this plugin to a Bevy app, it:
+
+1. **Loads config** from a RON file (CLI argument or `assets/config/default.ron`)
+2. **Creates a `Simulation`** and inserts it as the `SimulationRes` resource
+3. **Inserts `SimSpeed`** resource for controlling simulation speed
+4. **Registers the `EventWrapper` message** for bridging sim events to Bevy
+5. **Adds systems** for ticking the sim, rendering, AI passengers, input, and HUD
+
+## Key resources
+
+### SimulationRes
+
+The core simulation is wrapped in a Bevy resource:
+
+```rust,ignore
+#[derive(Resource)]
+pub struct SimulationRes {
+    pub sim: Simulation,
+}
+```
+
+Any Bevy system can access the simulation through `Res<SimulationRes>` (read) or `ResMut<SimulationRes>` (write).
+
+### SimSpeed
+
+Controls how many simulation ticks run per Bevy frame:
+
+```rust,ignore
+#[derive(Resource)]
+pub struct SimSpeed {
+    pub multiplier: u32,
+}
+```
+
+- `multiplier: 0` -- simulation is paused
+- `multiplier: 1` -- one tick per frame (normal speed)
+- `multiplier: 10` -- ten ticks per frame (fast forward)
+
+The built-in input system maps keyboard keys to speed changes.
+
+### EventWrapper
+
+Core simulation events are bridged into Bevy's message system:
+
+```rust,ignore
+#[derive(Message)]
+pub struct EventWrapper(pub Event);
+```
+
+Bevy systems can read simulation events using `MessageReader<EventWrapper>`:
+
+```rust,ignore
+fn my_system(mut events: MessageReader<EventWrapper>) {
+    for EventWrapper(event) in events.read() {
+        match event {
+            Event::RiderAlighted { rider, stop, tick, .. } => {
+                // React to rider arrival in Bevy-land.
+            }
+            _ => {}
+        }
+    }
+}
+```
+
+## The tick system
+
+The bridge between elevator-core and Bevy is a single system that runs each frame:
+
+```rust,ignore
+pub fn tick_simulation(
+    mut sim: ResMut<SimulationRes>,
+    speed: Res<SimSpeed>,
+    mut events: MessageWriter<EventWrapper>,
+) {
+    for _ in 0..speed.multiplier {
+        sim.sim.step();
+    }
+    for event in sim.sim.drain_events() {
+        events.write(EventWrapper(event));
+    }
+}
+```
+
+It steps the simulation `multiplier` times, then drains all events and re-emits them as Bevy messages. This is the only point where the core simulation and Bevy synchronize.
+
+## Writing custom Bevy systems
+
+To add your own gameplay systems that interact with the simulation, access `SimulationRes`:
+
+```rust,ignore
+use bevy::prelude::*;
+use elevator_bevy::sim_bridge::SimulationRes;
+use elevator_core::prelude::*;
+
+fn print_metrics(sim: Res<SimulationRes>) {
+    let m = sim.sim.metrics();
+    if sim.sim.current_tick() % 3600 == 0 {
+        println!(
+            "Minute {}: delivered={} avg_wait={:.0}",
+            sim.sim.current_tick() / 3600,
+            m.total_delivered(),
+            m.avg_wait_time(),
+        );
+    }
+}
+```
+
+Register your system in the Bevy app after the plugin:
+
+```rust,ignore
+app.add_plugins(ElevatorSimPlugin)
+    .add_systems(Update, print_metrics);
+```
+
+## Module layout
+
+The `elevator-bevy` crate is organized into focused modules:
+
+| Module | Responsibility |
+|---|---|
+| `plugin.rs` | `ElevatorSimPlugin` -- loads config, creates sim, registers everything |
+| `sim_bridge.rs` | `SimulationRes`, `SimSpeed`, `EventWrapper`, tick system |
+| `rendering.rs` | 2D visualization of the building, elevators, and riders |
+| `ui.rs` | HUD overlay showing metrics and simulation state |
+| `camera.rs` | Camera setup sized to the building |
+| `input.rs` | Keyboard controls for speed adjustment |
+| `passenger_ai.rs` | Timer-based passenger spawning |
+
+## When to use elevator-bevy vs. building your own
+
+**Use elevator-bevy** if you want a quick visual test of your dispatch strategy or config. Run it, watch the elevators move, tweak parameters.
+
+**Build your own** if you are making a game. The Bevy crate is intentionally simple -- it is a reference, not a framework. Copy the patterns you need (the `SimulationRes` resource, the tick system, the event bridge) into your own Bevy app and build your game systems around them.
+
+The core library does not depend on Bevy at all. You can use it with any Rust game engine, a TUI, a web frontend via WASM, or pure headless batch simulation.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -1,0 +1,228 @@
+# Configuration
+
+So far we have been wiring up the simulation entirely in code. This chapter covers both that programmatic path and an alternative: **RON config files** loaded from disk. Both produce the same `SimConfig` under the hood, so everything the builder can do, a config file can express, and vice versa.
+
+## Programmatic configuration
+
+The `SimulationBuilder` provides a fluent API for assembling a simulation in code. We have seen the basics already -- here is a more complete example that customizes everything:
+
+```rust,no_run
+use elevator_core::prelude::*;
+use elevator_core::config::ElevatorConfig;
+use elevator_core::stop::StopId;
+use elevator_core::dispatch::etd::EtdDispatch;
+
+fn main() -> Result<(), SimError> {
+    let sim = SimulationBuilder::new()
+        // Clear defaults and define our own building.
+        .stops(vec![])
+        .stop(StopId(0), "Ground", 0.0)
+        .stop(StopId(1), "Sky Lobby", 50.0)
+        .stop(StopId(2), "Observation Deck", 100.0)
+
+        // Clear the default elevator and add two custom ones.
+        .elevators(vec![])
+        .elevator(ElevatorConfig {
+            id: 0,
+            name: "Express A".into(),
+            max_speed: 5.0,
+            acceleration: 2.0,
+            deceleration: 3.0,
+            weight_capacity: 1200.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 60,
+            door_transition_ticks: 15,
+        })
+        .elevator(ElevatorConfig {
+            id: 1,
+            name: "Express B".into(),
+            max_speed: 5.0,
+            acceleration: 2.0,
+            deceleration: 3.0,
+            weight_capacity: 1200.0,
+            starting_stop: StopId(2),
+            door_open_ticks: 60,
+            door_transition_ticks: 15,
+        })
+
+        .building_name("Skyline Tower")
+        .ticks_per_second(60.0)
+        .dispatch(EtdDispatch::new())
+        .build()?;
+
+    Ok(())
+}
+```
+
+### ElevatorConfig fields
+
+| Field | Type | Description | Default |
+|---|---|---|---|
+| `id` | `u32` | Unique numeric ID within the config (mapped to `EntityId` at runtime) | -- |
+| `name` | `String` | Human-readable name for UIs and logs | -- |
+| `max_speed` | `f64` | Maximum travel speed (distance units/second) | `2.0` |
+| `acceleration` | `f64` | Acceleration rate (distance units/second^2) | `1.5` |
+| `deceleration` | `f64` | Deceleration rate (distance units/second^2) | `2.0` |
+| `weight_capacity` | `f64` | Maximum total rider weight | `800.0` |
+| `starting_stop` | `StopId` | Where this elevator starts | -- |
+| `door_open_ticks` | `u32` | Ticks doors stay fully open | `10` |
+| `door_transition_ticks` | `u32` | Ticks for a door open/close transition | `5` |
+
+## RON config files
+
+For data-driven workflows, you can define your building in a RON file and load it at runtime. RON (Rusty Object Notation) is a human-readable format that maps directly to Rust structs.
+
+Here is the `default.ron` included in the repository:
+
+```ron
+SimConfig(
+    building: BuildingConfig(
+        name: "Demo Tower",
+        stops: [
+            StopConfig(id: StopId(0), name: "Ground", position: 0.0),
+            StopConfig(id: StopId(1), name: "Floor 2", position: 4.0),
+            StopConfig(id: StopId(2), name: "Floor 3", position: 7.5),
+            StopConfig(id: StopId(3), name: "Floor 4", position: 11.0),
+            StopConfig(id: StopId(4), name: "Roof", position: 15.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0,
+            name: "Main",
+            max_speed: 2.0,
+            acceleration: 1.5,
+            deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 60,
+            door_transition_ticks: 15,
+        ),
+    ],
+    simulation: SimulationParams(
+        ticks_per_second: 60.0,
+    ),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 120,
+        weight_range: (50.0, 100.0),
+    ),
+)
+```
+
+### Loading a RON file
+
+Add `ron` to your dependencies (`cargo add ron`) since elevator-core re-uses it for config parsing but doesn't re-export the deserializer:
+
+```rust,no_run
+use elevator_core::prelude::*;
+use elevator_core::config::SimConfig;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let ron_str = std::fs::read_to_string("assets/config/default.ron")?;
+    let config: SimConfig = ron::from_str(&ron_str)?;
+
+    let sim = SimulationBuilder::from_config(config).build()?;
+
+    println!("Loaded simulation with {} tick rate",
+             sim.dt().recip() as u32);
+    Ok(())
+}
+```
+
+`SimulationBuilder::from_config(config)` accepts a deserialized `SimConfig` and still lets you chain builder methods on top -- for example, to override the dispatch strategy or register extensions.
+
+## Config sections
+
+### BuildingConfig
+
+Defines the building layout. The `stops` list must have at least one entry, and each `StopId` must be unique. Stop positions are arbitrary `f64` values along the shaft axis -- they do not need to be uniformly spaced.
+
+```ron
+building: BuildingConfig(
+    name: "My Building",
+    stops: [
+        StopConfig(id: StopId(0), name: "Lobby", position: 0.0),
+        StopConfig(id: StopId(1), name: "Mezzanine", position: 2.5),
+        StopConfig(id: StopId(2), name: "Floor 2", position: 6.0),
+    ],
+),
+```
+
+### ElevatorConfig (list)
+
+One or more elevator cars. Each must reference a valid `starting_stop` from the building config. All numeric physics parameters must be positive.
+
+### SimulationParams
+
+Controls simulation timing:
+
+```ron
+simulation: SimulationParams(
+    ticks_per_second: 60.0,
+),
+```
+
+The tick rate determines `dt` (time delta per tick): `dt = 1.0 / ticks_per_second`. Higher values produce smoother motion but require more computation. 60 is a good default.
+
+### PassengerSpawnConfig
+
+Advisory parameters for traffic generators. The core library does **not** spawn passengers automatically -- these values are consumed by game code or the optional `traffic` feature:
+
+```ron
+passenger_spawning: PassengerSpawnConfig(
+    mean_interval_ticks: 120,
+    weight_range: (50.0, 100.0),
+),
+```
+
+| Field | Meaning |
+|---|---|
+| `mean_interval_ticks` | Average ticks between passenger spawns (Poisson distribution) |
+| `weight_range` | `(min, max)` for uniformly distributed rider weight |
+
+## The space elevator
+
+To demonstrate that stops are truly arbitrary, the repository includes `space_elevator.ron`:
+
+```ron
+SimConfig(
+    building: BuildingConfig(
+        name: "Orbital Tether",
+        stops: [
+            StopConfig(id: StopId(0), name: "Ground Station", position: 0.0),
+            StopConfig(id: StopId(1), name: "Orbital Platform", position: 1000.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0,
+            name: "Climber Alpha",
+            max_speed: 50.0,
+            acceleration: 10.0,
+            deceleration: 15.0,
+            weight_capacity: 10000.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 120,
+            door_transition_ticks: 30,
+        ),
+    ],
+    // ...
+)
+```
+
+The stops are 1,000 distance units apart, the elevator has a max speed of 50, and the doors take twice as long to cycle. The same simulation engine handles both a 5-story office and an orbital tether -- the physics just scale.
+
+## Validation
+
+Config is validated at construction time (in `SimulationBuilder::build()` or `Simulation::new()`). Invalid configs produce a `SimError::InvalidConfig` with a descriptive message. Validation checks include:
+
+- At least one stop
+- No duplicate `StopId` values
+- At least one elevator
+- All physics parameters positive
+- Each elevator's `starting_stop` references an existing stop
+- Tick rate is positive
+
+## Next steps
+
+Head to [Metrics and Events](metrics-and-events.md) to learn how to observe what is happening inside your simulation.

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -1,0 +1,145 @@
+# Core Concepts
+
+This chapter covers the mental model behind elevator-core: how entities and components fit together, what happens during each tick, and how riders and elevators move through their lifecycles.
+
+## The World
+
+At the center of the simulation is the `World` -- a struct-of-arrays entity store inspired by ECS architecture. Every meaningful thing in the simulation (stops, elevators, riders) is an **entity**, identified by an `EntityId`. Entities have **components** attached to them -- typed data like `Position`, `Elevator`, `Rider`, or `Stop`.
+
+```text
+World
+  +-- Entity 0 (Stop)     -> Stop { name: "Lobby", position: 0.0 }, Position { value: 0.0 }
+  +-- Entity 1 (Stop)     -> Stop { name: "Floor 2", position: 4.0 }, Position { value: 4.0 }
+  +-- Entity 2 (Elevator) -> Elevator { phase: Idle, ... }, Position { value: 0.0 }, Velocity { value: 0.0 }
+  +-- Entity 3 (Rider)    -> Rider { phase: Waiting, weight: 75.0, ... }, Route { ... }
+```
+
+You access the world through `sim.world()` (shared) and `sim.world_mut()` (mutable). The simulation also provides convenience methods like `sim.spawn_rider_by_stop_id()` that handle world operations for you.
+
+## Identity types
+
+The library uses several identity types, and it is important to understand which one to use where:
+
+| Type | What it identifies | When you use it |
+|---|---|---|
+| `EntityId` | Any entity at runtime (stop, elevator, rider) | Event payloads, world lookups, dispatch decisions |
+| `StopId` | A stop in the *config* (e.g., `StopId(0)`) | Builder API, config files, `spawn_rider_by_stop_id` |
+| `GroupId` | An elevator group (e.g., `GroupId(0)`) | Multi-group dispatch, group-specific hooks |
+
+`StopId` is a config-level concept. When the simulation boots, each `StopId` is mapped to an `EntityId`. At runtime you work with `EntityId` everywhere -- events, world queries, dispatch. Use `sim.stop_entity(StopId(0))` if you need to convert.
+
+## The tick loop
+
+Each call to `sim.step()` runs one simulation tick. A tick consists of six phases, always executed in this order:
+
+```text
++-------------------+   +------------+   +------------+
+| Advance           |-->| Dispatch   |-->| Movement   |
+| Transient         |   |            |   |            |
++-------------------+   +------------+   +------------+
+                                              |
++-------------------+   +------------+   +------------+
+| Metrics           |<--| Loading    |<--| Doors      |
+|                   |   |            |   |            |
++-------------------+   +------------+   +------------+
+```
+
+### Phase 1: Advance Transient
+
+Riders in transitional states are advanced to their next phase:
+- `Boarding` -> `Riding` (the rider is now inside the elevator)
+- `Alighting` -> `Arrived` (the rider has left the elevator and is done)
+
+This ensures that boarding and alighting -- which are set during the Loading phase -- take effect at the start of the *next* tick, giving events a clean boundary.
+
+### Phase 2: Dispatch
+
+The dispatch strategy examines all idle elevators and waiting riders, then decides where each elevator should go. The strategy receives a `DispatchManifest` with full demand information (who is waiting where, who is riding to where) and returns a `DispatchDecision` for each elevator.
+
+The default strategy is SCAN (sweep end-to-end). You can swap in LOOK, NearestCar, ETD, or your own custom strategy -- see [Dispatch Strategies](dispatch.md).
+
+### Phase 3: Movement
+
+Elevators with a target stop are moved along the shaft axis using a **trapezoidal velocity profile**: accelerate up to max speed, cruise, then decelerate to stop precisely at the target position. This produces realistic motion without requiring complex physics.
+
+When an elevator arrives at its target stop, it emits an `ElevatorArrived` event and transitions to the door-opening state.
+
+### Phase 4: Doors
+
+The door finite-state machine ticks for each elevator. Doors transition through:
+
+```text
+Closed -> Opening (transition ticks) -> Open (hold ticks) -> Closing (transition ticks) -> Closed
+```
+
+`DoorOpened` and `DoorClosed` events fire at the appropriate moments. Riders can only board or alight when the doors are fully open.
+
+### Phase 5: Loading
+
+While an elevator's doors are open at a stop:
+- **Alighting**: riders whose destination matches the current stop exit the elevator.
+- **Boarding**: waiting riders at the current stop enter the elevator, subject to weight capacity.
+
+Riders that exceed the elevator's remaining capacity are rejected with a `RiderRejected` event.
+
+### Phase 6: Metrics
+
+Events from the current tick are processed to update aggregate metrics -- average wait time, ride time, throughput, abandonment rate, and total distance. Tagged metrics (per-zone or per-label breakdowns) are also updated here.
+
+## Rider lifecycle
+
+A rider moves through these phases:
+
+```text
+Waiting --> Boarding --> Riding --> Alighting --> Arrived
+                                                   |
+Waiting ----> Abandoned (gave up waiting)    (despawned)
+```
+
+| Phase | Where is the rider? | What triggers the transition? |
+|---|---|---|
+| `Waiting` | At a stop, in the queue | Elevator arrives, doors open, loading phase boards them |
+| `Boarding` | Being loaded into the elevator | Advance Transient phase (next tick) |
+| `Riding` | Inside the elevator | Elevator arrives at destination, doors open, loading phase alights them |
+| `Alighting` | Exiting the elevator | Advance Transient phase (next tick) |
+| `Arrived` | Done | Game can despawn or ignore |
+| `Abandoned` | Left the stop | Patience ran out (if configured) |
+
+Each transition emits an event: `RiderSpawned`, `RiderBoarded`, `RiderAlighted`, `RiderAbandoned`.
+
+## Elevator lifecycle
+
+Elevators cycle through these phases:
+
+| Phase | Meaning |
+|---|---|
+| `Idle` | No target, waiting for dispatch to assign a stop |
+| `MovingToStop(EntityId)` | Traveling toward a target stop |
+| `AtStop` | Stationary at a stop, doors cycling |
+
+An elevator at a stop will open its doors, hold them open for the configured duration, then close. If dispatch assigns a new target, the elevator departs after doors close.
+
+## Sub-stepping
+
+For advanced use cases, you can run individual phases instead of calling `step()`:
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn main() -> Result<(), SimError> {
+# let mut sim = SimulationBuilder::new().build()?;
+sim.run_advance_transient();
+sim.run_dispatch();
+sim.run_movement();
+sim.run_doors();
+sim.run_loading();
+sim.run_metrics();
+sim.advance_tick(); // flush events and increment tick counter
+# Ok(())
+# }
+```
+
+This is equivalent to `sim.step()` but lets you inject logic between phases or skip phases entirely. Lifecycle hooks (covered in [Extensions and Hooks](extensions-and-hooks.md)) provide a less manual way to achieve this.
+
+## Next steps
+
+Now that you understand the architecture, head to [Dispatch Strategies](dispatch.md) to learn how elevators decide where to go.

--- a/docs/src/dispatch.md
+++ b/docs/src/dispatch.md
@@ -1,0 +1,200 @@
+# Dispatch Strategies
+
+Dispatch is the brain of an elevator system. Each tick, the dispatch strategy looks at which stops have waiting riders and which elevators are idle, then decides where to send each elevator. This chapter covers the four built-in strategies, how to swap between them, and how to write your own.
+
+## How dispatch works
+
+During the Dispatch phase of each tick, the simulation:
+
+1. Builds a `DispatchManifest` containing per-stop demand (waiting riders, their weights, their wait times) and per-destination riding riders.
+2. Collects all idle elevators in each group along with their current positions.
+3. Calls the group's `DispatchStrategy` with this information.
+4. Applies the returned `DispatchDecision` for each elevator -- either `GoToStop(entity_id)` to assign a target, or `Idle` to do nothing.
+
+## Built-in strategies
+
+| Strategy | Algorithm | Best for | Trade-off |
+|---|---|---|---|
+| `ScanDispatch` | Sweep end-to-end, reversing at shaft extremes | Single elevator, uniform traffic | Simple and fair, but wastes time traveling past the last request |
+| `LookDispatch` | Like SCAN, but reverses at the last request in the current direction | Single elevator, sparse traffic | More efficient than SCAN when requests cluster, slightly less predictable |
+| `NearestCarDispatch` | Assign each call to the closest idle elevator | Multi-elevator groups | Low average wait, but can cause bunching when elevators cluster |
+| `EtdDispatch` | Minimize estimated time to destination across all riders | Multi-elevator groups with mixed traffic | Best average performance, higher per-tick computation |
+
+## Swapping strategies on the builder
+
+The builder defaults to `ScanDispatch`. To use a different strategy, call `.dispatch()`:
+
+```rust,no_run
+use elevator_core::prelude::*;
+use elevator_core::dispatch::look::LookDispatch;
+
+fn main() -> Result<(), SimError> {
+    let sim = SimulationBuilder::new()
+        .dispatch(LookDispatch::new())
+        .build()?;
+    Ok(())
+}
+```
+
+All four built-in strategies are available in their respective modules:
+
+```rust,no_run
+use elevator_core::dispatch::scan::ScanDispatch;
+use elevator_core::dispatch::look::LookDispatch;
+use elevator_core::dispatch::nearest_car::NearestCarDispatch;
+use elevator_core::dispatch::etd::EtdDispatch;
+```
+
+The ETD strategy accepts an optional delay weight that controls how much it penalizes delays to existing riders when assigning a new call:
+
+```rust,no_run
+use elevator_core::dispatch::etd::EtdDispatch;
+
+// Default: delay_weight = 1.0
+let etd = EtdDispatch::new();
+
+// Prioritize existing riders more heavily
+let etd_conservative = EtdDispatch::with_delay_weight(1.5);
+```
+
+## Multi-group dispatch
+
+Large buildings often have separate elevator banks -- a low-rise group serving floors 1-20 and a high-rise group serving floors 20-40, for example. Each group can have its own dispatch strategy.
+
+Use `.dispatch_for_group()` on the builder:
+
+```rust,no_run
+use elevator_core::prelude::*;
+use elevator_core::dispatch::scan::ScanDispatch;
+use elevator_core::dispatch::etd::EtdDispatch;
+
+fn main() -> Result<(), SimError> {
+    let sim = SimulationBuilder::new()
+        .dispatch_for_group(GroupId(0), ScanDispatch::new())
+        .dispatch_for_group(GroupId(1), EtdDispatch::new())
+        .build()?;
+    Ok(())
+}
+```
+
+## Writing a custom strategy
+
+To implement your own dispatch algorithm, implement the `DispatchStrategy` trait:
+
+```rust,no_run
+use elevator_core::prelude::*;
+use elevator_core::world::World;
+
+/// Always sends the elevator to the highest stop that has waiting riders.
+struct HighestFirstDispatch;
+
+impl DispatchStrategy for HighestFirstDispatch {
+    fn decide(
+        &mut self,
+        elevator: EntityId,
+        elevator_position: f64,
+        group: &ElevatorGroup,
+        manifest: &DispatchManifest,
+        world: &World,
+    ) -> DispatchDecision {
+        // Find the highest stop (by position) with waiting riders.
+        let mut best: Option<(EntityId, f64)> = None;
+
+        for &stop_eid in &group.stop_entities {
+            if manifest.waiting_count_at(stop_eid) == 0 {
+                continue;
+            }
+
+            if let Some(stop) = world.stop(stop_eid) {
+                match best {
+                    Some((_, best_pos)) if stop.position > best_pos => {
+                        best = Some((stop_eid, stop.position));
+                    }
+                    None => {
+                        best = Some((stop_eid, stop.position));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        match best {
+            Some((stop_eid, _)) => DispatchDecision::GoToStop(stop_eid),
+            None => DispatchDecision::Idle,
+        }
+    }
+}
+```
+
+Then plug it into the builder:
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# struct HighestFirstDispatch;
+# impl DispatchStrategy for HighestFirstDispatch {
+#     fn decide(&mut self, _: EntityId, _: f64, _: &elevator_core::dispatch::ElevatorGroup, _: &DispatchManifest, _: &elevator_core::world::World) -> DispatchDecision { DispatchDecision::Idle }
+# }
+fn main() -> Result<(), SimError> {
+    let sim = SimulationBuilder::new()
+        .dispatch(HighestFirstDispatch)
+        .build()?;
+    Ok(())
+}
+```
+
+### The `DispatchManifest`
+
+Your strategy receives a `DispatchManifest` with these convenience methods:
+
+| Method | Returns | Description |
+|---|---|---|
+| `waiting_count_at(stop)` | `usize` | Number of riders waiting at a stop |
+| `total_weight_at(stop)` | `f64` | Total weight of riders waiting at a stop |
+| `has_demand(stop)` | `bool` | Whether a stop has any demand (waiting or riding-to) |
+| `riding_count_to(stop)` | `usize` | Number of riders aboard elevators heading to a stop |
+
+For more advanced dispatch (priority-aware, weight-aware, VIP-first), you can iterate `manifest.waiting_at_stop` directly. Each entry contains a `Vec<RiderInfo>` with the rider's `id`, `destination`, `weight`, and `wait_ticks`.
+
+### Group-aware dispatch with `decide_all`
+
+The default `DispatchStrategy` trait calls `decide()` once per idle elevator. If your strategy needs to coordinate across all elevators in a group (to avoid sending two elevators to the same stop), override `decide_all()` instead:
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# use elevator_core::world::World;
+# struct MyStrategy;
+impl DispatchStrategy for MyStrategy {
+    fn decide(
+        &mut self,
+        _elevator: EntityId,
+        _pos: f64,
+        _group: &ElevatorGroup,
+        _manifest: &DispatchManifest,
+        _world: &World,
+    ) -> DispatchDecision {
+        // Required by the trait. When decide_all is overridden, the
+        // default trait impl calls decide_all instead of this method.
+        DispatchDecision::Idle
+    }
+
+    fn decide_all(
+        &mut self,
+        elevators: &[(EntityId, f64)],
+        group: &ElevatorGroup,
+        manifest: &DispatchManifest,
+        world: &World,
+    ) -> Vec<(EntityId, DispatchDecision)> {
+        // Your group-level coordination logic here.
+        elevators
+            .iter()
+            .map(|(eid, _)| (*eid, DispatchDecision::Idle))
+            .collect()
+    }
+}
+```
+
+Both `NearestCarDispatch` and `EtdDispatch` use this pattern internally to prevent duplicate assignments.
+
+## Next steps
+
+Now that you know how dispatch works, head to [Extensions and Hooks](extensions-and-hooks.md) to learn how to attach custom data to entities and inject logic into the tick loop.

--- a/docs/src/extensions-and-hooks.md
+++ b/docs/src/extensions-and-hooks.md
@@ -1,0 +1,249 @@
+# Extensions and Hooks
+
+The core library is deliberately unopinionated -- it provides riders, elevators, and stops, but your game decides what a rider *means*. Maybe riders have a VIP status, a mood, a destination preference, or a cargo manifest. Extensions and hooks are how you layer game-specific logic on top of the simulation without forking or wrapping.
+
+## Extension components
+
+Extension components let you attach arbitrary typed data to any entity. They work like the built-in components (`Rider`, `Elevator`, etc.) but are defined by your code.
+
+### Step 1: Define your type
+
+Extension types must implement `Serialize` and `DeserializeOwned` (for snapshot support), plus `Send + Sync`:
+
+```rust,no_run
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct VipTag {
+    level: u32,
+    lounge_access: bool,
+}
+```
+
+### Step 2: Register with the builder
+
+Call `.with_ext::<T>("name")` on the builder to register the extension type. The name string is used for snapshot serialization:
+
+```rust,no_run
+# use serde::{Serialize, Deserialize};
+# #[derive(Debug, Clone, Serialize, Deserialize)]
+# struct VipTag { level: u32, lounge_access: bool }
+use elevator_core::prelude::*;
+
+fn main() -> Result<(), SimError> {
+    let mut sim = SimulationBuilder::new()
+        .with_ext::<VipTag>("vip_tag")
+        .build()?;
+    Ok(())
+}
+```
+
+### Step 3: Attach to entities
+
+Use `world.insert_ext()` to attach your component to an entity:
+
+```rust,no_run
+# use serde::{Serialize, Deserialize};
+# #[derive(Debug, Clone, Serialize, Deserialize)]
+# struct VipTag { level: u32, lounge_access: bool }
+# use elevator_core::prelude::*;
+# use elevator_core::stop::StopId;
+# fn main() -> Result<(), SimError> {
+# let mut sim = SimulationBuilder::new().with_ext::<VipTag>("vip_tag").build()?;
+let rider_id = sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 75.0)?;
+
+sim.world_mut().insert_ext(
+    rider_id,
+    VipTag { level: 3, lounge_access: true },
+    "vip_tag",
+);
+# Ok(())
+# }
+```
+
+### Step 4: Read it back
+
+Use `world.get_ext()` for a cloned value, or `world.get_ext_mut()` for a mutable reference:
+
+```rust,no_run
+# use serde::{Serialize, Deserialize};
+# #[derive(Debug, Clone, Serialize, Deserialize)]
+# struct VipTag { level: u32, lounge_access: bool }
+# use elevator_core::prelude::*;
+# fn run(sim: &mut Simulation, rider_id: EntityId) {
+// Read (cloned)
+if let Some(vip) = sim.world().get_ext::<VipTag>(rider_id) {
+    println!("VIP level: {}", vip.level);
+}
+
+// Mutate
+if let Some(vip) = sim.world_mut().get_ext_mut::<VipTag>(rider_id) {
+    vip.level += 1;
+}
+# }
+```
+
+Extensions are automatically cleaned up when an entity is despawned, and they participate in snapshot save/load as long as you register them with `.with_ext()` or `world.register_ext()`.
+
+## World resources
+
+For global data that is not attached to a specific entity, use **resources**. Resources are typed singletons stored on the `World`:
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(sim: &mut Simulation) {
+// Insert a resource
+sim.world_mut().insert_resource(42u32);
+
+// Read it
+if let Some(value) = sim.world().resource::<u32>() {
+    println!("The answer is {}", value);
+}
+
+// Mutate it
+if let Some(value) = sim.world_mut().resource_mut::<u32>() {
+    *value += 1;
+}
+# }
+```
+
+Resources are useful for game state that hooks need to read or write -- score counters, time-of-day multipliers, spawn rate controllers, and so on.
+
+## Lifecycle hooks
+
+Hooks let you inject custom logic before or after any of the six tick phases. They receive `&mut World`, so they can read and modify any entity or resource.
+
+### Registering hooks on the builder
+
+```rust,no_run
+use elevator_core::prelude::*;
+
+fn main() -> Result<(), SimError> {
+    let sim = SimulationBuilder::new()
+        .after(Phase::Loading, |world| {
+            // This runs after every Loading phase.
+            // Check for newly arrived riders, update scores, etc.
+        })
+        .before(Phase::Dispatch, |world| {
+            // This runs before every Dispatch phase.
+            // Adjust demand, spawn dynamic riders, etc.
+        })
+        .build()?;
+    Ok(())
+}
+```
+
+### Registering hooks after build
+
+You can also add hooks to a running simulation:
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn main() -> Result<(), SimError> {
+# let mut sim = SimulationBuilder::new().build()?;
+sim.add_after_hook(Phase::Loading, |world| {
+    // Post-loading logic
+});
+# Ok(())
+# }
+```
+
+### Group-specific hooks
+
+For multi-group buildings, you can register hooks that only fire for a specific elevator group:
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn main() -> Result<(), SimError> {
+let sim = SimulationBuilder::new()
+    .after_group(Phase::Loading, GroupId(0), |world| {
+        // Only runs after loading for group 0
+    })
+    .build()?;
+# Ok(())
+# }
+```
+
+### Available phases
+
+| Phase | When hooks run |
+|---|---|
+| `Phase::AdvanceTransient` | Before/after transitional states advance |
+| `Phase::Dispatch` | Before/after elevator assignment |
+| `Phase::Movement` | Before/after position updates |
+| `Phase::Doors` | Before/after door state machine ticks |
+| `Phase::Loading` | Before/after boarding and alighting |
+| `Phase::Metrics` | Before/after metric aggregation |
+
+## Combining extensions and hooks
+
+The real power comes from using extensions and hooks together. Here is a walkthrough: we will track how long each rider has been waiting and print a warning if they wait too long.
+
+The hook closure cannot call `sim.current_tick()` directly (the simulation is borrowed during the tick), so we store the tick in a `World` resource and update it each iteration. The `CurrentTick` helper struct is defined at the bottom of the listing.
+
+```rust,no_run
+use elevator_core::prelude::*;
+use elevator_core::stop::StopId;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WaitWarning {
+    warned: bool,
+}
+
+fn main() -> Result<(), SimError> {
+    let mut sim = SimulationBuilder::new()
+        .stops(vec![])
+        .stop(StopId(0), "Lobby", 0.0)
+        .stop(StopId(1), "Floor 2", 4.0)
+        .stop(StopId(2), "Floor 3", 8.0)
+        .with_ext::<WaitWarning>("wait_warning")
+        .after(Phase::Metrics, |world| {
+            // Check all waiting riders for long waits.
+            let rider_ids: Vec<EntityId> = world.rider_ids();
+            for rid in rider_ids {
+                let Some(rider) = world.rider(rid) else { continue };
+                if rider.phase != RiderPhase::Waiting { continue; }
+
+                let current_tick = world.resource::<CurrentTick>()
+                    .map_or(0, |t| t.0);
+                let wait = current_tick.saturating_sub(rider.spawn_tick);
+
+                if wait > 300 {
+                    if let Some(warning) = world.get_ext_mut::<WaitWarning>(rid) {
+                        if !warning.warned {
+                            warning.warned = true;
+                            println!("WARNING: rider {:?} has been waiting {} ticks!", rid, wait);
+                        }
+                    }
+                }
+            }
+        })
+        .build()?;
+
+    // Seed the resource the hook reads.
+    sim.world_mut().insert_resource(CurrentTick(0));
+
+    // Spawn some riders and attach extensions.
+    let r1 = sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)?;
+    sim.world_mut().insert_ext(r1, WaitWarning { warned: false }, "wait_warning");
+
+    for _ in 0..600 {
+        // Update the current tick resource before stepping.
+        if let Some(t) = sim.world_mut().resource_mut::<CurrentTick>() {
+            t.0 = sim.current_tick();
+        }
+        sim.step();
+    }
+
+    Ok(())
+}
+
+struct CurrentTick(u64);
+```
+
+This pattern -- define a component, register it, attach it on spawn, read/write it in a hook -- is the standard way to add game-specific behavior to the simulation.
+
+## Next steps
+
+Head to [Configuration](configuration.md) to learn about RON config files and the programmatic configuration API.

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -1,0 +1,189 @@
+# Getting Started
+
+In this chapter we will build a minimal elevator simulation from scratch: a 3-stop building with one elevator, a single rider, and a loop that runs until the rider arrives at their destination.
+
+## Add the dependency
+
+```bash
+cargo add elevator-core
+```
+
+Or add it to your `Cargo.toml` manually:
+
+```toml
+[dependencies]
+elevator-core = "0.1"
+```
+
+## Import the prelude
+
+The prelude re-exports everything you need for typical usage:
+
+```rust
+use elevator_core::prelude::*;
+```
+
+## Build a simulation
+
+We will use `SimulationBuilder` to set up a 3-stop building. The builder starts with sensible defaults (2 stops, 1 elevator, SCAN dispatch, 60 ticks per second), but we will override the stops to create our own layout.
+
+```rust,no_run
+use elevator_core::prelude::*;
+use elevator_core::config::ElevatorConfig;
+use elevator_core::stop::StopId;
+
+fn main() -> Result<(), SimError> {
+    let mut sim = SimulationBuilder::new()
+        // Clear the default stops and define our own.
+        .stops(vec![])
+        .stop(StopId(0), "Lobby", 0.0)
+        .stop(StopId(1), "Floor 2", 4.0)
+        .stop(StopId(2), "Floor 3", 8.0)
+        .building_name("Tutorial Tower")
+        .build()?;
+
+    Ok(())
+}
+```
+
+`SimulationBuilder::new()` gives us one elevator with reasonable physics defaults (max speed 2.0, acceleration 1.5, deceleration 2.0, 800 kg capacity). That is plenty for our tutorial. If you want to customize the elevator, chain `.elevators(vec![])` followed by `.elevator(ElevatorConfig { ... })` -- we will cover that in the [Configuration](configuration.md) chapter.
+
+## Spawn a rider
+
+A rider is anything that rides an elevator. To spawn one, you provide an origin stop, a destination stop, and a weight:
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# use elevator_core::stop::StopId;
+# fn main() -> Result<(), SimError> {
+# let mut sim = SimulationBuilder::new()
+#     .stops(vec![])
+#     .stop(StopId(0), "Lobby", 0.0)
+#     .stop(StopId(1), "Floor 2", 4.0)
+#     .stop(StopId(2), "Floor 3", 8.0)
+#     .build()?;
+let rider_id = sim.spawn_rider_by_stop_id(
+    StopId(0),  // origin: Lobby
+    StopId(2),  // destination: Floor 3
+    75.0,       // weight in kg
+)?;
+println!("Spawned rider: {:?}", rider_id);
+# Ok(())
+# }
+```
+
+`spawn_rider_by_stop_id` maps config-level `StopId` values to runtime `EntityId` values internally. It returns `Result<EntityId, SimError>` -- it will fail if you pass a `StopId` that does not exist in your building.
+
+## Run the simulation loop
+
+Each call to `sim.step()` advances the simulation by one tick, running all six phases of the tick loop (advance transient, dispatch, movement, doors, loading, metrics). After stepping, you can drain events to see what happened:
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# use elevator_core::stop::StopId;
+# fn main() -> Result<(), SimError> {
+# let mut sim = SimulationBuilder::new()
+#     .stops(vec![])
+#     .stop(StopId(0), "Lobby", 0.0)
+#     .stop(StopId(1), "Floor 2", 4.0)
+#     .stop(StopId(2), "Floor 3", 8.0)
+#     .build()?;
+# let rider_id = sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)?;
+let mut arrived = false;
+
+while !arrived {
+    sim.step();
+
+    for event in sim.drain_events() {
+        match event {
+            Event::RiderBoarded { rider, elevator, tick } => {
+                println!("Tick {}: rider {:?} boarded elevator {:?}", tick, rider, elevator);
+            }
+            Event::ElevatorArrived { elevator, at_stop, tick } => {
+                println!("Tick {}: elevator {:?} arrived at stop {:?}", tick, elevator, at_stop);
+            }
+            Event::RiderAlighted { rider, stop, tick, .. } => {
+                println!("Tick {}: rider {:?} arrived at stop {:?}", tick, rider, stop);
+                if rider == rider_id {
+                    arrived = true;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+println!("Rider delivered!");
+println!("Total ticks: {}", sim.current_tick());
+println!("Avg wait time: {:.1} ticks", sim.metrics().avg_wait_time());
+# Ok(())
+# }
+```
+
+## The complete program
+
+Here is everything together as a single runnable file:
+
+```rust,no_run
+use elevator_core::prelude::*;
+use elevator_core::stop::StopId;
+
+fn main() -> Result<(), SimError> {
+    // 1. Build a 3-stop building.
+    let mut sim = SimulationBuilder::new()
+        .stops(vec![])
+        .stop(StopId(0), "Lobby", 0.0)
+        .stop(StopId(1), "Floor 2", 4.0)
+        .stop(StopId(2), "Floor 3", 8.0)
+        .building_name("Tutorial Tower")
+        .build()?;
+
+    // 2. Spawn a rider going from the Lobby to Floor 3.
+    let rider_id = sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)?;
+
+    // 3. Run until the rider arrives.
+    let mut arrived = false;
+    while !arrived {
+        sim.step();
+
+        for event in sim.drain_events() {
+            match event {
+                Event::RiderBoarded { rider, elevator, tick } => {
+                    println!("Tick {tick}: rider {rider:?} boarded elevator {elevator:?}");
+                }
+                Event::ElevatorArrived { elevator, at_stop, tick } => {
+                    println!("Tick {tick}: elevator {elevator:?} arrived at {at_stop:?}");
+                }
+                Event::RiderAlighted { rider, stop, tick, .. } => {
+                    println!("Tick {tick}: rider {rider:?} alighted at {stop:?}");
+                    if rider == rider_id {
+                        arrived = true;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // 4. Print summary metrics.
+    let m = sim.metrics();
+    println!("\n--- Summary ---");
+    println!("Total ticks:    {}", sim.current_tick());
+    println!("Avg wait time:  {:.1} ticks", m.avg_wait_time());
+    println!("Avg ride time:  {:.1} ticks", m.avg_ride_time());
+    println!("Delivered:      {}", m.total_delivered());
+
+    Ok(())
+}
+```
+
+Run it with `cargo run` and you should see the rider move from the Lobby to Floor 3, with events printed along the way.
+
+## What just happened?
+
+1. The **builder** created a `Simulation` containing a `World` with three stop entities and one elevator entity, plus a SCAN dispatch strategy.
+2. `spawn_rider_by_stop_id` created a rider entity at the Lobby with a route to Floor 3.
+3. Each `step()` ran the six-phase tick loop. The **dispatch** phase noticed a waiting rider and sent the elevator to the Lobby. The **movement** phase moved the elevator using a trapezoidal velocity profile. The **doors** phase opened and closed doors. The **loading** phase boarded and alighted the rider. The **metrics** phase updated aggregate stats.
+4. Events fired at each significant moment, and we pattern-matched on them to detect arrival.
+
+Next up: [Core Concepts](core-concepts.md) dives deeper into the entity model, the tick loop phases, and the lifecycle of riders and elevators.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,0 +1,35 @@
+# Introduction
+
+**elevator-core** is an engine-agnostic elevator simulation library written in pure Rust. It gives you a tick-based simulation with realistic trapezoidal motion profiles, pluggable dispatch algorithms, and a typed event bus -- everything you need to build elevator games, building management tools, or algorithm testbeds without coupling to any particular game engine or rendering framework.
+
+## Who is this for?
+
+- **Game developers** who want a ready-made elevator simulation they can drop into Bevy, macroquad, or any Rust game engine.
+- **Algorithm researchers** exploring dispatch strategies (SCAN, LOOK, ETD, or your own) on realistic elevator physics.
+- **Educators** looking for a visual, interactive way to teach scheduling and real-time systems concepts.
+- **Hobbyists** who just think elevators are neat.
+
+## What can you build?
+
+The library models **stops at arbitrary distances** along a shaft axis, not uniform floors. That means you can simulate a 5-story office building where each floor is 4 meters apart, a 160-story skyscraper with sky lobbies and express zones, or -- why not -- a **space elevator** climbing 1,000 km from a ground station to an orbital platform. The `space_elevator.ron` config included in the repo does exactly that.
+
+The core crate provides primitives, not opinions. Riders are generic entities that ride elevators. Your game decides whether they are office workers, hotel guests, cargo pallets, or astronauts. You attach semantics through the extension storage system, and the simulation handles the physics and logistics.
+
+## Project structure
+
+The repository is a Cargo workspace with two crates:
+
+| Crate | Purpose |
+|---|---|
+| `elevator-core` | The simulation library. Pure Rust, no engine dependencies. This is what you add to your project. |
+| `elevator-bevy` | A Bevy 0.18 binary that wraps the core sim with 2D rendering, a HUD, and keyboard controls. Useful as a reference implementation and visual debugger. |
+
+## Links
+
+- [crates.io](https://crates.io/crates/elevator-core)
+- [docs.rs](https://docs.rs/elevator-core)
+- [GitHub](https://github.com/andymai/elevator-core)
+
+## Next steps
+
+Head to [Getting Started](getting-started.md) to build your first simulation in under 30 lines of Rust.

--- a/docs/src/metrics-and-events.md
+++ b/docs/src/metrics-and-events.md
@@ -1,0 +1,251 @@
+# Metrics and Events
+
+Once your simulation is configured and running, you need to know what it is doing. Every significant moment -- a rider boarding, an elevator arriving, a door opening -- produces a typed event. The metrics system aggregates these events into summary statistics. Together, events and metrics give you full observability into what your simulation is doing and how well it is performing.
+
+## The event system
+
+### What events fire
+
+Events are emitted during the tick phases. Here are the main categories:
+
+**Elevator events:**
+
+| Event | When it fires |
+|---|---|
+| `ElevatorDeparted { elevator, from_stop, tick }` | An elevator leaves a stop |
+| `ElevatorArrived { elevator, at_stop, tick }` | An elevator arrives at a stop |
+| `DoorOpened { elevator, tick }` | Doors finish opening |
+| `DoorClosed { elevator, tick }` | Doors finish closing |
+| `PassingFloor { elevator, stop, moving_up, tick }` | An elevator passes a stop without stopping |
+| `ElevatorAssigned { elevator, stop, tick }` | Dispatch assigns an elevator to a stop |
+
+**Rider events:**
+
+| Event | When it fires |
+|---|---|
+| `RiderSpawned { rider, origin, destination, tick }` | A new rider appears at a stop |
+| `RiderBoarded { rider, elevator, tick }` | A rider enters an elevator |
+| `RiderAlighted { rider, elevator, stop, tick }` | A rider exits at their destination |
+| `RiderRejected { rider, elevator, reason, context, tick }` | A rider was refused boarding (over capacity) |
+| `RiderAbandoned { rider, stop, tick }` | A rider gave up waiting |
+| `RiderEjected { rider, elevator, stop, tick }` | A rider was ejected (elevator disabled) |
+
+**Topology events:**
+
+| Event | When it fires |
+|---|---|
+| `StopAdded { stop, group, tick }` | A stop was added at runtime |
+| `ElevatorAdded { elevator, group, tick }` | An elevator was added at runtime |
+| `EntityDisabled { entity, tick }` | An entity was disabled |
+| `EntityEnabled { entity, tick }` | An entity was re-enabled |
+| `RouteInvalidated { rider, affected_stop, reason, tick }` | A rider's route was broken by a topology change |
+| `RiderRerouted { rider, new_destination, tick }` | A rider was manually rerouted |
+
+### Draining events
+
+Events are buffered during each tick and made available via `sim.drain_events()`. This returns a `Vec<Event>` and clears the buffer:
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(sim: &mut Simulation) {
+sim.step();
+
+for event in sim.drain_events() {
+    match event {
+        Event::RiderBoarded { rider, elevator, tick } => {
+            println!("[{tick}] {rider:?} boarded {elevator:?}");
+        }
+        Event::RiderAlighted { rider, stop, tick, .. } => {
+            println!("[{tick}] {rider:?} arrived at {stop:?}");
+        }
+        Event::ElevatorArrived { elevator, at_stop, tick } => {
+            println!("[{tick}] {elevator:?} arrived at {at_stop:?}");
+        }
+        _ => {}
+    }
+}
+# }
+```
+
+You can call `drain_events()` after every tick, every N ticks, or only when you need to -- events accumulate until drained. The metrics system processes events independently each tick, so draining does not affect metric calculations.
+
+### Building an event log
+
+Here is a pattern for collecting a complete event log across a simulation run:
+
+```rust,no_run
+use elevator_core::prelude::*;
+use elevator_core::stop::StopId;
+
+fn main() -> Result<(), SimError> {
+    let mut sim = SimulationBuilder::new()
+        .stops(vec![])
+        .stop(StopId(0), "Lobby", 0.0)
+        .stop(StopId(1), "Floor 2", 4.0)
+        .stop(StopId(2), "Floor 3", 8.0)
+        .build()?;
+
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)?;
+    sim.spawn_rider_by_stop_id(StopId(2), StopId(0), 80.0)?;
+
+    let mut event_log: Vec<Event> = Vec::new();
+
+    for _ in 0..1000 {
+        sim.step();
+        event_log.extend(sim.drain_events());
+    }
+
+    // Analyze the log.
+    let boardings = event_log.iter()
+        .filter(|e| matches!(e, Event::RiderBoarded { .. }))
+        .count();
+    let arrivals = event_log.iter()
+        .filter(|e| matches!(e, Event::RiderAlighted { .. }))
+        .count();
+
+    println!("Total boardings: {boardings}");
+    println!("Total arrivals: {arrivals}");
+    println!("Total events: {}", event_log.len());
+
+    Ok(())
+}
+```
+
+## Metrics
+
+The `Metrics` struct aggregates key performance indicators across the entire simulation run. Access it via `sim.metrics()`:
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(sim: &Simulation) {
+let m = sim.metrics();
+
+println!("Avg wait time:     {:.1} ticks", m.avg_wait_time());
+println!("Avg ride time:     {:.1} ticks", m.avg_ride_time());
+println!("Max wait time:     {} ticks", m.max_wait_time());
+println!("Throughput:        {} riders/window", m.throughput());
+println!("Total delivered:   {}", m.total_delivered());
+println!("Total spawned:     {}", m.total_spawned());
+println!("Total abandoned:   {}", m.total_abandoned());
+println!("Abandonment rate:  {:.1}%", m.abandonment_rate() * 100.0);
+println!("Total distance:    {:.1} units", m.total_distance());
+# }
+```
+
+### What each metric means
+
+| Metric | Description |
+|---|---|
+| `avg_wait_time()` | Average ticks from spawn to board, across all riders that boarded |
+| `avg_ride_time()` | Average ticks from board to alight, across all delivered riders |
+| `max_wait_time()` | Longest wait observed (ticks) |
+| `throughput()` | Riders delivered in the current throughput window (default: 3600 ticks) |
+| `total_delivered()` | Cumulative riders successfully delivered |
+| `total_spawned()` | Cumulative riders spawned |
+| `total_abandoned()` | Cumulative riders who gave up waiting |
+| `abandonment_rate()` | `total_abandoned / total_spawned` (0.0 to 1.0) |
+| `total_distance()` | Sum of all elevator travel distance |
+
+Metrics are updated during the Metrics phase of each tick. They are always available and always reflect the latest tick, regardless of whether you drain events.
+
+### Converting ticks to seconds
+
+Metrics are reported in ticks. To convert to wall-clock seconds, use the `TimeAdapter`:
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(sim: &Simulation) {
+let time = sim.time();
+let avg_wait_seconds = time.ticks_to_seconds(sim.metrics().avg_wait_time() as u64);
+println!("Avg wait: {avg_wait_seconds:.1}s");
+# }
+```
+
+## Tagged metrics
+
+For per-zone or per-label breakdowns, you can tag entities with string labels and query metrics scoped to those tags.
+
+### Tagging entities
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# use elevator_core::stop::StopId;
+# fn main() -> Result<(), SimError> {
+# let mut sim = SimulationBuilder::new().build()?;
+// Tag a stop.
+let lobby = sim.stop_entity(StopId(0)).unwrap();
+sim.tag_entity(lobby, "zone:lobby");
+
+// Tag a rider (riders auto-inherit tags from their origin stop when spawned).
+let rider = sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 75.0)?;
+// rider automatically has "zone:lobby" because it was spawned at StopId(0).
+
+// You can also tag manually.
+sim.tag_entity(rider, "priority:vip");
+# Ok(())
+# }
+```
+
+### Querying tagged metrics
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(sim: &Simulation) {
+if let Some(lobby_metrics) = sim.metrics_for_tag("zone:lobby") {
+    println!("Lobby avg wait:  {:.1} ticks", lobby_metrics.avg_wait_time());
+    println!("Lobby delivered: {}", lobby_metrics.total_delivered());
+    println!("Lobby abandoned: {}", lobby_metrics.total_abandoned());
+    println!("Lobby max wait:  {} ticks", lobby_metrics.max_wait_time());
+}
+# }
+```
+
+Tagged metrics track `avg_wait_time`, `total_delivered`, `total_abandoned`, `total_spawned`, and `max_wait_time` per tag. They are updated automatically during the Metrics phase.
+
+### Practical example: comparing zones
+
+```rust,no_run
+use elevator_core::prelude::*;
+use elevator_core::stop::StopId;
+
+fn main() -> Result<(), SimError> {
+    let mut sim = SimulationBuilder::new()
+        .stops(vec![])
+        .stop(StopId(0), "Lobby", 0.0)
+        .stop(StopId(1), "Low Zone", 4.0)
+        .stop(StopId(2), "Mid Zone", 8.0)
+        .stop(StopId(3), "High Zone", 12.0)
+        .build()?;
+
+    // Tag stops by zone.
+    for (id, tag) in [(0, "zone:low"), (1, "zone:low"), (2, "zone:high"), (3, "zone:high")] {
+        if let Some(eid) = sim.stop_entity(StopId(id)) {
+            sim.tag_entity(eid, tag);
+        }
+    }
+
+    // Spawn riders from different zones.
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(3), 75.0)?;
+    sim.spawn_rider_by_stop_id(StopId(3), StopId(0), 80.0)?;
+
+    // Run the simulation.
+    for _ in 0..2000 {
+        sim.step();
+        sim.drain_events(); // clear the buffer
+    }
+
+    // Compare zone performance.
+    for zone in ["zone:low", "zone:high"] {
+        if let Some(m) = sim.metrics_for_tag(zone) {
+            println!("{zone}: avg_wait={:.0} delivered={} abandoned={}",
+                     m.avg_wait_time(), m.total_delivered(), m.total_abandoned());
+        }
+    }
+
+    Ok(())
+}
+```
+
+## Next steps
+
+Head to [Bevy Integration](bevy-integration.md) to see how the companion crate wraps all of this into a visual Bevy application.

--- a/docs/theme/custom.css
+++ b/docs/theme/custom.css
@@ -1,0 +1,23 @@
+/* Warm accent for active sidebar links */
+.sidebar .active > a {
+    color: #e06c40 !important;
+}
+
+/* Heading accent color */
+.content main h1,
+.content main h2,
+.content main h3 {
+    color: #c85a30;
+}
+
+/* Slightly softer code block background */
+.content main pre {
+    border-left: 3px solid #e06c40;
+    border-radius: 4px;
+}
+
+/* Inline code styling */
+.content main code {
+    border-radius: 3px;
+    padding: 1px 4px;
+}


### PR DESCRIPTION
## Summary

- **mdBook documentation site** (`docs/`) with 8 step-by-step tutorial chapters: introduction, getting started, core concepts, dispatch strategies, extensions & hooks, configuration, metrics & events, and Bevy integration. Light custom theme with warm accent color.
- **Showcase example** (`crates/elevator-core/examples/showcase.rs`) — one comprehensive, progressively-structured file demonstrating basic sim, custom dispatch, extensions, lifecycle hooks, tagged metrics, and programmatic configuration. Runs with `cargo run --example showcase -p elevator-core`.
- **Enhanced rustdoc** — rewritten `lib.rs` crate-level docs with capabilities list, runnable quick start, and crate layout table linking to all modules and the mdBook.
- **Doc-tests** — added runnable doc-tests to `SimulationBuilder::new`, `build`, `Simulation::step`, `spawn_rider_by_stop_id`, and `drain_events` (11 total passing).
- **GitHub Pages workflow** (`.github/workflows/docs.yml`) — builds and deploys the mdBook on push to main when `docs/**` changes.

All code examples in the mdBook were verified to compile against the crate. All 166 unit tests + 11 doc-tests pass, clippy clean.

## Test plan

- [x] CI passes (format, clippy, tests, doc-tests)
- [x] `cargo run --example showcase -p elevator-core` runs successfully
- [x] Review rendered mdBook chapters on GitHub for formatting
- [x] Verify GitHub Pages deployment after merge