### PR TITLE
feat!: add Resident phase, population tracking, and rider lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@ Key design decisions:
 - Tick-based with 6-phase loop: advance_transient → dispatch → movement → doors → loading → metrics
 - Pluggable dispatch via `DispatchStrategy` trait, per elevator group
 - Game-agnostic riders: `Rider` = anything that rides; games add semantics via extension storage
+- Rider lifecycle: Waiting → Boarding → Riding → Exiting → Arrived/Abandoned; consumer can settle (→ Resident) or despawn
+- Population tracking: `RiderIndex` maintains O(1) per-stop queries (residents_at, waiting_at, abandoned_at)
 - Route-based loading: riders with `Route` are auto-boarded/exited; no Route = game manages manually
 - Trapezoidal velocity profile for movement
 - Config validated at construction time

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@
 
 A tick-based elevator simulation engine for Rust. Model anything from a
 3-story office building to an orbital space elevator. Pluggable dispatch
-strategies, realistic trapezoidal motion profiles, and an extension system
-let you build exactly the simulation you need.
+strategies, realistic trapezoidal motion profiles, O(1) population tracking
+per stop, and an extension system let you build exactly the simulation you
+need.
 
 [Guide](https://andymai.github.io/elevator-core/) | [API Reference](https://docs.rs/elevator-core)
 
@@ -38,7 +39,7 @@ From there, the typical workflow is:
 1. **Configure stops** -- define the building layout with named stops at arbitrary positions.
 2. **Build the simulation** -- `SimulationBuilder` validates the config and returns a ready-to-run `Simulation`.
 3. **Spawn riders** -- place riders at origin stops with a destination and weight.
-4. **Step the loop** -- each call to `sim.step()` advances one tick through all six phases.
+4. **Step the loop** -- each call to `sim.step()` advances one tick through all seven phases.
 5. **Read metrics** -- query aggregate wait times, ride times, and throughput at any point.
 
 ## Examples
@@ -139,24 +140,25 @@ if let Some(tag) = sim.world().get_ext::<VipTag>(rider_id) {
 
 ## Architecture
 
-Each call to `sim.step()` executes six phases:
+Each call to `sim.step()` executes seven phases:
 
 ```text
-┌───────────────┐   ┌──────────┐   ┌──────────┐
-│ Advance       │──▶│ Dispatch │──▶│ Movement │
-│ Transient     │   │          │   │          │
-└───────────────┘   └──────────┘   └──────────┘
-                                        │
-┌───────────────┐   ┌──────────┐   ┌──────────┐
-│ Metrics       │◀──│ Loading  │◀──│ Doors    │
-│               │   │          │   │          │
-└───────────────┘   └──────────┘   └──────────┘
+┌───────────────┐   ┌──────────┐   ┌──────────────┐   ┌──────────┐
+│ Advance       │──▶│ Dispatch │──▶│ Reposition   │──▶│ Movement │
+│ Transient     │   │          │   │              │   │          │
+└───────────────┘   └──────────┘   └──────────────┘   └──────────┘
+                                                           │
+               ┌───────────────┐   ┌──────────┐   ┌──────────┐
+               │ Metrics       │◀──│ Loading  │◀──│ Doors    │
+               │               │   │          │   │          │
+               └───────────────┘   └──────────┘   └──────────┘
 ```
 
 | Phase | Description |
 |-------|-------------|
-| **Advance Transient** | Promotes one-tick states forward (Boarding to Riding, Exiting to Arrived). |
+| **Advance Transient** | Promotes one-tick states forward (Boarding to Riding, Exiting to Resident/Arrived). |
 | **Dispatch** | Assigns idle elevators to stops via the pluggable `DispatchStrategy`. |
+| **Reposition** | Moves idle elevators toward strategic positions to reduce future wait times. |
 | **Movement** | Updates elevator position and velocity using trapezoidal acceleration profiles. |
 | **Doors** | Ticks door open/close finite-state machines at each stop. |
 | **Loading** | Boards waiting riders onto elevators with open doors and exits riders at their destination. |

--- a/crates/elevator-core/src/components/rider.rs
+++ b/crates/elevator-core/src/components/rider.rs
@@ -23,6 +23,8 @@ pub enum RiderPhase {
     Arrived,
     /// Gave up waiting.
     Abandoned,
+    /// Parked at a stop, not seeking an elevator.
+    Resident,
 }
 
 impl std::fmt::Display for RiderPhase {
@@ -35,6 +37,7 @@ impl std::fmt::Display for RiderPhase {
             Self::Walking => write!(f, "Walking"),
             Self::Arrived => write!(f, "Arrived"),
             Self::Abandoned => write!(f, "Abandoned"),
+            Self::Resident => write!(f, "Resident"),
         }
     }
 }
@@ -51,7 +54,7 @@ pub struct Rider {
     pub(crate) weight: f64,
     /// Current rider lifecycle phase.
     pub(crate) phase: RiderPhase,
-    /// The stop entity this rider is currently at (while Waiting/Arrived/Abandoned).
+    /// The stop entity this rider is currently at (while Waiting/Arrived/Abandoned/Resident).
     pub(crate) current_stop: Option<EntityId>,
     /// Tick when this rider was spawned.
     pub(crate) spawn_tick: u64,
@@ -72,7 +75,7 @@ impl Rider {
         self.phase
     }
 
-    /// The stop entity this rider is currently at (while Waiting/Arrived/Abandoned).
+    /// The stop entity this rider is currently at (while Waiting/Arrived/Abandoned/Resident).
     #[must_use]
     pub const fn current_stop(&self) -> Option<EntityId> {
         self.current_stop

--- a/crates/elevator-core/src/components/route.rs
+++ b/crates/elevator-core/src/components/route.rs
@@ -75,4 +75,10 @@ impl Route {
     pub fn current_destination(&self) -> Option<EntityId> {
         self.current().map(|leg| leg.to)
     }
+
+    /// The final destination of the entire route.
+    #[must_use]
+    pub fn final_destination(&self) -> Option<EntityId> {
+        self.legs.last().map(|leg| leg.to)
+    }
 }

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -72,6 +72,8 @@ pub struct DispatchManifest {
     pub waiting_at_stop: BTreeMap<EntityId, Vec<RiderInfo>>,
     /// Riders currently aboard elevators, grouped by their destination stop.
     pub riding_to_stop: BTreeMap<EntityId, Vec<RiderInfo>>,
+    /// Number of residents at each stop (read-only hint for dispatch strategies).
+    pub resident_count_at_stop: BTreeMap<EntityId, usize>,
 }
 
 impl DispatchManifest {
@@ -99,6 +101,12 @@ impl DispatchManifest {
     #[must_use]
     pub fn has_demand(&self, stop: EntityId) -> bool {
         self.waiting_count_at(stop) > 0 || self.riding_count_to(stop) > 0
+    }
+
+    /// Number of residents at a stop (read-only hint, not active demand).
+    #[must_use]
+    pub fn resident_count_at(&self, stop: EntityId) -> usize {
+        self.resident_count_at_stop.get(&stop).copied().unwrap_or(0)
     }
 }
 

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -190,13 +190,30 @@ pub enum Event {
         /// The tick when invalidation occurred.
         tick: u64,
     },
-    /// A rider was manually rerouted via `sim.reroute()`.
+    /// A rider was manually rerouted via `sim.reroute()` or `sim.reroute_rider()`.
     RiderRerouted {
         /// The rerouted rider.
         rider: EntityId,
         /// The new destination stop.
         new_destination: EntityId,
         /// The tick when rerouting occurred.
+        tick: u64,
+    },
+
+    /// A rider settled at a stop, becoming a resident.
+    RiderSettled {
+        /// The rider that settled.
+        rider: EntityId,
+        /// The stop where the rider settled.
+        stop: EntityId,
+        /// The tick when settlement occurred.
+        tick: u64,
+    },
+    /// A rider was removed from the simulation.
+    RiderDespawned {
+        /// The rider that was removed.
+        rider: EntityId,
+        /// The tick when despawn occurred.
         tick: u64,
     },
 

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -168,6 +168,8 @@ pub mod hooks;
 pub mod metrics;
 /// Trapezoidal velocity-profile movement math.
 pub mod movement;
+/// Phase-partitioned reverse index for rider population queries.
+mod rider_index;
 /// Scenario replay from recorded event streams.
 pub mod scenario;
 /// Top-level simulation runner.

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -97,6 +97,31 @@
 //!                      └── Stop (served stops along the shaft)
 //! ```
 //!
+//! ### Rider lifecycle
+//!
+//! Riders progress through phases managed by the simulation:
+//!
+//! ```text
+//! Waiting → Boarding → Riding → Exiting → Arrived
+//!    ↑         (1 tick)           (1 tick)     │
+//!    │                                         ├── settle_rider() → Resident
+//!    │                                         │                       │
+//!    │                                         └── despawn_rider()     │
+//!    │                                                                 │
+//!    └──────── reroute_rider() ────────────────────────────────────────┘
+//!
+//! Waiting ──(patience exceeded)──→ Abandoned ──→ settle/despawn
+//! ```
+//!
+//! - **`Arrived`** / **`Abandoned`**: terminal states; consumer must explicitly
+//!   settle or despawn the rider.
+//! - **`Resident`**: parked at a stop, invisible to dispatch and loading.
+//!   Query with [`Simulation::residents_at()`](sim::Simulation::residents_at).
+//! - **Population queries**: O(1) via maintained reverse index —
+//!   [`residents_at`](sim::Simulation::residents_at),
+//!   [`waiting_at`](sim::Simulation::waiting_at),
+//!   [`abandoned_at`](sim::Simulation::abandoned_at).
+//!
 //! ### Extension storage
 //!
 //! Games attach custom data to any entity without modifying the library:
@@ -129,6 +154,7 @@
 //! | Entity iteration | O(n) via `SlotMap` secondary maps |
 //! | Stop-passing detection | O(log n) via `SortedStops` binary search |
 //! | Dispatch manifest build | O(riders) per group |
+//! | Population queries | O(1) via `RiderIndex` reverse index |
 //! | Topology graph queries | O(V+E) BFS, lazy rebuild |
 //!
 //! For narrative guides, tutorials, and architecture walkthroughs, see the

--- a/crates/elevator-core/src/metrics.rs
+++ b/crates/elevator-core/src/metrics.rs
@@ -38,6 +38,10 @@ pub struct Metrics {
     /// Total distance traveled by elevators while repositioning.
     #[serde(default)]
     pub(crate) reposition_distance: f64,
+    /// Total riders settled as residents.
+    pub(crate) total_settled: u64,
+    /// Total riders rerouted from resident phase.
+    pub(crate) total_rerouted: u64,
 
     // -- Internal accumulators --
     /// Running sum of wait ticks across all boarded riders.
@@ -139,6 +143,18 @@ impl Metrics {
         self.reposition_distance
     }
 
+    /// Total riders settled as residents.
+    #[must_use]
+    pub const fn total_settled(&self) -> u64 {
+        self.total_settled
+    }
+
+    /// Total riders rerouted from resident phase.
+    #[must_use]
+    pub const fn total_rerouted(&self) -> u64 {
+        self.total_rerouted
+    }
+
     /// Window size for throughput calculation (ticks).
     #[must_use]
     pub const fn throughput_window_ticks(&self) -> u64 {
@@ -180,6 +196,16 @@ impl Metrics {
         if self.total_spawned > 0 {
             self.abandonment_rate = self.total_abandoned as f64 / self.total_spawned as f64;
         }
+    }
+
+    /// Record a rider settling as a resident.
+    pub const fn record_settle(&mut self) {
+        self.total_settled += 1;
+    }
+
+    /// Record a resident rider being rerouted.
+    pub const fn record_reroute(&mut self) {
+        self.total_rerouted += 1;
     }
 
     /// Record elevator distance traveled this tick.

--- a/crates/elevator-core/src/rider_index.rs
+++ b/crates/elevator-core/src/rider_index.rs
@@ -77,17 +77,6 @@ impl RiderIndex {
         remove(&mut self.abandoned, stop, rider);
     }
 
-    /// Remove a rider from all partitions (fallback when phase is unknown).
-    #[allow(dead_code)]
-    pub(crate) fn remove_all(&mut self, rider: EntityId) {
-        for map in [&mut self.waiting, &mut self.residents, &mut self.abandoned] {
-            map.retain(|_, set| {
-                set.remove(&rider);
-                !set.is_empty()
-            });
-        }
-    }
-
     // ── Queries ─────────────────────────────────────────────────────
 
     /// Waiting riders at a stop.

--- a/crates/elevator-core/src/rider_index.rs
+++ b/crates/elevator-core/src/rider_index.rs
@@ -1,0 +1,144 @@
+//! Phase-partitioned reverse index: stop → rider entity IDs.
+//!
+//! Maintained incrementally by [`Simulation`](crate::sim::Simulation) methods
+//! and the loading/advance-transient systems. Uses `BTreeMap`/`BTreeSet` for
+//! deterministic iteration.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::components::RiderPhase;
+use crate::entity::EntityId;
+use crate::world::World;
+
+/// Partition map type used by each phase bucket.
+type Partition = BTreeMap<EntityId, BTreeSet<EntityId>>;
+
+/// Phase-partitioned reverse index mapping stops to the riders present there.
+#[derive(Debug, Clone, Default)]
+pub struct RiderIndex {
+    /// Riders in `Waiting` phase, keyed by their `current_stop`.
+    waiting: Partition,
+    /// Riders in `Resident` phase, keyed by their `current_stop`.
+    residents: Partition,
+    /// Riders in `Abandoned` phase, keyed by their `current_stop`.
+    abandoned: Partition,
+}
+
+/// Shared empty set returned by reference when a stop has no entries.
+static EMPTY: std::sync::LazyLock<BTreeSet<EntityId>> = std::sync::LazyLock::new(BTreeSet::new);
+
+/// Insert a rider into a partition.
+fn insert(partition: &mut Partition, stop: EntityId, rider: EntityId) {
+    partition.entry(stop).or_default().insert(rider);
+}
+
+/// Remove a rider from a partition, pruning empty sets.
+fn remove(partition: &mut Partition, stop: EntityId, rider: EntityId) {
+    if let Some(set) = partition.get_mut(&stop) {
+        set.remove(&rider);
+        if set.is_empty() {
+            partition.remove(&stop);
+        }
+    }
+}
+
+impl RiderIndex {
+    // ── Insertion ────────────────────────────────────────────────────
+
+    /// Add a rider to the waiting set for a stop.
+    pub(crate) fn insert_waiting(&mut self, stop: EntityId, rider: EntityId) {
+        insert(&mut self.waiting, stop, rider);
+    }
+
+    /// Add a rider to the resident set for a stop.
+    pub(crate) fn insert_resident(&mut self, stop: EntityId, rider: EntityId) {
+        insert(&mut self.residents, stop, rider);
+    }
+
+    /// Add a rider to the abandoned set for a stop.
+    pub(crate) fn insert_abandoned(&mut self, stop: EntityId, rider: EntityId) {
+        insert(&mut self.abandoned, stop, rider);
+    }
+
+    // ── Removal ─────────────────────────────────────────────────────
+
+    /// Remove a rider from the waiting set for a stop.
+    pub(crate) fn remove_waiting(&mut self, stop: EntityId, rider: EntityId) {
+        remove(&mut self.waiting, stop, rider);
+    }
+
+    /// Remove a rider from the resident set for a stop.
+    pub(crate) fn remove_resident(&mut self, stop: EntityId, rider: EntityId) {
+        remove(&mut self.residents, stop, rider);
+    }
+
+    /// Remove a rider from the abandoned set for a stop.
+    pub(crate) fn remove_abandoned(&mut self, stop: EntityId, rider: EntityId) {
+        remove(&mut self.abandoned, stop, rider);
+    }
+
+    /// Remove a rider from all partitions (fallback when phase is unknown).
+    #[allow(dead_code)]
+    pub(crate) fn remove_all(&mut self, rider: EntityId) {
+        for map in [&mut self.waiting, &mut self.residents, &mut self.abandoned] {
+            map.retain(|_, set| {
+                set.remove(&rider);
+                !set.is_empty()
+            });
+        }
+    }
+
+    // ── Queries ─────────────────────────────────────────────────────
+
+    /// Waiting riders at a stop.
+    pub(crate) fn waiting_at(&self, stop: EntityId) -> &BTreeSet<EntityId> {
+        self.waiting.get(&stop).unwrap_or(&EMPTY)
+    }
+
+    /// Resident riders at a stop.
+    pub(crate) fn residents_at(&self, stop: EntityId) -> &BTreeSet<EntityId> {
+        self.residents.get(&stop).unwrap_or(&EMPTY)
+    }
+
+    /// Abandoned riders at a stop.
+    pub(crate) fn abandoned_at(&self, stop: EntityId) -> &BTreeSet<EntityId> {
+        self.abandoned.get(&stop).unwrap_or(&EMPTY)
+    }
+
+    /// Count of waiting riders at a stop.
+    pub(crate) fn waiting_count_at(&self, stop: EntityId) -> usize {
+        self.waiting.get(&stop).map_or(0, BTreeSet::len)
+    }
+
+    /// Count of resident riders at a stop.
+    pub(crate) fn resident_count_at(&self, stop: EntityId) -> usize {
+        self.residents.get(&stop).map_or(0, BTreeSet::len)
+    }
+
+    /// Count of abandoned riders at a stop.
+    pub(crate) fn abandoned_count_at(&self, stop: EntityId) -> usize {
+        self.abandoned.get(&stop).map_or(0, BTreeSet::len)
+    }
+
+    // ── Rebuild ─────────────────────────────────────────────────────
+
+    /// Reconstruct the entire index from current world state.
+    ///
+    /// Used after snapshot restore or if the index becomes stale.
+    pub(crate) fn rebuild(&mut self, world: &World) {
+        self.waiting.clear();
+        self.residents.clear();
+        self.abandoned.clear();
+
+        for (id, rider) in world.iter_riders() {
+            if let Some(stop) = rider.current_stop() {
+                match rider.phase() {
+                    RiderPhase::Waiting => self.insert_waiting(stop, id),
+                    RiderPhase::Resident => self.insert_resident(stop, id),
+                    RiderPhase::Abandoned => self.insert_abandoned(stop, id),
+                    _ => {}
+                }
+            }
+        }
+    }
+}

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -16,6 +16,7 @@ use crate::events::{Event, EventBus};
 use crate::hooks::{Phase, PhaseHooks};
 use crate::ids::GroupId;
 use crate::metrics::Metrics;
+use crate::rider_index::RiderIndex;
 use crate::stop::StopId;
 use crate::systems::PhaseContext;
 use crate::time::TimeAdapter;
@@ -131,6 +132,8 @@ pub struct Simulation {
     elevator_ids_buf: Vec<EntityId>,
     /// Lazy-rebuilt connectivity graph for cross-line topology queries.
     topo_graph: Mutex<TopologyGraph>,
+    /// Phase-partitioned reverse index for O(1) population queries.
+    rider_index: RiderIndex,
 }
 
 impl Simulation {
@@ -261,6 +264,7 @@ impl Simulation {
             hooks,
             elevator_ids_buf: Vec::new(),
             topo_graph: Mutex::new(TopologyGraph::new()),
+            rider_index: RiderIndex::default(),
         })
     }
 
@@ -514,6 +518,8 @@ impl Simulation {
         metrics: Metrics,
         ticks_per_second: f64,
     ) -> Self {
+        let mut rider_index = RiderIndex::default();
+        rider_index.rebuild(&world);
         Self {
             world,
             events: EventBus::default(),
@@ -531,6 +537,7 @@ impl Simulation {
             hooks: PhaseHooks::default(),
             elevator_ids_buf: Vec::new(),
             topo_graph: Mutex::new(TopologyGraph::new()),
+            rider_index,
         }
     }
 
@@ -1016,6 +1023,7 @@ impl Simulation {
             },
         );
         self.world.set_route(eid, route);
+        self.rider_index.insert_waiting(origin, eid);
         self.events.emit(Event::RiderSpawned {
             rider: eid,
             origin,
@@ -1830,6 +1838,193 @@ impl Simulation {
         Ok(())
     }
 
+    // ── Rider settlement & population ─────────────────────────────
+
+    /// Transition an `Arrived` or `Abandoned` rider to `Resident` at their
+    /// current stop.
+    ///
+    /// Resident riders are parked — invisible to dispatch and loading, but
+    /// queryable via [`residents_at()`](Self::residents_at). They can later
+    /// be given a new route via [`reroute_rider()`](Self::reroute_rider).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SimError::EntityNotFound`] if `id` does not exist.
+    /// Returns [`SimError::InvalidState`] if the rider is not in
+    /// `Arrived` or `Abandoned` phase, or has no current stop.
+    pub fn settle_rider(&mut self, id: EntityId) -> Result<(), SimError> {
+        let rider = self.world.rider(id).ok_or(SimError::EntityNotFound(id))?;
+
+        let old_phase = rider.phase;
+        match old_phase {
+            RiderPhase::Arrived | RiderPhase::Abandoned => {}
+            _ => {
+                return Err(SimError::InvalidState {
+                    entity: id,
+                    reason: format!(
+                        "cannot settle rider in {old_phase} phase, expected Arrived or Abandoned"
+                    ),
+                });
+            }
+        }
+
+        let stop = rider.current_stop.ok_or_else(|| SimError::InvalidState {
+            entity: id,
+            reason: "rider has no current_stop".into(),
+        })?;
+
+        // Update index: remove from old partition (only Abandoned is indexed).
+        if old_phase == RiderPhase::Abandoned {
+            self.rider_index.remove_abandoned(stop, id);
+        }
+        self.rider_index.insert_resident(stop, id);
+
+        if let Some(r) = self.world.rider_mut(id) {
+            r.phase = RiderPhase::Resident;
+        }
+
+        self.metrics.record_settle();
+        self.events.emit(Event::RiderSettled {
+            rider: id,
+            stop,
+            tick: self.tick,
+        });
+        Ok(())
+    }
+
+    /// Give a `Resident` rider a new route, transitioning them to `Waiting`.
+    ///
+    /// The rider begins waiting at their current stop for an elevator
+    /// matching the route's transport mode. If the rider has a [`Patience`]
+    /// component, its `waited_ticks` is reset to zero.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SimError::EntityNotFound`] if `id` does not exist.
+    /// Returns [`SimError::InvalidState`] if the rider is not in `Resident` phase.
+    pub fn reroute_rider(&mut self, id: EntityId, route: Route) -> Result<(), SimError> {
+        let rider = self.world.rider(id).ok_or(SimError::EntityNotFound(id))?;
+
+        if rider.phase != RiderPhase::Resident {
+            return Err(SimError::InvalidState {
+                entity: id,
+                reason: format!(
+                    "cannot reroute rider in {} phase, expected Resident",
+                    rider.phase
+                ),
+            });
+        }
+
+        let stop = rider.current_stop.ok_or_else(|| SimError::InvalidState {
+            entity: id,
+            reason: "resident rider has no current_stop".into(),
+        })?;
+
+        let new_destination = route
+            .final_destination()
+            .ok_or_else(|| SimError::InvalidState {
+                entity: id,
+                reason: "route has no legs".into(),
+            })?;
+
+        self.rider_index.remove_resident(stop, id);
+        self.rider_index.insert_waiting(stop, id);
+
+        if let Some(r) = self.world.rider_mut(id) {
+            r.phase = RiderPhase::Waiting;
+        }
+        self.world.set_route(id, route);
+
+        // Reset patience if present.
+        if let Some(p) = self.world.patience_mut(id) {
+            p.waited_ticks = 0;
+        }
+
+        self.metrics.record_reroute();
+        self.events.emit(Event::RiderRerouted {
+            rider: id,
+            new_destination,
+            tick: self.tick,
+        });
+        Ok(())
+    }
+
+    /// Remove a rider from the simulation entirely.
+    ///
+    /// Cleans up the population index, metric tags, and elevator cross-references
+    /// (if the rider is currently aboard). Emits [`Event::RiderDespawned`].
+    ///
+    /// All rider removal should go through this method rather than calling
+    /// `world.despawn()` directly, to keep the population index consistent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SimError::EntityNotFound`] if `id` does not exist or is
+    /// not a rider.
+    pub fn despawn_rider(&mut self, id: EntityId) -> Result<(), SimError> {
+        let rider = self.world.rider(id).ok_or(SimError::EntityNotFound(id))?;
+
+        // Targeted index removal based on current phase (O(1) vs O(n) scan).
+        if let Some(stop) = rider.current_stop {
+            match rider.phase {
+                RiderPhase::Waiting => self.rider_index.remove_waiting(stop, id),
+                RiderPhase::Resident => self.rider_index.remove_resident(stop, id),
+                RiderPhase::Abandoned => self.rider_index.remove_abandoned(stop, id),
+                _ => {} // Boarding/Riding/Exiting/Walking/Arrived — not indexed
+            }
+        }
+
+        if let Some(tags) = self
+            .world
+            .resource_mut::<crate::tagged_metrics::MetricTags>()
+        {
+            tags.remove_entity(id);
+        }
+
+        self.world.despawn(id);
+
+        self.events.emit(Event::RiderDespawned {
+            rider: id,
+            tick: self.tick,
+        });
+        Ok(())
+    }
+
+    // ── Population queries ──────────────────────────────────────────
+
+    /// Iterate over resident rider IDs at a stop (O(1) lookup).
+    pub fn residents_at(&self, stop: EntityId) -> impl Iterator<Item = EntityId> + '_ {
+        self.rider_index.residents_at(stop).iter().copied()
+    }
+
+    /// Count of residents at a stop (O(1)).
+    #[must_use]
+    pub fn resident_count_at(&self, stop: EntityId) -> usize {
+        self.rider_index.resident_count_at(stop)
+    }
+
+    /// Iterate over waiting rider IDs at a stop (O(1) lookup).
+    pub fn waiting_at(&self, stop: EntityId) -> impl Iterator<Item = EntityId> + '_ {
+        self.rider_index.waiting_at(stop).iter().copied()
+    }
+
+    /// Count of waiting riders at a stop (O(1)).
+    #[must_use]
+    pub fn waiting_count_at(&self, stop: EntityId) -> usize {
+        self.rider_index.waiting_count_at(stop)
+    }
+
+    /// Iterate over abandoned rider IDs at a stop (O(1) lookup).
+    pub fn abandoned_at(&self, stop: EntityId) -> impl Iterator<Item = EntityId> + '_ {
+        self.rider_index.abandoned_at(stop).iter().copied()
+    }
+
+    /// Count of abandoned riders at a stop (O(1)).
+    #[must_use]
+    pub fn abandoned_count_at(&self, stop: EntityId) -> usize {
+        self.rider_index.abandoned_count_at(stop)
+    }
+
     // ── Entity lifecycle ────────────────────────────────────────────
 
     /// Disable an entity. Disabled entities are skipped by all systems.
@@ -1860,6 +2055,7 @@ impl Simulation {
                     r.board_tick = None;
                 }
                 if let Some(stop) = nearest_stop {
+                    self.rider_index.insert_waiting(stop, *rid);
                     self.events.emit(Event::RiderEjected {
                         rider: *rid,
                         elevator: id,
@@ -1994,6 +2190,10 @@ impl Simulation {
                 if let Some(r) = self.world.rider_mut(rid) {
                     r.phase = RiderPhase::Abandoned;
                 }
+                if let Some(stop) = rider_current_stop {
+                    self.rider_index.remove_waiting(stop, rid);
+                    self.rider_index.insert_abandoned(stop, rid);
+                }
                 self.events.emit(Event::RiderAbandoned {
                     rider: rid,
                     stop: abandon_stop,
@@ -2050,7 +2250,12 @@ impl Simulation {
                 .run_before_group(Phase::AdvanceTransient, group.id(), &mut self.world);
         }
         let ctx = self.phase_context();
-        crate::systems::advance_transient::run(&mut self.world, &mut self.events, &ctx);
+        crate::systems::advance_transient::run(
+            &mut self.world,
+            &mut self.events,
+            &ctx,
+            &mut self.rider_index,
+        );
         for group in &self.groups {
             self.hooks
                 .run_after_group(Phase::AdvanceTransient, group.id(), &mut self.world);
@@ -2073,6 +2278,7 @@ impl Simulation {
             &ctx,
             &self.groups,
             &mut self.dispatchers,
+            &self.rider_index,
         );
         for group in &self.groups {
             self.hooks
@@ -2140,6 +2346,7 @@ impl Simulation {
             &mut self.events,
             &ctx,
             &self.elevator_ids_buf,
+            &mut self.rider_index,
         );
         for group in &self.groups {
             self.hooks

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -1901,7 +1901,9 @@ impl Simulation {
     /// # Errors
     ///
     /// Returns [`SimError::EntityNotFound`] if `id` does not exist.
-    /// Returns [`SimError::InvalidState`] if the rider is not in `Resident` phase.
+    /// Returns [`SimError::InvalidState`] if the rider is not in `Resident` phase,
+    /// the route has no legs, or the route's first leg origin does not match the
+    /// rider's current stop.
     pub fn reroute_rider(&mut self, id: EntityId, route: Route) -> Result<(), SimError> {
         let rider = self.world.rider(id).ok_or(SimError::EntityNotFound(id))?;
 
@@ -1926,6 +1928,19 @@ impl Simulation {
                 entity: id,
                 reason: "route has no legs".into(),
             })?;
+
+        // Validate that the route departs from the rider's current stop.
+        if let Some(leg) = route.current() {
+            if leg.from != stop {
+                return Err(SimError::InvalidState {
+                    entity: id,
+                    reason: format!(
+                        "route origin {:?} does not match rider current_stop {:?}",
+                        leg.from, stop
+                    ),
+                });
+            }
+        }
 
         self.rider_index.remove_resident(stop, id);
         self.rider_index.insert_waiting(stop, id);
@@ -2031,6 +2046,11 @@ impl Simulation {
     ///
     /// If the entity is an elevator in motion, it is reset to `Idle` with
     /// zero velocity to prevent stale target references on re-enable.
+    ///
+    /// **Note on residents:** disabling a stop does not automatically handle
+    /// `Resident` riders parked there. Callers should listen for
+    /// [`Event::EntityDisabled`] and manually reroute or despawn any
+    /// residents at the affected stop.
     ///
     /// Emits `EntityDisabled`. Returns `Err` if the entity does not exist.
     ///

--- a/crates/elevator-core/src/systems/advance_transient.rs
+++ b/crates/elevator-core/src/systems/advance_transient.rs
@@ -3,6 +3,7 @@
 use crate::components::{RiderPhase, Route, TransportMode};
 use crate::entity::EntityId;
 use crate::events::{Event, EventBus};
+use crate::rider_index::RiderIndex;
 use crate::world::World;
 
 use super::PhaseContext;
@@ -18,7 +19,13 @@ enum TransientAction {
 /// Handle a rider that has just exited: advance the route and transition to
 /// the appropriate phase. Walk legs are executed immediately (the rider is
 /// teleported to the walk destination).
-fn handle_exit(id: EntityId, world: &mut World, events: &mut EventBus, ctx: &PhaseContext) {
+fn handle_exit(
+    id: EntityId,
+    world: &mut World,
+    events: &mut EventBus,
+    ctx: &PhaseContext,
+    rider_index: &mut RiderIndex,
+) {
     // Check if the route has more legs.
     let has_more_legs = world.route_mut(id).is_some_and(Route::advance);
 
@@ -60,6 +67,10 @@ fn handle_exit(id: EntityId, world: &mut World, events: &mut EventBus, ctx: &Pha
             if let Some(r) = world.rider_mut(id) {
                 r.phase = RiderPhase::Waiting;
             }
+            // Rider is now Waiting at their current_stop — add to index.
+            if let Some(stop) = world.rider(id).and_then(|r| r.current_stop) {
+                rider_index.insert_waiting(stop, id);
+            }
         }
     } else if let Some(r) = world.rider_mut(id) {
         r.phase = RiderPhase::Arrived;
@@ -94,7 +105,12 @@ fn handle_exit(id: EntityId, world: &mut World, events: &mut EventBus, ctx: &Pha
 ///
 /// These transient states last exactly one tick so they're
 /// visible for one frame in the visualization.
-pub fn run(world: &mut World, events: &mut EventBus, ctx: &PhaseContext) {
+pub(crate) fn run(
+    world: &mut World,
+    events: &mut EventBus,
+    ctx: &PhaseContext,
+    rider_index: &mut RiderIndex,
+) {
     // Only collect riders in transient phases to avoid allocating all IDs.
     let actionable: Vec<_> = world
         .iter_riders()
@@ -117,7 +133,7 @@ pub fn run(world: &mut World, events: &mut EventBus, ctx: &PhaseContext) {
                     r.phase = RiderPhase::Riding(eid);
                 }
             }
-            TransientAction::Exit => handle_exit(id, world, events, ctx),
+            TransientAction::Exit => handle_exit(id, world, events, ctx, rider_index),
         }
     }
 
@@ -157,10 +173,12 @@ pub fn run(world: &mut World, events: &mut EventBus, ctx: &PhaseContext) {
     }
 
     // Apply abandonments.
-    for (id, stop) in abandon {
+    for &(id, stop) in &abandon {
         if let Some(r) = world.rider_mut(id) {
             r.phase = RiderPhase::Abandoned;
         }
+        rider_index.remove_waiting(stop, id);
+        rider_index.insert_abandoned(stop, id);
         events.emit(Event::RiderAbandoned {
             rider: id,
             stop,

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -7,6 +7,7 @@ use crate::dispatch::{
 use crate::entity::EntityId;
 use crate::events::{Event, EventBus};
 use crate::ids::GroupId;
+use crate::rider_index::RiderIndex;
 use crate::world::World;
 
 use std::collections::BTreeMap;
@@ -14,15 +15,16 @@ use std::collections::BTreeMap;
 use super::PhaseContext;
 
 /// Assign idle/stopped elevators to stops via the dispatch strategy.
-pub fn run(
+pub(crate) fn run(
     world: &mut World,
     events: &mut EventBus,
     ctx: &PhaseContext,
     groups: &[ElevatorGroup],
     dispatchers: &mut BTreeMap<GroupId, Box<dyn DispatchStrategy>>,
+    rider_index: &RiderIndex,
 ) {
     for group in groups {
-        let manifest = build_manifest(world, group, ctx.tick);
+        let manifest = build_manifest(world, group, ctx.tick, rider_index);
 
         // Collect idle elevators in this group.
         let idle_elevators: Vec<(EntityId, f64)> = group
@@ -119,7 +121,12 @@ pub fn run(
 }
 
 /// Build a dispatch manifest with per-rider metadata for a group.
-fn build_manifest(world: &World, group: &ElevatorGroup, tick: u64) -> DispatchManifest {
+fn build_manifest(
+    world: &World,
+    group: &ElevatorGroup,
+    tick: u64,
+    rider_index: &RiderIndex,
+) -> DispatchManifest {
     let mut manifest = DispatchManifest::default();
 
     // Waiting riders at this group's stops.
@@ -168,6 +175,14 @@ fn build_manifest(world: &World, group: &ElevatorGroup, tick: u64) -> DispatchMa
                         });
                 }
             }
+        }
+    }
+
+    // Populate resident counts as read-only hints for dispatch strategies.
+    for &stop in group.stop_entities() {
+        let count = rider_index.resident_count_at(stop);
+        if count > 0 {
+            manifest.resident_count_at_stop.insert(stop, count);
         }
     }
 

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -5,6 +5,7 @@ use crate::entity::EntityId;
 use crate::error::{RejectionContext, RejectionReason};
 use crate::events::{Event, EventBus};
 use crate::ids::GroupId;
+use crate::rider_index::RiderIndex;
 use crate::world::World;
 
 use super::PhaseContext;
@@ -192,6 +193,7 @@ fn apply_actions(
     world: &mut World,
     events: &mut EventBus,
     ctx: &PhaseContext,
+    rider_index: &mut RiderIndex,
 ) {
     for action in actions {
         match action {
@@ -231,12 +233,17 @@ fn apply_actions(
             } => {
                 // Guard: skip if rider is no longer Waiting (another elevator at
                 // the same stop may have already boarded them in an earlier action).
-                if world
-                    .rider(rider)
-                    .is_none_or(|r| r.phase != RiderPhase::Waiting)
-                {
+                let boarding_stop = world.rider(rider).and_then(|r| {
+                    if r.phase == RiderPhase::Waiting {
+                        r.current_stop
+                    } else {
+                        None
+                    }
+                });
+                let Some(stop) = boarding_stop else {
                     continue;
-                }
+                };
+                rider_index.remove_waiting(stop, rider);
                 if let Some(car) = world.elevator_mut(elevator) {
                     car.current_load += weight;
                     car.riders.push(rider);
@@ -271,12 +278,13 @@ fn apply_actions(
 }
 
 /// One rider boards or exits per tick per elevator.
-pub fn run(
+pub(crate) fn run(
     world: &mut World,
     events: &mut EventBus,
     ctx: &PhaseContext,
     elevator_ids: &[EntityId],
+    rider_index: &mut RiderIndex,
 ) {
     let actions = collect_actions(world, elevator_ids);
-    apply_actions(actions, world, events, ctx);
+    apply_actions(actions, world, events, ctx, rider_index);
 }

--- a/crates/elevator-core/src/systems/metrics.rs
+++ b/crates/elevator-core/src/systems/metrics.rs
@@ -47,9 +47,6 @@ pub fn run(
                 metrics.record_abandonment();
                 tag_terminals.push((*rider, false));
             }
-            Event::RiderDespawned { rider, .. } => {
-                tag_terminals.push((*rider, false));
-            }
             _ => {}
         }
     }

--- a/crates/elevator-core/src/systems/metrics.rs
+++ b/crates/elevator-core/src/systems/metrics.rs
@@ -47,6 +47,9 @@ pub fn run(
                 metrics.record_abandonment();
                 tag_terminals.push((*rider, false));
             }
+            Event::RiderDespawned { rider, .. } => {
+                tag_terminals.push((*rider, false));
+            }
             _ => {}
         }
     }

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -32,3 +32,4 @@ mod event_payload_tests;
 mod multi_elevator_tests;
 mod multi_line_tests;
 mod reposition_tests;
+mod resident_tests;

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -2190,7 +2190,7 @@ fn despawn_waiting_rider_removes_from_world() {
     let rider = sim.spawn_rider(ground, transfer, 70.0).unwrap();
 
     // Rider is Waiting — despawn it.
-    sim.world_mut().despawn(rider);
+    sim.despawn_rider(rider).unwrap();
 
     assert!(
         !sim.world().is_alive(rider),
@@ -2233,7 +2233,7 @@ fn despawn_riding_rider_removes_from_elevator_riders_list() {
     );
 
     // Despawn the riding rider.
-    sim.world_mut().despawn(rider);
+    sim.despawn_rider(rider).unwrap();
 
     assert!(
         !sim.world().is_alive(rider),

--- a/crates/elevator-core/src/tests/resident_tests.rs
+++ b/crates/elevator-core/src/tests/resident_tests.rs
@@ -1,0 +1,382 @@
+use crate::components::{RiderPhase, Route};
+use crate::error::SimError;
+use crate::events::Event;
+use crate::ids::GroupId;
+use crate::sim::Simulation;
+use crate::stop::StopId;
+
+use super::helpers::{default_config, scan};
+
+/// Run until the given rider reaches Arrived, or panic after max ticks.
+fn run_until_arrived(sim: &mut Simulation, rider_id: crate::entity::EntityId) {
+    for _ in 0..10_000 {
+        sim.step();
+        if let Some(r) = sim.world().rider(rider_id) {
+            if r.phase() == RiderPhase::Arrived {
+                return;
+            }
+        }
+    }
+    panic!("rider did not arrive within 10,000 ticks");
+}
+
+/// Run until the given rider reaches Abandoned, or panic after max ticks.
+fn run_until_abandoned(sim: &mut Simulation, rider_id: crate::entity::EntityId) {
+    for _ in 0..10_000 {
+        sim.step();
+        if let Some(r) = sim.world().rider(rider_id) {
+            if r.phase() == RiderPhase::Abandoned {
+                return;
+            }
+        }
+    }
+    panic!("rider did not abandon within 10,000 ticks");
+}
+
+#[test]
+fn settle_from_arrived() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    let rider = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    run_until_arrived(&mut sim, rider);
+
+    // Settle the rider.
+    sim.settle_rider(rider).unwrap();
+
+    let r = sim.world().rider(rider).unwrap();
+    assert_eq!(r.phase(), RiderPhase::Resident);
+    assert!(r.current_stop().is_some());
+
+    let stop = r.current_stop().unwrap();
+    assert!(sim.residents_at(stop).any(|id| id == rider));
+    assert_eq!(sim.resident_count_at(stop), 1);
+
+    // Check event was emitted.
+    let events = sim.drain_events();
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::RiderSettled { rider: r, .. } if *r == rider))
+    );
+}
+
+#[test]
+fn settle_from_abandoned() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    let rider = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    // Give very short patience so rider abandons.
+    sim.world_mut().set_patience(
+        rider,
+        crate::components::Patience {
+            max_wait_ticks: 1,
+            waited_ticks: 0,
+        },
+    );
+
+    run_until_abandoned(&mut sim, rider);
+
+    sim.settle_rider(rider).unwrap();
+
+    let r = sim.world().rider(rider).unwrap();
+    assert_eq!(r.phase(), RiderPhase::Resident);
+
+    let stop = r.current_stop().unwrap();
+    assert!(sim.residents_at(stop).any(|id| id == rider));
+    // Should no longer be in abandoned index.
+    assert!(!sim.abandoned_at(stop).any(|id| id == rider));
+}
+
+#[test]
+fn settle_wrong_phase_returns_error() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    let rider = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    // Rider is Waiting — should fail.
+    let result = sim.settle_rider(rider);
+    assert!(matches!(result, Err(SimError::InvalidState { .. })));
+}
+
+#[test]
+fn reroute_resident_to_waiting() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    let rider = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    run_until_arrived(&mut sim, rider);
+    sim.settle_rider(rider).unwrap();
+    sim.drain_events(); // Clear events from settlement.
+
+    let stop = sim.world().rider(rider).unwrap().current_stop().unwrap();
+
+    // Resolve StopId(0) to EntityId for the route.
+    let dest = sim.stop_entity(StopId(0)).unwrap();
+    let route = Route::direct(stop, dest, GroupId(0));
+    sim.reroute_rider(rider, route).unwrap();
+
+    let r = sim.world().rider(rider).unwrap();
+    assert_eq!(r.phase(), RiderPhase::Waiting);
+
+    // Rider should be in waiting index, not resident index.
+    assert!(sim.waiting_at(stop).any(|id| id == rider));
+    assert!(!sim.residents_at(stop).any(|id| id == rider));
+
+    // Check event was emitted.
+    let events = sim.drain_events();
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::RiderRerouted { rider: r, .. } if *r == rider))
+    );
+}
+
+#[test]
+fn reroute_wrong_phase_returns_error() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    let rider = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    let dest = sim.stop_entity(StopId(2)).unwrap();
+    let origin = sim.stop_entity(StopId(0)).unwrap();
+    let route = Route::direct(origin, dest, GroupId(0));
+
+    // Rider is Waiting — should fail.
+    let result = sim.reroute_rider(rider, route);
+    assert!(matches!(result, Err(SimError::InvalidState { .. })));
+}
+
+#[test]
+fn despawn_rider_removes_from_world_and_index() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    let rider = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    run_until_arrived(&mut sim, rider);
+    sim.settle_rider(rider).unwrap();
+
+    let stop = sim.world().rider(rider).unwrap().current_stop().unwrap();
+    assert_eq!(sim.resident_count_at(stop), 1);
+
+    sim.drain_events();
+    sim.despawn_rider(rider).unwrap();
+
+    // Entity gone.
+    assert!(!sim.world().is_alive(rider));
+    // Index clean.
+    assert_eq!(sim.resident_count_at(stop), 0);
+
+    // Event emitted.
+    let events = sim.drain_events();
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::RiderDespawned { rider: r, .. } if *r == rider))
+    );
+}
+
+#[test]
+fn despawn_riding_rider_cleans_elevator() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    let rider = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    // Run until rider is Riding.
+    for _ in 0..10_000 {
+        sim.step();
+        if let Some(r) = sim.world().rider(rider) {
+            if matches!(r.phase(), RiderPhase::Riding(_)) {
+                break;
+            }
+        }
+    }
+
+    let riding_eid = match sim.world().rider(rider).unwrap().phase() {
+        RiderPhase::Riding(eid) => eid,
+        other => panic!("expected Riding, got {other}"),
+    };
+
+    // Confirm rider is in elevator's list.
+    assert!(
+        sim.world()
+            .elevator(riding_eid)
+            .unwrap()
+            .riders()
+            .contains(&rider)
+    );
+
+    sim.despawn_rider(rider).unwrap();
+
+    // Elevator should no longer reference the rider.
+    assert!(
+        !sim.world()
+            .elevator(riding_eid)
+            .unwrap()
+            .riders()
+            .contains(&rider)
+    );
+}
+
+#[test]
+fn full_lifecycle_spawn_ride_settle_reroute_ride_despawn() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    // Trip 1: Ground → Floor 3.
+    let rider = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    let origin = sim.stop_entity(StopId(0)).unwrap();
+    assert!(sim.waiting_at(origin).any(|id| id == rider));
+
+    run_until_arrived(&mut sim, rider);
+
+    // Settle at Floor 3.
+    sim.settle_rider(rider).unwrap();
+    let floor3 = sim.world().rider(rider).unwrap().current_stop().unwrap();
+    assert!(sim.residents_at(floor3).any(|id| id == rider));
+    assert_eq!(sim.metrics().total_settled(), 1);
+
+    // Reroute back to Ground.
+    let ground = sim.stop_entity(StopId(0)).unwrap();
+    let route = Route::direct(floor3, ground, GroupId(0));
+    sim.reroute_rider(rider, route).unwrap();
+    assert_eq!(sim.metrics().total_rerouted(), 1);
+
+    assert!(sim.waiting_at(floor3).any(|id| id == rider));
+    assert!(!sim.residents_at(floor3).any(|id| id == rider));
+
+    // Trip 2: ride back to Ground.
+    run_until_arrived(&mut sim, rider);
+
+    // Despawn.
+    sim.despawn_rider(rider).unwrap();
+    assert!(!sim.world().is_alive(rider));
+}
+
+#[test]
+fn resident_invisible_to_loading_system() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    // Spawn rider Ground → Floor 3, run until arrived, settle.
+    let rider = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    run_until_arrived(&mut sim, rider);
+    sim.settle_rider(rider).unwrap();
+    sim.drain_events();
+
+    // Run many more ticks — resident should NOT board any elevator.
+    for _ in 0..1000 {
+        sim.step();
+    }
+
+    let r = sim.world().rider(rider).unwrap();
+    assert_eq!(
+        r.phase(),
+        RiderPhase::Resident,
+        "Resident should not have boarded"
+    );
+}
+
+#[test]
+fn dispatch_manifest_includes_resident_counts() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    // Spawn and deliver 2 riders to Floor 3.
+    let r1 = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    run_until_arrived(&mut sim, r1);
+    sim.settle_rider(r1).unwrap();
+
+    let r2 = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    run_until_arrived(&mut sim, r2);
+    sim.settle_rider(r2).unwrap();
+
+    let floor3 = sim.world().rider(r1).unwrap().current_stop().unwrap();
+    assert_eq!(sim.resident_count_at(floor3), 2);
+}
+
+#[test]
+fn patience_reset_on_reroute() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let rider = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    sim.world_mut().set_patience(
+        rider,
+        crate::components::Patience {
+            max_wait_ticks: 1000,
+            waited_ticks: 500,
+        },
+    );
+
+    run_until_arrived(&mut sim, rider);
+    sim.settle_rider(rider).unwrap();
+
+    let stop = sim.world().rider(rider).unwrap().current_stop().unwrap();
+    let dest = sim.stop_entity(StopId(0)).unwrap();
+    let route = Route::direct(stop, dest, GroupId(0));
+    sim.reroute_rider(rider, route).unwrap();
+
+    // Patience should be reset.
+    let patience = sim.world().patience(rider).unwrap();
+    assert_eq!(patience.waited_ticks, 0);
+}
+
+#[test]
+fn snapshot_roundtrip_preserves_residents() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let rider = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    run_until_arrived(&mut sim, rider);
+    sim.settle_rider(rider).unwrap();
+
+    let stop = sim.world().rider(rider).unwrap().current_stop().unwrap();
+    assert_eq!(sim.resident_count_at(stop), 1);
+
+    // Snapshot and restore.
+    let snapshot = sim.snapshot();
+    let restored = snapshot.restore(None);
+
+    // Verify residents are in the index after restore.
+    // Entity IDs may be remapped, so find the resident rider.
+    let resident_riders: Vec<_> = restored
+        .world()
+        .iter_riders()
+        .filter(|(_, r)| r.phase() == RiderPhase::Resident)
+        .collect();
+    assert_eq!(resident_riders.len(), 1);
+
+    let (new_rider_id, r) = resident_riders[0];
+    let new_stop = r.current_stop().unwrap();
+    assert_eq!(restored.resident_count_at(new_stop), 1);
+    assert!(restored.residents_at(new_stop).any(|id| id == new_rider_id));
+}

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -30,18 +30,18 @@ The library uses several identity types, and it is important to understand which
 
 ## The tick loop
 
-Each call to `sim.step()` runs one simulation tick. A tick consists of six phases, always executed in this order:
+Each call to `sim.step()` runs one simulation tick. A tick consists of seven phases, always executed in this order:
 
 ```text
-+-------------------+   +------------+   +------------+
-| Advance           |-->| Dispatch   |-->| Movement   |
-| Transient         |   |            |   |            |
-+-------------------+   +------------+   +------------+
-                                              |
-+-------------------+   +------------+   +------------+
-| Metrics           |<--| Loading    |<--| Doors      |
-|                   |   |            |   |            |
-+-------------------+   +------------+   +------------+
++-------------------+   +------------+   +--------------+   +------------+
+| Advance           |-->| Dispatch   |-->| Reposition   |-->| Movement   |
+| Transient         |   |            |   |              |   |            |
++-------------------+   +------------+   +--------------+   +------------+
+                                                                  |
+          +-------------------+   +------------+   +------------+
+          | Metrics           |<--| Loading    |<--| Doors      |
+          |                   |   |            |   |            |
+          +-------------------+   +------------+   +------------+
 ```
 
 ### Phase 1: Advance Transient
@@ -58,13 +58,17 @@ The dispatch strategy examines all idle elevators and waiting riders, then decid
 
 The default strategy is SCAN (sweep end-to-end). You can swap in LOOK, NearestCar, ETD, or your own custom strategy -- see [Dispatch Strategies](dispatch.md).
 
-### Phase 3: Movement
+### Phase 3: Reposition
+
+Optional phase; idle elevators are repositioned for better coverage via the `RepositionStrategy`. Only runs if at least one group has a strategy configured.
+
+### Phase 4: Movement
 
 Elevators with a target stop are moved along the shaft axis using a **trapezoidal velocity profile**: accelerate up to max speed, cruise, then decelerate to stop precisely at the target position. This produces realistic motion without requiring complex physics.
 
 When an elevator arrives at its target stop, it emits an `ElevatorArrived` event and transitions to the door-opening state.
 
-### Phase 4: Doors
+### Phase 5: Doors
 
 The door finite-state machine ticks for each elevator. Doors transition through:
 
@@ -74,7 +78,7 @@ Closed -> Opening (transition ticks) -> Open (hold ticks) -> Closing (transition
 
 `DoorOpened` and `DoorClosed` events fire at the appropriate moments. Riders can only board or exit when the doors are fully open.
 
-### Phase 5: Loading
+### Phase 6: Loading
 
 While an elevator's doors are open at a stop:
 - **Exiting**: riders whose destination matches the current stop exit the elevator.
@@ -82,7 +86,7 @@ While an elevator's doors are open at a stop:
 
 Riders that exceed the elevator's remaining capacity are rejected with a `RiderRejected` event.
 
-### Phase 6: Metrics
+### Phase 7: Metrics
 
 Events from the current tick are processed to update aggregate metrics -- average wait time, ride time, throughput, abandonment rate, and total distance. Tagged metrics (per-zone or per-label breakdowns) are also updated here.
 
@@ -92,8 +96,14 @@ A rider moves through these phases:
 
 ```text
 Waiting --> Boarding --> Riding --> Exiting --> Arrived
-                                                   |
-Waiting ----> Abandoned (gave up waiting)    (despawned)
+   ^                                              |
+   |                          settle_rider() --> Resident
+   |                                              |
+   +------------- reroute_rider() ----------------+
+
+Waiting ----> Abandoned (patience expired)
+                  |
+                  +--> settle_rider() --> Resident
 ```
 
 | Phase | Where is the rider? | What triggers the transition? |
@@ -102,10 +112,31 @@ Waiting ----> Abandoned (gave up waiting)    (despawned)
 | `Boarding` | Being loaded into the elevator | Advance Transient phase (next tick) |
 | `Riding` | Inside the elevator | Elevator arrives at destination, doors open, loading phase exits them |
 | `Exiting` | Exiting the elevator | Advance Transient phase (next tick) |
-| `Arrived` | Done | Game can despawn or ignore |
-| `Abandoned` | Left the stop | Patience ran out (if configured) |
+| `Arrived` | Reached final destination | Consumer decides: settle (-> Resident), despawn, or leave |
+| `Abandoned` | Left the stop | Patience ran out; consumer can settle or despawn |
+| `Resident` | Parked at a stop, not seeking an elevator | Consumer calls `settle_rider()` on an Arrived or Abandoned rider |
 
-Each transition emits an event: `RiderSpawned`, `RiderBoarded`, `RiderExited`, `RiderAbandoned`.
+Each transition emits an event: `RiderSpawned`, `RiderBoarded`, `RiderExited`, `RiderAbandoned`, `RiderSettled`, `RiderRerouted`, `RiderDespawned`.
+
+### Population tracking
+
+Riders at each stop are tracked by a reverse index, enabling O(1) queries without scanning the full entity list.
+
+Three query methods provide population lookups:
+
+- `sim.residents_at(stop)` -- riders settled at a stop
+- `sim.waiting_at(stop)` -- riders waiting for an elevator at a stop
+- `sim.abandoned_at(stop)` -- riders who gave up waiting at a stop
+
+Each method has a corresponding count variant (e.g., `sim.residents_at(stop).len()`).
+
+Three lifecycle methods manage rider state transitions:
+
+- `sim.settle_rider(id)` -- transitions an Arrived or Abandoned rider to Resident
+- `sim.reroute_rider(id, route)` -- sends a Resident rider back to Waiting with a new route
+- `sim.despawn_rider(id)` -- removes the rider and updates all indexes
+
+Use `sim.despawn_rider(id)` instead of calling `world.despawn()` directly -- it keeps the stop index consistent.
 
 ## Elevator lifecycle
 
@@ -132,6 +163,7 @@ For advanced use cases, you can run individual phases instead of calling `step()
 # let mut sim = SimulationBuilder::new().build()?;
 sim.run_advance_transient();
 sim.run_dispatch();
+sim.run_reposition();
 sim.run_movement();
 sim.run_doors();
 sim.run_loading();

--- a/docs/src/metrics-and-events.md
+++ b/docs/src/metrics-and-events.md
@@ -18,6 +18,9 @@ Events are emitted during the tick phases. Here are the main categories:
 | `DoorClosed { elevator, tick }` | Doors finish closing |
 | `PassingFloor { elevator, stop, moving_up, tick }` | An elevator passes a stop without stopping |
 | `ElevatorAssigned { elevator, stop, tick }` | Dispatch assigns an elevator to a stop |
+| `ElevatorRepositioning { elevator, to_stop, tick }` | An idle elevator begins repositioning |
+| `ElevatorRepositioned { elevator, at_stop, tick }` | An elevator completed repositioning |
+| `ElevatorIdle { elevator, at_stop, tick }` | An elevator became idle |
 
 **Rider events:**
 
@@ -29,6 +32,9 @@ Events are emitted during the tick phases. Here are the main categories:
 | `RiderRejected { rider, elevator, reason, context, tick }` | A rider was refused boarding (over capacity) |
 | `RiderAbandoned { rider, stop, tick }` | A rider gave up waiting |
 | `RiderEjected { rider, elevator, stop, tick }` | A rider was ejected (elevator disabled) |
+| `RiderSettled { rider, stop, tick }` | A rider settled at a stop as a resident |
+| `RiderDespawned { rider, tick }` | A rider was removed from the simulation |
+| `RiderRerouted { rider, new_destination, tick }` | A rider was manually rerouted via `sim.reroute()` or `sim.reroute_rider()` |
 
 **Topology events:**
 
@@ -39,7 +45,10 @@ Events are emitted during the tick phases. Here are the main categories:
 | `EntityDisabled { entity, tick }` | An entity was disabled |
 | `EntityEnabled { entity, tick }` | An entity was re-enabled |
 | `RouteInvalidated { rider, affected_stop, reason, tick }` | A rider's route was broken by a topology change |
-| `RiderRerouted { rider, new_destination, tick }` | A rider was manually rerouted |
+| `LineAdded { line, group, tick }` | A line was added |
+| `LineRemoved { line, group, tick }` | A line was removed |
+| `LineReassigned { line, old_group, new_group, tick }` | A line was moved between groups |
+| `ElevatorReassigned { elevator, old_line, new_line, tick }` | An elevator was moved between lines |
 
 ### Draining events
 
@@ -127,6 +136,8 @@ println!("Throughput:        {} riders/window", m.throughput());
 println!("Total delivered:   {}", m.total_delivered());
 println!("Total spawned:     {}", m.total_spawned());
 println!("Total abandoned:   {}", m.total_abandoned());
+println!("Total settled:     {}", m.total_settled());
+println!("Total rerouted:    {}", m.total_rerouted());
 println!("Abandonment rate:  {:.1}%", m.abandonment_rate() * 100.0);
 println!("Total distance:    {:.1} units", m.total_distance());
 # }
@@ -144,7 +155,11 @@ println!("Total distance:    {:.1} units", m.total_distance());
 | `total_spawned()` | Cumulative riders spawned |
 | `total_abandoned()` | Cumulative riders who gave up waiting |
 | `abandonment_rate()` | `total_abandoned / total_spawned` (0.0 to 1.0) |
+| `total_settled()` | Cumulative riders settled as residents |
+| `total_rerouted()` | Cumulative riders rerouted from resident phase |
 | `total_distance()` | Sum of all elevator travel distance |
+| `utilization_by_group()` | Per-group fraction of elevators currently moving |
+| `reposition_distance()` | Total elevator distance traveled while repositioning |
 
 Metrics are updated during the Metrics phase of each tick. They are always available and always reflect the latest tick, regardless of whether you drain events.
 


### PR DESCRIPTION
## Summary

- Add `RiderPhase::Resident` — riders parked at stops, invisible to dispatch/loading, queryable via population APIs
- Add `RiderIndex` — phase-partitioned reverse index (`BTreeMap<EntityId, BTreeSet<EntityId>>`) for O(1) population queries per stop
- Add `settle_rider()`, `reroute_rider()`, `despawn_rider()` lifecycle methods on `Simulation`
- Add `residents_at()`, `waiting_at()`, `abandoned_at()` + count variants — O(1) iterators
- Add `Event::RiderSettled`, `Event::RiderDespawned`, `Route::final_destination()`
- Add `DispatchManifest::resident_count_at()` as read-only hint for smart dispatch strategies
- Add `Metrics::total_settled()`, `Metrics::total_rerouted()`
- Wire index updates into all phase transition sites (spawn, board, exit, arrive, abandon, settle, reroute, despawn, eject, route invalidation)
- Update existing `despawn` tests to use `sim.despawn_rider()` instead of `world.despawn()`

## Design

Enables three game archetypes without baking in assumptions:
- **SimTower**: settle arrived riders as residents, reroute them for commute patterns
- **Elevator Saga**: despawn arrived riders immediately, no population memory
- **RimWorld**: reroute persistent colonist entities via game AI

## Test plan

- [x] 12 new tests covering settle/reroute/despawn happy paths, error cases, full lifecycle, loading invisibility, dispatch manifest, patience reset, snapshot round-trip
- [x] All 248 existing tests pass (no regressions)
- [x] Zero clippy warnings
- [x] Full workspace builds clean (elevator-core + elevator-bevy)
- [x] Pre-commit hooks pass (fmt, clippy, tests)