### PR TITLE
docs: prefer new() + ElevatorConfig::default() over demo() in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ for _ in 0..1000 {
 println!("Delivered: {}", sim.metrics().total_delivered());
 ```
 
-For quick prototyping `SimulationBuilder::demo()` returns a two-stop, one-elevator building with reasonable physics defaults — useful when the stop layout isn't the point of the example.
+`ElevatorConfig` implements `Default` with sensible physics (max speed 2.0, acceleration 1.5, deceleration 2.0, 800 kg capacity), so `.elevator(ElevatorConfig { starting_stop: StopId(0), ..Default::default() })` is all you need when the physics aren't the point.
 
 ### Custom Dispatch
 
@@ -223,8 +223,15 @@ it to the builder:
 
 ```rust
 use elevator_core::prelude::*;
+use elevator_core::config::ElevatorConfig;
+use elevator_core::stop::StopConfig;
 
-let sim = SimulationBuilder::demo()
+let sim = SimulationBuilder::new()
+    .stops(vec![
+        StopConfig { id: StopId(0), name: "Ground".into(), position: 0.0 },
+        StopConfig { id: StopId(1), name: "Top".into(), position: 10.0 },
+    ])
+    .elevator(ElevatorConfig { starting_stop: StopId(0), ..Default::default() })
     .dispatch_for_group(GroupId(0), my_custom_strategy)
     .build()
     .unwrap();

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -13,15 +13,12 @@ use elevator_core::stop::StopId;
 use elevator_core::dispatch::etd::EtdDispatch;
 
 fn main() -> Result<(), SimError> {
-    let sim = SimulationBuilder::demo()
-        // Clear defaults and define our own building.
-        .stops(vec![])
+    let sim = SimulationBuilder::new()
         .stop(StopId(0), "Ground", 0.0)
         .stop(StopId(1), "Sky Lobby", 50.0)
         .stop(StopId(2), "Observation Deck", 100.0)
 
-        // Clear the default elevator and add two custom ones.
-        .elevators(vec![])
+        // Two identical express cars — override only what differs from Default.
         .elevator(ElevatorConfig {
             id: 0,
             name: "Express A".into(),
@@ -32,6 +29,7 @@ fn main() -> Result<(), SimError> {
             starting_stop: StopId(0),
             door_open_ticks: 60,
             door_transition_ticks: 15,
+            ..Default::default()
         })
         .elevator(ElevatorConfig {
             id: 1,
@@ -43,6 +41,7 @@ fn main() -> Result<(), SimError> {
             starting_stop: StopId(2),
             door_open_ticks: 60,
             door_transition_ticks: 15,
+            ..Default::default()
         })
 
         .building_name("Skyline Tower")

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -220,8 +220,14 @@ For advanced use cases, you can run individual phases instead of calling `step()
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::config::ElevatorConfig;
+# use elevator_core::stop::StopId;
 # fn main() -> Result<(), SimError> {
-# let mut sim = SimulationBuilder::demo().build()?;
+# let mut sim = SimulationBuilder::new()
+#     .stop(StopId(0), "Ground", 0.0)
+#     .stop(StopId(1), "Top", 10.0)
+#     .elevator(ElevatorConfig::default())
+#     .build()?;
 sim.run_advance_transient();
 sim.run_dispatch();
 sim.run_reposition();

--- a/docs/src/custom-dispatch.md
+++ b/docs/src/custom-dispatch.md
@@ -187,7 +187,11 @@ const PRIORITY_NAME: &str = "priority";
 // snapshot serialization. The builder's `.dispatch(...)` helper installs
 // the strategy but defaults the id to `BuiltinStrategy::Scan` — fine for
 // the built-in strategies, wrong for custom ones.
-let mut sim = SimulationBuilder::demo().build()?;
+let mut sim = SimulationBuilder::new()
+    .stop(StopId(0), "Ground", 0.0)
+    .stop(StopId(1), "Top", 10.0)
+    .elevator(ElevatorConfig::default())
+    .build()?;
 sim.set_dispatch(
     GroupId(0),
     Box::new(PriorityDispatch::default()),

--- a/docs/src/dispatch.md
+++ b/docs/src/dispatch.md
@@ -72,10 +72,15 @@ The builder defaults to `ScanDispatch`. To use a different strategy, call `.disp
 
 ```rust,no_run
 use elevator_core::prelude::*;
+use elevator_core::config::ElevatorConfig;
+use elevator_core::stop::StopId;
 use elevator_core::dispatch::look::LookDispatch;
 
 fn main() -> Result<(), SimError> {
-    let sim = SimulationBuilder::demo()
+    let sim = SimulationBuilder::new()
+        .stop(StopId(0), "Ground", 0.0)
+        .stop(StopId(1), "Top", 10.0)
+        .elevator(ElevatorConfig::default())
         .dispatch(LookDispatch::new())
         .build()?;
     Ok(())
@@ -111,11 +116,16 @@ Use `.dispatch_for_group()` on the builder:
 
 ```rust,no_run
 use elevator_core::prelude::*;
+use elevator_core::config::ElevatorConfig;
+use elevator_core::stop::StopId;
 use elevator_core::dispatch::scan::ScanDispatch;
 use elevator_core::dispatch::etd::EtdDispatch;
 
 fn main() -> Result<(), SimError> {
-    let sim = SimulationBuilder::demo()
+    let sim = SimulationBuilder::new()
+        .stop(StopId(0), "Ground", 0.0)
+        .stop(StopId(1), "Top", 10.0)
+        .elevator(ElevatorConfig::default())
         .dispatch_for_group(GroupId(0), ScanDispatch::new())
         .dispatch_for_group(GroupId(1), EtdDispatch::new())
         .build()?;
@@ -176,12 +186,17 @@ Then plug it into the builder:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::config::ElevatorConfig;
+# use elevator_core::stop::StopId;
 # struct HighestFirstDispatch;
 # impl DispatchStrategy for HighestFirstDispatch {
 #     fn decide(&mut self, _: EntityId, _: f64, _: &elevator_core::dispatch::ElevatorGroup, _: &DispatchManifest, _: &elevator_core::world::World) -> DispatchDecision { DispatchDecision::Idle }
 # }
 fn main() -> Result<(), SimError> {
-    let sim = SimulationBuilder::demo()
+    let sim = SimulationBuilder::new()
+        .stop(StopId(0), "Ground", 0.0)
+        .stop(StopId(1), "Top", 10.0)
+        .elevator(ElevatorConfig::default())
         .dispatch(HighestFirstDispatch)
         .build()?;
     Ok(())

--- a/docs/src/extensions-and-hooks.md
+++ b/docs/src/extensions-and-hooks.md
@@ -29,9 +29,14 @@ Call `.with_ext::<T>("name")` on the builder to register the extension type. The
 # #[derive(Debug, Clone, Serialize, Deserialize)]
 # struct VipTag { level: u32, lounge_access: bool }
 use elevator_core::prelude::*;
+use elevator_core::config::ElevatorConfig;
+use elevator_core::stop::StopId;
 
 fn main() -> Result<(), SimError> {
-    let mut sim = SimulationBuilder::demo()
+    let mut sim = SimulationBuilder::new()
+        .stop(StopId(0), "Ground", 0.0)
+        .stop(StopId(1), "Top", 10.0)
+        .elevator(ElevatorConfig::default())
         .with_ext::<VipTag>("vip_tag")
         .build()?;
     Ok(())
@@ -47,9 +52,15 @@ Use `world.insert_ext()` to attach your component to an entity:
 # #[derive(Debug, Clone, Serialize, Deserialize)]
 # struct VipTag { level: u32, lounge_access: bool }
 # use elevator_core::prelude::*;
+# use elevator_core::config::ElevatorConfig;
 # use elevator_core::stop::StopId;
 # fn main() -> Result<(), SimError> {
-# let mut sim = SimulationBuilder::demo().with_ext::<VipTag>("vip_tag").build()?;
+# let mut sim = SimulationBuilder::new()
+#     .stop(StopId(0), "Ground", 0.0)
+#     .stop(StopId(1), "Top", 10.0)
+#     .elevator(ElevatorConfig::default())
+#     .with_ext::<VipTag>("vip_tag")
+#     .build()?;
 let rider_id = sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 75.0)?;
 
 sim.world_mut().insert_ext(
@@ -129,9 +140,14 @@ Hooks let you inject custom logic before or after any of the seven tick phases. 
 
 ```rust,no_run
 use elevator_core::prelude::*;
+use elevator_core::config::ElevatorConfig;
+use elevator_core::stop::StopId;
 
 fn main() -> Result<(), SimError> {
-    let sim = SimulationBuilder::demo()
+    let sim = SimulationBuilder::new()
+        .stop(StopId(0), "Ground", 0.0)
+        .stop(StopId(1), "Top", 10.0)
+        .elevator(ElevatorConfig::default())
         .after(Phase::Loading, |world| {
             // This runs after every Loading phase.
             // Check for newly arrived riders, update scores, etc.
@@ -151,8 +167,14 @@ You can also add hooks to a running simulation:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::config::ElevatorConfig;
+# use elevator_core::stop::StopId;
 # fn main() -> Result<(), SimError> {
-# let mut sim = SimulationBuilder::demo().build()?;
+# let mut sim = SimulationBuilder::new()
+#     .stop(StopId(0), "Ground", 0.0)
+#     .stop(StopId(1), "Top", 10.0)
+#     .elevator(ElevatorConfig::default())
+#     .build()?;
 sim.add_after_hook(Phase::Loading, |world| {
     // Post-loading logic
 });
@@ -166,8 +188,13 @@ For multi-group buildings, you can register hooks that only fire for a specific 
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::config::ElevatorConfig;
+# use elevator_core::stop::StopId;
 # fn main() -> Result<(), SimError> {
-let sim = SimulationBuilder::demo()
+let sim = SimulationBuilder::new()
+    .stop(StopId(0), "Ground", 0.0)
+    .stop(StopId(1), "Top", 10.0)
+    .elevator(ElevatorConfig::default())
     .after_group(Phase::Loading, GroupId(0), |world| {
         // Only runs after loading for group 0
     })
@@ -215,6 +242,7 @@ The hook closure cannot call `sim.current_tick()` directly (the simulation is bo
 
 ```rust,no_run
 use elevator_core::prelude::*;
+use elevator_core::config::ElevatorConfig;
 use elevator_core::stop::StopId;
 use serde::{Serialize, Deserialize};
 
@@ -224,11 +252,11 @@ struct WaitWarning {
 }
 
 fn main() -> Result<(), SimError> {
-    let mut sim = SimulationBuilder::demo()
-        .stops(vec![])
+    let mut sim = SimulationBuilder::new()
         .stop(StopId(0), "Lobby", 0.0)
         .stop(StopId(1), "Floor 2", 4.0)
         .stop(StopId(2), "Floor 3", 8.0)
+        .elevator(ElevatorConfig { starting_stop: StopId(0), ..Default::default() })
         .with_ext::<WaitWarning>("wait_warning")
         .after(Phase::Metrics, |world| {
             // Check all waiting riders for long waits.

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -42,7 +42,7 @@ Turn off defaults with `default-features = false` if you want a leaner build and
 
 ## Build a simulation
 
-We will use `SimulationBuilder` to set up a 3-stop building. The builder starts with sensible defaults (2 stops, 1 elevator, SCAN dispatch, 60 ticks per second), but we will override the stops to create our own layout.
+We will use `SimulationBuilder` to set up a 3-stop building with one elevator, SCAN dispatch (the builder's default), and 60 ticks per second. `ElevatorConfig` implements `Default` with sensible physics (max speed 2.0, acceleration 1.5, deceleration 2.0, 800 kg capacity) so the elevator is one line; stops we spell out because positions are the whole point.
 
 ```rust,no_run
 use elevator_core::prelude::*;
@@ -50,12 +50,11 @@ use elevator_core::config::ElevatorConfig;
 use elevator_core::stop::StopId;
 
 fn main() -> Result<(), SimError> {
-    let mut sim = SimulationBuilder::demo()
-        // Clear the default stops and define our own.
-        .stops(vec![])
+    let mut sim = SimulationBuilder::new()
         .stop(StopId(0), "Lobby", 0.0)
         .stop(StopId(1), "Floor 2", 4.0)
         .stop(StopId(2), "Floor 3", 8.0)
+        .elevator(ElevatorConfig { starting_stop: StopId(0), ..Default::default() })
         .building_name("Tutorial Tower")
         .build()?;
 
@@ -63,7 +62,7 @@ fn main() -> Result<(), SimError> {
 }
 ```
 
-`SimulationBuilder::demo()` is the quick-start constructor: it pre-populates two stops plus one elevator with reasonable physics defaults (max speed 2.0, acceleration 1.5, deceleration 2.0, 800 kg capacity), so short examples like this one compile without ceremony. For a real project, start from `SimulationBuilder::new()` (empty) and configure stops + elevators explicitly — we cover that in the [Configuration](configuration.md) chapter.
+Override any `ElevatorConfig` field with struct-update syntax (`ElevatorConfig { max_speed: 4.0, ..Default::default() }`) — the [Configuration](configuration.md) chapter covers every field.
 
 ## Spawn a rider
 
@@ -71,13 +70,14 @@ A rider is anything that rides an elevator. To spawn one, you provide an origin 
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::config::ElevatorConfig;
 # use elevator_core::stop::StopId;
 # fn main() -> Result<(), SimError> {
-# let mut sim = SimulationBuilder::demo()
-#     .stops(vec![])
+# let mut sim = SimulationBuilder::new()
 #     .stop(StopId(0), "Lobby", 0.0)
 #     .stop(StopId(1), "Floor 2", 4.0)
 #     .stop(StopId(2), "Floor 3", 8.0)
+#     .elevator(ElevatorConfig { starting_stop: StopId(0), ..Default::default() })
 #     .build()?;
 let rider_id = sim.spawn_rider_by_stop_id(
     StopId(0),  // origin: Lobby
@@ -97,13 +97,14 @@ Each call to `sim.step()` advances the simulation by one tick, running all eight
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::config::ElevatorConfig;
 # use elevator_core::stop::StopId;
 # fn main() -> Result<(), SimError> {
-# let mut sim = SimulationBuilder::demo()
-#     .stops(vec![])
+# let mut sim = SimulationBuilder::new()
 #     .stop(StopId(0), "Lobby", 0.0)
 #     .stop(StopId(1), "Floor 2", 4.0)
 #     .stop(StopId(2), "Floor 3", 8.0)
+#     .elevator(ElevatorConfig { starting_stop: StopId(0), ..Default::default() })
 #     .build()?;
 # let rider_id = sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)?;
 let mut arrived = false;
@@ -143,15 +144,16 @@ Here is everything together as a single runnable file:
 
 ```rust,no_run
 use elevator_core::prelude::*;
+use elevator_core::config::ElevatorConfig;
 use elevator_core::stop::StopId;
 
 fn main() -> Result<(), SimError> {
     // 1. Build a 3-stop building.
-    let mut sim = SimulationBuilder::demo()
-        .stops(vec![])
+    let mut sim = SimulationBuilder::new()
         .stop(StopId(0), "Lobby", 0.0)
         .stop(StopId(1), "Floor 2", 4.0)
         .stop(StopId(2), "Floor 3", 8.0)
+        .elevator(ElevatorConfig { starting_stop: StopId(0), ..Default::default() })
         .building_name("Tutorial Tower")
         .build()?;
 

--- a/docs/src/metrics-and-events.md
+++ b/docs/src/metrics-and-events.md
@@ -98,14 +98,15 @@ Here is a pattern for collecting a complete event log across a simulation run:
 
 ```rust,no_run
 use elevator_core::prelude::*;
+use elevator_core::config::ElevatorConfig;
 use elevator_core::stop::StopId;
 
 fn main() -> Result<(), SimError> {
-    let mut sim = SimulationBuilder::demo()
-        .stops(vec![])
+    let mut sim = SimulationBuilder::new()
         .stop(StopId(0), "Lobby", 0.0)
         .stop(StopId(1), "Floor 2", 4.0)
         .stop(StopId(2), "Floor 3", 8.0)
+        .elevator(ElevatorConfig { starting_stop: StopId(0), ..Default::default() })
         .build()?;
 
     sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)?;
@@ -254,9 +255,14 @@ For per-zone or per-label breakdowns, you can tag entities with string labels an
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::config::ElevatorConfig;
 # use elevator_core::stop::StopId;
 # fn main() -> Result<(), SimError> {
-# let mut sim = SimulationBuilder::demo().build()?;
+# let mut sim = SimulationBuilder::new()
+#     .stop(StopId(0), "Ground", 0.0)
+#     .stop(StopId(1), "Top", 10.0)
+#     .elevator(ElevatorConfig::default())
+#     .build()?;
 // Tag a stop.
 let lobby = sim.stop_entity(StopId(0)).unwrap();
 sim.tag_entity(lobby, "zone:lobby");
@@ -291,15 +297,16 @@ Tagged metrics track `avg_wait_time`, `total_delivered`, `total_abandoned`, `tot
 
 ```rust,no_run
 use elevator_core::prelude::*;
+use elevator_core::config::ElevatorConfig;
 use elevator_core::stop::StopId;
 
 fn main() -> Result<(), SimError> {
-    let mut sim = SimulationBuilder::demo()
-        .stops(vec![])
+    let mut sim = SimulationBuilder::new()
         .stop(StopId(0), "Lobby", 0.0)
         .stop(StopId(1), "Low Zone", 4.0)
         .stop(StopId(2), "Mid Zone", 8.0)
         .stop(StopId(3), "High Zone", 12.0)
+        .elevator(ElevatorConfig { starting_stop: StopId(0), ..Default::default() })
         .build()?;
 
     // Tag stops by zone.

--- a/docs/src/snapshots-and-determinism.md
+++ b/docs/src/snapshots-and-determinism.md
@@ -26,8 +26,14 @@ A `WorldSnapshot` captures the full simulation state — all entities, component
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::config::ElevatorConfig;
+# use elevator_core::stop::StopId;
 # fn main() -> Result<(), SimError> {
-# let mut sim = SimulationBuilder::demo().build()?;
+# let mut sim = SimulationBuilder::new()
+#     .stop(StopId(0), "Ground", 0.0)
+#     .stop(StopId(1), "Top", 10.0)
+#     .elevator(ElevatorConfig::default())
+#     .build()?;
 for _ in 0..1000 { sim.step(); }
 
 let snapshot = sim.snapshot();
@@ -124,10 +130,18 @@ To compare dispatch strategies fairly, use identical seeded traffic across runs:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::config::ElevatorConfig;
+# use elevator_core::stop::StopId;
 # use elevator_core::dispatch::scan::ScanDispatch;
 # use elevator_core::dispatch::etd::EtdDispatch;
 # fn build_sim(dispatch: impl DispatchStrategy + 'static) -> Simulation {
-#   SimulationBuilder::demo().dispatch(dispatch).build().unwrap()
+#   SimulationBuilder::new()
+#       .stop(StopId(0), "Ground", 0.0)
+#       .stop(StopId(1), "Top", 10.0)
+#       .elevator(ElevatorConfig::default())
+#       .dispatch(dispatch)
+#       .build()
+#       .unwrap()
 # }
 # fn run_with(sim: &mut Simulation) {}
 let mut scan_sim = build_sim(ScanDispatch::new());

--- a/docs/src/traffic-generation.md
+++ b/docs/src/traffic-generation.md
@@ -8,10 +8,15 @@ Traffic generation is **external to the simulation loop**. A `TrafficSource` pro
 
 ```rust,no_run
 use elevator_core::prelude::*;
+use elevator_core::config::ElevatorConfig;
 use elevator_core::traffic::{PoissonSource, TrafficPattern, TrafficSchedule};
 
 # fn main() -> Result<(), SimError> {
-let mut sim = SimulationBuilder::demo().build()?;
+let mut sim = SimulationBuilder::new()
+    .stop(StopId(0), "Ground", 0.0)
+    .stop(StopId(1), "Top", 10.0)
+    .elevator(ElevatorConfig::default())
+    .build()?;
 let stops: Vec<StopId> = sim.stop_lookup_iter().map(|(id, _)| *id).collect();
 
 // Poisson arrivals with an office-day schedule.


### PR DESCRIPTION
## Summary
- The mdBook chapters (and the README's custom-dispatch snippet) still used \`SimulationBuilder::demo()\` as the quick-start shape. Since #53 landed \`Default\` for \`ElevatorConfig\`, \`new()\` + \`ElevatorConfig::default()\` is short enough to be the canonical idiom and shows readers the real configuration shape from line one.
- Replaces every doc reference to \`demo()\` with the \`new()\`-based form. \`demo()\` itself stays as a real API — tests, examples, and rustdoc on \`demo()\` are untouched.
- Files touched: \`README.md\` and 9 chapters under \`docs/src/\` (getting-started, core-concepts, dispatch, custom-dispatch, traffic-generation, snapshots-and-determinism, metrics-and-events, extensions-and-hooks, configuration).

## Test plan
- [x] \`grep -rn 'demo()' README.md docs/\` returns nothing
- [x] \`mdbook build docs\` succeeds
- [x] \`cargo test -p elevator-core\` passes (pre-commit hook ran it — 450 unit + doctests clean)
- [ ] GitHub Pages preview renders the new snippets correctly