### PR TITLE
docs: expand coverage for common consumer questions

### DIFF
--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -234,6 +234,38 @@ macro_rules! register_extensions {
 }
 
 /// Common imports for consumers of this library.
+///
+/// `use elevator_core::prelude::*;` pulls in the types you need for the vast
+/// majority of simulations — building a sim, stepping it, spawning riders,
+/// reading events and metrics, and writing custom dispatch strategies.
+///
+/// # Contents
+///
+/// - **Builder & simulation:** [`SimulationBuilder`], [`Simulation`],
+///   [`RiderBuilder`]
+/// - **Components:** [`Rider`], [`RiderPhase`], [`Elevator`], [`ElevatorPhase`],
+///   [`Stop`], [`Line`], [`Position`], [`Velocity`], [`FloorPosition`],
+///   [`Route`], [`Patience`], [`Preferences`], [`AccessControl`],
+///   [`Orientation`], [`ServiceMode`]
+/// - **Config:** [`SimConfig`], [`GroupConfig`], [`LineConfig`]
+/// - **Dispatch:** [`DispatchStrategy`], [`RepositionStrategy`], plus the
+///   built-in reposition strategies [`NearestIdle`], [`ReturnToLobby`],
+///   [`SpreadEvenly`], [`DemandWeighted`]
+/// - **Identity:** [`EntityId`], [`StopId`], [`GroupId`]
+/// - **Errors & events:** [`SimError`], [`RejectionReason`],
+///   [`RejectionContext`], [`Event`], [`EventBus`]
+/// - **Misc:** [`Metrics`], [`TimeAdapter`]
+///
+/// # Not included (import explicitly)
+///
+/// - Concrete dispatch implementations: `dispatch::scan::ScanDispatch`,
+///   `dispatch::look::LookDispatch`, `dispatch::nearest_car::NearestCarDispatch`,
+///   `dispatch::etd::EtdDispatch`
+/// - `ElevatorConfig` and `StopConfig` from [`crate::config`]
+/// - Traffic generation types from [`crate::traffic`] (feature-gated)
+/// - Snapshot types from [`crate::snapshot`]
+/// - The [`World`](crate::world::World) type (accessed via `sim.world()`,
+///   but required as a parameter when implementing custom dispatch)
 pub mod prelude {
     pub use crate::builder::SimulationBuilder;
     pub use crate::components::{

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -18,7 +18,7 @@
 //! - **Extension components** — attach arbitrary `Serialize + DeserializeOwned`
 //!   data to any entity via [`world::World::insert_ext`] without modifying the
 //!   library.
-//! - **Lifecycle hooks** — inject logic before or after any of the six
+//! - **Lifecycle hooks** — inject logic before or after any of the seven
 //!   simulation phases. See [`hooks::Phase`].
 //! - **Metrics and events** — query aggregate wait/ride times through
 //!   [`metrics::Metrics`] and react to fine-grained tick events via

--- a/crates/elevator-core/src/rider_index.rs
+++ b/crates/elevator-core/src/rider_index.rs
@@ -1,17 +1,24 @@
 //! Phase-partitioned reverse index: stop → rider entity IDs.
 //!
 //! Maintained incrementally by [`Simulation`](crate::sim::Simulation) methods
-//! and the loading/advance-transient systems. Uses `BTreeMap`/`BTreeSet` for
-//! deterministic iteration.
+//! and the loading/advance-transient systems.
+//!
+//! The outer `stop → set` map is a `HashMap` for O(1) per-stop lookup, which
+//! is what the public `residents_at` / `waiting_at` / `abandoned_at` methods
+//! promise. The inner per-stop `BTreeSet` preserves deterministic iteration
+//! order when callers walk the riders at a stop.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeSet, HashMap};
 
 use crate::components::RiderPhase;
 use crate::entity::EntityId;
 use crate::world::World;
 
 /// Partition map type used by each phase bucket.
-type Partition = BTreeMap<EntityId, BTreeSet<EntityId>>;
+///
+/// Outer `HashMap` for O(1) lookup; inner `BTreeSet` for deterministic
+/// iteration of the riders at a stop.
+type Partition = HashMap<EntityId, BTreeSet<EntityId>>;
 
 /// Phase-partitioned reverse index mapping stops to the riders present there.
 #[derive(Debug, Clone, Default)]

--- a/crates/elevator-core/src/tests/scenario_tests.rs
+++ b/crates/elevator-core/src/tests/scenario_tests.rs
@@ -167,6 +167,109 @@ fn events_are_emitted_in_order() {
     );
 }
 
+/// Documented invariant (metrics-and-events.md): for any given rider,
+/// `RiderBoarded` always fires before `RiderExited`. Exercised with multiple
+/// riders so per-rider ordering is the actual thing being tested (a global
+/// "any boarded before any exited" check would be weaker).
+#[test]
+fn rider_boarded_precedes_rider_exited_per_rider() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let r1 = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    let r2 = sim
+        .spawn_rider_by_stop_id(StopId(2), StopId(0), 60.0)
+        .unwrap();
+    let r3 = sim
+        .spawn_rider_by_stop_id(StopId(1), StopId(2), 65.0)
+        .unwrap();
+
+    let mut boarded_at: std::collections::HashMap<_, usize> = std::collections::HashMap::new();
+    let mut exited_at: std::collections::HashMap<_, usize> = std::collections::HashMap::new();
+    let mut idx = 0usize;
+
+    for _ in 0..20_000 {
+        sim.step();
+        for ev in sim.drain_events() {
+            match ev {
+                Event::RiderBoarded { rider, .. } => {
+                    boarded_at.entry(rider).or_insert(idx);
+                }
+                Event::RiderExited { rider, .. } => {
+                    exited_at.insert(rider, idx);
+                }
+                _ => {}
+            }
+            idx += 1;
+        }
+        if all_riders_arrived(&sim) {
+            break;
+        }
+    }
+
+    for rid in [r1, r2, r3] {
+        let b = boarded_at
+            .get(&rid)
+            .unwrap_or_else(|| panic!("rider {rid:?} never boarded"));
+        let e = exited_at
+            .get(&rid)
+            .unwrap_or_else(|| panic!("rider {rid:?} never exited"));
+        assert!(
+            b < e,
+            "RiderBoarded (idx {b}) must precede RiderExited (idx {e}) for {rid:?}",
+        );
+    }
+}
+
+/// Documented invariant (metrics-and-events.md): for a given elevator visit
+/// to a stop, `DoorOpened` always precedes the matching `DoorClosed`. Locks
+/// this pairing down so future refactors can't silently violate it.
+#[test]
+fn door_opened_precedes_door_closed() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    sim.spawn_rider_by_stop_id(StopId(2), StopId(0), 60.0)
+        .unwrap();
+
+    // Per-elevator open/close sequence; pairs must alternate open→close.
+    let mut per_elevator: std::collections::HashMap<_, Vec<&'static str>> =
+        std::collections::HashMap::new();
+
+    for _ in 0..20_000 {
+        sim.step();
+        for ev in sim.drain_events() {
+            match ev {
+                Event::DoorOpened { elevator, .. } => {
+                    per_elevator.entry(elevator).or_default().push("open");
+                }
+                Event::DoorClosed { elevator, .. } => {
+                    per_elevator.entry(elevator).or_default().push("close");
+                }
+                _ => {}
+            }
+        }
+        if all_riders_arrived(&sim) {
+            break;
+        }
+    }
+
+    assert!(!per_elevator.is_empty(), "expected at least one door event");
+    for (eid, seq) in per_elevator {
+        // Every even index must be "open", every odd "close" — strict pairing.
+        for (i, kind) in seq.iter().enumerate() {
+            let expected = if i % 2 == 0 { "open" } else { "close" };
+            assert_eq!(
+                *kind, expected,
+                "elevator {eid:?} door sequence violated at index {i}: {seq:?}",
+            );
+        }
+    }
+}
+
 #[test]
 fn deterministic_replay() {
     let config = default_config();

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -11,5 +11,7 @@
 - [Configuration](configuration.md)
 - [Traffic Generation](traffic-generation.md)
 - [Metrics and Events](metrics-and-events.md)
+- [Snapshots and Determinism](snapshots-and-determinism.md)
+- [Performance](performance.md)
 - [API Reference](api-reference.md)
 - [Bevy Integration](bevy-integration.md)

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -4,6 +4,31 @@ This chapter is a quick-reference for the public API of the `elevator-core` crat
 
 ---
 
+## Prelude
+
+`use elevator_core::prelude::*;` re-exports these items. Anything else must be imported from its module explicitly.
+
+| Category | Items |
+|---|---|
+| Builder & sim | `SimulationBuilder`, `Simulation`, `RiderBuilder` |
+| Components | `Rider`, `RiderPhase`, `Elevator`, `ElevatorPhase`, `Stop`, `Line`, `Position`, `Velocity`, `FloorPosition`, `Route`, `Patience`, `Preferences`, `AccessControl`, `Orientation`, `ServiceMode` |
+| Config | `SimConfig`, `GroupConfig`, `LineConfig` |
+| Dispatch traits | `DispatchStrategy`, `RepositionStrategy` |
+| Reposition strategies | `NearestIdle`, `ReturnToLobby`, `SpreadEvenly`, `DemandWeighted` |
+| Identity | `EntityId`, `StopId`, `GroupId` |
+| Errors & events | `SimError`, `RejectionReason`, `RejectionContext`, `Event`, `EventBus` |
+| Misc | `Metrics`, `TimeAdapter` |
+
+Not in the prelude (import explicitly):
+
+- `elevator_core::dispatch::scan::ScanDispatch`, `dispatch::look::LookDispatch`, `dispatch::nearest_car::NearestCarDispatch`, `dispatch::etd::EtdDispatch`
+- `elevator_core::config::{ElevatorConfig, StopConfig}`
+- `elevator_core::traffic::*` (feature-gated behind `traffic`)
+- `elevator_core::snapshot::WorldSnapshot`
+- `elevator_core::world::World` (parameter type for custom dispatch)
+
+---
+
 ## SimulationBuilder
 
 Fluent builder for constructing a `Simulation`. Starts with a minimal valid config (2 stops, 1 elevator, SCAN dispatch, 60 TPS). Override any part before calling `build()`.

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -66,10 +66,11 @@ The core simulation state. Advance it by calling `step()`, or run individual pha
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `step` | `(&mut self)` | Run all 6 phases and advance the tick counter |
+| `step` | `(&mut self)` | Run all 7 phases and advance the tick counter |
 | `advance_tick` | `(&mut self)` | Increment tick counter and flush events to output buffer |
 | `run_advance_transient` | `(&mut self)` | Run the advance-transient phase (with hooks) |
 | `run_dispatch` | `(&mut self)` | Run the dispatch phase (with hooks) |
+| `run_reposition` | `(&mut self)` | Run the reposition phase (with hooks) |
 | `run_movement` | `(&mut self)` | Run the movement phase (with hooks) |
 | `run_doors` | `(&mut self)` | Run the doors phase (with hooks) |
 | `run_loading` | `(&mut self)` | Run the loading phase (with hooks) |

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -28,6 +28,33 @@ The library uses several identity types, and it is important to understand which
 
 `StopId` is a config-level concept. When the simulation boots, each `StopId` is mapped to an `EntityId`. At runtime you work with `EntityId` everywhere -- events, world queries, dispatch. Use `sim.stop_entity(StopId(0))` if you need to convert.
 
+## Topology: groups, lines, elevators, stops
+
+Multi-bank buildings are modeled with a three-level hierarchy:
+
+```text
+Group (GroupId)
+  +-- Line (LineConfig)        <-- a physical shaft or column of stops
+  |     +-- Elevator           <-- one car running on this line
+  |     +-- Elevator
+  +-- Line
+        +-- Elevator
+```
+
+- A **Group** owns a dispatch strategy and a set of stops it serves. Typical use: "low-rise group" and "high-rise group" in a tall building.
+- A **Line** represents a shaft (or columnar group of shafts sharing the same physical path). Elevators are assigned to a line; they only serve stops their line reaches.
+- A **Stop** may be shared across lines (e.g., a sky lobby served by both low-rise and high-rise groups).
+- An **Elevator** belongs to exactly one line within one group at a time. Use `ElevatorReassigned` / `LineReassigned` events to observe runtime moves.
+
+The simplest buildings (single bank, single shaft) can ignore lines — the builder auto-creates one default line and one default group, and you can just call `.stop(...)` / `.elevator(...)` without touching `LineConfig` or `GroupConfig`.
+
+## Coordinate system and units
+
+- **Axis.** All positions are scalars along a single shaft axis. Higher values = higher up (or further along the axis for horizontal configs like the space elevator). There is no 2D/3D geometry in the core.
+- **Units are unspecified.** The library does not enforce meters, feet, or any other unit — positions, velocities, accelerations, and weights are just `f64` values. Internally consistent is all that matters. Convention: meters + kg + ticks.
+- **Origin.** There is no privileged zero. Stop 0 does not have to be at position `0.0`. Positions may be negative (useful for basements below a lobby at `0.0`, or for space elevators anchored at a non-zero reference frame).
+- **Time.** The fundamental unit is the **tick**. Convert to seconds via `sim.time().ticks_to_seconds(t)` (uses `ticks_per_second` from config). The default is 60 ticks/second.
+
 ## The tick loop
 
 Each call to `sim.step()` runs one simulation tick. A tick consists of seven phases, always executed in this order:

--- a/docs/src/dispatch.md
+++ b/docs/src/dispatch.md
@@ -20,6 +20,28 @@ During the Dispatch phase of each tick, the simulation:
 | `NearestCarDispatch` | Assign each call to the closest idle elevator | Multi-elevator groups | Low average wait, but can cause bunching when elevators cluster |
 | `EtdDispatch` | Minimize estimated time to destination across all riders | Multi-elevator groups with mixed traffic | Best average performance, higher per-tick computation |
 
+### Choosing a strategy
+
+Use this rough decision guide:
+
+```text
+                            +-- 1 elevator? ------------------> ScanDispatch (or LookDispatch for bursty demand)
+                            |
+Does the group have ...  ---+-- 2+ elevators, simple ---------> NearestCarDispatch
+                            |
+                            +-- 2+ elevators, mixed traffic --> EtdDispatch
+                                with SLA-sensitive riders
+```
+
+Concrete guidance:
+
+- **ScanDispatch** — Start here. Deterministic, fair, easy to reason about. Good baseline for benchmarking custom strategies.
+- **LookDispatch** — Swap in when SCAN wastes obvious time at the extremes (sparse/clustered requests).
+- **NearestCarDispatch** — The default "obvious" multi-car policy. Watch for bunching under heavy load.
+- **EtdDispatch** — Best average wait/ride time in most realistic mixes, at a higher per-tick cost. Use the `delay_weight` to favor existing riders vs. new calls.
+
+For everything else (priority, weight, fairness, accessibility) write a custom strategy.
+
 ## Swapping strategies on the builder
 
 The builder defaults to `ScanDispatch`. To use a different strategy, call `.dispatch()`:

--- a/docs/src/extensions-and-hooks.md
+++ b/docs/src/extensions-and-hooks.md
@@ -123,7 +123,7 @@ Extensions are auto-cleaned on `despawn_rider`; resources persist until you remo
 
 ## Lifecycle hooks
 
-Hooks let you inject custom logic before or after any of the six tick phases. They receive `&mut World`, so they can read and modify any entity or resource.
+Hooks let you inject custom logic before or after any of the seven tick phases. They receive `&mut World`, so they can read and modify any entity or resource.
 
 ### Registering hooks on the builder
 
@@ -201,6 +201,7 @@ Group-specific hooks run alongside global hooks for the same phase; all `before`
 |---|---|
 | `Phase::AdvanceTransient` | Before/after transitional states advance |
 | `Phase::Dispatch` | Before/after elevator assignment |
+| `Phase::Reposition` | Before/after idle-elevator repositioning (no-op if no reposition strategy configured) |
 | `Phase::Movement` | Before/after position updates |
 | `Phase::Doors` | Before/after door state machine ticks |
 | `Phase::Loading` | Before/after boarding and exiting |

--- a/docs/src/extensions-and-hooks.md
+++ b/docs/src/extensions-and-hooks.md
@@ -109,6 +109,18 @@ if let Some(value) = sim.world_mut().resource_mut::<u32>() {
 
 Resources are useful for game state that hooks need to read or write -- score counters, time-of-day multipliers, spawn rate controllers, and so on.
 
+### Extension vs. resource: which do I want?
+
+| Need | Use |
+|---|---|
+| Per-entity data that varies by rider/elevator (VIP status, mood, cargo manifest) | **Extension** (`with_ext` + `insert_ext`) |
+| One-of value for the whole sim (score, difficulty, tick clock mirror) | **Resource** (`insert_resource`) |
+| Data that must survive snapshot save/load | **Extension** (register by name; resources are not snapshotted) |
+| Quick scratchpad you can wipe between ticks | **Resource** |
+| Query "all entities that have X" | **Extension** (iterate `world.rider_ids()` and filter on `get_ext::<T>`) |
+
+Extensions are auto-cleaned on `despawn_rider`; resources persist until you remove them.
+
 ## Lifecycle hooks
 
 Hooks let you inject custom logic before or after any of the six tick phases. They receive `&mut World`, so they can read and modify any entity or resource.
@@ -163,6 +175,25 @@ let sim = SimulationBuilder::new()
 # Ok(())
 # }
 ```
+
+### What hooks can (and can't) do
+
+Hooks receive `&mut World` — not `&mut Simulation`. This means:
+
+- **You can:** read/mutate any component, insert/remove extensions, add/remove resources, read tick state via a resource mirror (see example below).
+- **You cannot:** call `sim.step()`, `sim.spawn_rider_by_stop_id()`, `sim.snapshot()` or other `Simulation`-level methods while a tick is in flight — the simulation is borrowed.
+- **Spawning during a hook:** use `world.spawn()` + direct component inserts, or queue `SpawnRequest`s into a resource and drain them after `sim.step()` returns. The `before(Phase::Dispatch, ...)` slot is a convenient place to inject riders because the next phase will see them.
+- **Events:** hooks do not emit events directly. Use an extension/resource to record side effects and translate to events in game code.
+
+Hook execution order within a tick:
+
+```text
+before(AdvanceTransient) -> [phase] -> after(AdvanceTransient)
+before(Dispatch)         -> [phase] -> after(Dispatch)
+  ... and so on for each phase
+```
+
+Group-specific hooks run alongside global hooks for the same phase; all `before` hooks fire before the phase body, all `after` hooks fire after.
 
 ### Available phases
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -16,6 +16,30 @@ The prelude re-exports everything you need for typical usage:
 use elevator_core::prelude::*;
 ```
 
+This brings in, at a glance:
+
+| Group | Items |
+|---|---|
+| Builder & sim | `SimulationBuilder`, `Simulation`, `RiderBuilder` |
+| Components | `Rider`, `RiderPhase`, `Elevator`, `ElevatorPhase`, `Stop`, `Line`, `Position`, `Velocity`, `FloorPosition`, `Route`, `Patience`, `Preferences`, `AccessControl`, `Orientation`, `ServiceMode` |
+| Config | `SimConfig`, `GroupConfig`, `LineConfig` |
+| Dispatch traits | `DispatchStrategy`, `RepositionStrategy` |
+| Reposition strategies | `NearestIdle`, `ReturnToLobby`, `SpreadEvenly`, `DemandWeighted` |
+| Identity | `EntityId`, `StopId`, `GroupId` |
+| Errors & events | `SimError`, `RejectionReason`, `RejectionContext`, `Event`, `EventBus` |
+| Misc | `Metrics`, `TimeAdapter` |
+
+**Not in the prelude** (import explicitly): the concrete built-in dispatch types (`ScanDispatch`, `LookDispatch`, `NearestCarDispatch`, `EtdDispatch` — see [Dispatch Strategies](dispatch.md)), `ElevatorConfig` and `StopConfig` from `elevator_core::config`, the `traffic` module (feature-gated), the `snapshot` module, and the `World` type (needed as a parameter when implementing custom dispatch).
+
+## Feature flags
+
+| Flag | Default? | Enables |
+|---|---|---|
+| `traffic` | yes | `traffic` module: `PoissonSource`, `TrafficPattern`, `TrafficSchedule`. Pulls in `rand`. |
+| `energy` | no | Per-elevator `EnergyProfile`/`EnergyMetrics` components and snapshot fields. |
+
+Turn off defaults with `default-features = false` if you want a leaner build and intend to write your own rider spawning.
+
 ## Build a simulation
 
 We will use `SimulationBuilder` to set up a 3-stop building. The builder starts with sensible defaults (2 stops, 1 elevator, SCAN dispatch, 60 ticks per second), but we will override the stops to create our own layout.

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -93,7 +93,7 @@ println!("Spawned rider: {:?}", rider_id);
 
 ## Run the simulation loop
 
-Each call to `sim.step()` advances the simulation by one tick, running all six phases of the tick loop (advance transient, dispatch, movement, doors, loading, metrics). After stepping, you can drain events to see what happened:
+Each call to `sim.step()` advances the simulation by one tick, running all seven phases of the tick loop (advance transient, dispatch, reposition, movement, doors, loading, metrics). After stepping, you can drain events to see what happened:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
@@ -204,7 +204,7 @@ Total ticks: 482
 
 1. The **builder** created a `Simulation` containing a `World` with three stop entities and one elevator entity, plus a SCAN dispatch strategy.
 2. `spawn_rider_by_stop_id` created a rider entity at the Lobby with a route to Floor 3.
-3. Each `step()` ran the six-phase tick loop. The **dispatch** phase noticed a waiting rider and sent the elevator to the Lobby. The **movement** phase moved the elevator using a trapezoidal velocity profile. The **doors** phase opened and closed doors. The **loading** phase boarded and exited the rider. The **metrics** phase updated aggregate stats.
+3. Each `step()` ran the seven-phase tick loop. The **dispatch** phase noticed a waiting rider and sent the elevator to the Lobby. The **reposition** phase was a no-op (no reposition strategy configured). The **movement** phase moved the elevator using a trapezoidal velocity profile. The **doors** phase opened and closed doors. The **loading** phase boarded and exited the rider. The **metrics** phase updated aggregate stats.
 4. Events fired at each significant moment, and we pattern-matched on them to detect arrival.
 
 Next up: [Core Concepts](core-concepts.md) dives deeper into the entity model, the tick loop phases, and the lifecycle of riders and elevators.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -15,6 +15,28 @@ The library models **stops at arbitrary distances** along a shaft axis, not unif
 
 The core crate provides primitives, not opinions. Riders are generic entities that ride elevators. Your game decides whether they are office workers, hotel guests, cargo pallets, or astronauts. You attach semantics through the extension storage system, and the simulation handles the physics and logistics.
 
+## What elevator-core is *not*
+
+- **Not a renderer.** No graphics, no windowing, no audio. The core crate is headless; see [Bevy Integration](bevy-integration.md) for a 2D visual wrapper.
+- **Not real-time.** The tick loop runs as fast as you drive it. There is no wall-clock coupling — a tick is whatever `ticks_per_second` says it is. Games layer real-time scheduling on top.
+- **Not an ECS framework.** It uses an ECS-inspired internal layout but exposes a focused simulation API, not a general-purpose ECS.
+- **Not networked or multi-building.** One simulation per process. Federation, multiplayer, and cross-building routing are out of scope.
+- **Not an optimizer.** Built-in dispatch strategies (SCAN, LOOK, NearestCar, ETD) are reference implementations — not tuned for any specific building. Bring your own algorithm if you need optimal performance.
+
+## Determinism
+
+Given the same initial config, the same sequence of inputs (`spawn_rider`, hook mutations, etc.), and a deterministic dispatch strategy, the simulation is fully deterministic. The core loop contains no internal randomness — every tick phase is pure over the world state.
+
+The built-in `PoissonSource` traffic generator uses a thread-local RNG and is **not** deterministic across runs. For reproducible traffic, implement a custom [`TrafficSource`](traffic-generation.md#custom-traffic-sources) over a seeded RNG (e.g., `rand::rngs::StdRng::seed_from_u64`).
+
+See [Snapshots and Determinism](snapshots-and-determinism.md) for save/load, replay, and seeded traffic patterns.
+
+## Stability and MSRV
+
+- **MSRV:** Rust 1.87.
+- **Versioning:** Semver. Breaking API changes bump the major version. Adding variants to `#[non_exhaustive]` enums (events, errors) is **not** considered breaking.
+- **Release cadence:** Managed via release-please; see `CHANGELOG.md` in the repo.
+
 ## Project structure
 
 The repository is a Cargo workspace with two crates:

--- a/docs/src/metrics-and-events.md
+++ b/docs/src/metrics-and-events.md
@@ -79,6 +79,17 @@ for event in sim.drain_events() {
 
 You can call `drain_events()` after every tick, every N ticks, or only when you need to -- events accumulate until drained. The metrics system processes events independently each tick, so draining does not affect metric calculations.
 
+### Event ordering guarantees
+
+- **Within a tick:** events fire in tick-phase order (Advance Transient → Dispatch → Reposition → Movement → Doors → Loading → Metrics). Events from a later phase are always later in the drained vec than events from an earlier phase of the same tick.
+- **Across ticks:** events from tick N are drained before events from tick N+1. Every event carries its `tick` field, so you can reconstruct a strict timeline even if you drain in batches.
+- **Within a phase:** ordering between events of the same phase is stable but not part of the public contract — do not rely on, e.g., "elevator 0's `RiderBoarded` always precedes elevator 1's" across library versions.
+- **Pair invariants:** `RiderBoarded` always precedes the matching `RiderExited` for the same rider; `DoorOpened` always precedes `DoorClosed` for the same elevator at a given stop.
+
+### Buffer size and memory
+
+`drain_events()` empties the internal buffer. If you never drain, the buffer grows unbounded — in long-running sims, drain at least periodically (every tick in most games, every N ticks in headless analyses). Each event is a small enum (tens of bytes); a 1M-rider simulation at 60 TPS produces on the order of a few million events over its run.
+
 ### Building an event log
 
 Here is a pattern for collecting a complete event log across a simulation run:

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -1,0 +1,75 @@
+# Performance
+
+This chapter covers complexity, memory, and practical scaling guidance. The core is designed to handle tens of thousands of riders per tick on a single thread, with per-tick cost dominated by the dispatch strategy you choose.
+
+## Complexity overview
+
+Let `E` = elevators, `R` = riders, `S` = stops. Per `sim.step()`:
+
+| Phase | Cost | Notes |
+|---|---|---|
+| Advance transient | O(R) worst-case, O(transitioning riders) typical | Only touches riders in `Boarding`/`Exiting`. |
+| Dispatch (SCAN/LOOK) | O(E · S) | Constant work per elevator per stop in the group. |
+| Dispatch (NearestCar) | O(E · S) | Uses `decide_all` to coordinate. |
+| Dispatch (ETD) | O(E · S · R_waiting) | Estimates per-rider delays; heaviest built-in. |
+| Reposition | O(E · S) | Only runs if configured. |
+| Movement | O(E) | Pure arithmetic per elevator. |
+| Doors | O(E) | Door FSM per elevator. |
+| Loading | O(boarding + exiting at each open door) | Uses the rider index for per-stop queues. |
+| Metrics | O(events this tick) | Linear in the event count. |
+
+Population queries (`residents_at`, `waiting_at`, `abandoned_at`) are **O(1)** via the rider index, so UIs and hooks can poll them every tick without penalty.
+
+## Memory
+
+Rough per-entity memory (native `x86_64`, with default components):
+
+| Entity | Bytes (approx.) |
+|---|---|
+| Stop | ~120 |
+| Elevator | ~200 |
+| Rider (with `Route` and `Patience`) | ~160 |
+
+Add your own extension components on top. A 10k-rider simulation with a dozen stops and a handful of elevators fits comfortably under 5 MB of live state.
+
+The event buffer grows until `drain_events()` is called — see [Metrics and Events → Buffer size and memory](metrics-and-events.md#buffer-size-and-memory).
+
+## Benchmarks
+
+The crate ships a benchmark suite (Criterion) in `crates/elevator-core/benches/`:
+
+| Bench | Measures |
+|---|---|
+| `sim_bench` | End-to-end `step()` across representative scenarios |
+| `scaling_bench` | Throughput vs. rider count |
+| `dispatch_bench` | Per-strategy cost at a fixed rider load |
+| `multi_line_bench` | Multi-group, multi-line buildings |
+| `query_bench` | Population and lookup queries |
+
+Run with:
+
+```bash
+cargo bench -p elevator-core
+```
+
+Results go to `target/criterion/` with HTML reports. Use these as a baseline when writing custom dispatch strategies — if your strategy's `dispatch_bench` time is 10× the ETD baseline, expect a 10× slowdown in loaded simulations.
+
+## Scaling checklist
+
+For simulations above ~10k concurrent riders or above ~50 elevators:
+
+1. **Pick the cheapest dispatch strategy that meets your needs.** `NearestCarDispatch` is usually a better default than ETD at scale.
+2. **Split into groups.** Each group dispatches independently; two groups of 20 elevators each is cheaper than one group of 40.
+3. **Drain events every tick** (or redirect into a bounded ring buffer) to keep memory flat.
+4. **Avoid heavy work in hooks.** A hook that iterates all riders every tick is O(R) on top of the dispatch cost — prefer extension-attached flags you can toggle on-event.
+5. **Profile before optimizing.** The Criterion benches make it straightforward to identify the hot phase — dispatch dominates far more often than movement or doors.
+
+## What we do not provide
+
+- **Parallelism.** The tick loop is single-threaded by design (determinism > throughput). Run multiple sims in parallel across threads if you need more aggregate work.
+- **GPU acceleration.** Movement and dispatch are scalar — no SIMD or GPU backends.
+- **Persistent indexes beyond per-stop population.** If you need "all riders with extension X", iterate and filter.
+
+## Next steps
+
+Head to [Bevy Integration](bevy-integration.md) for a visual wrapper, or [API Reference](api-reference.md) for the full API surface.

--- a/docs/src/snapshots-and-determinism.md
+++ b/docs/src/snapshots-and-determinism.md
@@ -75,7 +75,7 @@ let sim = snapshot.restore(Some(&|name: &str| match name {
 # }
 ```
 
-Custom strategies are registered with `BuiltinStrategy::Custom("name")` via `sim.set_dispatch(group, BuiltinStrategy::Custom("HighestFirst".into()), Box::new(HighestFirstDispatch))`. That registered name is what the snapshot stores and what the factory closure receives on restore — make sure the two match.
+Custom strategies are registered with `BuiltinStrategy::Custom("name")` via `sim.set_dispatch(group, Box::new(HighestFirstDispatch), BuiltinStrategy::Custom("HighestFirst".into()))`. That registered name is what the snapshot stores and what the factory closure receives on restore — make sure the two match.
 
 ### Extensions across restore
 

--- a/docs/src/snapshots-and-determinism.md
+++ b/docs/src/snapshots-and-determinism.md
@@ -1,0 +1,142 @@
+# Snapshots and Determinism
+
+elevator-core is designed for reproducible simulations. This chapter covers the determinism guarantees, the snapshot save/load API, and the patterns for replay, regression testing, and research comparisons.
+
+## Determinism guarantee
+
+The simulation is deterministic given:
+
+1. The same initial `SimConfig` (same stops, elevators, groups, lines, dispatch strategy).
+2. The same sequence of API calls (`spawn_rider`, `despawn_rider`, `tag_entity`, hook mutations, etc.).
+3. A deterministic dispatch strategy (the four built-ins — `ScanDispatch`, `LookDispatch`, `NearestCarDispatch`, `EtdDispatch` — are deterministic).
+
+Under those conditions two runs produce byte-identical snapshots and event streams.
+
+Sources of *non*-determinism to watch for:
+
+- **`PoissonSource` and similar traffic generators** use a thread-local RNG. See [Traffic Generation → Determinism and seeding](traffic-generation.md#determinism-and-seeding).
+- **Custom dispatch strategies or hooks** that read wall-clock time, thread IDs, or unseeded RNGs.
+- **HashMap iteration order** in your own hook code (the sim itself uses stable iteration).
+
+## Snapshots
+
+A `WorldSnapshot` captures the full simulation state — all entities, components, groups, lines, metrics, tagged metrics, tick counter — in a serializable struct. Extension components are captured by type name and need a matching registration on restore. Resources and hooks are **not** captured.
+
+### Saving
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn main() -> Result<(), SimError> {
+# let mut sim = SimulationBuilder::new().build()?;
+for _ in 0..1000 { sim.step(); }
+
+let snapshot = sim.snapshot();
+let bytes = ron::to_string(&snapshot).unwrap();
+std::fs::write("save.ron", bytes).unwrap();
+# Ok(())
+# }
+```
+
+The snapshot struct is `Serialize + Deserialize` — choose any serde format (RON, JSON, bincode, postcard).
+
+### Loading
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# use elevator_core::snapshot::WorldSnapshot;
+# fn main() -> Result<(), SimError> {
+let bytes = std::fs::read_to_string("save.ron").unwrap();
+let snapshot: WorldSnapshot = ron::from_str(&bytes).unwrap();
+
+// `None` means "only built-in dispatch strategies"; pass a closure to
+// resurrect custom strategies registered by name.
+let sim = snapshot.restore(None);
+# Ok(())
+# }
+```
+
+### Custom dispatch across restore
+
+Built-in strategies (`Scan`, `Look`, `NearestCar`, `Etd`) are auto-restored by name. Custom strategies need a factory:
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# use elevator_core::snapshot::WorldSnapshot;
+# use elevator_core::world::World;
+# struct HighestFirstDispatch;
+# impl DispatchStrategy for HighestFirstDispatch {
+#   fn decide(&mut self, _: EntityId, _: f64, _: &elevator_core::dispatch::ElevatorGroup, _: &DispatchManifest, _: &World) -> DispatchDecision { DispatchDecision::Idle }
+# }
+# fn run(snapshot: WorldSnapshot) {
+let sim = snapshot.restore(Some(&|name: &str| match name {
+    "HighestFirst" => Some(Box::new(HighestFirstDispatch)),
+    _ => None,
+}));
+# }
+```
+
+Custom strategies are registered with `BuiltinStrategy::Custom("name")` via `sim.set_dispatch(group, BuiltinStrategy::Custom("HighestFirst".into()), Box::new(HighestFirstDispatch))`. That registered name is what the snapshot stores and what the factory closure receives on restore — make sure the two match.
+
+### Extensions across restore
+
+Extensions are serialized by their registered name. To restore them, re-register on the restored simulation's world and then call `load_extensions`:
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# use elevator_core::snapshot::WorldSnapshot;
+# use serde::{Serialize, Deserialize};
+# #[derive(Clone, Serialize, Deserialize)] struct VipTag;
+# fn run(snapshot: WorldSnapshot) {
+let mut sim = snapshot.restore(None);
+sim.world_mut().register_ext::<VipTag>("vip_tag");
+sim.load_extensions();
+# }
+```
+
+Use the `register_extensions!` macro to register many types in one line.
+
+## Patterns
+
+### Replay
+
+1. Serialize the initial config.
+2. Log every external mutation (`spawn_rider`, `despawn_rider`, tag changes) with its tick.
+3. To replay: rebuild the sim from config, then step while replaying logged mutations at the right ticks.
+
+Snapshots are a stronger alternative — you can start replay from any tick by restoring a snapshot taken at that tick.
+
+### Regression testing
+
+Run a seeded scenario for N ticks, snapshot, and diff against a golden snapshot:
+
+```rust,ignore
+let snap = sim.snapshot();
+let actual = ron::to_string(&snap).unwrap();
+let expected = include_str!("../golden/scenario_a.ron");
+assert_eq!(actual, expected);
+```
+
+This catches unintended behavior changes anywhere in the tick pipeline.
+
+### Research comparisons
+
+To compare dispatch strategies fairly, use identical seeded traffic across runs:
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# use elevator_core::dispatch::scan::ScanDispatch;
+# use elevator_core::dispatch::etd::EtdDispatch;
+# fn build_sim(dispatch: impl DispatchStrategy + 'static) -> Simulation {
+#   SimulationBuilder::new().dispatch(dispatch).build().unwrap()
+# }
+# fn run_with(sim: &mut Simulation) {}
+let mut scan_sim = build_sim(ScanDispatch::new());
+let mut etd_sim  = build_sim(EtdDispatch::new());
+run_with(&mut scan_sim);  // same seed, same traffic source construction
+run_with(&mut etd_sim);
+// Compare metrics side-by-side.
+```
+
+## Next steps
+
+See [Performance](performance.md) for scaling guidance and benchmark interpretation.

--- a/docs/src/traffic-generation.md
+++ b/docs/src/traffic-generation.md
@@ -132,6 +132,50 @@ let source = PoissonSource::new(stops, TrafficSchedule::constant(TrafficPattern:
 # }
 ```
 
+## Determinism and seeding
+
+`PoissonSource` uses a thread-local RNG (`rand::rng()`) internally, so two runs of the same config will produce different traffic. This is convenient for exploration but unsuitable for replay, regression testing, or research comparisons.
+
+For reproducible traffic, write a custom [`TrafficSource`](#custom-traffic-sources) that owns a seeded RNG:
+
+```rust,no_run
+use elevator_core::traffic::{TrafficSource, SpawnRequest, TrafficPattern};
+use elevator_core::stop::StopId;
+use rand::{Rng, SeedableRng, rngs::StdRng};
+
+struct SeededPoisson {
+    stops: Vec<StopId>,
+    rng: StdRng,
+    mean_interval: u32,
+    next: u64,
+}
+
+impl SeededPoisson {
+    fn new(stops: Vec<StopId>, seed: u64, mean_interval: u32) -> Self {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let next = rng.random_range(1..=(mean_interval * 2) as u64);
+        Self { stops, rng, mean_interval, next }
+    }
+}
+
+impl TrafficSource for SeededPoisson {
+    fn generate(&mut self, tick: u64) -> Vec<SpawnRequest> {
+        let mut out = Vec::new();
+        while tick >= self.next {
+            if let Some((origin, destination)) =
+                TrafficPattern::Uniform.sample_stop_ids(&self.stops, &mut self.rng)
+            {
+                out.push(SpawnRequest { origin, destination, weight: 75.0 });
+            }
+            self.next += self.rng.random_range(1..=(self.mean_interval * 2) as u64);
+        }
+        out
+    }
+}
+```
+
+With a fixed seed, identical config, and a deterministic dispatch strategy, `sim.snapshot()` outputs byte-for-byte match across runs.
+
 ## Custom traffic sources
 
 The `TrafficSource` trait is trivial to implement for game-specific logic:


### PR DESCRIPTION
## Summary
- Audited mdBook, rustdoc, and API reference against the questions a new consumer would ask (evaluation → core model → dispatch → extensions → events → determinism → performance); filled the resulting gaps so each surface answers the same questions.
- Added two new chapters (snapshots-and-determinism, performance) and backfilled scope/MSRV/determinism notes, a prelude contents table, topology hierarchy, units, strategy-selection guide, extension-vs-resource matrix, hook safety rules, seeded-RNG pattern, and event-ordering guarantees.
- Expanded the \`prelude\` module rustdoc so docs.rs shows what it re-exports at a glance.

## Test plan
- [x] \`cargo test -p elevator-core\` (pre-commit hook ran all 361 tests + doctests, all pass)
- [x] \`cargo doc -p elevator-core --no-deps\` — no new warnings or errors
- [x] \`mdbook build docs\` — clean build
- [x] Visual skim of rendered mdBook for formatting
- [x] Verify new chapters appear in SUMMARY sidebar