### PR TITLE
docs: refresh module-layout tables in lib.rs and ARCHITECTURE.md

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "5.2.0"
+version = "5.4.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/ARCHITECTURE.md
+++ b/crates/elevator-core/ARCHITECTURE.md
@@ -29,40 +29,50 @@ system function.
 pub struct World {
     alive:       SlotMap<EntityId, ()>,
 
-    // Built-in component storages
-    positions:   SecondaryMap<EntityId, Position>,
-    velocities:  SecondaryMap<EntityId, Velocity>,
-    elevators:   SecondaryMap<EntityId, Elevator>,
-    riders:      SecondaryMap<EntityId, Rider>,
-    stops:       SecondaryMap<EntityId, Stop>,
-    routes:      SecondaryMap<EntityId, Route>,
-    lines:       SecondaryMap<EntityId, Line>,
-    patience:    SecondaryMap<EntityId, Patience>,
-    preferences: SecondaryMap<EntityId, Preferences>,
-    disabled:    SecondaryMap<EntityId, ()>,
+    // Built-in component storages (one SecondaryMap per component type)
+    positions, velocities, floor_positions,
+    elevators, riders, stops, routes, lines,
+    patience, preferences, access_control,
+    destination_queues, service_modes,
+    disabled: SecondaryMap<EntityId, ()>,
 
     // Extension storage (game-specific components)
     extensions:  HashMap<TypeId, Box<dyn AnyExtMap>>,
     ext_names:   HashMap<TypeId, String>,
 
-    // Global resources (singletons)
+    // Global resources (singletons — e.g. SortedStops, MetricTags)
     resources:   HashMap<TypeId, Box<dyn Any + Send + Sync>>,
 }
 ```
 
+The listing above elides the individual `SecondaryMap<EntityId, T>`
+types for readability; see [`world.rs`](../src/world.rs) for the
+concrete struct definition.
+
 ### Built-in components
 
-| Component     | Attached to   | Purpose                                     |
-|---------------|---------------|---------------------------------------------|
-| `Position`    | Elevator       | Shaft-axis position (`f64`)                |
-| `Velocity`    | Elevator       | Shaft-axis velocity (`f64`)                |
-| `Elevator`    | Elevator       | Phase, door FSM, riders, capacity, physics |
-| `Rider`       | Rider          | Phase, weight, spawn/board tick            |
-| `Stop`        | Stop           | Name, position                             |
-| `Route`       | Rider          | Multi-leg route (optional)                 |
-| `Line`        | Line           | Group, orientation, axis bounds            |
-| `Patience`    | Rider          | Patience threshold and tick tracking       |
-| `Preferences` | Rider          | Boarding preferences                       |
+| Component          | Attached to       | Purpose                                                          |
+|--------------------|-------------------|------------------------------------------------------------------|
+| `Position`         | Elevator, Stop    | Shaft-axis position (`f64`). Stops use it for lookup.            |
+| `Velocity`         | Elevator          | Shaft-axis velocity (`f64`, signed).                             |
+| `FloorPosition`    | Line              | Optional floor-plan position for rendering.                      |
+| `Elevator`         | Elevator          | Phase, door FSM, riders, capacity, physics, direction lamps.     |
+| `Rider`            | Rider             | Phase, weight, spawn/board tick.                                 |
+| `Stop`             | Stop              | Name + position pair.                                            |
+| `Line`             | Line              | Group, orientation, axis bounds, optional `max_cars`.            |
+| `Route`            | Rider             | Multi-leg route (optional — Route-less riders are game-managed). |
+| `Patience`         | Rider             | Patience threshold and tick tracking for abandonment.            |
+| `Preferences`      | Rider             | Boarding preferences (`skip_full_elevator`, `max_crowding_factor`). |
+| `AccessControl`    | Rider             | Per-rider allowlist of reachable stops.                          |
+| `DestinationQueue` | Elevator          | FIFO of pushed target stops; imperative-dispatch escape hatch.   |
+| `ServiceMode`      | Elevator          | `Normal` / `Independent` / `Inspection`.                         |
+| `Orientation`      | Line              | Vertical vs horizontal axis (for visualization).                 |
+
+All components above are re-exported from `elevator_core::prelude` so
+consumers don't need to dig into the `components` submodule for
+everyday code. Games attach additional per-entity data via the
+[extension storage system](#extension-storage) without modifying the
+library.
 
 ### Query builder
 

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -59,12 +59,26 @@
 //! | [`sim`] | Top-level [`Simulation`](sim::Simulation) runner and tick loop |
 //! | [`dispatch`] | Dispatch strategies and the [`DispatchStrategy`](dispatch::DispatchStrategy) trait |
 //! | [`world`] | ECS-style [`World`](world::World) with typed component storage |
-//! | [`components`] | Data types: [`Elevator`](components::Elevator), [`Rider`](components::Rider), [`Stop`](components::Stop), etc. |
+//! | [`components`] | Entity data types: [`Rider`](components::Rider), [`Elevator`](components::Elevator), [`Stop`](components::Stop), [`Line`](components::Line), [`Route`](components::Route), [`Patience`](components::Patience), [`Preferences`](components::Preferences), [`AccessControl`](components::AccessControl), [`DestinationQueue`](components::DestinationQueue), [`ServiceMode`](components::ServiceMode), [`Orientation`](components::Orientation), [`Position`](components::Position), [`Velocity`](components::Velocity), [`FloorPosition`](components::FloorPosition) |
+//! | [`config`] | RON-deserializable [`SimConfig`](config::SimConfig), [`GroupConfig`](config::GroupConfig), [`LineConfig`](config::LineConfig) |
 //! | [`events`] | [`Event`](events::Event) variants and the [`EventBus`](events::EventBus) |
 //! | [`metrics`] | Aggregate [`Metrics`](metrics::Metrics) (wait time, throughput, etc.) |
-//! | [`config`] | RON-deserializable [`SimConfig`](config::SimConfig) |
 //! | [`hooks`] | Lifecycle hook registration by [`Phase`](hooks::Phase) |
 //! | [`query`] | Entity query builder for filtering by component composition |
+//! | [`systems`] | Per-phase tick logic (dispatch, movement, doors, loading, ...) |
+//! | [`snapshot`] | [`WorldSnapshot`](snapshot::WorldSnapshot) save/restore with custom-strategy factory |
+//! | [`scenario`] | Deterministic scenario replay from recorded event streams |
+//! | [`topology`] | Lazy-rebuilt connectivity graph for cross-line routing |
+//! | [`traffic`] | [`TrafficSource`](traffic::TrafficSource) trait + `PoissonSource` (feature-gated) |
+//! | [`tagged_metrics`] | Per-tag metric accumulators for zone/line/priority breakdowns |
+//! | [`movement`] | Trapezoidal velocity-profile primitives ([`braking_distance`](movement::braking_distance), [`tick_movement`](movement::tick_movement)) |
+//! | [`door`] | Door finite-state machine ([`DoorState`](door::DoorState)) |
+//! | [`time`] | Tick-to-wall-clock conversion ([`TimeAdapter`](time::TimeAdapter)) |
+//! | `energy` | Simplified per-elevator energy modeling (gated behind the `energy` feature) |
+//! | [`stop`] | [`StopId`](stop::StopId) and [`StopConfig`](stop::StopConfig) |
+//! | [`entity`] | Opaque [`EntityId`](entity::EntityId) runtime identity |
+//! | [`ids`] | Config-level typed identifiers ([`GroupId`](ids::GroupId), etc.) |
+//! | [`error`] | [`SimError`](error::SimError), [`RejectionReason`](error::RejectionReason), [`RejectionContext`](error::RejectionContext) |
 //!
 //! ## Architecture overview
 //!


### PR DESCRIPTION
Closes gap-finder items #5 + #6 from the pre-release audit. Both tables drifted from the actual public surface.

## Changes

**`lib.rs` Crate Layout table**
- Was: 10 rows — the headline modules only.
- Now: 22 rows — every `pub mod` in the crate. Each row either (a) names the primary type the module exposes with an intra-doc link, or (b) states the module's responsibility in one line. Covers `systems`, `snapshot`, `scenario`, `topology`, `traffic`, `tagged_metrics`, `movement`, `door`, `time`, `stop`, `entity`, `ids`, `error`, plus the feature-gated `energy`. Matches `grep "^pub mod" lib.rs` 1:1.

**`ARCHITECTURE.md` §2 Built-in Components table**
- Was: 9 components; `Rider` incorrectly listed as carrying the route.
- Now: 14 — the full set re-exported in `elevator_core::prelude`. Adds `FloorPosition`, `AccessControl`, `DestinationQueue`, `ServiceMode`, `Orientation`. Each row clarifies attached-entity + purpose.
- Clarifies that the preceding `pub struct World` listing is illustrative, not exhaustive Rust.

No code changes. Rustdoc warning-free under `RUSTDOCFLAGS=-D warnings`.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test -p elevator-core` — 434 tests + 29 doctests pass
- [x] `cargo doc --no-deps` with `-D warnings` — zero warnings