### PR TITLE
feat: add observability, query ergonomics, traffic schedules, and test coverage

### DIFF
--- a/crates/elevator-core/src/builder.rs
+++ b/crates/elevator-core/src/builder.rs
@@ -336,6 +336,19 @@ impl SimulationBuilder {
         self
     }
 
+    /// Validate the configuration without building the simulation.
+    ///
+    /// Runs the same validation as [`build()`](Self::build) but does not
+    /// allocate entities or construct the simulation. Useful for CLI tools,
+    /// config editors, and dry-run checks.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SimError::InvalidConfig`] if the configuration is invalid.
+    pub fn validate(&self) -> Result<(), SimError> {
+        Simulation::validate_config(&self.config)
+    }
+
     /// Build the simulation, validating the configuration.
     ///
     /// Returns `Err(SimError)` if the configuration is invalid.

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -1,4 +1,32 @@
 //! Pluggable dispatch strategies for assigning elevators to stops.
+//!
+//! # Example: custom dispatch strategy
+//!
+//! ```rust
+//! use elevator_core::prelude::*;
+//!
+//! struct AlwaysFirstStop;
+//!
+//! impl DispatchStrategy for AlwaysFirstStop {
+//!     fn decide(
+//!         &mut self,
+//!         _elevator: EntityId,
+//!         _elevator_position: f64,
+//!         group: &ElevatorGroup,
+//!         _manifest: &DispatchManifest,
+//!         _world: &elevator_core::world::World,
+//!     ) -> DispatchDecision {
+//!         group.stop_entities().first()
+//!             .map(|&stop| DispatchDecision::GoToStop(stop))
+//!             .unwrap_or(DispatchDecision::Idle)
+//!     }
+//! }
+//!
+//! let sim = SimulationBuilder::new()
+//!     .dispatch(AlwaysFirstStop)
+//!     .build()
+//!     .unwrap();
+//! ```
 
 /// Estimated Time to Destination dispatch algorithm.
 pub mod etd;

--- a/crates/elevator-core/src/dispatch/reposition.rs
+++ b/crates/elevator-core/src/dispatch/reposition.rs
@@ -1,4 +1,15 @@
 //! Built-in repositioning strategies for idle elevators.
+//!
+//! # Example
+//!
+//! ```rust
+//! use elevator_core::prelude::*;
+//!
+//! let sim = SimulationBuilder::new()
+//!     .reposition(SpreadEvenly, BuiltinReposition::SpreadEvenly)
+//!     .build()
+//!     .unwrap();
+//! ```
 
 use crate::entity::EntityId;
 use crate::tagged_metrics::{MetricTags, TaggedMetric};

--- a/crates/elevator-core/src/error.rs
+++ b/crates/elevator-core/src/error.rs
@@ -38,6 +38,10 @@ pub enum SimError {
         origin: EntityId,
         /// The destination stop.
         destination: EntityId,
+        /// Groups that serve the origin (if any).
+        origin_groups: Vec<GroupId>,
+        /// Groups that serve the destination (if any).
+        destination_groups: Vec<GroupId>,
     },
     /// Multiple groups serve both origin and destination — caller must specify.
     AmbiguousRoute {
@@ -66,8 +70,14 @@ impl fmt::Display for SimError {
             Self::NoRoute {
                 origin,
                 destination,
+                origin_groups,
+                destination_groups,
             } => {
-                write!(f, "no route from {origin:?} to {destination:?}")
+                write!(
+                    f,
+                    "no route from {origin:?} to {destination:?} \
+                     (origin served by {origin_groups:?}, destination served by {destination_groups:?})"
+                )
             }
             Self::AmbiguousRoute {
                 origin,

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -269,6 +269,17 @@ pub enum Event {
         /// The tick when it arrived.
         tick: u64,
     },
+
+    // -- Observability events --
+    /// An elevator became idle (no more assignments or repositioning).
+    ElevatorIdle {
+        /// The elevator that became idle.
+        elevator: EntityId,
+        /// The stop where it became idle (if at a stop).
+        at_stop: Option<EntityId>,
+        /// The tick when it became idle.
+        tick: u64,
+    },
 }
 
 /// Reason a rider's route was invalidated.

--- a/crates/elevator-core/src/hooks.rs
+++ b/crates/elevator-core/src/hooks.rs
@@ -1,4 +1,21 @@
 //! Lifecycle hooks for injecting custom logic before/after simulation phases.
+//!
+//! # Example
+//!
+//! ```rust
+//! use elevator_core::prelude::*;
+//!
+//! let mut sim = SimulationBuilder::new()
+//!     .before(Phase::Dispatch, |world| {
+//!         // Inspect world state before dispatch runs
+//!         let idle_count = world.iter_idle_elevators().count();
+//!         let _ = idle_count; // use it
+//!     })
+//!     .build()
+//!     .unwrap();
+//!
+//! sim.step(); // hooks fire during each step
+//! ```
 
 use crate::ids::GroupId;
 use crate::world::World;

--- a/crates/elevator-core/src/metrics.rs
+++ b/crates/elevator-core/src/metrics.rs
@@ -1,6 +1,7 @@
 //! Aggregate simulation metrics (wait times, throughput, distance).
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::collections::VecDeque;
 
 /// Aggregated simulation metrics, updated each tick from events.
@@ -29,6 +30,14 @@ pub struct Metrics {
     pub(crate) abandonment_rate: f64,
     /// Total distance traveled by all elevators.
     pub(crate) total_distance: f64,
+    /// Per-group instantaneous elevator utilization: fraction of elevators
+    /// currently moving (in `MovingToStop` phase) vs total enabled elevators.
+    /// Overwritten each tick. Key is group name (String for serialization).
+    #[serde(default)]
+    pub(crate) utilization_by_group: HashMap<String, f64>,
+    /// Total distance traveled by elevators while repositioning.
+    #[serde(default)]
+    pub(crate) reposition_distance: f64,
 
     // -- Internal accumulators --
     /// Running sum of wait ticks across all boarded riders.
@@ -118,6 +127,18 @@ impl Metrics {
         self.total_distance
     }
 
+    /// Per-group instantaneous elevator utilization (fraction of elevators moving).
+    #[must_use]
+    pub const fn utilization_by_group(&self) -> &HashMap<String, f64> {
+        &self.utilization_by_group
+    }
+
+    /// Total distance traveled by elevators while repositioning.
+    #[must_use]
+    pub const fn reposition_distance(&self) -> f64 {
+        self.reposition_distance
+    }
+
     /// Window size for throughput calculation (ticks).
     #[must_use]
     pub const fn throughput_window_ticks(&self) -> u64 {
@@ -164,6 +185,11 @@ impl Metrics {
     /// Record elevator distance traveled this tick.
     pub fn record_distance(&mut self, distance: f64) {
         self.total_distance += distance;
+    }
+
+    /// Record elevator distance traveled while repositioning.
+    pub fn record_reposition_distance(&mut self, distance: f64) {
+        self.reposition_distance += distance;
     }
 
     /// Update windowed throughput. Call once per tick.

--- a/crates/elevator-core/src/query/iter.rs
+++ b/crates/elevator-core/src/query/iter.rs
@@ -170,3 +170,31 @@ impl<'w, Q: WorldQuery, F: QueryFilter> Iterator for QueryIter<'w, Q, F> {
         }
     }
 }
+
+impl<'w, Q: WorldQuery, F: QueryFilter> QueryIter<'w, Q, F> {
+    /// Count the number of matching entities without collecting.
+    #[must_use]
+    pub fn count_matches(self) -> usize {
+        self.count()
+    }
+
+    /// Return `true` if any entity matches the given predicate.
+    pub fn any_match(mut self, predicate: impl FnMut(Q::Item<'w>) -> bool) -> bool {
+        self.any(predicate)
+    }
+
+    /// Return `true` if all matching entities satisfy the predicate.
+    ///
+    /// Returns `true` for an empty query (vacuous truth).
+    pub fn all_match(mut self, predicate: impl FnMut(Q::Item<'w>) -> bool) -> bool {
+        self.all(predicate)
+    }
+
+    /// Find the first entity matching the predicate.
+    pub fn find_match(
+        mut self,
+        predicate: impl FnMut(&Q::Item<'w>) -> bool,
+    ) -> Option<Q::Item<'w>> {
+        self.find(predicate)
+    }
+}

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -535,7 +535,7 @@ impl Simulation {
     }
 
     /// Validate configuration before constructing the simulation.
-    fn validate_config(config: &SimConfig) -> Result<(), SimError> {
+    pub(crate) fn validate_config(config: &SimConfig) -> Result<(), SimError> {
         if config.building.stops.is_empty() {
             return Err(SimError::InvalidConfig {
                 field: "building.stops",
@@ -929,9 +929,23 @@ impl Simulation {
 
         let group = match matching.len() {
             0 => {
+                let origin_groups: Vec<GroupId> = self
+                    .groups
+                    .iter()
+                    .filter(|g| g.stop_entities().contains(&origin))
+                    .map(ElevatorGroup::id)
+                    .collect();
+                let destination_groups: Vec<GroupId> = self
+                    .groups
+                    .iter()
+                    .filter(|g| g.stop_entities().contains(&destination))
+                    .map(ElevatorGroup::id)
+                    .collect();
                 return Err(SimError::NoRoute {
                     origin,
                     destination,
+                    origin_groups,
+                    destination_groups,
                 });
             }
             1 => matching[0],
@@ -1009,6 +1023,12 @@ impl Simulation {
             tick: self.tick,
         });
 
+        // Auto-tag the rider with "stop:{name}" for per-stop wait time tracking.
+        let stop_tag = self
+            .world
+            .stop(origin)
+            .map(|s| format!("stop:{}", s.name()));
+
         // Inherit metric tags from the origin stop.
         if let Some(tags_res) = self
             .world
@@ -1016,6 +1036,10 @@ impl Simulation {
         {
             let origin_tags: Vec<String> = tags_res.tags_for(origin).to_vec();
             for tag in origin_tags {
+                tags_res.tag(eid, tag);
+            }
+            // Apply the origin stop tag.
+            if let Some(tag) = stop_tag {
                 tags_res.tag(eid, tag);
             }
         }
@@ -2071,6 +2095,7 @@ impl Simulation {
             &mut self.events,
             &ctx,
             &self.elevator_ids_buf,
+            &mut self.metrics,
         );
         for group in &self.groups {
             self.hooks
@@ -2165,7 +2190,13 @@ impl Simulation {
                 .run_before_group(Phase::Metrics, group.id(), &mut self.world);
         }
         let ctx = self.phase_context();
-        crate::systems::metrics::run(&mut self.world, &self.events, &mut self.metrics, &ctx);
+        crate::systems::metrics::run(
+            &mut self.world,
+            &self.events,
+            &mut self.metrics,
+            &ctx,
+            &self.groups,
+        );
         for group in &self.groups {
             self.hooks
                 .run_after_group(Phase::Metrics, group.id(), &mut self.world);

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -95,8 +95,22 @@ pub fn run(
                     }
                 }
                 DispatchDecision::Idle => {
+                    // Check if elevator was already idle before setting phase.
+                    let was_idle = world
+                        .elevator(eid)
+                        .is_some_and(|car| car.phase == ElevatorPhase::Idle);
                     if let Some(car) = world.elevator_mut(eid) {
                         car.phase = ElevatorPhase::Idle;
+                    }
+                    if !was_idle {
+                        let at_stop = world
+                            .position(eid)
+                            .and_then(|p| world.find_stop_at_position(p.value));
+                        events.emit(Event::ElevatorIdle {
+                            elevator: eid,
+                            at_stop,
+                            tick: ctx.tick,
+                        });
                     }
                 }
             }

--- a/crates/elevator-core/src/systems/metrics.rs
+++ b/crates/elevator-core/src/systems/metrics.rs
@@ -1,5 +1,7 @@
 //! Phase 6: update aggregate metrics from events emitted this tick.
 
+use crate::components::ElevatorPhase;
+use crate::dispatch::ElevatorGroup;
 use crate::events::{Event, EventBus};
 use crate::metrics::Metrics;
 use crate::tagged_metrics::MetricTags;
@@ -8,7 +10,13 @@ use crate::world::World;
 use super::PhaseContext;
 
 /// Update metrics from events emitted this tick.
-pub fn run(world: &mut World, events: &EventBus, metrics: &mut Metrics, ctx: &PhaseContext) {
+pub fn run(
+    world: &mut World,
+    events: &EventBus,
+    metrics: &mut Metrics,
+    ctx: &PhaseContext,
+    groups: &[ElevatorGroup],
+) {
     // Collect rider-level tag updates deferred until after event processing,
     // because `world` is borrowed immutably inside the event loop.
     let mut tag_spawns: Vec<crate::entity::EntityId> = Vec::new();
@@ -73,6 +81,32 @@ pub fn run(world: &mut World, events: &EventBus, metrics: &mut Metrics, ctx: &Ph
     }
     if total_dist > 0.0 {
         metrics.record_distance(total_dist);
+    }
+
+    // Compute per-group utilization (fraction of elevators currently moving).
+    for group in groups {
+        let mut total = 0u64;
+        let mut moving = 0u64;
+        for &eid in group.elevator_entities() {
+            if world.is_disabled(eid) {
+                continue;
+            }
+            if let Some(car) = world.elevator(eid) {
+                total += 1;
+                if matches!(car.phase, ElevatorPhase::MovingToStop(_)) {
+                    moving += 1;
+                }
+            }
+        }
+        #[allow(clippy::cast_precision_loss)]
+        let util = if total > 0 {
+            moving as f64 / total as f64
+        } else {
+            0.0
+        };
+        metrics
+            .utilization_by_group
+            .insert(group.name().to_owned(), util);
     }
 
     metrics.update_throughput(ctx.tick);

--- a/crates/elevator-core/src/systems/movement.rs
+++ b/crates/elevator-core/src/systems/movement.rs
@@ -3,17 +3,20 @@
 use crate::components::ElevatorPhase;
 use crate::door::DoorState;
 use crate::events::{Event, EventBus};
+use crate::metrics::Metrics;
 use crate::movement::tick_movement;
 use crate::world::{SortedStops, World};
 
 use super::PhaseContext;
 
 /// Update position/velocity for all moving elevators.
+#[allow(clippy::too_many_lines)]
 pub fn run(
     world: &mut World,
     events: &mut EventBus,
     ctx: &PhaseContext,
     elevator_ids: &[crate::entity::EntityId],
+    metrics: &mut Metrics,
 ) {
     for &eid in elevator_ids {
         if world.is_disabled(eid) {
@@ -70,6 +73,14 @@ pub fn run(
             v.value = result.velocity;
         }
 
+        // Track repositioning distance.
+        if is_repositioning {
+            let dist = (new_pos - old_pos).abs();
+            if dist > 0.0 {
+                metrics.record_reposition_distance(dist);
+            }
+        }
+
         // Emit PassingFloor for any stops crossed between old and new position
         // (excluding the target stop — that gets an ElevatorArrived instead).
         if !result.arrived {
@@ -108,6 +119,11 @@ pub fn run(
                 events.emit(Event::ElevatorRepositioned {
                     elevator: eid,
                     at_stop: target_stop_eid,
+                    tick: ctx.tick,
+                });
+                events.emit(Event::ElevatorIdle {
+                    elevator: eid,
+                    at_stop: Some(target_stop_eid),
                     tick: ctx.tick,
                 });
             } else {

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -31,3 +31,4 @@ mod boundary_tests;
 mod event_payload_tests;
 mod multi_elevator_tests;
 mod multi_line_tests;
+mod reposition_tests;

--- a/crates/elevator-core/src/tests/reposition_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_tests.rs
@@ -1,0 +1,692 @@
+//! Tests for the repositioning system and ETD dispatch overhaul.
+
+use crate::builder::SimulationBuilder;
+use crate::components::{ElevatorPhase, RiderPhase};
+use crate::dispatch::etd::EtdDispatch;
+use crate::dispatch::reposition::{DemandWeighted, NearestIdle, ReturnToLobby, SpreadEvenly};
+use crate::dispatch::{
+    BuiltinReposition, DispatchManifest, DispatchStrategy, ElevatorGroup, LineInfo,
+    RepositionStrategy,
+};
+use crate::entity::EntityId;
+use crate::events::Event;
+use crate::ids::GroupId;
+use crate::stop::{StopConfig, StopId};
+
+// ===== Helpers =====
+
+use crate::components::{Elevator, Position, Rider, Route, Stop, Velocity};
+use crate::config::ElevatorConfig;
+use crate::dispatch::{DispatchDecision, RiderInfo};
+use crate::door::DoorState;
+use crate::tagged_metrics::MetricTags;
+use crate::world::World;
+
+/// Build a `World` with `n` stops evenly spaced (0.0, 10.0, 20.0, ...)
+/// and return `(world, stop_entities)`.
+fn test_world_n(n: usize) -> (World, Vec<EntityId>) {
+    let mut world = World::new();
+    let stops: Vec<_> = (0..n)
+        .map(|i| {
+            let eid = world.spawn();
+            world.set_stop(
+                eid,
+                Stop {
+                    name: format!("Stop {i}"),
+                    position: i as f64 * 10.0,
+                },
+            );
+            eid
+        })
+        .collect();
+    (world, stops)
+}
+
+fn test_group(stop_entities: &[EntityId], elevator_entities: Vec<EntityId>) -> ElevatorGroup {
+    ElevatorGroup::new(
+        GroupId(0),
+        "Default".into(),
+        vec![LineInfo::new(
+            EntityId::default(),
+            elevator_entities,
+            stop_entities.to_vec(),
+        )],
+    )
+}
+
+fn spawn_elevator(world: &mut World, position: f64) -> EntityId {
+    let eid = world.spawn();
+    world.set_position(eid, Position { value: position });
+    world.set_velocity(eid, Velocity { value: 0.0 });
+    world.set_elevator(
+        eid,
+        Elevator {
+            phase: ElevatorPhase::Idle,
+            door: DoorState::Closed,
+            max_speed: 2.0,
+            acceleration: 1.5,
+            deceleration: 2.0,
+            weight_capacity: 800.0,
+            current_load: 0.0,
+            riders: vec![],
+            target_stop: None,
+            door_transition_ticks: 5,
+            door_open_ticks: 10,
+            line: EntityId::default(),
+            repositioning: false,
+        },
+    );
+    eid
+}
+
+fn add_demand(manifest: &mut DispatchManifest, world: &mut World, stop: EntityId, weight: f64) {
+    let dummy = world.spawn();
+    manifest
+        .waiting_at_stop
+        .entry(stop)
+        .or_default()
+        .push(RiderInfo {
+            id: dummy,
+            destination: None,
+            weight,
+            wait_ticks: 0,
+        });
+}
+
+// ===== Repositioning Strategy Tests =====
+
+// 1. SpreadEvenly: 2 idle elevators, 5 stops — verify they spread apart.
+#[test]
+fn spread_evenly_distributes_elevators() {
+    let (mut world, stops) = test_world_n(5);
+    // Elevator A at stop 0 (pos 0.0), Elevator B at stop 2 (pos 20.0).
+    let elev_a = spawn_elevator(&mut world, 0.0);
+    let elev_b = spawn_elevator(&mut world, 20.0);
+    let group = test_group(&stops, vec![elev_a, elev_b]);
+
+    let idle = vec![(elev_a, 0.0), (elev_b, 20.0)];
+    let stop_pos: Vec<(EntityId, f64)> = stops
+        .iter()
+        .map(|&sid| (sid, world.stop_position(sid).unwrap()))
+        .collect();
+
+    let mut strategy = SpreadEvenly;
+    let result = strategy.reposition(&idle, &stop_pos, &group, &world);
+
+    // Both should move to new positions (they shouldn't stay where they are).
+    assert!(
+        !result.is_empty(),
+        "at least one elevator should be repositioned"
+    );
+    // They should go to different stops.
+    if result.len() == 2 {
+        assert_ne!(result[0].1, result[1].1, "should spread to different stops");
+    }
+    // The first elevator should be sent to the farthest unoccupied stop (stop 4 at 40.0),
+    // maximizing min-distance from the other occupied position (elev_b at 20.0).
+    assert_eq!(result[0].1, stops[4]);
+}
+
+// SpreadEvenly edge case: single stop — no movement needed if already there.
+#[test]
+fn spread_evenly_single_stop_no_movement() {
+    let (mut world, stops) = test_world_n(1);
+    let elev = spawn_elevator(&mut world, 0.0); // already at the only stop
+    let group = test_group(&stops, vec![elev]);
+
+    let idle = vec![(elev, 0.0)];
+    let stop_pos = vec![(stops[0], 0.0)];
+
+    let mut strategy = SpreadEvenly;
+    let result = strategy.reposition(&idle, &stop_pos, &group, &world);
+    assert!(
+        result.is_empty(),
+        "no movement when already at the only stop"
+    );
+}
+
+// SpreadEvenly edge case: all elevators at same position.
+#[test]
+fn spread_evenly_all_at_same_position() {
+    let (mut world, stops) = test_world_n(3);
+    let elev_a = spawn_elevator(&mut world, 10.0);
+    let elev_b = spawn_elevator(&mut world, 10.0);
+    let group = test_group(&stops, vec![elev_a, elev_b]);
+
+    let idle = vec![(elev_a, 10.0), (elev_b, 10.0)];
+    let stop_pos: Vec<(EntityId, f64)> = stops
+        .iter()
+        .map(|&sid| (sid, world.stop_position(sid).unwrap()))
+        .collect();
+
+    let mut strategy = SpreadEvenly;
+    let result = strategy.reposition(&idle, &stop_pos, &group, &world);
+
+    // At least one should move away from the shared position.
+    assert!(!result.is_empty());
+    // They shouldn't both go to the same place.
+    if result.len() == 2 {
+        assert_ne!(result[0].1, result[1].1);
+    }
+}
+
+// 2. ReturnToLobby: idle elevators return to home stop (index 0).
+#[test]
+fn return_to_lobby_sends_to_home() {
+    let (mut world, stops) = test_world_n(3);
+    let elev = spawn_elevator(&mut world, 20.0); // at stop 2
+    let group = test_group(&stops, vec![elev]);
+
+    let idle = vec![(elev, 20.0)];
+    let stop_pos: Vec<(EntityId, f64)> = stops
+        .iter()
+        .map(|&sid| (sid, world.stop_position(sid).unwrap()))
+        .collect();
+
+    let mut strategy = ReturnToLobby::new();
+    let result = strategy.reposition(&idle, &stop_pos, &group, &world);
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0], (elev, stops[0]));
+}
+
+// ReturnToLobby with `with_home(2)`.
+#[test]
+fn return_to_lobby_custom_home() {
+    let (mut world, stops) = test_world_n(3);
+    let elev = spawn_elevator(&mut world, 0.0); // at stop 0
+    let group = test_group(&stops, vec![elev]);
+
+    let idle = vec![(elev, 0.0)];
+    let stop_pos: Vec<(EntityId, f64)> = stops
+        .iter()
+        .map(|&sid| (sid, world.stop_position(sid).unwrap()))
+        .collect();
+
+    let mut strategy = ReturnToLobby::with_home(2);
+    let result = strategy.reposition(&idle, &stop_pos, &group, &world);
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0], (elev, stops[2]));
+}
+
+// ReturnToLobby edge case: already at home.
+#[test]
+fn return_to_lobby_already_at_home() {
+    let (mut world, stops) = test_world_n(3);
+    let elev = spawn_elevator(&mut world, 0.0);
+    let group = test_group(&stops, vec![elev]);
+
+    let idle = vec![(elev, 0.0)];
+    let stop_pos: Vec<(EntityId, f64)> = stops
+        .iter()
+        .map(|&sid| (sid, world.stop_position(sid).unwrap()))
+        .collect();
+
+    let mut strategy = ReturnToLobby::new();
+    let result = strategy.reposition(&idle, &stop_pos, &group, &world);
+
+    assert!(result.is_empty(), "no movement when already at home");
+}
+
+// 3. DemandWeighted: elevators move toward high-demand stops.
+#[test]
+fn demand_weighted_prefers_high_demand() {
+    let (mut world, stops) = test_world_n(3);
+    // Elevator at stop 0.
+    let elev = spawn_elevator(&mut world, 0.0);
+    let group = test_group(&stops, vec![elev]);
+
+    // Set up MetricTags with higher throughput at stop 2.
+    let mut tags = MetricTags::default();
+    tags.tag(stops[0], "stop0");
+    tags.tag(stops[1], "stop1");
+    tags.tag(stops[2], "stop2");
+
+    // Simulate demand: record many deliveries at stop 2.
+    for _ in 0..20 {
+        tags.record_delivery(stops[2]);
+    }
+    // A few at stop 1.
+    for _ in 0..3 {
+        tags.record_delivery(stops[1]);
+    }
+    world.insert_resource(tags);
+
+    let idle = vec![(elev, 0.0)];
+    let stop_pos: Vec<(EntityId, f64)> = stops
+        .iter()
+        .map(|&sid| (sid, world.stop_position(sid).unwrap()))
+        .collect();
+
+    let mut strategy = DemandWeighted;
+    let result = strategy.reposition(&idle, &stop_pos, &group, &world);
+
+    assert_eq!(result.len(), 1);
+    // Should move toward the highest-demand stop (stop 2).
+    assert_eq!(result[0], (elev, stops[2]));
+}
+
+// 4. NearestIdle: verify no movements generated.
+#[test]
+fn nearest_idle_returns_empty() {
+    let (mut world, stops) = test_world_n(3);
+    let elev = spawn_elevator(&mut world, 0.0);
+    let group = test_group(&stops, vec![elev]);
+
+    let idle = vec![(elev, 0.0)];
+    let stop_pos: Vec<(EntityId, f64)> = stops
+        .iter()
+        .map(|&sid| (sid, world.stop_position(sid).unwrap()))
+        .collect();
+
+    let mut strategy = NearestIdle;
+    let result = strategy.reposition(&idle, &stop_pos, &group, &world);
+
+    assert!(result.is_empty(), "NearestIdle should never generate moves");
+}
+
+// ===== Repositioning Integration Tests =====
+
+/// Helper: build a simulation with 1 elevator, 3 stops, `ReturnToLobby` reposition.
+/// Elevator starts at stop 2 (position 20.0), should reposition to stop 0 (position 0.0).
+fn build_lobby_sim() -> crate::sim::Simulation {
+    SimulationBuilder::new()
+        .stops(vec![
+            StopConfig {
+                id: StopId(0),
+                name: "Lobby".into(),
+                position: 0.0,
+            },
+            StopConfig {
+                id: StopId(1),
+                name: "Mid".into(),
+                position: 10.0,
+            },
+            StopConfig {
+                id: StopId(2),
+                name: "Top".into(),
+                position: 20.0,
+            },
+        ])
+        .elevators(vec![ElevatorConfig {
+            id: 0,
+            name: "A".into(),
+            max_speed: 2.0,
+            acceleration: 1.5,
+            deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(2),
+            door_open_ticks: 10,
+            door_transition_ticks: 5,
+        }])
+        .dispatch(EtdDispatch::new())
+        .reposition(ReturnToLobby::new(), BuiltinReposition::ReturnToLobby)
+        .build()
+        .unwrap()
+}
+
+// 5. Repositioning flag lifecycle.
+#[test]
+fn repositioning_flag_lifecycle() {
+    let mut sim = build_lobby_sim();
+
+    // Drain the initial events.
+    sim.drain_events();
+
+    // Step once to trigger repositioning (elevator at stop 2 should head to lobby).
+    sim.step();
+
+    let elevators = sim.world().elevator_ids();
+    let eid = elevators[0];
+    let car = sim.world().elevator(eid).unwrap();
+    assert!(
+        car.repositioning(),
+        "elevator should be repositioning after first tick"
+    );
+    assert!(
+        matches!(car.phase(), ElevatorPhase::MovingToStop(_)),
+        "elevator should be MovingToStop while repositioning"
+    );
+
+    // Run enough ticks for the elevator to arrive at lobby (20 units at 2.0 u/s, ~600 ticks).
+    for _ in 0..2000 {
+        sim.step();
+    }
+
+    // After arrival at lobby, it stays at lobby (ReturnToLobby is idempotent there).
+    let car = sim.world().elevator(eid).unwrap();
+    assert!(
+        !car.repositioning(),
+        "repositioning flag should be false after arrival at home stop"
+    );
+    assert_eq!(
+        car.phase(),
+        ElevatorPhase::Idle,
+        "elevator should be Idle after repositioning arrival"
+    );
+}
+
+// 6. Door skip on repositioning arrival: should emit ElevatorRepositioned, not ElevatorArrived.
+#[test]
+fn repositioning_arrival_skips_doors() {
+    let mut sim = build_lobby_sim();
+    sim.drain_events();
+
+    // Run until repositioning completes (20 units at 2.0 u/s).
+    for _ in 0..2000 {
+        sim.step();
+    }
+    let events = sim.drain_events();
+
+    // Should have ElevatorRepositioned event.
+    let repositioned_count = events
+        .iter()
+        .filter(|e| matches!(e, Event::ElevatorRepositioned { .. }))
+        .count();
+    assert!(
+        repositioned_count > 0,
+        "should emit ElevatorRepositioned on arrival"
+    );
+
+    // Should have the initial ElevatorRepositioning event too.
+    let repositioning_targets: Vec<(EntityId, EntityId)> = events
+        .iter()
+        .filter_map(|e| match e {
+            Event::ElevatorRepositioning {
+                elevator, to_stop, ..
+            } => Some((*elevator, *to_stop)),
+            _ => None,
+        })
+        .collect();
+
+    // The repositioned stop should NOT have an ElevatorArrived event (doors skip).
+    for (elev, stop) in &repositioning_targets {
+        let arrived_at_same = events.iter().any(|e| {
+            matches!(
+                e,
+                Event::ElevatorArrived { elevator, at_stop, .. }
+                if *elevator == *elev && *at_stop == *stop
+            )
+        });
+        assert!(
+            !arrived_at_same,
+            "repositioned elevator should NOT emit ElevatorArrived"
+        );
+    }
+
+    // After repositioning, elevator should be Idle (not DoorOpening).
+    let elevators = sim.world().elevator_ids();
+    let car = sim.world().elevator(elevators[0]).unwrap();
+    assert_eq!(
+        car.phase(),
+        ElevatorPhase::Idle,
+        "elevator should be Idle after repositioning, not DoorOpening"
+    );
+}
+
+// 7. Dispatch overrides repositioning: when a repositioned elevator goes Idle and a
+//    rider appears, dispatch should assign it.
+#[test]
+fn dispatch_assigns_after_repositioning() {
+    let mut sim = build_lobby_sim();
+    sim.drain_events();
+
+    // Let repositioning complete (elevator goes from stop 2 to lobby).
+    for _ in 0..2000 {
+        sim.step();
+    }
+    sim.drain_events();
+
+    // Elevator should now be Idle at lobby with repositioning == false.
+    let elevators = sim.world().elevator_ids();
+    let car = sim.world().elevator(elevators[0]).unwrap();
+    assert_eq!(car.phase(), ElevatorPhase::Idle);
+    assert!(!car.repositioning());
+
+    // Spawn a rider — dispatch should pick up the now-idle elevator.
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    sim.step();
+
+    let events = sim.drain_events();
+    let assigned = events
+        .iter()
+        .any(|e| matches!(e, Event::ElevatorAssigned { .. }));
+    assert!(
+        assigned,
+        "dispatch should assign an elevator after repositioning completes"
+    );
+}
+
+// 8. Disabled elevator: should not be repositioned.
+#[test]
+fn disabled_elevator_not_repositioned() {
+    let mut sim = build_lobby_sim();
+    sim.drain_events();
+
+    let elevators = sim.world().elevator_ids();
+    let eid = elevators[0];
+    // Disable the elevator before it can be repositioned.
+    sim.disable(eid).unwrap();
+    sim.drain_events();
+
+    // Step to trigger reposition phase.
+    sim.step();
+    let events = sim.drain_events();
+
+    // The disabled elevator should not have ElevatorRepositioning events.
+    let repositioning_disabled = events.iter().any(|e| {
+        matches!(
+            e,
+            Event::ElevatorRepositioning { elevator, .. } if *elevator == eid
+        )
+    });
+    assert!(
+        !repositioning_disabled,
+        "disabled elevator should not be repositioned"
+    );
+}
+
+// ===== ETD Dispatch Tests =====
+
+// 9. Basic cost: closer elevator wins.
+#[test]
+fn etd_closer_elevator_wins() {
+    let (mut world, stops) = test_world_n(4);
+    let elev_a = spawn_elevator(&mut world, 0.0);
+    let elev_b = spawn_elevator(&mut world, 30.0);
+    let group = test_group(&stops, vec![elev_a, elev_b]);
+
+    let mut manifest = DispatchManifest::default();
+    // Demand at stop 1 (pos 10.0).
+    add_demand(&mut manifest, &mut world, stops[1], 70.0);
+
+    let mut etd = EtdDispatch::new();
+    let elevators = vec![(elev_a, 0.0), (elev_b, 30.0)];
+    let decisions = etd.decide_all(&elevators, &group, &manifest, &world);
+
+    // elev_a is closer to stop 1 (distance 10) vs elev_b (distance 20).
+    let a_dec = decisions.iter().find(|(e, _)| *e == elev_a).unwrap();
+    assert_eq!(a_dec.1, DispatchDecision::GoToStop(stops[1]));
+
+    let b_dec = decisions.iter().find(|(e, _)| *e == elev_b).unwrap();
+    assert_eq!(b_dec.1, DispatchDecision::Idle);
+}
+
+// 10. Direction bonus: moving elevator with target ahead gets cost reduction.
+#[test]
+fn etd_direction_bonus() {
+    let (mut world, stops) = test_world_n(4);
+    // elev_a at 5.0, already moving up toward stop 3 (pos 30.0).
+    let elev_a = spawn_elevator(&mut world, 5.0);
+    world.elevator_mut(elev_a).unwrap().phase = ElevatorPhase::MovingToStop(stops[3]);
+    world.elevator_mut(elev_a).unwrap().target_stop = Some(stops[3]);
+
+    // elev_b at 5.0, idle.
+    let elev_b = spawn_elevator(&mut world, 5.0);
+    let group = test_group(&stops, vec![elev_a, elev_b]);
+
+    let mut manifest = DispatchManifest::default();
+    // Demand at stop 1 (pos 10.0), which is ahead of both elevators.
+    add_demand(&mut manifest, &mut world, stops[1], 70.0);
+
+    let mut etd = EtdDispatch::new();
+    let elevators = vec![(elev_a, 5.0), (elev_b, 5.0)];
+    let decisions = etd.decide_all(&elevators, &group, &manifest, &world);
+
+    // elev_a is already moving up and stop 1 is ahead — should get direction bonus
+    // (-0.5 * travel_time). elev_b is idle, bonus is -0.3 * travel_time.
+    // So elev_a should be preferred.
+    let a_dec = decisions.iter().find(|(e, _)| *e == elev_a).unwrap();
+    assert_eq!(a_dec.1, DispatchDecision::GoToStop(stops[1]));
+}
+
+// 11. Rider delay: elevator with aboard riders heading opposite direction gets higher cost.
+#[test]
+fn etd_rider_delay_penalizes() {
+    let (mut world, stops) = test_world_n(4);
+    // elev_a at 20.0 with a rider heading to stop 3 (pos 30.0).
+    let elev_a = spawn_elevator(&mut world, 20.0);
+    let rider = world.spawn();
+    world.set_rider(
+        rider,
+        Rider {
+            phase: RiderPhase::Riding(elev_a),
+            weight: 70.0,
+            current_stop: None,
+            spawn_tick: 0,
+            board_tick: Some(0),
+        },
+    );
+    world.set_route(rider, Route::direct(stops[2], stops[3], GroupId(0)));
+    world.elevator_mut(elev_a).unwrap().riders.push(rider);
+
+    // elev_b at 20.0, no riders.
+    let elev_b = spawn_elevator(&mut world, 20.0);
+    let group = test_group(&stops, vec![elev_a, elev_b]);
+
+    let mut manifest = DispatchManifest::default();
+    // Demand at stop 0 (pos 0.0) — opposite direction from rider's destination.
+    add_demand(&mut manifest, &mut world, stops[0], 70.0);
+
+    let mut etd = EtdDispatch::new();
+    let elevators = vec![(elev_a, 20.0), (elev_b, 20.0)];
+    let decisions = etd.decide_all(&elevators, &group, &manifest, &world);
+
+    // elev_b (no riders) should win because elev_a would delay its rider.
+    let b_dec = decisions.iter().find(|(e, _)| *e == elev_b).unwrap();
+    assert_eq!(b_dec.1, DispatchDecision::GoToStop(stops[0]));
+
+    let a_dec = decisions.iter().find(|(e, _)| *e == elev_a).unwrap();
+    assert_eq!(a_dec.1, DispatchDecision::Idle);
+}
+
+// 12. Door overhead: intervening pending stops increase cost.
+//     Verify that an elevator with intervening pending stops pays more than one without.
+#[test]
+fn etd_door_overhead_for_intervening_stops() {
+    let (mut world, stops) = test_world_n(4);
+    // 3 elevators, 3 pending stops. Elevators A and B handle stops 1 and 2,
+    // leaving elevator C to compete for stop 3.
+    let elev_a = spawn_elevator(&mut world, 0.0);
+    let elev_b = spawn_elevator(&mut world, 10.0);
+    let elev_c = spawn_elevator(&mut world, 25.0);
+    let group = test_group(&stops, vec![elev_a, elev_b, elev_c]);
+
+    let mut manifest = DispatchManifest::default();
+    add_demand(&mut manifest, &mut world, stops[1], 70.0);
+    add_demand(&mut manifest, &mut world, stops[2], 70.0);
+    add_demand(&mut manifest, &mut world, stops[3], 70.0);
+
+    // High door weight makes intervening stop overhead dominate.
+    let mut etd = EtdDispatch::with_weights(1.0, 1.0, 10.0);
+    let elevators = vec![(elev_a, 0.0), (elev_b, 10.0), (elev_c, 25.0)];
+    let decisions = etd.decide_all(&elevators, &group, &manifest, &world);
+
+    // Stop 1 (pos 10): elev_b is right there (cost ~0). Gets stop 1.
+    // Stop 2 (pos 20): elev_a at 0 (dist 20, intervening stop 1 at 10) vs elev_c at 25 (dist 5, no intervening).
+    //   With door_weight=10, elev_a pays 10 * door_overhead for 1 intervening stop. elev_c wins.
+    // Stop 3 (pos 30): only elev_a left. Gets stop 3.
+    // Key: the mechanism works because intervening pending stops raise the cost.
+    let c_dec = decisions.iter().find(|(e, _)| *e == elev_c).unwrap();
+    assert_eq!(
+        c_dec.1,
+        DispatchDecision::GoToStop(stops[2]),
+        "elevator C at 25.0 should serve stop 2 (pos 20) due to lower door overhead vs elevator A"
+    );
+
+    let a_dec = decisions.iter().find(|(e, _)| *e == elev_a).unwrap();
+    assert_eq!(
+        a_dec.1,
+        DispatchDecision::GoToStop(stops[3]),
+        "elevator A should get stop 3 since B and C already assigned"
+    );
+}
+
+// 13. Weight configuration: with_weights(2.0, 0.5, 0.0) prioritizes travel time over delay.
+#[test]
+fn etd_custom_weights() {
+    let (mut world, stops) = test_world_n(4);
+    // elev_a at 0.0, elev_b at 20.0 with a rider heading to stop 3.
+    let elev_a = spawn_elevator(&mut world, 0.0);
+    let elev_b = spawn_elevator(&mut world, 20.0);
+
+    let rider = world.spawn();
+    world.set_rider(
+        rider,
+        Rider {
+            phase: RiderPhase::Riding(elev_b),
+            weight: 70.0,
+            current_stop: None,
+            spawn_tick: 0,
+            board_tick: Some(0),
+        },
+    );
+    world.set_route(rider, Route::direct(stops[2], stops[3], GroupId(0)));
+    world.elevator_mut(elev_b).unwrap().riders.push(rider);
+
+    let group = test_group(&stops, vec![elev_a, elev_b]);
+
+    let mut manifest = DispatchManifest::default();
+    // Demand at stop 2 (pos 20.0).
+    add_demand(&mut manifest, &mut world, stops[2], 70.0);
+
+    // High wait weight (2.0), low delay weight (0.5), zero door weight.
+    let mut etd = EtdDispatch::with_weights(2.0, 0.5, 0.0);
+    let elevators = vec![(elev_a, 0.0), (elev_b, 20.0)];
+    let decisions = etd.decide_all(&elevators, &group, &manifest, &world);
+
+    // elev_b is at stop 2 (distance 0), elev_a is 20 away.
+    // Even with rider delay, elev_b should win because wait_weight is high
+    // and elev_b has zero travel time.
+    let b_dec = decisions.iter().find(|(e, _)| *e == elev_b).unwrap();
+    assert_eq!(b_dec.1, DispatchDecision::GoToStop(stops[2]));
+}
+
+// 14. Zero max_speed: returns INFINITY cost (elevator never assigned).
+#[test]
+fn etd_zero_max_speed_infinite_cost() {
+    let (mut world, stops) = test_world_n(3);
+    let elev_a = spawn_elevator(&mut world, 0.0);
+    world.elevator_mut(elev_a).unwrap().max_speed = 0.0;
+
+    // Add a normal elevator to ensure demand is served by it instead.
+    let elev_b = spawn_elevator(&mut world, 20.0);
+    let group = test_group(&stops, vec![elev_a, elev_b]);
+
+    let mut manifest = DispatchManifest::default();
+    add_demand(&mut manifest, &mut world, stops[1], 70.0);
+
+    let mut etd = EtdDispatch::new();
+    let elevators = vec![(elev_a, 0.0), (elev_b, 20.0)];
+    let decisions = etd.decide_all(&elevators, &group, &manifest, &world);
+
+    // elev_a with max_speed=0 should NOT be assigned.
+    let a_dec = decisions.iter().find(|(e, _)| *e == elev_a).unwrap();
+    assert_eq!(a_dec.1, DispatchDecision::Idle);
+
+    // elev_b should get the assignment.
+    let b_dec = decisions.iter().find(|(e, _)| *e == elev_b).unwrap();
+    assert_eq!(b_dec.1, DispatchDecision::GoToStop(stops[1]));
+}

--- a/crates/elevator-core/src/tests/traffic_tests.rs
+++ b/crates/elevator-core/src/tests/traffic_tests.rs
@@ -1,5 +1,5 @@
 use crate::components::Stop;
-use crate::traffic::TrafficPattern;
+use crate::traffic::{TrafficPattern, TrafficSchedule};
 use crate::world::World;
 
 fn make_stops(world: &mut World, count: usize) -> Vec<crate::entity::EntityId> {
@@ -85,4 +85,106 @@ fn too_few_stops_returns_none() {
     let stops = make_stops(&mut world, 1);
     let mut rng = rand::rng();
     assert!(TrafficPattern::Uniform.sample(&stops, &mut rng).is_none());
+}
+
+// ── TrafficSchedule ──────────────────────────────────────────────────
+
+#[test]
+fn schedule_pattern_at_returns_correct_segment() {
+    let schedule = TrafficSchedule::new(vec![
+        (0..100, TrafficPattern::UpPeak),
+        (100..200, TrafficPattern::DownPeak),
+        (200..300, TrafficPattern::Lunchtime),
+    ]);
+
+    assert_eq!(schedule.pattern_at(0), &TrafficPattern::UpPeak);
+    assert_eq!(schedule.pattern_at(50), &TrafficPattern::UpPeak);
+    assert_eq!(schedule.pattern_at(99), &TrafficPattern::UpPeak);
+    assert_eq!(schedule.pattern_at(100), &TrafficPattern::DownPeak);
+    assert_eq!(schedule.pattern_at(199), &TrafficPattern::DownPeak);
+    assert_eq!(schedule.pattern_at(250), &TrafficPattern::Lunchtime);
+}
+
+#[test]
+fn schedule_fallback_when_outside_segments() {
+    let schedule = TrafficSchedule::new(vec![(10..20, TrafficPattern::UpPeak)]);
+
+    // Before, after, and at boundary should all return fallback (Uniform).
+    assert_eq!(schedule.pattern_at(0), &TrafficPattern::Uniform);
+    assert_eq!(schedule.pattern_at(5), &TrafficPattern::Uniform);
+    assert_eq!(schedule.pattern_at(20), &TrafficPattern::Uniform);
+    assert_eq!(schedule.pattern_at(1000), &TrafficPattern::Uniform);
+}
+
+#[test]
+fn schedule_custom_fallback() {
+    let schedule = TrafficSchedule::new(vec![(0..10, TrafficPattern::UpPeak)])
+        .with_fallback(TrafficPattern::Mixed);
+
+    assert_eq!(schedule.pattern_at(5), &TrafficPattern::UpPeak);
+    assert_eq!(schedule.pattern_at(10), &TrafficPattern::Mixed);
+    assert_eq!(schedule.pattern_at(999), &TrafficPattern::Mixed);
+}
+
+#[test]
+fn schedule_office_day_segments() {
+    let tph = 100;
+    let schedule = TrafficSchedule::office_day(tph);
+
+    assert_eq!(schedule.pattern_at(0), &TrafficPattern::UpPeak);
+    assert_eq!(schedule.pattern_at(99), &TrafficPattern::UpPeak);
+    assert_eq!(schedule.pattern_at(100), &TrafficPattern::Uniform);
+    assert_eq!(schedule.pattern_at(399), &TrafficPattern::Uniform);
+    assert_eq!(schedule.pattern_at(400), &TrafficPattern::Lunchtime);
+    assert_eq!(schedule.pattern_at(499), &TrafficPattern::Lunchtime);
+    assert_eq!(schedule.pattern_at(500), &TrafficPattern::Uniform);
+    assert_eq!(schedule.pattern_at(799), &TrafficPattern::Uniform);
+    assert_eq!(schedule.pattern_at(800), &TrafficPattern::DownPeak);
+    assert_eq!(schedule.pattern_at(899), &TrafficPattern::DownPeak);
+    // After hour 9 → fallback (Uniform).
+    assert_eq!(schedule.pattern_at(900), &TrafficPattern::Uniform);
+}
+
+#[test]
+fn schedule_sample_delegates_to_active_pattern() {
+    let mut world = World::new();
+    let stops = make_stops(&mut world, 10);
+    let lobby = stops[0];
+    let mut rng = rand::rng();
+
+    // Up-peak segment at tick 0..100, then uniform.
+    let schedule = TrafficSchedule::new(vec![(0..100, TrafficPattern::UpPeak)]);
+
+    // Sample during up-peak — expect bias toward lobby origin.
+    let mut lobby_origins = 0;
+    let total = 500;
+    for _ in 0..total {
+        if let Some((o, d)) = schedule.sample(50, &stops, &mut rng) {
+            assert_ne!(o, d);
+            if o == lobby {
+                lobby_origins += 1;
+            }
+        }
+    }
+    let ratio = lobby_origins as f64 / total as f64;
+    assert!(
+        ratio > 0.5,
+        "Up-peak schedule segment should bias origins to lobby, got {ratio:.2}"
+    );
+
+    // Sample outside segment — should use fallback (Uniform), less lobby bias.
+    let mut lobby_origins_fallback = 0;
+    for _ in 0..total {
+        if let Some((o, _)) = schedule.sample(200, &stops, &mut rng) {
+            if o == lobby {
+                lobby_origins_fallback += 1;
+            }
+        }
+    }
+    let fallback_ratio = lobby_origins_fallback as f64 / total as f64;
+    // Uniform with 10 stops should give ~10% lobby origins, definitely <50%.
+    assert!(
+        fallback_ratio < 0.5,
+        "Fallback (Uniform) should not bias to lobby, got {fallback_ratio:.2}"
+    );
 }

--- a/crates/elevator-core/src/traffic.rs
+++ b/crates/elevator-core/src/traffic.rs
@@ -118,3 +118,103 @@ impl TrafficPattern {
         (stops[origin_idx], stops[dest_idx])
     }
 }
+
+/// A time-varying traffic schedule that selects patterns based on tick count.
+///
+/// Maps tick ranges to traffic patterns, enabling realistic daily cycles
+/// (e.g., up-peak in the morning, lunchtime at noon, down-peak in evening).
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use elevator_core::traffic::{TrafficPattern, TrafficSchedule};
+///
+/// let schedule = TrafficSchedule::new(vec![
+///     (0..3600, TrafficPattern::UpPeak),      // First hour: morning rush
+///     (3600..7200, TrafficPattern::Uniform),   // Second hour: normal
+///     (7200..10800, TrafficPattern::Lunchtime), // Third hour: lunch
+///     (10800..14400, TrafficPattern::DownPeak), // Fourth hour: evening rush
+/// ]);
+///
+/// // Sampling uses the pattern active at the given tick
+/// let stops = vec![/* ... */];
+/// let (origin, dest) = schedule.sample(tick, &stops, &mut rng).unwrap();
+/// ```
+#[derive(Debug, Clone)]
+pub struct TrafficSchedule {
+    /// Tick ranges mapped to traffic patterns, in order.
+    segments: Vec<(std::ops::Range<u64>, TrafficPattern)>,
+    /// Pattern to use when tick falls outside all segments.
+    fallback: TrafficPattern,
+}
+
+impl TrafficSchedule {
+    /// Create a schedule from segments.
+    ///
+    /// Segments are `(tick_range, pattern)` pairs. If the current tick
+    /// doesn't fall within any segment, the fallback `Uniform` pattern is used.
+    #[must_use]
+    pub const fn new(segments: Vec<(std::ops::Range<u64>, TrafficPattern)>) -> Self {
+        Self {
+            segments,
+            fallback: TrafficPattern::Uniform,
+        }
+    }
+
+    /// Set the fallback pattern for ticks outside all segments.
+    #[must_use]
+    pub const fn with_fallback(mut self, pattern: TrafficPattern) -> Self {
+        self.fallback = pattern;
+        self
+    }
+
+    /// Get the active traffic pattern for the given tick.
+    #[must_use]
+    pub fn pattern_at(&self, tick: u64) -> &TrafficPattern {
+        self.segments
+            .iter()
+            .find(|(range, _)| range.contains(&tick))
+            .map_or(&self.fallback, |(_, pattern)| pattern)
+    }
+
+    /// Sample an (origin, destination) pair using the pattern active at `tick`.
+    ///
+    /// Delegates to [`TrafficPattern::sample()`] for the active pattern.
+    pub fn sample(
+        &self,
+        tick: u64,
+        stops: &[EntityId],
+        rng: &mut impl Rng,
+    ) -> Option<(EntityId, EntityId)> {
+        self.pattern_at(tick).sample(stops, rng)
+    }
+
+    /// Create a typical office-building daily schedule.
+    ///
+    /// Assumes `ticks_per_hour` ticks per real-world hour:
+    /// - Hours 0-1: Up-peak (morning rush)
+    /// - Hours 1-4: Uniform (normal traffic)
+    /// - Hours 4-5: Lunchtime
+    /// - Hours 5-8: Uniform (afternoon)
+    /// - Hours 8-9: Down-peak (evening rush)
+    /// - Hours 9+: Uniform (fallback)
+    #[must_use]
+    pub fn office_day(ticks_per_hour: u64) -> Self {
+        Self::new(vec![
+            (0..ticks_per_hour, TrafficPattern::UpPeak),
+            (ticks_per_hour..4 * ticks_per_hour, TrafficPattern::Uniform),
+            (
+                4 * ticks_per_hour..5 * ticks_per_hour,
+                TrafficPattern::Lunchtime,
+            ),
+            (
+                5 * ticks_per_hour..8 * ticks_per_hour,
+                TrafficPattern::Uniform,
+            ),
+            (
+                8 * ticks_per_hour..9 * ticks_per_hour,
+                TrafficPattern::DownPeak,
+            ),
+        ])
+    }
+}

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -371,6 +371,28 @@ impl World {
         self.stops.keys().collect()
     }
 
+    /// Iterate elevators in `Idle` phase (not disabled).
+    pub fn iter_idle_elevators(&self) -> impl Iterator<Item = (EntityId, &Position, &Elevator)> {
+        use crate::components::ElevatorPhase;
+        self.iter_elevators()
+            .filter(|(id, _, car)| car.phase == ElevatorPhase::Idle && !self.is_disabled(*id))
+    }
+
+    /// Iterate elevators in `MovingToStop` phase (not disabled).
+    pub fn iter_moving_elevators(&self) -> impl Iterator<Item = (EntityId, &Position, &Elevator)> {
+        self.iter_elevators().filter(|(id, _, car)| {
+            matches!(car.phase, crate::components::ElevatorPhase::MovingToStop(_))
+                && !self.is_disabled(*id)
+        })
+    }
+
+    /// Iterate riders in `Waiting` phase (not disabled).
+    pub fn iter_waiting_riders(&self) -> impl Iterator<Item = (EntityId, &Rider)> {
+        use crate::components::RiderPhase;
+        self.iter_riders()
+            .filter(|(id, r)| r.phase == RiderPhase::Waiting && !self.is_disabled(*id))
+    }
+
     /// Find the stop entity at a given position (within epsilon).
     #[must_use]
     pub fn find_stop_at_position(&self, position: f64) -> Option<EntityId> {


### PR DESCRIPTION
## Summary

Non-breaking improvements adding observability metrics, query API ergonomics, time-of-day traffic patterns, compilable doc examples, and comprehensive test coverage for the repositioning system and ETD dispatch.

## Changes

### Test coverage (+23 tests, 236→259)
- 18 repositioning/ETD tests: all 4 strategies, flag lifecycle, door-skip on arrival, dispatch override, ETD cost model edge cases (closer wins, direction bonus, rider delay, door overhead, custom weights, zero speed)
- 5 traffic schedule tests: pattern selection, fallback, `office_day()` constructor

### Observability
- `ElevatorIdle` event emitted when elevator transitions to idle
- Auto-tag riders with `"stop:{name}"` at spawn for per-stop wait time metrics (zero config)
- `metrics.utilization_by_group()` — instantaneous fraction of elevators moving per group
- `metrics.reposition_distance()` — total distance traveled while repositioning
- `#[serde(default)]` on new Metrics fields for backward-compatible snapshot deserialization

### API convenience
- `QueryIter` chain methods: `.count_matches()`, `.any_match()`, `.all_match()`, `.find_match()`
- Filtered iterators: `iter_idle_elevators()`, `iter_moving_elevators()`, `iter_waiting_riders()`
- `SimulationBuilder::validate()` — config validation without building
- Enhanced `NoRoute` error with `origin_groups`/`destination_groups` context

### Traffic
- `TrafficSchedule` — maps tick ranges to `TrafficPattern` with auto-selection and fallback
- `TrafficSchedule::office_day(ticks_per_hour)` — typical office building daily cycle

### Documentation
- Compilable doctests for custom `DispatchStrategy`, hook registration, and reposition strategy usage

## Test plan
- [x] 259 unit tests pass
- [x] 2 integration tests pass
- [x] 14 doctests pass (5 ignored — pre-existing)
- [x] Clippy clean (zero warnings)
- [x] Full workspace builds (including elevator-bevy)
- [x] All 6 benchmarks compile