### PR TITLE
fix: opt into Node.js 24 and remove stale version from docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   check:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,9 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: pages
   cancel-in-progress: false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -8,13 +8,6 @@ In this chapter we will build a minimal elevator simulation from scratch: a 3-st
 cargo add elevator-core
 ```
 
-Or add it to your `Cargo.toml` manually:
-
-```toml
-[dependencies]
-elevator-core = "0.1"
-```
-
 ## Import the prelude
 
 The prelude re-exports everything you need for typical usage:


### PR DESCRIPTION
## Summary

- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env to all three workflows (CI, Docs, Release Please) to eliminate Node.js 20 deprecation warnings
- Remove hardcoded `elevator-core = "0.1"` from mdBook getting started guide

## Test plan

- [ ] CI passes without Node.js 20 warnings
- [ ] No `"0.1"` version strings remain in docs