### PR TITLE
docs(readme): fix demo() + .stop() push-vs-replace bug in examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "5.2.0"
+version = "5.4.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/README.md
+++ b/README.md
@@ -51,11 +51,19 @@ Create a simulation, spawn a rider, and run until delivery.
 
 ```rust
 use elevator_core::prelude::*;
+use elevator_core::stop::StopConfig;
 
+// `::demo()` pre-populates two stops (Ground at 0.0, Top at 10.0) and
+// one elevator with SCAN dispatch. `.stops(vec![...])` *replaces* the
+// default stops so the building matches this example exactly — using
+// the singular `.stop(...)` instead would push, leaving the defaults
+// intact and duplicating StopId(0).
 let mut sim = SimulationBuilder::demo()
-    .stop(StopId(0), "Ground", 0.0)
-    .stop(StopId(1), "Floor 2", 4.0)
-    .stop(StopId(2), "Floor 3", 8.0)
+    .stops(vec![
+        StopConfig { id: StopId(0), name: "Ground".into(), position: 0.0 },
+        StopConfig { id: StopId(1), name: "Floor 2".into(), position: 4.0 },
+        StopConfig { id: StopId(2), name: "Floor 3".into(), position: 8.0 },
+    ])
     .build()
     .unwrap();
 
@@ -77,11 +85,14 @@ Swap in a different dispatch algorithm and react to simulation events.
 ```rust
 use elevator_core::prelude::*;
 use elevator_core::dispatch::etd::EtdDispatch;
+use elevator_core::stop::StopConfig;
 
 let mut sim = SimulationBuilder::demo()
-    .stop(StopId(0), "Lobby", 0.0)
-    .stop(StopId(1), "Sky Lounge", 50.0)
-    .stop(StopId(2), "Observatory", 120.0)
+    .stops(vec![
+        StopConfig { id: StopId(0), name: "Lobby".into(), position: 0.0 },
+        StopConfig { id: StopId(1), name: "Sky Lounge".into(), position: 50.0 },
+        StopConfig { id: StopId(2), name: "Observatory".into(), position: 120.0 },
+    ])
     .dispatch(EtdDispatch::new())
     .build()
     .unwrap();
@@ -111,6 +122,7 @@ Attach custom data to entities and inject logic into the tick loop.
 
 ```rust
 use elevator_core::prelude::*;
+use elevator_core::stop::StopConfig;
 use serde::{Serialize, Deserialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -119,8 +131,10 @@ struct VipTag {
 }
 
 let mut sim = SimulationBuilder::demo()
-    .stop(StopId(0), "Ground", 0.0)
-    .stop(StopId(1), "Penthouse", 100.0)
+    .stops(vec![
+        StopConfig { id: StopId(0), name: "Ground".into(), position: 0.0 },
+        StopConfig { id: StopId(1), name: "Penthouse".into(), position: 100.0 },
+    ])
     .with_ext::<VipTag>("vip_tag")
     .after(Phase::Loading, |world| {
         // Custom logic runs after the loading phase every tick.

--- a/crates/elevator-core/src/builder.rs
+++ b/crates/elevator-core/src/builder.rs
@@ -148,6 +148,29 @@ impl SimulationBuilder {
     /// let sim = SimulationBuilder::demo().build().unwrap();
     /// assert_eq!(sim.current_tick(), 0);
     /// ```
+    ///
+    /// # Customizing the demo stops
+    ///
+    /// [`.stop()`](Self::stop) is a *push*: calling it after `demo()`
+    /// appends to the two default stops rather than replacing them,
+    /// which silently duplicates `StopId(0)` and produces two stops
+    /// at position 0.0. To replace the defaults, use
+    /// [`.stops(vec![...])`](Self::stops) with the full list:
+    ///
+    /// ```
+    /// use elevator_core::prelude::*;
+    /// use elevator_core::stop::StopConfig;
+    ///
+    /// let sim = SimulationBuilder::demo()
+    ///     .stops(vec![
+    ///         StopConfig { id: StopId(0), name: "Lobby".into(),   position: 0.0 },
+    ///         StopConfig { id: StopId(1), name: "Mezzanine".into(), position: 4.0 },
+    ///         StopConfig { id: StopId(2), name: "Roof".into(),     position: 8.0 },
+    ///     ])
+    ///     .build()
+    ///     .unwrap();
+    /// # let _ = sim;
+    /// ```
     #[must_use]
     pub fn demo() -> Self {
         let mut b = Self::new();


### PR DESCRIPTION
All three `SimulationBuilder::demo()` examples in the README chained individual `.stop(...)` calls after it:

```rust
let mut sim = SimulationBuilder::demo()
    .stop(StopId(0), "Ground", 0.0)
    .stop(StopId(1), "Floor 2", 4.0)
    .stop(StopId(2), "Floor 3", 8.0)
    .build()
    .unwrap();
```

This is a real bug: `demo()` pre-populates **two** stops (`Ground` at 0.0, `Top` at 10.0), and `.stop(...)` is a **push**, not a replace. The resulting sim had 5 stops with `StopId(0)` duplicated and two stops at position 0.0. The examples aren't run as doctests (markdown only), so the bug shipped.

## Fix

- Swap each README example to `.stops(vec![...])`, which replaces the default stops list. Minimal diff; preserves narrative.
- Add a leading comment on the first example that spells out the gotcha, so readers who copy the pattern into `::new()`-based code understand the semantics.
- Harden `SimulationBuilder::demo()`'s docstring with a new `# Customizing the demo stops` section showing the correct `.stops(vec![...])` pattern and explicitly warning against `.stop(...)` for this case. The new doctest is compiled, so a future regression would fail `cargo test --doc`.

No other docs chapters hit this — they already use `.stops(vec![])` (clearing) before `.stop(...)` chains.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test -p elevator-core` — 434 + 30 doctests pass
- [x] `cargo doc --no-deps` with `RUSTDOCFLAGS=-D warnings` — zero warnings