### PR TITLE
feat: Default impl for ElevatorConfig; rewrite README with ::new()

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,19 +51,19 @@ Create a simulation, spawn a rider, and run until delivery.
 
 ```rust
 use elevator_core::prelude::*;
+use elevator_core::config::ElevatorConfig;
 use elevator_core::stop::StopConfig;
 
-// `::demo()` pre-populates two stops (Ground at 0.0, Top at 10.0) and
-// one elevator with SCAN dispatch. `.stops(vec![...])` *replaces* the
-// default stops so the building matches this example exactly — using
-// the singular `.stop(...)` instead would push, leaving the defaults
-// intact and duplicating StopId(0).
-let mut sim = SimulationBuilder::demo()
+let mut sim = SimulationBuilder::new()
     .stops(vec![
         StopConfig { id: StopId(0), name: "Ground".into(), position: 0.0 },
         StopConfig { id: StopId(1), name: "Floor 2".into(), position: 4.0 },
         StopConfig { id: StopId(2), name: "Floor 3".into(), position: 8.0 },
     ])
+    .elevator(ElevatorConfig {
+        starting_stop: StopId(0),
+        ..Default::default()
+    })
     .build()
     .unwrap();
 
@@ -78,21 +78,33 @@ for _ in 0..1000 {
 println!("Delivered: {}", sim.metrics().total_delivered());
 ```
 
+For quick prototyping `SimulationBuilder::demo()` returns a two-stop, one-elevator building with reasonable physics defaults — useful when the stop layout isn't the point of the example.
+
 ### Custom Dispatch
 
 Swap in a different dispatch algorithm and react to simulation events.
 
 ```rust
 use elevator_core::prelude::*;
+use elevator_core::config::ElevatorConfig;
 use elevator_core::dispatch::etd::EtdDispatch;
 use elevator_core::stop::StopConfig;
 
-let mut sim = SimulationBuilder::demo()
+let mut sim = SimulationBuilder::new()
     .stops(vec![
         StopConfig { id: StopId(0), name: "Lobby".into(), position: 0.0 },
         StopConfig { id: StopId(1), name: "Sky Lounge".into(), position: 50.0 },
         StopConfig { id: StopId(2), name: "Observatory".into(), position: 120.0 },
     ])
+    .elevator(ElevatorConfig {
+        name: "Sky Car".into(),
+        max_speed: 6.0,                 // taller building → faster car
+        acceleration: 2.0,
+        deceleration: 2.5,
+        weight_capacity: 1200.0,
+        starting_stop: StopId(0),
+        ..Default::default()
+    })
     .dispatch(EtdDispatch::new())
     .build()
     .unwrap();
@@ -122,6 +134,7 @@ Attach custom data to entities and inject logic into the tick loop.
 
 ```rust
 use elevator_core::prelude::*;
+use elevator_core::config::ElevatorConfig;
 use elevator_core::stop::StopConfig;
 use serde::{Serialize, Deserialize};
 
@@ -130,11 +143,16 @@ struct VipTag {
     level: u32,
 }
 
-let mut sim = SimulationBuilder::demo()
+let mut sim = SimulationBuilder::new()
     .stops(vec![
         StopConfig { id: StopId(0), name: "Ground".into(), position: 0.0 },
         StopConfig { id: StopId(1), name: "Penthouse".into(), position: 100.0 },
     ])
+    .elevator(ElevatorConfig {
+        max_speed: 4.0,                 // tall building → faster car
+        starting_stop: StopId(0),
+        ..Default::default()
+    })
     .with_ext::<VipTag>("vip_tag")
     .after(Phase::Loading, |world| {
         // Custom logic runs after the loading phase every tick.

--- a/crates/elevator-core/src/builder.rs
+++ b/crates/elevator-core/src/builder.rs
@@ -134,13 +134,12 @@ impl SimulationBuilder {
         }
     }
 
-    /// Create a pre-populated builder suitable for doctests, examples, and
-    /// quick prototyping.
+    /// Pre-populated builder for zero-config examples, doctests, and quick
+    /// prototyping where the building layout isn't the point.
     ///
     /// Provides two stops (Ground at 0.0, Top at 10.0) and one elevator
-    /// with SCAN dispatch. Override any piece with the fluent methods
-    /// before [`build`](Self::build). For a blank slate, use
-    /// [`new`](Self::new).
+    /// with SCAN dispatch. Use this when you want a working `Simulation`
+    /// in one call and don't care about the specific stops.
     ///
     /// ```
     /// use elevator_core::prelude::*;
@@ -149,28 +148,12 @@ impl SimulationBuilder {
     /// assert_eq!(sim.current_tick(), 0);
     /// ```
     ///
-    /// # Customizing the demo stops
-    ///
-    /// [`.stop()`](Self::stop) is a *push*: calling it after `demo()`
-    /// appends to the two default stops rather than replacing them,
-    /// which silently duplicates `StopId(0)` and produces two stops
-    /// at position 0.0. To replace the defaults, use
-    /// [`.stops(vec![...])`](Self::stops) with the full list:
-    ///
-    /// ```
-    /// use elevator_core::prelude::*;
-    /// use elevator_core::stop::StopConfig;
-    ///
-    /// let sim = SimulationBuilder::demo()
-    ///     .stops(vec![
-    ///         StopConfig { id: StopId(0), name: "Lobby".into(),   position: 0.0 },
-    ///         StopConfig { id: StopId(1), name: "Mezzanine".into(), position: 4.0 },
-    ///         StopConfig { id: StopId(2), name: "Roof".into(),     position: 8.0 },
-    ///     ])
-    ///     .build()
-    ///     .unwrap();
-    /// # let _ = sim;
-    /// ```
+    /// If you need a specific stop layout or elevator physics, use
+    /// [`new`](Self::new) and configure every field explicitly — it reads
+    /// more clearly than threading overrides on top of `demo`'s defaults.
+    /// [`.stop()`](Self::stop) is a *push* onto the current stops list,
+    /// so calling it after `demo()` appends to the two defaults rather
+    /// than replacing them.
     #[must_use]
     pub fn demo() -> Self {
         let mut b = Self::new();

--- a/crates/elevator-core/src/config.rs
+++ b/crates/elevator-core/src/config.rs
@@ -138,6 +138,46 @@ const fn default_inspection_speed_factor() -> f64 {
     0.25
 }
 
+impl Default for ElevatorConfig {
+    /// Reasonable defaults matching the physics values the rest of
+    /// this struct's field docs advertise. Override any field with
+    /// struct-update syntax:
+    ///
+    /// ```
+    /// use elevator_core::config::ElevatorConfig;
+    /// use elevator_core::stop::StopId;
+    ///
+    /// let fast = ElevatorConfig {
+    ///     name: "Express".into(),
+    ///     max_speed: 6.0,
+    ///     starting_stop: StopId(0),
+    ///     ..Default::default()
+    /// };
+    /// # let _ = fast;
+    /// ```
+    ///
+    /// `starting_stop` defaults to `StopId(0)` — the conventional lobby
+    /// id. Override if your config uses a different bottom-stop id.
+    fn default() -> Self {
+        Self {
+            id: 0,
+            name: "Elevator 1".into(),
+            max_speed: 2.0,
+            acceleration: 1.5,
+            deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 10,
+            door_transition_ticks: 5,
+            restricted_stops: Vec::new(),
+            #[cfg(feature = "energy")]
+            energy_profile: None,
+            service_mode: None,
+            inspection_speed_factor: default_inspection_speed_factor(),
+        }
+    }
+}
+
 /// Global simulation timing parameters.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SimulationParams {


### PR DESCRIPTION
Addresses your question \"why does the readme still use .demo and define stops?\". The #49 fix kept `SimulationBuilder::demo()` as the starting point; you're right that reading those examples `demo()` is doing nothing except silently inheriting a default elevator — the abstraction is weirder than it needs to be.

## Changes

**`impl Default for ElevatorConfig`** (config.rs). The struct's field docs already document every default (max_speed 2.0, acceleration 1.5, etc.); this makes the documentation real. `starting_stop` defaults to `StopId(0)` — the conventional lobby — so users who adopt that convention can elide even that field.

**Three README examples rewritten** to use `SimulationBuilder::new()` with an explicit `.elevator(ElevatorConfig { ..fields.., ..Default::default() })`. The struct-update syntax means examples only spell out the fields they care about — the \"Basic\" example is back to a 4-line builder chain, the \"Custom Dispatch\" example explicitly tunes speed/capacity for a tall building, and the \"Extensions and Hooks\" example only touches `max_speed` and `starting_stop`.

**`SimulationBuilder::demo()` docstring tightened.** States upfront when to prefer `demo()` vs `new()` and why `.stop()` after `demo()` is a push, not a replace. No longer buried in a \"customizing the demo stops\" subsection.

## Backward compatibility

Additive change — existing callers of `ElevatorConfig { ..all fields.. }` continue to work. The new `Default` impl is only a convenience.

## Test plan

- [x] `cargo build -p elevator-core` — clean
- [x] `cargo build -p elevator-core --features energy` — clean (Default handles the cfg-gated `energy_profile`)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test -p elevator-core` — 434 tests + 30 doctests pass
- [x] `cargo doc --no-deps` with `-D warnings` — zero warnings