### PR TITLE
chore(ci): skip CI jobs on release-please PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,15 @@ env:
 jobs:
   check:
     name: Check
+    # Skip on release-please PRs (machine-generated version bumps —
+    # no code changes to test). Branch-protection treats a SKIPPED
+    # required check as success, so this is safe to gate on. The
+    # `push: main` trigger is unaffected; we still validate the
+    # post-merge state on main.
+    if: |
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.user.login != 'release-kun[bot]' ||
+      !startsWith(github.event.pull_request.title, 'chore(main): release')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,6 +52,10 @@ jobs:
 
   supply-chain:
     name: Supply chain (cargo-deny)
+    if: |
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.user.login != 'release-kun[bot]' ||
+      !startsWith(github.event.pull_request.title, 'chore(main): release')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -53,6 +66,10 @@ jobs:
 
   msrv:
     name: MSRV (elevator-core)
+    if: |
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.user.login != 'release-kun[bot]' ||
+      !startsWith(github.event.pull_request.title, 'chore(main): release')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Release-please PRs are machine-generated version-bumps that touch \`.release-please-manifest.json\`, \`crates/elevator-core/Cargo.toml\`, and \`crates/elevator-core/CHANGELOG.md\` — no code, no logic, no reason to burn ~3 minutes of CI per release-please PR re-running clippy + the full test suite + cargo-deny + an MSRV build.

## Changes

Add a job-level \`if:\` to each of the three \`ci.yml\` jobs (\`check\`, \`supply-chain\`, \`msrv\`) that skips when:

- the trigger is \`pull_request\`, AND
- the author is \`release-kun[bot]\` (the App that release-please-action uses to author its PRs after #57), AND
- the title starts with \`chore(main): release\` (release-please's canonical title prefix).

The \`push: main\` trigger is unaffected — every release-please PR that lands on main still triggers the post-merge validation run because the \`push\` event has no PR context for the guard to match.

## Branch protection

Branch-protection rules treat a SKIPPED required check as success, so this is safe to gate even when \`Check\` is listed as required.

## Test plan

- [x] YAML syntax validated locally.
- [ ] After merge, the next release-please PR should show all three CI jobs as SKIPPED — but the PR still merges via the inline-approval flow added in #57.