### PR TITLE
refactor!: review and tighten elevator-core public API

### DIFF
--- a/crates/elevator-core/examples/showcase.rs
+++ b/crates/elevator-core/examples/showcase.rs
@@ -16,6 +16,7 @@ use elevator_core::config::{
     BuildingConfig, ElevatorConfig, PassengerSpawnConfig, SimConfig, SimulationParams,
 };
 use elevator_core::dispatch::etd::EtdDispatch;
+use elevator_core::hooks::Phase;
 use elevator_core::prelude::*;
 use elevator_core::stop::StopConfig;
 use serde::{Deserialize, Serialize};

--- a/crates/elevator-core/src/dispatch/look.rs
+++ b/crates/elevator-core/src/dispatch/look.rs
@@ -15,7 +15,7 @@ const EPSILON: f64 = 1e-9;
 /// Direction of travel.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
-pub enum Direction {
+pub(crate) enum Direction {
     /// Traveling upward (increasing position).
     Up,
     /// Traveling downward (decreasing position).

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -4,6 +4,9 @@
 //!
 //! ```rust
 //! use elevator_core::prelude::*;
+//! use elevator_core::dispatch::{
+//!     DispatchDecision, DispatchManifest, ElevatorGroup,
+//! };
 //!
 //! struct AlwaysFirstStop;
 //!
@@ -38,6 +41,11 @@ pub mod nearest_car;
 pub mod reposition;
 /// SCAN dispatch algorithm.
 pub mod scan;
+
+pub use etd::EtdDispatch;
+pub use look::LookDispatch;
+pub use nearest_car::NearestCarDispatch;
+pub use scan::ScanDispatch;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -227,12 +227,12 @@ impl LineInfo {
     }
 
     /// Mutable access to elevator entities on this line.
-    pub const fn elevators_mut(&mut self) -> &mut Vec<EntityId> {
+    pub(crate) const fn elevators_mut(&mut self) -> &mut Vec<EntityId> {
         &mut self.elevators
     }
 
     /// Mutable access to stop entities served by this line.
-    pub const fn serves_mut(&mut self) -> &mut Vec<EntityId> {
+    pub(crate) const fn serves_mut(&mut self) -> &mut Vec<EntityId> {
         &mut self.serves
     }
 }

--- a/crates/elevator-core/src/dispatch/reposition.rs
+++ b/crates/elevator-core/src/dispatch/reposition.rs
@@ -4,6 +4,7 @@
 //!
 //! ```rust
 //! use elevator_core::prelude::*;
+//! use elevator_core::dispatch::BuiltinReposition;
 //!
 //! let sim = SimulationBuilder::new()
 //!     .reposition(SpreadEvenly, BuiltinReposition::SpreadEvenly)

--- a/crates/elevator-core/src/dispatch/scan.rs
+++ b/crates/elevator-core/src/dispatch/scan.rs
@@ -15,7 +15,7 @@ const EPSILON: f64 = 1e-9;
 /// Direction of travel for the SCAN algorithm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
-pub enum ScanDirection {
+pub(crate) enum ScanDirection {
     /// Traveling upward (increasing position).
     Up,
     /// Traveling downward (decreasing position).

--- a/crates/elevator-core/src/energy.rs
+++ b/crates/elevator-core/src/energy.rs
@@ -118,7 +118,7 @@ impl EnergyMetrics {
 /// - Moving: consumed = `move_cost_per_tick + weight_factor * current_load`.
 /// - Moving downward (velocity < 0): regenerated = `consumed * regen_factor`.
 #[must_use]
-pub fn compute_tick_energy(
+pub(crate) fn compute_tick_energy(
     profile: &EnergyProfile,
     is_moving: bool,
     current_load: f64,

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -326,6 +326,32 @@ pub enum Event {
         /// The tick when it became idle.
         tick: u64,
     },
+
+    /// An elevator was permanently removed from the simulation.
+    ///
+    /// Distinct from [`EntityDisabled`] — a disabled elevator can be
+    /// re-enabled, but a removed elevator is despawned.
+    ElevatorRemoved {
+        /// The elevator that was removed.
+        elevator: EntityId,
+        /// The line it belonged to.
+        line: EntityId,
+        /// The group it belonged to.
+        group: GroupId,
+        /// The tick when removal occurred.
+        tick: u64,
+    },
+
+    /// A stop was permanently removed from the simulation.
+    ///
+    /// Distinct from [`EntityDisabled`] — a disabled stop can be
+    /// re-enabled, but a removed stop is despawned.
+    StopRemoved {
+        /// The stop that was removed.
+        stop: EntityId,
+        /// The tick when removal occurred.
+        tick: u64,
+    },
 }
 
 /// Reason a rider's route was invalidated.

--- a/crates/elevator-core/src/hooks.rs
+++ b/crates/elevator-core/src/hooks.rs
@@ -4,6 +4,7 @@
 //!
 //! ```rust
 //! use elevator_core::prelude::*;
+//! use elevator_core::hooks::Phase;
 //!
 //! let mut sim = SimulationBuilder::new()
 //!     .before(Phase::Dispatch, |world| {

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -14,7 +14,7 @@
 //!   [`dispatch::etd::EtdDispatch`]) plus the [`dispatch::DispatchStrategy`] trait
 //!   for custom implementations.
 //! - **Trapezoidal motion profiles** — realistic acceleration, cruise, and
-//!   deceleration computed per-tick in the [`movement`] module.
+//!   deceleration computed per-tick.
 //! - **Extension components** — attach arbitrary `Serialize + DeserializeOwned`
 //!   data to any entity via [`world::World::insert_ext`] without modifying the
 //!   library.
@@ -196,7 +196,7 @@ pub mod hooks;
 /// Aggregate simulation metrics.
 pub mod metrics;
 /// Trapezoidal velocity-profile movement math.
-pub mod movement;
+pub(crate) mod movement;
 /// Phase-partitioned reverse index for rider population queries.
 mod rider_index;
 /// Scenario replay from recorded event streams.
@@ -244,26 +244,15 @@ pub mod prelude {
     pub use crate::dispatch::reposition::{
         DemandWeighted, NearestIdle, ReturnToLobby, SpreadEvenly,
     };
-    pub use crate::dispatch::{
-        BuiltinReposition, BuiltinStrategy, DispatchDecision, DispatchManifest, DispatchStrategy,
-        RepositionStrategy, RiderInfo,
-    };
-    pub use crate::dispatch::{ElevatorGroup, LineInfo};
-    #[cfg(feature = "energy")]
-    pub use crate::energy::{EnergyMetrics, EnergyProfile};
+    pub use crate::dispatch::{DispatchStrategy, RepositionStrategy};
     pub use crate::entity::EntityId;
     pub use crate::error::{RejectionContext, RejectionReason, SimError};
-    pub use crate::events::{Event, EventBus, EventChannel, RouteInvalidReason};
-    pub use crate::hooks::Phase;
+    pub use crate::events::{Event, EventBus};
     pub use crate::ids::GroupId;
     pub use crate::metrics::Metrics;
-    pub use crate::sim::{ElevatorParams, LineParams, Simulation};
-    pub use crate::snapshot::WorldSnapshot;
+    pub use crate::sim::{RiderBuilder, Simulation};
     pub use crate::stop::StopId;
-    pub use crate::systems::PhaseContext;
-    pub use crate::tagged_metrics::{MetricTags, TaggedMetric};
     pub use crate::time::TimeAdapter;
-    pub use crate::topology::TopologyGraph;
 }
 
 #[cfg(test)]

--- a/crates/elevator-core/src/metrics.rs
+++ b/crates/elevator-core/src/metrics.rs
@@ -194,13 +194,13 @@ impl Metrics {
     // ── Recording ───────────────────���────────────────────────────────
 
     /// Record a rider spawning.
-    pub const fn record_spawn(&mut self) {
+    pub(crate) const fn record_spawn(&mut self) {
         self.total_spawned += 1;
     }
 
     /// Record a rider boarding. `wait_ticks` = `tick_boarded` - `tick_spawned`.
     #[allow(clippy::cast_precision_loss)] // rider counts fit in f64 mantissa
-    pub fn record_board(&mut self, wait_ticks: u64) {
+    pub(crate) fn record_board(&mut self, wait_ticks: u64) {
         self.boarded_count += 1;
         self.sum_wait_ticks += wait_ticks;
         self.avg_wait_time = self.sum_wait_ticks as f64 / self.boarded_count as f64;
@@ -211,7 +211,7 @@ impl Metrics {
 
     /// Record a rider exiting. `ride_ticks` = `tick_exited` - `tick_boarded`.
     #[allow(clippy::cast_precision_loss)] // rider counts fit in f64 mantissa
-    pub fn record_delivery(&mut self, ride_ticks: u64, tick: u64) {
+    pub(crate) fn record_delivery(&mut self, ride_ticks: u64, tick: u64) {
         self.delivered_count += 1;
         self.total_delivered += 1;
         self.sum_ride_ticks += ride_ticks;
@@ -221,7 +221,7 @@ impl Metrics {
 
     /// Record a rider abandoning.
     #[allow(clippy::cast_precision_loss)] // rider counts fit in f64 mantissa
-    pub fn record_abandonment(&mut self) {
+    pub(crate) fn record_abandonment(&mut self) {
         self.total_abandoned += 1;
         if self.total_spawned > 0 {
             self.abandonment_rate = self.total_abandoned as f64 / self.total_spawned as f64;
@@ -229,22 +229,22 @@ impl Metrics {
     }
 
     /// Record a rider settling as a resident.
-    pub const fn record_settle(&mut self) {
+    pub(crate) const fn record_settle(&mut self) {
         self.total_settled += 1;
     }
 
     /// Record a resident rider being rerouted.
-    pub const fn record_reroute(&mut self) {
+    pub(crate) const fn record_reroute(&mut self) {
         self.total_rerouted += 1;
     }
 
     /// Record elevator distance traveled this tick.
-    pub fn record_distance(&mut self, distance: f64) {
+    pub(crate) fn record_distance(&mut self, distance: f64) {
         self.total_distance += distance;
     }
 
     /// Record elevator distance traveled while repositioning.
-    pub fn record_reposition_distance(&mut self, distance: f64) {
+    pub(crate) fn record_reposition_distance(&mut self, distance: f64) {
         self.reposition_distance += distance;
     }
 
@@ -257,7 +257,7 @@ impl Metrics {
 
     /// Update windowed throughput. Call once per tick.
     #[allow(clippy::cast_possible_truncation)] // window len always fits in u64
-    pub fn update_throughput(&mut self, current_tick: u64) {
+    pub(crate) fn update_throughput(&mut self, current_tick: u64) {
         let cutoff = current_tick.saturating_sub(self.throughput_window_ticks);
         // Delivery ticks are inserted in order, so expired entries are at the front.
         while self.delivery_window.front().is_some_and(|&t| t <= cutoff) {

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -1755,6 +1755,7 @@ impl Simulation {
         let _ = self.disable(elevator);
 
         // Find and remove from group/line topology.
+        let mut group_id = GroupId(0);
         if let Ok((group_idx, line_idx)) = self.find_line(line) {
             self.groups[group_idx].lines_mut()[line_idx]
                 .elevators_mut()
@@ -1762,11 +1763,18 @@ impl Simulation {
             self.groups[group_idx].rebuild_caches();
 
             // Notify dispatch strategy.
-            let group_id = self.groups[group_idx].id();
+            group_id = self.groups[group_idx].id();
             if let Some(dispatcher) = self.dispatchers.get_mut(&group_id) {
                 dispatcher.notify_removed(elevator);
             }
         }
+
+        self.events.emit(Event::ElevatorRemoved {
+            elevator,
+            line,
+            group: group_id,
+            tick: self.tick,
+        });
 
         // Despawn from world.
         self.world.despawn(elevator);
@@ -1808,6 +1816,11 @@ impl Simulation {
 
         // Remove from stop_lookup.
         self.stop_lookup.retain(|_, &mut eid| eid != stop);
+
+        self.events.emit(Event::StopRemoved {
+            stop,
+            tick: self.tick,
+        });
 
         // Despawn from world.
         self.world.despawn(stop);

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -1,8 +1,8 @@
 //! Top-level simulation runner and tick loop.
 
 use crate::components::{
-    Elevator, ElevatorPhase, FloorPosition, Line, Orientation, Position, Rider, RiderPhase, Route,
-    Stop, Velocity,
+    AccessControl, Elevator, ElevatorPhase, FloorPosition, Line, Orientation, Patience, Position,
+    Preferences, Rider, RiderPhase, Route, Stop, Velocity,
 };
 use crate::config::SimConfig;
 use crate::dispatch::{
@@ -94,6 +94,171 @@ impl LineParams {
             position: None,
             max_cars: None,
         }
+    }
+}
+
+/// Fluent builder for spawning riders with optional configuration.
+///
+/// Created via [`Simulation::build_rider`] or [`Simulation::build_rider_by_stop_id`].
+///
+/// ```
+/// use elevator_core::prelude::*;
+///
+/// let mut sim = SimulationBuilder::new().build().unwrap();
+/// let rider = sim.build_rider_by_stop_id(StopId(0), StopId(1))
+///     .unwrap()
+///     .weight(80.0)
+///     .spawn()
+///     .unwrap();
+/// ```
+pub struct RiderBuilder<'a> {
+    /// Mutable reference to the simulation (consumed on spawn).
+    sim: &'a mut Simulation,
+    /// Origin stop entity.
+    origin: EntityId,
+    /// Destination stop entity.
+    destination: EntityId,
+    /// Rider weight (default: 75.0).
+    weight: f64,
+    /// Explicit dispatch group (skips auto-detection).
+    group: Option<GroupId>,
+    /// Explicit multi-leg route.
+    route: Option<Route>,
+    /// Maximum wait ticks before abandoning.
+    patience: Option<u64>,
+    /// Boarding preferences.
+    preferences: Option<Preferences>,
+    /// Per-rider access control.
+    access_control: Option<AccessControl>,
+}
+
+impl RiderBuilder<'_> {
+    /// Set the rider's weight (default: 75.0).
+    #[must_use]
+    pub const fn weight(mut self, weight: f64) -> Self {
+        self.weight = weight;
+        self
+    }
+
+    /// Set the dispatch group explicitly, skipping auto-detection.
+    #[must_use]
+    pub const fn group(mut self, group: GroupId) -> Self {
+        self.group = Some(group);
+        self
+    }
+
+    /// Provide an explicit multi-leg route.
+    #[must_use]
+    pub fn route(mut self, route: Route) -> Self {
+        self.route = Some(route);
+        self
+    }
+
+    /// Set maximum wait ticks before the rider abandons.
+    #[must_use]
+    pub const fn patience(mut self, max_wait_ticks: u64) -> Self {
+        self.patience = Some(max_wait_ticks);
+        self
+    }
+
+    /// Set boarding preferences.
+    #[must_use]
+    pub const fn preferences(mut self, prefs: Preferences) -> Self {
+        self.preferences = Some(prefs);
+        self
+    }
+
+    /// Set per-rider access control (allowed stops).
+    #[must_use]
+    pub fn access_control(mut self, ac: AccessControl) -> Self {
+        self.access_control = Some(ac);
+        self
+    }
+
+    /// Spawn the rider with the configured options.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SimError::NoRoute`] if no group serves both stops (when auto-detecting).
+    /// Returns [`SimError::AmbiguousRoute`] if multiple groups serve both stops (when auto-detecting).
+    /// Returns [`SimError::GroupNotFound`] if an explicit group does not exist.
+    pub fn spawn(self) -> Result<EntityId, SimError> {
+        let route = if let Some(route) = self.route {
+            route
+        } else if let Some(group) = self.group {
+            if !self.sim.groups.iter().any(|g| g.id() == group) {
+                return Err(SimError::GroupNotFound(group));
+            }
+            Route::direct(self.origin, self.destination, group)
+        } else {
+            // Auto-detect group (same logic as spawn_rider).
+            let matching: Vec<GroupId> = self
+                .sim
+                .groups
+                .iter()
+                .filter(|g| {
+                    g.stop_entities().contains(&self.origin)
+                        && g.stop_entities().contains(&self.destination)
+                })
+                .map(ElevatorGroup::id)
+                .collect();
+
+            match matching.len() {
+                0 => {
+                    let origin_groups: Vec<GroupId> = self
+                        .sim
+                        .groups
+                        .iter()
+                        .filter(|g| g.stop_entities().contains(&self.origin))
+                        .map(ElevatorGroup::id)
+                        .collect();
+                    let destination_groups: Vec<GroupId> = self
+                        .sim
+                        .groups
+                        .iter()
+                        .filter(|g| g.stop_entities().contains(&self.destination))
+                        .map(ElevatorGroup::id)
+                        .collect();
+                    return Err(SimError::NoRoute {
+                        origin: self.origin,
+                        destination: self.destination,
+                        origin_groups,
+                        destination_groups,
+                    });
+                }
+                1 => Route::direct(self.origin, self.destination, matching[0]),
+                _ => {
+                    return Err(SimError::AmbiguousRoute {
+                        origin: self.origin,
+                        destination: self.destination,
+                        groups: matching,
+                    });
+                }
+            }
+        };
+
+        let eid = self
+            .sim
+            .spawn_rider_inner(self.origin, self.destination, self.weight, route);
+
+        // Apply optional components.
+        if let Some(max_wait) = self.patience {
+            self.sim.world.set_patience(
+                eid,
+                Patience {
+                    max_wait_ticks: max_wait,
+                    waited_ticks: 0,
+                },
+            );
+        }
+        if let Some(prefs) = self.preferences {
+            self.sim.world.set_preferences(eid, prefs);
+        }
+        if let Some(ac) = self.access_control {
+            self.sim.world.set_access_control(eid, ac);
+        }
+
+        Ok(eid)
     }
 }
 
@@ -952,6 +1117,81 @@ impl Simulation {
 
     // ── Rider spawning ───────────────────────────────────────────────
 
+    /// Create a rider builder for fluent rider spawning.
+    ///
+    /// ```
+    /// use elevator_core::prelude::*;
+    ///
+    /// let mut sim = SimulationBuilder::new().build().unwrap();
+    /// let s0 = sim.stop_entity(StopId(0)).unwrap();
+    /// let s1 = sim.stop_entity(StopId(1)).unwrap();
+    /// let rider = sim.build_rider(s0, s1)
+    ///     .weight(80.0)
+    ///     .spawn()
+    ///     .unwrap();
+    /// ```
+    pub const fn build_rider(
+        &mut self,
+        origin: EntityId,
+        destination: EntityId,
+    ) -> RiderBuilder<'_> {
+        RiderBuilder {
+            sim: self,
+            origin,
+            destination,
+            weight: 75.0,
+            group: None,
+            route: None,
+            patience: None,
+            preferences: None,
+            access_control: None,
+        }
+    }
+
+    /// Create a rider builder using config `StopId`s.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SimError::StopNotFound`] if either stop ID is unknown.
+    ///
+    /// ```
+    /// use elevator_core::prelude::*;
+    ///
+    /// let mut sim = SimulationBuilder::new().build().unwrap();
+    /// let rider = sim.build_rider_by_stop_id(StopId(0), StopId(1))
+    ///     .unwrap()
+    ///     .weight(80.0)
+    ///     .spawn()
+    ///     .unwrap();
+    /// ```
+    pub fn build_rider_by_stop_id(
+        &mut self,
+        origin: StopId,
+        destination: StopId,
+    ) -> Result<RiderBuilder<'_>, SimError> {
+        let origin_eid = self
+            .stop_lookup
+            .get(&origin)
+            .copied()
+            .ok_or(SimError::StopNotFound(origin))?;
+        let dest_eid = self
+            .stop_lookup
+            .get(&destination)
+            .copied()
+            .ok_or(SimError::StopNotFound(destination))?;
+        Ok(RiderBuilder {
+            sim: self,
+            origin: origin_eid,
+            destination: dest_eid,
+            weight: 75.0,
+            group: None,
+            route: None,
+            patience: None,
+            preferences: None,
+            access_control: None,
+        })
+    }
+
     /// Spawn a rider at the given origin stop entity, headed to destination stop entity.
     ///
     /// Auto-detects the elevator group by finding groups that serve both origin
@@ -1208,6 +1448,40 @@ impl Simulation {
         std::mem::take(&mut self.pending_output)
     }
 
+    /// Drain only events matching a predicate.
+    ///
+    /// Events that don't match the predicate remain in the buffer
+    /// and will be returned by future `drain_events` or
+    /// `drain_events_where` calls.
+    ///
+    /// ```
+    /// use elevator_core::prelude::*;
+    ///
+    /// let mut sim = SimulationBuilder::new().build().unwrap();
+    /// sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0).unwrap();
+    /// sim.step();
+    ///
+    /// let spawns: Vec<Event> = sim.drain_events_where(|e| {
+    ///     matches!(e, Event::RiderSpawned { .. })
+    /// });
+    /// ```
+    pub fn drain_events_where(&mut self, predicate: impl Fn(&Event) -> bool) -> Vec<Event> {
+        // Flush bus into pending_output first.
+        self.pending_output.extend(self.events.drain());
+
+        let mut matched = Vec::new();
+        let mut remaining = Vec::new();
+        for event in std::mem::take(&mut self.pending_output) {
+            if predicate(&event) {
+                matched.push(event);
+            } else {
+                remaining.push(event);
+            }
+        }
+        self.pending_output = remaining;
+        matched
+    }
+
     // ── Dynamic topology ────────────────────────────────────────────
 
     /// Find the (`group_index`, `line_index`) for a line entity.
@@ -1459,6 +1733,88 @@ impl Simulation {
             group: group_id,
             tick: self.tick,
         });
+        Ok(())
+    }
+
+    /// Remove an elevator from the simulation.
+    ///
+    /// The elevator is disabled first (ejecting any riders), then removed
+    /// from its line and despawned from the world.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SimError::EntityNotFound`] if the elevator does not exist.
+    pub fn remove_elevator(&mut self, elevator: EntityId) -> Result<(), SimError> {
+        let line = self
+            .world
+            .elevator(elevator)
+            .ok_or(SimError::EntityNotFound(elevator))?
+            .line();
+
+        // Disable first to eject riders and reset state.
+        let _ = self.disable(elevator);
+
+        // Find and remove from group/line topology.
+        if let Ok((group_idx, line_idx)) = self.find_line(line) {
+            self.groups[group_idx].lines_mut()[line_idx]
+                .elevators_mut()
+                .retain(|&e| e != elevator);
+            self.groups[group_idx].rebuild_caches();
+
+            // Notify dispatch strategy.
+            let group_id = self.groups[group_idx].id();
+            if let Some(dispatcher) = self.dispatchers.get_mut(&group_id) {
+                dispatcher.notify_removed(elevator);
+            }
+        }
+
+        // Despawn from world.
+        self.world.despawn(elevator);
+
+        if let Ok(mut g) = self.topo_graph.lock() {
+            g.mark_dirty();
+        }
+        Ok(())
+    }
+
+    /// Remove a stop from the simulation.
+    ///
+    /// The stop is disabled first (invalidating routes that reference it),
+    /// then removed from all lines and despawned from the world.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SimError::EntityNotFound`] if the stop does not exist.
+    pub fn remove_stop(&mut self, stop: EntityId) -> Result<(), SimError> {
+        if self.world.stop(stop).is_none() {
+            return Err(SimError::EntityNotFound(stop));
+        }
+
+        // Disable first to invalidate routes referencing this stop.
+        let _ = self.disable(stop);
+
+        // Remove from all lines and groups.
+        for group in &mut self.groups {
+            for line_info in group.lines_mut() {
+                line_info.serves_mut().retain(|&s| s != stop);
+            }
+            group.rebuild_caches();
+        }
+
+        // Remove from SortedStops resource.
+        if let Some(sorted) = self.world.resource_mut::<crate::world::SortedStops>() {
+            sorted.0.retain(|&(_, s)| s != stop);
+        }
+
+        // Remove from stop_lookup.
+        self.stop_lookup.retain(|_, &mut eid| eid != stop);
+
+        // Despawn from world.
+        self.world.despawn(stop);
+
+        if let Ok(mut g) = self.topo_graph.lock() {
+            g.mark_dirty();
+        }
         Ok(())
     }
 
@@ -1721,6 +2077,13 @@ impl Simulation {
             .flat_map(ElevatorGroup::lines)
             .find(|li| li.elevators().contains(&elevator))
             .map(LineInfo::entity)
+    }
+
+    /// Iterate over elevators currently repositioning.
+    pub fn iter_repositioning_elevators(&self) -> impl Iterator<Item = EntityId> + '_ {
+        self.world
+            .iter_elevators()
+            .filter_map(|(id, _pos, car)| if car.repositioning() { Some(id) } else { None })
     }
 
     /// Get all line entities that serve a given stop.
@@ -2128,6 +2491,26 @@ impl Simulation {
     #[must_use]
     pub fn abandoned_count_at(&self, stop: EntityId) -> usize {
         self.rider_index.abandoned_count_at(stop)
+    }
+
+    /// Get the rider entities currently aboard an elevator.
+    ///
+    /// Returns an empty slice if the elevator does not exist.
+    #[must_use]
+    pub fn riders_on(&self, elevator: EntityId) -> &[EntityId] {
+        self.world
+            .elevator(elevator)
+            .map_or(&[], |car| car.riders())
+    }
+
+    /// Get the number of riders aboard an elevator.
+    ///
+    /// Returns 0 if the elevator does not exist.
+    #[must_use]
+    pub fn occupancy(&self, elevator: EntityId) -> usize {
+        self.world
+            .elevator(elevator)
+            .map_or(0, |car| car.riders().len())
     }
 
     // ── Entity lifecycle ────────────────────────────────────────────

--- a/crates/elevator-core/src/systems/advance_transient.rs
+++ b/crates/elevator-core/src/systems/advance_transient.rs
@@ -105,7 +105,7 @@ fn handle_exit(
 ///
 /// These transient states last exactly one tick so they're
 /// visible for one frame in the visualization.
-pub(crate) fn run(
+pub fn run(
     world: &mut World,
     events: &mut EventBus,
     ctx: &PhaseContext,

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -15,7 +15,7 @@ use std::collections::BTreeMap;
 use super::PhaseContext;
 
 /// Assign idle/stopped elevators to stops via the dispatch strategy.
-pub(crate) fn run(
+pub fn run(
     world: &mut World,
     events: &mut EventBus,
     ctx: &PhaseContext,

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -304,7 +304,7 @@ fn apply_actions(
 }
 
 /// One rider boards or exits per tick per elevator.
-pub(crate) fn run(
+pub fn run(
     world: &mut World,
     events: &mut EventBus,
     ctx: &PhaseContext,

--- a/crates/elevator-core/src/systems/mod.rs
+++ b/crates/elevator-core/src/systems/mod.rs
@@ -1,22 +1,22 @@
 //! Tick-loop system phases run in sequence each simulation step.
 
 /// Advance transient states (boarding/exiting) to their next state.
-pub mod advance_transient;
+pub(crate) mod advance_transient;
 /// Assign idle elevators to stops via dispatch strategy.
-pub mod dispatch;
+pub(crate) mod dispatch;
 /// Door open/close finite-state machine progression.
-pub mod doors;
+pub(crate) mod doors;
 /// Per-tick energy consumption and regeneration tracking.
 #[cfg(feature = "energy")]
-pub mod energy;
+pub(crate) mod energy;
 /// Board and exit riders at stops.
-pub mod loading;
+pub(crate) mod loading;
 /// Aggregate metrics collection.
-pub mod metrics;
+pub(crate) mod metrics;
 /// Trapezoidal-profile elevator movement.
-pub mod movement;
+pub(crate) mod movement;
 /// Reposition idle elevators for coverage.
-pub mod reposition;
+pub(crate) mod reposition;
 
 /// Context passed to every system phase.
 #[derive(Debug, Clone, Copy)]

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -1,0 +1,929 @@
+//! Tests for the new public API surface: remove_elevator, remove_stop,
+//! drain_events_where, riders_on, occupancy, iter_repositioning_elevators,
+//! RiderBuilder, and dispatch re-exports.
+
+use super::helpers::{default_config, scan};
+use crate::builder::SimulationBuilder;
+use crate::components::{AccessControl, Preferences, RiderPhase};
+use crate::dispatch::BuiltinReposition;
+use crate::dispatch::reposition::ReturnToLobby;
+use crate::dispatch::{EtdDispatch, LookDispatch, NearestCarDispatch, ScanDispatch};
+use crate::entity::EntityId;
+use crate::error::SimError;
+use crate::events::Event;
+use crate::ids::GroupId;
+use crate::sim::Simulation;
+use crate::stop::{StopConfig, StopId};
+use std::collections::HashSet;
+
+// ── remove_elevator ───────────────────────────────────────────────────────────
+
+#[test]
+fn remove_elevator_despawns_from_world() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let elevator_id = sim.groups()[0].elevator_entities()[0];
+
+    // Elevator is alive before removal.
+    assert!(sim.world().elevator(elevator_id).is_some());
+
+    sim.remove_elevator(elevator_id).unwrap();
+
+    // Elevator is gone from the world.
+    assert!(sim.world().elevator(elevator_id).is_none());
+}
+
+#[test]
+fn remove_elevator_removes_from_group_cache() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let elevator_id = sim.groups()[0].elevator_entities()[0];
+    assert!(sim.groups()[0].elevator_entities().contains(&elevator_id));
+
+    sim.remove_elevator(elevator_id).unwrap();
+
+    assert!(!sim.groups()[0].elevator_entities().contains(&elevator_id));
+}
+
+#[test]
+fn remove_elevator_ejects_riders_aboard() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    // Spawn a rider and let it board.
+    let rider_id = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    // Run enough ticks for the rider to board.
+    for _ in 0..300 {
+        sim.step();
+        let phase = sim.world().rider(rider_id).unwrap().phase;
+        if matches!(phase, RiderPhase::Riding(_)) {
+            break;
+        }
+    }
+
+    let elevator_id = sim.groups()[0].elevator_entities()[0];
+    let is_riding = matches!(
+        sim.world().rider(rider_id).unwrap().phase,
+        RiderPhase::Riding(_)
+    );
+
+    if is_riding {
+        // Rider is aboard — removing elevator should eject the rider.
+        sim.remove_elevator(elevator_id).unwrap();
+        sim.drain_events(); // consume events
+
+        let phase = sim.world().rider(rider_id).unwrap().phase;
+        // After ejection, rider is put back to Waiting.
+        assert!(
+            matches!(phase, RiderPhase::Waiting),
+            "rider should be Waiting after elevator removal, got {phase:?}"
+        );
+    } else {
+        // Rider didn't board yet — just verify removal succeeds cleanly.
+        sim.remove_elevator(elevator_id).unwrap();
+    }
+}
+
+#[test]
+fn remove_elevator_ejects_rider_emits_event() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    sim.drain_events();
+
+    let rider_id = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    // Run until rider is riding.
+    for _ in 0..300 {
+        sim.step();
+        if matches!(
+            sim.world().rider(rider_id).unwrap().phase,
+            RiderPhase::Riding(_)
+        ) {
+            break;
+        }
+    }
+
+    let elevator_id = sim.groups()[0].elevator_entities()[0];
+
+    if matches!(
+        sim.world().rider(rider_id).unwrap().phase,
+        RiderPhase::Riding(_)
+    ) {
+        sim.remove_elevator(elevator_id).unwrap();
+        let events = sim.drain_events();
+
+        let ejected = events
+            .iter()
+            .any(|e| matches!(e, Event::RiderEjected { rider, .. } if *rider == rider_id));
+        assert!(
+            ejected,
+            "should emit RiderEjected when removing elevator with rider aboard"
+        );
+    }
+}
+
+#[test]
+fn remove_nonexistent_elevator_returns_entity_not_found() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let fake_id = EntityId::default();
+    let result = sim.remove_elevator(fake_id);
+    assert!(
+        matches!(result, Err(SimError::EntityNotFound(_))),
+        "expected EntityNotFound, got {result:?}"
+    );
+}
+
+// ── remove_stop ───────────────────────────────────────────────────────────────
+
+#[test]
+fn remove_stop_despawns_from_world() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let stop_id = sim.stop_entity(StopId(2)).unwrap();
+    assert!(sim.world().stop(stop_id).is_some());
+
+    sim.remove_stop(stop_id).unwrap();
+
+    assert!(sim.world().stop(stop_id).is_none());
+}
+
+#[test]
+fn remove_stop_removes_from_group_stop_cache() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let stop_id = sim.stop_entity(StopId(2)).unwrap();
+    assert!(sim.groups()[0].stop_entities().contains(&stop_id));
+
+    sim.remove_stop(stop_id).unwrap();
+
+    assert!(!sim.groups()[0].stop_entities().contains(&stop_id));
+}
+
+#[test]
+fn remove_stop_removes_from_stop_lookup() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let stop_id = sim.stop_entity(StopId(2)).unwrap();
+    assert!(stop_id != EntityId::default());
+
+    sim.remove_stop(stop_id).unwrap();
+
+    // After removal, stop_entity should return None.
+    let after = sim.stop_entity(StopId(2));
+    assert!(
+        after.is_none(),
+        "stop_entity should return None after removal"
+    );
+}
+
+#[test]
+fn remove_stop_with_waiting_rider_invalidates_route() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    sim.drain_events();
+
+    // Spawn a rider targeting stop 2.
+    let rider_id = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    // Ensure the rider is in Waiting phase (before boarding).
+    let phase = sim.world().rider(rider_id).unwrap().phase;
+    assert_eq!(phase, RiderPhase::Waiting);
+
+    // Remove the destination stop.
+    let stop2 = sim.stop_entity(StopId(2)).unwrap();
+    sim.remove_stop(stop2).unwrap();
+
+    let events = sim.drain_events();
+    // Removing a stop should emit RouteInvalidated for any rider whose route references it.
+    let invalidated = events
+        .iter()
+        .any(|e| matches!(e, Event::RouteInvalidated { rider, .. } if *rider == rider_id));
+    assert!(
+        invalidated,
+        "should emit RouteInvalidated for rider targeting the removed stop"
+    );
+}
+
+#[test]
+fn remove_nonexistent_stop_returns_entity_not_found() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let fake_id = EntityId::default();
+    let result = sim.remove_stop(fake_id);
+    assert!(
+        matches!(result, Err(SimError::EntityNotFound(_))),
+        "expected EntityNotFound, got {result:?}"
+    );
+}
+
+// ── drain_events_where ────────────────────────────────────────────────────────
+
+#[test]
+fn drain_events_where_returns_only_matching_events() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    // Spawn a rider to generate events.
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    // Run a few ticks to generate events.
+    for _ in 0..5 {
+        sim.step();
+    }
+
+    // Drain only ElevatorAssigned events.
+    let matched = sim.drain_events_where(|e| matches!(e, Event::ElevatorAssigned { .. }));
+
+    // All returned events must be ElevatorAssigned.
+    for e in &matched {
+        assert!(
+            matches!(e, Event::ElevatorAssigned { .. }),
+            "unexpected event in matched set: {e:?}"
+        );
+    }
+}
+
+#[test]
+fn drain_events_where_retains_non_matching_events() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    for _ in 0..5 {
+        sim.step();
+    }
+
+    // Count total events before the filter drain.
+    let total_before: Vec<Event> = {
+        // Peek via a drain of everything and then restore via drain_events_where(|_| true).
+        // Instead, drain all first and count.
+        sim.drain_events()
+    };
+    let total_count = total_before.len();
+
+    // Re-run for fresh events.
+    let config2 = default_config();
+    let mut sim2 = Simulation::new(&config2, scan()).unwrap();
+    sim2.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    for _ in 0..5 {
+        sim2.step();
+    }
+
+    let matched = sim2.drain_events_where(|e| matches!(e, Event::ElevatorAssigned { .. }));
+    let remaining = sim2.drain_events();
+
+    // matched + remaining == total events.
+    assert_eq!(
+        matched.len() + remaining.len(),
+        total_count,
+        "drain_events_where + drain_events should account for all events"
+    );
+
+    // None of the remaining events should be ElevatorAssigned.
+    for e in &remaining {
+        assert!(
+            !matches!(e, Event::ElevatorAssigned { .. }),
+            "ElevatorAssigned should have been drained already: {e:?}"
+        );
+    }
+}
+
+#[test]
+fn drain_events_where_with_no_match_returns_empty_and_retains_all() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    for _ in 0..5 {
+        sim.step();
+    }
+
+    let all_before = sim.drain_events();
+    let count_before = all_before.len();
+
+    // Re-run for fresh events.
+    let config2 = default_config();
+    let mut sim2 = Simulation::new(&config2, scan()).unwrap();
+    sim2.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    for _ in 0..5 {
+        sim2.step();
+    }
+
+    // Drain with a predicate that never matches.
+    let matched = sim2.drain_events_where(|_| false);
+    assert!(
+        matched.is_empty(),
+        "should return empty vec when nothing matches"
+    );
+
+    let remaining = sim2.drain_events();
+    assert_eq!(
+        remaining.len(),
+        count_before,
+        "all events should remain after a no-match drain"
+    );
+}
+
+// ── riders_on ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn riders_on_returns_empty_for_idle_elevator() {
+    let config = default_config();
+    let sim = Simulation::new(&config, scan()).unwrap();
+    let elevator_id = sim.groups()[0].elevator_entities()[0];
+    assert!(sim.riders_on(elevator_id).is_empty());
+}
+
+#[test]
+fn riders_on_returns_rider_ids_after_boarding() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let rider_id = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    let elevator_id = sim.groups()[0].elevator_entities()[0];
+
+    // Run until rider is riding.
+    for _ in 0..300 {
+        sim.step();
+        if matches!(
+            sim.world().rider(rider_id).unwrap().phase,
+            RiderPhase::Riding(_)
+        ) {
+            break;
+        }
+    }
+
+    if matches!(
+        sim.world().rider(rider_id).unwrap().phase,
+        RiderPhase::Riding(_)
+    ) {
+        assert!(
+            sim.riders_on(elevator_id).contains(&rider_id),
+            "rider should appear in riders_on after boarding"
+        );
+    }
+}
+
+#[test]
+fn riders_on_returns_empty_for_nonexistent_elevator() {
+    let config = default_config();
+    let sim = Simulation::new(&config, scan()).unwrap();
+    let fake_id = EntityId::default();
+    assert!(sim.riders_on(fake_id).is_empty());
+}
+
+// ── occupancy ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn occupancy_returns_zero_for_idle_elevator() {
+    let config = default_config();
+    let sim = Simulation::new(&config, scan()).unwrap();
+    let elevator_id = sim.groups()[0].elevator_entities()[0];
+    assert_eq!(sim.occupancy(elevator_id), 0);
+}
+
+#[test]
+fn occupancy_returns_correct_count_after_boarding() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let rider_id = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    let elevator_id = sim.groups()[0].elevator_entities()[0];
+
+    // Run until rider is riding.
+    for _ in 0..300 {
+        sim.step();
+        if matches!(
+            sim.world().rider(rider_id).unwrap().phase,
+            RiderPhase::Riding(_)
+        ) {
+            break;
+        }
+    }
+
+    if matches!(
+        sim.world().rider(rider_id).unwrap().phase,
+        RiderPhase::Riding(_)
+    ) {
+        assert_eq!(
+            sim.occupancy(elevator_id),
+            1,
+            "occupancy should be 1 after one rider boards"
+        );
+    }
+}
+
+#[test]
+fn occupancy_returns_zero_for_nonexistent_elevator() {
+    let config = default_config();
+    let sim = Simulation::new(&config, scan()).unwrap();
+    let fake_id = EntityId::default();
+    assert_eq!(sim.occupancy(fake_id), 0);
+}
+
+// ── iter_repositioning_elevators ──────────────────────────────────────────────
+
+#[test]
+fn iter_repositioning_elevators_empty_when_no_reposition() {
+    let config = default_config();
+    let sim = Simulation::new(&config, scan()).unwrap();
+    let repositioning: Vec<EntityId> = sim.iter_repositioning_elevators().collect();
+    assert!(
+        repositioning.is_empty(),
+        "no elevators should be repositioning without a reposition strategy"
+    );
+}
+
+#[test]
+fn iter_repositioning_elevators_returns_elevator_during_reposition() {
+    // Build a sim with ReturnToLobby reposition strategy.
+    // Elevator starts at stop 2 (top) and should reposition to stop 0 (lobby).
+    let mut sim = SimulationBuilder::new()
+        .stops(vec![
+            StopConfig {
+                id: StopId(0),
+                name: "Lobby".into(),
+                position: 0.0,
+            },
+            StopConfig {
+                id: StopId(1),
+                name: "Mid".into(),
+                position: 10.0,
+            },
+            StopConfig {
+                id: StopId(2),
+                name: "Top".into(),
+                position: 20.0,
+            },
+        ])
+        .elevator(crate::config::ElevatorConfig {
+            id: 0,
+            name: "A".into(),
+            max_speed: 2.0,
+            acceleration: 1.5,
+            deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(2),
+            door_open_ticks: 10,
+            door_transition_ticks: 5,
+            restricted_stops: Vec::new(),
+            #[cfg(feature = "energy")]
+            energy_profile: None,
+            service_mode: None,
+            inspection_speed_factor: 0.25,
+        })
+        .dispatch(EtdDispatch::new())
+        .reposition(ReturnToLobby::new(), BuiltinReposition::ReturnToLobby)
+        .build()
+        .unwrap();
+
+    sim.drain_events();
+    // First step triggers reposition.
+    sim.step();
+
+    let repositioning: Vec<EntityId> = sim.iter_repositioning_elevators().collect();
+    assert!(
+        !repositioning.is_empty(),
+        "elevator should be repositioning after first tick"
+    );
+
+    // Every ID returned must be a known elevator.
+    let elevator_ids = sim.world().elevator_ids();
+    for repo_id in &repositioning {
+        assert!(
+            elevator_ids.contains(repo_id),
+            "iter_repositioning_elevators returned an unknown elevator ID"
+        );
+    }
+}
+
+#[test]
+fn iter_repositioning_elevators_empty_after_reposition_completes() {
+    let mut sim = SimulationBuilder::new()
+        .stops(vec![
+            StopConfig {
+                id: StopId(0),
+                name: "Lobby".into(),
+                position: 0.0,
+            },
+            StopConfig {
+                id: StopId(1),
+                name: "Mid".into(),
+                position: 10.0,
+            },
+            StopConfig {
+                id: StopId(2),
+                name: "Top".into(),
+                position: 20.0,
+            },
+        ])
+        .elevator(crate::config::ElevatorConfig {
+            id: 0,
+            name: "A".into(),
+            max_speed: 2.0,
+            acceleration: 1.5,
+            deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(2),
+            door_open_ticks: 10,
+            door_transition_ticks: 5,
+            restricted_stops: Vec::new(),
+            #[cfg(feature = "energy")]
+            energy_profile: None,
+            service_mode: None,
+            inspection_speed_factor: 0.25,
+        })
+        .dispatch(EtdDispatch::new())
+        .reposition(ReturnToLobby::new(), BuiltinReposition::ReturnToLobby)
+        .build()
+        .unwrap();
+
+    // Run long enough for reposition to complete (20 units at 2.0 u/s).
+    for _ in 0..2000 {
+        sim.step();
+    }
+
+    let repositioning: Vec<EntityId> = sim.iter_repositioning_elevators().collect();
+    assert!(
+        repositioning.is_empty(),
+        "no elevators should be repositioning after arrival at home stop"
+    );
+}
+
+// ── RiderBuilder ──────────────────────────────────────────────────────────────
+
+#[test]
+fn rider_builder_basic_spawn() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let rider_id = sim
+        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .unwrap()
+        .spawn()
+        .unwrap();
+
+    let rider = sim.world().rider(rider_id).unwrap();
+    assert_eq!(rider.phase, RiderPhase::Waiting);
+}
+
+#[test]
+fn rider_builder_custom_weight() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let rider_id = sim
+        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .unwrap()
+        .weight(90.0)
+        .spawn()
+        .unwrap();
+
+    let rider = sim.world().rider(rider_id).unwrap();
+    assert!(
+        (rider.weight - 90.0).abs() < f64::EPSILON,
+        "rider weight should be 90.0, got {}",
+        rider.weight
+    );
+}
+
+#[test]
+fn rider_builder_with_explicit_group() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    // The default config has one group: GroupId(0).
+    let rider_id = sim
+        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .unwrap()
+        .group(GroupId(0))
+        .spawn()
+        .unwrap();
+
+    let rider = sim.world().rider(rider_id).unwrap();
+    assert_eq!(rider.phase, RiderPhase::Waiting);
+}
+
+#[test]
+fn rider_builder_with_patience() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let rider_id = sim
+        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .unwrap()
+        .patience(100)
+        .spawn()
+        .unwrap();
+
+    let patience = sim.world().patience(rider_id).unwrap();
+    assert_eq!(
+        patience.max_wait_ticks(),
+        100,
+        "patience max_wait_ticks should be 100"
+    );
+    assert_eq!(patience.waited_ticks(), 0);
+}
+
+#[test]
+fn rider_builder_with_preferences() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let prefs = Preferences {
+        skip_full_elevator: true,
+        max_crowding_factor: 0.5,
+    };
+
+    let rider_id = sim
+        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .unwrap()
+        .preferences(prefs)
+        .spawn()
+        .unwrap();
+
+    let stored = sim.world().preferences(rider_id).unwrap();
+    assert!(
+        stored.skip_full_elevator(),
+        "skip_full_elevator should be true"
+    );
+    assert!(
+        (stored.max_crowding_factor() - 0.5).abs() < f64::EPSILON,
+        "max_crowding_factor should be 0.5"
+    );
+}
+
+#[test]
+fn rider_builder_with_access_control() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let stop0 = sim.stop_entity(StopId(0)).unwrap();
+    let stop2 = sim.stop_entity(StopId(2)).unwrap();
+    let mut allowed = HashSet::new();
+    allowed.insert(stop0);
+    allowed.insert(stop2);
+    let ac = AccessControl::new(allowed.clone());
+
+    let rider_id = sim
+        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .unwrap()
+        .access_control(ac)
+        .spawn()
+        .unwrap();
+
+    let stored = sim.world().access_control(rider_id).unwrap();
+    assert!(
+        stored.can_access(stop0),
+        "rider should have access to stop 0"
+    );
+    assert!(
+        stored.can_access(stop2),
+        "rider should have access to stop 2"
+    );
+}
+
+#[test]
+fn rider_builder_invalid_stop_id_returns_stop_not_found() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let result = sim.build_rider_by_stop_id(StopId(0), StopId(99));
+    assert!(
+        matches!(result, Err(SimError::StopNotFound(StopId(99)))),
+        "expected StopNotFound(99)"
+    );
+}
+
+#[test]
+fn rider_builder_no_route_when_stops_not_in_same_group() {
+    // Build a sim with two separate groups, each with its own stops.
+    let mut sim = SimulationBuilder::new()
+        .stops(vec![
+            StopConfig {
+                id: StopId(0),
+                name: "A".into(),
+                position: 0.0,
+            },
+            StopConfig {
+                id: StopId(1),
+                name: "B".into(),
+                position: 10.0,
+            },
+        ])
+        .elevator(crate::config::ElevatorConfig {
+            id: 0,
+            name: "E1".into(),
+            max_speed: 2.0,
+            acceleration: 1.5,
+            deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 10,
+            door_transition_ticks: 5,
+            restricted_stops: Vec::new(),
+            #[cfg(feature = "energy")]
+            energy_profile: None,
+            service_mode: None,
+            inspection_speed_factor: 0.25,
+        })
+        .build()
+        .unwrap();
+
+    // Remove stop 1 from the group so it's unreachable.
+    let stop1 = sim.stop_entity(StopId(1)).unwrap();
+    // Remove stop 1 from all lines so it's no longer in the group cache.
+    sim.remove_stop(stop1).unwrap();
+
+    // Now attempting to build a rider from stop 0 to the removed stop1
+    // should fail because stop1 is no longer in the stop_lookup.
+    let result = sim.build_rider_by_stop_id(StopId(0), StopId(1));
+    assert!(
+        matches!(result, Err(SimError::StopNotFound(_))),
+        "expected StopNotFound after stop removed"
+    );
+}
+
+#[test]
+fn rider_builder_spawn_returns_no_route_when_group_not_serving_both_stops() {
+    // Build a sim, then spawn a rider using entity IDs directly against a group
+    // that doesn't serve the destination — by using the builder with a bad explicit group.
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    // GroupId(99) does not exist.
+    let result = sim
+        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .unwrap()
+        .group(GroupId(99))
+        .spawn();
+
+    assert!(
+        matches!(result, Err(SimError::GroupNotFound(GroupId(99)))),
+        "expected GroupNotFound(99), got {result:?}"
+    );
+}
+
+// ── Dispatch re-exports (compilation / import tests) ─────────────────────────
+
+#[test]
+fn dispatch_scan_resolves() {
+    let _: ScanDispatch = ScanDispatch::new();
+}
+
+#[test]
+fn dispatch_look_resolves() {
+    let _: LookDispatch = LookDispatch::new();
+}
+
+#[test]
+fn dispatch_etd_resolves() {
+    let _: EtdDispatch = EtdDispatch::new();
+}
+
+#[test]
+fn dispatch_nearest_car_resolves() {
+    let _: NearestCarDispatch = NearestCarDispatch::new();
+}
+
+// ── Additional edge cases ─────────────────────────────────────────────────────
+
+#[test]
+fn remove_elevator_then_riders_on_returns_empty() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    let elevator_id = sim.groups()[0].elevator_entities()[0];
+
+    sim.remove_elevator(elevator_id).unwrap();
+
+    // After removal, riders_on should return empty (not panic).
+    assert!(sim.riders_on(elevator_id).is_empty());
+}
+
+#[test]
+fn remove_elevator_then_occupancy_returns_zero() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    let elevator_id = sim.groups()[0].elevator_entities()[0];
+
+    sim.remove_elevator(elevator_id).unwrap();
+
+    assert_eq!(sim.occupancy(elevator_id), 0);
+}
+
+#[test]
+fn drain_events_where_with_all_matching_empties_buffer() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    for _ in 0..5 {
+        sim.step();
+    }
+
+    // Drain everything.
+    let all = sim.drain_events_where(|_| true);
+    assert!(!all.is_empty(), "should have some events to drain");
+
+    // Buffer should now be empty.
+    let remaining = sim.drain_events();
+    assert!(
+        remaining.is_empty(),
+        "buffer should be empty after all-matching drain"
+    );
+}
+
+#[test]
+fn rider_builder_default_weight_is_75() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let rider_id = sim
+        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .unwrap()
+        .spawn()
+        .unwrap();
+
+    let rider = sim.world().rider(rider_id).unwrap();
+    assert!(
+        (rider.weight - 75.0).abs() < f64::EPSILON,
+        "default weight should be 75.0, got {}",
+        rider.weight
+    );
+}
+
+#[test]
+fn rider_builder_no_patience_by_default() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let rider_id = sim
+        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .unwrap()
+        .spawn()
+        .unwrap();
+
+    // Without calling .patience(), no Patience component is set.
+    assert!(
+        sim.world().patience(rider_id).is_none(),
+        "rider should have no Patience component by default"
+    );
+}
+
+#[test]
+fn rider_builder_no_preferences_by_default() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let rider_id = sim
+        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .unwrap()
+        .spawn()
+        .unwrap();
+
+    assert!(
+        sim.world().preferences(rider_id).is_none(),
+        "rider should have no Preferences component by default"
+    );
+}
+
+#[test]
+fn rider_builder_no_access_control_by_default() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let rider_id = sim
+        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .unwrap()
+        .spawn()
+        .unwrap();
+
+    assert!(
+        sim.world().access_control(rider_id).is_none(),
+        "rider should have no AccessControl component by default"
+    );
+}

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -67,26 +67,24 @@ fn remove_elevator_ejects_riders_aboard() {
     }
 
     let elevator_id = sim.groups()[0].elevator_entities()[0];
-    let is_riding = matches!(
-        sim.world().rider(rider_id).unwrap().phase,
-        RiderPhase::Riding(_)
+    assert!(
+        matches!(
+            sim.world().rider(rider_id).unwrap().phase,
+            RiderPhase::Riding(_)
+        ),
+        "rider should have boarded within 300 ticks"
     );
 
-    if is_riding {
-        // Rider is aboard — removing elevator should eject the rider.
-        sim.remove_elevator(elevator_id).unwrap();
-        sim.drain_events(); // consume events
+    // Rider is aboard — removing elevator should eject the rider.
+    sim.remove_elevator(elevator_id).unwrap();
+    sim.drain_events(); // consume events
 
-        let phase = sim.world().rider(rider_id).unwrap().phase;
-        // After ejection, rider is put back to Waiting.
-        assert!(
-            matches!(phase, RiderPhase::Waiting),
-            "rider should be Waiting after elevator removal, got {phase:?}"
-        );
-    } else {
-        // Rider didn't board yet — just verify removal succeeds cleanly.
-        sim.remove_elevator(elevator_id).unwrap();
-    }
+    let phase = sim.world().rider(rider_id).unwrap().phase;
+    // After ejection, rider is put back to Waiting.
+    assert!(
+        matches!(phase, RiderPhase::Waiting),
+        "rider should be Waiting after elevator removal, got {phase:?}"
+    );
 }
 
 #[test]
@@ -112,21 +110,24 @@ fn remove_elevator_ejects_rider_emits_event() {
 
     let elevator_id = sim.groups()[0].elevator_entities()[0];
 
-    if matches!(
-        sim.world().rider(rider_id).unwrap().phase,
-        RiderPhase::Riding(_)
-    ) {
-        sim.remove_elevator(elevator_id).unwrap();
-        let events = sim.drain_events();
+    assert!(
+        matches!(
+            sim.world().rider(rider_id).unwrap().phase,
+            RiderPhase::Riding(_)
+        ),
+        "rider should have boarded within 300 ticks"
+    );
 
-        let ejected = events
-            .iter()
-            .any(|e| matches!(e, Event::RiderEjected { rider, .. } if *rider == rider_id));
-        assert!(
-            ejected,
-            "should emit RiderEjected when removing elevator with rider aboard"
-        );
-    }
+    sim.remove_elevator(elevator_id).unwrap();
+    let events = sim.drain_events();
+
+    let ejected = events
+        .iter()
+        .any(|e| matches!(e, Event::RiderEjected { rider, .. } if *rider == rider_id));
+    assert!(
+        ejected,
+        "should emit RiderEjected when removing elevator with rider aboard"
+    );
 }
 
 #[test]
@@ -926,4 +927,38 @@ fn rider_builder_no_access_control_by_default() {
         sim.world().access_control(rider_id).is_none(),
         "rider should have no AccessControl component by default"
     );
+}
+
+// ── ElevatorRemoved / StopRemoved events ──────────────────────────────────────
+
+#[test]
+fn remove_elevator_emits_elevator_removed_event() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    sim.drain_events();
+
+    let elevator_id = sim.groups()[0].elevator_entities()[0];
+    sim.remove_elevator(elevator_id).unwrap();
+
+    let events = sim.drain_events();
+    let removed = events
+        .iter()
+        .any(|e| matches!(e, Event::ElevatorRemoved { elevator, .. } if *elevator == elevator_id));
+    assert!(removed, "should emit ElevatorRemoved event");
+}
+
+#[test]
+fn remove_stop_emits_stop_removed_event() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    sim.drain_events();
+
+    let stop_eid = sim.stop_entity(StopId(2)).unwrap();
+    sim.remove_stop(stop_eid).unwrap();
+
+    let events = sim.drain_events();
+    let removed = events
+        .iter()
+        .any(|e| matches!(e, Event::StopRemoved { stop, .. } if *stop == stop_eid));
+    assert!(removed, "should emit StopRemoved event");
 }

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -28,6 +28,7 @@ mod topology_tests;
 mod traffic_tests;
 mod world_tests;
 
+mod api_surface_tests;
 mod boundary_tests;
 #[cfg(feature = "energy")]
 mod energy_tests;

--- a/crates/elevator-core/tests/snapshot_roundtrip.rs
+++ b/crates/elevator-core/tests/snapshot_roundtrip.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use elevator_core::prelude::*;
+use elevator_core::snapshot::WorldSnapshot;
 
 #[test]
 fn snapshot_roundtrip_preserves_state() {


### PR DESCRIPTION
## Summary

- **Visibility reductions**: Restricted internal-only items (`Metrics::record_*`, `movement` module, `compute_tick_energy`, `systems` submodules, `ScanDirection`/`Direction`) to `pub(crate)`. Trimmed prelude from ~60 to ~20 items.
- **API additions**: `remove_elevator`/`remove_stop`, `riders_on`/`occupancy`, `drain_events_where`, `iter_repositioning_elevators`, `RiderBuilder` fluent API, dispatch strategy re-exports from module root.
- **Test coverage**: 42 new tests covering the entire new public API surface.

## BREAKING CHANGE

- Prelude no longer exports `PhaseContext`, `MetricTags`, `TaggedMetric`, `EnergyMetrics`, `EnergyProfile`, `EventChannel`, `RouteInvalidReason`, `Phase`, `WorldSnapshot`, `BuiltinStrategy`, `BuiltinReposition`, `RiderInfo`, `DispatchManifest`, `DispatchDecision`, `ElevatorGroup`, `LineInfo`, `ElevatorParams`, `LineParams`, `TopologyGraph` — import from submodules instead.
- `Metrics::record_*` and `update_throughput` are now `pub(crate)`.
- `movement` module is now `pub(crate)`.
- `energy::compute_tick_energy` is now `pub(crate)`.
- `systems` submodules are now `pub(crate)` (PhaseContext remains public).

## Test plan

- [x] All 329 unit tests pass
- [x] All 18 doc tests pass
- [x] Clippy clean
- [x] Full workspace builds (elevator-bevy compiles)
- [x] 42 new tests for: `remove_elevator`, `remove_stop`, `drain_events_where`, `riders_on`, `occupancy`, `iter_repositioning_elevators`, `RiderBuilder`, dispatch re-exports