### PR TITLE
fix: swap bincode for postcard (unblock main CI)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,6 +328,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,7 +1124,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde",
- "spin",
+ "spin 0.10.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
@@ -1400,7 +1409,7 @@ dependencies = [
  "crossbeam-queue",
  "derive_more",
  "futures-lite",
- "heapless",
+ "heapless 0.9.2",
  "pin-project",
 ]
 
@@ -1610,26 +1619,6 @@ dependencies = [
  "web-sys",
  "wgpu-types",
  "winit",
-]
-
-[[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
 ]
 
 [[package]]
@@ -1920,6 +1909,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "codespan-reporting"
@@ -2385,9 +2383,9 @@ dependencies = [
 name = "elevator-core"
 version = "5.8.1"
 dependencies = [
- "bincode",
  "criterion",
  "ordered-float",
+ "postcard",
  "proptest",
  "rand 0.10.1",
  "ron",
@@ -2396,6 +2394,18 @@ dependencies = [
  "slotmap",
  "smallvec",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encase"
@@ -2887,6 +2897,15 @@ dependencies = [
 
 [[package]]
 name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
@@ -2923,11 +2942,25 @@ checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32 0.2.1",
+ "rustc_version",
+ "serde",
+ "spin 0.9.8",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
 dependencies = [
- "hash32",
+ "hash32 0.3.1",
  "portable-atomic",
  "stable_deref_trait",
 ]
@@ -4054,6 +4087,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless 0.7.17",
+ "serde",
+]
+
+[[package]]
 name = "pp-rs"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4697,6 +4743,15 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
@@ -5129,12 +5184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "uuid"
 version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5174,12 +5223,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "5.8.1"
+version = "5.9.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,4 @@ serde = { version = "1", features = ["derive"] }
 ron = "0.12"
 rand = "0.10"
 slotmap = { version = "1", features = ["serde"] }
-bincode = { version = "2", features = ["serde"] }
+postcard = { version = "1", features = ["alloc"] }

--- a/crates/elevator-core/Cargo.toml
+++ b/crates/elevator-core/Cargo.toml
@@ -29,7 +29,7 @@ rand = { workspace = true, optional = true }
 slotmap.workspace = true
 ordered-float = { version = "5", features = ["serde"] }
 smallvec = { version = "1", features = ["serde"] }
-bincode.workspace = true
+postcard.workspace = true
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -173,7 +173,7 @@
 //! For the common case (save-to-disk, load-from-disk), skip the format choice
 //! and use [`Simulation::snapshot_bytes`](sim::Simulation::snapshot_bytes) /
 //! [`Simulation::restore_bytes`](sim::Simulation::restore_bytes). The byte
-//! blob is bincode-encoded and carries a magic prefix plus the crate version:
+//! blob is postcard-encoded and carries a magic prefix plus the crate version:
 //! restoring bytes from a different `elevator-core` version returns
 //! [`SimError::SnapshotVersion`](error::SimError::SnapshotVersion) instead of
 //! silently producing a garbled sim. Determinism is bit-exact across builds

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -609,7 +609,7 @@ impl crate::sim::Simulation {
 
     /// Serialize the current state to a self-describing byte blob.
     ///
-    /// The blob is bincode-encoded and carries a magic prefix plus the
+    /// The blob is postcard-encoded and carries a magic prefix plus the
     /// `elevator-core` crate version. Use [`Simulation::restore_bytes`]
     /// on the receiving end. Determinism is bit-exact across builds of
     /// the same crate version; cross-version restores return
@@ -624,7 +624,7 @@ impl crate::sim::Simulation {
     ///
     /// # Errors
     /// Returns [`SimError::SnapshotFormat`](crate::error::SimError::SnapshotFormat)
-    /// if bincode encoding fails. This is unreachable for well-formed
+    /// if postcard encoding fails. This is unreachable for well-formed
     /// `WorldSnapshot` values (all fields derive `Serialize`), so callers
     /// that don't care can `unwrap`.
     pub fn snapshot_bytes(&self) -> Result<Vec<u8>, crate::error::SimError> {
@@ -633,7 +633,7 @@ impl crate::sim::Simulation {
             version: env!("CARGO_PKG_VERSION").to_owned(),
             payload: self.snapshot(),
         };
-        bincode::serde::encode_to_vec(&envelope, bincode::config::standard())
+        postcard::to_allocvec(&envelope)
             .map_err(|e| crate::error::SimError::SnapshotFormat(e.to_string()))
     }
 
@@ -653,12 +653,12 @@ impl crate::sim::Simulation {
         bytes: &[u8],
         custom_strategy_factory: CustomStrategyFactory<'_>,
     ) -> Result<Self, crate::error::SimError> {
-        let (envelope, consumed): (SnapshotEnvelope, usize) =
-            bincode::serde::decode_from_slice(bytes, bincode::config::standard())
-                .map_err(|e| crate::error::SimError::SnapshotFormat(e.to_string()))?;
-        if consumed != bytes.len() {
+        let (envelope, tail): (SnapshotEnvelope, &[u8]) = postcard::take_from_bytes(bytes)
+            .map_err(|e| crate::error::SimError::SnapshotFormat(e.to_string()))?;
+        if !tail.is_empty() {
             return Err(crate::error::SimError::SnapshotFormat(format!(
-                "trailing bytes: consumed {consumed} of {}",
+                "trailing bytes: {} unread of {}",
+                tail.len(),
                 bytes.len()
             )));
         }

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -305,7 +305,7 @@ fn snapshot_bytes_rejects_wrong_version() {
         version: "0.0.0-definitely-not-real".to_owned(),
         payload: real,
     };
-    let bytes = bincode::serde::encode_to_vec(&fake, bincode::config::standard()).unwrap();
+    let bytes = postcard::to_allocvec(&fake).unwrap();
 
     let err = crate::sim::Simulation::restore_bytes(&bytes, None).unwrap_err();
     match err {


### PR DESCRIPTION
## Summary
bincode 2.x is unmaintained ([RUSTSEC-2025-0141](https://rustsec.org/advisories/RUSTSEC-2025-0141) — development ceased after a harassment incident). cargo-deny started flagging it after #80 landed, and main's CI has been red since.

Context: PR #82 was intended to bundle the postcard swap with greptile P2 fixes, but automerge squash-merged only the first commit before my second push (the swap) landed, leaving main broken. This PR applies just the swap.

**Changes:**
- Workspace + crate deps: `bincode` → `postcard` (serde-native, actively maintained, deterministic, used widely in netcode/embedded contexts).
- `snapshot_bytes` now uses `postcard::to_allocvec`.
- `restore_bytes` uses `postcard::take_from_bytes` — same trailing-byte guard from #82 via the returned tail slice.
- Doc refs updated (\`bincode-encoded\` → \`postcard-encoded\`).
- Version-mismatch test updated to forge an envelope via postcard.

The public API (\`snapshot_bytes() -> Result<Vec<u8>, SimError>\`, \`restore_bytes(&[u8])\`) is unchanged. No released crate version has shipped a bincode blob, so this is not a save-file break in practice.

## Test plan
- [x] \`cargo test -p elevator-core\` (513 pass)
- [x] \`cargo clippy -p elevator-core --all-targets -- -D warnings\` (clean)
- [x] All six \`snapshot_bytes_*\` tests pass against postcard