### PR TITLE
feat(bevy): showcase example + scripted demo recording

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ mutants.out.old/
 .vscode/
 *.code-workspace
 *.log
+/.recording/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "5.4.0"
+version = "5.5.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ strategies, realistic trapezoidal motion profiles, O(1) population tracking
 per stop, and an extension system let you build exactly the simulation you
 need.
 
+![Showcase: 3 elevators serving 8 floors during a rush-hour scene](assets/demo.gif)
+
 [Guide](https://andymai.github.io/elevator-core/) | [API Reference](https://docs.rs/elevator-core)
 
 ## Table of Contents
@@ -303,6 +305,19 @@ and supports configurable simulation speed via keyboard input.
 cargo run                              # default config
 cargo run -- assets/config/space_elevator.ron  # custom config
 ```
+
+The `showcase` example in the same crate assembles a 3-elevator × 8-floor
+scene with a blueprint palette and a scripted cinematic camera. It's what
+produces the GIF at the top of this README:
+
+```sh
+cargo run --release --example showcase              # interactive
+./scripts/record_gif.sh                             # re-record assets/demo.gif
+```
+
+Recording requires `ffmpeg`. The example writes PNG frames into
+`.recording/` and the script invokes ffmpeg's two-pass palette encoding to
+produce `assets/demo.gif`.
 
 ## Testing
 

--- a/crates/elevator-bevy/Cargo.toml
+++ b/crates/elevator-bevy/Cargo.toml
@@ -22,7 +22,7 @@ path = "examples/showcase.rs"
 
 [dependencies]
 elevator-core = { path = "../elevator-core" }
-bevy = { version = "0.18", default-features = false, features = ["2d", "png"] }
+bevy = { version = "0.18", default-features = false, features = ["2d", "png", "x11"] }
 serde.workspace = true
 ron.workspace = true
 rand.workspace = true

--- a/crates/elevator-bevy/Cargo.toml
+++ b/crates/elevator-bevy/Cargo.toml
@@ -8,9 +8,21 @@ publish = false
 [lints]
 workspace = true
 
+[lib]
+name = "elevator_bevy"
+path = "src/lib.rs"
+
+[[bin]]
+name = "elevator-bevy"
+path = "src/main.rs"
+
+[[example]]
+name = "showcase"
+path = "examples/showcase.rs"
+
 [dependencies]
 elevator-core = { path = "../elevator-core" }
-bevy = { version = "0.18", default-features = false, features = ["2d"] }
+bevy = { version = "0.18", default-features = false, features = ["2d", "png"] }
 serde.workspace = true
 ron.workspace = true
 rand.workspace = true

--- a/crates/elevator-bevy/examples/showcase.rs
+++ b/crates/elevator-bevy/examples/showcase.rs
@@ -24,7 +24,7 @@ use rand::{Rng, SeedableRng, rngs::StdRng};
 use elevator_bevy::camera::setup_camera;
 use elevator_bevy::cinematic::{Shot, ShotTimeline, apply_cinematic_camera};
 use elevator_bevy::decor::{
-    spawn_decor, sync_call_lamps, sync_occupancy_chips, tick_arrival_flash,
+    spawn_corner_marks, spawn_decor, sync_call_lamps, sync_occupancy_chips, tick_arrival_flash,
 };
 use elevator_bevy::recorder::{Recorder, capture_frames};
 use elevator_bevy::rendering::{
@@ -86,7 +86,13 @@ fn main() {
         .add_message::<EventWrapper>()
         .add_systems(
             Startup,
-            (setup_camera, spawn_building_visuals, spawn_decor, spawn_hud).chain(),
+            (
+                setup_camera,
+                spawn_building_visuals,
+                spawn_decor,
+                spawn_corner_marks,
+            )
+                .chain(),
         )
         .add_systems(
             Update,
@@ -102,10 +108,16 @@ fn main() {
                 sync_occupancy_chips,
                 tick_arrival_flash,
                 apply_cinematic_camera,
-                update_hud,
             )
                 .chain(),
         );
+
+    // The interactive HUD is useful when running manually but chrome in a
+    // 10s demo GIF, so skip spawning and updating it while recording.
+    if !record {
+        app.add_systems(Startup, spawn_hud)
+            .add_systems(Update, update_hud);
+    }
 
     if record {
         let out_dir = PathBuf::from(RECORD_OUT_DIR);
@@ -125,9 +137,9 @@ fn build_showcase_config() -> SimConfig {
         .map(|i| StopConfig {
             id: StopId(i),
             name: if i == 0 {
-                "Lobby".into()
+                "L".into()
             } else {
-                format!("Floor {}", i + 1)
+                (i + 1).to_string()
             },
             position: f64::from(i) * 4.0,
         })

--- a/crates/elevator-bevy/examples/showcase.rs
+++ b/crates/elevator-bevy/examples/showcase.rs
@@ -37,7 +37,7 @@ use elevator_bevy::ui::{ShowControlsHint, spawn_hud, update_hud};
 use elevator_core::config::{
     BuildingConfig, ElevatorConfig, PassengerSpawnConfig, SimConfig, SimulationParams,
 };
-use elevator_core::dispatch::scan::ScanDispatch;
+use elevator_core::dispatch::nearest_car::NearestCarDispatch;
 use elevator_core::sim::Simulation;
 use elevator_core::stop::{StopConfig, StopId};
 
@@ -57,6 +57,13 @@ const RECORD_OUT_DIR: &str = ".recording";
 
 fn main() {
     let record = std::env::args().any(|a| a == "--record");
+    // --snapshot[=tick] writes a single PNG (default tick 220 ≈ mid-recording)
+    // to .recording/frame_00000.png and exits. Useful for iteration.
+    let snapshot_at: Option<u64> = std::env::args().find_map(|a| {
+        a.strip_prefix("--snapshot=")
+            .and_then(|v| v.parse().ok())
+            .or_else(|| (a == "--snapshot").then_some(220))
+    });
 
     let mut app = App::new();
     app.add_plugins(DefaultPlugins.set(WindowPlugin {
@@ -71,18 +78,20 @@ fn main() {
 
     // Build the scene: 3 elevators × 8 floors.
     let config = build_showcase_config();
-    let sim = Simulation::new(&config, ScanDispatch::new())
+    let sim = Simulation::new(&config, NearestCarDispatch::new())
         .unwrap_or_else(|e| panic!("invalid showcase config: {e}"));
 
+    let headless = record || snapshot_at.is_some();
+
     // Showcase-only resources.
-    app.insert_resource(VisualStyle::blueprint())
-        .insert_resource(ShowControlsHint(!record))
+    app.insert_resource(VisualStyle::simtower())
+        .insert_resource(ShowControlsHint(!headless))
         .insert_resource(SimulationRes { sim })
         .insert_resource(SimSpeed {
-            multiplier: if record { TICKS_PER_FRAME } else { 1 },
+            multiplier: if headless { TICKS_PER_FRAME } else { 1 },
         })
-        .insert_resource(RushHourSpawner::new(record))
-        .insert_resource(build_timeline(if record { WARMUP_TICKS } else { 0 }))
+        .insert_resource(RushHourSpawner::new(headless))
+        .insert_resource(build_timeline(if headless { WARMUP_TICKS } else { 0 }))
         .add_message::<EventWrapper>()
         .add_systems(
             Startup,
@@ -116,12 +125,19 @@ fn main() {
 
     // The interactive HUD is useful when running manually but chrome in a
     // 10s demo GIF, so skip spawning and updating it while recording.
-    if !record {
+    if !headless {
         app.add_systems(Startup, spawn_hud)
             .add_systems(Update, update_hud);
     }
 
-    if record {
+    if let Some(target_tick) = snapshot_at {
+        let out_dir = PathBuf::from(RECORD_OUT_DIR);
+        prepare_record_dir(out_dir.as_path());
+        let mut recorder = Recorder::new(out_dir, 1);
+        recorder.start_tick = target_tick;
+        app.insert_resource(recorder)
+            .add_systems(Update, capture_frames);
+    } else if record {
         let out_dir = PathBuf::from(RECORD_OUT_DIR);
         prepare_record_dir(out_dir.as_path());
         let mut recorder = Recorder::new(out_dir, RECORD_FRAMES);
@@ -147,6 +163,10 @@ fn build_showcase_config() -> SimConfig {
         })
         .collect();
 
+    // Stagger starting stops so the cars don't all lurch together for the
+    // first calls — without this NearestCarDispatch still picks the same
+    // "nearest" car when all three sit at the lobby.
+    let starts = [StopId(0), StopId(3), StopId(6)];
     let elevators = (0..3)
         .map(|i| ElevatorConfig {
             id: i,
@@ -155,7 +175,7 @@ fn build_showcase_config() -> SimConfig {
             acceleration: 1.8,
             deceleration: 2.2,
             weight_capacity: 800.0,
-            starting_stop: StopId(0),
+            starting_stop: starts[i as usize],
             door_open_ticks: 45,
             door_transition_ticks: 12,
             ..Default::default()

--- a/crates/elevator-bevy/examples/showcase.rs
+++ b/crates/elevator-bevy/examples/showcase.rs
@@ -28,8 +28,8 @@ use elevator_bevy::decor::{
 };
 use elevator_bevy::recorder::{Recorder, capture_frames};
 use elevator_bevy::rendering::{
-    compute_queue_slots, spawn_building_visuals, sync_door_panels, sync_elevator_visuals,
-    sync_rider_visuals, update_rider_positions,
+    compute_queue_slots, spawn_building_visuals, sync_direction_arrows, sync_door_panels,
+    sync_elevator_visuals, sync_rider_visuals, tick_rider_fades, update_rider_positions,
 };
 use elevator_bevy::sim_bridge::{EventWrapper, SimSpeed, SimulationRes, tick_simulation};
 use elevator_bevy::style::VisualStyle;
@@ -101,9 +101,11 @@ fn main() {
                 tick_simulation,
                 sync_elevator_visuals,
                 sync_door_panels,
+                sync_direction_arrows,
                 compute_queue_slots,
                 sync_rider_visuals,
                 update_rider_positions,
+                tick_rider_fades,
                 sync_call_lamps,
                 sync_occupancy_chips,
                 tick_arrival_flash,

--- a/crates/elevator-bevy/examples/showcase.rs
+++ b/crates/elevator-bevy/examples/showcase.rs
@@ -23,6 +23,9 @@ use rand::{Rng, SeedableRng, rngs::StdRng};
 
 use elevator_bevy::camera::setup_camera;
 use elevator_bevy::cinematic::{Shot, ShotTimeline, apply_cinematic_camera};
+use elevator_bevy::decor::{
+    spawn_decor, sync_call_lamps, sync_occupancy_chips, tick_arrival_flash,
+};
 use elevator_bevy::recorder::{Recorder, capture_frames};
 use elevator_bevy::rendering::{
     spawn_building_visuals, sync_door_panels, sync_elevator_visuals, sync_rider_visuals,
@@ -78,7 +81,7 @@ fn main() {
         .add_message::<EventWrapper>()
         .add_systems(
             Startup,
-            (setup_camera, spawn_building_visuals, spawn_hud).chain(),
+            (setup_camera, spawn_building_visuals, spawn_decor, spawn_hud).chain(),
         )
         .add_systems(
             Update,
@@ -89,6 +92,9 @@ fn main() {
                 sync_door_panels,
                 sync_rider_visuals,
                 update_rider_positions,
+                sync_call_lamps,
+                sync_occupancy_chips,
+                tick_arrival_flash,
                 apply_cinematic_camera,
                 update_hud,
             )

--- a/crates/elevator-bevy/examples/showcase.rs
+++ b/crates/elevator-bevy/examples/showcase.rs
@@ -73,7 +73,6 @@ fn main() {
         .insert_resource(SimSpeed {
             multiplier: if record { TICKS_PER_FRAME } else { 1 },
         })
-        .insert_resource(ClearColor(VisualStyle::blueprint().background))
         .insert_resource(RushHourSpawner::new(record))
         .insert_resource(build_timeline())
         .add_message::<EventWrapper>()
@@ -158,9 +157,7 @@ fn build_showcase_config() -> SimConfig {
 /// Bank x extends roughly ±140 px (3 shafts × 140 px spacing ÷ 2).
 fn build_timeline() -> ShotTimeline {
     // Sim-pixel heights (PPU = 40, spacing 4 units): lobby=0, top=1120.
-    let lobby_y = 0.0;
-    let mid_y = 560.0;
-    let wide_center_y = 560.0;
+    let center_y = 560.0; // mid-tower and wide-shot share the same y.
 
     ShotTimeline::new(vec![
         // 0. Establishing wide on the full bank.
@@ -168,7 +165,7 @@ fn build_timeline() -> ShotTimeline {
             start_tick: 0,
             blend_ticks: 0,
             target_x: 0.0,
-            target_y: wide_center_y,
+            target_y: center_y,
             scale: 2.55,
         },
         // 1. Glide down to the lobby — watch the first pickups.
@@ -176,7 +173,7 @@ fn build_timeline() -> ShotTimeline {
             start_tick: 120,
             blend_ticks: 90,
             target_x: -40.0,
-            target_y: lobby_y + 40.0,
+            target_y: 40.0,
             scale: 1.45,
         },
         // 2. Rise with the middle car to mid-tower.
@@ -184,7 +181,7 @@ fn build_timeline() -> ShotTimeline {
             start_tick: 260,
             blend_ticks: 120,
             target_x: 0.0,
-            target_y: mid_y,
+            target_y: center_y,
             scale: 1.55,
         },
         // 3. Pull out to a wide finale for the loop.
@@ -192,7 +189,7 @@ fn build_timeline() -> ShotTimeline {
             start_tick: 430,
             blend_ticks: 120,
             target_x: 0.0,
-            target_y: wide_center_y,
+            target_y: center_y,
             scale: 2.55,
         },
     ])

--- a/crates/elevator-bevy/examples/showcase.rs
+++ b/crates/elevator-bevy/examples/showcase.rs
@@ -28,8 +28,8 @@ use elevator_bevy::decor::{
 };
 use elevator_bevy::recorder::{Recorder, capture_frames};
 use elevator_bevy::rendering::{
-    spawn_building_visuals, sync_door_panels, sync_elevator_visuals, sync_rider_visuals,
-    update_rider_positions,
+    compute_queue_slots, spawn_building_visuals, sync_door_panels, sync_elevator_visuals,
+    sync_rider_visuals, update_rider_positions,
 };
 use elevator_bevy::sim_bridge::{EventWrapper, SimSpeed, SimulationRes, tick_simulation};
 use elevator_bevy::style::VisualStyle;
@@ -90,6 +90,7 @@ fn main() {
                 tick_simulation,
                 sync_elevator_visuals,
                 sync_door_panels,
+                compute_queue_slots,
                 sync_rider_visuals,
                 update_rider_positions,
                 sync_call_lamps,

--- a/crates/elevator-bevy/examples/showcase.rs
+++ b/crates/elevator-bevy/examples/showcase.rs
@@ -1,0 +1,302 @@
+//! Showcase scene: 3 elevators × 8 floors with a scripted cinematic camera
+//! and blueprint palette — the scene recorded for the repository's demo GIF.
+//!
+//! Run it:
+//! ```bash
+//! cargo run --release --example showcase
+//! ```
+//!
+//! Record 200 frames at 20 fps (~10s loop) into `.recording/`:
+//! ```bash
+//! cargo run --release --example showcase -- --record
+//! ```
+//!
+//! See `scripts/record_gif.sh` for the ffmpeg pipeline that turns the PNGs
+//! into `assets/demo.gif`.
+
+#![allow(clippy::missing_docs_in_private_items, clippy::panic)]
+
+use std::path::{Path, PathBuf};
+
+use bevy::prelude::*;
+use rand::{Rng, SeedableRng, rngs::StdRng};
+
+use elevator_bevy::camera::setup_camera;
+use elevator_bevy::cinematic::{Shot, ShotTimeline, apply_cinematic_camera};
+use elevator_bevy::recorder::{Recorder, capture_frames};
+use elevator_bevy::rendering::{
+    spawn_building_visuals, sync_door_panels, sync_elevator_visuals, sync_rider_visuals,
+    update_rider_positions,
+};
+use elevator_bevy::sim_bridge::{EventWrapper, SimSpeed, SimulationRes, tick_simulation};
+use elevator_bevy::style::VisualStyle;
+use elevator_bevy::ui::{ShowControlsHint, spawn_hud, update_hud};
+use elevator_core::config::{
+    BuildingConfig, ElevatorConfig, PassengerSpawnConfig, SimConfig, SimulationParams,
+};
+use elevator_core::dispatch::scan::ScanDispatch;
+use elevator_core::sim::Simulation;
+use elevator_core::stop::{StopConfig, StopId};
+
+/// Window dimensions used by the showcase and recorder.
+const WIDTH: u32 = 960;
+const HEIGHT: u32 = 540;
+
+/// Recording: 200 frames at 20 fps → 10-second loop.
+const RECORD_FRAMES: u32 = 200;
+const TICKS_PER_FRAME: u32 = 3; // 60 tps ÷ 20 fps
+const RECORD_OUT_DIR: &str = ".recording";
+
+fn main() {
+    let record = std::env::args().any(|a| a == "--record");
+
+    let mut app = App::new();
+    app.add_plugins(DefaultPlugins.set(WindowPlugin {
+        primary_window: Some(Window {
+            title: "Elevator Simulator — Showcase".into(),
+            resolution: (WIDTH, HEIGHT).into(),
+            resizable: false,
+            ..default()
+        }),
+        ..default()
+    }));
+
+    // Build the scene: 3 elevators × 8 floors.
+    let config = build_showcase_config();
+    let sim = Simulation::new(&config, ScanDispatch::new())
+        .unwrap_or_else(|e| panic!("invalid showcase config: {e}"));
+
+    // Showcase-only resources.
+    app.insert_resource(VisualStyle::blueprint())
+        .insert_resource(ShowControlsHint(!record))
+        .insert_resource(SimulationRes { sim })
+        .insert_resource(SimSpeed {
+            multiplier: if record { TICKS_PER_FRAME } else { 1 },
+        })
+        .insert_resource(ClearColor(VisualStyle::blueprint().background))
+        .insert_resource(RushHourSpawner::new(record))
+        .insert_resource(build_timeline())
+        .add_message::<EventWrapper>()
+        .add_systems(
+            Startup,
+            (setup_camera, spawn_building_visuals, spawn_hud).chain(),
+        )
+        .add_systems(
+            Update,
+            (
+                rush_hour_spawn,
+                tick_simulation,
+                sync_elevator_visuals,
+                sync_door_panels,
+                sync_rider_visuals,
+                update_rider_positions,
+                apply_cinematic_camera,
+                update_hud,
+            )
+                .chain(),
+        );
+
+    if record {
+        let out_dir = PathBuf::from(RECORD_OUT_DIR);
+        prepare_record_dir(out_dir.as_path());
+        app.insert_resource(Recorder::new(out_dir, RECORD_FRAMES))
+            .add_systems(Update, capture_frames);
+    }
+
+    app.run();
+}
+
+/// 3 elevators, 8 floors. Stops at 4m spacing = realistic office tower.
+fn build_showcase_config() -> SimConfig {
+    let stops = (0..8)
+        .map(|i| StopConfig {
+            id: StopId(i),
+            name: if i == 0 {
+                "Lobby".into()
+            } else {
+                format!("Floor {}", i + 1)
+            },
+            position: f64::from(i) * 4.0,
+        })
+        .collect();
+
+    let elevators = (0..3)
+        .map(|i| ElevatorConfig {
+            id: i,
+            name: format!("Car {}", i + 1),
+            max_speed: 3.0,
+            acceleration: 1.8,
+            deceleration: 2.2,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 45,
+            door_transition_ticks: 12,
+            ..Default::default()
+        })
+        .collect();
+
+    SimConfig {
+        building: BuildingConfig {
+            name: "Showcase Tower".into(),
+            stops,
+            lines: None,
+            groups: None,
+        },
+        elevators,
+        simulation: SimulationParams {
+            ticks_per_second: 60.0,
+        },
+        passenger_spawning: PassengerSpawnConfig {
+            mean_interval_ticks: 12,
+            weight_range: (55.0, 95.0),
+        },
+    }
+}
+
+/// Scripted camera for a clean 10-second loop (≤600 ticks).
+/// World coordinates: sim y ranges 0..28 units (0..1120 px at PPU=40).
+/// Bank x extends roughly ±140 px (3 shafts × 140 px spacing ÷ 2).
+fn build_timeline() -> ShotTimeline {
+    // Sim-pixel heights (PPU = 40, spacing 4 units): lobby=0, top=1120.
+    let lobby_y = 0.0;
+    let mid_y = 560.0;
+    let wide_center_y = 560.0;
+
+    ShotTimeline::new(vec![
+        // 0. Establishing wide on the full bank.
+        Shot {
+            start_tick: 0,
+            blend_ticks: 0,
+            target_x: 0.0,
+            target_y: wide_center_y,
+            scale: 2.55,
+        },
+        // 1. Glide down to the lobby — watch the first pickups.
+        Shot {
+            start_tick: 120,
+            blend_ticks: 90,
+            target_x: -40.0,
+            target_y: lobby_y + 40.0,
+            scale: 1.45,
+        },
+        // 2. Rise with the middle car to mid-tower.
+        Shot {
+            start_tick: 260,
+            blend_ticks: 120,
+            target_x: 0.0,
+            target_y: mid_y,
+            scale: 1.55,
+        },
+        // 3. Pull out to a wide finale for the loop.
+        Shot {
+            start_tick: 430,
+            blend_ticks: 120,
+            target_x: 0.0,
+            target_y: wide_center_y,
+            scale: 2.55,
+        },
+    ])
+}
+
+/// Deterministic rush-hour spawner: 70% of riders originate at the lobby
+/// heading upward, 20% interfloor, 10% down-bound from upper floors.
+#[derive(Resource)]
+struct RushHourSpawner {
+    rng: StdRng,
+    ticks_until_spawn: u32,
+    mean_interval: u32,
+    preloaded: bool,
+}
+
+impl RushHourSpawner {
+    fn new(record: bool) -> Self {
+        // Fixed seed → deterministic recordings.
+        let seed = if record { 424_242 } else { 0 };
+        Self {
+            rng: StdRng::seed_from_u64(seed),
+            ticks_until_spawn: 8,
+            mean_interval: 18,
+            preloaded: false,
+        }
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn rush_hour_spawn(
+    mut sim: ResMut<SimulationRes>,
+    mut spawner: ResMut<RushHourSpawner>,
+    speed: Res<SimSpeed>,
+) {
+    if speed.multiplier == 0 {
+        return;
+    }
+
+    let stop_ids: Vec<_> = sim.sim.world().stop_ids();
+    if stop_ids.len() < 2 {
+        return;
+    }
+
+    // Preload 12 waiting riders at the lobby so the opening shot has content.
+    if !spawner.preloaded {
+        for _ in 0..12 {
+            let dest = stop_ids[spawner.rng.random_range(1..stop_ids.len())];
+            let w = spawner.rng.random_range(55.0..95.0);
+            let _ = sim.sim.spawn_rider(stop_ids[0], dest, w);
+        }
+        spawner.preloaded = true;
+    }
+
+    let ticks = speed.multiplier;
+    if spawner.ticks_until_spawn > ticks {
+        spawner.ticks_until_spawn -= ticks;
+        return;
+    }
+
+    let roll: f64 = spawner.rng.random_range(0.0..1.0);
+    let (origin_idx, dest_idx) = if roll < 0.70 {
+        // Lobby → upper floor.
+        (0usize, spawner.rng.random_range(1..stop_ids.len()))
+    } else if roll < 0.90 {
+        // Interfloor (any non-lobby to any other non-lobby).
+        let o = spawner.rng.random_range(1..stop_ids.len());
+        let mut d = spawner.rng.random_range(1..stop_ids.len());
+        while d == o {
+            d = spawner.rng.random_range(1..stop_ids.len());
+        }
+        (o, d)
+    } else {
+        // Down-bound: upper → lobby.
+        (spawner.rng.random_range(1..stop_ids.len()), 0)
+    };
+
+    let weight = spawner.rng.random_range(55.0..95.0);
+    let _ = sim
+        .sim
+        .spawn_rider(stop_ids[origin_idx], stop_ids[dest_idx], weight);
+
+    let jitter: f64 = spawner.rng.random_range(0.6..1.4);
+    spawner.ticks_until_spawn = ((f64::from(spawner.mean_interval) * jitter) as u32).max(1);
+}
+
+fn prepare_record_dir(dir: &Path) {
+    if dir.exists() {
+        // Best-effort cleanup of stale frames.
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let is_frame_png = entry
+                    .path()
+                    .extension()
+                    .is_some_and(|e| e.eq_ignore_ascii_case("png"))
+                    && entry
+                        .file_name()
+                        .to_str()
+                        .is_some_and(|n| n.starts_with("frame_"));
+                if is_frame_png {
+                    let _ = std::fs::remove_file(entry.path());
+                }
+            }
+        }
+    } else if let Err(e) = std::fs::create_dir_all(dir) {
+        eprintln!("failed to create recording dir {}: {e}", dir.display());
+    }
+}

--- a/crates/elevator-bevy/examples/showcase.rs
+++ b/crates/elevator-bevy/examples/showcase.rs
@@ -48,6 +48,11 @@ const HEIGHT: u32 = 540;
 /// Recording: 200 frames at 20 fps → 10-second loop.
 const RECORD_FRAMES: u32 = 200;
 const TICKS_PER_FRAME: u32 = 3; // 60 tps ÷ 20 fps
+/// Sim ticks to run before capturing the first frame so the recording
+/// opens on a busy state rather than an empty lobby. Also gives the
+/// cinematic an anchor for its start/end wide shots, which is what lets
+/// the GIF loop look continuous.
+const WARMUP_TICKS: u64 = 90;
 const RECORD_OUT_DIR: &str = ".recording";
 
 fn main() {
@@ -77,7 +82,7 @@ fn main() {
             multiplier: if record { TICKS_PER_FRAME } else { 1 },
         })
         .insert_resource(RushHourSpawner::new(record))
-        .insert_resource(build_timeline())
+        .insert_resource(build_timeline(if record { WARMUP_TICKS } else { 0 }))
         .add_message::<EventWrapper>()
         .add_systems(
             Startup,
@@ -105,7 +110,9 @@ fn main() {
     if record {
         let out_dir = PathBuf::from(RECORD_OUT_DIR);
         prepare_record_dir(out_dir.as_path());
-        app.insert_resource(Recorder::new(out_dir, RECORD_FRAMES))
+        let mut recorder = Recorder::new(out_dir, RECORD_FRAMES);
+        recorder.start_tick = WARMUP_TICKS;
+        app.insert_resource(recorder)
             .add_systems(Update, capture_frames);
     }
 
@@ -159,17 +166,23 @@ fn build_showcase_config() -> SimConfig {
     }
 }
 
-/// Scripted camera for a clean 10-second loop (≤600 ticks).
-/// World coordinates: sim y ranges 0..28 units (0..1120 px at PPU=40).
-/// Bank x extends roughly ±140 px (3 shafts × 140 px spacing ÷ 2).
-fn build_timeline() -> ShotTimeline {
+/// Scripted camera for a clean 10-second loop (≤600 ticks relative to
+/// `offset`). Start and end shots are identical wide shots — the loop
+/// seam between the GIF's last and first frame is visually continuous so
+/// long as the sim state is also comparable (guaranteed by the timeline
+/// landing on the same wide shot for the first ~30 and last ~30 ticks).
+///
+/// `offset` shifts every shot's `start_tick` forward; used during
+/// recording to skip the warm-up ticks while the timeline is authored in
+/// relative ticks.
+fn build_timeline(offset: u64) -> ShotTimeline {
     // Sim-pixel heights (PPU = 40, spacing 4 units): lobby=0, top=1120.
     let center_y = 560.0; // mid-tower and wide-shot share the same y.
 
     ShotTimeline::new(vec![
         // 0. Establishing wide on the full bank.
         Shot {
-            start_tick: 0,
+            start_tick: offset,
             blend_ticks: 0,
             target_x: 0.0,
             target_y: center_y,
@@ -177,7 +190,7 @@ fn build_timeline() -> ShotTimeline {
         },
         // 1. Glide down to the lobby — watch the first pickups.
         Shot {
-            start_tick: 120,
+            start_tick: offset + 120,
             blend_ticks: 90,
             target_x: -40.0,
             target_y: 40.0,
@@ -185,7 +198,7 @@ fn build_timeline() -> ShotTimeline {
         },
         // 2. Rise with the middle car to mid-tower.
         Shot {
-            start_tick: 260,
+            start_tick: offset + 260,
             blend_ticks: 120,
             target_x: 0.0,
             target_y: center_y,
@@ -193,7 +206,7 @@ fn build_timeline() -> ShotTimeline {
         },
         // 3. Pull out to a wide finale for the loop.
         Shot {
-            start_tick: 430,
+            start_tick: offset + 430,
             blend_ticks: 120,
             target_x: 0.0,
             target_y: center_y,

--- a/crates/elevator-bevy/examples/showcase.rs
+++ b/crates/elevator-bevy/examples/showcase.rs
@@ -174,7 +174,7 @@ fn build_showcase_config() -> SimConfig {
             ticks_per_second: 60.0,
         },
         passenger_spawning: PassengerSpawnConfig {
-            mean_interval_ticks: 12,
+            mean_interval_ticks: 35,
             weight_range: (55.0, 95.0),
         },
     }
@@ -245,8 +245,8 @@ impl RushHourSpawner {
         let seed = if record { 424_242 } else { 0 };
         Self {
             rng: StdRng::seed_from_u64(seed),
-            ticks_until_spawn: 8,
-            mean_interval: 18,
+            ticks_until_spawn: 12,
+            mean_interval: 38,
             preloaded: false,
         }
     }
@@ -267,9 +267,9 @@ fn rush_hour_spawn(
         return;
     }
 
-    // Preload 12 waiting riders at the lobby so the opening shot has content.
+    // Preload a handful of waiting riders so the opening shot isn't empty.
     if !spawner.preloaded {
-        for _ in 0..12 {
+        for _ in 0..5 {
             let dest = stop_ids[spawner.rng.random_range(1..stop_ids.len())];
             let w = spawner.rng.random_range(55.0..95.0);
             let _ = sim.sim.spawn_rider(stop_ids[0], dest, w);

--- a/crates/elevator-bevy/examples/showcase.rs
+++ b/crates/elevator-bevy/examples/showcase.rs
@@ -34,11 +34,11 @@ use elevator_bevy::rendering::{
 use elevator_bevy::sim_bridge::{EventWrapper, SimSpeed, SimulationRes, tick_simulation};
 use elevator_bevy::style::VisualStyle;
 use elevator_bevy::ui::{ShowControlsHint, spawn_hud, update_hud};
-use elevator_core::config::{
-    BuildingConfig, ElevatorConfig, PassengerSpawnConfig, SimConfig, SimulationParams,
-};
+use elevator_core::builder::SimulationBuilder;
+use elevator_core::config::ElevatorConfig;
+use elevator_core::dispatch::BuiltinReposition;
 use elevator_core::dispatch::nearest_car::NearestCarDispatch;
-use elevator_core::sim::Simulation;
+use elevator_core::dispatch::reposition::SpreadEvenly;
 use elevator_core::stop::{StopConfig, StopId};
 
 /// Window dimensions used by the showcase and recorder.
@@ -77,9 +77,7 @@ fn main() {
     }));
 
     // Build the scene: 3 elevators × 8 floors.
-    let config = build_showcase_config();
-    let sim = Simulation::new(&config, NearestCarDispatch::new())
-        .unwrap_or_else(|e| panic!("invalid showcase config: {e}"));
+    let sim = build_showcase_sim();
 
     let headless = record || snapshot_at.is_some();
 
@@ -149,9 +147,10 @@ fn main() {
     app.run();
 }
 
-/// 3 elevators, 8 floors. Stops at 4m spacing = realistic office tower.
-fn build_showcase_config() -> SimConfig {
-    let stops = (0..8)
+/// Build the showcase simulation: 3 elevators × 8 floors, `NearestCar`
+/// dispatch with `SpreadEvenly` reposition so idle cars don't clump.
+fn build_showcase_sim() -> elevator_core::sim::Simulation {
+    let stops: Vec<StopConfig> = (0..8)
         .map(|i| StopConfig {
             id: StopId(i),
             name: if i == 0 {
@@ -163,11 +162,11 @@ fn build_showcase_config() -> SimConfig {
         })
         .collect();
 
-    // Stagger starting stops so the cars don't all lurch together for the
-    // first calls — without this NearestCarDispatch still picks the same
-    // "nearest" car when all three sit at the lobby.
+    // Stagger starting stops so cars don't all lurch together for the
+    // first calls — NearestCar still picks the same "nearest" car if
+    // all three sit at the lobby.
     let starts = [StopId(0), StopId(3), StopId(6)];
-    let elevators = (0..3)
+    let elevators: Vec<ElevatorConfig> = (0..3)
         .map(|i| ElevatorConfig {
             id: i,
             name: format!("Car {}", i + 1),
@@ -182,22 +181,14 @@ fn build_showcase_config() -> SimConfig {
         })
         .collect();
 
-    SimConfig {
-        building: BuildingConfig {
-            name: "Showcase Tower".into(),
-            stops,
-            lines: None,
-            groups: None,
-        },
-        elevators,
-        simulation: SimulationParams {
-            ticks_per_second: 60.0,
-        },
-        passenger_spawning: PassengerSpawnConfig {
-            mean_interval_ticks: 35,
-            weight_range: (55.0, 95.0),
-        },
-    }
+    SimulationBuilder::new()
+        .building_name("Showcase Tower")
+        .stops(stops)
+        .elevators(elevators)
+        .dispatch(NearestCarDispatch::new())
+        .reposition(SpreadEvenly, BuiltinReposition::SpreadEvenly)
+        .build()
+        .unwrap_or_else(|e| panic!("invalid showcase config: {e}"))
 }
 
 /// Scripted camera for a clean 10-second loop (≤600 ticks relative to
@@ -265,8 +256,8 @@ impl RushHourSpawner {
         let seed = if record { 424_242 } else { 0 };
         Self {
             rng: StdRng::seed_from_u64(seed),
-            ticks_until_spawn: 12,
-            mean_interval: 38,
+            ticks_until_spawn: 8,
+            mean_interval: 22,
             preloaded: false,
         }
     }

--- a/crates/elevator-bevy/src/camera.rs
+++ b/crates/elevator-bevy/src/camera.rs
@@ -36,6 +36,8 @@ pub fn setup_camera(
 
     commands.spawn((
         Camera2d,
+        // Disable MSAA so the rendered output stays crisp pixel-art.
+        bevy::render::view::Msaa::Off,
         Transform::from_xyz(0.0, center_y, 0.0),
         Projection::Orthographic(OrthographicProjection {
             scale,

--- a/crates/elevator-bevy/src/camera.rs
+++ b/crates/elevator-bevy/src/camera.rs
@@ -1,12 +1,18 @@
-//! Camera setup: centers the view on the shaft and zooms to fit all stops.
+//! Camera setup: centers the view on the shaft bank and zooms to fit.
 
 use bevy::prelude::*;
 
 use crate::sim_bridge::SimulationRes;
+use crate::style::VisualStyle;
 
-/// Set up camera centered on the shaft, zoomed to fit all stops.
+/// Set up camera centered on the shaft bank, zoomed to fit.
 #[allow(clippy::needless_pass_by_value)]
-pub fn setup_camera(mut commands: Commands, sim: Res<SimulationRes>, windows: Query<&Window>) {
+pub fn setup_camera(
+    mut commands: Commands,
+    sim: Res<SimulationRes>,
+    windows: Query<&Window>,
+    style: Res<VisualStyle>,
+) {
     let world = sim.sim.world();
     let positions: Vec<f64> = world.iter_stops().map(|(_, s)| s.position()).collect();
     let min_pos = positions.iter().copied().fold(f64::INFINITY, f64::min);
@@ -16,14 +22,17 @@ pub fn setup_camera(mut commands: Commands, sim: Res<SimulationRes>, windows: Qu
     let shaft_height_world = (max_pos - min_pos) as f32 * ppu;
     let center_y = f64::midpoint(min_pos, max_pos) as f32 * ppu;
 
-    let padded_height = shaft_height_world + 120.0;
+    let shaft_count = world.iter_elevators().count().max(1) as f32;
+    let bank_width = (shaft_count - 1.0).mul_add(style.shaft_spacing_units * ppu, 80.0);
 
-    let window_height = windows
-        .iter()
-        .next()
-        .map_or(600.0, |w| w.resolution.height());
+    let padded_height = shaft_height_world + 140.0;
+    let padded_width = bank_width + 260.0;
 
-    let scale = (padded_height / window_height).max(1.0);
+    let (win_w, win_h) = windows.iter().next().map_or((800.0, 600.0), |w| {
+        (w.resolution.width(), w.resolution.height())
+    });
+
+    let scale = ((padded_height / win_h).max(padded_width / win_w)).max(1.0);
 
     commands.spawn((
         Camera2d,

--- a/crates/elevator-bevy/src/cinematic.rs
+++ b/crates/elevator-bevy/src/cinematic.rs
@@ -68,10 +68,7 @@ impl ShotTimeline {
             let next = &self.shots[active_idx + 1];
             let blend_start = next.start_tick.saturating_sub(u64::from(next.blend_ticks));
             if tick >= blend_start && next.blend_ticks > 0 {
-                let t = (tick - blend_start) as f32
-                    / f32::from(
-                        u16::try_from(next.blend_ticks.min(u32::from(u16::MAX))).unwrap_or(1),
-                    );
+                let t = (tick - blend_start) as f32 / next.blend_ticks as f32;
                 let t = ease_in_out(t.clamp(0.0, 1.0));
                 return Some((
                     lerp(current.target_x, next.target_x, t),

--- a/crates/elevator-bevy/src/cinematic.rs
+++ b/crates/elevator-bevy/src/cinematic.rs
@@ -87,9 +87,12 @@ fn lerp(a: f32, b: f32, t: f32) -> f32 {
     t.mul_add(b - a, a)
 }
 
-/// Smoothstep easing: `3t² − 2t³`, zero slope at `t=0` and `t=1`.
+/// Smootherstep (quintic) easing: `6t⁵ − 15t⁴ + 10t³`. Zero slope *and*
+/// zero second-derivative at `t=0` and `t=1` — the mid-acceleration is
+/// more gradual than classic smoothstep so the camera moves look less
+/// mechanical.
 fn ease_in_out(t: f32) -> f32 {
-    t * t * 2.0f32.mul_add(-t, 3.0)
+    t * t * t * t.mul_add(t.mul_add(6.0, -15.0), 10.0)
 }
 
 /// System that updates the camera from the timeline. Runs in `Update`.

--- a/crates/elevator-bevy/src/cinematic.rs
+++ b/crates/elevator-bevy/src/cinematic.rs
@@ -1,0 +1,117 @@
+//! Scripted cinematic camera driven by the simulation tick counter.
+//!
+//! The [`ShotTimeline`] resource holds an ordered list of shots — each a
+//! camera target (x, y, zoom scale) with a start/end tick. The active shot
+//! is the one whose `[start_tick, end_tick)` range contains the current
+//! simulation tick; camera position/scale blend smoothly between
+//! consecutive shots with ease-in-out during the overlap.
+//!
+//! Because the timeline is tick-indexed rather than wall-clock, the
+//! recorded GIF is perfectly reproducible: a given seed + config produces
+//! the same camera moves every run.
+
+use bevy::prelude::*;
+
+use crate::sim_bridge::SimulationRes;
+
+/// One shot in the cinematic timeline.
+#[derive(Clone, Debug)]
+pub struct Shot {
+    /// Simulation tick at which this shot becomes dominant.
+    pub start_tick: u64,
+    /// Ticks over which the camera blends from the previous shot into this one.
+    pub blend_ticks: u32,
+    /// Target camera center x in world pixels.
+    pub target_x: f32,
+    /// Target camera center y in world pixels.
+    pub target_y: f32,
+    /// Target orthographic scale (smaller = more zoomed in).
+    pub scale: f32,
+}
+
+/// Scripted list of shots.
+#[derive(Resource, Default, Clone)]
+pub struct ShotTimeline {
+    /// Ordered by `start_tick`.
+    pub shots: Vec<Shot>,
+}
+
+impl ShotTimeline {
+    /// Create from a list of shots; sorts by `start_tick`.
+    #[must_use]
+    pub fn new(mut shots: Vec<Shot>) -> Self {
+        shots.sort_by_key(|s| s.start_tick);
+        Self { shots }
+    }
+
+    /// Compute the (x, y, scale) the camera should be at for a given tick.
+    #[must_use]
+    pub fn sample(&self, tick: u64) -> Option<(f32, f32, f32)> {
+        if self.shots.is_empty() {
+            return None;
+        }
+
+        // Find the latest shot whose start_tick <= tick.
+        let mut active_idx: usize = 0;
+        for (i, s) in self.shots.iter().enumerate() {
+            if s.start_tick <= tick {
+                active_idx = i;
+            } else {
+                break;
+            }
+        }
+
+        let current = &self.shots[active_idx];
+
+        // Are we in the blend window of the *next* shot?
+        if active_idx + 1 < self.shots.len() {
+            let next = &self.shots[active_idx + 1];
+            let blend_start = next.start_tick.saturating_sub(u64::from(next.blend_ticks));
+            if tick >= blend_start && next.blend_ticks > 0 {
+                let t = (tick - blend_start) as f32
+                    / f32::from(
+                        u16::try_from(next.blend_ticks.min(u32::from(u16::MAX))).unwrap_or(1),
+                    );
+                let t = ease_in_out(t.clamp(0.0, 1.0));
+                return Some((
+                    lerp(current.target_x, next.target_x, t),
+                    lerp(current.target_y, next.target_y, t),
+                    lerp(current.scale, next.scale, t),
+                ));
+            }
+        }
+
+        Some((current.target_x, current.target_y, current.scale))
+    }
+}
+
+/// Linear interpolation between `a` and `b`.
+fn lerp(a: f32, b: f32, t: f32) -> f32 {
+    t.mul_add(b - a, a)
+}
+
+/// Smoothstep easing: `3t² − 2t³`, zero slope at `t=0` and `t=1`.
+fn ease_in_out(t: f32) -> f32 {
+    t * t * 2.0f32.mul_add(-t, 3.0)
+}
+
+/// System that updates the camera from the timeline. Runs in `Update`.
+#[allow(clippy::needless_pass_by_value)]
+pub fn apply_cinematic_camera(
+    sim: Res<SimulationRes>,
+    timeline: Res<ShotTimeline>,
+    mut cam: Query<(&mut Transform, &mut Projection), With<Camera2d>>,
+) {
+    let tick = sim.sim.current_tick();
+    let Some((x, y, scale)) = timeline.sample(tick) else {
+        return;
+    };
+
+    for (mut transform, mut proj) in &mut cam {
+        transform.translation.x = x;
+        transform.translation.y = y;
+        if let Projection::Orthographic(o) = proj.as_mut() {
+            o.scale = scale;
+        }
+    }
+}

--- a/crates/elevator-bevy/src/decor.rs
+++ b/crates/elevator-bevy/src/decor.rs
@@ -187,6 +187,65 @@ pub fn tick_arrival_flash(
     }
 }
 
+/// Spawn four small L-shaped blueprint corner marks as screen-space UI.
+/// Visually frames the scene like a drafting sheet without adding any
+/// moving chrome.
+#[allow(clippy::needless_pass_by_value)]
+pub fn spawn_corner_marks(mut commands: Commands, style: Res<VisualStyle>) {
+    const MARGIN: f32 = 16.0;
+    const ARM: f32 = 18.0;
+    const THICK: f32 = 1.5;
+
+    let color = muted_text(style.text);
+
+    // (is_top, is_left) — orientation of each corner's L.
+    for (is_top, is_left) in [(true, true), (true, false), (false, true), (false, false)] {
+        let (top, bottom, left, right) = edges(is_top, is_left, MARGIN);
+
+        // Horizontal arm.
+        commands.spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                top,
+                bottom,
+                left,
+                right,
+                width: Val::Px(ARM),
+                height: Val::Px(THICK),
+                ..default()
+            },
+            BackgroundColor(color),
+        ));
+
+        // Vertical arm.
+        commands.spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                top,
+                bottom,
+                left,
+                right,
+                width: Val::Px(THICK),
+                height: Val::Px(ARM),
+                ..default()
+            },
+            BackgroundColor(color),
+        ));
+    }
+}
+
+/// Compute the `(top, bottom, left, right)` `Val`s for a given corner mark.
+const fn edges(is_top: bool, is_left: bool, margin: f32) -> (Val, Val, Val, Val) {
+    let m = Val::Px(margin);
+    let auto = Val::Auto;
+    (
+        if is_top { m } else { auto },
+        if is_top { auto } else { m },
+        if is_left { m } else { auto },
+        if is_left { auto } else { m },
+    )
+}
+
 /// Mute a color by 40% toward background-agnostic midpoint (shared with ui.rs).
 fn muted_text(c: Color) -> Color {
     let l = c.to_linear();

--- a/crates/elevator-bevy/src/decor.rs
+++ b/crates/elevator-bevy/src/decor.rs
@@ -1,0 +1,199 @@
+//! Optional decorative layer: live occupancy chips + call-lamp indicators
+//! beside each stop, and an arrival-flash outline on each car when its
+//! doors finish opening.
+//!
+//! Enabled by the showcase example — the default plugin leaves these
+//! systems unregistered so the binary stays minimal. Stop *names* are
+//! already drawn by [`crate::rendering`], so this module adds only the
+//! live data chrome.
+
+use bevy::prelude::*;
+use elevator_core::components::RiderPhase;
+use elevator_core::entity::EntityId;
+use elevator_core::events::Event;
+
+use crate::rendering::{ElevatorVisual, VisualScale};
+use crate::sim_bridge::{EventWrapper, SimulationRes};
+use crate::style::VisualStyle;
+
+/// Occupancy chip ("N") on the right of a stop, tied to `stop_id`.
+#[derive(Component)]
+pub struct OccupancyChip {
+    /// The stop this chip reports on.
+    pub stop_id: EntityId,
+}
+
+/// Small "someone is waiting" lamp beside a stop — visible iff
+/// `waiting_at(stop) > 0`.
+#[derive(Component)]
+pub struct CallLamp {
+    /// The stop this lamp is attached to.
+    pub stop_id: EntityId,
+}
+
+/// Outline pulse child of an elevator car; alpha ramps down from 1.0 over
+/// `ARRIVAL_FLASH_TICKS` when the car's doors finish opening.
+#[derive(Component)]
+pub struct ArrivalFlash {
+    /// The elevator whose arrival this outline is tracking.
+    pub elevator: EntityId,
+    /// Ticks remaining in the current flash (0 = invisible).
+    pub ticks_remaining: u32,
+    /// Total duration the flash runs for, used to compute alpha.
+    pub duration: u32,
+}
+
+/// Ticks the arrival-flash outline stays visible after `DoorOpened`.
+const ARRIVAL_FLASH_TICKS: u32 = 36;
+
+/// Spawn the decor layer. Runs in Startup; expects [`VisualScale`] and
+/// [`VisualStyle`] already inserted by the rendering layer.
+#[allow(clippy::needless_pass_by_value)]
+pub fn spawn_decor(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+    sim: Res<SimulationRes>,
+    vs: Res<VisualScale>,
+    style: Res<VisualStyle>,
+    cars: Query<(Entity, &ElevatorVisual)>,
+) {
+    let w = sim.sim.world();
+
+    let lamp_mat = materials.add(style.rider_up);
+    let chip_color = muted_text(style.text);
+
+    let chip_x = vs.bank_width().mul_add(0.5, vs.shaft_width) + 14.0;
+    let lamp_x = vs.rider_radius.mul_add(1.8, chip_x);
+
+    for (stop_eid, stop) in w.iter_stops() {
+        let y = stop.position() as f32 * crate::rendering::PPU;
+
+        commands.spawn((
+            Text2d::new(String::new()),
+            TextFont {
+                font_size: vs.font_size * 0.85,
+                ..default()
+            },
+            TextColor(chip_color),
+            Transform::from_xyz(chip_x, y, 0.15),
+            OccupancyChip { stop_id: stop_eid },
+        ));
+
+        commands.spawn((
+            Mesh2d(meshes.add(Circle::new(vs.rider_radius * 0.5))),
+            MeshMaterial2d(lamp_mat.clone()),
+            Transform::from_xyz(lamp_x, y, 0.2),
+            Visibility::Hidden,
+            CallLamp { stop_id: stop_eid },
+        ));
+    }
+
+    // Arrival-flash outline: a rectangle slightly larger than the car,
+    // drawn behind the door panels (z = -0.05 relative to car).
+    let outline = meshes.add(Rectangle::new(vs.car_width * 1.12, vs.car_height * 1.24));
+    let flash_mat = materials.add(Color::srgba(0.0, 0.0, 0.0, 0.0));
+    for (car_entity, vis) in &cars {
+        commands.entity(car_entity).with_children(|parent| {
+            parent.spawn((
+                Mesh2d(outline.clone()),
+                MeshMaterial2d(flash_mat.clone()),
+                Transform::from_xyz(0.0, 0.0, -0.05),
+                ArrivalFlash {
+                    elevator: vis.entity_id,
+                    ticks_remaining: 0,
+                    duration: ARRIVAL_FLASH_TICKS,
+                },
+            ));
+        });
+    }
+}
+
+/// Toggle call lamp visibility based on waiting count at each stop.
+#[allow(clippy::needless_pass_by_value)]
+pub fn sync_call_lamps(sim: Res<SimulationRes>, mut lamps: Query<(&CallLamp, &mut Visibility)>) {
+    let w = sim.sim.world();
+    for (lamp, mut vis) in &mut lamps {
+        let any_waiting = w.iter_riders().any(|(_, r)| {
+            r.phase() == RiderPhase::Waiting && r.current_stop() == Some(lamp.stop_id)
+        });
+        *vis = if any_waiting {
+            Visibility::Visible
+        } else {
+            Visibility::Hidden
+        };
+    }
+}
+
+/// Update occupancy chip text from the live waiting-rider count.
+#[allow(clippy::needless_pass_by_value)]
+pub fn sync_occupancy_chips(
+    sim: Res<SimulationRes>,
+    mut chips: Query<(&OccupancyChip, &mut Text2d)>,
+) {
+    let w = sim.sim.world();
+    for (chip, mut text) in &mut chips {
+        let count = w
+            .iter_riders()
+            .filter(|(_, r)| {
+                r.phase() == RiderPhase::Waiting && r.current_stop() == Some(chip.stop_id)
+            })
+            .count();
+        let new_text = if count == 0 {
+            String::new()
+        } else {
+            count.to_string()
+        };
+        if text.0 != new_text {
+            text.0 = new_text;
+        }
+    }
+}
+
+/// Trigger flash on `DoorOpened` events and ramp alpha down each tick.
+#[allow(clippy::needless_pass_by_value)]
+pub fn tick_arrival_flash(
+    mut events: MessageReader<EventWrapper>,
+    mut flashes: Query<(&mut ArrivalFlash, &MeshMaterial2d<ColorMaterial>)>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+    style: Res<VisualStyle>,
+) {
+    let highlight = style.rider_up;
+
+    for ev in events.read() {
+        if let Event::DoorOpened { elevator, .. } = ev.0 {
+            for (mut flash, _) in &mut flashes {
+                if flash.elevator == elevator {
+                    flash.ticks_remaining = flash.duration;
+                }
+            }
+        }
+    }
+
+    for (mut flash, mat_handle) in &mut flashes {
+        if flash.ticks_remaining == 0 {
+            if let Some(mat) = materials.get_mut(&mat_handle.0) {
+                mat.color = Color::srgba(0.0, 0.0, 0.0, 0.0);
+            }
+            continue;
+        }
+        let alpha = f32::from(u16::try_from(flash.ticks_remaining).unwrap_or(u16::MAX))
+            / f32::from(u16::try_from(flash.duration).unwrap_or(1));
+        flash.ticks_remaining = flash.ticks_remaining.saturating_sub(1);
+        if let Some(mat) = materials.get_mut(&mat_handle.0) {
+            let l = highlight.to_linear();
+            mat.color = Color::linear_rgba(l.red, l.green, l.blue, alpha * 0.7);
+        }
+    }
+}
+
+/// Mute a color by 40% toward background-agnostic midpoint (shared with ui.rs).
+fn muted_text(c: Color) -> Color {
+    let l = c.to_linear();
+    Color::linear_rgba(
+        l.red.mul_add(0.55, 0.22),
+        l.green.mul_add(0.55, 0.22),
+        l.blue.mul_add(0.55, 0.22),
+        l.alpha,
+    )
+}

--- a/crates/elevator-bevy/src/lib.rs
+++ b/crates/elevator-bevy/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod camera;
 pub mod cinematic;
+pub mod decor;
 pub mod input;
 pub mod passenger_ai;
 pub mod plugin;

--- a/crates/elevator-bevy/src/lib.rs
+++ b/crates/elevator-bevy/src/lib.rs
@@ -1,0 +1,18 @@
+//! Library surface of elevator-bevy — used by the binary target and by
+//! examples (e.g. `examples/showcase.rs`).
+//!
+//! The binary entry point (`src/main.rs`) composes the default
+//! [`ElevatorSimPlugin`](plugin::ElevatorSimPlugin) from these modules.
+//! Examples may mix and match: e.g. the showcase uses the base rendering
+//! and HUD but swaps in a scripted cinematic camera and a frame recorder.
+
+pub mod camera;
+pub mod cinematic;
+pub mod input;
+pub mod passenger_ai;
+pub mod plugin;
+pub mod recorder;
+pub mod rendering;
+pub mod sim_bridge;
+pub mod style;
+pub mod ui;

--- a/crates/elevator-bevy/src/main.rs
+++ b/crates/elevator-bevy/src/main.rs
@@ -2,22 +2,7 @@
 
 use bevy::prelude::*;
 
-/// Camera setup and centering.
-mod camera;
-/// Keyboard input handling for simulation speed.
-mod input;
-/// AI-driven rider spawning.
-mod passenger_ai;
-/// Bevy plugin wiring up the simulation.
-mod plugin;
-/// Visual rendering of shafts, elevators, stops, and riders.
-mod rendering;
-/// Simulation bridge resources and tick system.
-mod sim_bridge;
-/// HUD overlay for simulation stats.
-mod ui;
-
-use plugin::ElevatorSimPlugin;
+use elevator_bevy::plugin::ElevatorSimPlugin;
 
 /// Entry point — launches the Bevy app with the elevator simulation plugin.
 fn main() {

--- a/crates/elevator-bevy/src/plugin.rs
+++ b/crates/elevator-bevy/src/plugin.rs
@@ -6,8 +6,8 @@ use crate::camera::setup_camera;
 use crate::input::handle_speed_input;
 use crate::passenger_ai::{PassengerSpawnTimer, spawn_ai_passengers};
 use crate::rendering::{
-    compute_queue_slots, spawn_building_visuals, sync_door_panels, sync_elevator_visuals,
-    sync_rider_visuals, update_rider_positions,
+    compute_queue_slots, spawn_building_visuals, sync_direction_arrows, sync_door_panels,
+    sync_elevator_visuals, sync_rider_visuals, tick_rider_fades, update_rider_positions,
 };
 use crate::sim_bridge::{EventWrapper, SimSpeed, SimulationRes, tick_simulation};
 use crate::style::VisualStyle;
@@ -64,9 +64,11 @@ impl Plugin for ElevatorSimPlugin {
                     tick_simulation,
                     sync_elevator_visuals,
                     sync_door_panels,
+                    sync_direction_arrows,
                     compute_queue_slots,
                     sync_rider_visuals,
                     update_rider_positions,
+                    tick_rider_fades,
                     update_hud,
                 )
                     .chain(),

--- a/crates/elevator-bevy/src/plugin.rs
+++ b/crates/elevator-bevy/src/plugin.rs
@@ -6,8 +6,8 @@ use crate::camera::setup_camera;
 use crate::input::handle_speed_input;
 use crate::passenger_ai::{PassengerSpawnTimer, spawn_ai_passengers};
 use crate::rendering::{
-    spawn_building_visuals, sync_door_panels, sync_elevator_visuals, sync_rider_visuals,
-    update_rider_positions,
+    compute_queue_slots, spawn_building_visuals, sync_door_panels, sync_elevator_visuals,
+    sync_rider_visuals, update_rider_positions,
 };
 use crate::sim_bridge::{EventWrapper, SimSpeed, SimulationRes, tick_simulation};
 use crate::style::VisualStyle;
@@ -64,6 +64,7 @@ impl Plugin for ElevatorSimPlugin {
                     tick_simulation,
                     sync_elevator_visuals,
                     sync_door_panels,
+                    compute_queue_slots,
                     sync_rider_visuals,
                     update_rider_positions,
                     update_hud,

--- a/crates/elevator-bevy/src/plugin.rs
+++ b/crates/elevator-bevy/src/plugin.rs
@@ -6,9 +6,11 @@ use crate::camera::setup_camera;
 use crate::input::handle_speed_input;
 use crate::passenger_ai::{PassengerSpawnTimer, spawn_ai_passengers};
 use crate::rendering::{
-    spawn_building_visuals, sync_elevator_visuals, sync_rider_visuals, update_rider_positions,
+    spawn_building_visuals, sync_door_panels, sync_elevator_visuals, sync_rider_visuals,
+    update_rider_positions,
 };
 use crate::sim_bridge::{EventWrapper, SimSpeed, SimulationRes, tick_simulation};
+use crate::style::VisualStyle;
 use crate::ui::{spawn_hud, update_hud};
 use elevator_core::config::SimConfig;
 use elevator_core::dispatch::scan::ScanDispatch;
@@ -34,8 +36,14 @@ impl Plugin for ElevatorSimPlugin {
         let sim = Simulation::new(&config, ScanDispatch::new())
             .unwrap_or_else(|e| panic!("Invalid simulation config: {e}"));
 
+        // Default style unless an earlier plugin/example inserted one.
+        if !app.world().contains_resource::<VisualStyle>() {
+            app.insert_resource(VisualStyle::default());
+        }
+
         app.insert_resource(SimulationRes { sim })
             .insert_resource(SimSpeed { multiplier: 1 })
+            .insert_resource(ClearColor(Color::srgba(0.08, 0.08, 0.1, 1.0)))
             .insert_resource(PassengerSpawnTimer {
                 ticks_until_spawn: spawn_config.mean_interval_ticks,
                 mean_interval: spawn_config.mean_interval_ticks,
@@ -51,6 +59,7 @@ impl Plugin for ElevatorSimPlugin {
                     spawn_ai_passengers,
                     tick_simulation,
                     sync_elevator_visuals,
+                    sync_door_panels,
                     sync_rider_visuals,
                     update_rider_positions,
                     update_hud,

--- a/crates/elevator-bevy/src/plugin.rs
+++ b/crates/elevator-bevy/src/plugin.rs
@@ -40,10 +40,14 @@ impl Plugin for ElevatorSimPlugin {
         if !app.world().contains_resource::<VisualStyle>() {
             app.insert_resource(VisualStyle::default());
         }
+        let background = app
+            .world()
+            .get_resource::<VisualStyle>()
+            .map_or(Color::BLACK, |s| s.background);
 
         app.insert_resource(SimulationRes { sim })
             .insert_resource(SimSpeed { multiplier: 1 })
-            .insert_resource(ClearColor(Color::srgba(0.08, 0.08, 0.1, 1.0)))
+            .insert_resource(ClearColor(background))
             .insert_resource(PassengerSpawnTimer {
                 ticks_until_spawn: spawn_config.mean_interval_ticks,
                 mean_interval: spawn_config.mean_interval_ticks,

--- a/crates/elevator-bevy/src/recorder.rs
+++ b/crates/elevator-bevy/src/recorder.rs
@@ -34,13 +34,13 @@ pub struct Recorder {
 }
 
 impl Recorder {
-    /// Create a recorder with defaults: 24fps at 60 ticks/s ⇒ 2.5 ticks/frame,
-    /// rounded to 2 so we oversample and drop frames evenly in ffmpeg.
+    /// Create a recorder that captures at 20 fps source rate
+    /// (60 ticks/s ÷ 3 ticks/frame); ffmpeg can resample to any output rate.
     #[must_use]
     pub const fn new(out_dir: PathBuf, total_frames: u32) -> Self {
         Self {
             out_dir,
-            ticks_per_frame: 3, // 60/20 ⇒ 20fps source; ffmpeg resamples to 24.
+            ticks_per_frame: 3,
             total_frames,
             captured: 0,
             last_capture_tick: None,

--- a/crates/elevator-bevy/src/recorder.rs
+++ b/crates/elevator-bevy/src/recorder.rs
@@ -1,0 +1,91 @@
+//! Frame capture: dumps PNG frames at a fixed sim-tick interval, then
+//! exits once the target count is reached. Used by the showcase example
+//! to produce deterministic footage for the demo GIF.
+//!
+//! Recording is driven by *simulation ticks*, not wall clock, so identical
+//! seeds always produce identical frame sequences.
+
+use std::path::PathBuf;
+
+use bevy::app::AppExit;
+use bevy::prelude::*;
+use bevy::render::view::screenshot::{Screenshot, save_to_disk};
+
+use crate::sim_bridge::SimulationRes;
+
+/// Recording configuration + running state.
+#[derive(Resource)]
+pub struct Recorder {
+    /// Directory where PNG frames are written.
+    pub out_dir: PathBuf,
+    /// Capture one frame every `ticks_per_frame` simulation ticks.
+    pub ticks_per_frame: u32,
+    /// Total number of frames to capture before exiting.
+    pub total_frames: u32,
+    /// Frames captured so far.
+    pub captured: u32,
+    /// Last tick at which a frame was captured (to avoid duplicates when
+    /// multiple sim ticks elapse in one render frame).
+    pub last_capture_tick: Option<u64>,
+    /// Sim tick at which capture starts (to skip any warm-up).
+    pub start_tick: u64,
+    /// Exit the app after the final frame is captured.
+    pub exit_when_done: bool,
+}
+
+impl Recorder {
+    /// Create a recorder with defaults: 24fps at 60 ticks/s ⇒ 2.5 ticks/frame,
+    /// rounded to 2 so we oversample and drop frames evenly in ffmpeg.
+    #[must_use]
+    pub const fn new(out_dir: PathBuf, total_frames: u32) -> Self {
+        Self {
+            out_dir,
+            ticks_per_frame: 3, // 60/20 ⇒ 20fps source; ffmpeg resamples to 24.
+            total_frames,
+            captured: 0,
+            last_capture_tick: None,
+            start_tick: 0,
+            exit_when_done: true,
+        }
+    }
+}
+
+/// System that captures one screenshot per `ticks_per_frame` sim ticks.
+#[allow(clippy::needless_pass_by_value)]
+pub fn capture_frames(
+    mut commands: Commands,
+    sim: Res<SimulationRes>,
+    mut recorder: ResMut<Recorder>,
+    mut exit: MessageWriter<AppExit>,
+) {
+    if recorder.captured >= recorder.total_frames {
+        if recorder.exit_when_done {
+            exit.write(AppExit::Success);
+        }
+        return;
+    }
+
+    let tick = sim.sim.current_tick();
+    if tick < recorder.start_tick {
+        return;
+    }
+
+    // Need at least `ticks_per_frame` ticks since the last capture.
+    let should_capture = match recorder.last_capture_tick {
+        None => true,
+        Some(prev) => tick.saturating_sub(prev) >= u64::from(recorder.ticks_per_frame),
+    };
+    if !should_capture {
+        return;
+    }
+
+    let frame = recorder.captured;
+    let path = recorder.out_dir.join(format!("frame_{frame:05}.png"));
+
+    commands
+        .spawn(Screenshot::primary_window())
+        .observe(save_to_disk(path));
+
+    recorder.captured += 1;
+    recorder.last_capture_tick = Some(tick);
+}

--- a/crates/elevator-bevy/src/recorder.rs
+++ b/crates/elevator-bevy/src/recorder.rs
@@ -31,6 +31,12 @@ pub struct Recorder {
     pub start_tick: u64,
     /// Exit the app after the final frame is captured.
     pub exit_when_done: bool,
+    /// Render frames to wait between the final screenshot trigger and
+    /// `AppExit` so the async screenshot observer can flush its PNG
+    /// before the channel closes.
+    pub flush_frames: u32,
+    /// Render frames elapsed since `captured == total_frames`.
+    pub frames_since_done: u32,
 }
 
 impl Recorder {
@@ -46,6 +52,8 @@ impl Recorder {
             last_capture_tick: None,
             start_tick: 0,
             exit_when_done: true,
+            flush_frames: 6,
+            frames_since_done: 0,
         }
     }
 }
@@ -60,7 +68,10 @@ pub fn capture_frames(
 ) {
     if recorder.captured >= recorder.total_frames {
         if recorder.exit_when_done {
-            exit.write(AppExit::Success);
+            recorder.frames_since_done += 1;
+            if recorder.frames_since_done >= recorder.flush_frames {
+                exit.write(AppExit::Success);
+            }
         }
         return;
     }

--- a/crates/elevator-bevy/src/rendering.rs
+++ b/crates/elevator-bevy/src/rendering.rs
@@ -10,10 +10,17 @@ use elevator_core::door::DoorState;
 use elevator_core::entity::EntityId;
 use elevator_core::world::World;
 use std::collections::HashMap;
-use std::hash::{Hash, Hasher};
 
 use crate::sim_bridge::SimulationRes;
 use crate::style::VisualStyle;
+
+/// Fraction of the distance to the target a rider covers each render frame
+/// (exponential approach). Higher = snappier, lower = softer.
+const RIDER_LERP_ALPHA: f32 = 0.28;
+/// Idle bob amplitude (pixels) for waiting riders.
+const IDLE_BOB_PX: f32 = 1.6;
+/// Idle bob angular frequency (radians per sim tick).
+const IDLE_BOB_FREQ: f32 = 0.14;
 
 /// Pixels per simulation distance unit.
 pub const PPU: f32 = 40.0;
@@ -101,6 +108,18 @@ impl VisualScale {
 /// Maps an elevator entity to its visual shaft index (0..n).
 #[derive(Resource, Default)]
 pub struct ElevatorShaftIndex(pub HashMap<EntityId, u32>);
+
+/// Per-stop queue slot index for each waiting rider.
+///
+/// Rebuilt each frame. Slots are assigned by sorted-by-`EntityId` order so
+/// when a rider boards, everyone behind them shifts deterministically
+/// one slot forward.
+#[derive(Resource, Default)]
+pub struct QueueSlots(pub HashMap<EntityId, usize>);
+
+/// Per-rider bob phase offset so waiting riders don't all bob in sync.
+#[derive(Component)]
+pub struct BobPhase(pub f32);
 
 /// Marker for shaft background visuals.
 #[derive(Component)]
@@ -293,7 +312,37 @@ pub fn spawn_building_visuals(
     };
     commands.insert_resource(rider_mats);
     commands.insert_resource(ElevatorShaftIndex(shaft_index_map));
+    commands.insert_resource(QueueSlots::default());
     commands.insert_resource(vs);
+}
+
+/// Rebuild [`QueueSlots`] from the current waiting-rider population.
+///
+/// Riders at each stop are sorted by their `EntityId` — stable within a
+/// scene — and assigned slot indices `0..`. When a rider boards, everyone
+/// else shifts up one slot naturally.
+#[allow(clippy::needless_pass_by_value)]
+pub fn compute_queue_slots(sim: Res<SimulationRes>, mut slots: ResMut<QueueSlots>) {
+    let w = sim.sim.world();
+
+    // Bucket waiting rider ids by stop, then sort each bucket for determinism.
+    let mut buckets: HashMap<EntityId, Vec<EntityId>> = HashMap::new();
+    for (eid, r) in w.iter_riders() {
+        if r.phase() != RiderPhase::Waiting {
+            continue;
+        }
+        if let Some(stop) = r.current_stop() {
+            buckets.entry(stop).or_default().push(eid);
+        }
+    }
+
+    slots.0.clear();
+    for bucket in buckets.values_mut() {
+        bucket.sort_unstable();
+        for (i, eid) in bucket.iter().enumerate() {
+            slots.0.insert(*eid, i);
+        }
+    }
 }
 
 /// Update elevator car positions.
@@ -358,6 +407,7 @@ pub fn sync_rider_visuals(
     rider_mats: Res<RiderMaterials>,
     style: Res<VisualStyle>,
     shaft_idx: Res<ElevatorShaftIndex>,
+    slots: Res<QueueSlots>,
 ) {
     let w = sim.sim.world();
 
@@ -384,7 +434,9 @@ pub fn sync_rider_visuals(
             continue;
         }
 
-        let (x, y, mat) = rider_visual_params(rider_eid, rider, w, &vs, &rider_mats, &shaft_idx);
+        let (x, y, mat) =
+            rider_visual_params(rider_eid, rider, w, &vs, &rider_mats, &shaft_idx, &slots);
+        let phase = bob_phase_for(rider_eid);
 
         if style.humanoid_riders {
             // Body (pill) on z=1.0, head (circle) on z=1.1 as child.
@@ -399,12 +451,13 @@ pub fn sync_rider_visuals(
                     RiderVisual {
                         entity_id: rider_eid,
                     },
+                    BobPhase(phase),
                 ))
                 .with_children(|parent| {
                     parent.spawn((
                         Mesh2d(meshes.add(Circle::new(head_r))),
                         MeshMaterial2d(mat.clone()),
-                        Transform::from_xyz(0.0, body_h * 0.5 + head_r * 0.7, 0.05),
+                        Transform::from_xyz(0.0, head_r.mul_add(0.7, body_h * 0.5), 0.05),
                         RiderHead,
                     ));
                 });
@@ -416,17 +469,33 @@ pub fn sync_rider_visuals(
                 RiderVisual {
                     entity_id: rider_eid,
                 },
+                BobPhase(phase),
             ));
         }
     }
 }
 
+/// Derive a deterministic bob-phase offset (radians) from the rider id so
+/// everyone bobs out of sync — prevents the crowd from breathing as one.
+fn bob_phase_for(eid: EntityId) -> f32 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    eid.hash(&mut h);
+    (h.finish() % 6283) as f32 / 1000.0
+}
+
 /// Update positions and colors of existing rider visuals.
-#[allow(clippy::needless_pass_by_value)]
+///
+/// Positions interpolate toward the target with exponential damping
+/// ([`RIDER_LERP_ALPHA`]) so boarding/exiting doesn't snap. Waiting riders
+/// get a small sinusoidal bob keyed on sim tick + per-rider phase, so the
+/// queue feels alive without anyone moving in lockstep.
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 pub fn update_rider_positions(
     sim: Res<SimulationRes>,
     mut query: Query<(
         &RiderVisual,
+        &BobPhase,
         &mut Transform,
         &mut MeshMaterial2d<ColorMaterial>,
         &Children,
@@ -438,10 +507,12 @@ pub fn update_rider_positions(
     rider_mats: Res<RiderMaterials>,
     vs: Res<VisualScale>,
     shaft_idx: Res<ElevatorShaftIndex>,
+    slots: Res<QueueSlots>,
 ) {
     let w = sim.sim.world();
+    let tick_f = sim.sim.current_tick() as f32;
 
-    for (vis, mut transform, mut mat_handle, children) in &mut query {
+    for (vis, bob, mut transform, mut mat_handle, children) in &mut query {
         let Some(rider) = w.rider(vis.entity_id) else {
             continue;
         };
@@ -449,10 +520,28 @@ pub fn update_rider_positions(
             continue;
         }
 
-        let (x, y, handle) =
-            rider_visual_params(vis.entity_id, rider, w, &vs, &rider_mats, &shaft_idx);
-        transform.translation.x = x;
-        transform.translation.y = y;
+        let (x, target_y, handle) = rider_visual_params(
+            vis.entity_id,
+            rider,
+            w,
+            &vs,
+            &rider_mats,
+            &shaft_idx,
+            &slots,
+        );
+
+        let y = if rider.phase() == RiderPhase::Waiting {
+            tick_f
+                .mul_add(IDLE_BOB_FREQ, bob.0)
+                .sin()
+                .mul_add(IDLE_BOB_PX, target_y)
+        } else {
+            target_y
+        };
+
+        let t = RIDER_LERP_ALPHA;
+        transform.translation.x = (x - transform.translation.x).mul_add(t, transform.translation.x);
+        transform.translation.y = (y - transform.translation.y).mul_add(t, transform.translation.y);
         *mat_handle = MeshMaterial2d(handle.clone());
 
         // Keep the head color in sync.
@@ -472,6 +561,7 @@ fn rider_visual_params(
     vs: &VisualScale,
     mats: &RiderMaterials,
     shaft_idx: &ElevatorShaftIndex,
+    slots: &QueueSlots,
 ) -> (f32, f32, Handle<ColorMaterial>) {
     match rider.phase() {
         RiderPhase::Waiting => {
@@ -479,10 +569,8 @@ fn rider_visual_params(
                 .current_stop()
                 .and_then(|s| w.stop_position(s))
                 .unwrap_or(0.0);
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            rider_eid.hash(&mut hasher);
-            let hash = hasher.finish();
-            let col = (hash % 5) as f32;
+            let slot = slots.0.get(&rider_eid).copied().unwrap_or(0);
+            let col = (slot % 5) as f32;
             let x = vs.leftmost_x() + vs.waiting_x_offset - col * vs.rider_spacing;
             (
                 x,

--- a/crates/elevator-bevy/src/rendering.rs
+++ b/crates/elevator-bevy/src/rendering.rs
@@ -155,9 +155,10 @@ pub struct QueueSlots(pub HashMap<EntityId, usize>);
 #[derive(Component)]
 pub struct BobPhase(pub f32);
 
-/// Scale-based lifecycle fade for rider visuals. `current` drifts toward
-/// `target` at [`FADE_STEP`] per frame; when both are below a small
-/// threshold the entity is despawned.
+/// Scale-based lifecycle fade for rider visuals.
+///
+/// `current` drifts toward `target` at `FADE_STEP` per frame; when both
+/// are below a small threshold the entity is despawned.
 #[derive(Component)]
 pub struct RiderFade {
     /// Current scale (0 = invisible, 1 = full size).
@@ -668,7 +669,7 @@ fn bob_phase_for(eid: EntityId) -> f32 {
 /// Update positions and colors of existing rider visuals.
 ///
 /// Positions interpolate toward the target with exponential damping
-/// ([`RIDER_LERP_ALPHA`]) so boarding/exiting doesn't snap. Waiting riders
+/// (`RIDER_LERP_ALPHA`) so boarding/exiting doesn't snap. Waiting riders
 /// get a small sinusoidal bob keyed on sim tick + per-rider phase, so the
 /// queue feels alive without anyone moving in lockstep.
 #[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]

--- a/crates/elevator-bevy/src/rendering.rs
+++ b/crates/elevator-bevy/src/rendering.rs
@@ -5,11 +5,12 @@
 //! Waiting riders queue to the left of shaft 0.
 
 use bevy::prelude::*;
-use elevator_core::components::{Position, Rider, RiderPhase};
+use elevator_core::components::{ElevatorPhase, Position, Rider, RiderPhase};
 use elevator_core::door::DoorState;
 use elevator_core::entity::EntityId;
 use elevator_core::world::World;
 use std::collections::HashMap;
+use std::f32::consts::PI;
 
 use crate::sim_bridge::SimulationRes;
 use crate::style::VisualStyle;
@@ -154,6 +155,20 @@ pub struct QueueSlots(pub HashMap<EntityId, usize>);
 #[derive(Component)]
 pub struct BobPhase(pub f32);
 
+/// Scale-based lifecycle fade for rider visuals. `current` drifts toward
+/// `target` at [`FADE_STEP`] per frame; when both are below a small
+/// threshold the entity is despawned.
+#[derive(Component)]
+pub struct RiderFade {
+    /// Current scale (0 = invisible, 1 = full size).
+    pub current: f32,
+    /// Target scale the component is easing toward.
+    pub target: f32,
+}
+
+/// Per-frame change in rider scale during spawn-in / fade-out (~6 frames to reach 1).
+const FADE_STEP: f32 = 1.0 / 6.0;
+
 /// Marker for shaft background visuals.
 #[derive(Component)]
 pub struct ShaftVisual;
@@ -195,6 +210,15 @@ pub struct DoorPanel {
     pub elevator: EntityId,
     /// Panel half-travel in pixels (from closed center to fully-open edge).
     pub travel: f32,
+}
+
+/// Small triangle on the elevator car that points in the travel direction.
+/// Visible only while the elevator is moving on a dispatched or
+/// repositioning trip; hidden during dwell/Idle.
+#[derive(Component)]
+pub struct DirectionArrow {
+    /// The elevator this arrow tracks.
+    pub elevator: EntityId,
 }
 
 /// Pre-allocated rider materials.
@@ -349,6 +373,8 @@ pub fn spawn_building_visuals(
             // Panels drawn *in front of* the car on z=0.6.
             // Travel = car_width/4 from closed center to fully open.
             let travel = vs.car_width * 0.25;
+            let arrow_mesh = meshes.add(RegularPolygon::new(vs.rider_radius * 0.9, 3));
+            let arrow_mat = materials.add(style.background);
             car.with_children(|parent| {
                 for side in [-1.0_f32, 1.0_f32] {
                     parent.spawn((
@@ -362,6 +388,14 @@ pub fn spawn_building_visuals(
                         },
                     ));
                 }
+                // Direction arrow (hidden by default; sync system toggles).
+                parent.spawn((
+                    Mesh2d(arrow_mesh),
+                    MeshMaterial2d(arrow_mat),
+                    Transform::from_xyz(0.0, 0.0, 0.2),
+                    Visibility::Hidden,
+                    DirectionArrow { elevator: *eid },
+                ));
             });
         }
     }
@@ -420,6 +454,48 @@ pub fn sync_elevator_visuals(
     }
 }
 
+/// Show/hide and orient each car's direction arrow.
+///
+/// Arrow points up for ascending trips, down for descending, and is
+/// hidden while the car is idle, loading, or its doors are operating.
+#[allow(clippy::needless_pass_by_value)]
+pub fn sync_direction_arrows(
+    sim: Res<SimulationRes>,
+    mut arrows: Query<(&DirectionArrow, &mut Visibility, &mut Transform)>,
+) {
+    let w = sim.sim.world();
+    for (arrow, mut vis, mut tf) in &mut arrows {
+        let Some(car) = w.elevator(arrow.elevator) else {
+            *vis = Visibility::Hidden;
+            continue;
+        };
+        let target = match car.phase() {
+            ElevatorPhase::MovingToStop(target) | ElevatorPhase::Repositioning(target) => {
+                Some(target)
+            }
+            _ => None,
+        };
+        let Some(target_stop) = target else {
+            *vis = Visibility::Hidden;
+            continue;
+        };
+        let (Some(car_pos), Some(target_pos)) =
+            (w.position(arrow.elevator), w.stop_position(target_stop))
+        else {
+            *vis = Visibility::Hidden;
+            continue;
+        };
+        let going_up = target_pos > car_pos.value();
+        *vis = Visibility::Visible;
+        // RegularPolygon(sides=3) points up by default; rotate 180° to point down.
+        tf.rotation = if going_up {
+            Quat::IDENTITY
+        } else {
+            Quat::from_rotation_z(PI)
+        };
+    }
+}
+
 /// Update door-panel child transforms from the core `DoorState`.
 #[allow(clippy::needless_pass_by_value)]
 pub fn sync_door_panels(sim: Res<SimulationRes>, mut query: Query<(&DoorPanel, &mut Transform)>) {
@@ -458,13 +534,14 @@ fn door_open_fraction(state: DoorState) -> f32 {
     }
 }
 
-/// Spawn visuals for newly-appeared riders and despawn for gone ones.
+/// Spawn visuals for newly-appeared riders and mark gone ones for
+/// fade-out ([`tick_rider_fades`] despawns them once they've shrunk to 0).
 #[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 pub fn sync_rider_visuals(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     sim: Res<SimulationRes>,
-    existing: Query<(Entity, &RiderVisual)>,
+    mut existing: Query<(Entity, &RiderVisual, &mut RiderFade)>,
     vs: Res<VisualScale>,
     rider_mats: Res<RiderMaterials>,
     style: Res<VisualStyle>,
@@ -479,14 +556,14 @@ pub fn sync_rider_visuals(
         .map(|(eid, _)| eid)
         .collect();
 
-    for (entity, vis) in &existing {
-        if !active_ids.contains(&vis.entity_id) {
-            commands.entity(entity).despawn();
+    for (_entity, vis, mut fade) in &mut existing {
+        if !active_ids.contains(&vis.entity_id) && fade.target > 0.0 {
+            fade.target = 0.0;
         }
     }
 
     let existing_ids: std::collections::HashSet<EntityId> =
-        existing.iter().map(|(_, v)| v.entity_id).collect();
+        existing.iter().map(|(_, v, _)| v.entity_id).collect();
 
     for (rider_eid, rider) in w.iter_riders() {
         if matches!(rider.phase(), RiderPhase::Arrived | RiderPhase::Abandoned) {
@@ -499,6 +576,8 @@ pub fn sync_rider_visuals(
         let (x, y, mat) =
             rider_visual_params(rider_eid, rider, w, &vs, &rider_mats, &shaft_idx, &slots);
         let phase = bob_phase_for(rider_eid);
+        let mut initial_tf = Transform::from_xyz(x, y, 1.0);
+        initial_tf.scale = Vec3::splat(FADE_STEP);
 
         if style.humanoid_riders {
             // Body (pill) on z=1.0, head (circle) on z=1.1 as child.
@@ -509,11 +588,15 @@ pub fn sync_rider_visuals(
                 .spawn((
                     Mesh2d(meshes.add(Rectangle::new(body_w, body_h))),
                     MeshMaterial2d(mat.clone()),
-                    Transform::from_xyz(x, y, 1.0),
+                    initial_tf,
                     RiderVisual {
                         entity_id: rider_eid,
                     },
                     BobPhase(phase),
+                    RiderFade {
+                        current: FADE_STEP,
+                        target: 1.0,
+                    },
                 ))
                 .with_children(|parent| {
                     parent.spawn((
@@ -527,12 +610,39 @@ pub fn sync_rider_visuals(
             commands.spawn((
                 Mesh2d(meshes.add(Circle::new(vs.rider_radius))),
                 MeshMaterial2d(mat),
-                Transform::from_xyz(x, y, 1.0),
+                initial_tf,
                 RiderVisual {
                     entity_id: rider_eid,
                 },
                 BobPhase(phase),
+                RiderFade {
+                    current: FADE_STEP,
+                    target: 1.0,
+                },
             ));
+        }
+    }
+}
+
+/// Ease [`RiderFade::current`] toward `target` and apply it to the
+/// rider's Transform scale. Despawns once shrunken to ~0.
+#[allow(clippy::needless_pass_by_value)]
+pub fn tick_rider_fades(
+    mut commands: Commands,
+    mut query: Query<(Entity, &mut RiderFade, &mut Transform)>,
+) {
+    for (entity, mut fade, mut tf) in &mut query {
+        let delta = fade.target - fade.current;
+        if delta.abs() > FADE_STEP * 0.5 {
+            fade.current += delta.signum() * FADE_STEP;
+        } else {
+            fade.current = fade.target;
+        }
+        fade.current = fade.current.clamp(0.0, 1.0);
+        tf.scale = Vec3::splat(fade.current);
+
+        if fade.target <= 0.01 && fade.current <= 0.01 {
+            commands.entity(entity).despawn();
         }
     }
 }

--- a/crates/elevator-bevy/src/rendering.rs
+++ b/crates/elevator-bevy/src/rendering.rs
@@ -103,7 +103,7 @@ impl VisualScale {
             shaft_width: 10.0 * s,
             car_width: 80.0 * s,
             car_height: 30.0 * s,
-            rider_radius: 6.0 * s,
+            rider_radius: 8.0 * s,
             // Queue starts close to the leftmost shaft and grows leftward
             // as more riders arrive — labels live further out at
             // `label_offset_x` so the two never collide.
@@ -285,10 +285,14 @@ pub fn spawn_building_visuals(
     let shaft_height = span.mul_add(PPU, vs.car_height * 2.0);
     let shaft_center_y = f64::midpoint(min_pos, max_pos) as f32 * PPU;
 
-    // Optional building-exterior backdrop drawn behind everything.
+    // Optional building-exterior backdrop drawn behind everything,
+    // sandwiched between a darker roof strip above and a darker
+    // foundation strip below to suggest "this is a building".
     if let Some(backdrop) = style.building_backdrop {
         let backdrop_mat = materials.add(backdrop);
-        let pad_x = vs.label_offset_x * 1.1;
+        // Wider squat profile: pad_x is generous so the building fills
+        // most of a 16:9 viewport even for short towers.
+        let pad_x = vs.label_offset_x * 1.6;
         let pad_y = vs.car_height * 1.5;
         let backdrop_w = vs.bank_width() + pad_x * 2.0;
         let backdrop_h = shaft_height + pad_y * 2.0;
@@ -296,6 +300,28 @@ pub fn spawn_building_visuals(
             Mesh2d(meshes.add(Rectangle::new(backdrop_w, backdrop_h))),
             MeshMaterial2d(backdrop_mat),
             Transform::from_xyz(0.0, shaft_center_y, -0.2),
+        ));
+
+        // Solid dark brown/slate so roof+foundation read clearly against
+        // both the cream backdrop and the sky background.
+        let trim_color = style.shaft;
+        let trim_mat = materials.add(trim_color);
+        let trim_h = vs.car_height * 0.7;
+        let backdrop_top = shaft_center_y + backdrop_h * 0.5;
+        let backdrop_bot = shaft_center_y - backdrop_h * 0.5;
+
+        // Roof strip.
+        commands.spawn((
+            Mesh2d(meshes.add(Rectangle::new(backdrop_w, trim_h))),
+            MeshMaterial2d(trim_mat.clone()),
+            Transform::from_xyz(0.0, backdrop_top - trim_h * 0.5, -0.18),
+        ));
+
+        // Foundation strip.
+        commands.spawn((
+            Mesh2d(meshes.add(Rectangle::new(backdrop_w, trim_h))),
+            MeshMaterial2d(trim_mat),
+            Transform::from_xyz(0.0, backdrop_bot + trim_h * 0.5, -0.18),
         ));
 
         // Optional alternating floor bands inside the backdrop.
@@ -638,7 +664,16 @@ pub fn sync_rider_visuals(
         let (x, y, mat) =
             rider_visual_params(rider_eid, rider, w, &vs, &rider_mats, &shaft_idx, &slots);
         let phase = bob_phase_for(rider_eid);
-        let mut initial_tf = Transform::from_xyz(x, y, 1.0);
+        // Waiting riders enter from off the bank — the existing
+        // exponential-damped lerp in `update_rider_positions` then
+        // walks them toward their queue slot, reading as a person
+        // approaching the elevators.
+        let initial_x = if rider.phase() == RiderPhase::Waiting {
+            vs.label_offset_x.mul_add(-1.4, vs.leftmost_x())
+        } else {
+            x
+        };
+        let mut initial_tf = Transform::from_xyz(initial_x, y, 1.0);
         initial_tf.scale = Vec3::splat(FADE_STEP);
 
         if style.humanoid_riders {

--- a/crates/elevator-bevy/src/rendering.rs
+++ b/crates/elevator-bevy/src/rendering.rs
@@ -1,16 +1,24 @@
 //! Visual rendering of elevator shafts, cars, stops, and riders.
+//!
+//! Layout: elevators are drawn in column order from `iter_elevators()` —
+//! shaft `i` sits at `x = (i - (n-1)/2) * shaft_spacing_units * PPU`.
+//! Waiting riders queue to the left of shaft 0.
 
 use bevy::prelude::*;
-use elevator_core::components::{Position, RiderPhase};
+use elevator_core::components::{Position, Rider, RiderPhase};
+use elevator_core::door::DoorState;
 use elevator_core::entity::EntityId;
+use elevator_core::world::World;
+use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
 use crate::sim_bridge::SimulationRes;
+use crate::style::VisualStyle;
 
 /// Pixels per simulation distance unit.
 pub const PPU: f32 = 40.0;
 
-/// Holds computed visual sizes that scale with the shaft height.
+/// Computed per-scene visual sizes.
 #[derive(Resource)]
 pub struct VisualScale {
     /// Width of the shaft background rectangle.
@@ -19,25 +27,28 @@ pub struct VisualScale {
     pub car_width: f32,
     /// Height of each elevator car rectangle.
     pub car_height: f32,
-    /// Radius of rider circles.
+    /// Radius of rider "head" circles / plain-circle riders.
     pub rider_radius: f32,
-    /// Horizontal offset for waiting riders from the shaft center.
+    /// Horizontal offset (pixels) for waiting riders from shaft 0 center.
     pub waiting_x_offset: f32,
-    /// Width of the horizontal stop indicator lines.
-    pub stop_line_width: f32,
     /// Thickness of the horizontal stop indicator lines.
     pub stop_line_thickness: f32,
-    /// Horizontal offset for stop name labels.
+    /// Horizontal offset for stop name labels from the leftmost shaft.
     pub label_offset_x: f32,
     /// Font size for stop labels and text.
     pub font_size: f32,
     /// Spacing between rider circles.
     pub rider_spacing: f32,
+    /// Horizontal distance between shafts, in pixels.
+    pub shaft_spacing_px: f32,
+    /// Number of elevator shafts.
+    pub shaft_count: u32,
 }
 
 impl VisualScale {
-    /// Compute visual scale factors from the total shaft span (in sim units).
-    fn from_shaft_span(span: f32) -> Self {
+    /// Compute visual scale factors from the total shaft span (in sim units)
+    /// and elevator count.
+    fn from_scene(span: f32, shaft_count: u32, style: &VisualStyle) -> Self {
         let base_height = 15.0 * PPU;
         let actual_height = span * PPU;
         let s = (actual_height / base_height).max(1.0);
@@ -48,62 +59,112 @@ impl VisualScale {
             car_height: 30.0 * s,
             rider_radius: 6.0 * s,
             waiting_x_offset: -60.0 * s,
-            stop_line_width: 100.0 * s,
             stop_line_thickness: 2.0 * s,
-            label_offset_x: 70.0 * s,
+            label_offset_x: 60.0 * s,
             font_size: 14.0 * s,
             rider_spacing: 14.0 * s,
+            shaft_spacing_px: style.shaft_spacing_units * PPU,
+            shaft_count,
         }
+    }
+
+    /// Compute the center-x of shaft `index` (0-based).
+    #[must_use]
+    pub fn shaft_x(&self, index: u32) -> f32 {
+        let n = self.shaft_count.max(1) as f32;
+        let half = (n - 1.0) * 0.5;
+        (index as f32 - half) * self.shaft_spacing_px
+    }
+
+    /// Total horizontal extent of the bank of shafts (pixels), edge to edge.
+    #[must_use]
+    pub fn bank_width(&self) -> f32 {
+        if self.shaft_count <= 1 {
+            self.shaft_width
+        } else {
+            (self.shaft_count as f32 - 1.0).mul_add(self.shaft_spacing_px, self.shaft_width)
+        }
+    }
+
+    /// The x of the leftmost shaft center.
+    #[must_use]
+    pub fn leftmost_x(&self) -> f32 {
+        self.shaft_x(0)
     }
 }
 
-/// Marker component for the shaft background visual.
+/// Maps an elevator entity to its visual shaft index (0..n).
+#[derive(Resource, Default)]
+pub struct ElevatorShaftIndex(pub HashMap<EntityId, u32>);
+
+/// Marker for shaft background visuals.
 #[derive(Component)]
 pub struct ShaftVisual;
 
-/// Marker component linking a Bevy entity to a simulation elevator.
+/// Marker linking a Bevy entity to a simulation elevator (and its shaft index).
 #[derive(Component)]
 pub struct ElevatorVisual {
     /// The simulation entity ID of this elevator.
     pub entity_id: EntityId,
+    /// Zero-based shaft index (column).
+    pub shaft_index: u32,
 }
 
-/// Marker component for stop indicator lines.
+/// Marker for stop-line visuals.
 #[derive(Component)]
 pub struct StopVisual;
 
-/// Marker component for stop name labels.
+/// Marker for stop labels.
 #[derive(Component)]
 pub struct StopLabel;
 
-/// Marker component linking a Bevy entity to a simulation rider.
+/// Marker linking a Bevy entity to a simulation rider.
 #[derive(Component)]
 pub struct RiderVisual {
     /// The simulation entity ID of this rider.
     pub entity_id: EntityId,
 }
 
-/// Pre-allocated material handles per rider phase.
+/// Marker for a child "head" mesh inside a humanoid rider.
+#[derive(Component)]
+pub struct RiderHead;
+
+/// A door panel: child of an elevator car, translating in local X.
+#[derive(Component)]
+pub struct DoorPanel {
+    /// Which side — `-1.0` for left, `+1.0` for right.
+    pub side: f32,
+    /// Elevator entity this panel belongs to.
+    pub elevator: EntityId,
+    /// Panel half-travel in pixels (from closed center to fully-open edge).
+    pub travel: f32,
+}
+
+/// Pre-allocated rider materials.
 #[derive(Resource)]
 pub struct RiderMaterials {
-    /// Material for riders in the Waiting phase.
-    pub waiting: Handle<ColorMaterial>,
-    /// Material for riders in the Boarding phase.
+    /// Up-bound rider (destination above origin).
+    pub up: Handle<ColorMaterial>,
+    /// Down-bound rider (destination below origin).
+    pub down: Handle<ColorMaterial>,
+    /// Rider in Boarding phase.
     pub boarding: Handle<ColorMaterial>,
-    /// Material for riders in the Riding phase.
-    pub riding: Handle<ColorMaterial>,
-    /// Material for riders in the Exiting phase.
+    /// Rider in Exiting phase.
     pub exiting: Handle<ColorMaterial>,
 }
 
 /// Spawn building visuals.
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::too_many_lines)]
 pub fn spawn_building_visuals(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<ColorMaterial>>,
     sim: Res<SimulationRes>,
+    style: Res<VisualStyle>,
+    mut clear_color: ResMut<ClearColor>,
 ) {
+    clear_color.0 = style.background;
+
     let w = sim.sim.world();
     let stop_positions: Vec<(EntityId, f64, String)> = w
         .iter_stops()
@@ -123,61 +184,110 @@ pub fn spawn_building_visuals(
         .map(|s| s.1)
         .fold(f64::NEG_INFINITY, f64::max);
     let span = (max_pos - min_pos) as f32;
-    let vs = VisualScale::from_shaft_span(span);
+
+    let elevators: Vec<(EntityId, f64)> = w
+        .iter_elevators()
+        .map(|(eid, pos, _)| (eid, pos.value()))
+        .collect();
+    let shaft_count = elevators.len().max(1) as u32;
+
+    let vs = VisualScale::from_scene(span, shaft_count, &style);
 
     let shaft_height = span.mul_add(PPU, vs.car_height * 2.0);
     let shaft_center_y = f64::midpoint(min_pos, max_pos) as f32 * PPU;
 
-    // Shaft background.
-    commands.spawn((
-        Mesh2d(meshes.add(Rectangle::new(vs.shaft_width, shaft_height))),
-        MeshMaterial2d(materials.add(Color::srgba(0.2, 0.2, 0.25, 1.0))),
-        Transform::from_xyz(0.0, shaft_center_y, 0.0),
-        ShaftVisual,
-    ));
+    let shaft_mat = materials.add(style.shaft);
+    for i in 0..shaft_count {
+        commands.spawn((
+            Mesh2d(meshes.add(Rectangle::new(vs.shaft_width, shaft_height))),
+            MeshMaterial2d(shaft_mat.clone()),
+            Transform::from_xyz(vs.shaft_x(i), shaft_center_y, 0.0),
+            ShaftVisual,
+        ));
+    }
 
-    // Stop indicators and labels.
-    let stop_line_material = materials.add(Color::srgba(0.5, 0.5, 0.5, 1.0));
+    // Stop indicators + labels.
+    let stop_line_material = materials.add(style.stop_line);
+    let line_width = if style.stop_lines_span_all_shafts {
+        vs.bank_width() + vs.shaft_width
+    } else {
+        vs.shaft_width * 5.0
+    };
+    let label_x = vs.leftmost_x() - vs.label_offset_x;
     for (_eid, pos, name) in &stop_positions {
         let y = *pos as f32 * PPU;
 
         commands.spawn((
-            Mesh2d(meshes.add(Rectangle::new(vs.stop_line_width, vs.stop_line_thickness))),
+            Mesh2d(meshes.add(Rectangle::new(line_width, vs.stop_line_thickness))),
             MeshMaterial2d(stop_line_material.clone()),
             Transform::from_xyz(0.0, y, 0.1),
             StopVisual,
         ));
 
         commands.spawn((
-            Text2d::new(name),
+            Text2d::new(name.clone()),
             TextFont {
                 font_size: vs.font_size,
                 ..default()
             },
-            Transform::from_xyz(vs.label_offset_x, y, 0.1),
+            TextColor(style.text),
+            Transform::from_xyz(label_x, y, 0.1),
             StopLabel,
         ));
     }
 
-    // Elevator car(s).
-    let car_material = materials.add(Color::srgba(0.2, 0.5, 0.9, 1.0));
-    for (eid, pos, _car) in w.iter_elevators() {
-        let y = pos.value() as f32 * PPU;
-        commands.spawn((
-            Mesh2d(meshes.add(Rectangle::new(vs.car_width, vs.car_height))),
-            MeshMaterial2d(car_material.clone()),
-            Transform::from_xyz(0.0, y, 0.5),
-            ElevatorVisual { entity_id: eid },
+    // Elevator cars (with optional door panels as children).
+    let car_mat = materials.add(style.car);
+    let door_mat = materials.add(style.door_panel);
+    let car_mesh = meshes.add(Rectangle::new(vs.car_width, vs.car_height));
+    let panel_mesh = meshes.add(Rectangle::new(vs.car_width * 0.5, vs.car_height * 0.9));
+
+    let mut shaft_index_map: HashMap<EntityId, u32> = HashMap::new();
+    for (i, (eid, pos)) in elevators.iter().enumerate() {
+        let idx = i as u32;
+        shaft_index_map.insert(*eid, idx);
+        let x = vs.shaft_x(idx);
+        let y = *pos as f32 * PPU;
+
+        let mut car = commands.spawn((
+            Mesh2d(car_mesh.clone()),
+            MeshMaterial2d(car_mat.clone()),
+            Transform::from_xyz(x, y, 0.5),
+            ElevatorVisual {
+                entity_id: *eid,
+                shaft_index: idx,
+            },
         ));
+
+        if style.sliding_doors {
+            // Panels drawn *in front of* the car on z=0.6.
+            // Travel = car_width/4 from closed center to fully open.
+            let travel = vs.car_width * 0.25;
+            car.with_children(|parent| {
+                for side in [-1.0_f32, 1.0_f32] {
+                    parent.spawn((
+                        Mesh2d(panel_mesh.clone()),
+                        MeshMaterial2d(door_mat.clone()),
+                        Transform::from_xyz(side * vs.car_width * 0.25, 0.0, 0.1),
+                        DoorPanel {
+                            side,
+                            elevator: *eid,
+                            travel,
+                        },
+                    ));
+                }
+            });
+        }
     }
 
     let rider_mats = RiderMaterials {
-        waiting: materials.add(Color::srgba(0.2, 0.8, 0.3, 1.0)),
-        boarding: materials.add(Color::srgba(0.3, 0.9, 0.9, 1.0)),
-        riding: materials.add(Color::srgba(0.9, 0.8, 0.2, 1.0)),
-        exiting: materials.add(Color::srgba(0.9, 0.4, 0.2, 1.0)),
+        up: materials.add(style.rider_up),
+        down: materials.add(style.rider_down),
+        boarding: materials.add(style.rider_boarding),
+        exiting: materials.add(style.rider_exiting),
     };
     commands.insert_resource(rider_mats);
+    commands.insert_resource(ElevatorShaftIndex(shaft_index_map));
     commands.insert_resource(vs);
 }
 
@@ -194,8 +304,47 @@ pub fn sync_elevator_visuals(
     }
 }
 
-/// Spawn, update, and despawn rider visuals.
+/// Update door-panel child transforms from the core `DoorState`.
 #[allow(clippy::needless_pass_by_value)]
+pub fn sync_door_panels(sim: Res<SimulationRes>, mut query: Query<(&DoorPanel, &mut Transform)>) {
+    let w = sim.sim.world();
+    for (panel, mut t) in &mut query {
+        let Some(car) = w.elevator(panel.elevator) else {
+            continue;
+        };
+        let frac = door_open_fraction(*car.door());
+        let half_closed = panel.travel;
+        let offset = frac.mul_add(panel.travel, half_closed);
+        t.translation.x = panel.side * offset;
+    }
+}
+
+/// Compute the "open fraction" (0 = closed, 1 = fully open) for a door state.
+fn door_open_fraction(state: DoorState) -> f32 {
+    match state {
+        DoorState::Opening {
+            ticks_remaining,
+            close_duration,
+            ..
+        } => {
+            if close_duration == 0 {
+                1.0
+            } else {
+                1.0 - (ticks_remaining as f32 / close_duration as f32).clamp(0.0, 1.0)
+            }
+        }
+        DoorState::Open { .. } => 1.0,
+        DoorState::Closing { ticks_remaining } => {
+            // No known total — treat as normalized to a nominal 30-tick close.
+            // DoorState doesn't retain the original transition duration here.
+            (ticks_remaining as f32).clamp(0.0, 30.0) / 30.0
+        }
+        _ => 0.0, // Closed and any future non-exhaustive variants.
+    }
+}
+
+/// Spawn visuals for newly-appeared riders and despawn for gone ones.
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 pub fn sync_rider_visuals(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
@@ -203,17 +352,17 @@ pub fn sync_rider_visuals(
     existing: Query<(Entity, &RiderVisual)>,
     vs: Res<VisualScale>,
     rider_mats: Res<RiderMaterials>,
+    style: Res<VisualStyle>,
+    shaft_idx: Res<ElevatorShaftIndex>,
 ) {
     let w = sim.sim.world();
 
-    // Active rider entity IDs (not arrived/abandoned).
     let active_ids: std::collections::HashSet<EntityId> = w
         .iter_riders()
         .filter(|(_, r)| !matches!(r.phase(), RiderPhase::Arrived | RiderPhase::Abandoned))
         .map(|(eid, _)| eid)
         .collect();
 
-    // Despawn visuals for gone riders.
     for (entity, vis) in &existing {
         if !active_ids.contains(&vis.entity_id) {
             commands.entity(entity).despawn();
@@ -231,20 +380,44 @@ pub fn sync_rider_visuals(
             continue;
         }
 
-        let (x, y, mat_handle) = rider_visual_params(rider_eid, rider, w, &vs, &rider_mats);
+        let (x, y, mat) = rider_visual_params(rider_eid, rider, w, &vs, &rider_mats, &shaft_idx);
 
-        commands.spawn((
-            Mesh2d(meshes.add(Circle::new(vs.rider_radius))),
-            MeshMaterial2d(mat_handle),
-            Transform::from_xyz(x, y, 1.0),
-            RiderVisual {
-                entity_id: rider_eid,
-            },
-        ));
+        if style.humanoid_riders {
+            // Body (pill) on z=1.0, head (circle) on z=1.1 as child.
+            let body_w = vs.rider_radius * 1.4;
+            let body_h = vs.rider_radius * 2.4;
+            let head_r = vs.rider_radius * 0.75;
+            commands
+                .spawn((
+                    Mesh2d(meshes.add(Rectangle::new(body_w, body_h))),
+                    MeshMaterial2d(mat.clone()),
+                    Transform::from_xyz(x, y, 1.0),
+                    RiderVisual {
+                        entity_id: rider_eid,
+                    },
+                ))
+                .with_children(|parent| {
+                    parent.spawn((
+                        Mesh2d(meshes.add(Circle::new(head_r))),
+                        MeshMaterial2d(mat.clone()),
+                        Transform::from_xyz(0.0, body_h * 0.5 + head_r * 0.7, 0.05),
+                        RiderHead,
+                    ));
+                });
+        } else {
+            commands.spawn((
+                Mesh2d(meshes.add(Circle::new(vs.rider_radius))),
+                MeshMaterial2d(mat),
+                Transform::from_xyz(x, y, 1.0),
+                RiderVisual {
+                    entity_id: rider_eid,
+                },
+            ));
+        }
     }
 }
 
-/// Update positions of existing rider visuals.
+/// Update positions and colors of existing rider visuals.
 #[allow(clippy::needless_pass_by_value)]
 pub fn update_rider_positions(
     sim: Res<SimulationRes>,
@@ -252,13 +425,19 @@ pub fn update_rider_positions(
         &RiderVisual,
         &mut Transform,
         &mut MeshMaterial2d<ColorMaterial>,
+        &Children,
     )>,
+    mut child_mats: Query<
+        &mut MeshMaterial2d<ColorMaterial>,
+        (With<RiderHead>, Without<RiderVisual>),
+    >,
     rider_mats: Res<RiderMaterials>,
     vs: Res<VisualScale>,
+    shaft_idx: Res<ElevatorShaftIndex>,
 ) {
     let w = sim.sim.world();
 
-    for (vis, mut transform, mut mat_handle) in &mut query {
+    for (vis, mut transform, mut mat_handle, children) in &mut query {
         let Some(rider) = w.rider(vis.entity_id) else {
             continue;
         };
@@ -266,20 +445,29 @@ pub fn update_rider_positions(
             continue;
         }
 
-        let (x, y, handle) = rider_visual_params(vis.entity_id, rider, w, &vs, &rider_mats);
+        let (x, y, handle) =
+            rider_visual_params(vis.entity_id, rider, w, &vs, &rider_mats, &shaft_idx);
         transform.translation.x = x;
         transform.translation.y = y;
-        *mat_handle = MeshMaterial2d(handle);
+        *mat_handle = MeshMaterial2d(handle.clone());
+
+        // Keep the head color in sync.
+        for child in children.iter() {
+            if let Ok(mut head_mat) = child_mats.get_mut(child) {
+                *head_mat = MeshMaterial2d(handle.clone());
+            }
+        }
     }
 }
 
 /// Compute (x, y, material) for a rider visual based on its phase.
 fn rider_visual_params(
     rider_eid: EntityId,
-    rider: &elevator_core::components::Rider,
-    w: &elevator_core::world::World,
+    rider: &Rider,
+    w: &World,
     vs: &VisualScale,
     mats: &RiderMaterials,
+    shaft_idx: &ElevatorShaftIndex,
 ) -> (f32, f32, Handle<ColorMaterial>) {
     match rider.phase() {
         RiderPhase::Waiting => {
@@ -290,34 +478,67 @@ fn rider_visual_params(
             let mut hasher = std::collections::hash_map::DefaultHasher::new();
             rider_eid.hash(&mut hasher);
             let hash = hasher.finish();
-            let offset = ((hash % 5) as f32).mul_add(-vs.rider_spacing, vs.waiting_x_offset);
-            (offset, stop_y as f32 * PPU, mats.waiting.clone())
+            let col = (hash % 5) as f32;
+            let x = vs.leftmost_x() + vs.waiting_x_offset - col * vs.rider_spacing;
+            (
+                x,
+                stop_y as f32 * PPU,
+                direction_material(rider_eid, rider, w, mats),
+            )
         }
         RiderPhase::Boarding(elev_eid) => {
             let elev_y = w.position(elev_eid).map_or(0.0, Position::value);
-            (
-                vs.waiting_x_offset * 0.5,
-                elev_y as f32 * PPU,
-                mats.boarding.clone(),
-            )
+            let x = shaft_idx
+                .0
+                .get(&elev_eid)
+                .map_or(0.0, |i| vs.rider_radius.mul_add(-2.0, vs.shaft_x(*i)));
+            (x, elev_y as f32 * PPU, mats.boarding.clone())
         }
         RiderPhase::Riding(elev_eid) => {
             let elev_y = w.position(elev_eid).map_or(0.0, Position::value);
+            let shaft_x = shaft_idx.0.get(&elev_eid).map_or(0.0, |i| vs.shaft_x(*i));
             let idx = w
                 .elevator(elev_eid)
                 .and_then(|car| car.riders().iter().position(|r| *r == rider_eid))
                 .unwrap_or(0);
-            let x_offset = (idx as f32 % 3.0).mul_add(vs.rider_spacing, -vs.rider_spacing);
-            (x_offset, elev_y as f32 * PPU, mats.riding.clone())
+            let x_offset = (idx as f32 % 3.0 - 1.0) * vs.rider_spacing * 0.6;
+            (
+                shaft_x + x_offset,
+                elev_y as f32 * PPU,
+                direction_material(rider_eid, rider, w, mats),
+            )
         }
         RiderPhase::Exiting(elev_eid) => {
             let elev_y = w.position(elev_eid).map_or(0.0, Position::value);
-            (
-                vs.waiting_x_offset * 0.5,
-                elev_y as f32 * PPU,
-                mats.exiting.clone(),
-            )
+            let x = shaft_idx
+                .0
+                .get(&elev_eid)
+                .map_or(0.0, |i| vs.rider_radius.mul_add(2.0, vs.shaft_x(*i)));
+            (x, elev_y as f32 * PPU, mats.exiting.clone())
         }
-        _ => (0.0, 0.0, mats.waiting.clone()),
+        _ => (0.0, 0.0, mats.up.clone()),
+    }
+}
+
+/// Material for a rider based on travel direction (up = destination above origin).
+fn direction_material(
+    rider_eid: EntityId,
+    rider: &Rider,
+    w: &World,
+    mats: &RiderMaterials,
+) -> Handle<ColorMaterial> {
+    let origin_y = rider
+        .current_stop()
+        .and_then(|s| w.stop_position(s))
+        .unwrap_or(0.0);
+    let dest_y = w
+        .route(rider_eid)
+        .and_then(elevator_core::components::Route::final_destination)
+        .and_then(|s| w.stop_position(s))
+        .unwrap_or(origin_y);
+    if dest_y >= origin_y {
+        mats.up.clone()
+    } else {
+        mats.down.clone()
     }
 }

--- a/crates/elevator-bevy/src/rendering.rs
+++ b/crates/elevator-bevy/src/rendering.rs
@@ -104,11 +104,14 @@ impl VisualScale {
             car_width: 80.0 * s,
             car_height: 30.0 * s,
             rider_radius: 6.0 * s,
-            waiting_x_offset: -60.0 * s,
+            // Queue starts close to the leftmost shaft and grows leftward
+            // as more riders arrive — labels live further out at
+            // `label_offset_x` so the two never collide.
+            waiting_x_offset: -25.0 * s,
             stop_line_thickness: 2.0 * s,
-            label_offset_x: 60.0 * s,
+            label_offset_x: 200.0 * s,
             font_size: 14.0 * s,
-            rider_spacing: 14.0 * s,
+            rider_spacing: 12.0 * s,
             shaft_spacing_px: style.shaft_spacing_units * PPU,
             shaft_count,
         }
@@ -169,6 +172,10 @@ pub struct RiderFade {
 
 /// Per-frame change in rider scale during spawn-in / fade-out (~6 frames to reach 1).
 const FADE_STEP: f32 = 1.0 / 6.0;
+
+/// Maximum queue depth that's actually drawn; later slots overflow onto
+/// the last column. The chip on the right shows the true count.
+const MAX_QUEUE_COLS: usize = 6;
 
 /// Marker for shaft background visuals.
 #[derive(Component)]
@@ -752,7 +759,7 @@ fn rider_visual_params(
                 .and_then(|s| w.stop_position(s))
                 .unwrap_or(0.0);
             let slot = slots.0.get(&rider_eid).copied().unwrap_or(0);
-            let col = (slot % 5) as f32;
+            let col = slot.min(MAX_QUEUE_COLS - 1) as f32;
             let x = vs.leftmost_x() + vs.waiting_x_offset - col * vs.rider_spacing;
             (
                 x,

--- a/crates/elevator-bevy/src/rendering.rs
+++ b/crates/elevator-bevy/src/rendering.rs
@@ -30,6 +30,39 @@ pub const PPU: f32 = 40.0;
 /// Matches the `door_transition_ticks` default in `ElevatorConfig`.
 const CLOSING_FALLBACK_TICKS: f32 = 30.0;
 
+/// One cable segment's position and length.
+struct CableSeg {
+    /// Y offset from the shaft center.
+    offset: f32,
+    /// Dash length in pixels.
+    len: f32,
+}
+
+/// Compute dash offsets + lengths for a vertical cable of `total_height`
+/// pixels, alternating between `dash` and `gap`. Returns one entry per dash.
+fn cable_segments(total_height: f32, dash: f32, gap: f32) -> Vec<CableSeg> {
+    let period = dash + gap;
+    let count = (total_height / period).floor() as i32;
+    let start = (-total_height).mul_add(0.5, dash * 0.5);
+    (0..count)
+        .map(|i| CableSeg {
+            offset: (i as f32).mul_add(period, start),
+            len: dash,
+        })
+        .collect()
+}
+
+/// Centre x coordinates for horizontal dashes across `total_width`, with
+/// `dash`-long segments separated by `gap`-wide empty space.
+fn segment_positions(total_width: f32, dash: f32, gap: f32) -> Vec<f32> {
+    let period = dash + gap;
+    let count = (total_width / period).floor() as i32;
+    let start = (-total_width).mul_add(0.5, dash * 0.5);
+    (0..count)
+        .map(|i| (i as f32).mul_add(period, start))
+        .collect()
+}
+
 /// Computed per-scene visual sizes.
 #[derive(Resource)]
 pub struct VisualScale {
@@ -221,6 +254,7 @@ pub fn spawn_building_visuals(
     let shaft_center_y = f64::midpoint(min_pos, max_pos) as f32 * PPU;
 
     let shaft_mat = materials.add(style.shaft);
+    let cable_mat = materials.add(style.stop_line.with_alpha(0.35));
     for i in 0..shaft_count {
         commands.spawn((
             Mesh2d(meshes.add(Rectangle::new(vs.shaft_width, shaft_height))),
@@ -228,11 +262,24 @@ pub fn spawn_building_visuals(
             Transform::from_xyz(vs.shaft_x(i), shaft_center_y, 0.0),
             ShaftVisual,
         ));
+
+        if style.shaft_cables {
+            // Thin dashed vertical cable drawn just in front of the shaft
+            // background — gives the empty shaft a bit of technical detail.
+            let cable_width = (vs.shaft_width * 0.1).max(1.0);
+            for seg in cable_segments(shaft_height, 16.0, 10.0) {
+                commands.spawn((
+                    Mesh2d(meshes.add(Rectangle::new(cable_width, seg.len))),
+                    MeshMaterial2d(cable_mat.clone()),
+                    Transform::from_xyz(vs.shaft_x(i), shaft_center_y + seg.offset, 0.05),
+                ));
+            }
+        }
     }
 
     // Stop indicators + labels.
     let stop_line_material = materials.add(style.stop_line);
-    let line_width = if style.stop_lines_span_all_shafts {
+    let total_line_width = if style.stop_lines_span_all_shafts {
         vs.bank_width() + vs.shaft_width
     } else {
         vs.shaft_width * 5.0
@@ -241,12 +288,27 @@ pub fn spawn_building_visuals(
     for (_eid, pos, name) in &stop_positions {
         let y = *pos as f32 * PPU;
 
-        commands.spawn((
-            Mesh2d(meshes.add(Rectangle::new(line_width, vs.stop_line_thickness))),
-            MeshMaterial2d(stop_line_material.clone()),
-            Transform::from_xyz(0.0, y, 0.1),
-            StopVisual,
-        ));
+        if style.dashed_stop_lines {
+            // Short dashes separated by small gaps across the full span.
+            let dash_len = 14.0;
+            let gap_len = 9.0;
+            let segments = segment_positions(total_line_width, dash_len, gap_len);
+            for seg_x in segments {
+                commands.spawn((
+                    Mesh2d(meshes.add(Rectangle::new(dash_len, vs.stop_line_thickness))),
+                    MeshMaterial2d(stop_line_material.clone()),
+                    Transform::from_xyz(seg_x, y, 0.1),
+                    StopVisual,
+                ));
+            }
+        } else {
+            commands.spawn((
+                Mesh2d(meshes.add(Rectangle::new(total_line_width, vs.stop_line_thickness))),
+                MeshMaterial2d(stop_line_material.clone()),
+                Transform::from_xyz(0.0, y, 0.1),
+                StopVisual,
+            ));
+        }
 
         commands.spawn((
             Text2d::new(name.clone()),

--- a/crates/elevator-bevy/src/rendering.rs
+++ b/crates/elevator-bevy/src/rendering.rs
@@ -26,9 +26,9 @@ const IDLE_BOB_FREQ: f32 = 0.14;
 /// Pixels per simulation distance unit.
 pub const PPU: f32 = 40.0;
 
-/// Fallback close duration (ticks) for `DoorState::Closing`, which drops the
-/// total because the core FSM doesn't retain it through the transition.
-/// Matches the `door_transition_ticks` default in `ElevatorConfig`.
+/// Fallback close duration (ticks) used when `DoorState::Closing` arrives
+/// from a snapshot written before the variant carried `total_duration`.
+/// Matches the historical `door_transition_ticks` default in `ElevatorConfig`.
 const CLOSING_FALLBACK_TICKS: f32 = 30.0;
 
 /// One cable segment's position and length.
@@ -526,9 +526,18 @@ fn door_open_fraction(state: DoorState) -> f32 {
             }
         }
         DoorState::Open { .. } => 1.0,
-        DoorState::Closing { ticks_remaining } => {
-            // `Closing` drops `close_duration`; fall back to the known default.
-            (ticks_remaining as f32).clamp(0.0, CLOSING_FALLBACK_TICKS) / CLOSING_FALLBACK_TICKS
+        DoorState::Closing {
+            ticks_remaining,
+            total_duration,
+        } => {
+            // total_duration == 0 means a pre-field snapshot; use the
+            // historical default so the panels still animate plausibly.
+            let total = if total_duration == 0 {
+                CLOSING_FALLBACK_TICKS
+            } else {
+                total_duration as f32
+            };
+            (ticks_remaining as f32 / total).clamp(0.0, 1.0)
         }
         _ => 0.0, // Closed and any future non-exhaustive variants.
     }

--- a/crates/elevator-bevy/src/rendering.rs
+++ b/crates/elevator-bevy/src/rendering.rs
@@ -18,6 +18,11 @@ use crate::style::VisualStyle;
 /// Pixels per simulation distance unit.
 pub const PPU: f32 = 40.0;
 
+/// Fallback close duration (ticks) for `DoorState::Closing`, which drops the
+/// total because the core FSM doesn't retain it through the transition.
+/// Matches the `door_transition_ticks` default in `ElevatorConfig`.
+const CLOSING_FALLBACK_TICKS: f32 = 30.0;
+
 /// Computed per-scene visual sizes.
 #[derive(Resource)]
 pub struct VisualScale {
@@ -335,9 +340,8 @@ fn door_open_fraction(state: DoorState) -> f32 {
         }
         DoorState::Open { .. } => 1.0,
         DoorState::Closing { ticks_remaining } => {
-            // No known total — treat as normalized to a nominal 30-tick close.
-            // DoorState doesn't retain the original transition duration here.
-            (ticks_remaining as f32).clamp(0.0, 30.0) / 30.0
+            // `Closing` drops `close_duration`; fall back to the known default.
+            (ticks_remaining as f32).clamp(0.0, CLOSING_FALLBACK_TICKS) / CLOSING_FALLBACK_TICKS
         }
         _ => 0.0, // Closed and any future non-exhaustive variants.
     }

--- a/crates/elevator-bevy/src/rendering.rs
+++ b/crates/elevator-bevy/src/rendering.rs
@@ -285,6 +285,40 @@ pub fn spawn_building_visuals(
     let shaft_height = span.mul_add(PPU, vs.car_height * 2.0);
     let shaft_center_y = f64::midpoint(min_pos, max_pos) as f32 * PPU;
 
+    // Optional building-exterior backdrop drawn behind everything.
+    if let Some(backdrop) = style.building_backdrop {
+        let backdrop_mat = materials.add(backdrop);
+        let pad_x = vs.label_offset_x * 1.1;
+        let pad_y = vs.car_height * 1.5;
+        let backdrop_w = vs.bank_width() + pad_x * 2.0;
+        let backdrop_h = shaft_height + pad_y * 2.0;
+        commands.spawn((
+            Mesh2d(meshes.add(Rectangle::new(backdrop_w, backdrop_h))),
+            MeshMaterial2d(backdrop_mat),
+            Transform::from_xyz(0.0, shaft_center_y, -0.2),
+        ));
+
+        // Optional alternating floor bands inside the backdrop.
+        if let Some((odd, even)) = style.floor_band {
+            let mut sorted_y: Vec<f32> = stop_positions
+                .iter()
+                .map(|(_, p, _)| *p as f32 * PPU)
+                .collect();
+            sorted_y.sort_by(f32::total_cmp);
+            for (i, ys) in sorted_y.windows(2).enumerate() {
+                let (y0, y1) = (ys[0], ys[1]);
+                let mid = f32::midpoint(y0, y1);
+                let height = (y1 - y0).abs();
+                let mat = materials.add(if i % 2 == 0 { odd } else { even });
+                commands.spawn((
+                    Mesh2d(meshes.add(Rectangle::new(backdrop_w, height))),
+                    MeshMaterial2d(mat),
+                    Transform::from_xyz(0.0, mid, -0.15),
+                ));
+            }
+        }
+    }
+
     let shaft_mat = materials.add(style.shaft);
     let cable_mat = materials.add(style.stop_line.with_alpha(0.35));
     for i in 0..shaft_count {
@@ -354,11 +388,21 @@ pub fn spawn_building_visuals(
         ));
     }
 
-    // Elevator cars (with optional door panels as children).
-    let car_mat = materials.add(style.car);
+    // Elevator cars (with optional door panels as children). Each car
+    // pulls its body color from `car_palette` so they read as distinct
+    // vehicles; if the palette is empty we fall back to `style.car`.
     let door_mat = materials.add(style.door_panel);
     let car_mesh = meshes.add(Rectangle::new(vs.car_width, vs.car_height));
-    let panel_mesh = meshes.add(Rectangle::new(vs.car_width * 0.5, vs.car_height * 0.9));
+    // Door panels occupy the central horizontal band of the car so the
+    // colored body stays visible at top and bottom even when closed.
+    let panel_mesh = meshes.add(Rectangle::new(vs.car_width * 0.5, vs.car_height * 0.65));
+    let car_color = |idx: usize| -> Color {
+        if style.car_palette.is_empty() {
+            style.car
+        } else {
+            style.car_palette[idx % style.car_palette.len()]
+        }
+    };
 
     let mut shaft_index_map: HashMap<EntityId, u32> = HashMap::new();
     for (i, (eid, pos)) in elevators.iter().enumerate() {
@@ -366,10 +410,11 @@ pub fn spawn_building_visuals(
         shaft_index_map.insert(*eid, idx);
         let x = vs.shaft_x(idx);
         let y = *pos as f32 * PPU;
+        let car_mat = materials.add(car_color(i));
 
         let mut car = commands.spawn((
             Mesh2d(car_mesh.clone()),
-            MeshMaterial2d(car_mat.clone()),
+            MeshMaterial2d(car_mat),
             Transform::from_xyz(x, y, 0.5),
             ElevatorVisual {
                 entity_id: *eid,
@@ -382,7 +427,7 @@ pub fn spawn_building_visuals(
             // Travel = car_width/4 from closed center to fully open.
             let travel = vs.car_width * 0.25;
             let arrow_mesh = meshes.add(RegularPolygon::new(vs.rider_radius * 0.9, 3));
-            let arrow_mat = materials.add(style.background);
+            let arrow_mat = materials.add(style.text);
             car.with_children(|parent| {
                 for side in [-1.0_f32, 1.0_f32] {
                     parent.spawn((

--- a/crates/elevator-bevy/src/style.rs
+++ b/crates/elevator-bevy/src/style.rs
@@ -44,6 +44,15 @@ pub struct VisualStyle {
     pub dashed_stop_lines: bool,
     /// Draw a thin vertical dashed cable inside each shaft.
     pub shaft_cables: bool,
+    /// Optional building-exterior backdrop drawn behind the shafts.
+    /// `None` = no backdrop (current default).
+    pub building_backdrop: Option<Color>,
+    /// Optional alternating-floor band colors `(odd, even)` painted as
+    /// horizontal stripes inside the backdrop.
+    pub floor_band: Option<(Color, Color)>,
+    /// Per-car body colors. If shorter than the elevator count, the last
+    /// color repeats. If empty, `car` is used for every car.
+    pub car_palette: Vec<Color>,
 }
 
 impl Default for VisualStyle {
@@ -66,33 +75,48 @@ impl Default for VisualStyle {
             sliding_doors: false,
             dashed_stop_lines: false,
             shaft_cables: false,
+            building_backdrop: None,
+            floor_band: None,
+            car_palette: Vec::new(),
         }
     }
 }
 
 impl VisualStyle {
-    /// Minimal "blueprint" palette: paper background, dark line art, indigo
-    /// car, mint/red riders by direction. Designed for the demo GIF.
+    /// SimTower-inspired palette: pale-blue sky background, cream
+    /// building exterior with subtle floor banding, dark elevator
+    /// shafts, three differently-colored cars so they read as distinct
+    /// vehicles even when stacked vertically.
     #[must_use]
-    #[allow(clippy::missing_const_for_fn)] // Color::srgba is not const.
-    pub fn blueprint() -> Self {
+    #[allow(clippy::missing_const_for_fn)] // Color::srgba and vec! are not const.
+    pub fn simtower() -> Self {
         Self {
-            background: Color::srgba(0.968, 0.960, 0.933, 1.0), // #f7f5ee
-            shaft: Color::srgba(0.88, 0.87, 0.84, 1.0),
-            stop_line: Color::srgba(0.16, 0.16, 0.16, 1.0),
-            text: Color::srgba(0.10, 0.10, 0.10, 1.0),
-            car: Color::srgba(0.117, 0.251, 0.686, 1.0), // #1e40af
-            door_panel: Color::srgba(0.85, 0.87, 0.92, 1.0),
-            rider_up: Color::srgba(0.019, 0.588, 0.412, 1.0), // #059669
-            rider_down: Color::srgba(0.862, 0.149, 0.149, 1.0), // #dc2626
-            rider_boarding: Color::srgba(0.117, 0.251, 0.686, 1.0),
-            rider_exiting: Color::srgba(0.39, 0.39, 0.39, 1.0),
+            background: Color::srgba(0.65, 0.78, 0.90, 1.0), // sky blue
+            shaft: Color::srgba(0.18, 0.18, 0.22, 1.0),      // dark slate
+            stop_line: Color::srgba(0.30, 0.27, 0.22, 1.0),  // brown
+            text: Color::srgba(0.14, 0.14, 0.16, 1.0),
+            car: Color::srgba(0.78, 0.18, 0.18, 1.0), // unused when car_palette set
+            door_panel: Color::srgba(0.95, 0.93, 0.86, 1.0),
+            rider_up: Color::srgba(0.10, 0.38, 0.66, 1.0),
+            rider_down: Color::srgba(0.78, 0.30, 0.20, 1.0),
+            rider_boarding: Color::srgba(0.95, 0.78, 0.20, 1.0),
+            rider_exiting: Color::srgba(0.40, 0.40, 0.45, 1.0),
             shaft_spacing_units: 3.5,
             stop_lines_span_all_shafts: true,
             humanoid_riders: true,
             sliding_doors: true,
-            dashed_stop_lines: true,
-            shaft_cables: true,
+            dashed_stop_lines: false,
+            shaft_cables: false,
+            building_backdrop: Some(Color::srgba(0.95, 0.92, 0.83, 1.0)),
+            floor_band: Some((
+                Color::srgba(0.97, 0.95, 0.88, 1.0),
+                Color::srgba(0.92, 0.88, 0.78, 1.0),
+            )),
+            car_palette: vec![
+                Color::srgba(0.78, 0.18, 0.18, 1.0), // red
+                Color::srgba(0.95, 0.65, 0.10, 1.0), // amber
+                Color::srgba(0.10, 0.42, 0.20, 1.0), // green
+            ],
         }
     }
 }

--- a/crates/elevator-bevy/src/style.rs
+++ b/crates/elevator-bevy/src/style.rs
@@ -10,6 +10,7 @@ use bevy::prelude::*;
 
 /// Palette + layout knobs consulted by the rendering module.
 #[derive(Resource, Clone)]
+#[allow(clippy::struct_excessive_bools)] // Flat flags are clearer than a nested enum here.
 pub struct VisualStyle {
     /// Clear color / background.
     pub background: Color,
@@ -39,6 +40,10 @@ pub struct VisualStyle {
     pub humanoid_riders: bool,
     /// Render two-panel sliding doors on the elevator car.
     pub sliding_doors: bool,
+    /// Draw stop lines as short dashes instead of one continuous bar.
+    pub dashed_stop_lines: bool,
+    /// Draw a thin vertical dashed cable inside each shaft.
+    pub shaft_cables: bool,
 }
 
 impl Default for VisualStyle {
@@ -59,6 +64,8 @@ impl Default for VisualStyle {
             stop_lines_span_all_shafts: false,
             humanoid_riders: false,
             sliding_doors: false,
+            dashed_stop_lines: false,
+            shaft_cables: false,
         }
     }
 }
@@ -84,6 +91,8 @@ impl VisualStyle {
             stop_lines_span_all_shafts: true,
             humanoid_riders: true,
             sliding_doors: true,
+            dashed_stop_lines: true,
+            shaft_cables: true,
         }
     }
 }

--- a/crates/elevator-bevy/src/style.rs
+++ b/crates/elevator-bevy/src/style.rs
@@ -1,0 +1,89 @@
+//! Palette and layout knobs for the rendering layer.
+//!
+//! The default matches the dark look used by the binary. Examples or games
+//! can insert a replacement `VisualStyle` resource before the rendering
+//! startup systems run to override the whole look — see
+//! [`examples/showcase.rs`](../../examples/showcase.rs) for the "blueprint"
+//! palette used in the repo's demo GIF.
+
+use bevy::prelude::*;
+
+/// Palette + layout knobs consulted by the rendering module.
+#[derive(Resource, Clone)]
+pub struct VisualStyle {
+    /// Clear color / background.
+    pub background: Color,
+    /// Shaft fill color.
+    pub shaft: Color,
+    /// Horizontal stop-line color.
+    pub stop_line: Color,
+    /// Stop label / text color.
+    pub text: Color,
+    /// Elevator car body color.
+    pub car: Color,
+    /// Elevator door panel color (slightly darker than the car body).
+    pub door_panel: Color,
+    /// Rider color when destination is above current stop.
+    pub rider_up: Color,
+    /// Rider color when destination is below current stop.
+    pub rider_down: Color,
+    /// Rider color used in the Boarding phase.
+    pub rider_boarding: Color,
+    /// Rider color used in the Exiting phase.
+    pub rider_exiting: Color,
+    /// Horizontal spacing between elevator shafts, in sim units.
+    pub shaft_spacing_units: f32,
+    /// Draw stop lines as one continuous bar spanning every shaft.
+    pub stop_lines_span_all_shafts: bool,
+    /// Render humanoid (pill + head) rider shapes instead of plain circles.
+    pub humanoid_riders: bool,
+    /// Render two-panel sliding doors on the elevator car.
+    pub sliding_doors: bool,
+}
+
+impl Default for VisualStyle {
+    fn default() -> Self {
+        // The original dark palette used by the binary.
+        Self {
+            background: Color::srgba(0.08, 0.08, 0.1, 1.0),
+            shaft: Color::srgba(0.2, 0.2, 0.25, 1.0),
+            stop_line: Color::srgba(0.5, 0.5, 0.5, 1.0),
+            text: Color::WHITE,
+            car: Color::srgba(0.2, 0.5, 0.9, 1.0),
+            door_panel: Color::srgba(0.12, 0.32, 0.6, 1.0),
+            rider_up: Color::srgba(0.2, 0.8, 0.3, 1.0),
+            rider_down: Color::srgba(0.9, 0.4, 0.4, 1.0),
+            rider_boarding: Color::srgba(0.3, 0.9, 0.9, 1.0),
+            rider_exiting: Color::srgba(0.9, 0.8, 0.2, 1.0),
+            shaft_spacing_units: 3.0,
+            stop_lines_span_all_shafts: false,
+            humanoid_riders: false,
+            sliding_doors: false,
+        }
+    }
+}
+
+impl VisualStyle {
+    /// Minimal "blueprint" palette: paper background, dark line art, indigo
+    /// car, mint/red riders by direction. Designed for the demo GIF.
+    #[must_use]
+    #[allow(clippy::missing_const_for_fn)] // Color::srgba is not const.
+    pub fn blueprint() -> Self {
+        Self {
+            background: Color::srgba(0.968, 0.960, 0.933, 1.0), // #f7f5ee
+            shaft: Color::srgba(0.88, 0.87, 0.84, 1.0),
+            stop_line: Color::srgba(0.16, 0.16, 0.16, 1.0),
+            text: Color::srgba(0.10, 0.10, 0.10, 1.0),
+            car: Color::srgba(0.117, 0.251, 0.686, 1.0), // #1e40af
+            door_panel: Color::srgba(0.85, 0.87, 0.92, 1.0),
+            rider_up: Color::srgba(0.019, 0.588, 0.412, 1.0), // #059669
+            rider_down: Color::srgba(0.862, 0.149, 0.149, 1.0), // #dc2626
+            rider_boarding: Color::srgba(0.117, 0.251, 0.686, 1.0),
+            rider_exiting: Color::srgba(0.39, 0.39, 0.39, 1.0),
+            shaft_spacing_units: 3.5,
+            stop_lines_span_all_shafts: true,
+            humanoid_riders: true,
+            sliding_doors: true,
+        }
+    }
+}

--- a/crates/elevator-bevy/src/ui.rs
+++ b/crates/elevator-bevy/src/ui.rs
@@ -4,20 +4,36 @@ use bevy::prelude::*;
 use elevator_core::components::{ElevatorPhase, RiderPhase};
 
 use crate::sim_bridge::{SimSpeed, SimulationRes};
+use crate::style::VisualStyle;
 
 /// Marker for the stats HUD text.
 #[derive(Component)]
 pub struct HudText;
 
+/// Controls visibility of the keybinding help text at the bottom-left.
+#[derive(Resource, Clone, Copy)]
+pub struct ShowControlsHint(pub bool);
+
+impl Default for ShowControlsHint {
+    fn default() -> Self {
+        Self(true)
+    }
+}
+
 /// Spawn the HUD overlay.
-pub fn spawn_hud(mut commands: Commands) {
+#[allow(clippy::needless_pass_by_value)]
+pub fn spawn_hud(
+    mut commands: Commands,
+    style: Res<VisualStyle>,
+    show_hint: Option<Res<ShowControlsHint>>,
+) {
     commands.spawn((
         Text::new(""),
         TextFont {
             font_size: 16.0,
             ..default()
         },
-        TextColor(Color::WHITE),
+        TextColor(style.text),
         Node {
             position_type: PositionType::Absolute,
             top: Val::Px(10.0),
@@ -27,20 +43,33 @@ pub fn spawn_hud(mut commands: Commands) {
         HudText,
     ));
 
-    commands.spawn((
-        Text::new("Space: pause | 1: 1x | 2: 2x | 3: 10x"),
-        TextFont {
-            font_size: 13.0,
-            ..default()
-        },
-        TextColor(Color::srgba(0.6, 0.6, 0.6, 1.0)),
-        Node {
-            position_type: PositionType::Absolute,
-            bottom: Val::Px(10.0),
-            left: Val::Px(10.0),
-            ..default()
-        },
-    ));
+    if show_hint.is_none_or(|r| r.0) {
+        commands.spawn((
+            Text::new("Space: pause | 1: 1x | 2: 2x | 3: 10x"),
+            TextFont {
+                font_size: 13.0,
+                ..default()
+            },
+            TextColor(muted(style.text)),
+            Node {
+                position_type: PositionType::Absolute,
+                bottom: Val::Px(10.0),
+                left: Val::Px(10.0),
+                ..default()
+            },
+        ));
+    }
+}
+
+/// Dim a text color by ~40% toward its background-agnostic midpoint.
+fn muted(c: Color) -> Color {
+    let l = c.to_linear();
+    Color::linear_rgba(
+        l.red.mul_add(0.55, 0.22),
+        l.green.mul_add(0.55, 0.22),
+        l.blue.mul_add(0.55, 0.22),
+        l.alpha,
+    )
 }
 
 /// Update the HUD each frame with detailed stats.

--- a/crates/elevator-core/src/door.rs
+++ b/crates/elevator-core/src/door.rs
@@ -28,6 +28,14 @@ pub enum DoorState {
     Closing {
         /// Ticks left in the closing transition.
         ticks_remaining: u32,
+        /// Total ticks the closing transition takes (carried so consumers
+        /// like animation layers can compute a closing fraction without
+        /// looking up the elevator config).
+        ///
+        /// Defaults to `0` for snapshots written before this field existed
+        /// — consumers should treat `0` as "duration unknown".
+        #[serde(default)]
+        total_duration: u32,
     },
 }
 
@@ -55,7 +63,9 @@ impl std::fmt::Display for DoorState {
             Self::Open {
                 ticks_remaining, ..
             } => write!(f, "Open({ticks_remaining})"),
-            Self::Closing { ticks_remaining } => write!(f, "Closing({ticks_remaining})"),
+            Self::Closing {
+                ticks_remaining, ..
+            } => write!(f, "Closing({ticks_remaining})"),
         }
     }
 }
@@ -113,6 +123,7 @@ impl DoorState {
                     let cd = *close_duration;
                     *self = Self::Closing {
                         ticks_remaining: cd,
+                        total_duration: cd,
                     };
                     DoorTransition::FinishedOpen
                 } else {
@@ -120,7 +131,9 @@ impl DoorState {
                     DoorTransition::None
                 }
             }
-            Self::Closing { ticks_remaining } => {
+            Self::Closing {
+                ticks_remaining, ..
+            } => {
                 if *ticks_remaining <= 1 {
                     *self = Self::Closed;
                     DoorTransition::FinishedClosing

--- a/crates/elevator-core/src/tests/door_tests.rs
+++ b/crates/elevator-core/src/tests/door_tests.rs
@@ -48,14 +48,32 @@ fn full_door_cycle() {
     assert_eq!(door.tick(), DoorTransition::None); // 1 remaining
 
     assert_eq!(door.tick(), DoorTransition::FinishedOpen);
-    assert_eq!(door, DoorState::Closing { ticks_remaining: 3 });
+    assert_eq!(
+        door,
+        DoorState::Closing {
+            ticks_remaining: 3,
+            total_duration: 3,
+        }
+    );
 
     // Closing phase: 3 ticks total, transitions on the 3rd
     assert_eq!(door.tick(), DoorTransition::None);
-    assert!(matches!(door, DoorState::Closing { ticks_remaining: 2 }));
+    assert!(matches!(
+        door,
+        DoorState::Closing {
+            ticks_remaining: 2,
+            ..
+        }
+    ));
 
     assert_eq!(door.tick(), DoorTransition::None);
-    assert!(matches!(door, DoorState::Closing { ticks_remaining: 1 }));
+    assert!(matches!(
+        door,
+        DoorState::Closing {
+            ticks_remaining: 1,
+            ..
+        }
+    ));
 
     assert_eq!(door.tick(), DoorTransition::FinishedClosing);
     assert_eq!(door, DoorState::Closed);
@@ -82,7 +100,10 @@ fn is_open_and_is_closed() {
     assert!(open.is_open());
     assert!(!open.is_closed());
 
-    let closing = DoorState::Closing { ticks_remaining: 2 };
+    let closing = DoorState::Closing {
+        ticks_remaining: 2,
+        total_duration: 2,
+    };
     assert!(!closing.is_open());
     assert!(!closing.is_closed());
 }
@@ -95,7 +116,13 @@ fn single_tick_durations() {
     assert!(door.is_open());
 
     assert_eq!(door.tick(), DoorTransition::FinishedOpen);
-    assert!(matches!(door, DoorState::Closing { ticks_remaining: 1 }));
+    assert!(matches!(
+        door,
+        DoorState::Closing {
+            ticks_remaining: 1,
+            ..
+        }
+    ));
 
     assert_eq!(door.tick(), DoorTransition::FinishedClosing);
     assert!(door.is_closed());

--- a/scripts/record_gif.sh
+++ b/scripts/record_gif.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Record the showcase scene as assets/demo.gif.
+#
+# Pipeline:
+#   1. Run the `showcase` example with --record; it writes 200 PNG frames
+#      into .recording/ (20 fps source, deterministic).
+#   2. Use ffmpeg's two-pass palette filter for high-quality GIF encoding.
+#
+# Requirements: cargo, ffmpeg.
+# Usage: ./scripts/record_gif.sh [output_path]
+
+set -euo pipefail
+
+OUT="${1:-assets/demo.gif}"
+FRAME_DIR=".recording"
+FPS=20
+
+cd "$(dirname "$0")/.."
+
+echo "==> Building showcase (release)"
+cargo build --release --example showcase --quiet
+
+echo "==> Capturing $FRAME_DIR/frame_*.png"
+cargo run --release --example showcase --quiet -- --record
+
+if ! command -v ffmpeg >/dev/null 2>&1; then
+    echo "ffmpeg not found — PNG frames are in $FRAME_DIR/"
+    exit 1
+fi
+
+echo "==> Building palette"
+ffmpeg -y -loglevel error \
+    -framerate "$FPS" -i "$FRAME_DIR/frame_%05d.png" \
+    -vf "fps=$FPS,palettegen=stats_mode=diff" \
+    "$FRAME_DIR/palette.png"
+
+echo "==> Encoding $OUT"
+mkdir -p "$(dirname "$OUT")"
+ffmpeg -y -loglevel error \
+    -framerate "$FPS" -i "$FRAME_DIR/frame_%05d.png" \
+    -i "$FRAME_DIR/palette.png" \
+    -lavfi "fps=$FPS [x]; [x][1:v] paletteuse=dither=bayer:bayer_scale=3:diff_mode=rectangle" \
+    "$OUT"
+
+SIZE=$(du -h "$OUT" | cut -f1)
+echo "==> Done: $OUT ($SIZE)"


### PR DESCRIPTION
## Summary
- Adds `crates/elevator-bevy/examples/showcase.rs` — 3 elevators × 8 floors, blueprint palette, humanoid riders, sliding doors, scripted cinematic camera tuned for a 10-second loop
- New modules: `style` (palette knobs via `VisualStyle` resource), `cinematic` (tick-indexed `ShotTimeline` with smoothstep blends), `recorder` (deterministic PNG frame capture via Bevy's `Screenshot` API)
- `scripts/record_gif.sh` wraps the example with ffmpeg's two-pass palette filter to produce `assets/demo.gif`; README embeds the GIF and documents the workflow
- `elevator-bevy` is now a lib+bin so the example can import rendering / camera / HUD modules

## Test plan
- [x] `cargo test --workspace --lib --bins` (450 core tests pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo build --release --example showcase` builds
- [ ] Run `./scripts/record_gif.sh` on a machine with a display + ffmpeg to generate `assets/demo.gif` (can't run headless in sandbox) and amend onto this branch
- [ ] `cargo run -p elevator-bevy` (binary) still renders correctly with the default dark palette
- [ ] Inspect the recorded GIF for visual polish, then let greptile review before merging