### PR TITLE
feat: sub-tick position interpolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2363,7 +2363,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "5.6.0"
+version = "5.7.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/examples/fp_player_rider.rs
+++ b/crates/elevator-core/examples/fp_player_rider.rs
@@ -1,0 +1,49 @@
+//! First-person "player rides the elevator" pattern.
+//!
+//! Demonstrates how a renderer running at a higher framerate than the sim
+//! can produce smooth elevator motion by interpolating between the previous
+//! and current tick's position via
+//! [`Simulation::position_at`](elevator_core::sim::Simulation::position_at).
+//!
+//! The loop below fakes a 4× render rate: for every sim tick we sample
+//! `position_at` at `alpha = 0.0, 0.25, 0.5, 0.75, 1.0` — the `0.0` and
+//! `1.0` samples bracket the tick, and the intermediates are what a camera
+//! parented to the elevator car would use between fixed-timestep updates.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo run -p elevator-core --example fp_player_rider --release
+//! ```
+#![allow(clippy::unwrap_used, clippy::missing_docs_in_private_items)]
+
+use elevator_core::prelude::*;
+
+fn main() {
+    let mut sim = SimulationBuilder::demo().build().unwrap();
+    let elev = sim.world().iter_elevators().next().unwrap().0;
+
+    // Give the car something to do.
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 75.0)
+        .unwrap();
+
+    println!("tick  alpha=0.00  alpha=0.50  alpha=1.00   vel");
+    println!("----  ----------  ----------  ----------  -----");
+
+    for _ in 0..60 {
+        sim.step();
+        let p0 = sim.position_at(elev, 0.0).unwrap();
+        let p_mid = sim.position_at(elev, 0.5).unwrap();
+        let p1 = sim.position_at(elev, 1.0).unwrap();
+        let v = sim.velocity(elev).unwrap_or(0.0);
+
+        println!(
+            "{:>4}   {:>8.3}m   {:>8.3}m   {:>8.3}m  {:>5.2}",
+            sim.current_tick(),
+            p0,
+            p_mid,
+            p1,
+            v,
+        );
+    }
+}

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -237,6 +237,35 @@
 //!
 //! [dex]: https://github.com/andymai/elevator-core/blob/main/crates/elevator-core/examples/door_commands.rs
 //!
+//! ## Sub-tick position interpolation
+//!
+//! Games that render at a higher framerate than the simulation ticks (e.g.
+//! a 60 Hz sim driving a 144 Hz camera, or a first-person game where the
+//! player is parented to an elevator car) need a smooth position between
+//! ticks. [`Simulation::position_at`](sim::Simulation::position_at) lerps
+//! between the snapshot taken at the start of the current tick and the
+//! post-tick position, using an `alpha` accumulator clamped to `[0.0, 1.0]`:
+//!
+//! ```text
+//! // typical fixed-timestep render loop
+//! accumulator += frame_dt;
+//! while accumulator >= sim.dt() {
+//!     sim.step();
+//!     accumulator -= sim.dt();
+//! }
+//! let alpha = accumulator / sim.dt();
+//! let y = sim.position_at(car, alpha).unwrap();
+//! ```
+//!
+//! The previous-position snapshot is refreshed automatically at the start
+//! of every [`step`](sim::Simulation::step). [`Simulation::velocity`] is
+//! a convenience that returns the raw `f64` along the shaft axis (signed:
+//! +up, -down) for camera tilt, motion blur, or cabin-sway effects.
+//!
+//! See [`examples/fp_player_rider.rs`][fpe] for a runnable demo.
+//!
+//! [fpe]: https://github.com/andymai/elevator-core/blob/main/crates/elevator-core/examples/fp_player_rider.rs
+//!
 //! For narrative guides, tutorials, and architecture walkthroughs, see the
 //! [mdBook documentation](https://andymai.github.io/elevator-core/).
 

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -69,6 +69,7 @@ mod topology;
 
 use crate::components::{
     AccessControl, FloorPosition, Orientation, Patience, Preferences, Rider, RiderPhase, Route,
+    Velocity,
 };
 use crate::dispatch::{BuiltinReposition, DispatchStrategy, ElevatorGroup, RepositionStrategy};
 use crate::entity::EntityId;
@@ -389,6 +390,39 @@ impl Simulation {
     #[must_use]
     pub const fn dt(&self) -> f64 {
         self.dt
+    }
+
+    /// Interpolated position between the previous and current tick.
+    ///
+    /// `alpha` is clamped to `[0.0, 1.0]`, where `0.0` returns the entity's
+    /// position at the start of the last completed tick and `1.0` returns
+    /// the current position. Intended for smooth rendering when a render
+    /// frame falls between simulation ticks.
+    ///
+    /// Returns `None` if the entity has no position component. Returns the
+    /// current position unchanged if no previous snapshot exists (i.e. before
+    /// the first [`step`](Self::step)).
+    ///
+    /// [`step`]: Self::step
+    #[must_use]
+    pub fn position_at(&self, id: EntityId, alpha: f64) -> Option<f64> {
+        let current = self.world.position(id)?.value;
+        let alpha = if alpha.is_nan() {
+            0.0
+        } else {
+            alpha.clamp(0.0, 1.0)
+        };
+        let prev = self.world.prev_position(id).map_or(current, |p| p.value);
+        Some((current - prev).mul_add(alpha, prev))
+    }
+
+    /// Current velocity of an entity along the shaft axis (signed: +up, -down).
+    ///
+    /// Convenience wrapper over [`World::velocity`] that returns the raw
+    /// `f64` value. Returns `None` if the entity has no velocity component.
+    #[must_use]
+    pub fn velocity(&self, id: EntityId) -> Option<f64> {
+        self.world.velocity(id).map(Velocity::value)
     }
 
     /// Get current simulation metrics.
@@ -1693,6 +1727,7 @@ impl Simulation {
     /// assert_eq!(sim.current_tick(), 1);
     /// ```
     pub fn step(&mut self) {
+        self.world.snapshot_prev_positions();
         self.run_advance_transient();
         self.run_dispatch();
         self.run_reposition();

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -52,6 +52,7 @@ mod multi_elevator_tests;
 mod multi_line_tests;
 mod mutation_kills_tests;
 mod phase_helpers_tests;
+mod position_interpolation_tests;
 mod query_event_tests;
 mod reposition_tests;
 mod resident_tests;

--- a/crates/elevator-core/src/tests/position_interpolation_tests.rs
+++ b/crates/elevator-core/src/tests/position_interpolation_tests.rs
@@ -1,0 +1,114 @@
+//! Tests for sub-tick position interpolation (`Simulation::position_at`).
+
+use crate::dispatch::scan::ScanDispatch;
+use crate::sim::Simulation;
+use crate::stop::StopId;
+use crate::tests::helpers::default_config;
+
+fn approx_eq(a: f64, b: f64) -> bool {
+    (a - b).abs() < 1e-9
+}
+
+#[test]
+fn position_at_before_first_step_returns_current() {
+    let sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let elev = sim.world().iter_elevators().next().unwrap().0;
+    let current = sim.world().position(elev).unwrap().value();
+
+    assert!(approx_eq(sim.position_at(elev, 0.0).unwrap(), current));
+    assert!(approx_eq(sim.position_at(elev, 0.5).unwrap(), current));
+    assert!(approx_eq(sim.position_at(elev, 1.0).unwrap(), current));
+}
+
+#[test]
+fn position_at_interpolates_between_prev_and_current() {
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let elev = sim.world().iter_elevators().next().unwrap().0;
+
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
+        .unwrap();
+
+    // Run until the elevator is actually moving (non-zero velocity).
+    for _ in 0..200 {
+        sim.step();
+        if sim.velocity(elev).is_some_and(|v| v.abs() > 0.01) {
+            break;
+        }
+    }
+    let vel = sim.velocity(elev).expect("velocity");
+    assert!(vel.abs() > 0.01, "expected elevator to be moving");
+
+    let prev = sim.world().prev_position(elev).unwrap().value();
+    let curr = sim.world().position(elev).unwrap().value();
+    assert!(
+        (curr - prev).abs() > 0.0,
+        "position should have changed across the tick"
+    );
+
+    assert!(approx_eq(sim.position_at(elev, 0.0).unwrap(), prev));
+    assert!(approx_eq(sim.position_at(elev, 1.0).unwrap(), curr));
+    let mid = (curr - prev).mul_add(0.5, prev);
+    assert!(approx_eq(sim.position_at(elev, 0.5).unwrap(), mid));
+}
+
+#[test]
+fn position_at_clamps_alpha_out_of_range() {
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let elev = sim.world().iter_elevators().next().unwrap().0;
+
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
+        .unwrap();
+    for _ in 0..200 {
+        sim.step();
+        if sim.velocity(elev).is_some_and(|v| v.abs() > 0.01) {
+            break;
+        }
+    }
+
+    let prev = sim.world().prev_position(elev).unwrap().value();
+    let curr = sim.world().position(elev).unwrap().value();
+
+    assert!(approx_eq(sim.position_at(elev, -1.0).unwrap(), prev));
+    assert!(approx_eq(sim.position_at(elev, 2.0).unwrap(), curr));
+    assert!(approx_eq(sim.position_at(elev, f64::NAN).unwrap(), prev));
+}
+
+#[test]
+fn position_at_returns_none_for_unknown_entity() {
+    let sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    // A stop entity has a position — an arbitrary default EntityId should not.
+    let bogus = crate::entity::EntityId::default();
+    assert!(sim.position_at(bogus, 0.5).is_none());
+    assert!(sim.velocity(bogus).is_none());
+}
+
+#[test]
+fn velocity_convenience_matches_world_velocity() {
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let elev = sim.world().iter_elevators().next().unwrap().0;
+
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
+        .unwrap();
+    for _ in 0..50 {
+        sim.step();
+    }
+
+    let world_v = sim.world().velocity(elev).unwrap().value();
+    let sim_v = sim.velocity(elev).unwrap();
+    assert!(approx_eq(world_v, sim_v));
+}
+
+#[test]
+fn stationary_elevator_prev_equals_current() {
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let elev = sim.world().iter_elevators().next().unwrap().0;
+
+    for _ in 0..5 {
+        sim.step();
+    }
+
+    let prev = sim.world().prev_position(elev).unwrap().value();
+    let curr = sim.world().position(elev).unwrap().value();
+    assert!(approx_eq(prev, curr));
+    assert!(approx_eq(sim.position_at(elev, 0.3).unwrap(), curr));
+}

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -30,6 +30,9 @@ pub struct World {
     // -- Built-in component storages (crate-internal) --
     /// Shaft-axis positions.
     pub(crate) positions: SecondaryMap<EntityId, Position>,
+    /// Snapshot of `positions` taken at the start of the current tick.
+    /// Enables sub-tick interpolation for smooth rendering between steps.
+    pub(crate) prev_positions: SecondaryMap<EntityId, Position>,
     /// Shaft-axis velocities.
     pub(crate) velocities: SecondaryMap<EntityId, Velocity>,
     /// Elevator components.
@@ -81,6 +84,7 @@ impl World {
         Self {
             alive: SlotMap::with_key(),
             positions: SecondaryMap::new(),
+            prev_positions: SecondaryMap::new(),
             velocities: SecondaryMap::new(),
             elevators: SecondaryMap::new(),
             stops: SecondaryMap::new(),
@@ -147,6 +151,7 @@ impl World {
 
         self.alive.remove(id);
         self.positions.remove(id);
+        self.prev_positions.remove(id);
         self.velocities.remove(id);
         self.elevators.remove(id);
         self.stops.remove(id);
@@ -202,6 +207,27 @@ impl World {
     /// Set an entity's position.
     pub fn set_position(&mut self, id: EntityId, pos: Position) {
         self.positions.insert(id, pos);
+    }
+
+    /// Snapshot of an entity's position at the start of the current tick.
+    ///
+    /// Pairs with [`position`](Self::position) to support sub-tick interpolation
+    /// (see [`Simulation::position_at`](crate::sim::Simulation::position_at)).
+    #[must_use]
+    pub fn prev_position(&self, id: EntityId) -> Option<&Position> {
+        self.prev_positions.get(id)
+    }
+
+    /// Snapshot all current positions into `prev_positions`.
+    ///
+    /// Called at the start of each tick by
+    /// [`Simulation::step`](crate::sim::Simulation::step) before any phase
+    /// mutates positions.
+    pub(crate) fn snapshot_prev_positions(&mut self) {
+        self.prev_positions.clear();
+        for (id, pos) in &self.positions {
+            self.prev_positions.insert(id, *pos);
+        }
     }
 
     // ── Velocity accessors ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `Simulation::position_at(eid, alpha)` lerps between prev and current tick for smooth renderer sampling when frame rate > sim tick rate.
- `World::prev_position` snapshots positions at the start of each `step()`.
- `Simulation::velocity(eid)` convenience returns raw `f64` shaft-axis velocity.
- New `fp_player_rider` example + docs section showing the fixed-timestep render pattern.

## Test plan
- [x] `cargo test -p elevator-core` (493 passing incl. 6 new interpolation tests)
- [x] `cargo clippy -p elevator-core --all-targets -- -D warnings`
- [x] `cargo run -p elevator-core --example fp_player_rider --release`