### PR TITLE
chore(ci): paths filter on release-kun workflow stops it appearing on every PR

### DIFF
--- a/.github/workflows/release-please-auto-merge.yml
+++ b/.github/workflows/release-please-auto-merge.yml
@@ -6,13 +6,17 @@ name: Release-please auto-approve and merge
 # is pure ceremony that would otherwise block the release pipeline.
 #
 # Safety rails:
-#   - Only fires on PRs authored by a release-please bot identity AND
-#     whose title matches the release-please title prefix. `release-
-#     please-action` creates PRs using the workflow's GITHUB_TOKEN by
-#     default, which makes the author `github-actions[bot]` — not
-#     `release-please[bot]`. The paired author + title check lets the
-#     workflow match in either configuration without false-positive on
-#     unrelated `github-actions[bot]` PRs.
+#   - The `paths:` filter below limits the workflow to PRs that touch
+#     the exact set of files release-please modifies. Other PRs don't
+#     register a workflow run at all, so the "auto-merge / SKIPPED"
+#     status check no longer appears on every PR.
+#   - The job-level `if:` is a belt-and-suspenders guard: even if a
+#     human PR happens to touch one of the release-please paths, the
+#     auto-approval only fires when the PR author is a known bot
+#     identity AND the title matches release-please's canonical
+#     `chore(main): release` prefix. `release-please-action` creates
+#     PRs using the workflow's `GITHUB_TOKEN` by default, which makes
+#     the author `github-actions[bot]` — not `release-please[bot]`.
 #   - Uses a dedicated App (release-kun) with scoped permissions, so
 #     the approval and merge credentials don't leak into regular CI.
 #   - `gh pr merge --auto` waits for required status checks to pass
@@ -21,6 +25,13 @@ name: Release-please auto-approve and merge
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      # Exactly the files release-please modifies in this repo, per
+      # `release-please-config.json`. Keep in sync if the manifest
+      # gains additional packages.
+      - '.release-please-manifest.json'
+      - 'crates/elevator-core/Cargo.toml'
+      - 'crates/elevator-core/CHANGELOG.md'
 
 jobs:
   auto-merge:


### PR DESCRIPTION
The release-kun auto-approval workflow had a job-level \`if:\` guard but no workflow-level filter, so every PR registered a workflow run that immediately skipped the job and left a cosmetic \`auto-merge / SKIPPED\` status check in the PR's checks tab. GitHub doesn't support workflow-level \`if:\`, but \`paths:\` on the trigger gives the same effect: the workflow only registers a run on PRs that touch one of release-please's three managed files.

## Changes

Added \`paths:\` to the workflow trigger, listing exactly the files release-please modifies in this repo per \`release-please-config.json\` (one package, \`crates/elevator-core\`):

- \`.release-please-manifest.json\`
- \`crates/elevator-core/Cargo.toml\`
- \`crates/elevator-core/CHANGELOG.md\`

Comment in the workflow notes the filter must be kept in sync if the manifest gains additional packages.

The job-level \`if:\` (author + title check) stays as a belt-and-suspenders guard against the unlikely case that a human PR happens to touch one of those files.

## Test plan

- [x] Workflow YAML syntax validated locally.
- [ ] After merge, confirm the \`auto-merge\` skipped-check no longer appears on PRs that don't touch the listed files.