### PR TITLE
feat: DestinationQueue component for imperative elevator control

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ ECS-like internal architecture (no ECS crate dependency). Struct-of-arrays `Worl
 Key design decisions:
 - Core crate is an unopinionated engine library — suggest primitives, not game mechanics
 - "Stops" at arbitrary distances, not uniform floors — supports buildings and space elevators
-- Tick-based with 6-phase loop: advance_transient → dispatch → movement → doors → loading → metrics
+- Tick-based with 8-phase loop: advance_transient → dispatch → reposition → advance_queue → movement → doors → loading → metrics
 - Pluggable dispatch via `DispatchStrategy` trait, per elevator group
 - Game-agnostic riders: `Rider` = anything that rides; games add semantics via extension storage
 - Rider lifecycle: Waiting → Boarding → Riding → Exiting → Arrived/Abandoned; consumer can settle (→ Resident) or despawn

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ From there, the typical workflow is:
 1. **Configure stops** -- define the building layout with named stops at arbitrary positions.
 2. **Build the simulation** -- `SimulationBuilder` validates the config and returns a ready-to-run `Simulation`.
 3. **Spawn riders** -- place riders at origin stops with a destination and weight.
-4. **Step the loop** -- each call to `sim.step()` advances one tick through all seven phases.
+4. **Step the loop** -- each call to `sim.step()` advances one tick through all eight phases.
 5. **Read metrics** -- query aggregate wait times, ride times, and throughput at any point.
 
 ## Examples
@@ -140,18 +140,18 @@ if let Some(tag) = sim.world().get_ext::<VipTag>(rider_id) {
 
 ## Architecture
 
-Each call to `sim.step()` executes seven phases:
+Each call to `sim.step()` executes eight phases:
 
 ```text
-┌───────────────┐   ┌──────────┐   ┌──────────────┐   ┌──────────┐
-│ Advance       │──▶│ Dispatch │──▶│ Reposition   │──▶│ Movement │
-│ Transient     │   │          │   │              │   │          │
-└───────────────┘   └──────────┘   └──────────────┘   └──────────┘
-                                                           │
-               ┌───────────────┐   ┌──────────┐   ┌──────────┐
-               │ Metrics       │◀──│ Loading  │◀──│ Doors    │
-               │               │   │          │   │          │
-               └───────────────┘   └──────────┘   └──────────┘
+┌───────────────┐   ┌──────────┐   ┌──────────────┐   ┌──────────────┐
+│ Advance       │──▶│ Dispatch │──▶│ Reposition   │──▶│ Advance      │
+│ Transient     │   │          │   │              │   │ Queue        │
+└───────────────┘   └──────────┘   └──────────────┘   └──────────────┘
+                                                             │
+          ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐
+          │ Metrics  │◀──│ Loading  │◀──│ Doors    │◀──│ Movement │
+          │          │   │          │   │          │   │          │
+          └──────────┘   └──────────┘   └──────────┘   └──────────┘
 ```
 
 | Phase | Description |
@@ -159,6 +159,7 @@ Each call to `sim.step()` executes seven phases:
 | **Advance Transient** | Promotes one-tick states forward (Boarding to Riding, Exiting to Resident/Arrived). |
 | **Dispatch** | Assigns idle elevators to stops via the pluggable `DispatchStrategy`. |
 | **Reposition** | Moves idle elevators toward strategic positions to reduce future wait times. |
+| **Advance Queue** | Reconciles each elevator's phase/target with its `DestinationQueue` front (honors imperative `push_destination` / `push_destination_front` / `clear_destinations` calls). |
 | **Movement** | Updates elevator position and velocity using trapezoidal acceleration profiles. |
 | **Doors** | Ticks door open/close finite-state machines at each stop. |
 | **Loading** | Boards waiting riders onto elevators with open doors and exits riders at their destination. |

--- a/crates/elevator-core/ARCHITECTURE.md
+++ b/crates/elevator-core/ARCHITECTURE.md
@@ -80,9 +80,9 @@ for (id, vip) in world.query::<(EntityId, &Ext<VipTag>)>().iter() { ... }
 world.query_ext_mut::<VipTag>().for_each_mut(|id, tag| { tag.level += 1; });
 ```
 
-## 3. The 7-Phase Tick Loop
+## 3. The 8-Phase Tick Loop
 
-Each call to `sim.step()` runs all seven phases in order, then advances the
+Each call to `sim.step()` runs all eight phases in order, then advances the
 tick counter. Events emitted during a tick are buffered and available to
 consumers via `drain_events()` after the tick completes.
 
@@ -97,16 +97,19 @@ consumers via `drain_events()` after the tick completes.
 │ 3. Reposition         │  systems/reposition.rs
 │                       │  Move idle elevators via RepositionStrategy (optional)
 ├───────────────────────┤
-│ 4. Movement           │  systems/movement.rs
+│ 4. AdvanceQueue       │  systems/advance_queue.rs
+│                       │  Reconcile phase/target with DestinationQueue front
+├───────────────────────┤
+│ 5. Movement           │  systems/movement.rs
 │                       │  Trapezoidal velocity profile, PassingFloor detection
 ├───────────────────────┤
-│ 5. Doors              │  systems/doors.rs
+│ 6. Doors              │  systems/doors.rs
 │                       │  DoorState FSM: Opening→Open→Closing→Closed
 ├───────────────────────┤
-│ 6. Loading            │  systems/loading.rs
+│ 7. Loading            │  systems/loading.rs
 │                       │  Board/exit riders, capacity checks, rejections
 ├───────────────────────┤
-│ 7. Metrics            │  systems/metrics.rs
+│ 8. Metrics            │  systems/metrics.rs
 │                       │  Aggregate wait/ride times, throughput, tagged metrics
 └───────────┬───────────┘
             ▼

--- a/crates/elevator-core/src/components/destination_queue.rs
+++ b/crates/elevator-core/src/components/destination_queue.rs
@@ -1,0 +1,102 @@
+//! Per-elevator destination queue (FIFO of target stop `EntityId`s).
+//!
+//! Inspired by elevator-saga's `destinationQueue` / `goToFloor(n, forceNow)`
+//! API: games can push stops to the back or the front of the queue, or clear
+//! it entirely, without writing a custom `DispatchStrategy`.
+//!
+//! The built-in dispatch also writes to the queue (via
+//! [`Simulation::push_destination`](crate::sim::Simulation::push_destination)),
+//! so the queue is always in sync with the elevator's current target.
+
+use crate::entity::EntityId;
+use serde::{Deserialize, Serialize};
+
+/// FIFO queue of target stop `EntityId`s for a single elevator.
+///
+/// Adjacent duplicates are collapsed on push:
+///
+/// - [`push_back`](Self::push_back) is a no-op if the *last* entry already
+///   equals the new stop.
+/// - [`push_front`](Self::push_front) is a no-op if the *first* entry already
+///   equals the new stop.
+///
+/// Games interact with the queue via
+/// [`Simulation::push_destination`](crate::sim::Simulation::push_destination),
+/// [`Simulation::push_destination_front`](crate::sim::Simulation::push_destination_front),
+/// and [`Simulation::clear_destinations`](crate::sim::Simulation::clear_destinations).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DestinationQueue {
+    /// Ordered FIFO of target stop `EntityId`s.
+    queue: Vec<EntityId>,
+}
+
+impl DestinationQueue {
+    /// Create an empty queue.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { queue: Vec::new() }
+    }
+
+    /// Read-only view of the current queue in FIFO order.
+    #[must_use]
+    pub fn queue(&self) -> &[EntityId] {
+        &self.queue
+    }
+
+    /// `true` if the queue contains no entries.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
+    /// Number of entries in the queue.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.queue.len()
+    }
+
+    /// The stop at the front of the queue (next destination).
+    #[must_use]
+    pub fn front(&self) -> Option<EntityId> {
+        self.queue.first().copied()
+    }
+
+    /// Push a stop onto the back of the queue.
+    ///
+    /// Returns `true` if the stop was actually appended. Returns `false` if
+    /// the queue is non-empty and its last entry already equals `stop`
+    /// (adjacent-duplicate dedup).
+    pub(crate) fn push_back(&mut self, stop: EntityId) -> bool {
+        if self.queue.last() == Some(&stop) {
+            return false;
+        }
+        self.queue.push(stop);
+        true
+    }
+
+    /// Insert a stop at the front of the queue (saga's `forceNow`).
+    ///
+    /// Returns `true` if the stop was actually inserted. Returns `false` if
+    /// the queue is non-empty and its first entry already equals `stop`.
+    pub(crate) fn push_front(&mut self, stop: EntityId) -> bool {
+        if self.queue.first() == Some(&stop) {
+            return false;
+        }
+        self.queue.insert(0, stop);
+        true
+    }
+
+    /// Drain all entries.
+    pub(crate) fn clear(&mut self) {
+        self.queue.clear();
+    }
+
+    /// Remove and return the front entry.
+    pub(crate) fn pop_front(&mut self) -> Option<EntityId> {
+        if self.queue.is_empty() {
+            None
+        } else {
+            Some(self.queue.remove(0))
+        }
+    }
+}

--- a/crates/elevator-core/src/components/mod.rs
+++ b/crates/elevator-core/src/components/mod.rs
@@ -2,6 +2,8 @@
 
 /// Access control for restricting rider stop access.
 pub mod access;
+/// Per-elevator ordered destination queue.
+pub mod destination_queue;
 /// Elevator state and properties.
 pub mod elevator;
 /// Line (physical path) — shaft, tether, track.
@@ -20,6 +22,7 @@ pub mod service_mode;
 pub mod stop;
 
 pub use access::AccessControl;
+pub use destination_queue::DestinationQueue;
 pub use elevator::{Elevator, ElevatorPhase};
 pub use line::{FloorPosition, Line, Orientation};
 pub use patience::{Patience, Preferences};

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -389,6 +389,22 @@ pub enum Event {
         tick: u64,
     },
 
+    /// A stop was queued as a destination for an elevator.
+    ///
+    /// Emitted by [`Simulation::push_destination`](crate::sim::Simulation::push_destination),
+    /// [`Simulation::push_destination_front`](crate::sim::Simulation::push_destination_front),
+    /// and the built-in dispatch phase whenever it actually appends a stop
+    /// to an elevator's [`DestinationQueue`](crate::components::DestinationQueue).
+    /// Adjacent-duplicate pushes (that are deduplicated) do not emit.
+    DestinationQueued {
+        /// The elevator whose queue was updated.
+        elevator: EntityId,
+        /// The stop that was queued.
+        stop: EntityId,
+        /// The tick when the push occurred.
+        tick: u64,
+    },
+
     /// A stop was permanently removed from the simulation.
     ///
     /// Distinct from [`EntityDisabled`] — a disabled stop can be

--- a/crates/elevator-core/src/hooks.rs
+++ b/crates/elevator-core/src/hooks.rs
@@ -41,6 +41,8 @@ pub enum Phase {
     Loading,
     /// Reposition idle elevators for better coverage.
     Reposition,
+    /// Reconcile elevator phase with its `DestinationQueue` front.
+    AdvanceQueue,
     /// Aggregate metrics from tick events.
     Metrics,
 }

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -5,7 +5,7 @@
 //! This crate provides the building blocks for modeling vertical transportation
 //! systems — from a 3-story office building to an orbital space elevator.
 //! Stops sit at arbitrary positions rather than uniform floors, and the
-//! simulation is driven by a deterministic 7-phase tick loop.
+//! simulation is driven by a deterministic 8-phase tick loop.
 //!
 //! ## Key capabilities
 //!
@@ -18,7 +18,7 @@
 //! - **Extension components** — attach arbitrary `Serialize + DeserializeOwned`
 //!   data to any entity via [`world::World::insert_ext`] without modifying the
 //!   library.
-//! - **Lifecycle hooks** — inject logic before or after any of the seven
+//! - **Lifecycle hooks** — inject logic before or after any of the eight
 //!   simulation phases. See [`hooks::Phase`].
 //! - **Metrics and events** — query aggregate wait/ride times through
 //!   [`metrics::Metrics`] and react to fine-grained tick events via
@@ -68,7 +68,7 @@
 //!
 //! ## Architecture overview
 //!
-//! ### 7-phase tick loop
+//! ### 8-phase tick loop
 //!
 //! Each call to [`Simulation::step()`](sim::Simulation::step) runs these
 //! phases in order:
@@ -79,11 +79,14 @@
 //!    and calls each group's [`DispatchStrategy`](dispatch::DispatchStrategy).
 //! 3. **Reposition** — optional phase; moves idle elevators via
 //!    [`RepositionStrategy`](dispatch::RepositionStrategy) for better coverage.
-//! 4. **Movement** — applies trapezoidal velocity profiles, detects stop arrivals
+//! 4. **`AdvanceQueue`** — reconciles each elevator's phase/target with the
+//!    front of its [`DestinationQueue`](components::DestinationQueue), so
+//!    imperative pushes from game code take effect before movement.
+//! 5. **Movement** — applies trapezoidal velocity profiles, detects stop arrivals
 //!    and emits [`PassingFloor`](events::Event::PassingFloor) events.
-//! 5. **Doors** — ticks the [`DoorState`](door::DoorState) FSM per elevator.
-//! 6. **Loading** — boards/exits riders with capacity and preference checks.
-//! 7. **Metrics** — aggregates wait/ride times into [`Metrics`](metrics::Metrics)
+//! 6. **Doors** — ticks the [`DoorState`](door::DoorState) FSM per elevator.
+//! 7. **Loading** — boards/exits riders with capacity and preference checks.
+//! 8. **Metrics** — aggregates wait/ride times into [`Metrics`](metrics::Metrics)
 //!    and per-tag accumulators.
 //!
 //! ### Component relationships
@@ -273,8 +276,8 @@ macro_rules! register_extensions {
 pub mod prelude {
     pub use crate::builder::SimulationBuilder;
     pub use crate::components::{
-        AccessControl, Elevator, ElevatorPhase, FloorPosition, Line, Orientation, Patience,
-        Position, Preferences, Rider, RiderPhase, Route, ServiceMode, Stop, Velocity,
+        AccessControl, DestinationQueue, Elevator, ElevatorPhase, FloorPosition, Line, Orientation,
+        Patience, Position, Preferences, Rider, RiderPhase, Route, ServiceMode, Stop, Velocity,
     };
     pub use crate::config::{GroupConfig, LineConfig, SimConfig};
     pub use crate::dispatch::reposition::{

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -515,6 +515,7 @@ impl Simulation {
             if let Some(mode) = ec.service_mode {
                 world.set_service_mode(eid, mode);
             }
+            world.set_destination_queue(eid, crate::components::DestinationQueue::new());
             elevator_entities.push(eid);
         }
 
@@ -643,6 +644,7 @@ impl Simulation {
                 if let Some(mode) = ec.service_mode {
                     world.set_service_mode(eid, mode);
                 }
+                world.set_destination_queue(eid, crate::components::DestinationQueue::new());
                 elevator_entities.push(eid);
             }
 
@@ -1035,6 +1037,120 @@ impl Simulation {
     #[must_use]
     pub fn pending_events(&self) -> &[Event] {
         &self.pending_output
+    }
+
+    // ── Destination queue (saga-style imperative dispatch) ──────────
+
+    /// Read-only view of an elevator's destination queue (FIFO of target
+    /// stop `EntityId`s).
+    ///
+    /// Returns `None` if `elev` is not an elevator entity. Returns
+    /// `Some(&[])` for elevators with an empty queue.
+    #[must_use]
+    pub fn destination_queue(&self, elev: EntityId) -> Option<&[EntityId]> {
+        self.world
+            .destination_queue(elev)
+            .map(crate::components::DestinationQueue::queue)
+    }
+
+    /// Push a stop onto the back of an elevator's destination queue.
+    ///
+    /// Adjacent duplicates are suppressed: if the last entry already equals
+    /// `stop`, the queue is unchanged and no event is emitted.
+    /// Otherwise emits [`Event::DestinationQueued`].
+    ///
+    /// # Errors
+    ///
+    /// - [`SimError::InvalidState`] if `elev` is not an elevator.
+    /// - [`SimError::InvalidState`] if `stop` is not a stop.
+    pub fn push_destination(&mut self, elev: EntityId, stop: EntityId) -> Result<(), SimError> {
+        self.validate_push_targets(elev, stop)?;
+        let appended = self
+            .world
+            .destination_queue_mut(elev)
+            .is_some_and(|q| q.push_back(stop));
+        if appended {
+            self.events.emit(Event::DestinationQueued {
+                elevator: elev,
+                stop,
+                tick: self.tick,
+            });
+        }
+        Ok(())
+    }
+
+    /// Insert a stop at the front of an elevator's destination queue
+    /// (elevator-saga's `forceNow`).
+    ///
+    /// On the next `AdvanceQueue` phase (between Dispatch and Movement),
+    /// the elevator redirects to this new front if it differs from the
+    /// current target.
+    ///
+    /// Adjacent duplicates are suppressed: if the first entry already equals
+    /// `stop`, the queue is unchanged and no event is emitted.
+    ///
+    /// # Errors
+    ///
+    /// - [`SimError::InvalidState`] if `elev` is not an elevator.
+    /// - [`SimError::InvalidState`] if `stop` is not a stop.
+    pub fn push_destination_front(
+        &mut self,
+        elev: EntityId,
+        stop: EntityId,
+    ) -> Result<(), SimError> {
+        self.validate_push_targets(elev, stop)?;
+        let inserted = self
+            .world
+            .destination_queue_mut(elev)
+            .is_some_and(|q| q.push_front(stop));
+        if inserted {
+            self.events.emit(Event::DestinationQueued {
+                elevator: elev,
+                stop,
+                tick: self.tick,
+            });
+        }
+        Ok(())
+    }
+
+    /// Clear an elevator's destination queue.
+    ///
+    /// TODO: clearing does not currently abort an in-flight movement — the
+    /// elevator will finish its current leg and then go idle (since the
+    /// queue is empty). A future change can add a phase transition to
+    /// cancel mid-flight.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SimError::InvalidState`] if `elev` is not an elevator.
+    pub fn clear_destinations(&mut self, elev: EntityId) -> Result<(), SimError> {
+        if self.world.elevator(elev).is_none() {
+            return Err(SimError::InvalidState {
+                entity: elev,
+                reason: "not an elevator".into(),
+            });
+        }
+        if let Some(q) = self.world.destination_queue_mut(elev) {
+            q.clear();
+        }
+        Ok(())
+    }
+
+    /// Validate that `elev` is an elevator and `stop` is a stop.
+    fn validate_push_targets(&self, elev: EntityId, stop: EntityId) -> Result<(), SimError> {
+        if self.world.elevator(elev).is_none() {
+            return Err(SimError::InvalidState {
+                entity: elev,
+                reason: "not an elevator".into(),
+            });
+        }
+        if self.world.stop(stop).is_none() {
+            return Err(SimError::InvalidState {
+                entity: stop,
+                reason: "not a stop".into(),
+            });
+        }
+        Ok(())
     }
 
     // ── Dispatch management ──────────────────────────────────────────
@@ -1618,6 +1734,8 @@ impl Simulation {
                 move_count: 0,
             },
         );
+        self.world
+            .set_destination_queue(eid, crate::components::DestinationQueue::new());
         self.groups[group_idx].lines_mut()[line_idx]
             .elevators_mut()
             .push(eid);
@@ -3067,6 +3185,32 @@ impl Simulation {
         self.hooks.run_after(Phase::Loading, &mut self.world);
     }
 
+    /// Run only the advance-queue phase (with hooks).
+    ///
+    /// Reconciles each elevator's phase/target with the front of its
+    /// [`DestinationQueue`](crate::components::DestinationQueue). Runs
+    /// between Reposition and Movement.
+    pub fn run_advance_queue(&mut self) {
+        self.hooks.run_before(Phase::AdvanceQueue, &mut self.world);
+        for group in &self.groups {
+            self.hooks
+                .run_before_group(Phase::AdvanceQueue, group.id(), &mut self.world);
+        }
+        let ctx = self.phase_context();
+        self.world.elevator_ids_into(&mut self.elevator_ids_buf);
+        crate::systems::advance_queue::run(
+            &mut self.world,
+            &mut self.events,
+            &ctx,
+            &self.elevator_ids_buf,
+        );
+        for group in &self.groups {
+            self.hooks
+                .run_after_group(Phase::AdvanceQueue, group.id(), &mut self.world);
+        }
+        self.hooks.run_after(Phase::AdvanceQueue, &mut self.world);
+    }
+
     /// Run only the reposition phase (with hooks).
     ///
     /// Only runs if at least one group has a [`RepositionStrategy`] configured.
@@ -3206,6 +3350,7 @@ impl Simulation {
         self.run_advance_transient();
         self.run_dispatch();
         self.run_reposition();
+        self.run_advance_queue();
         self.run_movement();
         self.run_doors();
         self.run_loading();

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -8,7 +8,8 @@
 //! own extensions separately and re-attach them after restoring.
 
 use crate::components::{
-    AccessControl, Elevator, Line, Patience, Position, Preferences, Rider, Route, Stop, Velocity,
+    AccessControl, DestinationQueue, Elevator, Line, Patience, Position, Preferences, Rider, Route,
+    Stop, Velocity,
 };
 use crate::entity::EntityId;
 use crate::ids::GroupId;
@@ -58,6 +59,9 @@ pub struct EntitySnapshot {
     /// Service mode (if present).
     #[serde(default)]
     pub service_mode: Option<crate::components::ServiceMode>,
+    /// Destination queue (per-elevator; absent in legacy snapshots).
+    #[serde(default)]
+    pub destination_queue: Option<DestinationQueue>,
 }
 
 /// Serializable snapshot of the entire simulation state.
@@ -346,6 +350,16 @@ impl WorldSnapshot {
             if let Some(mode) = snap.service_mode {
                 world.set_service_mode(eid, mode);
             }
+            if let Some(ref dq) = snap.destination_queue {
+                // Remap EntityIds inside the queue.
+                use crate::components::DestinationQueue as DQ;
+                let remapped: Vec<EntityId> = dq.queue().iter().map(|&e| remap(e)).collect();
+                let mut new_dq = DQ::new();
+                for eid_q in remapped {
+                    new_dq.push_back(eid_q);
+                }
+                world.set_destination_queue(eid, new_dq);
+            }
         }
     }
 
@@ -496,6 +510,7 @@ impl crate::sim::Simulation {
                 #[cfg(feature = "energy")]
                 energy_metrics: world.energy_metrics(eid).cloned(),
                 service_mode: world.service_mode(eid).copied(),
+                destination_queue: world.destination_queue(eid).cloned(),
             })
             .collect();
 

--- a/crates/elevator-core/src/systems/advance_queue.rs
+++ b/crates/elevator-core/src/systems/advance_queue.rs
@@ -1,0 +1,111 @@
+//! Reconcile each elevator's phase/target with the front of its
+//! [`DestinationQueue`](crate::components::DestinationQueue).
+//!
+//! This phase runs after Dispatch and Reposition but before Movement.
+//! Dispatch keeps driving elevators the usual way (it sets `target_stop`
+//! and `phase` directly AND pushes to the queue, so they stay in sync).
+//! This system is primarily responsible for responding to *imperative*
+//! mutations from game code — `push_destination_front` / `clear_destinations`
+//! — which may bypass dispatch entirely.
+//!
+//! Rules per elevator:
+//!
+//! - If phase is `Idle` or `Stopped` and the queue has a front stop:
+//!   if we're already at that stop, pop it and open doors; otherwise
+//!   transition to `MovingToStop(front)`.
+//! - If phase is `MovingToStop(t)` and `queue.front() != Some(t)`:
+//!   redirect to the new front (or fall back to `Idle` if the queue is empty
+//!   and we are not repositioning).
+
+use crate::components::ElevatorPhase;
+use crate::door::DoorState;
+use crate::entity::EntityId;
+use crate::events::{Event, EventBus};
+use crate::world::World;
+
+use super::PhaseContext;
+
+/// Reconcile every elevator's phase with its destination-queue front.
+pub fn run(
+    world: &mut World,
+    events: &mut EventBus,
+    ctx: &PhaseContext,
+    elevator_ids: &[EntityId],
+) {
+    for &eid in elevator_ids {
+        if world.is_disabled(eid) {
+            continue;
+        }
+        let Some(car) = world.elevator(eid) else {
+            continue;
+        };
+        // Don't interfere with repositioning — it has its own lifecycle.
+        if car.repositioning {
+            continue;
+        }
+        let phase = car.phase;
+        let current_target = car.target_stop;
+        let Some(queue) = world.destination_queue(eid) else {
+            continue;
+        };
+        let front = queue.front();
+
+        match phase {
+            ElevatorPhase::Idle | ElevatorPhase::Stopped => {
+                let Some(next) = front else { continue };
+                let pos = world.position(eid).map_or(0.0, |p| p.value);
+                let at_stop = world.find_stop_at_position(pos);
+                if at_stop == Some(next) {
+                    // Already at the queued stop — pop and open doors.
+                    if let Some(q) = world.destination_queue_mut(eid) {
+                        q.pop_front();
+                    }
+                    events.emit(Event::ElevatorArrived {
+                        elevator: eid,
+                        at_stop: next,
+                        tick: ctx.tick,
+                    });
+                    if let Some(car) = world.elevator_mut(eid) {
+                        car.phase = ElevatorPhase::DoorOpening;
+                        car.door =
+                            DoorState::request_open(car.door_transition_ticks, car.door_open_ticks);
+                    }
+                } else {
+                    let from_stop = at_stop;
+                    if let Some(car) = world.elevator_mut(eid) {
+                        car.phase = ElevatorPhase::MovingToStop(next);
+                        car.target_stop = Some(next);
+                    }
+                    if let Some(from) = from_stop {
+                        events.emit(Event::ElevatorDeparted {
+                            elevator: eid,
+                            from_stop: from,
+                            tick: ctx.tick,
+                        });
+                    }
+                }
+            }
+            ElevatorPhase::MovingToStop(t) => {
+                if front == Some(t) {
+                    // In sync — nothing to do.
+                    continue;
+                }
+                match front {
+                    Some(new_target) => {
+                        if let Some(car) = world.elevator_mut(eid) {
+                            car.phase = ElevatorPhase::MovingToStop(new_target);
+                            car.target_stop = Some(new_target);
+                        }
+                    }
+                    None => {
+                        // Queue was cleared; leave current target in place for
+                        // this PR (clearing does not abort mid-flight — see
+                        // TODO on Simulation::clear_destinations).
+                        let _ = current_target;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}

--- a/crates/elevator-core/src/systems/advance_queue.rs
+++ b/crates/elevator-core/src/systems/advance_queue.rs
@@ -24,6 +24,18 @@ use crate::events::{Event, EventBus};
 use crate::world::World;
 
 use super::PhaseContext;
+use super::dispatch::update_indicators;
+
+/// Compute directional indicator flags for an elevator heading from
+/// `from_pos` toward the stop at `target`. Returns `(going_up, going_down)`.
+/// Equal or missing target positions leave both lamps lit.
+fn indicators_for_travel(world: &World, target: EntityId, from_pos: f64) -> (bool, bool) {
+    match world.stop_position(target) {
+        Some(p) if p > from_pos => (true, false),
+        Some(p) if p < from_pos => (false, true),
+        _ => (true, true),
+    }
+}
 
 /// Reconcile every elevator's phase with its destination-queue front.
 pub fn run(
@@ -72,10 +84,12 @@ pub fn run(
                     }
                 } else {
                     let from_stop = at_stop;
+                    let (new_up, new_down) = indicators_for_travel(world, next, pos);
                     if let Some(car) = world.elevator_mut(eid) {
                         car.phase = ElevatorPhase::MovingToStop(next);
                         car.target_stop = Some(next);
                     }
+                    update_indicators(world, events, eid, new_up, new_down, ctx.tick);
                     if let Some(from) = from_stop {
                         events.emit(Event::ElevatorDeparted {
                             elevator: eid,
@@ -92,10 +106,13 @@ pub fn run(
                 }
                 match front {
                     Some(new_target) => {
+                        let pos = world.position(eid).map_or(0.0, |p| p.value);
+                        let (new_up, new_down) = indicators_for_travel(world, new_target, pos);
                         if let Some(car) = world.elevator_mut(eid) {
                             car.phase = ElevatorPhase::MovingToStop(new_target);
                             car.target_stop = Some(new_target);
                         }
+                        update_indicators(world, events, eid, new_up, new_down, ctx.tick);
                     }
                     None => {
                         // Queue was cleared; leave current target in place for

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -155,7 +155,10 @@ pub fn run(
 
 /// Update the direction indicator lamps on an elevator and emit a
 /// [`Event::DirectionIndicatorChanged`] iff the pair actually changed.
-fn update_indicators(
+///
+/// Shared with `systems::advance_queue` so both dispatch- and
+/// imperative-driven movement keep the indicators in sync.
+pub fn update_indicators(
     world: &mut World,
     events: &mut EventBus,
     eid: EntityId,

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -15,6 +15,7 @@ use std::collections::BTreeMap;
 use super::PhaseContext;
 
 /// Assign idle/stopped elevators to stops via the dispatch strategy.
+#[allow(clippy::too_many_lines)]
 pub fn run(
     world: &mut World,
     events: &mut EventBus,
@@ -85,7 +86,7 @@ pub fn run(
                     };
                     update_indicators(world, events, eid, new_up, new_down, ctx.tick);
 
-                    // Already at this stop — open doors directly.
+                    // Already at this stop — open doors directly, don't push.
                     if current_stop == Some(stop_eid) {
                         events.emit(Event::ElevatorArrived {
                             elevator: eid,
@@ -100,6 +101,17 @@ pub fn run(
                             );
                         }
                         continue;
+                    }
+
+                    // Push onto queue with adjacent dedup; emit event iff appended.
+                    if let Some(q) = world.destination_queue_mut(eid) {
+                        if q.push_back(stop_eid) {
+                            events.emit(Event::DestinationQueued {
+                                elevator: eid,
+                                stop: stop_eid,
+                                tick: ctx.tick,
+                            });
+                        }
                     }
 
                     if let Some(car) = world.elevator_mut(eid) {

--- a/crates/elevator-core/src/systems/mod.rs
+++ b/crates/elevator-core/src/systems/mod.rs
@@ -1,5 +1,7 @@
 //! Tick-loop system phases run in sequence each simulation step.
 
+/// Reconcile elevator phase with its destination queue front.
+pub(crate) mod advance_queue;
 /// Advance transient states (boarding/exiting) to their next state.
 pub(crate) mod advance_transient;
 /// Assign idle elevators to stops via dispatch strategy.

--- a/crates/elevator-core/src/systems/movement.rs
+++ b/crates/elevator-core/src/systems/movement.rs
@@ -126,6 +126,12 @@ pub fn run(
         }
 
         if result.arrived {
+            // Pop the queue front if it matches the target we arrived at.
+            if let Some(q) = world.destination_queue_mut(eid) {
+                if q.front() == Some(target_stop_eid) {
+                    q.pop_front();
+                }
+            }
             let Some(car) = world.elevator_mut(eid) else {
                 continue;
             };

--- a/crates/elevator-core/src/tests/destination_queue_tests.rs
+++ b/crates/elevator-core/src/tests/destination_queue_tests.rs
@@ -1,0 +1,287 @@
+//! Tests for the per-elevator `DestinationQueue` component and its
+//! imperative push/clear API (inspired by elevator-saga's `destinationQueue`).
+
+use crate::builder::SimulationBuilder;
+use crate::components::ElevatorPhase;
+use crate::dispatch::scan::ScanDispatch;
+use crate::events::Event;
+use crate::stop::StopId;
+
+use super::helpers::default_config;
+
+fn build_sim() -> crate::sim::Simulation {
+    SimulationBuilder::from_config(default_config())
+        .dispatch(ScanDispatch::new())
+        .build()
+        .unwrap()
+}
+
+fn first_elevator(sim: &crate::sim::Simulation) -> crate::entity::EntityId {
+    sim.world().elevator_ids()[0]
+}
+
+// 1
+#[test]
+fn fresh_queue_is_empty() {
+    let sim = build_sim();
+    let elev = first_elevator(&sim);
+    assert_eq!(sim.destination_queue(elev), Some(&[][..]));
+}
+
+// 2
+#[test]
+fn dispatch_populates_queue() {
+    let mut sim = build_sim();
+    // Spawn rider traveling from stop 1 (not elevator's start) to stop 2,
+    // so dispatch has to send the car somewhere — triggering a queue push.
+    sim.spawn_rider_by_stop_id(StopId(1), StopId(2), 75.0)
+        .unwrap();
+    sim.step();
+    let elev = first_elevator(&sim);
+    let queue = sim.destination_queue(elev).unwrap();
+    assert!(
+        !queue.is_empty(),
+        "queue should contain the dispatched target (got {queue:?})"
+    );
+}
+
+// 3
+#[test]
+fn queue_pops_on_arrival() {
+    let mut sim = build_sim();
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
+        .unwrap();
+    // Run enough ticks for the elevator to reach stop 2.
+    for _ in 0..2000 {
+        sim.step();
+        let elev = first_elevator(&sim);
+        let car = sim.world().elevator(elev).unwrap();
+        if !matches!(car.phase(), ElevatorPhase::MovingToStop(_))
+            && sim.destination_queue(elev).is_some_and(<[_]>::is_empty)
+        {
+            break;
+        }
+    }
+    let elev = first_elevator(&sim);
+    // After arrival, the queue should be empty.
+    assert!(sim.destination_queue(elev).unwrap().is_empty());
+}
+
+// 4
+#[test]
+fn push_destination_adds_to_back() {
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+    let s1 = sim.stop_entity(StopId(1)).unwrap();
+    sim.push_destination(elev, s1).unwrap();
+    assert_eq!(sim.destination_queue(elev).unwrap(), &[s1]);
+}
+
+// 5
+#[test]
+fn push_destination_adjacent_dedup_back() {
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+    let s1 = sim.stop_entity(StopId(1)).unwrap();
+    sim.push_destination(elev, s1).unwrap();
+    sim.push_destination(elev, s1).unwrap();
+    assert_eq!(sim.destination_queue(elev).unwrap(), &[s1]);
+}
+
+// 6
+#[test]
+fn push_destination_front_inserts_at_index_0() {
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+    let s1 = sim.stop_entity(StopId(1)).unwrap();
+    let s2 = sim.stop_entity(StopId(2)).unwrap();
+    sim.push_destination(elev, s1).unwrap();
+    sim.push_destination_front(elev, s2).unwrap();
+    assert_eq!(sim.destination_queue(elev).unwrap(), &[s2, s1]);
+}
+
+// 7
+#[test]
+fn push_destination_front_adjacent_dedup() {
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+    let s1 = sim.stop_entity(StopId(1)).unwrap();
+    sim.push_destination_front(elev, s1).unwrap();
+    sim.push_destination_front(elev, s1).unwrap();
+    assert_eq!(sim.destination_queue(elev).unwrap(), &[s1]);
+}
+
+// 8
+#[test]
+fn clear_destinations_empties_queue() {
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+    let s0 = sim.stop_entity(StopId(0)).unwrap();
+    let s1 = sim.stop_entity(StopId(1)).unwrap();
+    let s2 = sim.stop_entity(StopId(2)).unwrap();
+    sim.push_destination(elev, s1).unwrap();
+    sim.push_destination(elev, s2).unwrap();
+    sim.push_destination(elev, s0).unwrap();
+    sim.clear_destinations(elev).unwrap();
+    assert!(sim.destination_queue(elev).unwrap().is_empty());
+}
+
+// 9
+#[test]
+fn imperative_push_drives_elevator() {
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+    let s2 = sim.stop_entity(StopId(2)).unwrap();
+    sim.push_destination(elev, s2).unwrap();
+
+    let mut arrived = false;
+    for _ in 0..2000 {
+        sim.step();
+        for ev in sim.drain_events() {
+            if let Event::ElevatorArrived {
+                elevator, at_stop, ..
+            } = ev
+            {
+                if elevator == elev && at_stop == s2 {
+                    arrived = true;
+                }
+            }
+        }
+        if arrived {
+            break;
+        }
+    }
+    assert!(
+        arrived,
+        "elevator should have arrived at stop 2 via imperative queue"
+    );
+}
+
+// 10
+#[test]
+fn push_front_overrides_current_target() {
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+    let s1 = sim.stop_entity(StopId(1)).unwrap();
+    let s2 = sim.stop_entity(StopId(2)).unwrap();
+
+    // First put s2 on the queue and get the elevator moving toward it.
+    sim.push_destination(elev, s2).unwrap();
+    sim.step(); // AdvanceQueue sets target to s2
+    sim.step();
+
+    // Now override: put s1 at the front.
+    sim.push_destination_front(elev, s1).unwrap();
+
+    let mut arrived_at = None;
+    for _ in 0..2000 {
+        sim.step();
+        for ev in sim.drain_events() {
+            if let Event::ElevatorArrived {
+                elevator, at_stop, ..
+            } = ev
+            {
+                if elevator == elev {
+                    arrived_at = Some(at_stop);
+                    break;
+                }
+            }
+        }
+        if arrived_at.is_some() {
+            break;
+        }
+    }
+    assert_eq!(
+        arrived_at,
+        Some(s1),
+        "elevator should arrive at s1 first after push_front"
+    );
+}
+
+// 11
+#[test]
+fn destination_queued_event_fires_on_push() {
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+    let s2 = sim.stop_entity(StopId(2)).unwrap();
+
+    // One push via sim helper (top stop — elevator is at stop 0).
+    sim.push_destination(elev, s2).unwrap();
+    // Second push via dispatch: rider at stop 1 triggers a GoToStop(s1) push.
+    sim.spawn_rider_by_stop_id(StopId(1), StopId(2), 75.0)
+        .unwrap();
+    sim.step();
+
+    let events = sim.drain_events();
+    let count = events
+        .iter()
+        .filter(|e| matches!(e, Event::DestinationQueued { .. }))
+        .count();
+    // One from direct push (s2) + one from dispatch (s1).
+    assert!(
+        count >= 2,
+        "expected at least 2 DestinationQueued events, got {count}"
+    );
+}
+
+// 12
+#[test]
+fn destination_queued_event_suppressed_on_dedup() {
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+    let s1 = sim.stop_entity(StopId(1)).unwrap();
+
+    sim.push_destination(elev, s1).unwrap();
+    sim.push_destination(elev, s1).unwrap(); // dedup
+
+    let events = sim.drain_events();
+    let count = events
+        .iter()
+        .filter(|e| matches!(e, Event::DestinationQueued { .. }))
+        .count();
+    assert_eq!(count, 1);
+}
+
+// 13
+#[test]
+fn snapshot_roundtrip_preserves_queue() {
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+    let s0 = sim.stop_entity(StopId(0)).unwrap();
+    let s1 = sim.stop_entity(StopId(1)).unwrap();
+    let s2 = sim.stop_entity(StopId(2)).unwrap();
+
+    sim.push_destination(elev, s1).unwrap();
+    sim.push_destination(elev, s2).unwrap();
+    sim.push_destination(elev, s0).unwrap();
+
+    let snapshot = sim.snapshot();
+    let restored = snapshot.restore(None);
+    let new_elev = restored.world().elevator_ids()[0];
+
+    let restored_queue = restored.destination_queue(new_elev).unwrap();
+    assert_eq!(restored_queue.len(), 3);
+}
+
+// 14
+#[test]
+fn push_destination_errors_on_non_elevator() {
+    let mut sim = build_sim();
+    let s1 = sim.stop_entity(StopId(1)).unwrap();
+    // Spawn a rider entity — not an elevator.
+    let rider = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
+        .unwrap();
+    let result = sim.push_destination(rider, s1);
+    assert!(result.is_err());
+}
+
+// 15
+#[test]
+fn push_destination_errors_on_non_stop() {
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+    // Use the elevator entity as the target — not a stop.
+    let result = sim.push_destination(elev, elev);
+    assert!(result.is_err());
+}

--- a/crates/elevator-core/src/tests/destination_queue_tests.rs
+++ b/crates/elevator-core/src/tests/destination_queue_tests.rs
@@ -285,3 +285,45 @@ fn push_destination_errors_on_non_stop() {
     let result = sim.push_destination(elev, elev);
     assert!(result.is_err());
 }
+
+// Regression for greptile P1: when `advance_queue` redirects a moving
+// elevator via `push_destination_front`, the direction indicators used
+// by loading.rs to gate boarding must be updated — otherwise downward
+// riders get silently rejected by a physically-descending car still
+// flagged as going up.
+#[test]
+fn redirect_via_push_front_updates_direction_indicators() {
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+
+    // Dispatch sends the elevator upward toward stop 2.
+    sim.spawn_rider_by_stop_id(StopId(1), StopId(2), 75.0)
+        .unwrap();
+    // Let dispatch push to the queue and the elevator begin moving up.
+    for _ in 0..20 {
+        sim.step();
+        if matches!(
+            sim.world()
+                .elevator(elev)
+                .map(crate::components::Elevator::phase),
+            Some(ElevatorPhase::MovingToStop(_))
+        ) {
+            break;
+        }
+    }
+    assert_eq!(sim.elevator_going_up(elev), Some(true));
+    assert_eq!(sim.elevator_going_down(elev), Some(false));
+
+    // Game imperatively redirects to a stop below the current position.
+    let stop_0 = sim.stop_entity(StopId(0)).unwrap();
+    sim.push_destination_front(elev, stop_0).unwrap();
+    // One step of advance_queue flips the target and must refresh the lamps.
+    sim.step();
+
+    assert_eq!(
+        sim.elevator_going_up(elev),
+        Some(false),
+        "push_destination_front to a lower stop must clear going_up",
+    );
+    assert_eq!(sim.elevator_going_down(elev), Some(true));
+}

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -31,6 +31,7 @@ mod world_tests;
 mod api_surface_tests;
 mod boundary_tests;
 mod braking_tests;
+mod destination_queue_tests;
 mod direction_indicator_tests;
 #[cfg(feature = "energy")]
 mod energy_tests;

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -6,8 +6,8 @@ use std::collections::HashMap;
 use slotmap::{SecondaryMap, SlotMap};
 
 use crate::components::{
-    AccessControl, Elevator, Line, Patience, Position, Preferences, Rider, Route, ServiceMode,
-    Stop, Velocity,
+    AccessControl, DestinationQueue, Elevator, Line, Patience, Position, Preferences, Rider, Route,
+    ServiceMode, Stop, Velocity,
 };
 #[cfg(feature = "energy")]
 use crate::energy::{EnergyMetrics, EnergyProfile};
@@ -57,6 +57,8 @@ pub struct World {
     pub(crate) energy_metrics: SecondaryMap<EntityId, EnergyMetrics>,
     /// Elevator service modes.
     pub(crate) service_modes: SecondaryMap<EntityId, ServiceMode>,
+    /// Per-elevator destination queues.
+    pub(crate) destination_queues: SecondaryMap<EntityId, DestinationQueue>,
 
     /// Disabled marker (entities skipped by all systems).
     pub(crate) disabled: SecondaryMap<EntityId, ()>,
@@ -93,6 +95,7 @@ impl World {
             #[cfg(feature = "energy")]
             energy_metrics: SecondaryMap::new(),
             service_modes: SecondaryMap::new(),
+            destination_queues: SecondaryMap::new(),
             disabled: SecondaryMap::new(),
             extensions: HashMap::new(),
             ext_names: HashMap::new(),
@@ -158,6 +161,7 @@ impl World {
         #[cfg(feature = "energy")]
         self.energy_metrics.remove(id);
         self.service_modes.remove(id);
+        self.destination_queues.remove(id);
         self.disabled.remove(id);
 
         for ext in self.extensions.values_mut() {
@@ -412,6 +416,25 @@ impl World {
     /// Set an entity's service mode.
     pub fn set_service_mode(&mut self, id: EntityId, mode: ServiceMode) {
         self.service_modes.insert(id, mode);
+    }
+
+    // ── Destination queue accessors ─────────────────────────────────
+
+    /// Get an entity's destination queue.
+    #[must_use]
+    pub fn destination_queue(&self, id: EntityId) -> Option<&DestinationQueue> {
+        self.destination_queues.get(id)
+    }
+
+    /// Get an entity's destination queue mutably (crate-internal — games
+    /// mutate via the [`Simulation`](crate::sim::Simulation) helpers).
+    pub(crate) fn destination_queue_mut(&mut self, id: EntityId) -> Option<&mut DestinationQueue> {
+        self.destination_queues.get_mut(id)
+    }
+
+    /// Set an entity's destination queue.
+    pub fn set_destination_queue(&mut self, id: EntityId, queue: DestinationQueue) {
+        self.destination_queues.insert(id, queue);
     }
 
     // ── Typed query helpers ──────────────────────────────────────────

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -66,11 +66,12 @@ The core simulation state. Advance it by calling `step()`, or run individual pha
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `step` | `(&mut self)` | Run all 7 phases and advance the tick counter |
+| `step` | `(&mut self)` | Run all 8 phases and advance the tick counter |
 | `advance_tick` | `(&mut self)` | Increment tick counter and flush events to output buffer |
 | `run_advance_transient` | `(&mut self)` | Run the advance-transient phase (with hooks) |
 | `run_dispatch` | `(&mut self)` | Run the dispatch phase (with hooks) |
 | `run_reposition` | `(&mut self)` | Run the reposition phase (with hooks) |
+| `run_advance_queue` | `(&mut self)` | Run the advance-queue phase — reconcile `DestinationQueue` (with hooks) |
 | `run_movement` | `(&mut self)` | Run the movement phase (with hooks) |
 | `run_doors` | `(&mut self)` | Run the doors phase (with hooks) |
 | `run_loading` | `(&mut self)` | Run the loading phase (with hooks) |

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -57,18 +57,18 @@ The simplest buildings (single bank, single shaft) can ignore lines — the buil
 
 ## The tick loop
 
-Each call to `sim.step()` runs one simulation tick. A tick consists of seven phases, always executed in this order:
+Each call to `sim.step()` runs one simulation tick. A tick consists of eight phases, always executed in this order:
 
 ```text
-+-------------------+   +------------+   +--------------+   +------------+
-| Advance           |-->| Dispatch   |-->| Reposition   |-->| Movement   |
-| Transient         |   |            |   |              |   |            |
-+-------------------+   +------------+   +--------------+   +------------+
-                                                                  |
-          +-------------------+   +------------+   +------------+
-          | Metrics           |<--| Loading    |<--| Doors      |
-          |                   |   |            |   |            |
-          +-------------------+   +------------+   +------------+
++------------+   +------------+   +--------------+   +--------------+
+| Advance    |-->| Dispatch   |-->| Reposition   |-->| Advance      |
+| Transient  |   |            |   |              |   | Queue        |
++------------+   +------------+   +--------------+   +--------------+
+                                                           |
+      +------------+   +------------+   +------------+   +------------+
+      | Metrics    |<--| Loading    |<--| Doors      |<--| Movement   |
+      |            |   |            |   |            |   |            |
+      +------------+   +------------+   +------------+   +------------+
 ```
 
 ### Phase 1: Advance Transient
@@ -89,13 +89,17 @@ The default strategy is SCAN (sweep end-to-end). You can swap in LOOK, NearestCa
 
 Optional phase; idle elevators are repositioned for better coverage via the `RepositionStrategy`. Only runs if at least one group has a strategy configured.
 
-### Phase 4: Movement
+### Phase 4: Advance Queue
+
+Reconciles each elevator's current phase/target with the front of its `DestinationQueue`. This is where imperative pushes from game code (`sim.push_destination`, `sim.push_destination_front`) take effect: an idle elevator with a non-empty queue transitions to `MovingToStop(front)`, and an elevator already in transit is redirected if a `push_front` changed the queue head. Zero-impact for games that never touch the queue — dispatch keeps the queue and `target_stop` in sync on its own.
+
+### Phase 5: Movement
 
 Elevators with a target stop are moved along the shaft axis using a **trapezoidal velocity profile**: accelerate up to max speed, cruise, then decelerate to stop precisely at the target position. This produces realistic motion without requiring complex physics.
 
 When an elevator arrives at its target stop, it emits an `ElevatorArrived` event and transitions to the door-opening state.
 
-### Phase 5: Doors
+### Phase 6: Doors
 
 The door finite-state machine ticks for each elevator. Doors transition through:
 
@@ -105,7 +109,7 @@ Closed -> Opening (transition ticks) -> Open (hold ticks) -> Closing (transition
 
 `DoorOpened` and `DoorClosed` events fire at the appropriate moments. Riders can only board or exit when the doors are fully open.
 
-### Phase 6: Loading
+### Phase 7: Loading
 
 While an elevator's doors are open at a stop:
 - **Exiting**: riders whose destination matches the current stop exit the elevator.
@@ -113,7 +117,7 @@ While an elevator's doors are open at a stop:
 
 Riders that exceed the elevator's remaining capacity are rejected with a `RiderRejected` event.
 
-### Phase 7: Metrics
+### Phase 8: Metrics
 
 Events from the current tick are processed to update aggregate metrics -- average wait time, ride time, throughput, abandonment rate, and total distance. Tagged metrics (per-zone or per-label breakdowns) are also updated here.
 

--- a/docs/src/dispatch.md
+++ b/docs/src/dispatch.md
@@ -13,6 +13,28 @@ During the Dispatch phase of each tick, the simulation:
 
 Direction indicators (`going_up`/`going_down`) are derived automatically from each dispatch decision: `GoToStop` sets them from target vs. current position, `Idle` resets them to both-lit. This means SCAN, LOOK, NearestCar, and ETD -- along with any custom strategy you write -- drive the indicators for free, and downstream boarding gets direction-awareness with no extra work from the strategy. See [Direction indicators](core-concepts.md#direction-indicators) for details.
 
+## Imperative dispatch (destination queue)
+
+If you want saga-style "just tell the elevator where to go" control, you don't need to implement a `DispatchStrategy`. Every elevator carries a `DestinationQueue` (a FIFO of stop `EntityId`s) that you can push to directly:
+
+```rust,no_run
+# use elevator_core::prelude::*;
+# let mut sim: Simulation = todo!();
+# let elev: EntityId = todo!();
+# let stop_a: EntityId = todo!();
+# let stop_b: EntityId = todo!();
+sim.push_destination(elev, stop_a).unwrap();        // enqueue at back
+sim.push_destination_front(elev, stop_b).unwrap();  // saga's forceNow
+sim.clear_destinations(elev).unwrap();              // cancel pending work
+let queue: &[EntityId] = sim.destination_queue(elev).unwrap();
+```
+
+Adjacent duplicates are suppressed: pushing the same stop twice in a row is a no-op (and emits a single `DestinationQueued` event, not two).
+
+Between the Dispatch and Movement phases, an `AdvanceQueue` phase reconciles each elevator's phase/target with the front of its queue. Idle elevators with a non-empty queue begin moving toward the front entry; elevators mid-flight whose queue front has changed (because you called `push_destination_front`) are redirected. Movement pops the front on arrival.
+
+You can mix the two modes freely: dispatch keeps the queue in sync with its own decisions, so games can observe the queue for visualization and intervene only when needed.
+
 ## Built-in strategies
 
 | Strategy | Algorithm | Best for | Trade-off |

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -93,7 +93,7 @@ println!("Spawned rider: {:?}", rider_id);
 
 ## Run the simulation loop
 
-Each call to `sim.step()` advances the simulation by one tick, running all seven phases of the tick loop (advance transient, dispatch, reposition, movement, doors, loading, metrics). After stepping, you can drain events to see what happened:
+Each call to `sim.step()` advances the simulation by one tick, running all eight phases of the tick loop (advance transient, dispatch, reposition, advance queue, movement, doors, loading, metrics). After stepping, you can drain events to see what happened:
 
 ```rust,no_run
 # use elevator_core::prelude::*;

--- a/docs/src/metrics-and-events.md
+++ b/docs/src/metrics-and-events.md
@@ -23,6 +23,7 @@ Events are emitted during the tick phases. Here are the main categories:
 | `ElevatorIdle { elevator, at_stop, tick }` | An elevator became idle |
 | `CapacityChanged { elevator, current_load, capacity, tick }` | An elevator's load changed (after board or exit) |
 | `DirectionIndicatorChanged { elevator, going_up, going_down, tick }` | An elevator's direction indicator lamps changed (set by dispatch) |
+| `DestinationQueued { elevator, stop, tick }` | A stop was pushed onto an elevator's `DestinationQueue` (via dispatch or `sim.push_destination*`). Adjacent-duplicate pushes that are deduplicated do not emit. |
 
 **Rider events:**
 


### PR DESCRIPTION
## Summary
- Fourth and final PR in the saga-inspired stack. Adds a first-class \`DestinationQueue\` component (FIFO of stop EntityIds) on every elevator.
- Dispatch writes to it (GoToStop pushes, adjacent-dedup); new \`AdvanceQueue\` phase between Reposition and Movement reconciles queue front with elevator target; Movement pops on arrival.
- Games can drive elevators imperatively without writing a custom \`DispatchStrategy\`: \`sim.push_destination\`, \`.push_destination_front\` (saga's forceNow), \`.clear_destinations\`, \`.destination_queue\`.
- Dispatch + imperative modes mix cleanly.

**Stacked on**: #33 (braking helpers). Will rebase as upstream PRs merge.

## Notable changes
- New \`Phase::AdvanceQueue\` — tick loop is now 8 phases (was 7)
- New \`Event::DestinationQueued\` (suppressed on adjacent-dedup)
- Snapshot round-trip preserves the queue via serde default

## Test plan
- [x] 15 new tests in \`destination_queue_tests.rs\` covering push/pop, adjacent dedup (both front + back), imperative push, push_front redirect mid-flight, snapshot round-trip, error paths (non-elevator, non-stop)
- [x] Full suite: 401 pass (was 386)
- [x] Clippy clean on lib + tests, mdbook builds