### PR TITLE
feat: ServiceMode::Manual with direct velocity commands

### DIFF
--- a/crates/elevator-core/examples/manual_driver.rs
+++ b/crates/elevator-core/examples/manual_driver.rs
@@ -1,0 +1,47 @@
+//! "Player-as-elevator" demo — direct velocity control via
+//! [`ServiceMode::Manual`](elevator_core::components::ServiceMode::Manual).
+//!
+//! The sim is placed into Manual mode; the "driver" commands ascent,
+//! cruises, then triggers an emergency stop. Each tick we print the
+//! current position and velocity so you can see the trapezoidal
+//! acceleration/deceleration clamped to the elevator's kinematic caps.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo run -p elevator-core --example manual_driver --release
+//! ```
+#![allow(clippy::unwrap_used, clippy::missing_docs_in_private_items)]
+
+use elevator_core::prelude::*;
+
+fn main() {
+    let mut sim = SimulationBuilder::demo().build().unwrap();
+    let elev = sim.world().iter_elevators().next().unwrap().0;
+
+    sim.set_service_mode(elev, ServiceMode::Manual).unwrap();
+
+    // Phase 1: command full ascent.
+    sim.set_target_velocity(elev, 2.0).unwrap();
+
+    println!("tick  phase        pos     vel");
+    println!("----  -----------  ------  -----");
+
+    for t in 0..180 {
+        // Halfway through, slam the emergency brake.
+        if t == 90 {
+            sim.emergency_stop(elev).unwrap();
+        }
+        sim.step();
+
+        let pos = sim.world().position(elev).unwrap().value();
+        let vel = sim.velocity(elev).unwrap();
+        let phase = if t < 90 { "ascending " } else { "e-stopping" };
+        println!("{t:>4}  {phase}  {pos:>5.2}m  {vel:>5.2}");
+
+        if t > 90 && vel.abs() < 1e-6 {
+            println!("\nCar stopped at {pos:.2}m after {t} ticks.");
+            break;
+        }
+    }
+}

--- a/crates/elevator-core/src/components/elevator.rs
+++ b/crates/elevator-core/src/components/elevator.rs
@@ -166,6 +166,14 @@ pub struct Elevator {
     /// doors phase; commands that aren't yet valid remain queued.
     #[serde(default)]
     pub(crate) door_command_queue: Vec<DoorCommand>,
+    /// Target velocity commanded by the game while in
+    /// [`ServiceMode::Manual`](crate::components::ServiceMode::Manual).
+    ///
+    /// `None` means no command is active — the car coasts to a stop using
+    /// `deceleration`. Read the current target via
+    /// [`Elevator::manual_target_velocity`].
+    #[serde(default)]
+    pub(crate) manual_target_velocity: Option<f64>,
 }
 
 /// Default inspection speed factor (25% of normal speed).
@@ -320,5 +328,16 @@ impl Elevator {
     #[must_use]
     pub fn door_command_queue(&self) -> &[DoorCommand] {
         &self.door_command_queue
+    }
+
+    /// Currently commanded target velocity for
+    /// [`ServiceMode::Manual`](crate::components::ServiceMode::Manual).
+    ///
+    /// Returns `None` if no target is set, meaning the car coasts to a
+    /// stop using the configured deceleration. Positive values command
+    /// upward travel, negative values command downward travel.
+    #[must_use]
+    pub const fn manual_target_velocity(&self) -> Option<f64> {
+        self.manual_target_velocity
     }
 }

--- a/crates/elevator-core/src/components/service_mode.rs
+++ b/crates/elevator-core/src/components/service_mode.rs
@@ -21,6 +21,27 @@ pub enum ServiceMode {
     /// Inspection mode: reduced speed, doors hold open indefinitely.
     /// Speed is reduced by [`Elevator::inspection_speed_factor`](super::Elevator::inspection_speed_factor).
     Inspection,
+    /// Manual mode: elevator is driven by direct velocity commands from the
+    /// game (see
+    /// [`Simulation::set_target_velocity`](crate::sim::Simulation::set_target_velocity)
+    /// and [`Simulation::emergency_stop`](crate::sim::Simulation::emergency_stop)).
+    /// Excluded from dispatch and repositioning; doors follow the manual
+    /// door-control API. Can stop at any position — the elevator is not
+    /// required to align with a configured stop.
+    Manual,
+}
+
+impl ServiceMode {
+    /// `true` if elevators in this mode are skipped by the automatic
+    /// dispatch and repositioning phases.
+    ///
+    /// Returns `true` for [`Independent`](Self::Independent) and
+    /// [`Manual`](Self::Manual), which both hand elevator movement over
+    /// to the consumer.
+    #[must_use]
+    pub const fn is_dispatch_excluded(self) -> bool {
+        matches!(self, Self::Independent | Self::Manual)
+    }
 }
 
 impl std::fmt::Display for ServiceMode {
@@ -29,6 +50,7 @@ impl std::fmt::Display for ServiceMode {
             Self::Normal => write!(f, "Normal"),
             Self::Independent => write!(f, "Independent"),
             Self::Inspection => write!(f, "Inspection"),
+            Self::Manual => write!(f, "Manual"),
         }
     }
 }

--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -103,7 +103,7 @@ impl DispatchStrategy for DestinationDispatch {
             .filter(|eid| {
                 !world
                     .service_mode(*eid)
-                    .is_some_and(|m| *m == crate::components::ServiceMode::Independent)
+                    .is_some_and(|m| m.is_dispatch_excluded())
             })
             .filter(|eid| world.elevator(*eid).is_some())
             .collect();

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -469,6 +469,22 @@ pub enum Event {
         /// The tick when the upgrade was applied.
         tick: u64,
     },
+
+    /// A velocity command was submitted to an elevator running in
+    /// [`ServiceMode::Manual`](crate::components::ServiceMode::Manual).
+    ///
+    /// Emitted by
+    /// [`Simulation::set_target_velocity`](crate::sim::Simulation::set_target_velocity)
+    /// and [`Simulation::emergency_stop`](crate::sim::Simulation::emergency_stop).
+    ManualVelocityCommanded {
+        /// The elevator targeted by the command.
+        elevator: EntityId,
+        /// The new target velocity (clamped to `[-max_speed, max_speed]`),
+        /// or `None` when the command clears the target.
+        target_velocity: Option<ordered_float::OrderedFloat<f64>>,
+        /// The tick when the command was submitted.
+        tick: u64,
+    },
 }
 
 /// Identifies which elevator parameter was changed in an
@@ -620,7 +636,8 @@ impl Event {
             Self::DirectionIndicatorChanged { .. } => EventCategory::Direction,
             Self::ServiceModeChanged { .. }
             | Self::CapacityChanged { .. }
-            | Self::ElevatorUpgraded { .. } => EventCategory::Observability,
+            | Self::ElevatorUpgraded { .. }
+            | Self::ManualVelocityCommanded { .. } => EventCategory::Observability,
             #[cfg(feature = "energy")]
             Self::EnergyConsumed { .. } => EventCategory::Observability,
         }

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -266,6 +266,33 @@
 //!
 //! [fpe]: https://github.com/andymai/elevator-core/blob/main/crates/elevator-core/examples/fp_player_rider.rs
 //!
+//! ## Manual-drive mode
+//!
+//! Games where the player *is* the elevator — driving the car with a
+//! velocity stick, slamming an emergency brake, stopping between floors
+//! — use [`ServiceMode::Manual`](components::ServiceMode::Manual). Manual
+//! elevators are skipped by the automatic dispatch and repositioning
+//! phases; the consumer drives movement via:
+//!
+//! - [`Simulation::set_target_velocity`](sim::Simulation::set_target_velocity) — signed target speed (+up, -down), clamped to the car's `max_speed`.
+//! - [`Simulation::emergency_stop`](sim::Simulation::emergency_stop) — commands an immediate deceleration to zero.
+//!
+//! Physics still apply: velocity ramps toward the target using the car's
+//! `acceleration` / `deceleration` caps, and positions update at the same
+//! rate as normal elevators. Manual elevators can come to rest at any
+//! position — they are not required to align with a configured stop.
+//! Door behaviour is governed by the [manual door-control API](#door-control);
+//! nothing opens or closes automatically. Leaving `Manual` clears any
+//! pending velocity command.
+//!
+//! Each command emits
+//! [`Event::ManualVelocityCommanded`](events::Event::ManualVelocityCommanded)
+//! with the clamped target, or `None` for an emergency stop.
+//!
+//! See [`examples/manual_driver.rs`][mde] for a runnable demo.
+//!
+//! [mde]: https://github.com/andymai/elevator-core/blob/main/crates/elevator-core/examples/manual_driver.rs
+//!
 //! For narrative guides, tutorials, and architecture walkthroughs, see the
 //! [mdBook documentation](https://andymai.github.io/elevator-core/).
 

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -948,6 +948,89 @@ impl Simulation {
         Ok(())
     }
 
+    /// Set the target velocity for a manual-mode elevator.
+    ///
+    /// The velocity is clamped to the elevator's `[-max_speed, max_speed]`
+    /// range after validation. The car ramps toward the target each tick
+    /// using `acceleration` (speeding up, or starting from rest) or
+    /// `deceleration` (slowing down, or reversing direction). Positive
+    /// values command upward travel, negative values command downward travel.
+    ///
+    /// # Errors
+    /// - Entity is not an elevator, or is disabled.
+    /// - Elevator is not in [`ServiceMode::Manual`].
+    /// - `velocity` is not finite (NaN or infinite).
+    ///
+    /// [`ServiceMode::Manual`]: crate::components::ServiceMode::Manual
+    pub fn set_target_velocity(
+        &mut self,
+        elevator: EntityId,
+        velocity: f64,
+    ) -> Result<(), SimError> {
+        self.require_enabled_elevator(elevator)?;
+        self.require_manual_mode(elevator)?;
+        if !velocity.is_finite() {
+            return Err(SimError::InvalidConfig {
+                field: "target_velocity",
+                reason: format!("must be finite, got {velocity}"),
+            });
+        }
+        let max = self
+            .world
+            .elevator(elevator)
+            .map_or(f64::INFINITY, |c| c.max_speed);
+        let clamped = velocity.clamp(-max, max);
+        if let Some(car) = self.world.elevator_mut(elevator) {
+            car.manual_target_velocity = Some(clamped);
+        }
+        self.events.emit(Event::ManualVelocityCommanded {
+            elevator,
+            target_velocity: Some(ordered_float::OrderedFloat(clamped)),
+            tick: self.tick,
+        });
+        Ok(())
+    }
+
+    /// Command an immediate stop on a manual-mode elevator.
+    ///
+    /// Sets the target velocity to zero; the car decelerates at its
+    /// configured `deceleration` rate. Equivalent to
+    /// `set_target_velocity(elevator, 0.0)` but emits a distinct
+    /// [`Event::ManualVelocityCommanded`] with `None` payload so games can
+    /// distinguish an emergency stop from a deliberate hold.
+    ///
+    /// # Errors
+    /// Same as [`set_target_velocity`](Self::set_target_velocity), minus
+    /// the finite-velocity check.
+    pub fn emergency_stop(&mut self, elevator: EntityId) -> Result<(), SimError> {
+        self.require_enabled_elevator(elevator)?;
+        self.require_manual_mode(elevator)?;
+        if let Some(car) = self.world.elevator_mut(elevator) {
+            car.manual_target_velocity = Some(0.0);
+        }
+        self.events.emit(Event::ManualVelocityCommanded {
+            elevator,
+            target_velocity: None,
+            tick: self.tick,
+        });
+        Ok(())
+    }
+
+    /// Internal: require an elevator be in `ServiceMode::Manual`.
+    fn require_manual_mode(&self, elevator: EntityId) -> Result<(), SimError> {
+        let is_manual = self
+            .world
+            .service_mode(elevator)
+            .is_some_and(|m| *m == crate::components::ServiceMode::Manual);
+        if !is_manual {
+            return Err(SimError::InvalidState {
+                entity: elevator,
+                reason: "elevator is not in ServiceMode::Manual".into(),
+            });
+        }
+        Ok(())
+    }
+
     /// Internal: push a command onto the queue, collapsing adjacent
     /// duplicates, capping length, and emitting `DoorCommandQueued`.
     fn enqueue_door_command(&mut self, elevator: EntityId, command: crate::door::DoorCommand) {

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -220,6 +220,7 @@ impl Simulation {
                 going_down: true,
                 move_count: 0,
                 door_command_queue: Vec::new(),
+                manual_target_velocity: None,
             },
         );
         #[cfg(feature = "energy")]

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -760,6 +760,13 @@ impl Simulation {
         if old == mode {
             return Ok(());
         }
+        // Leaving Manual: clear any pending velocity command so a later
+        // re-entry to Manual doesn't pick up a stale target.
+        if old == crate::components::ServiceMode::Manual
+            && let Some(car) = self.world.elevator_mut(elevator)
+        {
+            car.manual_target_velocity = None;
+        }
         self.world.set_service_mode(elevator, mode);
         self.events.emit(Event::ServiceModeChanged {
             elevator,

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -161,6 +161,7 @@ impl Simulation {
                 going_down: true,
                 move_count: 0,
                 door_command_queue: Vec::new(),
+                manual_target_velocity: None,
             },
         );
         self.world

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -41,10 +41,10 @@ pub fn run(
                 if world.is_disabled(*eid) {
                     return None;
                 }
-                // Skip elevators in Independent service mode.
+                // Skip elevators that opt out of automatic dispatch.
                 if world
                     .service_mode(*eid)
-                    .is_some_and(|m| *m == crate::components::ServiceMode::Independent)
+                    .is_some_and(|m| m.is_dispatch_excluded())
                 {
                     return None;
                 }

--- a/crates/elevator-core/src/systems/movement.rs
+++ b/crates/elevator-core/src/systems/movement.rs
@@ -22,6 +22,13 @@ pub fn run(
         if world.is_disabled(eid) {
             continue;
         }
+        if world
+            .service_mode(eid)
+            .is_some_and(|m| *m == crate::components::ServiceMode::Manual)
+        {
+            tick_manual(world, events, ctx, eid);
+            continue;
+        }
         let target_stop_eid = match world.elevator(eid) {
             Some(car) => match car.phase {
                 ElevatorPhase::MovingToStop(stop_eid) | ElevatorPhase::Repositioning(stop_eid) => {
@@ -177,5 +184,88 @@ pub fn run(
                 });
             }
         }
+    }
+}
+
+/// One tick of manual-mode physics: ramp velocity toward
+/// `manual_target_velocity` using the car's `acceleration`/`deceleration`
+/// caps, then integrate position. Emits [`Event::PassingFloor`] for any
+/// stops crossed during the tick.
+fn tick_manual(
+    world: &mut World,
+    events: &mut EventBus,
+    ctx: &PhaseContext,
+    eid: crate::entity::EntityId,
+) {
+    let Some(car) = world.elevator(eid) else {
+        return;
+    };
+    let target = car.manual_target_velocity.unwrap_or(0.0);
+    let accel = car.acceleration;
+    let decel = car.deceleration;
+    let max_speed = car.max_speed;
+    let Some(pos_comp) = world.position(eid) else {
+        return;
+    };
+    let old_pos = pos_comp.value;
+    let Some(vel_comp) = world.velocity(eid) else {
+        return;
+    };
+    let vel = vel_comp.value;
+
+    // Signed clamp of target to the kinematic cap.
+    let target = target.clamp(-max_speed, max_speed);
+
+    // Pick the right rate: if we're slowing down (target is closer to 0
+    // than current speed, or opposite sign), use deceleration; otherwise
+    // use acceleration.
+    let slowing = target.abs() < vel.abs() || target.signum() * vel.signum() < 0.0;
+    let rate = if slowing { decel } else { accel };
+    let dv_max = rate * ctx.dt;
+
+    let new_vel = if (target - vel).abs() <= dv_max {
+        target
+    } else if target > vel {
+        vel + dv_max
+    } else {
+        vel - dv_max
+    };
+
+    let new_pos = new_vel.mul_add(ctx.dt, old_pos);
+
+    if let Some(p) = world.position_mut(eid) {
+        p.value = new_pos;
+    }
+    if let Some(v) = world.velocity_mut(eid) {
+        v.value = new_vel;
+    }
+
+    // PassingFloor for every stop actually crossed.
+    let mut passing_moves: u64 = 0;
+    let (lo, hi) = if new_pos >= old_pos {
+        (old_pos, new_pos)
+    } else {
+        (new_pos, old_pos)
+    };
+    let moving_up = new_pos > old_pos;
+    if (hi - lo) > 1e-9
+        && let Some(sorted) = world.resource::<SortedStops>()
+    {
+        let start = sorted.0.partition_point(|&(p, _)| p <= lo + 1e-9);
+        let end = sorted.0.partition_point(|&(p, _)| p < hi - 1e-9);
+        for &(_, stop_eid) in &sorted.0[start..end] {
+            events.emit(Event::PassingFloor {
+                elevator: eid,
+                stop: stop_eid,
+                moving_up,
+                tick: ctx.tick,
+            });
+            passing_moves += 1;
+        }
+    }
+    if passing_moves > 0
+        && let Some(car) = world.elevator_mut(eid)
+    {
+        car.move_count += passing_moves;
     }
 }

--- a/crates/elevator-core/src/systems/reposition.rs
+++ b/crates/elevator-core/src/systems/reposition.rs
@@ -35,10 +35,10 @@ pub fn run(
                 if world.is_disabled(eid) {
                     return None;
                 }
-                // Skip elevators in Independent service mode.
+                // Skip elevators that opt out of automatic dispatch.
                 if world
                     .service_mode(eid)
-                    .is_some_and(|m| *m == crate::components::ServiceMode::Independent)
+                    .is_some_and(|m| m.is_dispatch_excluded())
                 {
                     return None;
                 }

--- a/crates/elevator-core/src/tests/dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/dispatch_tests.rs
@@ -79,6 +79,7 @@ fn spawn_elevator(world: &mut World, position: f64) -> crate::entity::EntityId {
             going_down: true,
             move_count: 0,
             door_command_queue: Vec::new(),
+            manual_target_velocity: None,
         },
     );
     eid

--- a/crates/elevator-core/src/tests/feature_tests.rs
+++ b/crates/elevator-core/src/tests/feature_tests.rs
@@ -566,6 +566,7 @@ fn despawn_elevator_resets_rider_to_waiting() {
             going_down: true,
             move_count: 0,
             door_command_queue: Vec::new(),
+            manual_target_velocity: None,
         },
     );
 
@@ -651,6 +652,7 @@ fn despawn_rider_mid_transit_removes_from_elevator_load() {
             going_down: true,
             move_count: 0,
             door_command_queue: Vec::new(),
+            manual_target_velocity: None,
         },
     );
 

--- a/crates/elevator-core/src/tests/manual_mode_tests.rs
+++ b/crates/elevator-core/src/tests/manual_mode_tests.rs
@@ -1,0 +1,199 @@
+//! Tests for `ServiceMode::Manual` and its command API.
+
+use crate::components::{RiderPhase, ServiceMode};
+use crate::dispatch::scan::ScanDispatch;
+use crate::events::Event;
+use crate::sim::Simulation;
+use crate::stop::StopId;
+use crate::tests::helpers::default_config;
+
+fn make_manual() -> (Simulation, crate::entity::EntityId) {
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let elev = sim.world().iter_elevators().next().unwrap().0;
+    sim.set_service_mode(elev, ServiceMode::Manual).unwrap();
+    (sim, elev)
+}
+
+#[test]
+fn manual_skips_dispatch() {
+    let (mut sim, _elev) = make_manual();
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
+        .unwrap();
+    for _ in 0..500 {
+        sim.step();
+    }
+    assert!(
+        sim.world()
+            .iter_riders()
+            .any(|(_, r)| r.phase() == RiderPhase::Waiting),
+        "rider should stay Waiting with Manual elevator"
+    );
+    assert_eq!(sim.metrics().total_delivered(), 0);
+}
+
+#[test]
+fn set_target_velocity_moves_elevator_up() {
+    let (mut sim, elev) = make_manual();
+    sim.set_target_velocity(elev, 1.0).unwrap();
+
+    let p0 = sim.world().position(elev).unwrap().value();
+    for _ in 0..60 {
+        sim.step();
+    }
+    let p1 = sim.world().position(elev).unwrap().value();
+    let v = sim.velocity(elev).unwrap();
+    assert!(p1 > p0, "elevator should move upward: {p0} -> {p1}");
+    assert!(v > 0.0, "velocity should be positive, got {v}");
+}
+
+#[test]
+fn set_target_velocity_ramps_using_acceleration() {
+    let (mut sim, elev) = make_manual();
+    // max_speed = 2.0, acceleration = 1.5, dt = 1/60. After 1 tick,
+    // velocity should be acceleration*dt ≈ 0.025.
+    sim.set_target_velocity(elev, 2.0).unwrap();
+    sim.step();
+    let v = sim.velocity(elev).unwrap();
+    assert!(
+        (v - (1.5 / 60.0)).abs() < 1e-6,
+        "expected ~{}, got {v}",
+        1.5 / 60.0
+    );
+}
+
+#[test]
+fn set_target_velocity_clamped_to_max_speed() {
+    let (mut sim, elev) = make_manual();
+    // Overshoot: request 100 m/s with max_speed = 2.0 — should clamp.
+    sim.set_target_velocity(elev, 100.0).unwrap();
+    for _ in 0..1000 {
+        sim.step();
+    }
+    let v = sim.velocity(elev).unwrap();
+    assert!(v <= 2.0 + 1e-9, "velocity should cap at max_speed, got {v}");
+    assert!((v - 2.0).abs() < 1e-6, "should reach max_speed, got {v}");
+}
+
+#[test]
+fn emergency_stop_decelerates_to_zero() {
+    let (mut sim, elev) = make_manual();
+    sim.set_target_velocity(elev, 2.0).unwrap();
+    for _ in 0..1000 {
+        sim.step();
+    }
+    assert!(sim.velocity(elev).unwrap() > 1.0, "needs to be moving");
+
+    sim.emergency_stop(elev).unwrap();
+    for _ in 0..1000 {
+        sim.step();
+        if sim.velocity(elev).unwrap().abs() < 1e-6 {
+            break;
+        }
+    }
+    let v = sim.velocity(elev).unwrap();
+    assert!(v.abs() < 1e-6, "velocity should reach zero, got {v}");
+}
+
+#[test]
+fn manual_elevator_can_stop_at_any_position() {
+    let (mut sim, elev) = make_manual();
+    sim.set_target_velocity(elev, 0.5).unwrap();
+    for _ in 0..200 {
+        sim.step();
+    }
+    sim.emergency_stop(elev).unwrap();
+    for _ in 0..1000 {
+        sim.step();
+        if sim.velocity(elev).unwrap().abs() < 1e-6 {
+            break;
+        }
+    }
+    let pos = sim.world().position(elev).unwrap().value();
+    // Should be somewhere between stops 0 (0.0) and 1 (4.0) — not snapped.
+    assert!(
+        pos > 0.1 && pos < 3.9,
+        "expected intermediate position, got {pos}"
+    );
+}
+
+#[test]
+fn set_target_velocity_on_non_manual_errors() {
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let elev = sim.world().iter_elevators().next().unwrap().0;
+    // Mode is default Normal.
+    let err = sim.set_target_velocity(elev, 1.0).unwrap_err();
+    assert!(
+        format!("{err}").contains("Manual"),
+        "error should mention Manual: {err}"
+    );
+}
+
+#[test]
+fn set_target_velocity_rejects_nonfinite() {
+    let (mut sim, elev) = make_manual();
+    assert!(sim.set_target_velocity(elev, f64::NAN).is_err());
+    assert!(sim.set_target_velocity(elev, f64::INFINITY).is_err());
+}
+
+#[test]
+fn set_target_velocity_emits_event() {
+    let (mut sim, elev) = make_manual();
+    sim.drain_events();
+    sim.set_target_velocity(elev, 1.5).unwrap();
+    let events = sim.drain_events();
+    assert!(events.iter().any(|e| matches!(
+        e,
+        Event::ManualVelocityCommanded { target_velocity: Some(v), .. } if (v.0 - 1.5).abs() < 1e-9
+    )));
+}
+
+#[test]
+fn emergency_stop_emits_event_with_none_payload() {
+    let (mut sim, elev) = make_manual();
+    sim.drain_events();
+    sim.emergency_stop(elev).unwrap();
+    let events = sim.drain_events();
+    assert!(events.iter().any(|e| matches!(
+        e,
+        Event::ManualVelocityCommanded {
+            target_velocity: None,
+            ..
+        }
+    )));
+}
+
+#[test]
+fn leaving_manual_clears_target_velocity() {
+    let (mut sim, elev) = make_manual();
+    sim.set_target_velocity(elev, 1.0).unwrap();
+    assert_eq!(
+        sim.world().elevator(elev).unwrap().manual_target_velocity(),
+        Some(1.0)
+    );
+    sim.set_service_mode(elev, ServiceMode::Normal).unwrap();
+    assert_eq!(
+        sim.world().elevator(elev).unwrap().manual_target_velocity(),
+        None
+    );
+}
+
+#[test]
+fn manual_mode_emits_passing_floor_events() {
+    let (mut sim, elev) = make_manual();
+    sim.set_target_velocity(elev, 2.0).unwrap();
+    sim.drain_events();
+    // Run long enough to cross stop 1 (position 4.0).
+    for _ in 0..300 {
+        sim.step();
+        if sim.world().position(elev).unwrap().value() > 5.0 {
+            break;
+        }
+    }
+    let events = sim.drain_events();
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::PassingFloor { .. })),
+        "should emit PassingFloor while cruising"
+    );
+}

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -47,6 +47,7 @@ mod door_control_tests;
 #[cfg(feature = "energy")]
 mod energy_tests;
 mod event_payload_tests;
+mod manual_mode_tests;
 mod move_count_tests;
 mod multi_elevator_tests;
 mod multi_line_tests;

--- a/crates/elevator-core/src/tests/mutation_kills_tests.rs
+++ b/crates/elevator-core/src/tests/mutation_kills_tests.rs
@@ -221,6 +221,7 @@ fn spawn_elev(world: &mut World, pos: f64, n: usize) -> Vec<EntityId> {
                     going_down: true,
                     move_count: 0,
                     door_command_queue: Vec::new(),
+                    manual_target_velocity: None,
                 },
             );
             eid

--- a/crates/elevator-core/src/tests/query_tests.rs
+++ b/crates/elevator-core/src/tests/query_tests.rs
@@ -49,6 +49,7 @@ fn test_world() -> (World, EntityId, EntityId, EntityId) {
             going_down: true,
             move_count: 0,
             door_command_queue: Vec::new(),
+            manual_target_velocity: None,
         },
     );
 

--- a/crates/elevator-core/src/tests/reposition_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_tests.rs
@@ -81,6 +81,7 @@ fn spawn_elevator(world: &mut World, position: f64) -> EntityId {
             going_down: true,
             move_count: 0,
             door_command_queue: Vec::new(),
+            manual_target_velocity: None,
         },
     );
     eid

--- a/crates/elevator-core/src/tests/world_tests.rs
+++ b/crates/elevator-core/src/tests/world_tests.rs
@@ -65,6 +65,7 @@ fn elevator_query_returns_entities_with_both_components() {
             going_down: true,
             move_count: 0,
             door_command_queue: Vec::new(),
+            manual_target_velocity: None,
         },
     );
 


### PR DESCRIPTION
## Summary
- New `ServiceMode::Manual`: elevators driven by direct velocity commands (player-as-elevator games, first-person cab controls).
- `Simulation::set_target_velocity(eid, v)` — signed target speed, clamped to `max_speed`; ramps via the car's accel/decel caps.
- `Simulation::emergency_stop(eid)` — immediate decel to zero.
- Manual elevators are skipped by dispatch & repositioning (via new `ServiceMode::is_dispatch_excluded()` helper — also replaces the three inline Independent checks).
- Car can stop at any position, not just configured stops. Doors follow the existing manual door-control API.
- New `Event::ManualVelocityCommanded`. Leaving Manual clears pending velocity commands.
- New \`manual_driver\` example + lib.rs doc section.

## Test plan
- [x] 12 new \`manual_mode_tests\` (dispatch skip, accel ramp, max_speed clamp, e-stop, intermediate-position stops, error cases, events, mode-transition clears)
- [x] \`cargo test -p elevator-core\` — 505 passing (was 493)
- [x] \`cargo clippy -p elevator-core --all-targets -- -D warnings\`
- [x] \`cargo run -p elevator-core --example manual_driver --release\`