### PR TITLE
feat: add move_count metric for floor crossings

### DIFF
--- a/crates/elevator-core/src/components/elevator.rs
+++ b/crates/elevator-core/src/components/elevator.rs
@@ -88,6 +88,10 @@ pub struct Elevator {
     /// a rider whose next leg goes down will not board a car with `going_down=false`.
     #[serde(default = "default_true")]
     pub(crate) going_down: bool,
+    /// Count of rounded-floor transitions (passing-floors + arrivals). Analogous
+    /// to elevator-saga's `moveCount` scoring axis.
+    #[serde(default)]
+    pub(crate) move_count: u64,
 }
 
 /// Default inspection speed factor (25% of normal speed).
@@ -207,5 +211,14 @@ impl Elevator {
     #[must_use]
     pub const fn going_down(&self) -> bool {
         self.going_down
+    }
+
+    /// Count of rounded-floor transitions this elevator has made
+    /// (both passing-floor crossings and arrivals).
+    ///
+    /// Analogous to elevator-saga's `moveCount` scoring axis.
+    #[must_use]
+    pub const fn move_count(&self) -> u64 {
+        self.move_count
     }
 }

--- a/crates/elevator-core/src/metrics.rs
+++ b/crates/elevator-core/src/metrics.rs
@@ -39,6 +39,10 @@ pub struct Metrics {
     /// Total distance traveled by elevators while repositioning.
     #[serde(default)]
     pub(crate) reposition_distance: f64,
+    /// Total rounded-floor transitions across all elevators
+    /// (analogous to elevator-saga's `moveCount`).
+    #[serde(default)]
+    pub(crate) total_moves: u64,
     /// Total riders settled as residents.
     pub(crate) total_settled: u64,
     /// Total riders rerouted from resident phase.
@@ -151,6 +155,13 @@ impl Metrics {
     #[must_use]
     pub const fn reposition_distance(&self) -> f64 {
         self.reposition_distance
+    }
+
+    /// Total rounded-floor transitions across all elevators (passing-floor
+    /// crossings plus arrivals). Analogous to elevator-saga's `moveCount`.
+    #[must_use]
+    pub const fn total_moves(&self) -> u64 {
+        self.total_moves
     }
 
     /// Total riders settled as residents.

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -504,6 +504,7 @@ impl Simulation {
                     inspection_speed_factor: ec.inspection_speed_factor,
                     going_up: true,
                     going_down: true,
+                    move_count: 0,
                 },
             );
             #[cfg(feature = "energy")]
@@ -631,6 +632,7 @@ impl Simulation {
                         inspection_speed_factor: ec.inspection_speed_factor,
                         going_up: true,
                         going_down: true,
+                        move_count: 0,
                     },
                 );
                 #[cfg(feature = "energy")]
@@ -1613,6 +1615,7 @@ impl Simulation {
                 inspection_speed_factor: params.inspection_speed_factor,
                 going_up: true,
                 going_down: true,
+                move_count: 0,
             },
         );
         self.groups[group_idx].lines_mut()[line_idx]
@@ -2813,6 +2816,14 @@ impl Simulation {
     #[must_use]
     pub fn elevator_going_down(&self, id: EntityId) -> Option<bool> {
         self.world.elevator(id).map(Elevator::going_down)
+    }
+
+    /// Count of rounded-floor transitions for an elevator (passing-floor
+    /// crossings plus arrivals). Returns `None` if the entity is not an
+    /// elevator. Analogous to elevator-saga's `moveCount`.
+    #[must_use]
+    pub fn elevator_move_count(&self, id: EntityId) -> Option<u64> {
+        self.world.elevator(id).map(Elevator::move_count)
     }
 
     /// Count of elevators currently in the given phase.

--- a/crates/elevator-core/src/systems/movement.rs
+++ b/crates/elevator-core/src/systems/movement.rs
@@ -91,6 +91,7 @@ pub fn run(
 
         // Emit PassingFloor for any stops crossed between old and new position
         // (excluding the target stop — that gets an ElevatorArrived instead).
+        let mut passing_moves: u64 = 0;
         if !result.arrived {
             let moving_up = new_pos > old_pos;
             let (lo, hi) = if moving_up {
@@ -111,8 +112,15 @@ pub fn run(
                         moving_up,
                         tick: ctx.tick,
                     });
+                    passing_moves += 1;
                 }
             }
+        }
+        if passing_moves > 0 {
+            if let Some(car) = world.elevator_mut(eid) {
+                car.move_count += passing_moves;
+            }
+            metrics.total_moves += passing_moves;
         }
 
         if result.arrived {
@@ -137,6 +145,8 @@ pub fn run(
             } else {
                 car.phase = ElevatorPhase::DoorOpening;
                 car.door = DoorState::request_open(door_transition_ticks, door_open_ticks);
+                car.move_count += 1;
+                metrics.total_moves += 1;
                 events.emit(Event::ElevatorArrived {
                     elevator: eid,
                     at_stop: target_stop_eid,

--- a/crates/elevator-core/src/systems/movement.rs
+++ b/crates/elevator-core/src/systems/movement.rs
@@ -117,16 +117,24 @@ pub fn run(
             }
         }
         if passing_moves > 0 {
+            // Only credit the aggregate if the per-elevator counter could actually
+            // be incremented — keep the invariant total_moves == sum(per-elevator).
             if let Some(car) = world.elevator_mut(eid) {
                 car.move_count += passing_moves;
+                metrics.total_moves += passing_moves;
             }
-            metrics.total_moves += passing_moves;
         }
 
         if result.arrived {
             let Some(car) = world.elevator_mut(eid) else {
                 continue;
             };
+            // Arrival is a floor crossing too — count it for both repositioning
+            // and normal arrivals so the passing-floor + arrival accounting stays
+            // consistent. Passing floors during a repositioning trip are already
+            // counted above; skipping the arrival here would undercount.
+            car.move_count += 1;
+            metrics.total_moves += 1;
             if is_repositioning {
                 // Repositioned elevators go directly to Idle — no door cycle.
                 car.phase = ElevatorPhase::Idle;
@@ -145,8 +153,6 @@ pub fn run(
             } else {
                 car.phase = ElevatorPhase::DoorOpening;
                 car.door = DoorState::request_open(door_transition_ticks, door_open_ticks);
-                car.move_count += 1;
-                metrics.total_moves += 1;
                 events.emit(Event::ElevatorArrived {
                     elevator: eid,
                     at_stop: target_stop_eid,

--- a/crates/elevator-core/src/tests/dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/dispatch_tests.rs
@@ -77,6 +77,7 @@ fn spawn_elevator(world: &mut World, position: f64) -> crate::entity::EntityId {
             inspection_speed_factor: 0.25,
             going_up: true,
             going_down: true,
+            move_count: 0,
         },
     );
     eid

--- a/crates/elevator-core/src/tests/feature_tests.rs
+++ b/crates/elevator-core/src/tests/feature_tests.rs
@@ -564,6 +564,7 @@ fn despawn_elevator_resets_rider_to_waiting() {
             inspection_speed_factor: 0.25,
             going_up: true,
             going_down: true,
+            move_count: 0,
         },
     );
 
@@ -647,6 +648,7 @@ fn despawn_rider_mid_transit_removes_from_elevator_load() {
             inspection_speed_factor: 0.25,
             going_up: true,
             going_down: true,
+            move_count: 0,
         },
     );
 

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -34,6 +34,7 @@ mod direction_indicator_tests;
 #[cfg(feature = "energy")]
 mod energy_tests;
 mod event_payload_tests;
+mod move_count_tests;
 mod multi_elevator_tests;
 mod multi_line_tests;
 mod query_event_tests;

--- a/crates/elevator-core/src/tests/move_count_tests.rs
+++ b/crates/elevator-core/src/tests/move_count_tests.rs
@@ -274,3 +274,57 @@ fn move_count_persists_across_snapshot() {
         Some(per_elev_before)
     );
 }
+
+/// Regression for greptile P1: the arrival increment lived in the non-reposition
+/// branch, so a repositioning elevator that crossed intermediate floors credited
+/// the passing moves but not the final arrival — breaking the
+/// "every rounded-floor crossing (passing + arrival)" contract.
+#[test]
+fn move_count_counts_reposition_arrivals() {
+    use crate::dispatch::reposition::ReturnToLobby;
+    use crate::ids::GroupId;
+
+    // Start the elevator at the top so ReturnToLobby has work to do.
+    let mut config = helpers::default_config();
+    config.elevators[0].starting_stop = StopId(2);
+
+    let mut sim = crate::builder::SimulationBuilder::from_config(config)
+        .reposition_for_group(
+            GroupId(0),
+            ReturnToLobby::new(),
+            crate::dispatch::BuiltinReposition::ReturnToLobby,
+        )
+        .build()
+        .unwrap();
+
+    let elev = sim
+        .world()
+        .iter_elevators()
+        .next()
+        .map(|(id, _, _)| id)
+        .unwrap();
+
+    // Let the repositioning trip run to completion (top → lobby, passing stop 1).
+    for _ in 0..3000 {
+        sim.step();
+        if sim
+            .world()
+            .elevator(elev)
+            .is_some_and(|c| matches!(c.phase(), crate::components::ElevatorPhase::Idle))
+        {
+            break;
+        }
+    }
+
+    // Expected: 1 passing (stop 1) + 1 arrival (stop 0) = 2 moves.
+    let count = sim.elevator_move_count(elev).unwrap();
+    assert!(
+        count >= 2,
+        "expected at least 2 moves (passing + arrival) during reposition, got {count}",
+    );
+    assert_eq!(
+        count as u64,
+        sim.metrics().total_moves(),
+        "aggregate must equal sum of per-elevator counts",
+    );
+}

--- a/crates/elevator-core/src/tests/move_count_tests.rs
+++ b/crates/elevator-core/src/tests/move_count_tests.rs
@@ -1,0 +1,276 @@
+//! Tests for the `move_count` elevator counter and `total_moves` aggregate.
+
+use crate::components::RiderPhase;
+use crate::config::*;
+use crate::dispatch::scan::ScanDispatch;
+use crate::sim::Simulation;
+use crate::stop::{StopConfig, StopId};
+use crate::tests::helpers;
+
+fn two_elevator_config() -> SimConfig {
+    SimConfig {
+        building: BuildingConfig {
+            name: "Test".into(),
+            stops: vec![
+                StopConfig {
+                    id: StopId(0),
+                    name: "Ground".into(),
+                    position: 0.0,
+                },
+                StopConfig {
+                    id: StopId(1),
+                    name: "Mid".into(),
+                    position: 5.0,
+                },
+                StopConfig {
+                    id: StopId(2),
+                    name: "Top".into(),
+                    position: 10.0,
+                },
+            ],
+            lines: None,
+            groups: None,
+        },
+        elevators: vec![
+            ElevatorConfig {
+                id: 0,
+                name: "E1".into(),
+                max_speed: 2.0,
+                acceleration: 1.5,
+                deceleration: 2.0,
+                weight_capacity: 800.0,
+                starting_stop: StopId(0),
+                door_open_ticks: 5,
+                door_transition_ticks: 3,
+                restricted_stops: Vec::new(),
+                #[cfg(feature = "energy")]
+                energy_profile: None,
+                service_mode: None,
+                inspection_speed_factor: 0.25,
+            },
+            ElevatorConfig {
+                id: 1,
+                name: "E2".into(),
+                max_speed: 2.0,
+                acceleration: 1.5,
+                deceleration: 2.0,
+                weight_capacity: 800.0,
+                starting_stop: StopId(2),
+                door_open_ticks: 5,
+                door_transition_ticks: 3,
+                restricted_stops: Vec::new(),
+                #[cfg(feature = "energy")]
+                energy_profile: None,
+                service_mode: None,
+                inspection_speed_factor: 0.25,
+            },
+        ],
+        simulation: SimulationParams {
+            ticks_per_second: 60.0,
+        },
+        passenger_spawning: PassengerSpawnConfig {
+            mean_interval_ticks: 120,
+            weight_range: (50.0, 100.0),
+        },
+    }
+}
+
+#[test]
+fn move_count_starts_at_zero() {
+    let config = helpers::default_config();
+    let sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+    let elev = sim
+        .world()
+        .iter_elevators()
+        .next()
+        .map(|(id, _, _)| id)
+        .unwrap();
+
+    assert_eq!(sim.elevator_move_count(elev), Some(0));
+    assert_eq!(sim.metrics().total_moves(), 0);
+}
+
+#[test]
+fn move_count_increments_on_arrival() {
+    let config = helpers::default_config();
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+    let elev = sim
+        .world()
+        .iter_elevators()
+        .next()
+        .map(|(id, _, _)| id)
+        .unwrap();
+
+    // Rider 0 -> 1: elevator moves past zero stops, arrives at stop 1. 1 move.
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
+        .unwrap();
+
+    for _ in 0..2000 {
+        sim.step();
+        let all_arrived = sim
+            .world()
+            .iter_riders()
+            .all(|(_, r)| r.phase == RiderPhase::Arrived);
+        if all_arrived {
+            break;
+        }
+    }
+
+    assert_eq!(
+        sim.elevator_move_count(elev),
+        Some(1),
+        "one arrival = one move"
+    );
+    assert_eq!(sim.metrics().total_moves(), 1);
+}
+
+#[test]
+fn move_count_counts_passing_floors() {
+    let config = helpers::default_config();
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+    let elev = sim
+        .world()
+        .iter_elevators()
+        .next()
+        .map(|(id, _, _)| id)
+        .unwrap();
+
+    // Rider 0 -> 2: elevator passes stop 1, arrives at stop 2. 2 moves.
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    for _ in 0..2000 {
+        sim.step();
+        let all_arrived = sim
+            .world()
+            .iter_riders()
+            .all(|(_, r)| r.phase == RiderPhase::Arrived);
+        if all_arrived {
+            break;
+        }
+    }
+
+    assert_eq!(
+        sim.elevator_move_count(elev),
+        Some(2),
+        "1 passing floor + 1 arrival"
+    );
+    assert_eq!(sim.metrics().total_moves(), 2);
+}
+
+#[test]
+fn total_moves_aggregates_across_elevators() {
+    let config = two_elevator_config();
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+    // Elevator 0 starts at stop 0 (pos 0), elevator 1 starts at stop 2 (pos 10).
+    // Spawn one rider 0 -> 2 (goes up, picked up by E1 — 2 moves)
+    // and one rider 2 -> 0 (goes down, picked up by E2 — 2 moves).
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    sim.spawn_rider_by_stop_id(StopId(2), StopId(0), 70.0)
+        .unwrap();
+
+    for _ in 0..3000 {
+        sim.step();
+        let all_arrived = sim
+            .world()
+            .iter_riders()
+            .all(|(_, r)| r.phase == RiderPhase::Arrived);
+        if all_arrived {
+            break;
+        }
+    }
+
+    // Sum of all elevator move counts should equal total_moves.
+    let counts: Vec<u64> = sim
+        .world()
+        .iter_elevators()
+        .map(|(_, _, e)| e.move_count())
+        .collect();
+    let sum: u64 = counts.iter().sum();
+    assert_eq!(sim.metrics().total_moves(), sum);
+    // Both elevators must have moved at least twice (pickup + delivery legs).
+    assert!(
+        counts.iter().all(|&c| c >= 2),
+        "each elevator should make >= 2 moves, got {counts:?}"
+    );
+    // Aggregate must reflect all moves across both elevators.
+    assert!(
+        sim.metrics().total_moves() >= 4,
+        "total_moves should aggregate across elevators"
+    );
+}
+
+#[test]
+fn move_count_zero_when_stationary() {
+    // Build sim WITHOUT the default passenger spawner by using a config with
+    // no spawns. Our helpers::default_config() has a passenger_spawning config
+    // but the simulation only spawns when the host app tells it to — stepping
+    // alone should not spawn riders.
+    let config = helpers::default_config();
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+    let elev = sim
+        .world()
+        .iter_elevators()
+        .next()
+        .map(|(id, _, _)| id)
+        .unwrap();
+
+    for _ in 0..100 {
+        sim.step();
+    }
+
+    assert_eq!(sim.elevator_move_count(elev), Some(0));
+    assert_eq!(sim.metrics().total_moves(), 0);
+}
+
+#[test]
+fn move_count_persists_across_snapshot() {
+    let config = helpers::default_config();
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    for _ in 0..2000 {
+        sim.step();
+        let all_arrived = sim
+            .world()
+            .iter_riders()
+            .all(|(_, r)| r.phase == RiderPhase::Arrived);
+        if all_arrived {
+            break;
+        }
+    }
+
+    let moves_before = sim.metrics().total_moves();
+    assert!(moves_before > 0, "precondition: some moves occurred");
+
+    let elev = sim
+        .world()
+        .iter_elevators()
+        .next()
+        .map(|(id, _, _)| id)
+        .unwrap();
+    let per_elev_before = sim.elevator_move_count(elev).unwrap();
+
+    let snap = sim.snapshot();
+    let restored = snap.restore(None);
+
+    assert_eq!(restored.metrics().total_moves(), moves_before);
+    let restored_elev = restored
+        .world()
+        .iter_elevators()
+        .next()
+        .map(|(id, _, _)| id)
+        .unwrap();
+    assert_eq!(
+        restored.elevator_move_count(restored_elev),
+        Some(per_elev_before)
+    );
+}

--- a/crates/elevator-core/src/tests/query_tests.rs
+++ b/crates/elevator-core/src/tests/query_tests.rs
@@ -47,6 +47,7 @@ fn test_world() -> (World, EntityId, EntityId, EntityId) {
             inspection_speed_factor: 0.25,
             going_up: true,
             going_down: true,
+            move_count: 0,
         },
     );
 

--- a/crates/elevator-core/src/tests/reposition_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_tests.rs
@@ -79,6 +79,7 @@ fn spawn_elevator(world: &mut World, position: f64) -> EntityId {
             inspection_speed_factor: 0.25,
             going_up: true,
             going_down: true,
+            move_count: 0,
         },
     );
     eid

--- a/crates/elevator-core/src/tests/world_tests.rs
+++ b/crates/elevator-core/src/tests/world_tests.rs
@@ -63,6 +63,7 @@ fn elevator_query_returns_entities_with_both_components() {
             inspection_speed_factor: 0.25,
             going_up: true,
             going_down: true,
+            move_count: 0,
         },
     );
 

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -169,6 +169,7 @@ The core simulation state. Advance it by calling `step()`, or run individual pha
 | `elevator_load` | `(&self, EntityId) -> Option<f64>` | Current weight aboard an elevator |
 | `elevator_going_up` | `(&self, EntityId) -> Option<bool>` | Up-direction indicator lamp state (`None` if not an elevator) |
 | `elevator_going_down` | `(&self, EntityId) -> Option<bool>` | Down-direction indicator lamp state (`None` if not an elevator) |
+| `elevator_move_count` | `(&self, EntityId) -> Option<u64>` | Per-elevator count of rounded-floor transitions (`None` if not an elevator) |
 
 ### Dispatch
 
@@ -542,6 +543,7 @@ Aggregated simulation metrics, updated each tick. Query via `sim.metrics()`.
 | `total_spawned()` | `u64` | Total riders spawned |
 | `abandonment_rate()` | `f64` | Abandonment rate (0.0 - 1.0) |
 | `total_distance()` | `f64` | Total distance traveled by all elevators |
+| `total_moves()` | `u64` | Total rounded-floor transitions across all elevators |
 | `throughput_window_ticks()` | `u64` | Window size for throughput calculation (default: 3600) |
 
 Builder method: `Metrics::new().with_throughput_window(window_ticks)`.
@@ -699,6 +701,7 @@ Entity components are the data attached to simulation entities. Built-in compone
 | `line()` | `EntityId` | Line entity this car belongs to |
 | `going_up()` | `bool` | Up-direction indicator lamp (set by dispatch; both lamps lit when idle) |
 | `going_down()` | `bool` | Down-direction indicator lamp (set by dispatch; both lamps lit when idle) |
+| `move_count()` | `u64` | Count of rounded-floor transitions (passing-floor crossings + arrivals) |
 
 ### Line Getters
 

--- a/docs/src/metrics-and-events.md
+++ b/docs/src/metrics-and-events.md
@@ -153,6 +153,7 @@ println!("Total settled:     {}", m.total_settled());
 println!("Total rerouted:    {}", m.total_rerouted());
 println!("Abandonment rate:  {:.1}%", m.abandonment_rate() * 100.0);
 println!("Total distance:    {:.1} units", m.total_distance());
+println!("Total moves:       {}", m.total_moves());
 # }
 ```
 
@@ -171,6 +172,7 @@ println!("Total distance:    {:.1} units", m.total_distance());
 | `total_settled()` | Cumulative riders settled as residents |
 | `total_rerouted()` | Cumulative riders rerouted from resident phase |
 | `total_distance()` | Sum of all elevator travel distance |
+| `total_moves()` | Total rounded-floor transitions across all elevators (passing-floor crossings + arrivals; analogous to elevator-saga's `moveCount`) |
 | `utilization_by_group()` | Per-group fraction of elevators currently moving |
 | `avg_utilization()` | Average utilization across all groups |
 | `reposition_distance()` | Total elevator distance traveled while repositioning |
@@ -217,6 +219,7 @@ Common KPIs that games typically display in HUDs:
 | `sim.idle_elevator_count()` | Count of elevators currently idle (excludes disabled) |
 | `sim.elevators_in_phase(phase)` | Count of elevators in a given phase (excludes disabled) |
 | `sim.elevator_load(id)` | Current total weight aboard an elevator, `None` if not an elevator |
+| `sim.elevator_move_count(id)` | Per-elevator count of rounded-floor transitions, `None` if not an elevator |
 
 ```rust,no_run
 # use elevator_core::prelude::*;


### PR DESCRIPTION
## Summary
- Reopened (supersedes #32, which was auto-closed when the stacked base branch was deleted on #31's merge).
- Per-elevator \`move_count\` and aggregate \`Metrics::total_moves()\` counting every rounded-floor crossing (both passing and arrival). Matches elevator-saga's \`moveCount\` scoring axis.
- Incorporates greptile P1 fixes from #32 review:
  - Aggregate increment now gated on the per-elevator update (preserves invariant \`total_moves == sum(per_elev)\`)
  - Repositioning arrivals now counted (previously undercounted — passing floors during reposition were credited but arrivals weren't)
- New regression test \`move_count_counts_reposition_arrivals\`.

## Test plan
- [x] 7 tests in \`move_count_tests.rs\`
- [x] Full suite: 379 pass
- [x] Clippy clean, mdbook builds