### PR TITLE
fix: prevent stuck-elevator door-cycle loops in multi-line configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "5.4.0"
+version = "5.5.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/systems/advance_queue.rs
+++ b/crates/elevator-core/src/systems/advance_queue.rs
@@ -78,6 +78,11 @@ pub fn run(
                     if let Some(q) = world.destination_queue_mut(eid) {
                         q.pop_front();
                     }
+                    // Reset indicators to both-lit so stale direction flags
+                    // from a prior trip don't filter out waiting riders in
+                    // the loading phase. Mirrors dispatch.rs's arrive-in-place
+                    // semantics.
+                    update_indicators(world, events, eid, true, true, ctx.tick);
                     events.emit(Event::ElevatorArrived {
                         elevator: eid,
                         at_stop: next,

--- a/crates/elevator-core/src/systems/advance_queue.rs
+++ b/crates/elevator-core/src/systems/advance_queue.rs
@@ -90,6 +90,7 @@ pub fn run(
                     });
                     if let Some(car) = world.elevator_mut(eid) {
                         car.phase = ElevatorPhase::DoorOpening;
+                        car.target_stop = Some(next);
                         car.door =
                             DoorState::request_open(car.door_transition_ticks, car.door_open_ticks);
                     }

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -1,6 +1,6 @@
 //! Phase 2: assign idle/stopped elevators to stops via the dispatch strategy.
 
-use crate::components::{ElevatorPhase, RiderPhase, Route};
+use crate::components::{ElevatorPhase, RiderPhase, Route, TransportMode};
 use crate::dispatch::{
     DispatchDecision, DispatchManifest, DispatchStrategy, ElevatorGroup, RiderInfo,
 };
@@ -88,6 +88,13 @@ pub fn run(
 
                     // Already at this stop — open doors directly, don't push.
                     if current_stop == Some(stop_eid) {
+                        // Pop the queue front if it equals this stop, mirroring
+                        // the arrive-in-place branch of advance_queue.
+                        if let Some(q) = world.destination_queue_mut(eid)
+                            && q.front() == Some(stop_eid)
+                        {
+                            q.pop_front();
+                        }
                         events.emit(Event::ElevatorArrived {
                             elevator: eid,
                             at_stop: stop_eid,
@@ -95,6 +102,7 @@ pub fn run(
                         });
                         if let Some(car) = world.elevator_mut(eid) {
                             car.phase = ElevatorPhase::DoorOpening;
+                            car.target_stop = Some(stop_eid);
                             car.door = crate::door::DoorState::request_open(
                                 car.door_transition_ticks,
                                 car.door_open_ticks,
@@ -202,6 +210,26 @@ fn build_manifest(
         if let Some(stop) = rider.current_stop
             && group.stop_entities().contains(&stop)
         {
+            // Group/line match: only include riders whose current route leg targets
+            // this group (or one of its lines). Mirrors the filter in systems/loading.rs
+            // so dispatch and loading agree about which riders this group can serve.
+            if let Some(route) = world.route(rid)
+                && let Some(leg) = route.current()
+            {
+                match leg.via {
+                    TransportMode::Group(g) => {
+                        if g != group.id() {
+                            continue;
+                        }
+                    }
+                    TransportMode::Line(l) => {
+                        if !group.lines().iter().any(|line| line.entity() == l) {
+                            continue;
+                        }
+                    }
+                    TransportMode::Walk => continue,
+                }
+            }
             let destination = world.route(rid).and_then(Route::current_destination);
             let wait_ticks = tick.saturating_sub(rider.spawn_tick);
             manifest

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -10,6 +10,7 @@ use crate::world::World;
 use ordered_float::OrderedFloat;
 
 use super::PhaseContext;
+use super::dispatch::update_indicators;
 
 /// Intermediate action collected in the read-only pass, applied in the mutation pass.
 enum LoadAction {
@@ -41,6 +42,15 @@ enum LoadAction {
         reason: RejectionReason,
         /// Numeric details of the rejection.
         context: Option<RejectionContext>,
+    },
+    /// Re-light both direction indicator lamps on a car. Emitted when a
+    /// Loading tick produces no board/exit/reject yet there is at least
+    /// one eligible waiting rider filtered out solely by the car's
+    /// directional lamps — without this, the car would cycle doors
+    /// closed and be re-dispatched to the same stop indefinitely.
+    ResetIndicators {
+        /// Elevator whose lamps are being re-lit.
+        elevator: EntityId,
     },
 }
 
@@ -98,6 +108,10 @@ fn collect_actions(world: &World, elevator_ids: &[EntityId]) -> Vec<LoadAction> 
         let mut rejected_candidate: Option<EntityId> = None;
         let mut preference_rejected: Option<EntityId> = None;
         let mut access_rejected: Option<EntityId> = None;
+        // Track riders filtered out only by the car's direction lamps —
+        // used below to detect the "stuck doors" case where every waiting
+        // rider wants to go the opposite direction from the car's indicator.
+        let mut direction_filtered: Option<EntityId> = None;
 
         let board_rider = world.iter_riders().find_map(|(rid, rider)| {
             if world.is_disabled(rid) {
@@ -157,9 +171,15 @@ fn collect_actions(world: &World, elevator_ids: &[EntityId]) -> Vec<LoadAction> 
                 let dest_pos = world.position(dest).map(|p| p.value);
                 if let (Some(cp), Some(dp)) = (cur_pos, dest_pos) {
                     if dp > cp && !car.going_up {
+                        if direction_filtered.is_none() {
+                            direction_filtered = Some(rid);
+                        }
                         return None;
                     }
                     if dp < cp && !car.going_down {
+                        if direction_filtered.is_none() {
+                            direction_filtered = Some(rid);
+                        }
                         return None;
                     }
                 }
@@ -222,6 +242,19 @@ fn collect_actions(world: &World, elevator_ids: &[EntityId]) -> Vec<LoadAction> 
                     capacity: car.weight_capacity.into(),
                 }),
             });
+        } else if direction_filtered.is_some()
+            && car.riders.is_empty()
+            && !(car.going_up && car.going_down)
+        {
+            // Empty car, no boards / exits / rejections this tick, but at
+            // least one eligible waiting rider was filtered out purely by
+            // this car's direction lamps. Nothing commits the car to its
+            // current direction — re-light both lamps so the next Loading
+            // tick can board the rider. Otherwise doors would cycle closed
+            // and dispatch would immediately re-send the car to the same
+            // stop (infinite loop). Skipped when the car has riders aboard,
+            // since their destinations legitimately pin the direction.
+            actions.push(LoadAction::ResetIndicators { elevator: eid });
         }
     }
 
@@ -329,6 +362,9 @@ fn apply_actions(
                     context,
                     tick: ctx.tick,
                 });
+            }
+            LoadAction::ResetIndicators { elevator } => {
+                update_indicators(world, events, elevator, true, true, ctx.tick);
             }
         }
     }

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -1,12 +1,13 @@
 //! Tests for multi-line and multi-group simulation support.
 
-use crate::components::{Orientation, RiderPhase, Route, RouteLeg, TransportMode};
+use crate::components::{ElevatorPhase, Orientation, RiderPhase, Route, RouteLeg, TransportMode};
 use crate::config::{
     BuildingConfig, ElevatorConfig, GroupConfig, LineConfig, PassengerSpawnConfig, SimConfig,
     SimulationParams,
 };
 use crate::dispatch::scan::ScanDispatch;
 use crate::error::SimError;
+use crate::events::Event as SimEvent;
 use crate::ids::GroupId;
 use crate::sim::Simulation;
 use crate::stop::{StopConfig, StopId};
@@ -2754,5 +2755,257 @@ fn orphan_line_not_referenced_by_any_group_fails_validation() {
             })
         ),
         "expected InvalidConfig for orphan line, got {result:?}"
+    );
+}
+
+// ── 20. Dispatch group-filter regression ─────────────────────────────────────
+
+/// When two groups share a stop and a rider is bound for Group B, Group A's
+/// elevator must not be dispatched to serve that phantom demand (which would
+/// otherwise cause a perpetual open/close oscillation: dispatch → arrive →
+/// open → no eligible rider → close → re-dispatch).
+#[test]
+fn dispatch_ignores_waiting_rider_targeting_another_group() {
+    let config = overlapping_groups_config();
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+    let bottom = sim.stop_entity(StopId(0)).unwrap();
+    let top = sim.stop_entity(StopId(1)).unwrap();
+
+    // Group A's elevator starts at Stop 0 (Bottom), idle with doors closed.
+    let group_a_elevator = sim
+        .groups()
+        .iter()
+        .find(|g| g.id() == GroupId(0))
+        .unwrap()
+        .elevator_entities()[0];
+
+    // Spawn a rider at Bottom waiting to ride Group B to Top.
+    let route = Route {
+        legs: vec![RouteLeg {
+            from: bottom,
+            to: top,
+            via: TransportMode::Group(GroupId(1)),
+        }],
+        current_leg: 0,
+    };
+    let rider = sim
+        .spawn_rider_with_route(bottom, top, 70.0, route)
+        .unwrap();
+    assert_eq!(sim.world().rider(rider).unwrap().phase, RiderPhase::Waiting);
+
+    // Tick for a while. Group A's elevator should never open its doors
+    // because no Group-A rider is waiting.
+    let mut saw_door_opening = false;
+    for _ in 0..100 {
+        sim.step();
+        let phase = sim.world().elevator(group_a_elevator).unwrap().phase;
+        if matches!(
+            phase,
+            ElevatorPhase::DoorOpening | ElevatorPhase::Loading | ElevatorPhase::DoorClosing
+        ) {
+            saw_door_opening = true;
+            break;
+        }
+    }
+
+    assert!(
+        !saw_door_opening,
+        "Group A elevator must not open/close doors when only a Group B rider is waiting"
+    );
+}
+
+// ── 21. Direction-indicator silent-skip regression (Bug A) ───────────────────
+
+/// When a car arrives at a stop committed to one direction and every waiting
+/// rider there wants the opposite direction, Loading would silently skip all
+/// of them — doors cycle shut, dispatch re-sends the car, repeat forever.
+/// With the fix, Loading detects the direction-filter-only skip and re-lights
+/// both indicator lamps so the rider boards within a bounded number of ticks.
+#[test]
+fn car_with_opposite_indicator_eventually_boards_waiting_rider() {
+    let config = two_group_config();
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+    let ground = sim.stop_entity(StopId(0)).unwrap();
+    let transfer = sim.stop_entity(StopId(1)).unwrap();
+
+    // Group 0's elevator starts at Ground, serves Ground+Transfer.
+    let g0_elev = sim
+        .groups()
+        .iter()
+        .find(|g| g.id() == GroupId(0))
+        .unwrap()
+        .elevator_entities()[0];
+
+    // Spawn a rider at Transfer heading down to Ground via Group 0.
+    // Group 0's car will be dispatched up to Transfer (indicators: up only),
+    // arrive, and — pre-fix — silently skip the rider since they want to
+    // travel down (going_down=false on the car).
+    let route = Route {
+        legs: vec![RouteLeg {
+            from: transfer,
+            to: ground,
+            via: TransportMode::Group(GroupId(0)),
+        }],
+        current_leg: 0,
+    };
+    let rider = sim
+        .spawn_rider_with_route(transfer, ground, 70.0, route)
+        .unwrap();
+
+    // Run until the rider boards (or times out), collecting events so we can
+    // observe how many door-open/close cycles it took. Without the fix, the
+    // car arrives, silently skips the rider during its first Loading session,
+    // cycles doors closed, gets re-dispatched in-place (which resets lamps
+    // via dispatch.rs's arrive-in-place branch), and only THEN boards —
+    // costing an extra door cycle per stuck pass. With the fix, Loading
+    // re-lights the lamps mid-session and the rider boards before doors
+    // close.
+    let mut events: Vec<SimEvent> = Vec::new();
+    let mut boarded = false;
+    for _ in 0..3000 {
+        sim.step();
+        events.extend(sim.drain_events());
+        if let Some(r) = sim.world().rider(rider)
+            && matches!(
+                r.phase,
+                RiderPhase::Boarding(_) | RiderPhase::Riding(_) | RiderPhase::Arrived
+            )
+        {
+            boarded = true;
+            break;
+        }
+    }
+    assert!(
+        boarded,
+        "rider going the opposite direction of the car's indicator should still board \
+         (car entity {g0_elev:?})"
+    );
+
+    // Count door-close events on this elevator before the rider boarded.
+    // Pre-fix: at least one close cycle happens before boarding. Post-fix:
+    // the rider boards during the first Loading session, so zero door-close
+    // events precede the RiderBoarded event.
+    let mut door_closes_before_board = 0;
+    for e in &events {
+        match e {
+            SimEvent::DoorClosed { elevator, .. } if *elevator == g0_elev => {
+                door_closes_before_board += 1;
+            }
+            SimEvent::RiderBoarded { rider: r, .. } if *r == rider => break,
+            _ => {}
+        }
+    }
+    assert_eq!(
+        door_closes_before_board, 0,
+        "direction-filtered rider should board during the car's first Loading \
+         session — a non-zero count means doors cycled shut with the rider \
+         still waiting (Bug A)"
+    );
+}
+
+// ── 22. Dispatch arrive-in-place consistency (Bug B) ─────────────────────────
+
+/// When dispatch assigns an elevator to the stop it's already parked at, it
+/// must set `target_stop` and pop that stop from the destination queue —
+/// mirroring the semantics of the non-trivial branch and of `advance_queue`.
+#[test]
+fn dispatch_arrive_in_place_sets_target_and_pops_queue() {
+    let config = two_group_config();
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+    let ground = sim.stop_entity(StopId(0)).unwrap();
+
+    // Group 0's elevator starts at Ground.
+    let elev = sim
+        .groups()
+        .iter()
+        .find(|g| g.id() == GroupId(0))
+        .unwrap()
+        .elevator_entities()[0];
+
+    // Seed the queue with the current stop so we can observe the pop.
+    sim.push_destination(elev, ground).unwrap();
+    assert_eq!(sim.destination_queue(elev).unwrap().len(), 1);
+
+    // Spawn a rider at Ground so dispatch has demand at this stop.
+    let transfer = sim.stop_entity(StopId(1)).unwrap();
+    let route = Route {
+        legs: vec![RouteLeg {
+            from: ground,
+            to: transfer,
+            via: TransportMode::Group(GroupId(0)),
+        }],
+        current_leg: 0,
+    };
+    let _rider = sim
+        .spawn_rider_with_route(ground, transfer, 70.0, route)
+        .unwrap();
+
+    // One step runs dispatch; the Idle car will be assigned Ground and, since
+    // it is already there, take the arrive-in-place branch.
+    sim.step();
+
+    let car = sim.world().elevator(elev).unwrap();
+    assert_eq!(
+        car.target_stop(),
+        Some(ground),
+        "arrive-in-place dispatch must set target_stop to the assigned stop"
+    );
+    assert!(
+        !sim.destination_queue(elev).unwrap().contains(&ground),
+        "arrive-in-place dispatch must pop the matching queue front"
+    );
+}
+
+// ── 23. advance_queue arrive-in-place indicator reset (Bug C) ────────────────
+
+/// An imperative `push_destination_front` onto a car already parked at that
+/// stop must re-light both indicator lamps before doors open, so stale
+/// direction state from a prior trip doesn't feed into loading's filter.
+#[test]
+fn advance_queue_arrive_in_place_resets_direction_indicators() {
+    use crate::components::ServiceMode;
+
+    let config = two_group_config();
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+    let ground = sim.stop_entity(StopId(0)).unwrap();
+    let elev = sim
+        .groups()
+        .iter()
+        .find(|g| g.id() == GroupId(0))
+        .unwrap()
+        .elevator_entities()[0];
+
+    // Put the car in Independent mode so dispatch/reposition skip it —
+    // otherwise dispatch's arrive-in-place branch would reset indicators
+    // before advance_queue gets a chance, masking the bug under test.
+    sim.set_service_mode(elev, ServiceMode::Independent)
+        .unwrap();
+
+    // Manually set stale indicators — as if the car had just finished a
+    // downward trip.
+    {
+        let car = sim.world_mut().elevator_mut(elev).unwrap();
+        car.going_up = false;
+        car.going_down = true;
+    }
+
+    // Queue the car to its own stop via the imperative front-push API.
+    sim.push_destination_front(elev, ground).unwrap();
+
+    // One step: advance_queue runs, sees at_stop == front, pops and opens
+    // doors — and must reset lamps to (true, true) along the way.
+    sim.step();
+
+    let car = sim.world().elevator(elev).unwrap();
+    assert!(
+        car.going_up() && car.going_down(),
+        "advance_queue arrive-in-place must re-light both indicator lamps \
+         (got going_up={}, going_down={})",
+        car.going_up(),
+        car.going_down()
     );
 }

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -3008,4 +3008,10 @@ fn advance_queue_arrive_in_place_resets_direction_indicators() {
         car.going_up(),
         car.going_down()
     );
+    assert_eq!(
+        car.target_stop(),
+        Some(ground),
+        "advance_queue arrive-in-place must set target_stop, mirroring \
+         dispatch.rs's arrive-in-place semantics"
+    );
 }


### PR DESCRIPTION
## Summary

Fixes three related defects in the dispatch/loading pipeline that could leave an
elevator cycling doors open/closed at a stop without ever boarding the riders
waiting there. All stem from disagreements between a car's direction-indicator
lamps and the destinations of waiting riders — easiest to reproduce in multi-line
/ multi-group configurations.

### Bug A — silent direction-indicator skip in loading

`crates/elevator-core/src/systems/loading.rs`

When doors open at a stop and every eligible waiting rider is filtered out solely
by the car's direction lamps, Loading would silently take no action — doors cycle
closed, dispatch re-sends the same empty car to the same stop. Now detects this
case and emits a `ResetIndicators` action that re-lights both lamps mid-session,
so the rider boards before doors close. Guarded on the car having no riders
aboard, so legitimate direction commitments from passengers in-transit are
preserved (protects the existing `rider_going_up_skips_down_only_car` test).

### Bug B — dispatch arrive-in-place missed target_stop / queue pop

`crates/elevator-core/src/systems/dispatch.rs`

The arrive-in-place branch (elevator assigned to the stop it's already parked at)
neither set `target_stop` nor popped the matching queue front, diverging from
the normal `GoToStop` path and from `advance_queue`'s equivalent branch. Now
sets `target_stop` and pops the queue front when it matches.

### Bug C — advance_queue arrive-in-place left stale indicators

`crates/elevator-core/src/systems/advance_queue.rs`

The imperative arrive-in-place branch (`push_destination_front` onto a car
already at that stop) opened doors without resetting direction lamps, so stale
`going_up` / `going_down` from a prior trip fed into loading's direction filter.
Now calls `update_indicators(true, true, ...)` before opening doors, matching
`dispatch.rs`'s arrive-in-place semantics.

### Baseline included

Also includes the previously uncommitted multi-group `TransportMode` demand
filter in `dispatch::build_manifest` — dispatch and loading now agree on which
waiting riders a given group can serve.

## Test plan

- [x] `cargo test -p elevator-core` — 454 tests pass
- [x] `cargo clippy -p elevator-core --all-targets -- -D warnings` — clean
- [x] Each new regression test verified to fail on `main` without its respective fix, pass with it
  - `car_with_opposite_indicator_eventually_boards_waiting_rider` (Bug A)
  - `dispatch_arrive_in_place_sets_target_and_pops_queue` (Bug B)
  - `advance_queue_arrive_in_place_resets_direction_indicators` (Bug C)