### PR TITLE
chore: untrack .claude/scheduled_tasks.lock

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"5bf17be4-22a9-4f00-932b-2cc7540be3c3","pid":1335108,"acquiredAt":1776092566692}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 mutants.out/
 mutants.out.old/
 .claude/agent-memory-local/
+.claude/*.lock
 .idea/
 .vscode/
 *.code-workspace


### PR DESCRIPTION
## Summary
- `.claude/scheduled_tasks.lock` is a Claude Code runtime lock file (session id + pid + acquire timestamp) that was accidentally committed in #19.
- Removes it from tracking and adds `.claude/*.lock` to `.gitignore` so other lock files stay out too.

## Test plan
- [x] `git ls-files .claude/` no longer returns `scheduled_tasks.lock`
- [x] `.gitignore` rule matches: creating a new `.claude/scheduled_tasks.lock` locally shows as ignored in `git status`
- [x] `cargo test -p elevator-core` passes (pre-commit hook ran it)