### PR TITLE
test: raise mutation score on tick-loop hot path

### DIFF
--- a/crates/elevator-core/src/components/destination_queue.rs
+++ b/crates/elevator-core/src/components/destination_queue.rs
@@ -89,6 +89,19 @@ impl DestinationQueue {
         self.queue.clear();
     }
 
+    /// Retain only entries that satisfy `predicate`.
+    ///
+    /// Used by `remove_stop` to scrub references to a despawned stop.
+    pub(crate) fn retain(&mut self, mut predicate: impl FnMut(EntityId) -> bool) {
+        self.queue.retain(|&eid| predicate(eid));
+    }
+
+    /// `true` if the queue contains `stop` anywhere.
+    #[must_use]
+    pub fn contains(&self, stop: &EntityId) -> bool {
+        self.queue.contains(stop)
+    }
+
     /// Remove and return the front entry.
     pub(crate) fn pop_front(&mut self) -> Option<EntityId> {
         (!self.queue.is_empty()).then(|| self.queue.remove(0))

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -55,6 +55,16 @@ impl Simulation {
         position: f64,
         line: EntityId,
     ) -> Result<EntityId, SimError> {
+        if !position.is_finite() {
+            return Err(SimError::InvalidConfig {
+                field: "position",
+                reason: format!(
+                    "stop position must be finite (got {position}); NaN/±inf \
+                     corrupt SortedStops ordering and find_stop_at_position lookup"
+                ),
+            });
+        }
+
         let group_id = self
             .world
             .line(line)

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -500,6 +500,9 @@ impl Simulation {
             }
         }
 
+        let old_group_id = self.groups[old_group_idx].id();
+        let new_group_id = self.groups[new_group_idx].id();
+
         self.groups[old_group_idx].lines_mut()[old_line_idx]
             .elevators_mut()
             .retain(|&e| e != elevator);
@@ -514,10 +517,18 @@ impl Simulation {
         self.groups[old_group_idx].rebuild_caches();
         if new_group_idx != old_group_idx {
             self.groups[new_group_idx].rebuild_caches();
+
+            // Notify the old group's dispatcher so it clears per-elevator
+            // state (ScanDispatch/LookDispatch track direction by
+            // EntityId). Matches the symmetry with `remove_elevator`.
+            if let Some(old_dispatcher) = self.dispatchers.get_mut(&old_group_id) {
+                old_dispatcher.notify_removed(elevator);
+            }
         }
 
         self.mark_topo_dirty();
 
+        let _ = new_group_id; // reserved for symmetric notify_added once the trait gains one
         self.events.emit(Event::ElevatorReassigned {
             elevator,
             old_line,

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -338,6 +338,23 @@ impl Simulation {
         // Disable first to invalidate routes referencing this stop.
         let _ = self.disable(stop);
 
+        // Scrub references to the removed stop from every elevator so the
+        // post-despawn tick loop does not chase a dead EntityId through
+        // `target_stop`, the destination queue, or access-control checks.
+        let elevator_ids: Vec<EntityId> =
+            self.world.iter_elevators().map(|(eid, _, _)| eid).collect();
+        for eid in elevator_ids {
+            if let Some(car) = self.world.elevator_mut(eid) {
+                if car.target_stop == Some(stop) {
+                    car.target_stop = None;
+                }
+                car.restricted_stops.remove(&stop);
+            }
+            if let Some(q) = self.world.destination_queue_mut(eid) {
+                q.retain(|s| s != stop);
+            }
+        }
+
         // Remove from all lines and groups.
         for group in &mut self.groups {
             for line_info in group.lines_mut() {

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -219,6 +219,61 @@ fn remove_stop_with_waiting_rider_invalidates_route() {
     );
 }
 
+/// `remove_stop` must not leave dangling references in elevator state.
+/// Pre-fix: `target_stop`, `DestinationQueue`, and `restricted_stops` all
+/// kept pointing at the despawned `EntityId`, which caused subsequent
+/// `movement`/`advance_queue` phases to ask `world.stop_position(target_stop)`
+/// and get `None`, potentially stalling the elevator.
+#[test]
+fn remove_stop_clears_dangling_references_on_elevator() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let stop2 = sim.stop_entity(StopId(2)).unwrap();
+    let elev = sim.groups()[0].elevator_entities()[0];
+
+    // Queue stop 2 as a destination, then dispatch so the elevator picks
+    // it as its target.
+    sim.push_destination(elev, stop2).unwrap();
+    sim.step();
+
+    // Seed the restricted_stops set directly (normally populated via
+    // config but we want to cover the cleanup path).
+    if let Some(car) = sim.world_mut().elevator_mut(elev) {
+        car.restricted_stops.insert(stop2);
+    }
+
+    // Sanity: the references exist before removal.
+    let car = sim.world().elevator(elev).unwrap();
+    assert!(
+        car.target_stop == Some(stop2)
+            || sim
+                .destination_queue(elev)
+                .is_some_and(|q| q.contains(&stop2)),
+        "test precondition: elevator should reference stop2 somehow"
+    );
+    assert!(car.restricted_stops.contains(&stop2));
+
+    sim.remove_stop(stop2).unwrap();
+
+    let car = sim.world().elevator(elev).unwrap();
+    assert_ne!(
+        car.target_stop,
+        Some(stop2),
+        "target_stop must be cleared when the referenced stop is removed"
+    );
+    if let Some(q) = sim.destination_queue(elev) {
+        assert!(
+            !q.contains(&stop2),
+            "DestinationQueue must not contain the removed stop"
+        );
+    }
+    assert!(
+        !car.restricted_stops.contains(&stop2),
+        "restricted_stops must not contain the removed stop"
+    );
+}
+
 #[test]
 fn remove_nonexistent_stop_returns_entity_not_found() {
     let config = default_config();

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -52,4 +52,5 @@ mod phase_helpers_tests;
 mod query_event_tests;
 mod reposition_tests;
 mod resident_tests;
+mod rider_index_tests;
 mod service_mode_tests;

--- a/crates/elevator-core/src/tests/movement_tests.rs
+++ b/crates/elevator-core/src/tests/movement_tests.rs
@@ -1,4 +1,4 @@
-use crate::movement::tick_movement;
+use crate::movement::{braking_distance, tick_movement};
 
 const DT: f64 = 1.0 / 60.0;
 const MAX_SPEED: f64 = 2.0;
@@ -102,6 +102,142 @@ fn overshoot_prevention() {
     assert!(result.arrived, "should snap to target on overshoot");
     assert!((result.position - 10.0).abs() < 1e-9);
     assert!(result.velocity.abs() < 1e-9);
+}
+
+// ── Mutation-coverage tests: assert exact numeric outputs from the motion
+// primitives so mutants that flip an operator (`*` → `+`, `>` → `>=`) or
+// arithmetic (`v² / 2a` → `v² * 2a`) produce a visibly wrong number.
+
+#[test]
+fn braking_distance_matches_kinematic_formula() {
+    // v² / (2·a). Kills `replace * with +` in braking_distance (speed*speed
+    // would become speed+speed = 2·v which is dimensionally wrong).
+    // v=2, a=2  →  4 / 4  =  1.0.
+    assert!((braking_distance(2.0, 2.0) - 1.0).abs() < 1e-9);
+    // v=10, a=2 →  100 / 4 = 25.0.
+    assert!((braking_distance(10.0, 2.0) - 25.0).abs() < 1e-9);
+    // Scales quadratically with velocity.
+    let d1 = braking_distance(3.0, 2.0);
+    let d2 = braking_distance(6.0, 2.0);
+    assert!(
+        (d2 / d1 - 4.0).abs() < 1e-9,
+        "doubling velocity should 4× the braking distance, got {d2}/{d1}"
+    );
+    // Edge: zero velocity, any deceleration → 0.
+    assert_eq!(braking_distance(0.0, 2.0), 0.0);
+    // Edge: non-positive deceleration → 0 (defensive return).
+    assert_eq!(braking_distance(10.0, 0.0), 0.0);
+    assert_eq!(braking_distance(10.0, -2.0), 0.0);
+    // Velocity sign doesn't matter — uses |v|.
+    assert!((braking_distance(-5.0, 2.0) - braking_distance(5.0, 2.0)).abs() < 1e-9);
+}
+
+#[test]
+fn tick_movement_exact_single_step_from_rest() {
+    // Fresh acceleration from rest: new velocity should be a·dt, new
+    // position should be v·dt = a·dt² from this tick's movement. Kills
+    // `replace * with /` and `replace * with +` mutations in the
+    // acceleration branch (v = acc·dt·sign + velocity).
+    let r = tick_movement(0.0, 0.0, 100.0, MAX_SPEED, ACCELERATION, DECELERATION, DT);
+
+    let expected_v = ACCELERATION * DT; // 1.5 / 60 = 0.025
+    let expected_p = expected_v * DT; // 0.025 / 60 ≈ 4.167e-4
+    assert!(
+        (r.velocity - expected_v).abs() < 1e-12,
+        "velocity after one tick: expected {expected_v}, got {}",
+        r.velocity
+    );
+    assert!(
+        (r.position - expected_p).abs() < 1e-12,
+        "position after one tick: expected {expected_p}, got {}",
+        r.position
+    );
+    assert!(!r.arrived);
+}
+
+#[test]
+fn tick_movement_caps_velocity_at_max_speed() {
+    // Starting at velocity just below max_speed with plenty of distance to
+    // go — the next tick should clamp to exactly max_speed. Kills the
+    // `>` vs `>=` mutation on the `v.abs() > max_speed` branch.
+    let start_v = MAX_SPEED - 0.001;
+    let r = tick_movement(
+        0.0,
+        start_v,
+        1000.0,
+        MAX_SPEED,
+        ACCELERATION,
+        DECELERATION,
+        DT,
+    );
+    assert!(
+        (r.velocity - MAX_SPEED).abs() < 1e-9,
+        "velocity should clamp to max_speed = {MAX_SPEED}, got {}",
+        r.velocity
+    );
+}
+
+#[test]
+fn tick_movement_cruise_phase_holds_max_speed() {
+    // At exactly max_speed, with plenty of distance — the cruise branch
+    // should keep us at max_speed exactly. Kills `speed < max_speed` vs
+    // `<=` mutation.
+    let r = tick_movement(
+        0.0,
+        MAX_SPEED,
+        1000.0,
+        MAX_SPEED,
+        ACCELERATION,
+        DECELERATION,
+        DT,
+    );
+    assert!(
+        (r.velocity - MAX_SPEED).abs() < 1e-9,
+        "cruise velocity should equal max_speed"
+    );
+    // Position should advance by max_speed * dt.
+    let expected_p = MAX_SPEED * DT;
+    assert!(
+        (r.position - expected_p).abs() < 1e-12,
+        "position advances by v·dt during cruise"
+    );
+}
+
+#[test]
+fn tick_movement_snaps_to_target_on_overshoot() {
+    // Large velocity within epsilon of the target — next tick crosses
+    // target. Kills the `new_displacement.abs() < EPSILON` vs `>=` mutation
+    // on the overshoot guard.
+    let r = tick_movement(9.999, 2.0, 10.0, MAX_SPEED, ACCELERATION, DECELERATION, DT);
+    assert!(r.arrived);
+    assert_eq!(r.position, 10.0, "snap to exact target");
+    assert_eq!(r.velocity, 0.0, "velocity zeroed on snap");
+}
+
+#[test]
+fn tick_movement_decelerates_near_target() {
+    // Position 9.0, velocity 2.0, target 10.0 — braking distance at v=2,
+    // a=2 is 1.0, matching remaining distance. The decel branch fires.
+    // Kills `stopping_distance >= distance_remaining` vs `<=` mutation.
+    let r = tick_movement(9.0, 2.0, 10.0, MAX_SPEED, ACCELERATION, DECELERATION, DT);
+    let decel_step = DECELERATION * DT;
+    let expected_v = 2.0 - decel_step;
+    assert!(
+        (r.velocity - expected_v).abs() < 1e-9,
+        "should decelerate by decel·dt: expected {expected_v}, got {}",
+        r.velocity
+    );
+    assert!(!r.arrived);
+}
+
+#[test]
+fn tick_movement_zero_sign_when_already_at_target() {
+    // At target with zero velocity — should return arrived with no motion.
+    // Kills `velocity > 0.0 ... v < 0.0` sign-flip check when position == target.
+    let r = tick_movement(5.0, 0.0, 5.0, MAX_SPEED, ACCELERATION, DECELERATION, DT);
+    assert!(r.arrived);
+    assert_eq!(r.position, 5.0);
+    assert_eq!(r.velocity, 0.0);
 }
 
 #[test]

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -1585,6 +1585,67 @@ fn remove_line_marks_topology_graph_dirty() {
 
 // ── 14. Elevator reassignment (swing car) ────────────────────────────────────
 
+/// Cross-group reassignment must notify the old group's dispatcher so it
+/// clears per-elevator state (e.g. `ScanDispatch::direction`,
+/// `LookDispatch::direction`). Pre-fix the old dispatcher kept the stale
+/// entry, leaking memory and — for strategies that consult it — mis-
+/// dispatching the next call.
+#[test]
+fn reassign_elevator_to_line_notifies_old_group_dispatcher_on_cross_group() {
+    use crate::dispatch::{DispatchDecision, DispatchManifest, DispatchStrategy, ElevatorGroup};
+    use crate::entity::EntityId;
+    use crate::world::World;
+    use std::sync::{Arc, Mutex};
+
+    /// Dispatcher that records every `notify_removed` call it receives.
+    struct TrackingDispatch {
+        removed: Arc<Mutex<Vec<EntityId>>>,
+        inner: ScanDispatch,
+    }
+    impl DispatchStrategy for TrackingDispatch {
+        fn decide(
+            &mut self,
+            elevator: EntityId,
+            position: f64,
+            group: &ElevatorGroup,
+            manifest: &DispatchManifest,
+            world: &World,
+        ) -> DispatchDecision {
+            self.inner
+                .decide(elevator, position, group, manifest, world)
+        }
+        fn notify_removed(&mut self, elevator: EntityId) {
+            self.removed.lock().unwrap().push(elevator);
+            self.inner.notify_removed(elevator);
+        }
+    }
+
+    let config = two_group_config();
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+    let old_removed = Arc::new(Mutex::new(Vec::<EntityId>::new()));
+    sim.dispatchers_mut().insert(
+        GroupId(0),
+        Box::new(TrackingDispatch {
+            removed: old_removed.clone(),
+            inner: ScanDispatch::new(),
+        }),
+    );
+
+    let low_line = sim.lines_in_group(GroupId(0))[0];
+    let high_line = sim.lines_in_group(GroupId(1))[0];
+    let low_elevator = sim.elevators_on_line(low_line)[0];
+
+    sim.reassign_elevator_to_line(low_elevator, high_line)
+        .unwrap();
+
+    let saw_removal = old_removed.lock().unwrap().contains(&low_elevator);
+    assert!(
+        saw_removal,
+        "old group's dispatcher should receive notify_removed for cross-group reassignment"
+    );
+}
+
 #[test]
 fn reassign_elevator_to_line_moves_elevator() {
     let config = two_group_config();

--- a/crates/elevator-core/src/tests/reposition_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_tests.rs
@@ -128,8 +128,13 @@ fn spread_evenly_distributes_elevators() {
     if result.len() == 2 {
         assert_ne!(result[0].1, result[1].1, "should spread to different stops");
     }
-    // The first elevator should be sent to the farthest unoccupied stop (stop 4 at 40.0),
-    // maximizing min-distance from the other occupied position (elev_b at 20.0).
+    // `elev_b` is also idle so it's excluded from `occupied` when elev_a is
+    // placed — the `occupied` set is empty, `min_distance_to` returns
+    // INFINITY for every stop, and `max_by(..total_cmp)` deterministically
+    // returns the last element (`stops[4]`). The outcome is correct but
+    // the "farthest from other occupied positions" intuition is only what
+    // the strategy *would* do once `elev_b` is assigned a position — here
+    // elev_a is processed first while `occupied` is still empty.
     assert_eq!(result[0].1, stops[4]);
 }
 

--- a/crates/elevator-core/src/tests/reposition_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_tests.rs
@@ -292,6 +292,141 @@ fn nearest_idle_returns_empty() {
     assert!(result.is_empty(), "NearestIdle should never generate moves");
 }
 
+// ── Mutation-coverage tests for the return-content of each strategy ──
+// The three live strategies (SpreadEvenly, ReturnToLobby, DemandWeighted)
+// had mutants of the form "replace reposition -> Vec<..> with vec![]" that
+// were not killed by existing tests. These tests assert specific targets
+// rather than just "is_empty or not".
+
+#[test]
+fn spread_evenly_sends_idle_car_to_specific_stop() {
+    // 3 stops at 0/10/20, one idle car at position 0, one busy car at 20.
+    // SpreadEvenly should send the idle car to the stop furthest from 20 —
+    // that's stop 0, but the idle is already at 0, so no movement for idle.
+    // Instead: put idle at 5 so it has to move, and test that target is 0.
+    let (mut world, stops) = test_world_n(3);
+    let idle_elev = spawn_elevator(&mut world, 5.0);
+    let busy_elev = spawn_elevator(&mut world, 20.0);
+    let group = test_group(&stops, vec![idle_elev, busy_elev]);
+
+    let idle = vec![(idle_elev, 5.0)];
+    let stop_pos: Vec<(EntityId, f64)> = stops
+        .iter()
+        .map(|&sid| (sid, world.stop_position(sid).unwrap()))
+        .collect();
+
+    let mut strategy = SpreadEvenly;
+    let result = strategy.reposition(&idle, &stop_pos, &group, &world);
+
+    assert_eq!(result.len(), 1, "one assignment expected");
+    let (elev, target) = result[0];
+    assert_eq!(elev, idle_elev);
+    assert_eq!(
+        target, stops[0],
+        "SpreadEvenly should pick the stop farthest from the busy car at 20 \
+         (stop 0 at 0.0), got target index unknown"
+    );
+}
+
+#[test]
+fn spread_evenly_empty_inputs_return_empty() {
+    // Kills `replace == with != in SpreadEvenly::reposition` on the
+    // empty-guard clauses.
+    let (world, stops) = test_world_n(3);
+    let group = test_group(&stops, vec![]);
+    let stop_pos: Vec<(EntityId, f64)> = stops
+        .iter()
+        .map(|&sid| (sid, world.stop_position(sid).unwrap()))
+        .collect();
+
+    let mut strategy = SpreadEvenly;
+    assert!(
+        strategy
+            .reposition(&[], &stop_pos, &group, &world)
+            .is_empty(),
+        "no idle elevators → empty result"
+    );
+    assert!(
+        strategy
+            .reposition(&[(EntityId::default(), 0.0)], &[], &group, &world)
+            .is_empty(),
+        "no stop positions → empty result"
+    );
+}
+
+#[test]
+fn return_to_lobby_targets_the_home_stop_specifically() {
+    // Kills `replace RepositionStrategy for NearestIdle::reposition -> Vec
+    // with vec![]` (wrong strategy name but similar mutants exist on RTL)
+    // AND the `home_stop_index` accessor mutations.
+    let (mut world, stops) = test_world_n(3);
+    let elev = spawn_elevator(&mut world, 15.0);
+    let group = test_group(&stops, vec![elev]);
+
+    let idle = vec![(elev, 15.0)];
+    let stop_pos: Vec<(EntityId, f64)> = stops
+        .iter()
+        .map(|&sid| (sid, world.stop_position(sid).unwrap()))
+        .collect();
+
+    // Default home is index 0, which is stops[0] at position 0.
+    let mut rtl = ReturnToLobby::new();
+    let r = rtl.reposition(&idle, &stop_pos, &group, &world);
+    assert_eq!(r, vec![(elev, stops[0])]);
+
+    // with_home(2) picks stops[2] at position 20.0.
+    let mut rtl2 = ReturnToLobby::with_home(2);
+    let r2 = rtl2.reposition(&idle, &stop_pos, &group, &world);
+    assert_eq!(r2, vec![(elev, stops[2])]);
+}
+
+#[test]
+fn return_to_lobby_skips_cars_already_at_home() {
+    // Kills `replace > with >= in ReturnToLobby::reposition` on the
+    // (pos - home_pos).abs() > 1e-6 threshold.
+    let (mut world, stops) = test_world_n(3);
+    let at_home = spawn_elevator(&mut world, 0.0);
+    let away = spawn_elevator(&mut world, 20.0);
+    let group = test_group(&stops, vec![at_home, away]);
+
+    let idle = vec![(at_home, 0.0), (away, 20.0)];
+    let stop_pos: Vec<(EntityId, f64)> = stops
+        .iter()
+        .map(|&sid| (sid, world.stop_position(sid).unwrap()))
+        .collect();
+
+    let mut rtl = ReturnToLobby::new();
+    let r = rtl.reposition(&idle, &stop_pos, &group, &world);
+    assert_eq!(
+        r,
+        vec![(away, stops[0])],
+        "only the car not at home should be reassigned"
+    );
+}
+
+#[test]
+fn demand_weighted_empty_inputs_return_empty() {
+    // Kills the `|| → &&` mutant on DemandWeighted's empty-guard.
+    let (world, stops) = test_world_n(3);
+    let group = test_group(&stops, vec![]);
+    let stop_pos: Vec<(EntityId, f64)> = stops
+        .iter()
+        .map(|&sid| (sid, world.stop_position(sid).unwrap()))
+        .collect();
+
+    let mut strategy = DemandWeighted;
+    assert!(
+        strategy
+            .reposition(&[], &stop_pos, &group, &world)
+            .is_empty()
+    );
+    assert!(
+        strategy
+            .reposition(&[(EntityId::default(), 0.0)], &[], &group, &world)
+            .is_empty()
+    );
+}
+
 // ===== Repositioning Integration Tests =====
 
 /// Helper: build a simulation with 1 elevator, 3 stops, `ReturnToLobby` reposition.

--- a/crates/elevator-core/src/tests/rider_index_tests.rs
+++ b/crates/elevator-core/src/tests/rider_index_tests.rs
@@ -1,0 +1,205 @@
+//! Direct unit tests for the `RiderIndex` reverse-population index.
+//!
+//! These exercise the partition methods against their own invariants rather
+//! than through the tick loop, so a mutation that turns `insert_abandoned`
+//! into `()` or swaps a count accessor's return flips an assertion
+//! immediately. Written to pin down rider-index behavior against the
+//! mutation coverage gaps in `src/rider_index.rs`.
+
+use crate::components::{Rider, RiderPhase, Stop};
+use crate::entity::EntityId;
+use crate::rider_index::RiderIndex;
+use crate::world::World;
+
+/// Spawn an entity to use as a stop id in unit-level index tests.
+fn fresh_stop(world: &mut World) -> EntityId {
+    let eid = world.spawn();
+    world.set_stop(
+        eid,
+        Stop {
+            name: "s".into(),
+            position: 0.0,
+        },
+    );
+    eid
+}
+
+/// Make a rider entity in a given phase with a current-stop so
+/// `rebuild()` picks it up into the corresponding partition.
+fn rider_in_phase(world: &mut World, at: EntityId, phase: RiderPhase) -> EntityId {
+    let r = world.spawn();
+    world.set_rider(
+        r,
+        Rider {
+            weight: 70.0,
+            phase,
+            current_stop: Some(at),
+            spawn_tick: 0,
+            board_tick: None,
+        },
+    );
+    r
+}
+
+#[test]
+fn insert_and_query_waiting_matches_count() {
+    let mut world = World::new();
+    let stop = fresh_stop(&mut world);
+    let r1 = world.spawn();
+    let r2 = world.spawn();
+
+    let mut idx = RiderIndex::default();
+    idx.insert_waiting(stop, r1);
+    idx.insert_waiting(stop, r2);
+
+    assert_eq!(idx.waiting_count_at(stop), 2);
+    let set = idx.waiting_at(stop);
+    assert!(set.contains(&r1));
+    assert!(set.contains(&r2));
+}
+
+#[test]
+fn insert_abandoned_is_observable() {
+    let mut world = World::new();
+    let stop = fresh_stop(&mut world);
+    let rider = world.spawn();
+
+    let mut idx = RiderIndex::default();
+    idx.insert_abandoned(stop, rider);
+
+    // Kills the `replace RiderIndex::insert_abandoned with ()` mutant:
+    // if insert was a no-op, the count and the set would be empty.
+    assert_eq!(idx.abandoned_count_at(stop), 1);
+    assert!(idx.abandoned_at(stop).contains(&rider));
+}
+
+#[test]
+fn remove_waiting_drops_the_entry() {
+    let mut world = World::new();
+    let stop = fresh_stop(&mut world);
+    let r1 = world.spawn();
+    let r2 = world.spawn();
+
+    let mut idx = RiderIndex::default();
+    idx.insert_waiting(stop, r1);
+    idx.insert_waiting(stop, r2);
+    assert_eq!(idx.waiting_count_at(stop), 2);
+
+    idx.remove_waiting(stop, r1);
+
+    // Kills the `replace RiderIndex::remove_waiting with ()` mutant.
+    assert_eq!(idx.waiting_count_at(stop), 1);
+    assert!(!idx.waiting_at(stop).contains(&r1));
+    assert!(idx.waiting_at(stop).contains(&r2));
+}
+
+#[test]
+fn empty_stop_returns_count_zero_and_empty_set() {
+    let mut world = World::new();
+    let stop = fresh_stop(&mut world);
+    let other = world.spawn();
+
+    let idx = RiderIndex::default();
+
+    // Kills `replace ...count_at -> usize with 0/1` — but importantly the
+    // `with 1` variant is killed by this assert on an empty stop.
+    assert_eq!(idx.waiting_count_at(stop), 0);
+    assert_eq!(idx.resident_count_at(stop), 0);
+    assert_eq!(idx.abandoned_count_at(stop), 0);
+    assert!(idx.waiting_at(stop).is_empty());
+    assert!(idx.residents_at(stop).is_empty());
+    assert!(idx.abandoned_at(other).is_empty());
+}
+
+#[test]
+fn populated_stop_returns_count_one() {
+    let mut world = World::new();
+    let stop = fresh_stop(&mut world);
+    let rider = world.spawn();
+
+    let mut idx = RiderIndex::default();
+    idx.insert_resident(stop, rider);
+
+    // Kills `...count_at -> usize with 0` — if it always returned 0, this
+    // would fail.
+    assert_eq!(idx.resident_count_at(stop), 1);
+}
+
+#[test]
+fn rebuild_populates_waiting_partition() {
+    let mut world = World::new();
+    let stop = fresh_stop(&mut world);
+    let rider = rider_in_phase(&mut world, stop, RiderPhase::Waiting);
+
+    let mut idx = RiderIndex::default();
+    idx.rebuild(&world);
+
+    // Kills `delete match arm RiderPhase::Waiting in RiderIndex::rebuild`.
+    assert!(
+        idx.waiting_at(stop).contains(&rider),
+        "rebuild must add Waiting riders to the waiting partition"
+    );
+    assert_eq!(idx.waiting_count_at(stop), 1);
+}
+
+#[test]
+fn rebuild_populates_abandoned_partition() {
+    let mut world = World::new();
+    let stop = fresh_stop(&mut world);
+    let rider = rider_in_phase(&mut world, stop, RiderPhase::Abandoned);
+
+    let mut idx = RiderIndex::default();
+    idx.rebuild(&world);
+
+    // Kills `delete match arm RiderPhase::Abandoned in RiderIndex::rebuild`.
+    assert!(
+        idx.abandoned_at(stop).contains(&rider),
+        "rebuild must add Abandoned riders to the abandoned partition"
+    );
+    assert_eq!(idx.abandoned_count_at(stop), 1);
+}
+
+#[test]
+fn rebuild_clears_stale_entries() {
+    let mut world = World::new();
+    let stop = fresh_stop(&mut world);
+
+    // Pre-populate the index with a rider that is NOT in world state.
+    let ghost = world.spawn();
+    let mut idx = RiderIndex::default();
+    idx.insert_waiting(stop, ghost);
+    assert_eq!(idx.waiting_count_at(stop), 1);
+
+    idx.rebuild(&world);
+
+    // After rebuild, the ghost should be gone — world has no rider component
+    // for it, so rebuild skips it.
+    assert_eq!(idx.waiting_count_at(stop), 0);
+}
+
+#[test]
+fn rider_index_phases_are_independent() {
+    // A rider id can only live in one partition at a time in practice, but
+    // the index does not enforce that; it just keeps the partitions disjoint
+    // by phase. Verify the partitions don't alias.
+    let mut world = World::new();
+    let stop = fresh_stop(&mut world);
+    let w = world.spawn();
+    let r = world.spawn();
+    let a = world.spawn();
+
+    let mut idx = RiderIndex::default();
+    idx.insert_waiting(stop, w);
+    idx.insert_resident(stop, r);
+    idx.insert_abandoned(stop, a);
+
+    assert_eq!(idx.waiting_count_at(stop), 1);
+    assert_eq!(idx.resident_count_at(stop), 1);
+    assert_eq!(idx.abandoned_count_at(stop), 1);
+    assert!(idx.waiting_at(stop).contains(&w));
+    assert!(idx.residents_at(stop).contains(&r));
+    assert!(idx.abandoned_at(stop).contains(&a));
+    assert!(!idx.waiting_at(stop).contains(&r));
+    assert!(!idx.residents_at(stop).contains(&a));
+    assert!(!idx.abandoned_at(stop).contains(&w));
+}

--- a/crates/elevator-core/src/tests/topology_tests.rs
+++ b/crates/elevator-core/src/tests/topology_tests.rs
@@ -67,6 +67,30 @@ fn add_elevator_at_runtime() {
     )));
 }
 
+/// `add_stop` must reject non-finite positions instead of silently
+/// inserting them into `SortedStops` (where `partition_point` on NaN
+/// is undefined behavior for ordering) and the position map (where
+/// `find_stop_at_position` with `f64::NAN` returns nondeterministic
+/// results).
+#[test]
+fn add_stop_rejects_non_finite_position() {
+    let config = default_config();
+    let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
+    let line = sim.lines_in_group(GroupId(0))[0];
+
+    for (label, value) in [
+        ("NaN", f64::NAN),
+        ("+inf", f64::INFINITY),
+        ("-inf", f64::NEG_INFINITY),
+    ] {
+        let result = sim.add_stop(label.into(), value, line);
+        assert!(
+            matches!(result, Err(crate::error::SimError::InvalidConfig { .. })),
+            "add_stop with {label} position must return InvalidConfig, got {result:?}"
+        );
+    }
+}
+
 #[test]
 fn add_to_nonexistent_line_returns_error() {
     let config = default_config();

--- a/crates/elevator-core/src/tests/traffic_tests.rs
+++ b/crates/elevator-core/src/tests/traffic_tests.rs
@@ -494,3 +494,34 @@ fn traffic_schedule_serde_roundtrip() {
     assert_eq!(deserialized.pattern_at(150), &TrafficPattern::DownPeak);
     assert_eq!(deserialized.pattern_at(999), &TrafficPattern::Mixed);
 }
+
+/// `with_mean_interval` must resample `next_arrival_tick` so the builder
+/// chain `PoissonSource::new(..., tiny_mean, ...).with_mean_interval(big_mean)`
+/// does not leak the tick-0 arrival drawn from `tiny_mean`.
+///
+/// Pre-fix, building with `mean=1` then shifting to `mean=10_000` kept
+/// the `mean=1` draw (`next_arrival` <= ~10). Post-fix, the draw is
+/// redone at the new mean on the builder call.
+#[test]
+fn with_mean_interval_resamples_next_arrival() {
+    use rand::SeedableRng;
+
+    let stops = vec![StopId(0), StopId(1)];
+    let seeded = rand::rngs::StdRng::seed_from_u64(0xD1E7);
+
+    let source = PoissonSource::new(
+        stops,
+        TrafficSchedule::constant(TrafficPattern::Uniform),
+        1, // tiny mean at construction
+        (60.0, 90.0),
+    )
+    .with_rng(seeded) // deterministic resample sequence
+    .with_mean_interval(10_000); // shift to a mean where first draw >> 10
+
+    let first = source.next_arrival_tick();
+    assert!(
+        first > 100,
+        "pre-fix bug: first arrival should reflect the new mean=10_000 \
+         (draw should be well over 100), got {first}"
+    );
+}

--- a/crates/elevator-core/src/traffic.rs
+++ b/crates/elevator-core/src/traffic.rs
@@ -432,12 +432,16 @@ impl PoissonSource {
     /// silently keeps the tick-0-ish arrival drawn at lambda = 1 — users
     /// get their first rider ~1 tick in despite asking for one every 1200.
     ///
-    /// The method now draws `next_arrival_tick` afresh from the updated
-    /// mean so the builder chain behaves as the docs imply.
+    /// The method draws `next_arrival_tick` afresh from the updated mean,
+    /// anchored to the source's current `next_arrival_tick` so that mid-
+    /// simulation calls do not rewind the anchor and trigger a catch-up
+    /// burst on the next [`generate`](TrafficSource::generate). See
+    /// [`with_rng`](Self::with_rng) for the analogous rationale.
     #[must_use]
     pub fn with_mean_interval(mut self, ticks: u32) -> Self {
         self.mean_interval = ticks;
-        self.next_arrival_tick = sample_next_arrival(0, self.mean_interval, &mut self.rng);
+        self.next_arrival_tick =
+            sample_next_arrival(self.next_arrival_tick, self.mean_interval, &mut self.rng);
         self
     }
 

--- a/crates/elevator-core/src/traffic.rs
+++ b/crates/elevator-core/src/traffic.rs
@@ -424,11 +424,30 @@ impl PoissonSource {
         self
     }
 
-    /// Replace the mean arrival interval.
+    /// Replace the mean arrival interval and resample the next arrival.
+    ///
+    /// The first scheduled arrival is drawn in [`Self::new`] using whatever
+    /// mean the constructor received. Without resampling here, a chain like
+    /// `PoissonSource::new(stops, schedule, 1, range).with_mean_interval(1200)`
+    /// silently keeps the tick-0-ish arrival drawn at lambda = 1 — users
+    /// get their first rider ~1 tick in despite asking for one every 1200.
+    ///
+    /// The method now draws `next_arrival_tick` afresh from the updated
+    /// mean so the builder chain behaves as the docs imply.
     #[must_use]
-    pub const fn with_mean_interval(mut self, ticks: u32) -> Self {
+    pub fn with_mean_interval(mut self, ticks: u32) -> Self {
         self.mean_interval = ticks;
+        self.next_arrival_tick = sample_next_arrival(0, self.mean_interval, &mut self.rng);
         self
+    }
+
+    /// Tick of the next scheduled arrival.
+    ///
+    /// Exposed so callers (and tests) can confirm when the next spawn is
+    /// due without advancing the simulation.
+    #[must_use]
+    pub const fn next_arrival_tick(&self) -> u64 {
+        self.next_arrival_tick
     }
 
     /// Replace the internal RNG with a caller-supplied one.


### PR DESCRIPTION
Stacked on #41. Adds targeted tests to close the mutation-coverage gaps identified in PR #40's published 64.0% score. Does not modify production code.

## Scope

21 new tests, organized by module:

- **`rider_index_tests.rs`** (new file, 9 tests) — direct unit coverage of `RiderIndex::{insert_*, remove_*, *_at, *_count_at, rebuild}`. Kills the "replace fn with ()" and "return 0/1" mutants for insert_abandoned, remove_waiting, the count accessors, and the rebuild match-arm-deletion mutants.
- **`reposition_tests.rs`** (5 new tests) — `SpreadEvenly`, `ReturnToLobby`, and `DemandWeighted` strategies asserted against specific return vectors (not just `is_empty`). Kills the "replace reposition() -> Vec with vec![]" cluster and the `==` vs `!=` on empty-guard clauses.
- **`movement_tests.rs`** (7 new tests) — exact-value assertions on `braking_distance` (v²/2a kinematic formula) and `tick_movement` boundaries: accel from rest, cruise-clamp, decel near target, snap-on-overshoot. Kills the arithmetic-operator and boundary-comparison mutants.

## Verification

A mutation rerun over the scoped tick-loop hot path will be posted in a follow-up comment once it completes.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test -p elevator-core` — 434 pass (21 new), 0 fail
- [x] `cargo doc --no-deps` — zero warnings