### PR TITLE
fix: correctness bugs surfaced by review pass

### DIFF
--- a/crates/elevator-core/src/components/destination_queue.rs
+++ b/crates/elevator-core/src/components/destination_queue.rs
@@ -89,6 +89,19 @@ impl DestinationQueue {
         self.queue.clear();
     }
 
+    /// Retain only entries that satisfy `predicate`.
+    ///
+    /// Used by `remove_stop` to scrub references to a despawned stop.
+    pub(crate) fn retain(&mut self, mut predicate: impl FnMut(EntityId) -> bool) {
+        self.queue.retain(|&eid| predicate(eid));
+    }
+
+    /// `true` if the queue contains `stop` anywhere.
+    #[must_use]
+    pub fn contains(&self, stop: &EntityId) -> bool {
+        self.queue.contains(stop)
+    }
+
     /// Remove and return the front entry.
     pub(crate) fn pop_front(&mut self) -> Option<EntityId> {
         (!self.queue.is_empty()).then(|| self.queue.remove(0))

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -55,6 +55,16 @@ impl Simulation {
         position: f64,
         line: EntityId,
     ) -> Result<EntityId, SimError> {
+        if !position.is_finite() {
+            return Err(SimError::InvalidConfig {
+                field: "position",
+                reason: format!(
+                    "stop position must be finite (got {position}); NaN/±inf \
+                     corrupt SortedStops ordering and find_stop_at_position lookup"
+                ),
+            });
+        }
+
         let group_id = self
             .world
             .line(line)

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -500,6 +500,9 @@ impl Simulation {
             }
         }
 
+        let old_group_id = self.groups[old_group_idx].id();
+        let new_group_id = self.groups[new_group_idx].id();
+
         self.groups[old_group_idx].lines_mut()[old_line_idx]
             .elevators_mut()
             .retain(|&e| e != elevator);
@@ -514,10 +517,18 @@ impl Simulation {
         self.groups[old_group_idx].rebuild_caches();
         if new_group_idx != old_group_idx {
             self.groups[new_group_idx].rebuild_caches();
+
+            // Notify the old group's dispatcher so it clears per-elevator
+            // state (ScanDispatch/LookDispatch track direction by
+            // EntityId). Matches the symmetry with `remove_elevator`.
+            if let Some(old_dispatcher) = self.dispatchers.get_mut(&old_group_id) {
+                old_dispatcher.notify_removed(elevator);
+            }
         }
 
         self.mark_topo_dirty();
 
+        let _ = new_group_id; // reserved for symmetric notify_added once the trait gains one
         self.events.emit(Event::ElevatorReassigned {
             elevator,
             old_line,

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -338,6 +338,23 @@ impl Simulation {
         // Disable first to invalidate routes referencing this stop.
         let _ = self.disable(stop);
 
+        // Scrub references to the removed stop from every elevator so the
+        // post-despawn tick loop does not chase a dead EntityId through
+        // `target_stop`, the destination queue, or access-control checks.
+        let elevator_ids: Vec<EntityId> =
+            self.world.iter_elevators().map(|(eid, _, _)| eid).collect();
+        for eid in elevator_ids {
+            if let Some(car) = self.world.elevator_mut(eid) {
+                if car.target_stop == Some(stop) {
+                    car.target_stop = None;
+                }
+                car.restricted_stops.remove(&stop);
+            }
+            if let Some(q) = self.world.destination_queue_mut(eid) {
+                q.retain(|s| s != stop);
+            }
+        }
+
         // Remove from all lines and groups.
         for group in &mut self.groups {
             for line_info in group.lines_mut() {

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -219,6 +219,61 @@ fn remove_stop_with_waiting_rider_invalidates_route() {
     );
 }
 
+/// `remove_stop` must not leave dangling references in elevator state.
+/// Pre-fix: `target_stop`, `DestinationQueue`, and `restricted_stops` all
+/// kept pointing at the despawned `EntityId`, which caused subsequent
+/// `movement`/`advance_queue` phases to ask `world.stop_position(target_stop)`
+/// and get `None`, potentially stalling the elevator.
+#[test]
+fn remove_stop_clears_dangling_references_on_elevator() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let stop2 = sim.stop_entity(StopId(2)).unwrap();
+    let elev = sim.groups()[0].elevator_entities()[0];
+
+    // Queue stop 2 as a destination, then dispatch so the elevator picks
+    // it as its target.
+    sim.push_destination(elev, stop2).unwrap();
+    sim.step();
+
+    // Seed the restricted_stops set directly (normally populated via
+    // config but we want to cover the cleanup path).
+    if let Some(car) = sim.world_mut().elevator_mut(elev) {
+        car.restricted_stops.insert(stop2);
+    }
+
+    // Sanity: the references exist before removal.
+    let car = sim.world().elevator(elev).unwrap();
+    assert!(
+        car.target_stop == Some(stop2)
+            || sim
+                .destination_queue(elev)
+                .is_some_and(|q| q.contains(&stop2)),
+        "test precondition: elevator should reference stop2 somehow"
+    );
+    assert!(car.restricted_stops.contains(&stop2));
+
+    sim.remove_stop(stop2).unwrap();
+
+    let car = sim.world().elevator(elev).unwrap();
+    assert_ne!(
+        car.target_stop,
+        Some(stop2),
+        "target_stop must be cleared when the referenced stop is removed"
+    );
+    if let Some(q) = sim.destination_queue(elev) {
+        assert!(
+            !q.contains(&stop2),
+            "DestinationQueue must not contain the removed stop"
+        );
+    }
+    assert!(
+        !car.restricted_stops.contains(&stop2),
+        "restricted_stops must not contain the removed stop"
+    );
+}
+
 #[test]
 fn remove_nonexistent_stop_returns_entity_not_found() {
     let config = default_config();

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -1585,6 +1585,67 @@ fn remove_line_marks_topology_graph_dirty() {
 
 // ── 14. Elevator reassignment (swing car) ────────────────────────────────────
 
+/// Cross-group reassignment must notify the old group's dispatcher so it
+/// clears per-elevator state (e.g. `ScanDispatch::direction`,
+/// `LookDispatch::direction`). Pre-fix the old dispatcher kept the stale
+/// entry, leaking memory and — for strategies that consult it — mis-
+/// dispatching the next call.
+#[test]
+fn reassign_elevator_to_line_notifies_old_group_dispatcher_on_cross_group() {
+    use crate::dispatch::{DispatchDecision, DispatchManifest, DispatchStrategy, ElevatorGroup};
+    use crate::entity::EntityId;
+    use crate::world::World;
+    use std::sync::{Arc, Mutex};
+
+    /// Dispatcher that records every `notify_removed` call it receives.
+    struct TrackingDispatch {
+        removed: Arc<Mutex<Vec<EntityId>>>,
+        inner: ScanDispatch,
+    }
+    impl DispatchStrategy for TrackingDispatch {
+        fn decide(
+            &mut self,
+            elevator: EntityId,
+            position: f64,
+            group: &ElevatorGroup,
+            manifest: &DispatchManifest,
+            world: &World,
+        ) -> DispatchDecision {
+            self.inner
+                .decide(elevator, position, group, manifest, world)
+        }
+        fn notify_removed(&mut self, elevator: EntityId) {
+            self.removed.lock().unwrap().push(elevator);
+            self.inner.notify_removed(elevator);
+        }
+    }
+
+    let config = two_group_config();
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+    let old_removed = Arc::new(Mutex::new(Vec::<EntityId>::new()));
+    sim.dispatchers_mut().insert(
+        GroupId(0),
+        Box::new(TrackingDispatch {
+            removed: old_removed.clone(),
+            inner: ScanDispatch::new(),
+        }),
+    );
+
+    let low_line = sim.lines_in_group(GroupId(0))[0];
+    let high_line = sim.lines_in_group(GroupId(1))[0];
+    let low_elevator = sim.elevators_on_line(low_line)[0];
+
+    sim.reassign_elevator_to_line(low_elevator, high_line)
+        .unwrap();
+
+    let saw_removal = old_removed.lock().unwrap().contains(&low_elevator);
+    assert!(
+        saw_removal,
+        "old group's dispatcher should receive notify_removed for cross-group reassignment"
+    );
+}
+
 #[test]
 fn reassign_elevator_to_line_moves_elevator() {
     let config = two_group_config();

--- a/crates/elevator-core/src/tests/topology_tests.rs
+++ b/crates/elevator-core/src/tests/topology_tests.rs
@@ -67,6 +67,30 @@ fn add_elevator_at_runtime() {
     )));
 }
 
+/// `add_stop` must reject non-finite positions instead of silently
+/// inserting them into `SortedStops` (where `partition_point` on NaN
+/// is undefined behavior for ordering) and the position map (where
+/// `find_stop_at_position` with `f64::NAN` returns nondeterministic
+/// results).
+#[test]
+fn add_stop_rejects_non_finite_position() {
+    let config = default_config();
+    let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
+    let line = sim.lines_in_group(GroupId(0))[0];
+
+    for (label, value) in [
+        ("NaN", f64::NAN),
+        ("+inf", f64::INFINITY),
+        ("-inf", f64::NEG_INFINITY),
+    ] {
+        let result = sim.add_stop(label.into(), value, line);
+        assert!(
+            matches!(result, Err(crate::error::SimError::InvalidConfig { .. })),
+            "add_stop with {label} position must return InvalidConfig, got {result:?}"
+        );
+    }
+}
+
 #[test]
 fn add_to_nonexistent_line_returns_error() {
     let config = default_config();

--- a/crates/elevator-core/src/tests/traffic_tests.rs
+++ b/crates/elevator-core/src/tests/traffic_tests.rs
@@ -494,3 +494,34 @@ fn traffic_schedule_serde_roundtrip() {
     assert_eq!(deserialized.pattern_at(150), &TrafficPattern::DownPeak);
     assert_eq!(deserialized.pattern_at(999), &TrafficPattern::Mixed);
 }
+
+/// `with_mean_interval` must resample `next_arrival_tick` so the builder
+/// chain `PoissonSource::new(..., tiny_mean, ...).with_mean_interval(big_mean)`
+/// does not leak the tick-0 arrival drawn from `tiny_mean`.
+///
+/// Pre-fix, building with `mean=1` then shifting to `mean=10_000` kept
+/// the `mean=1` draw (`next_arrival` <= ~10). Post-fix, the draw is
+/// redone at the new mean on the builder call.
+#[test]
+fn with_mean_interval_resamples_next_arrival() {
+    use rand::SeedableRng;
+
+    let stops = vec![StopId(0), StopId(1)];
+    let seeded = rand::rngs::StdRng::seed_from_u64(0xD1E7);
+
+    let source = PoissonSource::new(
+        stops,
+        TrafficSchedule::constant(TrafficPattern::Uniform),
+        1, // tiny mean at construction
+        (60.0, 90.0),
+    )
+    .with_rng(seeded) // deterministic resample sequence
+    .with_mean_interval(10_000); // shift to a mean where first draw >> 10
+
+    let first = source.next_arrival_tick();
+    assert!(
+        first > 100,
+        "pre-fix bug: first arrival should reflect the new mean=10_000 \
+         (draw should be well over 100), got {first}"
+    );
+}

--- a/crates/elevator-core/src/traffic.rs
+++ b/crates/elevator-core/src/traffic.rs
@@ -432,12 +432,16 @@ impl PoissonSource {
     /// silently keeps the tick-0-ish arrival drawn at lambda = 1 — users
     /// get their first rider ~1 tick in despite asking for one every 1200.
     ///
-    /// The method now draws `next_arrival_tick` afresh from the updated
-    /// mean so the builder chain behaves as the docs imply.
+    /// The method draws `next_arrival_tick` afresh from the updated mean,
+    /// anchored to the source's current `next_arrival_tick` so that mid-
+    /// simulation calls do not rewind the anchor and trigger a catch-up
+    /// burst on the next [`generate`](TrafficSource::generate). See
+    /// [`with_rng`](Self::with_rng) for the analogous rationale.
     #[must_use]
     pub fn with_mean_interval(mut self, ticks: u32) -> Self {
         self.mean_interval = ticks;
-        self.next_arrival_tick = sample_next_arrival(0, self.mean_interval, &mut self.rng);
+        self.next_arrival_tick =
+            sample_next_arrival(self.next_arrival_tick, self.mean_interval, &mut self.rng);
         self
     }
 

--- a/crates/elevator-core/src/traffic.rs
+++ b/crates/elevator-core/src/traffic.rs
@@ -424,11 +424,30 @@ impl PoissonSource {
         self
     }
 
-    /// Replace the mean arrival interval.
+    /// Replace the mean arrival interval and resample the next arrival.
+    ///
+    /// The first scheduled arrival is drawn in [`Self::new`] using whatever
+    /// mean the constructor received. Without resampling here, a chain like
+    /// `PoissonSource::new(stops, schedule, 1, range).with_mean_interval(1200)`
+    /// silently keeps the tick-0-ish arrival drawn at lambda = 1 — users
+    /// get their first rider ~1 tick in despite asking for one every 1200.
+    ///
+    /// The method now draws `next_arrival_tick` afresh from the updated
+    /// mean so the builder chain behaves as the docs imply.
     #[must_use]
-    pub const fn with_mean_interval(mut self, ticks: u32) -> Self {
+    pub fn with_mean_interval(mut self, ticks: u32) -> Self {
         self.mean_interval = ticks;
+        self.next_arrival_tick = sample_next_arrival(0, self.mean_interval, &mut self.rng);
         self
+    }
+
+    /// Tick of the next scheduled arrival.
+    ///
+    /// Exposed so callers (and tests) can confirm when the next spawn is
+    /// due without advancing the simulation.
+    #[must_use]
+    pub const fn next_arrival_tick(&self) -> u64 {
+        self.next_arrival_tick
     }
 
     /// Replace the internal RNG with a caller-supplied one.


### PR DESCRIPTION
Re-open of #41 (auto-closed when its base branch was merged + deleted). Same content, rebased cleanly onto main.

Closes four real correctness bugs surfaced by the gap-finder + reviewer passes during the pre-release audit. Each commit contains one regression test that fails before the fix and passes after.

## Bugs

1. **`remove_stop` left dangling elevator references.** `target_stop`, `DestinationQueue`, and `restricted_stops` all kept pointing at the despawned `EntityId`, so the next `movement` / `advance_queue` tick could chase a dead id. Fix walks all elevators and scrubs references before despawn.

2. **Cross-group `reassign_elevator_to_line` did not notify the old dispatcher.** `ScanDispatch` and `LookDispatch` track per-elevator direction in a `HashMap<EntityId, _>` — the reassignment path leaked entries in the old group's map and, for any dispatcher consulting the table by id, could mis-dispatch. Fix calls `dispatcher.notify_removed(id)` on the old group when `new_group_idx != old_group_idx`, matching the symmetry already present in `remove_elevator`.

3. **`PoissonSource::with_mean_interval` did not resample `next_arrival_tick`.** Chain `PoissonSource::new(stops, schedule, 1, range).with_mean_interval(1200)` kept the tick-0-ish draw from `mean=1`. Fix drops `const` and resamples from the new mean, anchored to current `next_arrival_tick` (mirroring the `with_rng` fix for mid-sim use).

4. **Runtime `add_stop` accepted NaN / ±inf positions.** Non-finite positions corrupt `SortedStops` (binary-search invariant) and `find_stop_at_position` (NaN comparisons). Fix: guard at the top of `add_stop` with `is_finite()` and return `SimError::InvalidConfig`.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test -p elevator-core` — 413 pass (4 new regression tests), 0 fail
- [x] `cargo doc --no-deps` with `RUSTDOCFLAGS=-D warnings` — zero warnings
- [x] Each regression test was verified to fail on the pre-fix commit and pass after.