### PR TITLE
fix: improve error message readability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "4.1.0"
+version = "5.0.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/error.rs
+++ b/crates/elevator-core/src/error.rs
@@ -61,8 +61,8 @@ impl fmt::Display for SimError {
                 write!(f, "invalid config '{field}': {reason}")
             }
             Self::EntityNotFound(id) => write!(f, "entity not found: {id:?}"),
-            Self::StopNotFound(id) => write!(f, "stop not found: {id:?}"),
-            Self::GroupNotFound(id) => write!(f, "group not found: {id:?}"),
+            Self::StopNotFound(id) => write!(f, "stop not found: {id}"),
+            Self::GroupNotFound(id) => write!(f, "group not found: {id}"),
             Self::InvalidState { entity, reason } => {
                 write!(f, "invalid state for {entity:?}: {reason}")
             }
@@ -75,8 +75,9 @@ impl fmt::Display for SimError {
             } => {
                 write!(
                     f,
-                    "no route from {origin:?} to {destination:?} \
-                     (origin served by {origin_groups:?}, destination served by {destination_groups:?})"
+                    "no route from {origin:?} to {destination:?} (origin served by {}, destination served by {})",
+                    format_group_list(origin_groups),
+                    format_group_list(destination_groups),
                 )
             }
             Self::AmbiguousRoute {
@@ -86,7 +87,8 @@ impl fmt::Display for SimError {
             } => {
                 write!(
                     f,
-                    "ambiguous route from {origin:?} to {destination:?}: served by groups {groups:?}"
+                    "ambiguous route from {origin:?} to {destination:?}: served by groups {}",
+                    format_group_list(groups),
                 )
             }
         }
@@ -97,6 +99,15 @@ impl std::error::Error for SimError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         None
     }
+}
+
+/// Format a list of `GroupId`s as `[GroupId(0), GroupId(1)]` or `[]` if empty.
+fn format_group_list(groups: &[GroupId]) -> String {
+    if groups.is_empty() {
+        return "[]".to_string();
+    }
+    let parts: Vec<String> = groups.iter().map(GroupId::to_string).collect();
+    format!("[{}]", parts.join(", "))
 }
 
 /// Reason a rider was rejected from boarding an elevator.

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -757,7 +757,7 @@ impl Simulation {
             if !seen_ids.insert(stop.id) {
                 return Err(SimError::InvalidConfig {
                     field: "building.stops",
-                    reason: format!("duplicate StopId({:?})", stop.id),
+                    reason: format!("duplicate {}", stop.id),
                 });
             }
         }
@@ -842,7 +842,7 @@ impl Simulation {
         if !building.stops.iter().any(|s| s.id == elev.starting_stop) {
             return Err(SimError::InvalidConfig {
                 field: "elevators.starting_stop",
-                reason: format!("references non-existent StopId({:?})", elev.starting_stop),
+                reason: format!("references non-existent {}", elev.starting_stop),
             });
         }
         Ok(())

--- a/crates/elevator-core/src/tests/error_tests.rs
+++ b/crates/elevator-core/src/tests/error_tests.rs
@@ -175,3 +175,53 @@ fn spawn_rider_unknown_destination_returns_error() {
         .unwrap_err();
     assert!(matches!(err, SimError::StopNotFound(StopId(99))));
 }
+
+// ── Error message quality ────────────────────────────────────────
+
+#[test]
+fn stop_not_found_display_is_readable() {
+    let err = SimError::StopNotFound(StopId(42));
+    let msg = format!("{err}");
+    // Should render as "stop not found: StopId(42)" — NOT "StopId(StopId(42))".
+    assert_eq!(msg, "stop not found: StopId(42)");
+    assert!(!msg.contains("StopId(StopId"));
+}
+
+#[test]
+fn duplicate_stop_id_message_readable() {
+    let mut config = default_config();
+    config.building.stops.push(StopConfig {
+        id: StopId(0),
+        name: "Dup".into(),
+        position: 12.0,
+    });
+    let err = Simulation::new(&config, scan()).unwrap_err();
+    let msg = format!("{err}");
+    // Should render "duplicate StopId(0)" not "duplicate StopId(StopId(0))".
+    assert!(
+        msg.contains("duplicate StopId(0)"),
+        "expected readable duplicate message, got: {msg}"
+    );
+    assert!(!msg.contains("StopId(StopId"));
+}
+
+#[test]
+fn no_route_display_formats_groups_cleanly() {
+    use crate::entity::EntityId;
+    use crate::ids::GroupId;
+    use slotmap::KeyData;
+
+    let err = SimError::NoRoute {
+        origin: EntityId::from(KeyData::from_ffi(1)),
+        destination: EntityId::from(KeyData::from_ffi(2)),
+        origin_groups: vec![GroupId(0), GroupId(1)],
+        destination_groups: vec![],
+    };
+    let msg = format!("{err}");
+    // Groups should render as "[GroupId(0), GroupId(1)]" not Debug format.
+    assert!(
+        msg.contains("[GroupId(0), GroupId(1)]"),
+        "expected clean group list, got: {msg}"
+    );
+    assert!(msg.contains("[]"), "empty list should render as []");
+}


### PR DESCRIPTION
## Summary

Improves `SimError` display output for consumers (game devs debugging config / routing errors):

- `SimError` `Display` uses `{}` instead of `{:?}` for `StopId` and `GroupId` (which already have `Display` impls), avoiding the double-wrapped `"StopId(StopId(0))"` output
- `NoRoute` / `AmbiguousRoute` render group lists cleanly as `"[GroupId(0), GroupId(1)]"` instead of Debug output
- Config validation messages no longer double-wrap `StopId` references

## Before / After

| Before | After |
|--------|-------|
| `stop not found: StopId(42)` ✓ | (unchanged — reference case) |
| `duplicate StopId(StopId(0))` ✗ | `duplicate StopId(0)` ✓ |
| `references non-existent StopId(StopId(1))` ✗ | `references non-existent StopId(1)` ✓ |
| `...groups [GroupId(0), GroupId(1)]` (via Debug) | `...groups [GroupId(0), GroupId(1)]` (via Display, consistent) |

## Test plan

- [x] 3 new tests verifying improved message formatting
- [x] Full test suite passes (361 tests, up from 358)
- [x] Clippy clean
- [x] Purely additive — `SimError` variants unchanged, only Display strings