### PR TITLE
feat: expose braking-distance helpers on the simulation API

### DIFF
--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -196,7 +196,11 @@ pub mod hooks;
 /// Aggregate simulation metrics.
 pub mod metrics;
 /// Trapezoidal velocity-profile movement math.
-pub(crate) mod movement;
+///
+/// Exposes [`braking_distance`](movement::braking_distance) for consumers
+/// writing opportunistic dispatch strategies that need the kinematic answer
+/// without constructing a `Simulation`.
+pub mod movement;
 /// Phase-partitioned reverse index for rider population queries.
 mod rider_index;
 /// Scenario replay from recorded event streams.

--- a/crates/elevator-core/src/movement.rs
+++ b/crates/elevator-core/src/movement.rs
@@ -1,5 +1,20 @@
 //! Trapezoidal velocity-profile movement physics.
 
+/// Distance required to brake to a stop from a given velocity at a fixed
+/// deceleration rate.
+///
+/// Uses the standard kinematic formula `v² / (2·a)`. Returns `0.0` for a
+/// stationary object or a non-positive deceleration (defensive: avoids
+/// division-by-zero / negative-distance footguns in consumer code).
+#[must_use]
+pub fn braking_distance(velocity: f64, deceleration: f64) -> f64 {
+    if deceleration <= 0.0 {
+        return 0.0;
+    }
+    let speed = velocity.abs();
+    speed * speed / (2.0 * deceleration)
+}
+
 /// Result of one tick of movement physics.
 #[derive(Debug, Clone, Copy)]
 pub struct MovementResult {

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -2826,6 +2826,38 @@ impl Simulation {
         self.world.elevator(id).map(Elevator::move_count)
     }
 
+    /// Distance the elevator would travel while braking to a stop from its
+    /// current velocity, at its configured deceleration rate.
+    ///
+    /// Uses the standard `v² / (2·a)` kinematic formula. A stationary
+    /// elevator returns `Some(0.0)`. Returns `None` if the entity is not
+    /// an elevator or lacks a velocity component.
+    ///
+    /// Useful for writing opportunistic dispatch strategies (e.g. "stop at
+    /// this floor if we can brake in time") without duplicating the physics
+    /// computation.
+    #[must_use]
+    pub fn braking_distance(&self, id: EntityId) -> Option<f64> {
+        let car = self.world.elevator(id)?;
+        let vel = self.world.velocity(id)?.value;
+        Some(crate::movement::braking_distance(vel, car.deceleration))
+    }
+
+    /// The position where the elevator would come to rest if it began braking
+    /// this instant. Current position plus a signed braking distance in the
+    /// direction of travel.
+    ///
+    /// Returns `None` if the entity is not an elevator or lacks the required
+    /// components.
+    #[must_use]
+    pub fn future_stop_position(&self, id: EntityId) -> Option<f64> {
+        let pos = self.world.position(id)?.value;
+        let vel = self.world.velocity(id)?.value;
+        let car = self.world.elevator(id)?;
+        let dist = crate::movement::braking_distance(vel, car.deceleration);
+        Some(vel.signum().mul_add(dist, pos))
+    }
+
     /// Count of elevators currently in the given phase.
     ///
     /// Excludes disabled elevators (whose phase is reset to `Idle` on disable).

--- a/crates/elevator-core/src/tests/braking_tests.rs
+++ b/crates/elevator-core/src/tests/braking_tests.rs
@@ -1,0 +1,106 @@
+//! Tests for the public braking-distance helpers.
+
+use crate::components::ElevatorPhase;
+use crate::movement::braking_distance;
+use crate::sim::Simulation;
+use crate::stop::StopId;
+
+use super::helpers::{default_config, scan};
+
+/// Grab the first elevator in a sim.
+fn first_elevator(sim: &Simulation) -> crate::entity::EntityId {
+    sim.world().elevator_ids()[0]
+}
+
+#[test]
+fn braking_distance_zero_velocity_is_zero() {
+    assert_eq!(braking_distance(0.0, 2.0), 0.0);
+}
+
+#[test]
+fn braking_distance_formula() {
+    // v=4, a=2 → 16 / 4 = 4.0
+    assert!((braking_distance(4.0, 2.0) - 4.0).abs() < 1e-12);
+    // Sign-agnostic (magnitude only)
+    assert!((braking_distance(-4.0, 2.0) - 4.0).abs() < 1e-12);
+}
+
+#[test]
+fn braking_distance_rejects_nonpositive_deceleration() {
+    // Defensive: deceleration <= 0 returns 0 rather than dividing by zero
+    // or returning a negative distance.
+    assert_eq!(braking_distance(10.0, 0.0), 0.0);
+    assert_eq!(braking_distance(10.0, -2.0), 0.0);
+}
+
+#[test]
+fn sim_braking_distance_stationary_elevator_is_zero() {
+    let sim = Simulation::new(&default_config(), scan()).unwrap();
+    let elev = first_elevator(&sim);
+    assert_eq!(sim.braking_distance(elev), Some(0.0));
+}
+
+#[test]
+fn sim_braking_distance_nonzero_while_moving() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    // Step until the elevator has picked up speed.
+    let elev = first_elevator(&sim);
+    for _ in 0..500 {
+        sim.step();
+        let is_moving = sim
+            .world()
+            .elevator(elev)
+            .is_some_and(|c| matches!(c.phase(), ElevatorPhase::MovingToStop(_)));
+        let vel = sim.world().velocity(elev).map_or(0.0, |v| v.value);
+        if is_moving && vel.abs() > 0.5 {
+            break;
+        }
+    }
+
+    let d = sim.braking_distance(elev).expect("is an elevator");
+    assert!(d > 0.0, "expected nonzero braking distance while moving");
+}
+
+#[test]
+fn sim_future_stop_position_stationary_equals_current() {
+    let sim = Simulation::new(&default_config(), scan()).unwrap();
+    let elev = first_elevator(&sim);
+    let pos = sim.world().position(elev).unwrap().value;
+    assert_eq!(sim.future_stop_position(elev), Some(pos));
+}
+
+#[test]
+fn sim_future_stop_position_ahead_while_moving_up() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    let elev = first_elevator(&sim);
+    for _ in 0..500 {
+        sim.step();
+        let vel = sim.world().velocity(elev).map_or(0.0, |v| v.value);
+        if vel > 0.5 {
+            break;
+        }
+    }
+
+    let pos = sim.world().position(elev).unwrap().value;
+    let future = sim.future_stop_position(elev).unwrap();
+    assert!(
+        future > pos,
+        "future stop position {future} should be above current {pos} while moving up",
+    );
+}
+
+#[test]
+fn sim_braking_distance_none_for_non_elevator() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    let rider = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
+        .unwrap();
+    assert_eq!(sim.braking_distance(rider), None);
+    assert_eq!(sim.future_stop_position(rider), None);
+}

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -30,6 +30,7 @@ mod world_tests;
 
 mod api_surface_tests;
 mod boundary_tests;
+mod braking_tests;
 mod direction_indicator_tests;
 #[cfg(feature = "energy")]
 mod energy_tests;

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -170,6 +170,8 @@ The core simulation state. Advance it by calling `step()`, or run individual pha
 | `elevator_going_up` | `(&self, EntityId) -> Option<bool>` | Up-direction indicator lamp state (`None` if not an elevator) |
 | `elevator_going_down` | `(&self, EntityId) -> Option<bool>` | Down-direction indicator lamp state (`None` if not an elevator) |
 | `elevator_move_count` | `(&self, EntityId) -> Option<u64>` | Per-elevator count of rounded-floor transitions (`None` if not an elevator) |
+| `braking_distance` | `(&self, EntityId) -> Option<f64>` | Distance required to brake to a stop from the current velocity at the elevator's deceleration (`v² / 2a`). `Some(0.0)` when stationary; `None` if not an elevator |
+| `future_stop_position` | `(&self, EntityId) -> Option<f64>` | Current position plus signed braking distance in the direction of travel — where the elevator would come to rest if braking began now |
 
 ### Dispatch
 

--- a/docs/src/dispatch.md
+++ b/docs/src/dispatch.md
@@ -179,6 +179,10 @@ Your strategy receives a `DispatchManifest` with these convenience methods:
 
 For more advanced dispatch (priority-aware, weight-aware, VIP-first), you can iterate `manifest.waiting_at_stop` directly. Each entry contains a `Vec<RiderInfo>` with the rider's `id`, `destination`, `weight`, and `wait_ticks`.
 
+### Opportunistic stops: braking helpers
+
+For strategies that want to consider stopping at a passing floor only if the elevator can brake in time, `sim.braking_distance(elev)` and `sim.future_stop_position(elev)` expose the kinematic answer directly — no need to reimplement the trapezoidal physics. The free function `elevator_core::movement::braking_distance(velocity, deceleration)` is also available for pure computation off a `Simulation`.
+
 ### Group-aware dispatch with `decide_all`
 
 The default `DispatchStrategy` trait calls `decide()` once per idle elevator. If your strategy needs to coordinate across all elevators in a group (to avoid sending two elevators to the same stop), override `decide_all()` instead:


### PR DESCRIPTION
## Summary
- Third in the saga-inspired stack. Surfaces the trapezoidal-braking kinematic (v²/2a) already computed internally each tick.
- Two new Simulation helpers: \`braking_distance(id)\` and \`future_stop_position(id)\`. One free function: \`movement::braking_distance(velocity, deceleration)\`.
- Useful for opportunistic dispatch strategies that want to stop at a passing floor only if they can brake in time, without reimplementing the physics.

**Stacked on**: #32 (move_count). Base branch is \`feat/move-count-metric\`; will rebase as upstream PRs merge.

## Test plan
- [x] 8 new tests covering formula correctness, zero-velocity, non-positive deceleration defensive path, stationary-elevator, moving-elevator, sign direction, None for non-elevators
- [x] Full suite: 386 pass (was 378)
- [x] Clippy clean, mdbook builds