### PR TITLE
fix: greptile findings on manual mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2363,7 +2363,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "5.7.0"
+version = "5.8.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -416,12 +416,6 @@ pub enum Event {
         tick: u64,
     },
 
-    /// An elevator parameter was mutated at runtime via one of the
-    /// `Simulation::set_*` upgrade setters (e.g. buying a speed upgrade
-    /// in an RPG, or a scripted event changing capacity mid-game).
-    ///
-    /// Emitted immediately when the setter succeeds. Games can use this
-    /// to trigger score popups, SFX, or UI updates.
     /// A manual door-control command was received and either applied
     /// immediately or stored for later.
     ///

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -760,12 +760,18 @@ impl Simulation {
         if old == mode {
             return Ok(());
         }
-        // Leaving Manual: clear any pending velocity command so a later
-        // re-entry to Manual doesn't pick up a stale target.
-        if old == crate::components::ServiceMode::Manual
-            && let Some(car) = self.world.elevator_mut(elevator)
-        {
-            car.manual_target_velocity = None;
+        // Leaving Manual: clear the pending velocity command and zero
+        // the velocity component. Otherwise a car moving at transition
+        // time is stranded — the Normal movement system only runs for
+        // MovingToStop/Repositioning phases, so velocity would linger
+        // forever without producing any position change.
+        if old == crate::components::ServiceMode::Manual {
+            if let Some(car) = self.world.elevator_mut(elevator) {
+                car.manual_target_velocity = None;
+            }
+            if let Some(v) = self.world.velocity_mut(elevator) {
+                v.value = 0.0;
+            }
         }
         self.world.set_service_mode(elevator, mode);
         self.events.emit(Event::ServiceModeChanged {

--- a/crates/elevator-core/src/systems/movement.rs
+++ b/crates/elevator-core/src/systems/movement.rs
@@ -26,7 +26,7 @@ pub fn run(
             .service_mode(eid)
             .is_some_and(|m| *m == crate::components::ServiceMode::Manual)
         {
-            tick_manual(world, events, ctx, eid);
+            tick_manual(world, events, ctx, eid, metrics);
             continue;
         }
         let target_stop_eid = match world.elevator(eid) {
@@ -196,6 +196,7 @@ fn tick_manual(
     events: &mut EventBus,
     ctx: &PhaseContext,
     eid: crate::entity::EntityId,
+    metrics: &mut Metrics,
 ) {
     let Some(car) = world.elevator(eid) else {
         return;
@@ -267,5 +268,6 @@ fn tick_manual(
         && let Some(car) = world.elevator_mut(eid)
     {
         car.move_count += passing_moves;
+        metrics.total_moves += passing_moves;
     }
 }

--- a/crates/elevator-core/src/tests/manual_mode_tests.rs
+++ b/crates/elevator-core/src/tests/manual_mode_tests.rs
@@ -178,6 +178,50 @@ fn leaving_manual_clears_target_velocity() {
 }
 
 #[test]
+fn manual_mode_updates_total_moves_metric() {
+    // Regression: tick_manual used to bump car.move_count but not
+    // metrics.total_moves, breaking the invariant that total_moves equals
+    // the sum of per-elevator move_count.
+    let (mut sim, elev) = make_manual();
+    sim.set_target_velocity(elev, 2.0).unwrap();
+    for _ in 0..300 {
+        sim.step();
+        if sim.world().position(elev).unwrap().value() > 8.5 {
+            break;
+        }
+    }
+    let car_count = sim.world().elevator(elev).unwrap().move_count();
+    assert!(car_count > 0, "expected per-elevator move_count > 0");
+    assert_eq!(
+        sim.metrics().total_moves(),
+        car_count,
+        "metrics.total_moves must match per-elevator move_count"
+    );
+}
+
+#[test]
+fn leaving_manual_zeroes_velocity() {
+    // Regression: leaving Manual while the car was moving would leave a
+    // lingering velocity that the Normal movement system never updates.
+    let (mut sim, elev) = make_manual();
+    sim.set_target_velocity(elev, 2.0).unwrap();
+    for _ in 0..200 {
+        sim.step();
+    }
+    assert!(
+        sim.velocity(elev).unwrap().abs() > 0.1,
+        "needs to be moving"
+    );
+
+    sim.set_service_mode(elev, ServiceMode::Normal).unwrap();
+    assert_eq!(
+        sim.velocity(elev).unwrap(),
+        0.0,
+        "velocity should be zeroed on Manual exit"
+    );
+}
+
+#[test]
 fn manual_mode_emits_passing_floor_events() {
     let (mut sim, elev) = make_manual();
     sim.set_target_velocity(elev, 2.0).unwrap();


### PR DESCRIPTION
## Summary
Address greptile review feedback from #77:

- **P1**: `tick_manual` bumped `car.move_count` but not `metrics.total_moves`, breaking the invariant that `total_moves == sum(per-elevator move_count)`. Now passes `&mut Metrics` and credits both.
- **P2**: Leaving Manual mode while the car was moving left a lingering velocity that Normal-mode movement never touches (since it only updates velocity for cars in `MovingToStop`/`Repositioning`). Exiting Manual now zeroes velocity alongside clearing `manual_target_velocity`.
- Cleaned up a stray `ElevatorUpgraded`-related doc fragment prepended to `DoorCommandQueued`.

Added two regression tests: `manual_mode_updates_total_moves_metric` and `leaving_manual_zeroes_velocity`.

## Test plan
- [x] `cargo test -p elevator-core` (all pass)
- [x] `cargo clippy -p elevator-core -- -D warnings` (clean)