### PR TITLE
fix(ci): release-kun guard misses PRs authored by github-actions[bot]

### DIFF
--- a/.github/workflows/release-please-auto-merge.yml
+++ b/.github/workflows/release-please-auto-merge.yml
@@ -6,7 +6,13 @@ name: Release-please auto-approve and merge
 # is pure ceremony that would otherwise block the release pipeline.
 #
 # Safety rails:
-#   - Only fires on PRs authored by the `release-please[bot]` login.
+#   - Only fires on PRs authored by a release-please bot identity AND
+#     whose title matches the release-please title prefix. `release-
+#     please-action` creates PRs using the workflow's GITHUB_TOKEN by
+#     default, which makes the author `github-actions[bot]` — not
+#     `release-please[bot]`. The paired author + title check lets the
+#     workflow match in either configuration without false-positive on
+#     unrelated `github-actions[bot]` PRs.
 #   - Uses a dedicated App (release-kun) with scoped permissions, so
 #     the approval and merge credentials don't leak into regular CI.
 #   - `gh pr merge --auto` waits for required status checks to pass
@@ -18,7 +24,10 @@ on:
 
 jobs:
   auto-merge:
-    if: github.event.pull_request.user.login == 'release-please[bot]'
+    if: |
+      (github.event.pull_request.user.login == 'release-please[bot]' ||
+       github.event.pull_request.user.login == 'github-actions[bot]') &&
+      startsWith(github.event.pull_request.title, 'chore(main): release')
     runs-on: ubuntu-latest
     # The token minted below needs to both approve and merge. The App
     # itself is granted `pull_requests: write` via the installation;


### PR DESCRIPTION
PR #47 is the end-to-end test of release-kun auto-approval, and it exposed a bug: release-kun didn't fire.

Root cause: `release-please-action` creates its release PR using the workflow's default `GITHUB_TOKEN`, so the PR's author is `github-actions[bot]`, not `release-please[bot]`. The previous if-guard filtered on `release-please[bot]` only.

Fix: widen the author match to either `release-please[bot]` OR `github-actions[bot]`, AND require the title to start with `chore(main): release` — release-please's canonical release-PR title prefix. The conjunction prevents false positives on unrelated `github-actions[bot]` PRs (dependabot, etc.).

## Test plan

- [x] Workflow YAML syntax validated locally.
- [ ] After merge, re-trigger #47 (close+reopen, or push an empty commit to the release-please branch). Expect release-kun to approve and enable auto-merge.