### PR TITLE
chore: revert manual release, let release-please manage versioning

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "crates/elevator-core": "3.1.0"
+  "crates/elevator-core": "3.0.0"
 }

--- a/crates/elevator-core/CHANGELOG.md
+++ b/crates/elevator-core/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Changelog
 
-## [3.1.0](https://github.com/andymai/elevator-core/compare/elevator-core-v3.0.0...elevator-core-v3.1.0) (2026-04-13)
-
-
-### Features
-
-* add Resident phase, population tracking, and rider lifecycle management ([#13](https://github.com/andymai/elevator-core/pull/13)) ([16d09d7](https://github.com/andymai/elevator-core/commit/16d09d7))
-* add observability, query ergonomics, traffic schedules, and test coverage ([e29c930](https://github.com/andymai/elevator-core/commit/e29c930))
-
 ## [3.0.0](https://github.com/andymai/elevator-core/compare/elevator-core-v2.0.0...elevator-core-v3.0.0) (2026-04-13)
 
 

--- a/crates/elevator-core/Cargo.toml
+++ b/crates/elevator-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elevator-core"
-version = "3.1.0" # managed by release-please
+version = "3.0.0" # managed by release-please
 edition.workspace = true
 description = "Engine-agnostic elevator simulation library with pluggable dispatch strategies"
 license.workspace = true


### PR DESCRIPTION
Reverts the manual 3.1.0 bump so release-please can generate its own release PR with proper Trusted Publishing.