### PR TITLE
feat: bincode snapshot_bytes with version-checked restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,6 +1613,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2363,8 +2383,9 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "5.8.0"
+version = "5.8.1"
 dependencies = [
+ "bincode",
  "criterion",
  "ordered-float",
  "proptest",
@@ -5108,6 +5129,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "uuid"
 version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5147,6 +5174,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,4 @@ serde = { version = "1", features = ["derive"] }
 ron = "0.12"
 rand = "0.10"
 slotmap = { version = "1", features = ["serde"] }
+bincode = { version = "2", features = ["serde"] }

--- a/crates/elevator-core/Cargo.toml
+++ b/crates/elevator-core/Cargo.toml
@@ -29,6 +29,7 @@ rand = { workspace = true, optional = true }
 slotmap.workspace = true
 ordered-float = { version = "5", features = ["serde"] }
 smallvec = { version = "1", features = ["serde"] }
+bincode.workspace = true
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/elevator-core/src/error.rs
+++ b/crates/elevator-core/src/error.rs
@@ -52,6 +52,15 @@ pub enum SimError {
         /// The groups that serve both stops.
         groups: Vec<GroupId>,
     },
+    /// Snapshot bytes were produced by a different crate version.
+    SnapshotVersion {
+        /// Crate version recorded in the snapshot header.
+        saved: String,
+        /// Current crate version attempting the restore.
+        current: String,
+    },
+    /// Snapshot bytes are malformed or not a snapshot at all.
+    SnapshotFormat(String),
 }
 
 impl fmt::Display for SimError {
@@ -91,6 +100,13 @@ impl fmt::Display for SimError {
                     format_group_list(groups),
                 )
             }
+            Self::SnapshotVersion { saved, current } => {
+                write!(
+                    f,
+                    "snapshot was saved on elevator-core {saved}, but current version is {current}",
+                )
+            }
+            Self::SnapshotFormat(reason) => write!(f, "malformed snapshot: {reason}"),
         }
     }
 }

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -170,6 +170,16 @@
 //! 4. Re-register extensions: `world.register_ext::<T>(name)` per type
 //! 5. Load extension data: `sim.load_extensions()`
 //!
+//! For the common case (save-to-disk, load-from-disk), skip the format choice
+//! and use [`Simulation::snapshot_bytes`](sim::Simulation::snapshot_bytes) /
+//! [`Simulation::restore_bytes`](sim::Simulation::restore_bytes). The byte
+//! blob is bincode-encoded and carries a magic prefix plus the crate version:
+//! restoring bytes from a different `elevator-core` version returns
+//! [`SimError::SnapshotVersion`](error::SimError::SnapshotVersion) instead of
+//! silently producing a garbled sim. Determinism is bit-exact across builds
+//! of the same crate version, which makes snapshots viable as rollback-netcode
+//! checkpoints or deterministic replay fixtures.
+//!
 //! ### Performance
 //!
 //! | Operation | Complexity |

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -474,6 +474,24 @@ impl WorldSnapshot {
     }
 }
 
+/// Magic bytes identifying a bincode snapshot blob.
+const SNAPSHOT_MAGIC: [u8; 8] = *b"ELEVSNAP";
+
+/// Byte-level snapshot envelope: magic + crate version + payload.
+///
+/// Serialized via bincode. The magic and version fields are checked on
+/// restore to reject blobs from other tools or from a different
+/// `elevator-core` version.
+#[derive(Debug, Serialize, Deserialize)]
+struct SnapshotEnvelope {
+    /// Magic bytes; must equal [`SNAPSHOT_MAGIC`] or the blob is rejected.
+    magic: [u8; 8],
+    /// `elevator-core` crate version that produced the blob.
+    version: String,
+    /// The captured simulation state.
+    payload: WorldSnapshot,
+}
+
 impl crate::sim::Simulation {
     /// Create a serializable snapshot of the current simulation state.
     ///
@@ -587,5 +605,66 @@ impl crate::sim::Simulation {
             extensions: self.world().serialize_extensions(),
             ticks_per_second: 1.0 / self.dt(),
         }
+    }
+
+    /// Serialize the current state to a self-describing byte blob.
+    ///
+    /// The blob is bincode-encoded and carries a magic prefix plus the
+    /// `elevator-core` crate version. Use [`Simulation::restore_bytes`]
+    /// on the receiving end. Determinism is bit-exact across builds of
+    /// the same crate version; cross-version restores return
+    /// [`SimError::SnapshotVersion`](crate::error::SimError::SnapshotVersion).
+    ///
+    /// Extension components are included as in [`Simulation::snapshot`];
+    /// custom dispatch strategies and arbitrary `World` resources are
+    /// not.
+    ///
+    /// # Errors
+    /// Returns [`SimError::SnapshotFormat`](crate::error::SimError::SnapshotFormat)
+    /// if bincode encoding fails. This is unreachable for well-formed
+    /// `WorldSnapshot` values (all fields derive `Serialize`), so callers
+    /// that don't care can `unwrap`.
+    pub fn snapshot_bytes(&self) -> Result<Vec<u8>, crate::error::SimError> {
+        let envelope = SnapshotEnvelope {
+            magic: SNAPSHOT_MAGIC,
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+            payload: self.snapshot(),
+        };
+        bincode::serde::encode_to_vec(&envelope, bincode::config::standard())
+            .map_err(|e| crate::error::SimError::SnapshotFormat(e.to_string()))
+    }
+
+    /// Restore a simulation from bytes produced by [`Simulation::snapshot_bytes`].
+    ///
+    /// Built-in dispatch strategies are auto-restored. For groups using
+    /// [`BuiltinStrategy::Custom`](crate::dispatch::BuiltinStrategy::Custom),
+    /// provide a factory; pass `None` otherwise.
+    ///
+    /// # Errors
+    /// - [`SimError::SnapshotFormat`](crate::error::SimError::SnapshotFormat)
+    ///   if the bytes are not a valid envelope or the magic prefix does
+    ///   not match.
+    /// - [`SimError::SnapshotVersion`](crate::error::SimError::SnapshotVersion)
+    ///   if the blob was produced by a different crate version.
+    pub fn restore_bytes(
+        bytes: &[u8],
+        custom_strategy_factory: CustomStrategyFactory<'_>,
+    ) -> Result<Self, crate::error::SimError> {
+        let (envelope, _consumed): (SnapshotEnvelope, usize) =
+            bincode::serde::decode_from_slice(bytes, bincode::config::standard())
+                .map_err(|e| crate::error::SimError::SnapshotFormat(e.to_string()))?;
+        if envelope.magic != SNAPSHOT_MAGIC {
+            return Err(crate::error::SimError::SnapshotFormat(
+                "magic bytes do not match".to_string(),
+            ));
+        }
+        let current = env!("CARGO_PKG_VERSION");
+        if envelope.version != current {
+            return Err(crate::error::SimError::SnapshotVersion {
+                saved: envelope.version,
+                current: current.to_owned(),
+            });
+        }
+        Ok(envelope.payload.restore(custom_strategy_factory))
     }
 }

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -252,3 +252,120 @@ fn snapshot_preserves_extension_components() {
     }
     assert!(found, "VipTag extension should survive snapshot roundtrip");
 }
+
+#[test]
+fn snapshot_bytes_roundtrip() {
+    let config = helpers::default_config();
+    let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    for _ in 0..50 {
+        sim.step();
+    }
+
+    let bytes = sim.snapshot_bytes().unwrap();
+    assert!(!bytes.is_empty());
+    let restored = crate::sim::Simulation::restore_bytes(&bytes, None).unwrap();
+    assert_eq!(restored.current_tick(), sim.current_tick());
+    assert_eq!(
+        restored.metrics().total_delivered(),
+        sim.metrics().total_delivered(),
+    );
+}
+
+#[test]
+fn snapshot_bytes_rejects_wrong_magic() {
+    let config = helpers::default_config();
+    let sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+    let mut bytes = sim.snapshot_bytes().unwrap();
+    // The magic is serialized first — flip a byte inside the first 8.
+    bytes[0] ^= 0xFF;
+    let err = crate::sim::Simulation::restore_bytes(&bytes, None).unwrap_err();
+    assert!(
+        matches!(err, crate::error::SimError::SnapshotFormat(_)),
+        "expected SnapshotFormat, got {err:?}",
+    );
+}
+
+#[derive(Serialize)]
+struct FakeEnvelope {
+    magic: [u8; 8],
+    version: String,
+    payload: crate::snapshot::WorldSnapshot,
+}
+
+#[test]
+fn snapshot_bytes_rejects_wrong_version() {
+    let config = helpers::default_config();
+    let sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+    let real = sim.snapshot();
+
+    let fake = FakeEnvelope {
+        magic: *b"ELEVSNAP",
+        version: "0.0.0-definitely-not-real".to_owned(),
+        payload: real,
+    };
+    let bytes = bincode::serde::encode_to_vec(&fake, bincode::config::standard()).unwrap();
+
+    let err = crate::sim::Simulation::restore_bytes(&bytes, None).unwrap_err();
+    match err {
+        crate::error::SimError::SnapshotVersion { saved, current } => {
+            assert_eq!(saved, "0.0.0-definitely-not-real");
+            assert_eq!(current, env!("CARGO_PKG_VERSION"));
+        }
+        other => panic!("expected SnapshotVersion, got {other:?}"),
+    }
+}
+
+#[test]
+fn snapshot_bytes_rejects_garbage() {
+    let err = crate::sim::Simulation::restore_bytes(&[1, 2, 3, 4], None).unwrap_err();
+    assert!(matches!(err, crate::error::SimError::SnapshotFormat(_)));
+}
+
+#[test]
+fn snapshot_bytes_midrun_determinism() {
+    // Snapshot at tick N, restore, step to 2N. A fresh sim stepped
+    // straight to 2N should produce identical metrics. This proves
+    // that (a) the snapshot captures all state the movement/loading
+    // systems read, and (b) restoration doesn't introduce divergence.
+    let config = helpers::default_config();
+
+    let mut fresh = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+    fresh
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    fresh
+        .spawn_rider_by_stop_id(StopId(1), StopId(0), 80.0)
+        .unwrap();
+
+    let mut via_snapshot = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+    via_snapshot
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    via_snapshot
+        .spawn_rider_by_stop_id(StopId(1), StopId(0), 80.0)
+        .unwrap();
+
+    for _ in 0..250 {
+        fresh.step();
+        via_snapshot.step();
+    }
+    let bytes = via_snapshot.snapshot_bytes().unwrap();
+    let mut via_snapshot = crate::sim::Simulation::restore_bytes(&bytes, None).unwrap();
+
+    for _ in 0..250 {
+        fresh.step();
+        via_snapshot.step();
+    }
+
+    assert_eq!(fresh.current_tick(), via_snapshot.current_tick());
+    assert_eq!(
+        fresh.metrics().total_delivered(),
+        via_snapshot.metrics().total_delivered(),
+    );
+    assert_eq!(
+        fresh.metrics().total_moves(),
+        via_snapshot.metrics().total_moves(),
+    );
+}


### PR DESCRIPTION
## Summary
- Adds `Simulation::snapshot_bytes() -> Result<Vec<u8>, SimError>` and `Simulation::restore_bytes(bytes, factory) -> Result<Simulation, SimError>` as a thin bincode layer over the existing `WorldSnapshot` machinery.
- The envelope carries an `ELEVSNAP` magic prefix plus the `elevator-core` crate version. Cross-version blobs fail fast with `SimError::SnapshotVersion { saved, current }` instead of silently producing garbled state.
- Adds `SimError::SnapshotVersion` and `SimError::SnapshotFormat(String)` (non_exhaustive, so additive).
- No change to the existing `snapshot() -> WorldSnapshot` / `WorldSnapshot::restore(factory)` API — games that want a specific format (RON for debugging, JSON for interop) still have it.

## Motivation
For the common save-to-disk / rollback-checkpoint use case, callers previously had to pick a serde format, manage magic bytes, and handle version checks themselves. This ships the ergonomic default: call `snapshot_bytes()`, stash the bytes, call `restore_bytes(&bytes, None)` later. Determinism is bit-exact within a crate version, making these blobs usable as rollback-netcode checkpoints or replay-test fixtures.

## Test plan
- [x] `cargo test -p elevator-core` (512 tests pass)
- [x] `cargo clippy -p elevator-core --all-targets -- -D warnings` (clean)
- [x] `snapshot_bytes_roundtrip` — tick and metrics survive a bincode round trip.
- [x] `snapshot_bytes_rejects_wrong_magic` — corrupted magic → `SnapshotFormat`.
- [x] `snapshot_bytes_rejects_wrong_version` — forged envelope with bogus version → `SnapshotVersion` with both `saved` and `current` populated.
- [x] `snapshot_bytes_rejects_garbage` — random bytes → `SnapshotFormat`.
- [x] `snapshot_bytes_midrun_determinism` — snapshot at tick 250, resume, run to 500; metrics match a fresh sim run straight to 500 with the same seed.