### PR TITLE
feat: elevator direction indicators and direction-aware boarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/components/elevator.rs
+++ b/crates/elevator-core/src/components/elevator.rs
@@ -74,11 +74,30 @@ pub struct Elevator {
     /// Speed multiplier for Inspection mode (0.0..1.0).
     #[serde(default = "default_inspection_speed_factor")]
     pub(crate) inspection_speed_factor: f64,
+    /// Up-direction indicator lamp: whether this car will serve upward trips.
+    ///
+    /// Auto-managed by the dispatch phase: set true when heading up (or idle),
+    /// false while actively committed to a downward trip. Affects boarding:
+    /// a rider whose next leg goes up will not board a car with `going_up=false`.
+    #[serde(default = "default_true")]
+    pub(crate) going_up: bool,
+    /// Down-direction indicator lamp: whether this car will serve downward trips.
+    ///
+    /// Auto-managed by the dispatch phase: set true when heading down (or idle),
+    /// false while actively committed to an upward trip. Affects boarding:
+    /// a rider whose next leg goes down will not board a car with `going_down=false`.
+    #[serde(default = "default_true")]
+    pub(crate) going_down: bool,
 }
 
 /// Default inspection speed factor (25% of normal speed).
 const fn default_inspection_speed_factor() -> f64 {
     0.25
+}
+
+/// Default value for direction indicator fields (both lamps on = idle/either direction).
+const fn default_true() -> bool {
+    true
 }
 
 impl Elevator {
@@ -170,5 +189,23 @@ impl Elevator {
     #[must_use]
     pub const fn inspection_speed_factor(&self) -> f64 {
         self.inspection_speed_factor
+    }
+
+    /// Whether this car's up-direction indicator lamp is lit.
+    ///
+    /// A lit up-lamp signals the car will serve upward-travelling riders.
+    /// Both lamps lit means the car is idle and will accept either direction.
+    #[must_use]
+    pub const fn going_up(&self) -> bool {
+        self.going_up
+    }
+
+    /// Whether this car's down-direction indicator lamp is lit.
+    ///
+    /// A lit down-lamp signals the car will serve downward-travelling riders.
+    /// Both lamps lit means the car is idle and will accept either direction.
+    #[must_use]
+    pub const fn going_down(&self) -> bool {
+        self.going_down
     }
 }

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -354,6 +354,26 @@ pub enum Event {
         tick: u64,
     },
 
+    /// An elevator's direction indicator lamps changed.
+    ///
+    /// Emitted by the dispatch phase when the pair
+    /// `(going_up, going_down)` transitions to a new value — e.g. when
+    /// a car is assigned a target above it (up-only), below it (down-only),
+    /// or returns to idle (both lamps lit).
+    ///
+    /// Games can use this for UI (lighting up-arrow / down-arrow indicators
+    /// on a car) without polling the elevator each tick.
+    DirectionIndicatorChanged {
+        /// The elevator whose indicator lamps changed.
+        elevator: EntityId,
+        /// New state of the up-direction lamp.
+        going_up: bool,
+        /// New state of the down-direction lamp.
+        going_down: bool,
+        /// The tick when the change occurred.
+        tick: u64,
+    },
+
     /// An elevator was permanently removed from the simulation.
     ///
     /// Distinct from [`EntityDisabled`] — a disabled elevator can be

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -502,6 +502,8 @@ impl Simulation {
                     repositioning: false,
                     restricted_stops: restricted,
                     inspection_speed_factor: ec.inspection_speed_factor,
+                    going_up: true,
+                    going_down: true,
                 },
             );
             #[cfg(feature = "energy")]
@@ -627,6 +629,8 @@ impl Simulation {
                         repositioning: false,
                         restricted_stops: restricted,
                         inspection_speed_factor: ec.inspection_speed_factor,
+                        going_up: true,
+                        going_down: true,
                     },
                 );
                 #[cfg(feature = "energy")]
@@ -1607,6 +1611,8 @@ impl Simulation {
                 repositioning: false,
                 restricted_stops: params.restricted_stops.clone(),
                 inspection_speed_factor: params.inspection_speed_factor,
+                going_up: true,
+                going_down: true,
             },
         );
         self.groups[group_idx].lines_mut()[line_idx]
@@ -2789,6 +2795,24 @@ impl Simulation {
     #[must_use]
     pub fn elevator_load(&self, id: EntityId) -> Option<f64> {
         self.world.elevator(id).map(|e| e.current_load)
+    }
+
+    /// Whether the elevator's up-direction indicator lamp is lit.
+    ///
+    /// Returns `None` if the entity is not an elevator. See
+    /// [`Elevator::going_up`] for semantics.
+    #[must_use]
+    pub fn elevator_going_up(&self, id: EntityId) -> Option<bool> {
+        self.world.elevator(id).map(Elevator::going_up)
+    }
+
+    /// Whether the elevator's down-direction indicator lamp is lit.
+    ///
+    /// Returns `None` if the entity is not an elevator. See
+    /// [`Elevator::going_down`] for semantics.
+    #[must_use]
+    pub fn elevator_going_down(&self, id: EntityId) -> Option<bool> {
+        self.world.elevator(id).map(Elevator::going_down)
     }
 
     /// Count of elevators currently in the given phase.

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -73,6 +73,18 @@ pub fn run(
                         tick: ctx.tick,
                     });
 
+                    // Compute direction indicators from target vs current position.
+                    let target_pos = world.stop_position(stop_eid).unwrap_or(pos);
+                    let (new_up, new_down) = if target_pos > pos {
+                        (true, false)
+                    } else if target_pos < pos {
+                        (false, true)
+                    } else {
+                        // At the target already — treat as idle (both lamps lit).
+                        (true, true)
+                    };
+                    update_indicators(world, events, eid, new_up, new_down, ctx.tick);
+
                     // Already at this stop — open doors directly.
                     if current_stop == Some(stop_eid) {
                         events.emit(Event::ElevatorArrived {
@@ -111,6 +123,8 @@ pub fn run(
                     if let Some(car) = world.elevator_mut(eid) {
                         car.phase = ElevatorPhase::Idle;
                     }
+                    // Reset indicators to both-lit when returning to idle.
+                    update_indicators(world, events, eid, true, true, ctx.tick);
                     if !was_idle {
                         let at_stop = world
                             .position(eid)
@@ -125,6 +139,32 @@ pub fn run(
             }
         }
     }
+}
+
+/// Update the direction indicator lamps on an elevator and emit a
+/// [`Event::DirectionIndicatorChanged`] iff the pair actually changed.
+fn update_indicators(
+    world: &mut World,
+    events: &mut EventBus,
+    eid: EntityId,
+    new_up: bool,
+    new_down: bool,
+    tick: u64,
+) {
+    let Some(car) = world.elevator_mut(eid) else {
+        return;
+    };
+    if car.going_up == new_up && car.going_down == new_down {
+        return;
+    }
+    car.going_up = new_up;
+    car.going_down = new_down;
+    events.emit(Event::DirectionIndicatorChanged {
+        elevator: eid,
+        going_up: new_up,
+        going_down: new_down,
+        tick,
+    });
 }
 
 /// Build a dispatch manifest with per-rider metadata for a group.

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -149,6 +149,20 @@ fn collect_actions(world: &World, elevator_ids: &[EntityId]) -> Vec<LoadAction> 
                         return None;
                     }
                 }
+                // Direction indicator filter: rider must be going in a direction
+                // this car will serve. A filtered rider silently stays waiting —
+                // no rejection event — so a later car in the right direction can
+                // pick them up.
+                let cur_pos = world.position(current_stop).map(|p| p.value);
+                let dest_pos = world.position(dest).map(|p| p.value);
+                if let (Some(cp), Some(dp)) = (cur_pos, dest_pos) {
+                    if dp > cp && !car.going_up {
+                        return None;
+                    }
+                    if dp < cp && !car.going_down {
+                        return None;
+                    }
+                }
             }
             // Rider preferences: skip crowded elevators.
             if let Some(prefs) = world.preferences(rid)

--- a/crates/elevator-core/src/tests/direction_indicator_tests.rs
+++ b/crates/elevator-core/src/tests/direction_indicator_tests.rs
@@ -1,0 +1,306 @@
+//! Tests for the elevator direction indicator lamps (`going_up`/`going_down`).
+
+use crate::components::{ElevatorPhase, RiderPhase};
+use crate::events::Event;
+use crate::sim::Simulation;
+use crate::stop::StopId;
+
+use super::helpers::{all_riders_arrived, default_config, scan};
+
+/// Grab the first (and usually only) elevator in a sim.
+fn first_elevator(sim: &Simulation) -> crate::entity::EntityId {
+    sim.world().elevator_ids()[0]
+}
+
+#[test]
+fn default_indicators_both_true() {
+    let config = default_config();
+    let sim = Simulation::new(&config, scan()).unwrap();
+    let elev = first_elevator(&sim);
+
+    assert_eq!(sim.elevator_going_up(elev), Some(true));
+    assert_eq!(sim.elevator_going_down(elev), Some(true));
+}
+
+#[test]
+fn dispatch_upward_sets_going_up_only() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    // Step until the elevator is moving upward.
+    let elev = first_elevator(&sim);
+    let mut saw_moving = false;
+    for _ in 0..1_000 {
+        sim.step();
+        if let Some(car) = sim.world().elevator(elev) {
+            if matches!(car.phase(), ElevatorPhase::MovingToStop(_)) {
+                saw_moving = true;
+                break;
+            }
+        }
+    }
+    assert!(saw_moving, "elevator should start moving within 1000 ticks");
+    assert_eq!(sim.elevator_going_up(elev), Some(true));
+    assert_eq!(sim.elevator_going_down(elev), Some(false));
+}
+
+#[test]
+fn dispatch_downward_sets_going_down_only() {
+    // Start the elevator at the top (stop 2) and spawn a rider who wants to go down.
+    let mut config = default_config();
+    config.elevators[0].starting_stop = StopId(2);
+
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    sim.spawn_rider_by_stop_id(StopId(2), StopId(0), 70.0)
+        .unwrap();
+
+    let elev = first_elevator(&sim);
+    let mut saw_moving = false;
+    for _ in 0..1_000 {
+        sim.step();
+        if let Some(car) = sim.world().elevator(elev) {
+            if matches!(car.phase(), ElevatorPhase::MovingToStop(_)) {
+                saw_moving = true;
+                break;
+            }
+        }
+    }
+    assert!(saw_moving, "elevator should start moving within 1000 ticks");
+    assert_eq!(sim.elevator_going_up(elev), Some(false));
+    assert_eq!(sim.elevator_going_down(elev), Some(true));
+}
+
+#[test]
+fn becoming_idle_resets_both_true() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    for _ in 0..10_000 {
+        sim.step();
+        if all_riders_arrived(&sim) {
+            break;
+        }
+    }
+    assert!(all_riders_arrived(&sim));
+
+    // Step a few more ticks so dispatch runs with no pending work → Idle.
+    for _ in 0..60 {
+        sim.step();
+    }
+
+    let elev = first_elevator(&sim);
+    assert_eq!(sim.elevator_going_up(elev), Some(true));
+    assert_eq!(sim.elevator_going_down(elev), Some(true));
+}
+
+#[test]
+fn direction_indicator_changed_event_fires_on_change() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    let mut all_events = Vec::new();
+    for _ in 0..10_000 {
+        sim.step();
+        all_events.extend(sim.drain_events());
+        if all_riders_arrived(&sim) {
+            break;
+        }
+    }
+
+    let changes: Vec<_> = all_events
+        .iter()
+        .filter_map(|e| match e {
+            Event::DirectionIndicatorChanged {
+                going_up,
+                going_down,
+                ..
+            } => Some((*going_up, *going_down)),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        !changes.is_empty(),
+        "expected at least one DirectionIndicatorChanged event"
+    );
+    // The first change should reflect the upward trip.
+    assert_eq!(changes[0], (true, false));
+}
+
+#[test]
+fn direction_indicator_event_does_not_spam() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    let mut all_events = Vec::new();
+    for _ in 0..10_000 {
+        sim.step();
+        all_events.extend(sim.drain_events());
+        if all_riders_arrived(&sim) {
+            break;
+        }
+    }
+    // A few extra ticks so we catch the Idle-reset.
+    for _ in 0..60 {
+        sim.step();
+        all_events.extend(sim.drain_events());
+    }
+
+    let count = all_events
+        .iter()
+        .filter(|e| matches!(e, Event::DirectionIndicatorChanged { .. }))
+        .count();
+
+    assert!(
+        count <= 4,
+        "DirectionIndicatorChanged should fire at most a few times for a single trip, got {count}"
+    );
+}
+
+#[test]
+fn rider_going_up_skips_down_only_car() {
+    // Scenario: car starts at top (stop 2), a rider at stop 2 wants to go to
+    // stop 0 (down). When the car passes stop 1 on its way down, a rider at
+    // stop 1 wanting to go up (stop 1 → stop 2) must NOT board during that
+    // downward trip.
+    let mut config = default_config();
+    config.elevators[0].starting_stop = StopId(2);
+
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    let down_rider = sim
+        .spawn_rider_by_stop_id(StopId(2), StopId(0), 70.0)
+        .unwrap();
+    let up_rider = sim
+        .spawn_rider_by_stop_id(StopId(1), StopId(2), 70.0)
+        .unwrap();
+
+    let mut all_events = Vec::new();
+    // Run until the downward rider arrives at stop 0.
+    for _ in 0..20_000 {
+        sim.step();
+        all_events.extend(sim.drain_events());
+        if sim.world().rider(down_rider).map(|r| r.phase) == Some(RiderPhase::Arrived) {
+            break;
+        }
+    }
+    assert_eq!(
+        sim.world().rider(down_rider).map(|r| r.phase),
+        Some(RiderPhase::Arrived)
+    );
+
+    // During the downward trip, the up-rider should NOT have boarded.
+    let up_rider_boarded_during_down = all_events.iter().any(|e| {
+        matches!(
+            e,
+            Event::RiderBoarded { rider, .. } if *rider == up_rider
+        )
+    });
+    assert!(
+        !up_rider_boarded_during_down,
+        "rider going up must not board a car committed to a downward trip"
+    );
+    // And must not have been rejected either — just left waiting.
+    let up_rider_rejected = all_events.iter().any(|e| {
+        matches!(
+            e,
+            Event::RiderRejected { rider, .. } if *rider == up_rider
+        )
+    });
+    assert!(
+        !up_rider_rejected,
+        "direction-filtered riders are not rejected, just left waiting"
+    );
+
+    // Now run until the up-rider arrives — the car should turn around and pick them up.
+    for _ in 0..20_000 {
+        sim.step();
+        if sim.world().rider(up_rider).map(|r| r.phase) == Some(RiderPhase::Arrived) {
+            break;
+        }
+    }
+    assert_eq!(
+        sim.world().rider(up_rider).map(|r| r.phase),
+        Some(RiderPhase::Arrived),
+        "up-rider should eventually be picked up on the return trip"
+    );
+}
+
+#[test]
+fn idle_car_boards_riders_either_direction() {
+    // Elevator sits at stop 1 (the middle). A rider wanting to go up and a
+    // rider wanting to go down both appear at stop 1 — an idle car
+    // (indicators both true) should board whichever one dispatch picks first.
+    let mut config = default_config();
+    config.elevators[0].starting_stop = StopId(1);
+
+    // First rider: up-bound.
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    let up_rider = sim
+        .spawn_rider_by_stop_id(StopId(1), StopId(2), 70.0)
+        .unwrap();
+    for _ in 0..20_000 {
+        sim.step();
+        if sim.world().rider(up_rider).map(|r| r.phase) == Some(RiderPhase::Arrived) {
+            break;
+        }
+    }
+    assert_eq!(
+        sim.world().rider(up_rider).map(|r| r.phase),
+        Some(RiderPhase::Arrived)
+    );
+
+    // Second rider in the same sim: down-bound from the middle.
+    // (Elevator is at stop 2 now; let it return to Idle first.)
+    for _ in 0..60 {
+        sim.step();
+    }
+    let down_rider = sim
+        .spawn_rider_by_stop_id(StopId(1), StopId(0), 70.0)
+        .unwrap();
+    for _ in 0..20_000 {
+        sim.step();
+        if sim.world().rider(down_rider).map(|r| r.phase) == Some(RiderPhase::Arrived) {
+            break;
+        }
+    }
+    assert_eq!(
+        sim.world().rider(down_rider).map(|r| r.phase),
+        Some(RiderPhase::Arrived)
+    );
+}
+
+#[test]
+fn snapshot_roundtrip_preserves_indicators() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    let elev = first_elevator(&sim);
+
+    // Step until indicators are (true, false) — upward-only.
+    for _ in 0..1_000 {
+        sim.step();
+        if sim.elevator_going_up(elev) == Some(true) && sim.elevator_going_down(elev) == Some(false)
+        {
+            break;
+        }
+    }
+    assert_eq!(sim.elevator_going_up(elev), Some(true));
+    assert_eq!(sim.elevator_going_down(elev), Some(false));
+
+    let snap = sim.snapshot();
+    let restored = snap.restore(None);
+    let restored_elev = restored.world().elevator_ids()[0];
+
+    assert_eq!(restored.elevator_going_up(restored_elev), Some(true));
+    assert_eq!(restored.elevator_going_down(restored_elev), Some(false));
+}

--- a/crates/elevator-core/src/tests/dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/dispatch_tests.rs
@@ -75,6 +75,8 @@ fn spawn_elevator(world: &mut World, position: f64) -> crate::entity::EntityId {
             repositioning: false,
             restricted_stops: HashSet::new(),
             inspection_speed_factor: 0.25,
+            going_up: true,
+            going_down: true,
         },
     );
     eid

--- a/crates/elevator-core/src/tests/feature_tests.rs
+++ b/crates/elevator-core/src/tests/feature_tests.rs
@@ -562,6 +562,8 @@ fn despawn_elevator_resets_rider_to_waiting() {
             repositioning: false,
             restricted_stops: HashSet::new(),
             inspection_speed_factor: 0.25,
+            going_up: true,
+            going_down: true,
         },
     );
 
@@ -643,6 +645,8 @@ fn despawn_rider_mid_transit_removes_from_elevator_load() {
             repositioning: false,
             restricted_stops: HashSet::new(),
             inspection_speed_factor: 0.25,
+            going_up: true,
+            going_down: true,
         },
     );
 

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -30,6 +30,7 @@ mod world_tests;
 
 mod api_surface_tests;
 mod boundary_tests;
+mod direction_indicator_tests;
 #[cfg(feature = "energy")]
 mod energy_tests;
 mod event_payload_tests;

--- a/crates/elevator-core/src/tests/query_tests.rs
+++ b/crates/elevator-core/src/tests/query_tests.rs
@@ -45,6 +45,8 @@ fn test_world() -> (World, EntityId, EntityId, EntityId) {
             repositioning: false,
             restricted_stops: HashSet::new(),
             inspection_speed_factor: 0.25,
+            going_up: true,
+            going_down: true,
         },
     );
 

--- a/crates/elevator-core/src/tests/reposition_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_tests.rs
@@ -77,6 +77,8 @@ fn spawn_elevator(world: &mut World, position: f64) -> EntityId {
             repositioning: false,
             restricted_stops: HashSet::new(),
             inspection_speed_factor: 0.25,
+            going_up: true,
+            going_down: true,
         },
     );
     eid

--- a/crates/elevator-core/src/tests/world_tests.rs
+++ b/crates/elevator-core/src/tests/world_tests.rs
@@ -61,6 +61,8 @@ fn elevator_query_returns_entities_with_both_components() {
             repositioning: false,
             restricted_stops: HashSet::new(),
             inspection_speed_factor: 0.25,
+            going_up: true,
+            going_down: true,
         },
     );
 

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -167,6 +167,8 @@ The core simulation state. Advance it by calling `step()`, or run individual pha
 | `idle_elevator_count` | `(&self) -> usize` | Count of elevators in `Idle` phase (excludes disabled) |
 | `elevators_in_phase` | `(&self, ElevatorPhase) -> usize` | Count of elevators in a given phase (excludes disabled) |
 | `elevator_load` | `(&self, EntityId) -> Option<f64>` | Current weight aboard an elevator |
+| `elevator_going_up` | `(&self, EntityId) -> Option<bool>` | Up-direction indicator lamp state (`None` if not an elevator) |
+| `elevator_going_down` | `(&self, EntityId) -> Option<bool>` | Down-direction indicator lamp state (`None` if not an elevator) |
 
 ### Dispatch
 
@@ -457,6 +459,7 @@ Events are emitted during tick execution and buffered for consumers. Drain them 
 | `PassingFloor` | `elevator: EntityId`, `stop: EntityId`, `moving_up: bool`, `tick: u64` | Elevator passed a stop without stopping |
 | `ElevatorIdle` | `elevator: EntityId`, `at_stop: Option<EntityId>`, `tick: u64` | Elevator became idle |
 | `CapacityChanged` | `elevator: EntityId`, `current_load: OrderedFloat<f64>`, `capacity: OrderedFloat<f64>`, `tick: u64` | Elevator load changed after board or exit |
+| `DirectionIndicatorChanged` | `elevator: EntityId`, `going_up: bool`, `going_down: bool`, `tick: u64` | Direction indicator lamps changed (dispatch-driven) |
 
 ### Rider Events
 
@@ -694,6 +697,8 @@ Entity components are the data attached to simulation entities. Built-in compone
 | `door_transition_ticks()` | `u32` | Ticks for a door transition |
 | `door_open_ticks()` | `u32` | Ticks the door stays open |
 | `line()` | `EntityId` | Line entity this car belongs to |
+| `going_up()` | `bool` | Up-direction indicator lamp (set by dispatch; both lamps lit when idle) |
+| `going_down()` | `bool` | Down-direction indicator lamp (set by dispatch; both lamps lit when idle) |
 
 ### Line Getters
 

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -190,6 +190,26 @@ Elevators cycle through these phases:
 
 An elevator arriving at a stop cycles through `DoorOpening` → `Loading` → `DoorClosing` → `Stopped`. If dispatch assigns a new target, the elevator departs from `Stopped`.
 
+### Direction indicators
+
+Every elevator carries two indicator lamps: `going_up` and `going_down`. Together they tell riders (and the loading system) which direction the car will serve next.
+
+| `going_up` | `going_down` | Meaning |
+|---|---|---|
+| `true` | `true` | Idle — the car will accept riders in either direction |
+| `true` | `false` | Committed to an upward trip |
+| `false` | `true` | Committed to a downward trip |
+
+The lamps are auto-managed by the dispatch phase:
+
+- On `DispatchDecision::GoToStop(target)`, the car's indicators are set from `target` vs. current position.
+- On `DispatchDecision::Idle` the pair resets to `(true, true)`.
+- A [`DirectionIndicatorChanged`](metrics-and-events.md) event is emitted only when the pair actually changes.
+
+The loading phase uses these lamps as a filter: a rider whose next route leg heads up (`dest_pos > cur_pos`) won't board a car with `going_up = false`, and vice versa. The rider is silently left waiting — **no rejection event** is emitted — so a later car heading in their direction picks them up naturally. Idle cars (both lamps lit) accept riders in either direction.
+
+Read the lamps through `sim.elevator_going_up(id)` / `sim.elevator_going_down(id)`, or directly off the component via `Elevator::going_up()` / `going_down()`.
+
 ## Sub-stepping
 
 For advanced use cases, you can run individual phases instead of calling `step()`:

--- a/docs/src/dispatch.md
+++ b/docs/src/dispatch.md
@@ -11,6 +11,8 @@ During the Dispatch phase of each tick, the simulation:
 3. Calls the group's `DispatchStrategy` with this information.
 4. Applies the returned `DispatchDecision` for each elevator -- either `GoToStop(entity_id)` to assign a target, or `Idle` to do nothing.
 
+Direction indicators (`going_up`/`going_down`) are derived automatically from each dispatch decision: `GoToStop` sets them from target vs. current position, `Idle` resets them to both-lit. This means SCAN, LOOK, NearestCar, and ETD -- along with any custom strategy you write -- drive the indicators for free, and downstream boarding gets direction-awareness with no extra work from the strategy. See [Direction indicators](core-concepts.md#direction-indicators) for details.
+
 ## Built-in strategies
 
 | Strategy | Algorithm | Best for | Trade-off |

--- a/docs/src/metrics-and-events.md
+++ b/docs/src/metrics-and-events.md
@@ -22,6 +22,7 @@ Events are emitted during the tick phases. Here are the main categories:
 | `ElevatorRepositioned { elevator, at_stop, tick }` | An elevator completed repositioning |
 | `ElevatorIdle { elevator, at_stop, tick }` | An elevator became idle |
 | `CapacityChanged { elevator, current_load, capacity, tick }` | An elevator's load changed (after board or exit) |
+| `DirectionIndicatorChanged { elevator, going_up, going_down, tick }` | An elevator's direction indicator lamps changed (set by dispatch) |
 
 **Rider events:**
 


### PR DESCRIPTION
## Summary
- First of a stacked series of saga-inspired core additions. Adds `going_up` / `going_down` bool fields on `Elevator` (the hall indicator lamps real elevators have) and wires the loading phase to honor them.
- Sim auto-updates the indicators during dispatch based on target-vs-current position. Custom `DispatchStrategy` impls get this for free — no trait change.
- New `Event::DirectionIndicatorChanged` (fired only when the pair actually changes, not every tick).
- Snapshot round-trip preserves the fields via `#[serde(default)]` so 5.1.0 snapshots still load into 5.2.

## Behavior change
Waiting riders now skip an arriving car whose indicators don't match their travel direction. An idle car (both lamps on) still boards anyone. No `RiderRejected` is emitted — riders just wait for a car going their way. Existing SCAN/LOOK/NearestCar/ETD strategies all benefit automatically.

## Test plan
- [x] 9 new tests in `direction_indicator_tests.rs` covering defaults, up/down dispatch, reset-on-idle, event emission, direction-aware boarding, snapshot round-trip
- [x] Full suite: 372 pass (was 363)
- [x] Clippy clean, mdbook builds
- [ ] Visual skim of rendered mdBook changes
- [ ] Consumer sanity-check (SCAN behavior unchanged for upward-only traffic)

## Follow-ups (stacked on this branch)
- PR #2: `move_count` metric
- PR #3: braking-distance helpers
- PR #4: `DestinationQueue` component