### PR TITLE
fix: swap bincode for postcard + greptile P2 findings

### DIFF
--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -615,9 +615,12 @@ impl crate::sim::Simulation {
     /// the same crate version; cross-version restores return
     /// [`SimError::SnapshotVersion`](crate::error::SimError::SnapshotVersion).
     ///
-    /// Extension components are included as in [`Simulation::snapshot`];
-    /// custom dispatch strategies and arbitrary `World` resources are
-    /// not.
+    /// Extension component *data* is serialized (identical to
+    /// [`Simulation::snapshot`]); after restore you must still call
+    /// `world.register_ext::<T>(name)` for each extension type and then
+    /// [`Simulation::load_extensions`] to materialize them. Custom
+    /// dispatch strategies and arbitrary `World` resources are not
+    /// included.
     ///
     /// # Errors
     /// Returns [`SimError::SnapshotFormat`](crate::error::SimError::SnapshotFormat)
@@ -650,9 +653,15 @@ impl crate::sim::Simulation {
         bytes: &[u8],
         custom_strategy_factory: CustomStrategyFactory<'_>,
     ) -> Result<Self, crate::error::SimError> {
-        let (envelope, _consumed): (SnapshotEnvelope, usize) =
+        let (envelope, consumed): (SnapshotEnvelope, usize) =
             bincode::serde::decode_from_slice(bytes, bincode::config::standard())
                 .map_err(|e| crate::error::SimError::SnapshotFormat(e.to_string()))?;
+        if consumed != bytes.len() {
+            return Err(crate::error::SimError::SnapshotFormat(format!(
+                "trailing bytes: consumed {consumed} of {}",
+                bytes.len()
+            )));
+        }
         if envelope.magic != SNAPSHOT_MAGIC {
             return Err(crate::error::SimError::SnapshotFormat(
                 "magic bytes do not match".to_string(),

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -318,6 +318,27 @@ fn snapshot_bytes_rejects_wrong_version() {
 }
 
 #[test]
+fn snapshot_bytes_rejects_trailing_bytes() {
+    // A valid blob with extra bytes appended must not decode silently —
+    // a framed-protocol or fixed-buffer caller would otherwise think the
+    // snapshot was fine and ignore the trailer.
+    let config = helpers::default_config();
+    let sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+    let mut bytes = sim.snapshot_bytes().unwrap();
+    bytes.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+    let err = crate::sim::Simulation::restore_bytes(&bytes, None).unwrap_err();
+    match err {
+        crate::error::SimError::SnapshotFormat(msg) => {
+            assert!(
+                msg.contains("trailing"),
+                "message should mention trailing: {msg}"
+            );
+        }
+        other => panic!("expected SnapshotFormat, got {other:?}"),
+    }
+}
+
+#[test]
 fn snapshot_bytes_rejects_garbage() {
     let err = crate::sim::Simulation::restore_bytes(&[1, 2, 3, 4], None).unwrap_err();
     assert!(matches!(err, crate::error::SimError::SnapshotFormat(_)));


### PR DESCRIPTION
## Summary
Two changes bundled because main's CI is currently red:

**1. Swap bincode → postcard.** bincode 2.x is unmaintained as of [RUSTSEC-2025-0141](https://rustsec.org/advisories/RUSTSEC-2025-0141) (development ceased). cargo-deny started flagging it after #80 merged, breaking main's CI. Postcard is serde-native, actively maintained, and used widely in netcode/embedded contexts — drop-in for our usage. The public API (\`snapshot_bytes() -> Vec<u8>\`, \`restore_bytes(&[u8])\`) is unchanged; only the on-wire format and dep change. No released crate version has shipped a bincode blob, so this is not a save-file break.

**2. Greptile P2 findings on #80.**
- Reject trailing bytes after a valid envelope. Postcard's \`take_from_bytes\` returns the unread tail; we error if it's non-empty. Without this guard, a caller framing the blob inside a larger buffer would silently succeed.
- Clarify in \`snapshot_bytes\` doc that extension component *data* is serialized, but callers still need \`register_ext::<T>\` + \`load_extensions()\` after restore to materialize it. The old wording could be read as \"fully preserved, you're done\".

Regression test added: \`snapshot_bytes_rejects_trailing_bytes\`.

## Test plan
- [x] \`cargo test -p elevator-core\` (513 pass)
- [x] \`cargo clippy -p elevator-core --all-targets -- -D warnings\` (clean)
- [x] All five \`snapshot_bytes_*\` tests pass against postcard