### PR TITLE
docs: update mdBook with recent polish features

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -9,6 +9,7 @@
 - [Dispatch Strategies](dispatch.md)
 - [Extensions and Hooks](extensions-and-hooks.md)
 - [Configuration](configuration.md)
+- [Traffic Generation](traffic-generation.md)
 - [Metrics and Events](metrics-and-events.md)
 - [API Reference](api-reference.md)
 - [Bevy Integration](bevy-integration.md)

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -130,6 +130,18 @@ The core simulation state. Advance it by calling `step()`, or run individual pha
 | `dispatchers` | `(&self) -> &BTreeMap<GroupId, Box<dyn DispatchStrategy>>` | Get the dispatch strategies map |
 | `dispatchers_mut` | `(&mut self) -> &mut BTreeMap<GroupId, Box<dyn DispatchStrategy>>` | Get the dispatch strategies map mutably |
 
+### Inspection Queries
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `is_elevator` | `(&self, EntityId) -> bool` | Check if an entity has an `Elevator` component |
+| `is_rider` | `(&self, EntityId) -> bool` | Check if an entity has a `Rider` component |
+| `is_stop` | `(&self, EntityId) -> bool` | Check if an entity has a `Stop` component |
+| `is_disabled` | `(&self, EntityId) -> bool` | Check if an entity is disabled |
+| `idle_elevator_count` | `(&self) -> usize` | Count of elevators in `Idle` phase (excludes disabled) |
+| `elevators_in_phase` | `(&self, ElevatorPhase) -> usize` | Count of elevators in a given phase (excludes disabled) |
+| `elevator_load` | `(&self, EntityId) -> Option<f64>` | Current weight aboard an elevator |
+
 ### Dispatch
 
 | Method | Signature | Description |
@@ -417,6 +429,8 @@ Events are emitted during tick execution and buffered for consumers. Drain them 
 | `DoorOpened` | `elevator: EntityId`, `tick: u64` | Doors finished opening |
 | `DoorClosed` | `elevator: EntityId`, `tick: u64` | Doors finished closing |
 | `PassingFloor` | `elevator: EntityId`, `stop: EntityId`, `moving_up: bool`, `tick: u64` | Elevator passed a stop without stopping |
+| `ElevatorIdle` | `elevator: EntityId`, `at_stop: Option<EntityId>`, `tick: u64` | Elevator became idle |
+| `CapacityChanged` | `elevator: EntityId`, `current_load: OrderedFloat<f64>`, `capacity: OrderedFloat<f64>`, `tick: u64` | Elevator load changed after board or exit |
 
 ### Rider Events
 
@@ -829,3 +843,73 @@ Simulation phase identifiers for hook registration.
 | `Doors` | Tick door finite-state machines |
 | `Loading` | Board and exit riders |
 | `Metrics` | Aggregate metrics from tick events |
+
+---
+
+## Traffic Generation
+
+Available when the `traffic` feature is enabled (on by default). See the [Traffic Generation](traffic-generation.md) chapter for a guided walkthrough.
+
+### TrafficPattern
+
+Preset origin/destination distributions.
+
+| Variant | Description |
+|---------|-------------|
+| `Uniform` | Equal probability for all pairs |
+| `UpPeak` | 80% from lobby, 20% inter-floor |
+| `DownPeak` | 80% to lobby, 20% inter-floor |
+| `Lunchtime` | 40% upper→mid, 40% mid→upper, 20% random |
+| `Mixed` | 30% up-peak, 30% down-peak, 40% inter-floor |
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `sample` | `(&self, &[EntityId], &mut impl Rng) -> Option<(EntityId, EntityId)>` | Sample a pair from entity IDs |
+| `sample_stop_ids` | `(&self, &[StopId], &mut impl Rng) -> Option<(StopId, StopId)>` | Sample a pair from config stop IDs |
+
+### TrafficSchedule
+
+Time-varying pattern selection.
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `new` | `(Vec<(Range<u64>, TrafficPattern)>) -> Self` | Build from segment list |
+| `with_fallback` | `(self, TrafficPattern) -> Self` | Set the out-of-range fallback |
+| `constant` | `(TrafficPattern) -> Self` | Schedule with a single pattern for all ticks |
+| `office_day` | `(ticks_per_hour: u64) -> Self` | 9-hour office day preset |
+| `pattern_at` | `(&self, u64) -> &TrafficPattern` | Get the active pattern at a tick |
+| `sample` | `(&self, u64, &[EntityId], &mut impl Rng) -> Option<(EntityId, EntityId)>` | Sample using the active pattern |
+| `sample_stop_ids` | `(&self, u64, &[StopId], &mut impl Rng) -> Option<(StopId, StopId)>` | Same, by stop ID |
+
+### TrafficSource
+
+Trait for external traffic generators.
+
+```rust,ignore
+pub trait TrafficSource {
+    fn generate(&mut self, tick: u64) -> Vec<SpawnRequest>;
+}
+```
+
+### SpawnRequest
+
+```rust,ignore
+pub struct SpawnRequest {
+    pub origin: StopId,
+    pub destination: StopId,
+    pub weight: f64,
+}
+```
+
+### PoissonSource
+
+Poisson-arrival traffic generator.
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `new` | `(Vec<StopId>, TrafficSchedule, u32, (f64, f64)) -> Self` | Build with stops, schedule, mean interval, weight range |
+| `from_config` | `(&SimConfig) -> Self` | Build from simulation config |
+| `with_schedule` | `(self, TrafficSchedule) -> Self` | Replace the schedule |
+| `with_mean_interval` | `(self, u32) -> Self` | Replace the mean arrival interval |
+| `with_weight_range` | `(self, (f64, f64)) -> Self` | Replace the weight range (min/max auto-swapped) |
+| `generate` | `(&mut self, u64) -> Vec<SpawnRequest>` | Generate spawn requests for a tick (from `TrafficSource`) |

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -130,6 +130,16 @@ Three query methods provide population lookups:
 
 Each method has a corresponding count variant (e.g., `sim.residents_at(stop).len()`).
 
+### Entity type checks
+
+To identify what an `EntityId` refers to, use the type-check helpers:
+
+- `sim.is_elevator(id)` — the entity has an `Elevator` component
+- `sim.is_rider(id)` — the entity has a `Rider` component
+- `sim.is_stop(id)` — the entity has a `Stop` component
+
+These are preferable to querying `world.elevator(id).is_some()` etc., and make game code more readable.
+
 Three lifecycle methods manage rider state transitions:
 
 - `sim.settle_rider(id)` -- transitions an Arrived or Abandoned rider to Resident

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -159,18 +159,22 @@ fn main() -> Result<(), SimError> {
     }
 
     // 4. Print summary metrics.
-    let m = sim.metrics();
     println!("\n--- Summary ---");
-    println!("Total ticks:    {}", sim.current_tick());
-    println!("Avg wait time:  {:.1} ticks", m.avg_wait_time());
-    println!("Avg ride time:  {:.1} ticks", m.avg_ride_time());
-    println!("Delivered:      {}", m.total_delivered());
+    println!("Total ticks: {}", sim.current_tick());
+    // Metrics implements Display for a compact one-liner.
+    println!("{}", sim.metrics());
 
     Ok(())
 }
 ```
 
-Run it with `cargo run` and you should see the rider move from the Lobby to Floor 3, with events printed along the way.
+Run it with `cargo run` and you should see the rider move from the Lobby to Floor 3, with events printed along the way. The summary output looks like:
+
+```text
+--- Summary ---
+Total ticks: 482
+1 delivered, avg wait 87.3t, 0% util
+```
 
 ## What just happened?
 

--- a/docs/src/metrics-and-events.md
+++ b/docs/src/metrics-and-events.md
@@ -21,6 +21,7 @@ Events are emitted during the tick phases. Here are the main categories:
 | `ElevatorRepositioning { elevator, to_stop, tick }` | An idle elevator begins repositioning |
 | `ElevatorRepositioned { elevator, at_stop, tick }` | An elevator completed repositioning |
 | `ElevatorIdle { elevator, at_stop, tick }` | An elevator became idle |
+| `CapacityChanged { elevator, current_load, capacity, tick }` | An elevator's load changed (after board or exit) |
 
 **Rider events:**
 
@@ -159,9 +160,62 @@ println!("Total distance:    {:.1} units", m.total_distance());
 | `total_rerouted()` | Cumulative riders rerouted from resident phase |
 | `total_distance()` | Sum of all elevator travel distance |
 | `utilization_by_group()` | Per-group fraction of elevators currently moving |
+| `avg_utilization()` | Average utilization across all groups |
 | `reposition_distance()` | Total elevator distance traveled while repositioning |
 
 Metrics are updated during the Metrics phase of each tick. They are always available and always reflect the latest tick, regardless of whether you drain events.
+
+### Compact summary
+
+`Metrics` implements `Display` for a one-line KPI summary suitable for HUDs and logs:
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(sim: &Simulation) {
+println!("{}", sim.metrics());
+// Output: "42 delivered, avg wait 87.3t, 65% util"
+# }
+```
+
+## Inspection queries
+
+The `Simulation` exposes several read-only query helpers for game UIs and dispatch logic.
+
+### Entity type checks
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(sim: &Simulation, id: EntityId) {
+if sim.is_elevator(id) {
+    // ...
+} else if sim.is_rider(id) {
+    // ...
+} else if sim.is_stop(id) {
+    // ...
+}
+# }
+```
+
+### Aggregate queries
+
+Common KPIs that games typically display in HUDs:
+
+| Method | Returns |
+|---|---|
+| `sim.idle_elevator_count()` | Count of elevators currently idle (excludes disabled) |
+| `sim.elevators_in_phase(phase)` | Count of elevators in a given phase (excludes disabled) |
+| `sim.elevator_load(id)` | Current total weight aboard an elevator, `None` if not an elevator |
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(sim: &Simulation) {
+let idle = sim.idle_elevator_count();
+let loading = sim.elevators_in_phase(ElevatorPhase::Loading);
+println!("{idle} idle, {loading} loading");
+# }
+```
+
+Disabled elevators are excluded from phase counts — their phase is reset to `Idle` on disable, but they should not appear as "available" in game UIs.
 
 ### Converting ticks to seconds
 

--- a/docs/src/traffic-generation.md
+++ b/docs/src/traffic-generation.md
@@ -1,0 +1,213 @@
+# Traffic Generation
+
+Real simulations need rider arrivals. The `traffic` module (enabled by default via the `traffic` feature flag) provides tools for generating realistic passenger traffic — from uniform random spawns to time-varying daily patterns.
+
+Traffic generation is **external to the simulation loop**. A `TrafficSource` produces `SpawnRequest`s each tick; your code feeds them into the simulation. This keeps the core loop untouched and gives you full control over *when* and *how* riders spawn.
+
+## Quick start
+
+```rust,no_run
+use elevator_core::prelude::*;
+use elevator_core::traffic::{PoissonSource, TrafficPattern, TrafficSchedule};
+
+# fn main() -> Result<(), SimError> {
+let mut sim = SimulationBuilder::new().build()?;
+let stops: Vec<StopId> = sim.stop_lookup_iter().map(|(id, _)| *id).collect();
+
+// Poisson arrivals with an office-day schedule.
+let mut source = PoissonSource::new(
+    stops,
+    TrafficSchedule::office_day(3600), // 3600 ticks per hour
+    120,                                // mean inter-arrival: 120 ticks
+    (60.0, 90.0),                       // weight range: 60-90kg
+);
+
+for _ in 0..10_000 {
+    let tick = sim.current_tick();
+    for req in source.generate(tick) {
+        let _ = sim.spawn_rider_by_stop_id(req.origin, req.destination, req.weight);
+    }
+    sim.step();
+}
+# Ok(())
+# }
+```
+
+## Patterns
+
+`TrafficPattern` selects origin/destination distributions. Five presets cover common building scenarios:
+
+| Pattern | Distribution |
+|---|---|
+| `Uniform` | Equal probability for all origin/destination pairs |
+| `UpPeak` | 80% from lobby, 20% inter-floor (morning rush) |
+| `DownPeak` | 80% to lobby, 20% inter-floor (evening rush) |
+| `Lunchtime` | 40% upper→mid, 40% mid→upper, 20% random |
+| `Mixed` | 30% up-peak, 30% down-peak, 40% inter-floor |
+
+The first stop in the slice is treated as the "lobby" — make sure stops are sorted by position.
+
+```rust,no_run
+use elevator_core::traffic::TrafficPattern;
+
+# fn run(stops: &[elevator_core::stop::StopId]) {
+let mut rng = rand::rng();
+if let Some((origin, destination)) = TrafficPattern::UpPeak.sample_stop_ids(stops, &mut rng) {
+    println!("{origin} → {destination}");
+}
+# }
+```
+
+## Schedules
+
+A `TrafficSchedule` maps tick ranges to patterns, enabling realistic daily cycles:
+
+```rust,no_run
+use elevator_core::traffic::{TrafficPattern, TrafficSchedule};
+
+let schedule = TrafficSchedule::new(vec![
+    (0..3600, TrafficPattern::UpPeak),        // First hour: morning rush
+    (3600..7200, TrafficPattern::Uniform),    // Second hour: normal
+    (7200..10800, TrafficPattern::Lunchtime), // Third hour: lunch
+    (10800..14400, TrafficPattern::DownPeak), // Fourth hour: evening rush
+]);
+```
+
+When the current tick falls outside all segments, the schedule uses a fallback pattern (default: `Uniform`):
+
+```rust,no_run
+# use elevator_core::traffic::{TrafficPattern, TrafficSchedule};
+let schedule = TrafficSchedule::new(vec![(0..1000, TrafficPattern::UpPeak)])
+    .with_fallback(TrafficPattern::Mixed);
+```
+
+### Built-in schedule presets
+
+- `TrafficSchedule::office_day(ticks_per_hour)` — typical 9-hour office day with morning rush, lunch, and evening rush
+- `TrafficSchedule::constant(pattern)` — a single pattern for all ticks
+
+## Poisson arrivals
+
+`PoissonSource` is the default traffic generator. It uses exponential inter-arrival times — a standard Poisson process — driven by a mean interval parameter:
+
+```rust,no_run
+use elevator_core::traffic::{PoissonSource, TrafficSchedule, TrafficPattern};
+use elevator_core::stop::StopId;
+
+let stops = vec![StopId(0), StopId(1), StopId(2)];
+let source = PoissonSource::new(
+    stops,
+    TrafficSchedule::constant(TrafficPattern::Uniform),
+    60,              // mean arrival every 60 ticks
+    (50.0, 100.0),   // weight range (min, max) in kg
+);
+```
+
+Each call to `source.generate(tick)` returns a `Vec<SpawnRequest>` — zero, one, or multiple requests depending on how many arrivals are due since the last call.
+
+### From config
+
+If your `SimConfig` already has `passenger_spawning` populated, use `from_config`:
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# use elevator_core::traffic::PoissonSource;
+# fn run(config: &SimConfig) {
+let source = PoissonSource::from_config(config);
+# }
+```
+
+This uses the config's `mean_interval_ticks` and `weight_range`, and defaults to a `Uniform` schedule. Override with `.with_schedule(...)` for time-varying traffic.
+
+### Fluent configuration
+
+```rust,no_run
+# use elevator_core::traffic::{PoissonSource, TrafficSchedule, TrafficPattern};
+# use elevator_core::stop::StopId;
+# fn run(stops: Vec<StopId>) {
+let source = PoissonSource::new(stops, TrafficSchedule::constant(TrafficPattern::Uniform), 100, (50.0, 100.0))
+    .with_schedule(TrafficSchedule::office_day(3600))
+    .with_mean_interval(50)
+    .with_weight_range((65.0, 85.0));
+# }
+```
+
+## Custom traffic sources
+
+The `TrafficSource` trait is trivial to implement for game-specific logic:
+
+```rust,no_run
+use elevator_core::traffic::{TrafficSource, SpawnRequest};
+use elevator_core::stop::StopId;
+
+/// Spawns a single VIP rider at a fixed tick.
+struct VipSpawn {
+    tick: u64,
+    origin: StopId,
+    destination: StopId,
+    fired: bool,
+}
+
+impl TrafficSource for VipSpawn {
+    fn generate(&mut self, tick: u64) -> Vec<SpawnRequest> {
+        if !self.fired && tick >= self.tick {
+            self.fired = true;
+            vec![SpawnRequest {
+                origin: self.origin,
+                destination: self.destination,
+                weight: 85.0,
+            }]
+        } else {
+            Vec::new()
+        }
+    }
+}
+```
+
+You can layer multiple sources, wrap them in a composite, or mix Poisson arrivals with scripted events. The simulation doesn't care how requests are generated — only that you feed them in.
+
+## SpawnRequest
+
+A `SpawnRequest` is the minimal description of a rider to spawn:
+
+```rust,ignore
+pub struct SpawnRequest {
+    pub origin: StopId,
+    pub destination: StopId,
+    pub weight: f64,
+}
+```
+
+For riders that need patience, preferences, or access control, spawn through the simulation's `build_rider_by_stop_id` fluent API instead of using `spawn_rider_by_stop_id` directly:
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# use elevator_core::traffic::SpawnRequest;
+# fn run(sim: &mut Simulation, req: SpawnRequest) -> Result<(), SimError> {
+sim.build_rider_by_stop_id(req.origin, req.destination)?
+    .weight(req.weight)
+    .patience(600)  // abandon after 10 seconds at 60 tps
+    .spawn()?;
+# Ok(())
+# }
+```
+
+## RON configuration
+
+`TrafficPattern` and `TrafficSchedule` derive `Serialize`/`Deserialize`, so you can include them in RON config files:
+
+```ron
+// traffic_config.ron
+TrafficSchedule(
+    segments: [
+        (0..3600, UpPeak),
+        (3600..7200, Uniform),
+        (7200..10800, Lunchtime),
+    ],
+    fallback: Uniform,
+)
+```
+
+## Next steps
+
+Head to [Metrics and Events](metrics-and-events.md) to see how generated traffic produces events and summary statistics.


### PR DESCRIPTION
## Summary

Comprehensive mdBook update reflecting polish work merged in PRs #24-28:

- **New chapter: Traffic Generation** — guided walkthrough of `TrafficPattern`, `TrafficSchedule`, `TrafficSource`, `PoissonSource`, `SpawnRequest`, custom sources, and RON config
- **Metrics and Events** — adds `CapacityChanged` event, `avg_utilization` metric, `Metrics` Display output example, and a new Inspection Queries section covering `is_elevator`/`is_rider`/`is_stop`/`idle_elevator_count`/`elevator_load`/`elevators_in_phase`
- **Core Concepts** — documents entity type-check helpers alongside existing population queries
- **Getting Started** — simplified metrics summary using the new `Metrics` Display impl
- **API Reference** — new Inspection Queries table, `CapacityChanged` and `ElevatorIdle` event variants, full Traffic Generation section with all method signatures

## Test plan

- [x] `mdbook build` succeeds with no warnings
- [x] `cargo test -p elevator-core` passes (361 tests unchanged)
- [x] SUMMARY.md registers the new chapter
- [x] All cross-references use valid paths