### PR TITLE
feat!: score-based dispatch with Hungarian assignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2351,6 +2351,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "deprecate-until"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d0795c0c5b2cab72b80d75b5cb08bde679e616c67e954669a2476668319ac3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "semver",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2456,6 +2468,7 @@ version = "5.10.0"
 dependencies = [
  "criterion",
  "ordered-float",
+ "pathfinding",
  "postcard",
  "proptest",
  "rand 0.10.1",
@@ -2468,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cbindgen",
  "elevator-core",
@@ -3125,6 +3138,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "integer-sqrt"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -4041,6 +4063,20 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathfinding"
+version = "4.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835ad2773f8587ad2d90a0f7f0022ca743dfd5a6a24ea25062f3519c38d2fcfa"
+dependencies = [
+ "deprecate-until",
+ "indexmap",
+ "integer-sqrt",
+ "num-traits",
+ "rustc-hash 2.1.2",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "percent-encoding"

--- a/crates/elevator-core/ARCHITECTURE.md
+++ b/crates/elevator-core/ARCHITECTURE.md
@@ -102,7 +102,7 @@ consumers via `drain_events()` after the tick completes.
 │                       │  Boarding→Riding, Exiting→Arrived, walk legs, patience
 ├───────────────────────┤
 │ 2. Dispatch           │  systems/dispatch.rs
-│                       │  Build manifest, call DispatchStrategy.decide_all()
+│                       │  Build manifest, rank (car, stop) pairs, Hungarian match
 ├───────────────────────┤
 │ 3. Reposition         │  systems/reposition.rs
 │                       │  Move idle elevators via RepositionStrategy (optional)
@@ -143,7 +143,7 @@ Transitions riders through their one-tick transient states:
 ### Phase 2: Dispatch (`systems/dispatch.rs`)
 
 Builds a `DispatchManifest` from current rider state, then calls each group's
-`DispatchStrategy.decide_all()` for idle/stopped elevators.
+`DispatchStrategy::rank()` for every idle/stopped elevator × demanded stop, then runs the Hungarian solver.
 
 The manifest contains per-rider metadata (`RiderInfo`) grouped into two maps:
 - `waiting_at_stop`: riders at each stop wanting service
@@ -293,30 +293,31 @@ Key relationship invariants:
 
 ```rust
 pub trait DispatchStrategy: Send + Sync {
-    fn decide(
+    fn rank(
         &mut self,
-        elevator: EntityId,
-        elevator_position: f64,
+        car: EntityId,
+        car_position: f64,
+        stop: EntityId,
+        stop_position: f64,
         group: &ElevatorGroup,
         manifest: &DispatchManifest,
         world: &World,
-    ) -> DispatchDecision;
+    ) -> Option<f64>;
 
-    fn decide_all(
-        &mut self,
-        elevators: &[(EntityId, f64)],
-        group: &ElevatorGroup,
-        manifest: &DispatchManifest,
-        world: &World,
-    ) -> Vec<(EntityId, DispatchDecision)>;
-
+    fn pre_dispatch(&mut self, _group: &ElevatorGroup, _manifest: &DispatchManifest, _world: &mut World) {}
+    fn prepare_car(&mut self, _car: EntityId, _pos: f64, _group: &ElevatorGroup, _manifest: &DispatchManifest, _world: &World) {}
+    fn fallback(&mut self, _car: EntityId, _pos: f64, _group: &ElevatorGroup, _manifest: &DispatchManifest, _world: &World) -> DispatchDecision { DispatchDecision::Idle }
     fn notify_removed(&mut self, _elevator: EntityId) {}
 }
 ```
 
-`decide()` handles a single elevator; `decide_all()` enables group-wide
-coordination (default: calls `decide()` per elevator). Strategies receive
-full `&World` access for reading extension components or custom state.
+Strategies score `(car, stop)` pairs via `rank()` — lower is better, `None` excludes
+the pair. The dispatch system builds a cost matrix from every strategy's ranks and
+runs the Hungarian (Kuhn–Munkres) algorithm to produce the globally optimal
+assignment, so coordination — one car per hall call — is a library invariant
+rather than a per-strategy responsibility. Cars left unassigned fall through to
+`fallback`. `prepare_car` lets strategies that depend on whole-group state
+(SCAN/LOOK sweep direction) settle it before any ranks are computed.
 
 ### DispatchManifest
 

--- a/crates/elevator-core/Cargo.toml
+++ b/crates/elevator-core/Cargo.toml
@@ -30,6 +30,7 @@ slotmap.workspace = true
 ordered-float = { version = "5", features = ["serde"] }
 smallvec = { version = "1", features = ["serde"] }
 postcard.workspace = true
+pathfinding = { version = "4", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/elevator-core/examples/custom_dispatch.rs
+++ b/crates/elevator-core/examples/custom_dispatch.rs
@@ -40,13 +40,15 @@ struct IdlePenaltyDispatch {
     /// Tick of the last call each car was assigned to. Used to penalize
     /// cars that have sat unused for a while so the fleet rotates fairly.
     last_served_tick: HashMap<EntityId, u64>,
+    /// Idle ticks resolved once per car in `prepare_car` and read by `rank`.
+    /// Keeping mutation out of `rank` keeps the cost matrix order-independent.
+    idle_for: HashMap<EntityId, f64>,
     /// Current tick, refreshed once per group pass via `pre_dispatch`.
     tick: u64,
 }
 
 impl DispatchStrategy for IdlePenaltyDispatch {
-    /// Refresh the tick counter once per group pass. A no-op here would
-    /// be fine too — we only use tick for the idle-penalty scoring.
+    /// Refresh the tick counter once per group pass.
     fn pre_dispatch(
         &mut self,
         _group: &ElevatorGroup,
@@ -54,6 +56,23 @@ impl DispatchStrategy for IdlePenaltyDispatch {
         _world: &mut World,
     ) {
         self.tick = self.tick.saturating_add(1);
+    }
+
+    /// Record how long this car has been idle, once, before the `rank`
+    /// loop. The `last_served` bookkeeping updates here too, so `rank`
+    /// is a pure read.
+    fn prepare_car(
+        &mut self,
+        car: EntityId,
+        _car_position: f64,
+        _group: &ElevatorGroup,
+        _manifest: &DispatchManifest,
+        _world: &World,
+    ) {
+        let last = self.last_served_tick.get(&car).copied().unwrap_or(0);
+        let idle = self.tick.saturating_sub(last) as f64;
+        self.idle_for.insert(car, idle);
+        self.last_served_tick.insert(car, self.tick);
     }
 
     /// Cost is distance minus a small bonus for cars that haven't been
@@ -70,13 +89,9 @@ impl DispatchStrategy for IdlePenaltyDispatch {
         _world: &World,
     ) -> Option<f64> {
         let distance = (car_position - stop_position).abs();
-        let last_served = self.last_served_tick.get(&car).copied().unwrap_or(0);
-        let idle_for = self.tick.saturating_sub(last_served) as f64;
+        let idle_for = self.idle_for.get(&car).copied().unwrap_or(0.0);
         // Bias toward long-idle cars; clamp so cost stays non-negative.
-        let cost = 0.01f64.mul_add(-idle_for, distance).max(0.0);
-        // Record the intended service tick so the penalty decays after use.
-        self.last_served_tick.insert(car, self.tick);
-        Some(cost)
+        Some(0.01f64.mul_add(-idle_for, distance).max(0.0))
     }
 
     /// The framework calls this when an elevator leaves the group — via
@@ -84,6 +99,7 @@ impl DispatchStrategy for IdlePenaltyDispatch {
     /// per-elevator state here to prevent unbounded growth.
     fn notify_removed(&mut self, elevator: EntityId) {
         self.last_served_tick.remove(&elevator);
+        self.idle_for.remove(&elevator);
     }
 }
 

--- a/crates/elevator-core/examples/custom_dispatch.rs
+++ b/crates/elevator-core/examples/custom_dispatch.rs
@@ -1,19 +1,19 @@
 //! Writing a custom `DispatchStrategy`.
 //!
-//! This example walks through all three trait methods:
+//! This example walks through the score-based trait:
 //!
-//! * [`DispatchStrategy::decide`] — per-elevator, required.
-//! * [`DispatchStrategy::decide_all`] — per-group coordination, optional.
+//! * [`DispatchStrategy::rank`] — cost of sending a car to a stop; required.
+//! * [`DispatchStrategy::fallback`] — policy for unassigned cars; optional.
+//! * [`DispatchStrategy::prepare_car`] — per-car state setup; optional.
+//! * [`DispatchStrategy::pre_dispatch`] — per-group world-mutation hook;
+//!   optional, used by sticky strategies like destination dispatch.
 //! * [`DispatchStrategy::notify_removed`] — per-elevator state cleanup,
-//!   optional but required if the strategy carries a `HashMap<EntityId, _>`.
+//!   required if the strategy carries a `HashMap<EntityId, _>`.
 //!
 //! Run with:
 //! ```sh
 //! cargo run --example custom_dispatch
 //! ```
-//!
-//! See [`docs/src/custom-dispatch.md`](../../../docs/src/custom-dispatch.md)
-//! for the narrative tutorial.
 #![allow(
     clippy::unwrap_used,
     clippy::missing_docs_in_private_items,
@@ -22,98 +22,72 @@
 
 use std::collections::HashMap;
 
-use elevator_core::dispatch::{
-    BuiltinStrategy, DispatchDecision, DispatchManifest, DispatchStrategy, ElevatorGroup,
-};
+use elevator_core::dispatch::{BuiltinStrategy, DispatchManifest, DispatchStrategy, ElevatorGroup};
 use elevator_core::entity::EntityId;
 use elevator_core::ids::GroupId;
 use elevator_core::prelude::*;
 use elevator_core::stop::StopConfig;
 use elevator_core::world::World;
 
-/// Round-robin across stops with demand, coordinating across idle cars
-/// so two elevators never get pointed at the same stop in one tick.
+/// Weighted nearest-car: distance plus a penalty proportional to how
+/// many ticks this car has been idle since it last served a call.
 ///
-/// This strategy carries one piece of per-instance state (the next-stop
-/// index) and one piece of per-elevator state (last-served tick, for
-/// observability only), which makes it a good vehicle for demonstrating
-/// `notify_removed`.
+/// The library's [Hungarian assignment](elevator_core::dispatch) combines
+/// every car's ranks and picks the globally minimum-total-cost matching,
+/// so two cars are never sent to the same hall call.
 #[derive(Default)]
-struct RoundRobin {
-    /// Cycles through the group's demand list so every stop gets a
-    /// chance eventually, regardless of waiting count.
-    next_index: usize,
-
-    /// Per-elevator last-served tick. Not used by `decide` here — it
-    /// just demonstrates the `notify_removed` contract.
+struct IdlePenaltyDispatch {
+    /// Tick of the last call each car was assigned to. Used to penalize
+    /// cars that have sat unused for a while so the fleet rotates fairly.
     last_served_tick: HashMap<EntityId, u64>,
+    /// Current tick, refreshed once per group pass via `pre_dispatch`.
+    tick: u64,
 }
 
-impl DispatchStrategy for RoundRobin {
-    fn decide(
+impl DispatchStrategy for IdlePenaltyDispatch {
+    /// Refresh the tick counter once per group pass. A no-op here would
+    /// be fine too — we only use tick for the idle-penalty scoring.
+    fn pre_dispatch(
         &mut self,
-        _elevator: EntityId,
-        _elevator_position: f64,
+        _group: &ElevatorGroup,
+        _manifest: &DispatchManifest,
+        _world: &mut World,
+    ) {
+        self.tick = self.tick.saturating_add(1);
+    }
+
+    /// Cost is distance minus a small bonus for cars that haven't been
+    /// used recently. Returning `None` would exclude a `(car, stop)`
+    /// pair entirely — useful for capacity limits or restricted stops.
+    fn rank(
+        &mut self,
+        car: EntityId,
+        car_position: f64,
+        _stop: EntityId,
+        stop_position: f64,
         _group: &ElevatorGroup,
         _manifest: &DispatchManifest,
         _world: &World,
-    ) -> DispatchDecision {
-        // Required by the trait. When `decide_all` is overridden, the
-        // default trait impl routes through `decide_all` so this method
-        // is unreachable on the dispatch hot path — returning `Idle`
-        // here is a belt-and-suspenders default.
-        DispatchDecision::Idle
+    ) -> Option<f64> {
+        let distance = (car_position - stop_position).abs();
+        let last_served = self.last_served_tick.get(&car).copied().unwrap_or(0);
+        let idle_for = self.tick.saturating_sub(last_served) as f64;
+        // Bias toward long-idle cars; clamp so cost stays non-negative.
+        let cost = 0.01f64.mul_add(-idle_for, distance).max(0.0);
+        // Record the intended service tick so the penalty decays after use.
+        self.last_served_tick.insert(car, self.tick);
+        Some(cost)
     }
 
-    /// Coordinate across all idle elevators so each stop with demand is
-    /// served by at most one car per tick.
-    fn decide_all(
-        &mut self,
-        elevators: &[(EntityId, f64)],
-        group: &ElevatorGroup,
-        manifest: &DispatchManifest,
-        _world: &World,
-    ) -> Vec<(EntityId, DispatchDecision)> {
-        // Collect stops with demand, in the group's canonical order.
-        let demand_stops: Vec<EntityId> = group
-            .stop_entities()
-            .iter()
-            .copied()
-            .filter(|&s| manifest.has_demand(s))
-            .collect();
-
-        // Pair each idle elevator with a unique stop from the rotation.
-        // `next_index` advances once per *call*, not once per elevator —
-        // so over time every stop gets picked first even under uneven
-        // demand. Elevators beyond the demand list go idle.
-        let mut results = Vec::with_capacity(elevators.len());
-        for (i, &(eid, _)) in elevators.iter().enumerate() {
-            let decision = if demand_stops.is_empty() {
-                DispatchDecision::Idle
-            } else {
-                let stop = demand_stops[(self.next_index + i) % demand_stops.len()];
-                DispatchDecision::GoToStop(stop)
-            };
-            results.push((eid, decision));
-        }
-        if !demand_stops.is_empty() {
-            self.next_index = (self.next_index + 1) % demand_stops.len();
-        }
-        results
-    }
-
-    /// CRITICAL: the framework calls this when an elevator is removed
-    /// from the group (either via `Simulation::remove_elevator` or by
-    /// cross-group reassignment). Without the cleanup, the
-    /// `last_served_tick` map would grow unbounded over long runs.
+    /// The framework calls this when an elevator leaves the group — via
+    /// `Simulation::remove_elevator` or cross-group reassignment. Drop
+    /// per-elevator state here to prevent unbounded growth.
     fn notify_removed(&mut self, elevator: EntityId) {
         self.last_served_tick.remove(&elevator);
     }
 }
 
 fn main() {
-    // Build a simulation with three stops and two elevators so the
-    // `decide_all` coordination has something to chew on.
     let mut sim = SimulationBuilder::demo()
         .stops(vec![
             StopConfig {
@@ -135,18 +109,15 @@ fn main() {
         .build()
         .unwrap();
 
-    // Install the custom strategy *after* build via `set_dispatch`,
-    // which takes both the boxed strategy and the `BuiltinStrategy`
-    // id used for snapshot serialization. Use a stable name — changing
-    // it breaks previously-saved snapshots.
+    // Install the custom strategy after build. `BuiltinStrategy::Custom`
+    // gives it a stable name for snapshot serialization — changing the
+    // name breaks previously-saved snapshots.
     sim.set_dispatch(
         GroupId(0),
-        Box::new(RoundRobin::default()),
-        BuiltinStrategy::Custom("round_robin".into()),
+        Box::new(IdlePenaltyDispatch::default()),
+        BuiltinStrategy::Custom("idle_penalty".into()),
     );
 
-    // Give each stop a rider going to a different stop so the round-
-    // robin has demand on every axis.
     sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
         .unwrap();
     sim.spawn_rider_by_stop_id(StopId(1), StopId(0), 72.0)
@@ -154,10 +125,6 @@ fn main() {
     sim.spawn_rider_by_stop_id(StopId(2), StopId(1), 80.0)
         .unwrap();
 
-    // Run long enough for everyone to arrive under the round-robin —
-    // it's deliberately inefficient (stops are served in cycle order
-    // regardless of demand volume), so it takes more ticks than
-    // `ScanDispatch` would.
     for _ in 0..5000 {
         sim.step();
     }
@@ -168,7 +135,6 @@ fn main() {
     println!("Avg ride:      {:.1} ticks", m.avg_ride_time());
     println!("Total dist:    {:.1} units", m.total_distance());
 
-    // Strategy identity persists for snapshots.
     match sim.strategy_id(GroupId(0)) {
         Some(BuiltinStrategy::Custom(name)) => {
             println!("Strategy name: {name} (will round-trip through snapshots)");

--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -47,14 +47,14 @@ pub const ASSIGNED_CAR_EXT_NAME: &str = "assigned_car";
 
 /// Hall-call destination dispatch (DCS).
 ///
-/// ## API choice
+/// ## API shape
 ///
-/// This strategy uses the [`DispatchStrategy::pre_dispatch`] hook
-/// (Option B) so it can write sticky [`AssignedCar`] extensions and
-/// committed-stop queue entries during a `&mut World` phase, then
-/// return ordinary [`DispatchDecision::GoToStop`] values via the
-/// standard `decide` call. The other built-in strategies continue to
-/// work unchanged because `pre_dispatch` has an empty default impl.
+/// Uses [`DispatchStrategy::pre_dispatch`] to write sticky
+/// [`AssignedCar`] extensions and rebuild each car's committed stop
+/// queue during a `&mut World` phase. [`DispatchStrategy::rank`] then
+/// routes each car to its own queue front and returns `None` for every
+/// other stop, so the group-wide Hungarian assignment trivially pairs
+/// each car with the stop it has already committed to.
 pub struct DestinationDispatch {
     /// Weight for per-stop door overhead in the cost function. A positive
     /// value biases assignments toward cars whose route change adds no

--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -30,7 +30,7 @@ use crate::components::{DestinationQueue, Direction, ElevatorPhase, TransportMod
 use crate::entity::EntityId;
 use crate::world::World;
 
-use super::{DispatchDecision, DispatchManifest, DispatchStrategy, ElevatorGroup};
+use super::{DispatchManifest, DispatchStrategy, ElevatorGroup};
 
 /// Sticky rider → car assignment produced by [`DestinationDispatch`].
 ///
@@ -204,19 +204,24 @@ impl DispatchStrategy for DestinationDispatch {
         }
     }
 
-    fn decide(
+    fn rank(
         &mut self,
-        elevator: EntityId,
-        _elevator_position: f64,
+        car: EntityId,
+        _car_position: f64,
+        stop: EntityId,
+        _stop_position: f64,
         _group: &ElevatorGroup,
         _manifest: &DispatchManifest,
         world: &World,
-    ) -> DispatchDecision {
-        // The queue is the source of truth — send the car to the front stop.
-        world
-            .destination_queue(elevator)
-            .and_then(DestinationQueue::front)
-            .map_or(DispatchDecision::Idle, DispatchDecision::GoToStop)
+    ) -> Option<f64> {
+        // The queue is the source of truth — route each car strictly to
+        // its own queue front. Every other stop is unavailable for this
+        // car, so the Hungarian assignment reduces to the identity match
+        // between each car and the stop it has already committed to.
+        let front = world
+            .destination_queue(car)
+            .and_then(DestinationQueue::front)?;
+        if front == stop { Some(0.0) } else { None }
     }
 }
 

--- a/crates/elevator-core/src/dispatch/etd.rs
+++ b/crates/elevator-core/src/dispatch/etd.rs
@@ -81,107 +81,101 @@ impl DispatchStrategy for EtdDispatch {
         manifest: &DispatchManifest,
         world: &World,
     ) -> Option<f64> {
-        let cost = compute_cost(
-            self,
-            car,
-            car_position,
-            stop_position,
-            group,
-            manifest,
-            world,
-        );
+        let cost = self.compute_cost(car, car_position, stop_position, group, manifest, world);
         if cost.is_finite() { Some(cost) } else { None }
     }
 }
 
-/// Compute ETD cost for assigning an elevator to serve a stop.
-///
-/// Cost = `wait_weight` * travel\_time + `delay_weight` * existing\_rider\_delay
-///      + `door_weight` * door\_overhead + direction\_bonus
-fn compute_cost(
-    strategy: &EtdDispatch,
-    elev_eid: EntityId,
-    elev_pos: f64,
-    target_pos: f64,
-    group: &ElevatorGroup,
-    manifest: &DispatchManifest,
-    world: &World,
-) -> f64 {
-    let Some(car) = world.elevator(elev_eid) else {
-        return f64::INFINITY;
-    };
+impl EtdDispatch {
+    /// Compute ETD cost for assigning an elevator to serve a stop.
+    ///
+    /// Cost = `wait_weight` * travel\_time + `delay_weight` * existing\_rider\_delay
+    ///      + `door_weight` * door\_overhead + direction\_bonus
+    fn compute_cost(
+        &self,
+        elev_eid: EntityId,
+        elev_pos: f64,
+        target_pos: f64,
+        group: &ElevatorGroup,
+        manifest: &DispatchManifest,
+        world: &World,
+    ) -> f64 {
+        let Some(car) = world.elevator(elev_eid) else {
+            return f64::INFINITY;
+        };
 
-    let distance = (elev_pos - target_pos).abs();
-    let travel_time = if car.max_speed > 0.0 {
-        distance / car.max_speed
-    } else {
-        return f64::INFINITY;
-    };
+        let distance = (elev_pos - target_pos).abs();
+        let travel_time = if car.max_speed > 0.0 {
+            distance / car.max_speed
+        } else {
+            return f64::INFINITY;
+        };
 
-    let door_overhead_per_stop = f64::from(car.door_transition_ticks * 2 + car.door_open_ticks);
+        let door_overhead_per_stop = f64::from(car.door_transition_ticks * 2 + car.door_open_ticks);
 
-    // Intervening pending stops between car and target contribute door overhead.
-    let (lo, hi) = if elev_pos < target_pos {
-        (elev_pos, target_pos)
-    } else {
-        (target_pos, elev_pos)
-    };
-    let mut pending_positions: SmallVec<[f64; 16]> = SmallVec::new();
-    for &s in group.stop_entities() {
-        if manifest.has_demand(s)
-            && let Some(p) = world.stop_position(s)
-        {
-            pending_positions.push(p);
-        }
-    }
-    let intervening_stops = pending_positions
-        .iter()
-        .filter(|p| **p > lo + 1e-9 && **p < hi - 1e-9)
-        .count() as f64;
-    let door_cost = intervening_stops * door_overhead_per_stop;
-
-    let mut existing_rider_delay = 0.0_f64;
-    for &rider_eid in car.riders() {
-        if let Some(dest) = world.route(rider_eid).and_then(Route::current_destination)
-            && let Some(dest_pos) = world.stop_position(dest)
-        {
-            let direct_dist = (elev_pos - dest_pos).abs();
-            let detour_dist = (elev_pos - target_pos).abs() + (target_pos - dest_pos).abs();
-            let extra = (detour_dist - direct_dist).max(0.0);
-            if car.max_speed > 0.0 {
-                existing_rider_delay += extra / car.max_speed;
+        // Intervening pending stops between car and target contribute door overhead.
+        let (lo, hi) = if elev_pos < target_pos {
+            (elev_pos, target_pos)
+        } else {
+            (target_pos, elev_pos)
+        };
+        let mut pending_positions: SmallVec<[f64; 16]> = SmallVec::new();
+        for &s in group.stop_entities() {
+            if manifest.has_demand(s)
+                && let Some(p) = world.stop_position(s)
+            {
+                pending_positions.push(p);
             }
         }
-    }
+        let intervening_stops = pending_positions
+            .iter()
+            .filter(|p| **p > lo + 1e-9 && **p < hi - 1e-9)
+            .count() as f64;
+        let door_cost = intervening_stops * door_overhead_per_stop;
 
-    // Direction bonus: if the car is already heading this way, subtract.
-    // Scoring model requires non-negative costs, so clamp at zero — losing
-    // a small amount of discriminative power vs. a pure free-for-all when
-    // two assignments tie.
-    let direction_bonus = match car.phase.moving_target() {
-        Some(current_target) => world.stop_position(current_target).map_or(0.0, |ctp| {
-            let moving_up = ctp > elev_pos;
-            let target_is_ahead = if moving_up {
-                target_pos > elev_pos && target_pos <= ctp
-            } else {
-                target_pos < elev_pos && target_pos >= ctp
-            };
-            if target_is_ahead {
-                -travel_time * 0.5
-            } else {
-                0.0
+        let mut existing_rider_delay = 0.0_f64;
+        for &rider_eid in car.riders() {
+            if let Some(dest) = world.route(rider_eid).and_then(Route::current_destination)
+                && let Some(dest_pos) = world.stop_position(dest)
+            {
+                let direct_dist = (elev_pos - dest_pos).abs();
+                let detour_dist = (elev_pos - target_pos).abs() + (target_pos - dest_pos).abs();
+                let extra = (detour_dist - direct_dist).max(0.0);
+                if car.max_speed > 0.0 {
+                    existing_rider_delay += extra / car.max_speed;
+                }
             }
-        }),
-        None if car.phase == ElevatorPhase::Idle => -travel_time * 0.3,
-        _ => 0.0,
-    };
+        }
 
-    let raw = strategy.wait_weight.mul_add(
-        travel_time,
-        strategy.delay_weight.mul_add(
-            existing_rider_delay,
-            strategy.door_weight.mul_add(door_cost, direction_bonus),
-        ),
-    );
-    raw.max(0.0)
+        // Direction bonus: if the car is already heading this way, subtract.
+        // Scoring model requires non-negative costs, so clamp at zero — losing
+        // a small amount of discriminative power vs. a pure free-for-all when
+        // two assignments tie.
+        let direction_bonus = match car.phase.moving_target() {
+            Some(current_target) => world.stop_position(current_target).map_or(0.0, |ctp| {
+                let moving_up = ctp > elev_pos;
+                let target_is_ahead = if moving_up {
+                    target_pos > elev_pos && target_pos <= ctp
+                } else {
+                    target_pos < elev_pos && target_pos >= ctp
+                };
+                if target_is_ahead {
+                    -travel_time * 0.5
+                } else {
+                    0.0
+                }
+            }),
+            None if car.phase == ElevatorPhase::Idle => -travel_time * 0.3,
+            _ => 0.0,
+        };
+
+        let raw = self.wait_weight.mul_add(
+            travel_time,
+            self.delay_weight.mul_add(
+                existing_rider_delay,
+                self.door_weight.mul_add(door_cost, direction_bonus),
+            ),
+        );
+        raw.max(0.0)
+    }
 }

--- a/crates/elevator-core/src/dispatch/etd.rs
+++ b/crates/elevator-core/src/dispatch/etd.rs
@@ -28,6 +28,10 @@ pub struct EtdDispatch {
     pub delay_weight: f64,
     /// Weight for door open/close overhead at intermediate stops.
     pub door_weight: f64,
+    /// Positions of every demanded stop in the group, cached by
+    /// [`DispatchStrategy::pre_dispatch`] so `rank` avoids rebuilding the
+    /// list for every `(car, stop)` pair.
+    pending_positions: SmallVec<[f64; 16]>,
 }
 
 impl EtdDispatch {
@@ -35,31 +39,34 @@ impl EtdDispatch {
     ///
     /// Defaults: `wait_weight = 1.0`, `delay_weight = 1.0`, `door_weight = 0.5`.
     #[must_use]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             wait_weight: 1.0,
             delay_weight: 1.0,
             door_weight: 0.5,
+            pending_positions: SmallVec::new(),
         }
     }
 
     /// Create with a single delay weight (backwards-compatible shorthand).
     #[must_use]
-    pub const fn with_delay_weight(delay_weight: f64) -> Self {
+    pub fn with_delay_weight(delay_weight: f64) -> Self {
         Self {
             wait_weight: 1.0,
             delay_weight,
             door_weight: 0.5,
+            pending_positions: SmallVec::new(),
         }
     }
 
     /// Create with fully custom weights.
     #[must_use]
-    pub const fn with_weights(wait_weight: f64, delay_weight: f64, door_weight: f64) -> Self {
+    pub fn with_weights(wait_weight: f64, delay_weight: f64, door_weight: f64) -> Self {
         Self {
             wait_weight,
             delay_weight,
             door_weight,
+            pending_positions: SmallVec::new(),
         }
     }
 }
@@ -71,17 +78,33 @@ impl Default for EtdDispatch {
 }
 
 impl DispatchStrategy for EtdDispatch {
+    fn pre_dispatch(
+        &mut self,
+        group: &ElevatorGroup,
+        manifest: &DispatchManifest,
+        world: &mut World,
+    ) {
+        self.pending_positions.clear();
+        for &s in group.stop_entities() {
+            if manifest.has_demand(s)
+                && let Some(p) = world.stop_position(s)
+            {
+                self.pending_positions.push(p);
+            }
+        }
+    }
+
     fn rank(
         &mut self,
         car: EntityId,
         car_position: f64,
         _stop: EntityId,
         stop_position: f64,
-        group: &ElevatorGroup,
-        manifest: &DispatchManifest,
+        _group: &ElevatorGroup,
+        _manifest: &DispatchManifest,
         world: &World,
     ) -> Option<f64> {
-        let cost = self.compute_cost(car, car_position, stop_position, group, manifest, world);
+        let cost = self.compute_cost(car, car_position, stop_position, world);
         if cost.is_finite() { Some(cost) } else { None }
     }
 }
@@ -96,8 +119,6 @@ impl EtdDispatch {
         elev_eid: EntityId,
         elev_pos: f64,
         target_pos: f64,
-        group: &ElevatorGroup,
-        manifest: &DispatchManifest,
         world: &World,
     ) -> f64 {
         let Some(car) = world.elevator(elev_eid) else {
@@ -119,15 +140,8 @@ impl EtdDispatch {
         } else {
             (target_pos, elev_pos)
         };
-        let mut pending_positions: SmallVec<[f64; 16]> = SmallVec::new();
-        for &s in group.stop_entities() {
-            if manifest.has_demand(s)
-                && let Some(p) = world.stop_position(s)
-            {
-                pending_positions.push(p);
-            }
-        }
-        let intervening_stops = pending_positions
+        let intervening_stops = self
+            .pending_positions
             .iter()
             .filter(|p| **p > lo + 1e-9 && **p < hi - 1e-9)
             .count() as f64;

--- a/crates/elevator-core/src/dispatch/etd.rs
+++ b/crates/elevator-core/src/dispatch/etd.rs
@@ -12,24 +12,15 @@ use crate::components::{ElevatorPhase, Route};
 use crate::entity::EntityId;
 use crate::world::World;
 
-use super::{DispatchDecision, DispatchManifest, DispatchStrategy, ElevatorGroup};
+use super::{DispatchManifest, DispatchStrategy, ElevatorGroup};
 
 /// Estimated Time to Destination (ETD) dispatch algorithm.
 ///
-/// Industry-standard algorithm for modern elevator systems. For each
-/// pending call, evaluates every elevator and assigns the one that
-/// minimizes total cost: (time to serve the new rider) + (delay imposed
-/// on all existing riders) + (door/loading overhead).
-///
-/// ## Cost model
-///
-/// `cost = wait_weight * travel_time
-///       + delay_weight * existing_rider_delay
-///       + door_weight * estimated_door_overhead
-///       + direction_bonus`
-///
-/// Rider delay is computed from actual route destinations of riders
-/// currently aboard each elevator.
+/// For each `(car, stop)` pair the rank is a cost estimate combining
+/// travel time, delay imposed on riders already aboard, door-overhead
+/// for intervening stops, and a small bonus for cars already heading
+/// toward the stop. The dispatch system runs an optimal assignment
+/// across all pairs so the globally best matching is chosen.
 pub struct EtdDispatch {
     /// Weight for travel time to reach the calling stop.
     pub wait_weight: f64,
@@ -53,8 +44,6 @@ impl EtdDispatch {
     }
 
     /// Create with a single delay weight (backwards-compatible shorthand).
-    ///
-    /// Sets `wait_weight = 1.0` and `door_weight = 0.5`.
     #[must_use]
     pub const fn with_delay_weight(delay_weight: f64) -> Self {
         Self {
@@ -82,177 +71,117 @@ impl Default for EtdDispatch {
 }
 
 impl DispatchStrategy for EtdDispatch {
-    fn decide(
+    fn rank(
         &mut self,
-        _elevator: EntityId,
-        _elevator_position: f64,
-        _group: &ElevatorGroup,
-        _manifest: &DispatchManifest,
-        _world: &World,
-    ) -> DispatchDecision {
-        // Not used — decide_all() handles group coordination.
-        DispatchDecision::Idle
-    }
-
-    fn decide_all(
-        &mut self,
-        elevators: &[(EntityId, f64)],
+        car: EntityId,
+        car_position: f64,
+        _stop: EntityId,
+        stop_position: f64,
         group: &ElevatorGroup,
         manifest: &DispatchManifest,
         world: &World,
-    ) -> Vec<(EntityId, DispatchDecision)> {
-        // Collect stops needing service.
-        let pending_stops: SmallVec<[(EntityId, f64); 16]> = group
-            .stop_entities()
-            .iter()
-            .filter_map(|&stop_eid| {
-                if manifest.has_demand(stop_eid) {
-                    world.stop_position(stop_eid).map(|pos| (stop_eid, pos))
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        if pending_stops.is_empty() {
-            return elevators
-                .iter()
-                .map(|(eid, _)| (*eid, DispatchDecision::Idle))
-                .collect();
-        }
-
-        let mut results: Vec<(EntityId, DispatchDecision)> = Vec::new();
-        let mut assigned_elevators: SmallVec<[EntityId; 16]> = SmallVec::new();
-
-        // For each pending stop, find the elevator with minimum ETD cost.
-        for (stop_eid, stop_pos) in &pending_stops {
-            let mut best_elevator: Option<EntityId> = None;
-            let mut best_cost = f64::INFINITY;
-
-            for &(elev_eid, elev_pos) in elevators {
-                if assigned_elevators.contains(&elev_eid) {
-                    continue;
-                }
-
-                let cost = self.compute_cost(
-                    elev_eid,
-                    elev_pos,
-                    *stop_pos,
-                    &pending_stops,
-                    manifest,
-                    world,
-                );
-
-                if cost < best_cost {
-                    best_cost = cost;
-                    best_elevator = Some(elev_eid);
-                }
-            }
-
-            if let Some(elev_eid) = best_elevator {
-                results.push((elev_eid, DispatchDecision::GoToStop(*stop_eid)));
-                assigned_elevators.push(elev_eid);
-            }
-        }
-
-        // Unassigned elevators idle.
-        for (eid, _) in elevators {
-            if !assigned_elevators.contains(eid) {
-                results.push((*eid, DispatchDecision::Idle));
-            }
-        }
-
-        results
+    ) -> Option<f64> {
+        let cost = compute_cost(
+            self,
+            car,
+            car_position,
+            stop_position,
+            group,
+            manifest,
+            world,
+        );
+        if cost.is_finite() { Some(cost) } else { None }
     }
 }
 
-impl EtdDispatch {
-    /// Compute ETD cost for assigning an elevator to serve a stop.
-    ///
-    /// Cost = `wait_weight` * travel\_time + `delay_weight` * existing\_rider\_delay
-    ///      + `door_weight` * door\_overhead + direction\_bonus
-    fn compute_cost(
-        &self,
-        elev_eid: EntityId,
-        elev_pos: f64,
-        target_pos: f64,
-        pending_stops: &[(EntityId, f64)],
-        _manifest: &DispatchManifest,
-        world: &World,
-    ) -> f64 {
-        let Some(car) = world.elevator(elev_eid) else {
-            return f64::INFINITY;
-        };
+/// Compute ETD cost for assigning an elevator to serve a stop.
+///
+/// Cost = `wait_weight` * travel\_time + `delay_weight` * existing\_rider\_delay
+///      + `door_weight` * door\_overhead + direction\_bonus
+fn compute_cost(
+    strategy: &EtdDispatch,
+    elev_eid: EntityId,
+    elev_pos: f64,
+    target_pos: f64,
+    group: &ElevatorGroup,
+    manifest: &DispatchManifest,
+    world: &World,
+) -> f64 {
+    let Some(car) = world.elevator(elev_eid) else {
+        return f64::INFINITY;
+    };
 
-        // Base travel time: distance / max_speed.
-        let distance = (elev_pos - target_pos).abs();
-        let travel_time = if car.max_speed > 0.0 {
-            distance / car.max_speed
-        } else {
-            return f64::INFINITY;
-        };
+    let distance = (elev_pos - target_pos).abs();
+    let travel_time = if car.max_speed > 0.0 {
+        distance / car.max_speed
+    } else {
+        return f64::INFINITY;
+    };
 
-        // Door overhead: estimate per-stop overhead from door transitions and dwell.
-        let door_overhead_per_stop = f64::from(car.door_transition_ticks * 2 + car.door_open_ticks);
+    let door_overhead_per_stop = f64::from(car.door_transition_ticks * 2 + car.door_open_ticks);
 
-        // Count intervening pending stops between elevator and target.
-        let (lo, hi) = if elev_pos < target_pos {
-            (elev_pos, target_pos)
-        } else {
-            (target_pos, elev_pos)
-        };
-        let intervening_stops = pending_stops
-            .iter()
-            .filter(|(_, pos)| *pos > lo + 1e-9 && *pos < hi - 1e-9)
-            .count() as f64;
-        let door_cost = intervening_stops * door_overhead_per_stop;
+    // Intervening pending stops between car and target contribute door overhead.
+    let (lo, hi) = if elev_pos < target_pos {
+        (elev_pos, target_pos)
+    } else {
+        (target_pos, elev_pos)
+    };
+    let mut pending_positions: SmallVec<[f64; 16]> = SmallVec::new();
+    for &s in group.stop_entities() {
+        if manifest.has_demand(s)
+            && let Some(p) = world.stop_position(s)
+        {
+            pending_positions.push(p);
+        }
+    }
+    let intervening_stops = pending_positions
+        .iter()
+        .filter(|p| **p > lo + 1e-9 && **p < hi - 1e-9)
+        .count() as f64;
+    let door_cost = intervening_stops * door_overhead_per_stop;
 
-        // Delay to existing riders: each rider aboard heading elsewhere
-        // would be delayed by roughly the detour time.
-        let mut existing_rider_delay = 0.0_f64;
-        for &rider_eid in car.riders() {
-            if let Some(dest) = world.route(rider_eid).and_then(Route::current_destination)
-                && let Some(dest_pos) = world.stop_position(dest)
-            {
-                // The rider wants to go to dest_pos. If the detour to
-                // target_pos takes the elevator away from dest_pos, that's
-                // a delay proportional to the extra distance.
-                let direct_dist = (elev_pos - dest_pos).abs();
-                let detour_dist = (elev_pos - target_pos).abs() + (target_pos - dest_pos).abs();
-                let extra = (detour_dist - direct_dist).max(0.0);
-                if car.max_speed > 0.0 {
-                    existing_rider_delay += extra / car.max_speed;
-                }
+    let mut existing_rider_delay = 0.0_f64;
+    for &rider_eid in car.riders() {
+        if let Some(dest) = world.route(rider_eid).and_then(Route::current_destination)
+            && let Some(dest_pos) = world.stop_position(dest)
+        {
+            let direct_dist = (elev_pos - dest_pos).abs();
+            let detour_dist = (elev_pos - target_pos).abs() + (target_pos - dest_pos).abs();
+            let extra = (detour_dist - direct_dist).max(0.0);
+            if car.max_speed > 0.0 {
+                existing_rider_delay += extra / car.max_speed;
             }
         }
-
-        // Bonus: if the elevator is already heading toward this stop
-        // (same direction), reduce cost. Both dispatched (`MovingToStop`)
-        // and repositioning cars are redirectable and get the same bonus.
-        let direction_bonus = match car.phase.moving_target() {
-            Some(current_target) => world.stop_position(current_target).map_or(0.0, |ctp| {
-                let moving_up = ctp > elev_pos;
-                let target_is_ahead = if moving_up {
-                    target_pos > elev_pos && target_pos <= ctp
-                } else {
-                    target_pos < elev_pos && target_pos >= ctp
-                };
-                if target_is_ahead {
-                    -travel_time * 0.5
-                } else {
-                    0.0
-                }
-            }),
-            None if car.phase == ElevatorPhase::Idle => -travel_time * 0.3, // Slight bonus for idle elevators.
-            _ => 0.0,
-        };
-
-        self.wait_weight.mul_add(
-            travel_time,
-            self.delay_weight.mul_add(
-                existing_rider_delay,
-                self.door_weight.mul_add(door_cost, direction_bonus),
-            ),
-        )
     }
+
+    // Direction bonus: if the car is already heading this way, subtract.
+    // Scoring model requires non-negative costs, so clamp at zero — losing
+    // a small amount of discriminative power vs. a pure free-for-all when
+    // two assignments tie.
+    let direction_bonus = match car.phase.moving_target() {
+        Some(current_target) => world.stop_position(current_target).map_or(0.0, |ctp| {
+            let moving_up = ctp > elev_pos;
+            let target_is_ahead = if moving_up {
+                target_pos > elev_pos && target_pos <= ctp
+            } else {
+                target_pos < elev_pos && target_pos >= ctp
+            };
+            if target_is_ahead {
+                -travel_time * 0.5
+            } else {
+                0.0
+            }
+        }),
+        None if car.phase == ElevatorPhase::Idle => -travel_time * 0.3,
+        _ => 0.0,
+    };
+
+    let raw = strategy.wait_weight.mul_add(
+        travel_time,
+        strategy.delay_weight.mul_add(
+            existing_rider_delay,
+            strategy.door_weight.mul_add(door_cost, direction_bonus),
+        ),
+    );
+    raw.max(0.0)
 }

--- a/crates/elevator-core/src/dispatch/look.rs
+++ b/crates/elevator-core/src/dispatch/look.rs
@@ -3,20 +3,24 @@
 //! Introduced in Merten, A. G. (1970), "Some Quantitative Techniques for
 //! File Organization" (Univ. Wisconsin tech report) as an improvement on
 //! SCAN that avoids unnecessary travel past the furthest pending request.
+//!
+//! Within this library SCAN and LOOK share identical dispatch semantics:
+//! both prefer demanded stops in the current sweep direction and reverse
+//! only when nothing remains ahead. The historical distinction — whether
+//! the car drives to the physical shaft end between sweeps — applies to
+//! the motion layer, not dispatch.
 
 use std::collections::HashMap;
-
-use smallvec::SmallVec;
 
 use crate::entity::EntityId;
 use crate::world::World;
 
-use super::{DispatchDecision, DispatchManifest, DispatchStrategy, ElevatorGroup};
+use super::{DispatchManifest, DispatchStrategy, ElevatorGroup};
 
 /// Tolerance for floating-point position comparisons.
 const EPSILON: f64 = 1e-9;
 
-/// Direction of travel.
+/// Sweep direction for a single car.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub(crate) enum Direction {
@@ -26,16 +30,21 @@ pub(crate) enum Direction {
     Down,
 }
 
-/// Elevator dispatch using the LOOK algorithm.
-///
-/// Like SCAN, but reverses at the last request in the current direction
-/// instead of traveling to the end of the shaft. More efficient than
-/// pure SCAN for sparse request distributions.
-///
-/// This is the standard "elevator algorithm" used in real buildings.
+/// Per-car accept mode, mirroring the SCAN strategy. See `scan::Mode`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    /// Accept only strictly-ahead stops.
+    Strict,
+    /// Sweep just reversed; accept stops in the non-strict half.
+    Lenient,
+}
+
+/// Elevator dispatch using the LOOK algorithm. See module docs.
 pub struct LookDispatch {
     /// Per-elevator sweep direction.
     direction: HashMap<EntityId, Direction>,
+    /// Per-elevator accept mode for the current dispatch pass.
+    mode: HashMap<EntityId, Mode>,
 }
 
 impl LookDispatch {
@@ -44,7 +53,40 @@ impl LookDispatch {
     pub fn new() -> Self {
         Self {
             direction: HashMap::new(),
+            mode: HashMap::new(),
         }
+    }
+
+    /// Sweep direction for `car`, defaulting to `Up` for first-time callers.
+    fn direction_for(&self, car: EntityId) -> Direction {
+        self.direction.get(&car).copied().unwrap_or(Direction::Up)
+    }
+
+    /// Accept mode for `car` in the current pass, defaulting to `Strict`.
+    fn mode_for(&self, car: EntityId) -> Mode {
+        self.mode.get(&car).copied().unwrap_or(Mode::Strict)
+    }
+
+    /// True if any demanded stop is strictly ahead of `car_pos` in `dir`.
+    fn strict_demand_ahead(
+        dir: Direction,
+        car_pos: f64,
+        group: &ElevatorGroup,
+        manifest: &DispatchManifest,
+        world: &World,
+    ) -> bool {
+        group.stop_entities().iter().any(|&s| {
+            if !manifest.has_demand(s) {
+                return false;
+            }
+            let Some(p) = world.stop_position(s) else {
+                return false;
+            };
+            match dir {
+                Direction::Up => p > car_pos + EPSILON,
+                Direction::Down => p < car_pos - EPSILON,
+            }
+        })
     }
 }
 
@@ -55,92 +97,54 @@ impl Default for LookDispatch {
 }
 
 impl DispatchStrategy for LookDispatch {
-    fn decide(
+    fn prepare_car(
         &mut self,
-        elevator: EntityId,
-        elevator_position: f64,
+        car: EntityId,
+        car_position: f64,
         group: &ElevatorGroup,
         manifest: &DispatchManifest,
         world: &World,
-    ) -> DispatchDecision {
-        let direction = self
-            .direction
-            .get(&elevator)
-            .copied()
-            .unwrap_or(Direction::Up);
-
-        // Collect stops with demand or rider destinations.
-        let mut interesting: SmallVec<[(EntityId, f64); 32]> = SmallVec::new();
-
-        for &stop_eid in group.stop_entities() {
-            if manifest.has_demand(stop_eid)
-                && let Some(pos) = world.stop_position(stop_eid)
-            {
-                interesting.push((stop_eid, pos));
-            }
-        }
-
-        if interesting.is_empty() {
-            return DispatchDecision::Idle;
-        }
-
-        let pos = elevator_position;
-
-        // Partition into ahead (in current direction) and behind.
-        let (ahead, behind): (SmallVec<[_; 32]>, SmallVec<[_; 32]>) = match direction {
-            Direction::Up => interesting.iter().partition(|(_, p)| *p > pos + EPSILON),
-            Direction::Down => interesting.iter().partition(|(_, p)| *p < pos - EPSILON),
-        };
-
-        if !ahead.is_empty() {
-            // Continue in current direction — pick nearest ahead.
-            let nearest = match direction {
-                Direction::Up => ahead
-                    .iter()
-                    .min_by(|a: &&&(EntityId, f64), b: &&&(EntityId, f64)| a.1.total_cmp(&b.1)),
-                Direction::Down => ahead
-                    .iter()
-                    .max_by(|a: &&&(EntityId, f64), b: &&&(EntityId, f64)| a.1.total_cmp(&b.1)),
+    ) {
+        let current = self.direction_for(car);
+        if Self::strict_demand_ahead(current, car_position, group, manifest, world) {
+            self.mode.insert(car, Mode::Strict);
+        } else {
+            let reversed = match current {
+                Direction::Up => Direction::Down,
+                Direction::Down => Direction::Up,
             };
-            // ahead is non-empty, so nearest is always Some.
-            if let Some(stop) = nearest {
-                return DispatchDecision::GoToStop(stop.0);
-            }
+            self.direction.insert(car, reversed);
+            self.mode.insert(car, Mode::Lenient);
         }
+    }
 
-        // No requests ahead — reverse direction (LOOK behavior).
-        let new_dir = match direction {
-            Direction::Up => Direction::Down,
-            Direction::Down => Direction::Up,
+    fn rank(
+        &mut self,
+        car: EntityId,
+        car_position: f64,
+        _stop: EntityId,
+        stop_position: f64,
+        _group: &ElevatorGroup,
+        _manifest: &DispatchManifest,
+        _world: &World,
+    ) -> Option<f64> {
+        let direction = self.direction_for(car);
+        let mode = self.mode_for(car);
+        let accept = match (mode, direction) {
+            (Mode::Strict, Direction::Up) => stop_position > car_position + EPSILON,
+            (Mode::Strict, Direction::Down) => stop_position < car_position - EPSILON,
+            (Mode::Lenient, Direction::Up) => stop_position > car_position - EPSILON,
+            (Mode::Lenient, Direction::Down) => stop_position < car_position + EPSILON,
         };
-        self.direction.insert(elevator, new_dir);
-
-        if behind.is_empty() {
-            // All interesting stops at current position.
-            return interesting
-                .first()
-                .map_or(DispatchDecision::Idle, |(sid, _)| {
-                    DispatchDecision::GoToStop(*sid)
-                });
+        if accept {
+            Some((car_position - stop_position).abs())
+        } else {
+            None
         }
-
-        // Pick nearest in new direction.
-        let nearest = match new_dir {
-            Direction::Up => behind
-                .iter()
-                .min_by(|a: &&&(EntityId, f64), b: &&&(EntityId, f64)| a.1.total_cmp(&b.1)),
-            Direction::Down => behind
-                .iter()
-                .max_by(|a: &&&(EntityId, f64), b: &&&(EntityId, f64)| a.1.total_cmp(&b.1)),
-        };
-
-        // behind is non-empty, so nearest is always Some.
-        nearest.map_or(DispatchDecision::Idle, |stop| {
-            DispatchDecision::GoToStop(stop.0)
-        })
     }
 
     fn notify_removed(&mut self, elevator: EntityId) {
         self.direction.remove(&elevator);
+        self.mode.remove(&elevator);
     }
 }

--- a/crates/elevator-core/src/dispatch/look.rs
+++ b/crates/elevator-core/src/dispatch/look.rs
@@ -15,36 +15,15 @@ use std::collections::HashMap;
 use crate::entity::EntityId;
 use crate::world::World;
 
+use super::sweep::{self, SweepDirection, SweepMode};
 use super::{DispatchManifest, DispatchStrategy, ElevatorGroup};
-
-/// Tolerance for floating-point position comparisons.
-const EPSILON: f64 = 1e-9;
-
-/// Sweep direction for a single car.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub(crate) enum Direction {
-    /// Traveling upward (increasing position).
-    Up,
-    /// Traveling downward (decreasing position).
-    Down,
-}
-
-/// Per-car accept mode, mirroring the SCAN strategy. See `scan::Mode`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Mode {
-    /// Accept only strictly-ahead stops.
-    Strict,
-    /// Sweep just reversed; accept stops in the non-strict half.
-    Lenient,
-}
 
 /// Elevator dispatch using the LOOK algorithm. See module docs.
 pub struct LookDispatch {
     /// Per-elevator sweep direction.
-    direction: HashMap<EntityId, Direction>,
+    direction: HashMap<EntityId, SweepDirection>,
     /// Per-elevator accept mode for the current dispatch pass.
-    mode: HashMap<EntityId, Mode>,
+    mode: HashMap<EntityId, SweepMode>,
 }
 
 impl LookDispatch {
@@ -58,35 +37,16 @@ impl LookDispatch {
     }
 
     /// Sweep direction for `car`, defaulting to `Up` for first-time callers.
-    fn direction_for(&self, car: EntityId) -> Direction {
-        self.direction.get(&car).copied().unwrap_or(Direction::Up)
+    fn direction_for(&self, car: EntityId) -> SweepDirection {
+        self.direction
+            .get(&car)
+            .copied()
+            .unwrap_or(SweepDirection::Up)
     }
 
     /// Accept mode for `car` in the current pass, defaulting to `Strict`.
-    fn mode_for(&self, car: EntityId) -> Mode {
-        self.mode.get(&car).copied().unwrap_or(Mode::Strict)
-    }
-
-    /// True if any demanded stop is strictly ahead of `car_pos` in `dir`.
-    fn strict_demand_ahead(
-        dir: Direction,
-        car_pos: f64,
-        group: &ElevatorGroup,
-        manifest: &DispatchManifest,
-        world: &World,
-    ) -> bool {
-        group.stop_entities().iter().any(|&s| {
-            if !manifest.has_demand(s) {
-                return false;
-            }
-            let Some(p) = world.stop_position(s) else {
-                return false;
-            };
-            match dir {
-                Direction::Up => p > car_pos + EPSILON,
-                Direction::Down => p < car_pos - EPSILON,
-            }
-        })
+    fn mode_for(&self, car: EntityId) -> SweepMode {
+        self.mode.get(&car).copied().unwrap_or(SweepMode::Strict)
     }
 }
 
@@ -106,15 +66,11 @@ impl DispatchStrategy for LookDispatch {
         world: &World,
     ) {
         let current = self.direction_for(car);
-        if Self::strict_demand_ahead(current, car_position, group, manifest, world) {
-            self.mode.insert(car, Mode::Strict);
+        if sweep::strict_demand_ahead(current, car_position, group, manifest, world) {
+            self.mode.insert(car, SweepMode::Strict);
         } else {
-            let reversed = match current {
-                Direction::Up => Direction::Down,
-                Direction::Down => Direction::Up,
-            };
-            self.direction.insert(car, reversed);
-            self.mode.insert(car, Mode::Lenient);
+            self.direction.insert(car, current.reversed());
+            self.mode.insert(car, SweepMode::Lenient);
         }
     }
 
@@ -128,19 +84,12 @@ impl DispatchStrategy for LookDispatch {
         _manifest: &DispatchManifest,
         _world: &World,
     ) -> Option<f64> {
-        let direction = self.direction_for(car);
-        let mode = self.mode_for(car);
-        let accept = match (mode, direction) {
-            (Mode::Strict, Direction::Up) => stop_position > car_position + EPSILON,
-            (Mode::Strict, Direction::Down) => stop_position < car_position - EPSILON,
-            (Mode::Lenient, Direction::Up) => stop_position > car_position - EPSILON,
-            (Mode::Lenient, Direction::Down) => stop_position < car_position + EPSILON,
-        };
-        if accept {
-            Some((car_position - stop_position).abs())
-        } else {
-            None
-        }
+        sweep::rank(
+            self.mode_for(car),
+            self.direction_for(car),
+            car_position,
+            stop_position,
+        )
     }
 
     fn notify_removed(&mut self, elevator: EntityId) {

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -1,5 +1,12 @@
 //! Pluggable dispatch strategies for assigning elevators to stops.
 //!
+//! Strategies express preferences as scores on `(car, stop)` pairs via
+//! [`DispatchStrategy::rank`]. The dispatch system then runs an optimal
+//! bipartite assignment (Kuhn–Munkres / Hungarian algorithm) so coordination
+//! — one car per hall call — is a library invariant, not a per-strategy
+//! responsibility. Cars left unassigned are handed to
+//! [`DispatchStrategy::fallback`] for per-car policy (idle, park, etc.).
+//!
 //! # Example: custom dispatch strategy
 //!
 //! ```rust
@@ -11,17 +18,22 @@
 //! struct AlwaysFirstStop;
 //!
 //! impl DispatchStrategy for AlwaysFirstStop {
-//!     fn decide(
+//!     fn rank(
 //!         &mut self,
-//!         _elevator: EntityId,
-//!         _elevator_position: f64,
+//!         _car: EntityId,
+//!         car_position: f64,
+//!         stop: EntityId,
+//!         stop_position: f64,
 //!         group: &ElevatorGroup,
 //!         _manifest: &DispatchManifest,
 //!         _world: &elevator_core::world::World,
-//!     ) -> DispatchDecision {
-//!         group.stop_entities().first()
-//!             .map(|&stop| DispatchDecision::GoToStop(stop))
-//!             .unwrap_or(DispatchDecision::Idle)
+//!     ) -> Option<f64> {
+//!         // Prefer the group's first stop; everything else is unavailable.
+//!         if Some(&stop) == group.stop_entities().first() {
+//!             Some((car_position - stop_position).abs())
+//!         } else {
+//!             None
+//!         }
 //!     }
 //! }
 //!
@@ -356,21 +368,24 @@ impl ElevatorGroup {
 
 /// Pluggable dispatch algorithm.
 ///
-/// Receives a manifest with per-rider metadata grouped by stop.
-/// Convenience methods provide aggregate counts; implementations
-/// can also iterate individual riders for priority/weight-aware dispatch.
+/// Strategies implement [`rank`](Self::rank) to score each `(car, stop)`
+/// pair; the dispatch system then performs an optimal assignment across
+/// the whole group, guaranteeing that no two cars are sent to the same
+/// hall call.
+///
+/// Returning `None` from `rank` excludes a pair from assignment — useful
+/// for capacity limits, direction preferences, restricted stops, or
+/// sticky commitments.
+///
+/// Cars that receive no stop fall through to [`fallback`](Self::fallback),
+/// which returns the policy for that car (idle, park, etc.).
 pub trait DispatchStrategy: Send + Sync {
-    /// Optional hook called once before the per-group dispatch pass.
+    /// Optional hook called once per group before the assignment pass.
     ///
     /// Strategies that need to mutate [`World`] extension storage (e.g.
-    /// [`DestinationDispatch`] writing sticky rider → car assignments) or
-    /// [`crate::components::DestinationQueue`] entries before per-elevator
-    /// decisions override this. The default is a no-op.
-    ///
-    /// Called by [`crate::systems::dispatch::run`] for every group with
-    /// mutable world access. The corresponding [`DispatchManifest`] is
-    /// rebuilt internally so downstream `decide`/`decide_all` calls see
-    /// consistent state.
+    /// [`DestinationDispatch`] writing sticky rider → car assignments)
+    /// or pre-populate [`crate::components::DestinationQueue`] entries
+    /// override this. Default: no-op.
     fn pre_dispatch(
         &mut self,
         _group: &ElevatorGroup,
@@ -379,36 +394,179 @@ pub trait DispatchStrategy: Send + Sync {
     ) {
     }
 
-    /// Decide for a single elevator.
-    fn decide(
+    /// Optional hook called once per candidate car, before any
+    /// [`rank`](Self::rank) calls for that car in the current pass.
+    ///
+    /// Strategies whose ranking depends on stable per-car state (e.g. the
+    /// sweep direction used by SCAN/LOOK) set that state here so later
+    /// `rank` calls see a consistent view regardless of iteration order.
+    /// The default is a no-op.
+    fn prepare_car(
         &mut self,
-        elevator: EntityId,
-        elevator_position: f64,
-        group: &ElevatorGroup,
-        manifest: &DispatchManifest,
-        world: &World,
-    ) -> DispatchDecision;
+        _car: EntityId,
+        _car_position: f64,
+        _group: &ElevatorGroup,
+        _manifest: &DispatchManifest,
+        _world: &World,
+    ) {
+    }
 
-    /// Decide for all idle elevators in a group.
-    /// Default: calls `decide()` per elevator.
-    fn decide_all(
+    /// Score the cost of sending `car` to `stop`. Lower is better.
+    ///
+    /// Returning `None` marks this `(car, stop)` pair as unavailable;
+    /// the assignment algorithm will never pair them. Use this for
+    /// capacity limits, wrong-direction stops, stops outside the line's
+    /// topology, or pairs already committed via a sticky assignment.
+    ///
+    /// Must return a finite, non-negative value if `Some` — infinities
+    /// and NaN can destabilize the underlying Hungarian solver.
+    #[allow(clippy::too_many_arguments)]
+    fn rank(
         &mut self,
-        elevators: &[(EntityId, f64)], // (entity, position)
+        car: EntityId,
+        car_position: f64,
+        stop: EntityId,
+        stop_position: f64,
         group: &ElevatorGroup,
         manifest: &DispatchManifest,
         world: &World,
-    ) -> Vec<(EntityId, DispatchDecision)> {
-        elevators
-            .iter()
-            .map(|(eid, pos)| (*eid, self.decide(*eid, *pos, group, manifest, world)))
-            .collect()
+    ) -> Option<f64>;
+
+    /// Decide what an idle car should do when no stop was assigned to it.
+    ///
+    /// Called for each car the assignment phase could not pair with a
+    /// stop (because there were no stops, or all candidate stops had
+    /// rank `None` for this car). Default: [`DispatchDecision::Idle`].
+    fn fallback(
+        &mut self,
+        _car: EntityId,
+        _car_position: f64,
+        _group: &ElevatorGroup,
+        _manifest: &DispatchManifest,
+        _world: &World,
+    ) -> DispatchDecision {
+        DispatchDecision::Idle
     }
 
     /// Notify the strategy that an elevator has been removed.
     ///
-    /// Implementations with per-elevator state (e.g., direction tracking)
-    /// should clean up here to prevent unbounded memory growth. Default: no-op.
+    /// Implementations with per-elevator state (e.g. direction tracking)
+    /// should clean up here to prevent unbounded memory growth.
     fn notify_removed(&mut self, _elevator: EntityId) {}
+}
+
+/// Resolution of a single dispatch assignment pass for one group.
+///
+/// Produced by [`assign`] and consumed by
+/// [`crate::systems::dispatch::run`] to apply decisions to the world.
+#[derive(Debug, Clone)]
+pub struct AssignmentResult {
+    /// `(car, decision)` pairs for every idle car in the group.
+    pub decisions: Vec<(EntityId, DispatchDecision)>,
+}
+
+/// Sentinel weight used to pad unavailable `(car, stop)` pairs when
+/// building the cost matrix for the Hungarian solver. Chosen so that
+/// `n * SENTINEL` cannot overflow `i64` for realistic group sizes.
+const ASSIGNMENT_SENTINEL: i64 = 1 << 56;
+/// Fixed-point scale for converting `f64` costs to the `i64` values the
+/// Hungarian solver requires. One unit ≈ one micro-tick / millimeter.
+const ASSIGNMENT_SCALE: f64 = 1_000_000.0;
+
+/// Convert a `f64` rank cost into the fixed-point `i64` the Hungarian
+/// solver consumes. Non-finite, negative, or overflow-prone inputs map
+/// to the unavailable sentinel.
+fn scale_cost(cost: f64) -> i64 {
+    if !cost.is_finite() || cost < 0.0 {
+        return ASSIGNMENT_SENTINEL;
+    }
+    // Cap at just below sentinel so any real rank always beats unavailable.
+    let scaled = (cost * ASSIGNMENT_SCALE).round();
+    if scaled >= (ASSIGNMENT_SENTINEL as f64) {
+        ASSIGNMENT_SENTINEL - 1
+    } else {
+        scaled as i64
+    }
+}
+
+/// Run one group's assignment pass: build the cost matrix, solve the
+/// optimal bipartite matching, then resolve unassigned cars via
+/// [`DispatchStrategy::fallback`].
+///
+/// Visible to the `systems` module; not part of the public API.
+pub(crate) fn assign(
+    strategy: &mut dyn DispatchStrategy,
+    idle_cars: &[(EntityId, f64)],
+    group: &ElevatorGroup,
+    manifest: &DispatchManifest,
+    world: &World,
+) -> AssignmentResult {
+    // Collect stops with active demand and known positions.
+    let pending_stops: Vec<(EntityId, f64)> = group
+        .stop_entities()
+        .iter()
+        .filter(|s| manifest.has_demand(**s))
+        .filter_map(|s| world.stop_position(*s).map(|p| (*s, p)))
+        .collect();
+
+    let n = idle_cars.len();
+    let m = pending_stops.len();
+
+    if n == 0 {
+        return AssignmentResult {
+            decisions: Vec::new(),
+        };
+    }
+
+    let mut decisions: Vec<(EntityId, DispatchDecision)> = Vec::with_capacity(n);
+
+    if m == 0 {
+        for &(eid, pos) in idle_cars {
+            let d = strategy.fallback(eid, pos, group, manifest, world);
+            decisions.push((eid, d));
+        }
+        return AssignmentResult { decisions };
+    }
+
+    // Build cost matrix. Hungarian requires rows <= cols.
+    let cols = n.max(m);
+    let mut data: Vec<i64> = vec![ASSIGNMENT_SENTINEL; n * cols];
+    for (i, &(car_eid, car_pos)) in idle_cars.iter().enumerate() {
+        strategy.prepare_car(car_eid, car_pos, group, manifest, world);
+        for (j, &(stop_eid, stop_pos)) in pending_stops.iter().enumerate() {
+            let scaled = strategy
+                .rank(car_eid, car_pos, stop_eid, stop_pos, group, manifest, world)
+                .map_or(ASSIGNMENT_SENTINEL, scale_cost);
+            data[i * cols + j] = scaled;
+        }
+    }
+    // `from_vec` only fails if `n * cols != data.len()` — both derived
+    // from `n` and `cols` above, so the construction is infallible. Fall
+    // back to an empty-result shape in the unlikely event the invariant
+    // is violated in future refactors.
+    let Ok(matrix) = pathfinding::matrix::Matrix::from_vec(n, cols, data) else {
+        for &(car_eid, car_pos) in idle_cars {
+            let d = strategy.fallback(car_eid, car_pos, group, manifest, world);
+            decisions.push((car_eid, d));
+        }
+        return AssignmentResult { decisions };
+    };
+    let (_, assignments) = pathfinding::kuhn_munkres::kuhn_munkres_min(&matrix);
+
+    for (i, &(car_eid, car_pos)) in idle_cars.iter().enumerate() {
+        let col = assignments[i];
+        // A real assignment is: col points to a real stop (col < m) AND
+        // the cost isn't sentinel-padded (meaning rank() returned Some).
+        if col < m && matrix[(i, col)] < ASSIGNMENT_SENTINEL {
+            let (stop_eid, _) = pending_stops[col];
+            decisions.push((car_eid, DispatchDecision::GoToStop(stop_eid)));
+        } else {
+            let d = strategy.fallback(car_eid, car_pos, group, manifest, world);
+            decisions.push((car_eid, d));
+        }
+    }
+
+    AssignmentResult { decisions }
 }
 
 /// Pluggable strategy for repositioning idle elevators.

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -422,6 +422,14 @@ pub trait DispatchStrategy: Send + Sync {
     ///
     /// Must return a finite, non-negative value if `Some` — infinities
     /// and NaN can destabilize the underlying Hungarian solver.
+    ///
+    /// Implementations must not mutate per-car state inside `rank`: the
+    /// dispatch system calls `rank(car, stop_0..stop_m)` in a loop, so
+    /// mutating `self` on one call affects subsequent calls for the same
+    /// car within the same pass and produces an asymmetric cost matrix
+    /// whose results depend on iteration order. Use
+    /// [`prepare_car`](Self::prepare_car) to compute and store any
+    /// per-car state before `rank` is called.
     #[allow(clippy::too_many_arguments)]
     fn rank(
         &mut self,

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -55,6 +55,8 @@ pub mod nearest_car;
 pub mod reposition;
 /// SCAN dispatch algorithm.
 pub mod scan;
+/// Shared sweep-direction logic used by SCAN and LOOK.
+pub(crate) mod sweep;
 
 pub use destination::{AssignedCar, DestinationDispatch};
 pub use etd::EtdDispatch;
@@ -467,8 +469,11 @@ pub struct AssignmentResult {
 
 /// Sentinel weight used to pad unavailable `(car, stop)` pairs when
 /// building the cost matrix for the Hungarian solver. Chosen so that
-/// `n * SENTINEL` cannot overflow `i64` for realistic group sizes.
-const ASSIGNMENT_SENTINEL: i64 = 1 << 56;
+/// `n · SENTINEL` can't overflow `i64`: the Kuhn–Munkres implementation
+/// sums weights and potentials across each row/column internally, so
+/// headroom of ~2¹⁵ above the sentinel lets groups scale past 30 000
+/// cars or stops before any arithmetic risk appears.
+const ASSIGNMENT_SENTINEL: i64 = 1 << 48;
 /// Fixed-point scale for converting `f64` costs to the `i64` values the
 /// Hungarian solver requires. One unit ≈ one micro-tick / millimeter.
 const ASSIGNMENT_SCALE: f64 = 1_000_000.0;
@@ -481,12 +486,9 @@ fn scale_cost(cost: f64) -> i64 {
         return ASSIGNMENT_SENTINEL;
     }
     // Cap at just below sentinel so any real rank always beats unavailable.
-    let scaled = (cost * ASSIGNMENT_SCALE).round();
-    if scaled >= (ASSIGNMENT_SENTINEL as f64) {
-        ASSIGNMENT_SENTINEL - 1
-    } else {
-        scaled as i64
-    }
+    (cost * ASSIGNMENT_SCALE)
+        .round()
+        .clamp(0.0, (ASSIGNMENT_SENTINEL - 1) as f64) as i64
 }
 
 /// Run one group's assignment pass: build the cost matrix, solve the

--- a/crates/elevator-core/src/dispatch/nearest_car.rs
+++ b/crates/elevator-core/src/dispatch/nearest_car.rs
@@ -1,17 +1,15 @@
 //! Nearest-car dispatch — assigns each call to the closest idle elevator.
 
-use smallvec::SmallVec;
-
 use crate::entity::EntityId;
 use crate::world::World;
 
-use super::{DispatchDecision, DispatchManifest, DispatchStrategy, ElevatorGroup};
+use super::{DispatchManifest, DispatchStrategy, ElevatorGroup};
 
-/// Assigns each call to the nearest idle elevator.
+/// Scores `(car, stop)` by absolute distance between the car and the stop.
 ///
-/// For multi-elevator groups, this overrides `decide_all()` to coordinate
-/// across the entire group — preventing two elevators from responding to
-/// the same call.
+/// Paired with the Hungarian assignment in the dispatch system, this
+/// yields the globally minimum-total-distance matching across the group
+/// — no two cars can be sent to the same hall call.
 pub struct NearestCarDispatch;
 
 impl NearestCarDispatch {
@@ -29,83 +27,16 @@ impl Default for NearestCarDispatch {
 }
 
 impl DispatchStrategy for NearestCarDispatch {
-    fn decide(
+    fn rank(
         &mut self,
-        _elevator: EntityId,
-        _elevator_position: f64,
+        _car: EntityId,
+        car_position: f64,
+        _stop: EntityId,
+        stop_position: f64,
         _group: &ElevatorGroup,
         _manifest: &DispatchManifest,
         _world: &World,
-    ) -> DispatchDecision {
-        // Not used — decide_all() handles everything.
-        DispatchDecision::Idle
-    }
-
-    fn decide_all(
-        &mut self,
-        elevators: &[(EntityId, f64)],
-        group: &ElevatorGroup,
-        manifest: &DispatchManifest,
-        world: &World,
-    ) -> Vec<(EntityId, DispatchDecision)> {
-        // Collect stops that need service (have demand or rider destinations).
-        let mut pending_stops: SmallVec<[(EntityId, f64); 16]> = SmallVec::new();
-        for &stop_eid in group.stop_entities() {
-            if manifest.has_demand(stop_eid)
-                && let Some(pos) = world.stop_position(stop_eid)
-            {
-                pending_stops.push((stop_eid, pos));
-            }
-        }
-
-        if pending_stops.is_empty() {
-            return elevators
-                .iter()
-                .map(|(eid, _)| (*eid, DispatchDecision::Idle))
-                .collect();
-        }
-
-        let mut results: Vec<(EntityId, DispatchDecision)> = Vec::new();
-        let mut assigned_stops: SmallVec<[EntityId; 16]> = SmallVec::new();
-        let mut assigned_elevators: SmallVec<[EntityId; 16]> = SmallVec::new();
-
-        // Greedy assignment: for each unassigned stop, find nearest unassigned elevator.
-        // Sort stops by total demand (highest first) for priority.
-        pending_stops.sort_by(|a, b| {
-            let demand_a = manifest.waiting_count_at(a.0);
-            let demand_b = manifest.waiting_count_at(b.0);
-            demand_b.cmp(&demand_a)
-        });
-
-        for (stop_eid, stop_pos) in &pending_stops {
-            if assigned_stops.contains(stop_eid) {
-                continue;
-            }
-
-            // Find nearest unassigned elevator.
-            let nearest = elevators
-                .iter()
-                .filter(|(eid, _)| !assigned_elevators.contains(eid))
-                .min_by(|a, b| {
-                    let dist_a = (a.1 - stop_pos).abs();
-                    let dist_b = (b.1 - stop_pos).abs();
-                    dist_a.total_cmp(&dist_b)
-                });
-
-            if let Some((elev_eid, _)) = nearest {
-                results.push((*elev_eid, DispatchDecision::GoToStop(*stop_eid)));
-                assigned_elevators.push(*elev_eid);
-                assigned_stops.push(*stop_eid);
-            }
-        }
-
-        // Remaining unassigned elevators get Idle.
-        for (eid, _) in elevators {
-            if !assigned_elevators.contains(eid) {
-                results.push((*eid, DispatchDecision::Idle));
-            }
-        }
-
-        results
+    ) -> Option<f64> {
+        Some((car_position - stop_position).abs())
     }
 }

--- a/crates/elevator-core/src/dispatch/scan.rs
+++ b/crates/elevator-core/src/dispatch/scan.rs
@@ -7,12 +7,10 @@
 
 use std::collections::HashMap;
 
-use smallvec::SmallVec;
-
 use crate::entity::EntityId;
 use crate::world::World;
 
-use super::{DispatchDecision, DispatchManifest, DispatchStrategy, ElevatorGroup};
+use super::{DispatchManifest, DispatchStrategy, ElevatorGroup};
 
 /// Tolerance for floating-point position comparisons.
 const EPSILON: f64 = 1e-9;
@@ -27,12 +25,31 @@ pub(crate) enum ScanDirection {
     Down,
 }
 
+/// Per-car state computed by [`DispatchStrategy::prepare_car`] and read
+/// by [`DispatchStrategy::rank`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    /// Demand exists strictly ahead in the stored direction; accept
+    /// only strictly-ahead stops.
+    Strict,
+    /// The sweep just reversed; accept any demanded stop in the new
+    /// direction's non-strict half (including the car's current position).
+    Lenient,
+}
+
 /// Elevator dispatch using the SCAN (elevator) algorithm.
 ///
-/// Serves all requests in the current direction of travel before reversing.
+/// Each car tracks a sweep direction; stops demanded in that direction
+/// receive a positional cost while stops behind are excluded. When
+/// nothing remains ahead, the sweep reverses and the car considers the
+/// reverse side. Direction and mode are resolved once per pass in
+/// [`DispatchStrategy::prepare_car`] so ranking is independent of the
+/// iteration order over stops.
 pub struct ScanDispatch {
     /// Per-elevator sweep direction.
     direction: HashMap<EntityId, ScanDirection>,
+    /// Per-elevator accept mode for the current dispatch pass.
+    mode: HashMap<EntityId, Mode>,
 }
 
 impl ScanDispatch {
@@ -41,7 +58,43 @@ impl ScanDispatch {
     pub fn new() -> Self {
         Self {
             direction: HashMap::new(),
+            mode: HashMap::new(),
         }
+    }
+
+    /// Sweep direction for `car`, defaulting to `Up` for first-time callers.
+    fn direction_for(&self, car: EntityId) -> ScanDirection {
+        self.direction
+            .get(&car)
+            .copied()
+            .unwrap_or(ScanDirection::Up)
+    }
+
+    /// Accept mode for `car` in the current pass, defaulting to `Strict`.
+    fn mode_for(&self, car: EntityId) -> Mode {
+        self.mode.get(&car).copied().unwrap_or(Mode::Strict)
+    }
+
+    /// True if any demanded stop is strictly ahead of `car_pos` in `dir`.
+    fn strict_demand_ahead(
+        dir: ScanDirection,
+        car_pos: f64,
+        group: &ElevatorGroup,
+        manifest: &DispatchManifest,
+        world: &World,
+    ) -> bool {
+        group.stop_entities().iter().any(|&s| {
+            if !manifest.has_demand(s) {
+                return false;
+            }
+            let Some(p) = world.stop_position(s) else {
+                return false;
+            };
+            match dir {
+                ScanDirection::Up => p > car_pos + EPSILON,
+                ScanDirection::Down => p < car_pos - EPSILON,
+            }
+        })
     }
 }
 
@@ -52,90 +105,54 @@ impl Default for ScanDispatch {
 }
 
 impl DispatchStrategy for ScanDispatch {
-    fn decide(
+    fn prepare_car(
         &mut self,
-        elevator: EntityId,
-        elevator_position: f64,
+        car: EntityId,
+        car_position: f64,
         group: &ElevatorGroup,
         manifest: &DispatchManifest,
         world: &World,
-    ) -> DispatchDecision {
-        let direction = self
-            .direction
-            .get(&elevator)
-            .copied()
-            .unwrap_or(ScanDirection::Up);
-
-        // Collect "interesting" stops: stops with demand or rider destinations.
-        let mut interesting: SmallVec<[(EntityId, f64); 32]> = SmallVec::new();
-
-        for &stop_eid in group.stop_entities() {
-            if manifest.has_demand(stop_eid)
-                && let Some(pos) = world.stop_position(stop_eid)
-            {
-                interesting.push((stop_eid, pos));
-            }
-        }
-
-        if interesting.is_empty() {
-            return DispatchDecision::Idle;
-        }
-
-        let pos = elevator_position;
-
-        // Partition into ahead and behind based on current direction.
-        let (ahead, behind): (SmallVec<[_; 32]>, SmallVec<[_; 32]>) = match direction {
-            ScanDirection::Up => interesting.iter().partition(|(_, p)| *p > pos + EPSILON),
-            ScanDirection::Down => interesting.iter().partition(|(_, p)| *p < pos - EPSILON),
-        };
-
-        if !ahead.is_empty() {
-            let nearest = match direction {
-                ScanDirection::Up => ahead
-                    .iter()
-                    .min_by(|a: &&&(EntityId, f64), b: &&&(EntityId, f64)| a.1.total_cmp(&b.1)),
-                ScanDirection::Down => ahead
-                    .iter()
-                    .max_by(|a: &&&(EntityId, f64), b: &&&(EntityId, f64)| a.1.total_cmp(&b.1)),
+    ) {
+        let current = self.direction_for(car);
+        if Self::strict_demand_ahead(current, car_position, group, manifest, world) {
+            self.mode.insert(car, Mode::Strict);
+        } else {
+            let reversed = match current {
+                ScanDirection::Up => ScanDirection::Down,
+                ScanDirection::Down => ScanDirection::Up,
             };
-            // ahead is non-empty, so nearest is always Some.
-            if let Some(stop) = nearest {
-                return DispatchDecision::GoToStop(stop.0);
-            }
+            self.direction.insert(car, reversed);
+            self.mode.insert(car, Mode::Lenient);
         }
+    }
 
-        // Nothing ahead — reverse direction.
-        let new_dir = match direction {
-            ScanDirection::Up => ScanDirection::Down,
-            ScanDirection::Down => ScanDirection::Up,
+    fn rank(
+        &mut self,
+        car: EntityId,
+        car_position: f64,
+        _stop: EntityId,
+        stop_position: f64,
+        _group: &ElevatorGroup,
+        _manifest: &DispatchManifest,
+        _world: &World,
+    ) -> Option<f64> {
+        let direction = self.direction_for(car);
+        let mode = self.mode_for(car);
+        let accept = match (mode, direction) {
+            (Mode::Strict, ScanDirection::Up) => stop_position > car_position + EPSILON,
+            (Mode::Strict, ScanDirection::Down) => stop_position < car_position - EPSILON,
+            (Mode::Lenient, ScanDirection::Up) => stop_position > car_position - EPSILON,
+            (Mode::Lenient, ScanDirection::Down) => stop_position < car_position + EPSILON,
         };
-        self.direction.insert(elevator, new_dir);
-
-        if behind.is_empty() {
-            // All interesting stops at current position (handled above).
-            return interesting
-                .first()
-                .map_or(DispatchDecision::Idle, |(sid, _)| {
-                    DispatchDecision::GoToStop(*sid)
-                });
+        if accept {
+            Some((car_position - stop_position).abs())
+        } else {
+            None
         }
-
-        let nearest = match new_dir {
-            ScanDirection::Up => behind
-                .iter()
-                .min_by(|a: &&&(EntityId, f64), b: &&&(EntityId, f64)| a.1.total_cmp(&b.1)),
-            ScanDirection::Down => behind
-                .iter()
-                .max_by(|a: &&&(EntityId, f64), b: &&&(EntityId, f64)| a.1.total_cmp(&b.1)),
-        };
-
-        // behind is non-empty, so nearest is always Some.
-        nearest.map_or(DispatchDecision::Idle, |stop| {
-            DispatchDecision::GoToStop(stop.0)
-        })
     }
 
     fn notify_removed(&mut self, elevator: EntityId) {
         self.direction.remove(&elevator);
+        self.mode.remove(&elevator);
     }
 }

--- a/crates/elevator-core/src/dispatch/scan.rs
+++ b/crates/elevator-core/src/dispatch/scan.rs
@@ -10,32 +10,8 @@ use std::collections::HashMap;
 use crate::entity::EntityId;
 use crate::world::World;
 
+use super::sweep::{self, SweepDirection, SweepMode};
 use super::{DispatchManifest, DispatchStrategy, ElevatorGroup};
-
-/// Tolerance for floating-point position comparisons.
-const EPSILON: f64 = 1e-9;
-
-/// Direction of travel for the SCAN algorithm.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub(crate) enum ScanDirection {
-    /// Traveling upward (increasing position).
-    Up,
-    /// Traveling downward (decreasing position).
-    Down,
-}
-
-/// Per-car state computed by [`DispatchStrategy::prepare_car`] and read
-/// by [`DispatchStrategy::rank`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Mode {
-    /// Demand exists strictly ahead in the stored direction; accept
-    /// only strictly-ahead stops.
-    Strict,
-    /// The sweep just reversed; accept any demanded stop in the new
-    /// direction's non-strict half (including the car's current position).
-    Lenient,
-}
 
 /// Elevator dispatch using the SCAN (elevator) algorithm.
 ///
@@ -47,9 +23,9 @@ enum Mode {
 /// iteration order over stops.
 pub struct ScanDispatch {
     /// Per-elevator sweep direction.
-    direction: HashMap<EntityId, ScanDirection>,
+    direction: HashMap<EntityId, SweepDirection>,
     /// Per-elevator accept mode for the current dispatch pass.
-    mode: HashMap<EntityId, Mode>,
+    mode: HashMap<EntityId, SweepMode>,
 }
 
 impl ScanDispatch {
@@ -63,38 +39,16 @@ impl ScanDispatch {
     }
 
     /// Sweep direction for `car`, defaulting to `Up` for first-time callers.
-    fn direction_for(&self, car: EntityId) -> ScanDirection {
+    fn direction_for(&self, car: EntityId) -> SweepDirection {
         self.direction
             .get(&car)
             .copied()
-            .unwrap_or(ScanDirection::Up)
+            .unwrap_or(SweepDirection::Up)
     }
 
     /// Accept mode for `car` in the current pass, defaulting to `Strict`.
-    fn mode_for(&self, car: EntityId) -> Mode {
-        self.mode.get(&car).copied().unwrap_or(Mode::Strict)
-    }
-
-    /// True if any demanded stop is strictly ahead of `car_pos` in `dir`.
-    fn strict_demand_ahead(
-        dir: ScanDirection,
-        car_pos: f64,
-        group: &ElevatorGroup,
-        manifest: &DispatchManifest,
-        world: &World,
-    ) -> bool {
-        group.stop_entities().iter().any(|&s| {
-            if !manifest.has_demand(s) {
-                return false;
-            }
-            let Some(p) = world.stop_position(s) else {
-                return false;
-            };
-            match dir {
-                ScanDirection::Up => p > car_pos + EPSILON,
-                ScanDirection::Down => p < car_pos - EPSILON,
-            }
-        })
+    fn mode_for(&self, car: EntityId) -> SweepMode {
+        self.mode.get(&car).copied().unwrap_or(SweepMode::Strict)
     }
 }
 
@@ -114,15 +68,11 @@ impl DispatchStrategy for ScanDispatch {
         world: &World,
     ) {
         let current = self.direction_for(car);
-        if Self::strict_demand_ahead(current, car_position, group, manifest, world) {
-            self.mode.insert(car, Mode::Strict);
+        if sweep::strict_demand_ahead(current, car_position, group, manifest, world) {
+            self.mode.insert(car, SweepMode::Strict);
         } else {
-            let reversed = match current {
-                ScanDirection::Up => ScanDirection::Down,
-                ScanDirection::Down => ScanDirection::Up,
-            };
-            self.direction.insert(car, reversed);
-            self.mode.insert(car, Mode::Lenient);
+            self.direction.insert(car, current.reversed());
+            self.mode.insert(car, SweepMode::Lenient);
         }
     }
 
@@ -136,19 +86,12 @@ impl DispatchStrategy for ScanDispatch {
         _manifest: &DispatchManifest,
         _world: &World,
     ) -> Option<f64> {
-        let direction = self.direction_for(car);
-        let mode = self.mode_for(car);
-        let accept = match (mode, direction) {
-            (Mode::Strict, ScanDirection::Up) => stop_position > car_position + EPSILON,
-            (Mode::Strict, ScanDirection::Down) => stop_position < car_position - EPSILON,
-            (Mode::Lenient, ScanDirection::Up) => stop_position > car_position - EPSILON,
-            (Mode::Lenient, ScanDirection::Down) => stop_position < car_position + EPSILON,
-        };
-        if accept {
-            Some((car_position - stop_position).abs())
-        } else {
-            None
-        }
+        sweep::rank(
+            self.mode_for(car),
+            self.direction_for(car),
+            car_position,
+            stop_position,
+        )
     }
 
     fn notify_removed(&mut self, elevator: EntityId) {

--- a/crates/elevator-core/src/dispatch/sweep.rs
+++ b/crates/elevator-core/src/dispatch/sweep.rs
@@ -1,0 +1,85 @@
+//! Shared sweep-direction logic for the SCAN and LOOK dispatch algorithms.
+//!
+//! Both algorithms track a per-car direction and an accept mode, and apply
+//! identical positional filtering. This module centralises that logic so the
+//! two strategy structs stay thin and consistent.
+
+use crate::world::World;
+
+use super::{DispatchManifest, ElevatorGroup};
+
+/// Tolerance for floating-point position comparisons.
+pub const EPSILON: f64 = 1e-9;
+
+/// Sweep direction for a single car.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SweepDirection {
+    /// Traveling upward (increasing position).
+    Up,
+    /// Traveling downward (decreasing position).
+    Down,
+}
+
+impl SweepDirection {
+    /// Return the opposite direction.
+    pub const fn reversed(self) -> Self {
+        match self {
+            Self::Up => Self::Down,
+            Self::Down => Self::Up,
+        }
+    }
+}
+
+/// Per-car accept mode for one dispatch pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SweepMode {
+    /// Demand exists strictly ahead — accept only strictly-ahead stops.
+    Strict,
+    /// Sweep just reversed — accept stops in the non-strict half (including
+    /// the car's current position).
+    Lenient,
+}
+
+/// True if any demanded stop is strictly ahead of `car_pos` in `dir`.
+pub fn strict_demand_ahead(
+    dir: SweepDirection,
+    car_pos: f64,
+    group: &ElevatorGroup,
+    manifest: &DispatchManifest,
+    world: &World,
+) -> bool {
+    group.stop_entities().iter().any(|&s| {
+        if !manifest.has_demand(s) {
+            return false;
+        }
+        let Some(p) = world.stop_position(s) else {
+            return false;
+        };
+        match dir {
+            SweepDirection::Up => p > car_pos + EPSILON,
+            SweepDirection::Down => p < car_pos - EPSILON,
+        }
+    })
+}
+
+/// Return the rank cost for a `(car, stop)` pair given the car's current
+/// direction and mode. Returns `None` when the stop is outside the
+/// accepted half-sweep.
+pub fn rank(
+    mode: SweepMode,
+    direction: SweepDirection,
+    car_position: f64,
+    stop_position: f64,
+) -> Option<f64> {
+    let accept = match (mode, direction) {
+        (SweepMode::Strict, SweepDirection::Up) => stop_position > car_position + EPSILON,
+        (SweepMode::Strict, SweepDirection::Down) => stop_position < car_position - EPSILON,
+        (SweepMode::Lenient, SweepDirection::Up) => stop_position > car_position - EPSILON,
+        (SweepMode::Lenient, SweepDirection::Down) => stop_position < car_position + EPSILON,
+    };
+    if accept {
+        Some((car_position - stop_position).abs())
+    } else {
+        None
+    }
+}

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -2,7 +2,7 @@
 
 use crate::components::{ElevatorPhase, RiderPhase, Route, TransportMode};
 use crate::dispatch::{
-    DispatchDecision, DispatchManifest, DispatchStrategy, ElevatorGroup, RiderInfo,
+    self, DispatchDecision, DispatchManifest, DispatchStrategy, ElevatorGroup, RiderInfo,
 };
 use crate::entity::EntityId;
 use crate::events::{Event, EventBus};
@@ -66,9 +66,9 @@ pub fn run(
             continue;
         };
 
-        let decisions = dispatch.decide_all(&idle_elevators, group, &manifest, world);
+        let result = dispatch::assign(dispatch.as_mut(), &idle_elevators, group, &manifest, world);
 
-        for (eid, decision) in decisions {
+        for (eid, decision) in result.decisions {
             match decision {
                 DispatchDecision::GoToStop(stop_eid) => {
                     let pos = world.position(eid).map_or(0.0, |p| p.value);

--- a/crates/elevator-core/src/tests/dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/dispatch_tests.rs
@@ -559,3 +559,50 @@ fn nearest_car_ignores_zero_demand() {
     // Should skip stop[1] (0 demand) and go to stop[3].
     assert_eq!(dec.1, DispatchDecision::GoToStop(stops[3]));
 }
+
+/// Stress the Hungarian matrix with a realistic large group to verify the
+/// sentinel + scaling bounds don't overflow `i64` in the solver's internal
+/// potential sums. Mirrors the upper end of `benches/dispatch_bench.rs`.
+#[test]
+fn assign_handles_large_group_without_overflow() {
+    let mut world = World::new();
+    let stop_count = 64;
+    let car_count = 32;
+    let stops: Vec<_> = (0..stop_count)
+        .map(|i| {
+            let eid = world.spawn();
+            world.set_stop(
+                eid,
+                Stop {
+                    name: format!("S{i}"),
+                    position: i as f64 * 4.0,
+                },
+            );
+            eid
+        })
+        .collect();
+    let cars: Vec<_> = (0..car_count)
+        .map(|i| spawn_elevator(&mut world, (i as f64) * 4.0))
+        .collect();
+    let group = test_group(&stops, cars.clone());
+    let mut manifest = DispatchManifest::default();
+    for &s in &stops {
+        add_demand(&mut manifest, &mut world, s, 70.0);
+    }
+    let positions: Vec<_> = cars
+        .iter()
+        .map(|&c| (c, world.position(c).unwrap().value))
+        .collect();
+
+    let mut nc = NearestCarDispatch::new();
+    let decisions = decide_all(&mut nc, &positions, &group, &manifest, &world);
+    // Every car should be assigned to a distinct stop (car_count < stop_count).
+    let assigned_stops: HashSet<_> = decisions
+        .iter()
+        .filter_map(|(_, d)| match d {
+            DispatchDecision::GoToStop(s) => Some(*s),
+            DispatchDecision::Idle => None,
+        })
+        .collect();
+    assert_eq!(assigned_stops.len(), car_count);
+}

--- a/crates/elevator-core/src/tests/dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/dispatch_tests.rs
@@ -6,11 +6,35 @@ use crate::dispatch::look::LookDispatch;
 use crate::dispatch::nearest_car::NearestCarDispatch;
 use crate::dispatch::scan::ScanDispatch;
 use crate::dispatch::{
-    DispatchDecision, DispatchManifest, DispatchStrategy, ElevatorGroup, RiderInfo,
+    self, DispatchDecision, DispatchManifest, DispatchStrategy, ElevatorGroup, RiderInfo,
 };
 use crate::door::DoorState;
 use crate::ids::GroupId;
 use crate::world::World;
+
+/// Run the assignment for a single car and return its decision.
+fn decide_one(
+    strategy: &mut dyn DispatchStrategy,
+    car: crate::entity::EntityId,
+    pos: f64,
+    group: &ElevatorGroup,
+    manifest: &DispatchManifest,
+    world: &World,
+) -> DispatchDecision {
+    let result = dispatch::assign(strategy, &[(car, pos)], group, manifest, world);
+    result.decisions[0].1.clone()
+}
+
+/// Run the assignment for several cars in one pass.
+fn decide_all(
+    strategy: &mut dyn DispatchStrategy,
+    cars: &[(crate::entity::EntityId, f64)],
+    group: &ElevatorGroup,
+    manifest: &DispatchManifest,
+    world: &World,
+) -> Vec<(crate::entity::EntityId, DispatchDecision)> {
+    dispatch::assign(strategy, cars, group, manifest, world).decisions
+}
 
 /// Build a `World` with 4 stops and return (world, `stop_entities`).
 fn test_world() -> (World, Vec<crate::entity::EntityId>) {
@@ -133,7 +157,7 @@ fn scan_no_requests_returns_idle() {
     let group = test_group(&stops, vec![elev]);
     let manifest = DispatchManifest::default();
     let mut scan = ScanDispatch::new();
-    let decision = scan.decide(elev, 0.0, &group, &manifest, &world);
+    let decision = decide_one(&mut scan, elev, 0.0, &group, &manifest, &world);
     assert_eq!(decision, DispatchDecision::Idle);
 }
 
@@ -146,7 +170,7 @@ fn scan_goes_to_nearest_in_direction() {
     add_demand(&mut manifest, &mut world, stops[1], 70.0);
     add_demand(&mut manifest, &mut world, stops[3], 80.0);
     let mut scan = ScanDispatch::new();
-    let decision = scan.decide(elev, 0.0, &group, &manifest, &world);
+    let decision = decide_one(&mut scan, elev, 0.0, &group, &manifest, &world);
     assert_eq!(decision, DispatchDecision::GoToStop(stops[1]));
 }
 
@@ -159,7 +183,7 @@ fn scan_reverses_when_nothing_ahead() {
     add_demand(&mut manifest, &mut world, stops[0], 70.0);
     add_demand(&mut manifest, &mut world, stops[1], 80.0);
     let mut scan = ScanDispatch::new();
-    let decision = scan.decide(elev, 8.0, &group, &manifest, &world);
+    let decision = decide_one(&mut scan, elev, 8.0, &group, &manifest, &world);
     assert_eq!(decision, DispatchDecision::GoToStop(stops[1]));
 }
 
@@ -171,7 +195,7 @@ fn scan_serves_rider_destination() {
     let mut manifest = DispatchManifest::default();
     add_rider_dest(&mut manifest, &mut world, stops[2]);
     let mut scan = ScanDispatch::new();
-    let decision = scan.decide(elev, 0.0, &group, &manifest, &world);
+    let decision = decide_one(&mut scan, elev, 0.0, &group, &manifest, &world);
     assert_eq!(decision, DispatchDecision::GoToStop(stops[2]));
 }
 
@@ -184,7 +208,7 @@ fn scan_prefers_current_direction() {
     add_demand(&mut manifest, &mut world, stops[0], 70.0);
     add_demand(&mut manifest, &mut world, stops[2], 80.0);
     let mut scan = ScanDispatch::new();
-    let decision = scan.decide(elev, 4.0, &group, &manifest, &world);
+    let decision = decide_one(&mut scan, elev, 4.0, &group, &manifest, &world);
     assert_eq!(decision, DispatchDecision::GoToStop(stops[2]));
 }
 
@@ -197,7 +221,7 @@ fn look_no_requests_returns_idle() {
     let group = test_group(&stops, vec![elev]);
     let manifest = DispatchManifest::default();
     let mut look = LookDispatch::new();
-    let decision = look.decide(elev, 0.0, &group, &manifest, &world);
+    let decision = decide_one(&mut look, elev, 0.0, &group, &manifest, &world);
     assert_eq!(decision, DispatchDecision::Idle);
 }
 
@@ -210,7 +234,7 @@ fn look_reverses_at_last_request() {
     // Only demand at stop 1 (pos 4.0) — LOOK should go there then reverse.
     add_demand(&mut manifest, &mut world, stops[1], 70.0);
     let mut look = LookDispatch::new();
-    let decision = look.decide(elev, 0.0, &group, &manifest, &world);
+    let decision = decide_one(&mut look, elev, 0.0, &group, &manifest, &world);
     assert_eq!(decision, DispatchDecision::GoToStop(stops[1]));
 }
 
@@ -228,7 +252,7 @@ fn nearest_car_assigns_closest_elevator() {
 
     let mut nc = NearestCarDispatch::new();
     let elevators = vec![(elev_a, 0.0), (elev_b, 12.0)];
-    let decisions = nc.decide_all(&elevators, &group, &manifest, &world);
+    let decisions = decide_all(&mut nc, &elevators, &group, &manifest, &world);
 
     // Elevator A (at 0.0) is closer to stop 1 (at 4.0) than Elevator B (at 12.0).
     let a_decision = decisions.iter().find(|(e, _)| *e == elev_a).unwrap();
@@ -252,7 +276,7 @@ fn nearest_car_multiple_stops() {
 
     let mut nc = NearestCarDispatch::new();
     let elevators = vec![(elev_a, 0.0), (elev_b, 12.0)];
-    let decisions = nc.decide_all(&elevators, &group, &manifest, &world);
+    let decisions = decide_all(&mut nc, &elevators, &group, &manifest, &world);
 
     // Stop 0 has higher demand — assigned first. elev_a (at 0.0) is nearest to stop 0.
     // Stop 3: elev_b (at 12.0) is nearest to stop 3.
@@ -278,7 +302,7 @@ fn etd_prefers_idle_elevator() {
 
     let mut etd = EtdDispatch::new();
     let elevators = vec![(elev_a, 4.0), (elev_b, 4.0)];
-    let decisions = etd.decide_all(&elevators, &group, &manifest, &world);
+    let decisions = decide_all(&mut etd, &elevators, &group, &manifest, &world);
 
     // elev_a (0 riders) should be preferred over elev_b (2 riders).
     let a_dec = decisions.iter().find(|(e, _)| *e == elev_a).unwrap();
@@ -297,7 +321,7 @@ fn etd_closer_elevator_wins() {
 
     let mut etd = EtdDispatch::new();
     let elevators = vec![(elev_a, 0.0), (elev_b, 8.0)];
-    let decisions = etd.decide_all(&elevators, &group, &manifest, &world);
+    let decisions = decide_all(&mut etd, &elevators, &group, &manifest, &world);
 
     // Stop 2 at position 8.0. elev_b is at 8.0 (distance 0), elev_a at 0.0 (distance 8).
     let b_dec = decisions.iter().find(|(e, _)| *e == elev_b).unwrap();
@@ -320,7 +344,7 @@ fn scan_at_exact_stop_skips_current_position() {
     add_demand(&mut manifest, &mut world, stops[2], 70.0);
 
     let mut scan = ScanDispatch::new();
-    let decision = scan.decide(elev, 4.0, &group, &manifest, &world);
+    let decision = decide_one(&mut scan, elev, 4.0, &group, &manifest, &world);
     // Elevator is UP. Stop at 4.0 is NOT ahead (it's at current pos).
     // Should go to stop[2] at 8.0, not stop[1] at 4.0.
     assert_eq!(decision, DispatchDecision::GoToStop(stops[2]));
@@ -339,7 +363,7 @@ fn scan_reversal_picks_nearest_behind() {
     add_demand(&mut manifest, &mut world, stops[2], 70.0);
 
     let mut scan = ScanDispatch::new();
-    let decision = scan.decide(elev, 12.0, &group, &manifest, &world);
+    let decision = decide_one(&mut scan, elev, 12.0, &group, &manifest, &world);
     // Nothing ahead (up), reverses to Down. Nearest behind in Down direction = stop[2] at 8.0.
     assert_eq!(decision, DispatchDecision::GoToStop(stops[2]));
 }
@@ -358,7 +382,7 @@ fn scan_notify_removed_cleans_state() {
 
     let mut scan = ScanDispatch::new();
     // First call: nothing Up from 12.0 → reverses to Down, picks stops[1] (nearest below).
-    let d1 = scan.decide(elev, 12.0, &group, &manifest, &world);
+    let d1 = decide_one(&mut scan, elev, 12.0, &group, &manifest, &world);
     assert_eq!(d1, DispatchDecision::GoToStop(stops[1]));
 
     // Now direction is stored as Down for this elevator.
@@ -367,7 +391,7 @@ fn scan_notify_removed_cleans_state() {
 
     // Re-query same elevator from position 4.0 with demand above AND below.
     add_demand(&mut manifest, &mut world, stops[2], 70.0);
-    let d2 = scan.decide(elev, 4.0, &group, &manifest, &world);
+    let d2 = decide_one(&mut scan, elev, 4.0, &group, &manifest, &world);
     // If notify_removed worked: default direction is Up → goes to stops[2] (pos 8.0).
     // If notify_removed was no-op: direction is still Down → goes to stops[1] (pos 4.0) or stops[0] (pos 0.0).
     assert_eq!(d2, DispatchDecision::GoToStop(stops[2]));
@@ -384,12 +408,12 @@ fn look_notify_removed_cleans_state() {
 
     let mut look = LookDispatch::new();
     // Establish direction state (will reverse to Down since nothing is Up from 12.0).
-    look.decide(elev, 12.0, &group, &manifest, &world);
+    decide_one(&mut look, elev, 12.0, &group, &manifest, &world);
     // Remove elevator.
     look.notify_removed(elev);
     // Reuse the same ID — direction should be gone.
     add_demand(&mut manifest, &mut world, stops[2], 70.0);
-    let decision = look.decide(elev, 4.0, &group, &manifest, &world);
+    let decision = decide_one(&mut look, elev, 4.0, &group, &manifest, &world);
     // Default direction is Up, should go up to stop[2] (pos 8.0).
     assert_eq!(decision, DispatchDecision::GoToStop(stops[2]));
 }
@@ -407,12 +431,12 @@ fn look_down_direction_partitions_correctly() {
 
     let mut look = LookDispatch::new();
     // First call: nothing ahead (Up from 8.0 with only stops at 0 and 4), reverses.
-    let d1 = look.decide(elev, 8.0, &group, &manifest, &world);
+    let d1 = decide_one(&mut look, elev, 8.0, &group, &manifest, &world);
     // After reversal to Down: nearest below = stops[1] at pos 4.0 (not stops[0] at 0.0).
     assert_eq!(d1, DispatchDecision::GoToStop(stops[1]));
 
     // Second call: still going Down, both stops ahead. Nearest = stops[1].
-    let d2 = look.decide(elev, 8.0, &group, &manifest, &world);
+    let d2 = decide_one(&mut look, elev, 8.0, &group, &manifest, &world);
     assert_eq!(d2, DispatchDecision::GoToStop(stops[1]));
 }
 
@@ -431,19 +455,19 @@ fn scan_down_direction_serves_below() {
 
     let mut scan = ScanDispatch::new();
     // First call: default Up → goes to stops[3] (above).
-    let d1 = scan.decide(elev, 8.0, &group, &manifest, &world);
+    let d1 = decide_one(&mut scan, elev, 8.0, &group, &manifest, &world);
     assert_eq!(d1, DispatchDecision::GoToStop(stops[3]));
 
     // Remove demand above, only below remains. Call again.
     manifest.waiting_at_stop.remove(&stops[3]);
-    let d2 = scan.decide(elev, 12.0, &group, &manifest, &world);
+    let d2 = decide_one(&mut scan, elev, 12.0, &group, &manifest, &world);
     // Nothing ahead (Up from 12.0), reverses to Down. Nearest below = stops[1].
     assert_eq!(d2, DispatchDecision::GoToStop(stops[1]));
 
     // Now call again at position 8.0 with direction Down.
     // Demand at stops[0] (pos 0.0) and stops[1] (pos 4.0).
     add_demand(&mut manifest, &mut world, stops[0], 70.0);
-    let d3 = scan.decide(elev, 8.0, &group, &manifest, &world);
+    let d3 = decide_one(&mut scan, elev, 8.0, &group, &manifest, &world);
     // Direction is Down. Both stops below. Nearest in Down = stops[1] (pos 4.0, highest below).
     assert_eq!(d3, DispatchDecision::GoToStop(stops[1]));
 }
@@ -462,7 +486,7 @@ fn nearest_car_distance_calculation() {
 
     let mut nc = NearestCarDispatch::new();
     let elevators = vec![(elev_a, 3.0), (elev_b, 5.0)];
-    let decisions = nc.decide_all(&elevators, &group, &manifest, &world);
+    let decisions = decide_all(&mut nc, &elevators, &group, &manifest, &world);
 
     // Both are 1.0 away from stop[1] at 4.0. First in iteration order wins.
     let a_dec = decisions.iter().find(|(e, _)| *e == elev_a).unwrap();
@@ -474,15 +498,17 @@ fn nearest_car_distance_calculation() {
 struct AlwaysIdleDispatch;
 
 impl DispatchStrategy for AlwaysIdleDispatch {
-    fn decide(
+    fn rank(
         &mut self,
-        _elevator: crate::entity::EntityId,
-        _elevator_position: f64,
+        _car: crate::entity::EntityId,
+        _car_position: f64,
+        _stop: crate::entity::EntityId,
+        _stop_position: f64,
         _group: &ElevatorGroup,
         _manifest: &DispatchManifest,
         _world: &World,
-    ) -> DispatchDecision {
-        DispatchDecision::Idle
+    ) -> Option<f64> {
+        None
     }
 }
 
@@ -527,7 +553,7 @@ fn nearest_car_ignores_zero_demand() {
 
     let mut nc = NearestCarDispatch::new();
     let elevators = vec![(elev, 0.0)];
-    let decisions = nc.decide_all(&elevators, &group, &manifest, &world);
+    let decisions = decide_all(&mut nc, &elevators, &group, &manifest, &world);
 
     let dec = decisions.iter().find(|(e, _)| *e == elev).unwrap();
     // Should skip stop[1] (0 demand) and go to stop[3].

--- a/crates/elevator-core/src/tests/dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/dispatch_tests.rs
@@ -12,27 +12,31 @@ use crate::door::DoorState;
 use crate::ids::GroupId;
 use crate::world::World;
 
-/// Run the assignment for a single car and return its decision.
+/// Run the assignment for a single car and return its decision. Mirrors
+/// the production flow in `systems::dispatch::run`: runs `pre_dispatch`
+/// (which can mutate `world`) and then the Hungarian assignment.
 fn decide_one(
     strategy: &mut dyn DispatchStrategy,
     car: crate::entity::EntityId,
     pos: f64,
     group: &ElevatorGroup,
     manifest: &DispatchManifest,
-    world: &World,
+    world: &mut World,
 ) -> DispatchDecision {
+    strategy.pre_dispatch(group, manifest, world);
     let result = dispatch::assign(strategy, &[(car, pos)], group, manifest, world);
     result.decisions[0].1.clone()
 }
 
-/// Run the assignment for several cars in one pass.
+/// Run the assignment for several cars in one pass (with `pre_dispatch`).
 fn decide_all(
     strategy: &mut dyn DispatchStrategy,
     cars: &[(crate::entity::EntityId, f64)],
     group: &ElevatorGroup,
     manifest: &DispatchManifest,
-    world: &World,
+    world: &mut World,
 ) -> Vec<(crate::entity::EntityId, DispatchDecision)> {
+    strategy.pre_dispatch(group, manifest, world);
     dispatch::assign(strategy, cars, group, manifest, world).decisions
 }
 
@@ -157,7 +161,7 @@ fn scan_no_requests_returns_idle() {
     let group = test_group(&stops, vec![elev]);
     let manifest = DispatchManifest::default();
     let mut scan = ScanDispatch::new();
-    let decision = decide_one(&mut scan, elev, 0.0, &group, &manifest, &world);
+    let decision = decide_one(&mut scan, elev, 0.0, &group, &manifest, &mut world);
     assert_eq!(decision, DispatchDecision::Idle);
 }
 
@@ -170,7 +174,7 @@ fn scan_goes_to_nearest_in_direction() {
     add_demand(&mut manifest, &mut world, stops[1], 70.0);
     add_demand(&mut manifest, &mut world, stops[3], 80.0);
     let mut scan = ScanDispatch::new();
-    let decision = decide_one(&mut scan, elev, 0.0, &group, &manifest, &world);
+    let decision = decide_one(&mut scan, elev, 0.0, &group, &manifest, &mut world);
     assert_eq!(decision, DispatchDecision::GoToStop(stops[1]));
 }
 
@@ -183,7 +187,7 @@ fn scan_reverses_when_nothing_ahead() {
     add_demand(&mut manifest, &mut world, stops[0], 70.0);
     add_demand(&mut manifest, &mut world, stops[1], 80.0);
     let mut scan = ScanDispatch::new();
-    let decision = decide_one(&mut scan, elev, 8.0, &group, &manifest, &world);
+    let decision = decide_one(&mut scan, elev, 8.0, &group, &manifest, &mut world);
     assert_eq!(decision, DispatchDecision::GoToStop(stops[1]));
 }
 
@@ -195,7 +199,7 @@ fn scan_serves_rider_destination() {
     let mut manifest = DispatchManifest::default();
     add_rider_dest(&mut manifest, &mut world, stops[2]);
     let mut scan = ScanDispatch::new();
-    let decision = decide_one(&mut scan, elev, 0.0, &group, &manifest, &world);
+    let decision = decide_one(&mut scan, elev, 0.0, &group, &manifest, &mut world);
     assert_eq!(decision, DispatchDecision::GoToStop(stops[2]));
 }
 
@@ -208,7 +212,7 @@ fn scan_prefers_current_direction() {
     add_demand(&mut manifest, &mut world, stops[0], 70.0);
     add_demand(&mut manifest, &mut world, stops[2], 80.0);
     let mut scan = ScanDispatch::new();
-    let decision = decide_one(&mut scan, elev, 4.0, &group, &manifest, &world);
+    let decision = decide_one(&mut scan, elev, 4.0, &group, &manifest, &mut world);
     assert_eq!(decision, DispatchDecision::GoToStop(stops[2]));
 }
 
@@ -221,7 +225,7 @@ fn look_no_requests_returns_idle() {
     let group = test_group(&stops, vec![elev]);
     let manifest = DispatchManifest::default();
     let mut look = LookDispatch::new();
-    let decision = decide_one(&mut look, elev, 0.0, &group, &manifest, &world);
+    let decision = decide_one(&mut look, elev, 0.0, &group, &manifest, &mut world);
     assert_eq!(decision, DispatchDecision::Idle);
 }
 
@@ -234,7 +238,7 @@ fn look_reverses_at_last_request() {
     // Only demand at stop 1 (pos 4.0) — LOOK should go there then reverse.
     add_demand(&mut manifest, &mut world, stops[1], 70.0);
     let mut look = LookDispatch::new();
-    let decision = decide_one(&mut look, elev, 0.0, &group, &manifest, &world);
+    let decision = decide_one(&mut look, elev, 0.0, &group, &manifest, &mut world);
     assert_eq!(decision, DispatchDecision::GoToStop(stops[1]));
 }
 
@@ -252,7 +256,7 @@ fn nearest_car_assigns_closest_elevator() {
 
     let mut nc = NearestCarDispatch::new();
     let elevators = vec![(elev_a, 0.0), (elev_b, 12.0)];
-    let decisions = decide_all(&mut nc, &elevators, &group, &manifest, &world);
+    let decisions = decide_all(&mut nc, &elevators, &group, &manifest, &mut world);
 
     // Elevator A (at 0.0) is closer to stop 1 (at 4.0) than Elevator B (at 12.0).
     let a_decision = decisions.iter().find(|(e, _)| *e == elev_a).unwrap();
@@ -276,7 +280,7 @@ fn nearest_car_multiple_stops() {
 
     let mut nc = NearestCarDispatch::new();
     let elevators = vec![(elev_a, 0.0), (elev_b, 12.0)];
-    let decisions = decide_all(&mut nc, &elevators, &group, &manifest, &world);
+    let decisions = decide_all(&mut nc, &elevators, &group, &manifest, &mut world);
 
     // Stop 0 has higher demand — assigned first. elev_a (at 0.0) is nearest to stop 0.
     // Stop 3: elev_b (at 12.0) is nearest to stop 3.
@@ -302,7 +306,7 @@ fn etd_prefers_idle_elevator() {
 
     let mut etd = EtdDispatch::new();
     let elevators = vec![(elev_a, 4.0), (elev_b, 4.0)];
-    let decisions = decide_all(&mut etd, &elevators, &group, &manifest, &world);
+    let decisions = decide_all(&mut etd, &elevators, &group, &manifest, &mut world);
 
     // elev_a (0 riders) should be preferred over elev_b (2 riders).
     let a_dec = decisions.iter().find(|(e, _)| *e == elev_a).unwrap();
@@ -321,7 +325,7 @@ fn etd_closer_elevator_wins() {
 
     let mut etd = EtdDispatch::new();
     let elevators = vec![(elev_a, 0.0), (elev_b, 8.0)];
-    let decisions = decide_all(&mut etd, &elevators, &group, &manifest, &world);
+    let decisions = decide_all(&mut etd, &elevators, &group, &manifest, &mut world);
 
     // Stop 2 at position 8.0. elev_b is at 8.0 (distance 0), elev_a at 0.0 (distance 8).
     let b_dec = decisions.iter().find(|(e, _)| *e == elev_b).unwrap();
@@ -344,7 +348,7 @@ fn scan_at_exact_stop_skips_current_position() {
     add_demand(&mut manifest, &mut world, stops[2], 70.0);
 
     let mut scan = ScanDispatch::new();
-    let decision = decide_one(&mut scan, elev, 4.0, &group, &manifest, &world);
+    let decision = decide_one(&mut scan, elev, 4.0, &group, &manifest, &mut world);
     // Elevator is UP. Stop at 4.0 is NOT ahead (it's at current pos).
     // Should go to stop[2] at 8.0, not stop[1] at 4.0.
     assert_eq!(decision, DispatchDecision::GoToStop(stops[2]));
@@ -363,7 +367,7 @@ fn scan_reversal_picks_nearest_behind() {
     add_demand(&mut manifest, &mut world, stops[2], 70.0);
 
     let mut scan = ScanDispatch::new();
-    let decision = decide_one(&mut scan, elev, 12.0, &group, &manifest, &world);
+    let decision = decide_one(&mut scan, elev, 12.0, &group, &manifest, &mut world);
     // Nothing ahead (up), reverses to Down. Nearest behind in Down direction = stop[2] at 8.0.
     assert_eq!(decision, DispatchDecision::GoToStop(stops[2]));
 }
@@ -382,7 +386,7 @@ fn scan_notify_removed_cleans_state() {
 
     let mut scan = ScanDispatch::new();
     // First call: nothing Up from 12.0 → reverses to Down, picks stops[1] (nearest below).
-    let d1 = decide_one(&mut scan, elev, 12.0, &group, &manifest, &world);
+    let d1 = decide_one(&mut scan, elev, 12.0, &group, &manifest, &mut world);
     assert_eq!(d1, DispatchDecision::GoToStop(stops[1]));
 
     // Now direction is stored as Down for this elevator.
@@ -391,7 +395,7 @@ fn scan_notify_removed_cleans_state() {
 
     // Re-query same elevator from position 4.0 with demand above AND below.
     add_demand(&mut manifest, &mut world, stops[2], 70.0);
-    let d2 = decide_one(&mut scan, elev, 4.0, &group, &manifest, &world);
+    let d2 = decide_one(&mut scan, elev, 4.0, &group, &manifest, &mut world);
     // If notify_removed worked: default direction is Up → goes to stops[2] (pos 8.0).
     // If notify_removed was no-op: direction is still Down → goes to stops[1] (pos 4.0) or stops[0] (pos 0.0).
     assert_eq!(d2, DispatchDecision::GoToStop(stops[2]));
@@ -408,12 +412,12 @@ fn look_notify_removed_cleans_state() {
 
     let mut look = LookDispatch::new();
     // Establish direction state (will reverse to Down since nothing is Up from 12.0).
-    decide_one(&mut look, elev, 12.0, &group, &manifest, &world);
+    decide_one(&mut look, elev, 12.0, &group, &manifest, &mut world);
     // Remove elevator.
     look.notify_removed(elev);
     // Reuse the same ID — direction should be gone.
     add_demand(&mut manifest, &mut world, stops[2], 70.0);
-    let decision = decide_one(&mut look, elev, 4.0, &group, &manifest, &world);
+    let decision = decide_one(&mut look, elev, 4.0, &group, &manifest, &mut world);
     // Default direction is Up, should go up to stop[2] (pos 8.0).
     assert_eq!(decision, DispatchDecision::GoToStop(stops[2]));
 }
@@ -431,12 +435,12 @@ fn look_down_direction_partitions_correctly() {
 
     let mut look = LookDispatch::new();
     // First call: nothing ahead (Up from 8.0 with only stops at 0 and 4), reverses.
-    let d1 = decide_one(&mut look, elev, 8.0, &group, &manifest, &world);
+    let d1 = decide_one(&mut look, elev, 8.0, &group, &manifest, &mut world);
     // After reversal to Down: nearest below = stops[1] at pos 4.0 (not stops[0] at 0.0).
     assert_eq!(d1, DispatchDecision::GoToStop(stops[1]));
 
     // Second call: still going Down, both stops ahead. Nearest = stops[1].
-    let d2 = decide_one(&mut look, elev, 8.0, &group, &manifest, &world);
+    let d2 = decide_one(&mut look, elev, 8.0, &group, &manifest, &mut world);
     assert_eq!(d2, DispatchDecision::GoToStop(stops[1]));
 }
 
@@ -455,19 +459,19 @@ fn scan_down_direction_serves_below() {
 
     let mut scan = ScanDispatch::new();
     // First call: default Up → goes to stops[3] (above).
-    let d1 = decide_one(&mut scan, elev, 8.0, &group, &manifest, &world);
+    let d1 = decide_one(&mut scan, elev, 8.0, &group, &manifest, &mut world);
     assert_eq!(d1, DispatchDecision::GoToStop(stops[3]));
 
     // Remove demand above, only below remains. Call again.
     manifest.waiting_at_stop.remove(&stops[3]);
-    let d2 = decide_one(&mut scan, elev, 12.0, &group, &manifest, &world);
+    let d2 = decide_one(&mut scan, elev, 12.0, &group, &manifest, &mut world);
     // Nothing ahead (Up from 12.0), reverses to Down. Nearest below = stops[1].
     assert_eq!(d2, DispatchDecision::GoToStop(stops[1]));
 
     // Now call again at position 8.0 with direction Down.
     // Demand at stops[0] (pos 0.0) and stops[1] (pos 4.0).
     add_demand(&mut manifest, &mut world, stops[0], 70.0);
-    let d3 = decide_one(&mut scan, elev, 8.0, &group, &manifest, &world);
+    let d3 = decide_one(&mut scan, elev, 8.0, &group, &manifest, &mut world);
     // Direction is Down. Both stops below. Nearest in Down = stops[1] (pos 4.0, highest below).
     assert_eq!(d3, DispatchDecision::GoToStop(stops[1]));
 }
@@ -486,7 +490,7 @@ fn nearest_car_distance_calculation() {
 
     let mut nc = NearestCarDispatch::new();
     let elevators = vec![(elev_a, 3.0), (elev_b, 5.0)];
-    let decisions = decide_all(&mut nc, &elevators, &group, &manifest, &world);
+    let decisions = decide_all(&mut nc, &elevators, &group, &manifest, &mut world);
 
     // Both are 1.0 away from stop[1] at 4.0. First in iteration order wins.
     let a_dec = decisions.iter().find(|(e, _)| *e == elev_a).unwrap();
@@ -553,7 +557,7 @@ fn nearest_car_ignores_zero_demand() {
 
     let mut nc = NearestCarDispatch::new();
     let elevators = vec![(elev, 0.0)];
-    let decisions = decide_all(&mut nc, &elevators, &group, &manifest, &world);
+    let decisions = decide_all(&mut nc, &elevators, &group, &manifest, &mut world);
 
     let dec = decisions.iter().find(|(e, _)| *e == elev).unwrap();
     // Should skip stop[1] (0 demand) and go to stop[3].
@@ -595,7 +599,7 @@ fn assign_handles_large_group_without_overflow() {
         .collect();
 
     let mut nc = NearestCarDispatch::new();
-    let decisions = decide_all(&mut nc, &positions, &group, &manifest, &world);
+    let decisions = decide_all(&mut nc, &positions, &group, &manifest, &mut world);
     // Every car should be assigned to a distinct stop (car_count < stop_count).
     let assigned_stops: HashSet<_> = decisions
         .iter()
@@ -605,4 +609,117 @@ fn assign_handles_large_group_without_overflow() {
         })
         .collect();
     assert_eq!(assigned_stops.len(), car_count);
+}
+
+/// `EtdDispatch::pre_dispatch` must cache the group's demanded-stop
+/// positions so subsequent `rank` calls are O(1) in the full stop list
+/// rather than O(`total_stops`). Regression against the review finding
+/// where the old `decide_all` computed this once and the refactor
+/// accidentally moved it into the per-pair hot path.
+#[test]
+fn etd_pre_dispatch_caches_pending_positions() {
+    use crate::dispatch::DispatchStrategy;
+    let (mut world, stops) = test_world();
+    let elev = spawn_elevator(&mut world, 0.0);
+    let group = test_group(&stops, vec![elev]);
+
+    let mut manifest = DispatchManifest::default();
+    add_demand(&mut manifest, &mut world, stops[1], 70.0);
+    add_demand(&mut manifest, &mut world, stops[2], 70.0);
+
+    let mut etd = EtdDispatch::new();
+    // Second invocation after a pre_dispatch with different demand must
+    // reflect the new manifest — demonstrates the cache is refreshed
+    // per pass, not frozen at construction.
+    etd.pre_dispatch(&group, &manifest, &mut world);
+    let first = dispatch::assign(&mut etd, &[(elev, 0.0)], &group, &manifest, &world).decisions;
+    assert!(matches!(first[0].1, DispatchDecision::GoToStop(_)));
+
+    let mut manifest2 = DispatchManifest::default();
+    add_demand(&mut manifest2, &mut world, stops[3], 80.0);
+    etd.pre_dispatch(&group, &manifest2, &mut world);
+    let second = dispatch::assign(&mut etd, &[(elev, 0.0)], &group, &manifest2, &world).decisions;
+    assert_eq!(second[0].1, DispatchDecision::GoToStop(stops[3]));
+}
+
+/// The dispatch pass calls `rank` for every `(car, stop)` pair in order.
+/// If a strategy mutates per-car state inside `rank`, the cost matrix
+/// becomes order-dependent and the assignment is unstable. This test
+/// verifies the contract: a well-behaved strategy using `prepare_car`
+/// produces the same assignment regardless of how many stops the group
+/// has (i.e. how many times `rank` was called).
+#[test]
+fn strategy_rank_is_order_independent_when_state_lives_in_prepare_car() {
+    use crate::dispatch::DispatchStrategy;
+    use std::collections::HashMap;
+
+    /// Cost = distance, idle-boost resolved once in `prepare_car`.
+    #[derive(Default)]
+    struct IdleBoost {
+        idle: HashMap<crate::entity::EntityId, f64>,
+        tick: u64,
+    }
+    impl DispatchStrategy for IdleBoost {
+        fn pre_dispatch(&mut self, _g: &ElevatorGroup, _m: &DispatchManifest, _w: &mut World) {
+            self.tick = self.tick.saturating_add(1);
+        }
+        fn prepare_car(
+            &mut self,
+            car: crate::entity::EntityId,
+            _pos: f64,
+            _g: &ElevatorGroup,
+            _m: &DispatchManifest,
+            _w: &World,
+        ) {
+            // Snapshot once; `rank` reads only.
+            self.idle.insert(car, self.tick as f64);
+        }
+        fn rank(
+            &mut self,
+            car: crate::entity::EntityId,
+            car_pos: f64,
+            _s: crate::entity::EntityId,
+            stop_pos: f64,
+            _g: &ElevatorGroup,
+            _m: &DispatchManifest,
+            _w: &World,
+        ) -> Option<f64> {
+            let boost = self.idle.get(&car).copied().unwrap_or(0.0);
+            Some(
+                0.001f64
+                    .mul_add(-boost, (car_pos - stop_pos).abs())
+                    .max(0.0),
+            )
+        }
+    }
+
+    let (mut world, stops) = test_world();
+    let elev_a = spawn_elevator(&mut world, 0.0);
+    let elev_b = spawn_elevator(&mut world, 12.0);
+    let group = test_group(&stops, vec![elev_a, elev_b]);
+    let mut manifest = DispatchManifest::default();
+    add_demand(&mut manifest, &mut world, stops[1], 70.0);
+    add_demand(&mut manifest, &mut world, stops[2], 70.0);
+
+    let mut strat = IdleBoost::default();
+    let first = decide_all(
+        &mut strat,
+        &[(elev_a, 0.0), (elev_b, 12.0)],
+        &group,
+        &manifest,
+        &mut world,
+    );
+    // Swap iteration order; the strategy must produce the same matching.
+    let second = decide_all(
+        &mut strat,
+        &[(elev_b, 12.0), (elev_a, 0.0)],
+        &group,
+        &manifest,
+        &mut world,
+    );
+    let pair = |v: Vec<(crate::entity::EntityId, DispatchDecision)>| {
+        let mut map: HashMap<_, _> = v.into_iter().collect();
+        (map.remove(&elev_a).unwrap(), map.remove(&elev_b).unwrap())
+    };
+    assert_eq!(pair(first), pair(second));
 }

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -1593,7 +1593,7 @@ fn remove_line_marks_topology_graph_dirty() {
 /// dispatching the next call.
 #[test]
 fn reassign_elevator_to_line_notifies_old_group_dispatcher_on_cross_group() {
-    use crate::dispatch::{DispatchDecision, DispatchManifest, DispatchStrategy, ElevatorGroup};
+    use crate::dispatch::{DispatchManifest, DispatchStrategy, ElevatorGroup};
     use crate::entity::EntityId;
     use crate::world::World;
     use std::sync::{Arc, Mutex};
@@ -1604,16 +1604,25 @@ fn reassign_elevator_to_line_notifies_old_group_dispatcher_on_cross_group() {
         inner: ScanDispatch,
     }
     impl DispatchStrategy for TrackingDispatch {
-        fn decide(
+        fn rank(
             &mut self,
-            elevator: EntityId,
-            position: f64,
+            car: EntityId,
+            car_position: f64,
+            stop: EntityId,
+            stop_position: f64,
             group: &ElevatorGroup,
             manifest: &DispatchManifest,
             world: &World,
-        ) -> DispatchDecision {
-            self.inner
-                .decide(elevator, position, group, manifest, world)
+        ) -> Option<f64> {
+            self.inner.rank(
+                car,
+                car_position,
+                stop,
+                stop_position,
+                group,
+                manifest,
+                world,
+            )
         }
         fn notify_removed(&mut self, elevator: EntityId) {
             self.removed.lock().unwrap().push(elevator);

--- a/crates/elevator-core/src/tests/mutation_kills_tests.rs
+++ b/crates/elevator-core/src/tests/mutation_kills_tests.rs
@@ -9,7 +9,7 @@ use crate::components::{Elevator, ElevatorPhase, Preferences, Rider, RiderPhase,
 use crate::dispatch::etd::EtdDispatch;
 use crate::dispatch::scan::ScanDispatch;
 use crate::dispatch::{
-    DispatchDecision, DispatchManifest, DispatchStrategy, ElevatorGroup, LineInfo, RiderInfo,
+    self, DispatchDecision, DispatchManifest, ElevatorGroup, LineInfo, RiderInfo,
 };
 use crate::door::DoorState;
 use crate::entity::EntityId;
@@ -414,7 +414,8 @@ fn scan_at_stop_position_does_not_target_self() {
     }
 
     let mut scan = ScanDispatch::new();
-    let decision = scan.decide(elev, 0.0, &group, &manifest, &world);
+    let result = dispatch::assign(&mut scan, &[(elev, 0.0)], &group, &manifest, &world);
+    let decision = result.decisions[0].1.clone();
     // Elevator at stop 0 with demand both there and ahead should go to
     // stop 2 (the only "ahead" stop in the Up direction) — not stay
     // at its own position.

--- a/crates/elevator-core/src/tests/reposition_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_tests.rs
@@ -5,8 +5,7 @@ use crate::components::{ElevatorPhase, RiderPhase};
 use crate::dispatch::etd::EtdDispatch;
 use crate::dispatch::reposition::{DemandWeighted, NearestIdle, ReturnToLobby, SpreadEvenly};
 use crate::dispatch::{
-    BuiltinReposition, DispatchManifest, DispatchStrategy, ElevatorGroup, LineInfo,
-    RepositionStrategy,
+    self, BuiltinReposition, DispatchManifest, ElevatorGroup, LineInfo, RepositionStrategy,
 };
 use crate::entity::EntityId;
 use crate::events::Event;
@@ -657,7 +656,7 @@ fn etd_closer_elevator_wins() {
 
     let mut etd = EtdDispatch::new();
     let elevators = vec![(elev_a, 0.0), (elev_b, 30.0)];
-    let decisions = etd.decide_all(&elevators, &group, &manifest, &world);
+    let decisions = dispatch::assign(&mut etd, &elevators, &group, &manifest, &world).decisions;
 
     // elev_a is closer to stop 1 (distance 10) vs elev_b (distance 20).
     let a_dec = decisions.iter().find(|(e, _)| *e == elev_a).unwrap();
@@ -686,7 +685,7 @@ fn etd_direction_bonus() {
 
     let mut etd = EtdDispatch::new();
     let elevators = vec![(elev_a, 5.0), (elev_b, 5.0)];
-    let decisions = etd.decide_all(&elevators, &group, &manifest, &world);
+    let decisions = dispatch::assign(&mut etd, &elevators, &group, &manifest, &world).decisions;
 
     // elev_a is already moving up and stop 1 is ahead — should get direction bonus
     // (-0.5 * travel_time). elev_b is idle, bonus is -0.3 * travel_time.
@@ -725,7 +724,7 @@ fn etd_rider_delay_penalizes() {
 
     let mut etd = EtdDispatch::new();
     let elevators = vec![(elev_a, 20.0), (elev_b, 20.0)];
-    let decisions = etd.decide_all(&elevators, &group, &manifest, &world);
+    let decisions = dispatch::assign(&mut etd, &elevators, &group, &manifest, &world).decisions;
 
     // elev_b (no riders) should win because elev_a would delay its rider.
     let b_dec = decisions.iter().find(|(e, _)| *e == elev_b).unwrap();
@@ -735,45 +734,43 @@ fn etd_rider_delay_penalizes() {
     assert_eq!(a_dec.1, DispatchDecision::Idle);
 }
 
-// 12. Door overhead: intervening pending stops increase cost.
-//     Verify that an elevator with intervening pending stops pays more than one without.
+// 12. Door overhead: intervening pending stops raise cost enough to reorder
+//     the optimal assignment away from a naive-distance match.
 #[test]
 fn etd_door_overhead_for_intervening_stops() {
     let (mut world, stops) = test_world_n(4);
-    // 3 elevators, 3 pending stops. Elevators A and B handle stops 1 and 2,
-    // leaving elevator C to compete for stop 3.
-    let elev_a = spawn_elevator(&mut world, 0.0);
-    let elev_b = spawn_elevator(&mut world, 10.0);
-    let elev_c = spawn_elevator(&mut world, 25.0);
-    let group = test_group(&stops, vec![elev_a, elev_b, elev_c]);
+    // elev_a at stop 1 (pos 10), elev_b at stop 2 (pos 20).
+    // Two demands: stop 0 (pos 0) and stop 3 (pos 30). Symmetric by raw
+    // distance — each elevator is 10 from its near demand and 20 from
+    // the far demand, so pure nearest-car ties. Intervening overhead
+    // breaks the tie: elev_a's 20-unit reach to stop 3 passes elev_b's
+    // stop at pos 20 (intervening), while elev_b's 20-unit reach to
+    // stop 0 passes elev_a's stop at pos 10 (intervening). With a high
+    // door weight the optimal assignment is the "no intervening" one:
+    // each car serves the demand on its own side.
+    let elev_a = spawn_elevator(&mut world, 10.0);
+    let elev_b = spawn_elevator(&mut world, 20.0);
+    let group = test_group(&stops, vec![elev_a, elev_b]);
 
     let mut manifest = DispatchManifest::default();
-    add_demand(&mut manifest, &mut world, stops[1], 70.0);
-    add_demand(&mut manifest, &mut world, stops[2], 70.0);
+    add_demand(&mut manifest, &mut world, stops[0], 70.0);
     add_demand(&mut manifest, &mut world, stops[3], 70.0);
 
-    // High door weight makes intervening stop overhead dominate.
     let mut etd = EtdDispatch::with_weights(1.0, 1.0, 10.0);
-    let elevators = vec![(elev_a, 0.0), (elev_b, 10.0), (elev_c, 25.0)];
-    let decisions = etd.decide_all(&elevators, &group, &manifest, &world);
-
-    // Stop 1 (pos 10): elev_b is right there (cost ~0). Gets stop 1.
-    // Stop 2 (pos 20): elev_a at 0 (dist 20, intervening stop 1 at 10) vs elev_c at 25 (dist 5, no intervening).
-    //   With door_weight=10, elev_a pays 10 * door_overhead for 1 intervening stop. elev_c wins.
-    // Stop 3 (pos 30): only elev_a left. Gets stop 3.
-    // Key: the mechanism works because intervening pending stops raise the cost.
-    let c_dec = decisions.iter().find(|(e, _)| *e == elev_c).unwrap();
-    assert_eq!(
-        c_dec.1,
-        DispatchDecision::GoToStop(stops[2]),
-        "elevator C at 25.0 should serve stop 2 (pos 20) due to lower door overhead vs elevator A"
-    );
+    let elevators = vec![(elev_a, 10.0), (elev_b, 20.0)];
+    let decisions = dispatch::assign(&mut etd, &elevators, &group, &manifest, &world).decisions;
 
     let a_dec = decisions.iter().find(|(e, _)| *e == elev_a).unwrap();
     assert_eq!(
         a_dec.1,
+        DispatchDecision::GoToStop(stops[0]),
+        "elev_a should serve stop 0 (no intervening)"
+    );
+    let b_dec = decisions.iter().find(|(e, _)| *e == elev_b).unwrap();
+    assert_eq!(
+        b_dec.1,
         DispatchDecision::GoToStop(stops[3]),
-        "elevator A should get stop 3 since B and C already assigned"
+        "elev_b should serve stop 3 (no intervening)"
     );
 }
 
@@ -808,7 +805,7 @@ fn etd_custom_weights() {
     // High wait weight (2.0), low delay weight (0.5), zero door weight.
     let mut etd = EtdDispatch::with_weights(2.0, 0.5, 0.0);
     let elevators = vec![(elev_a, 0.0), (elev_b, 20.0)];
-    let decisions = etd.decide_all(&elevators, &group, &manifest, &world);
+    let decisions = dispatch::assign(&mut etd, &elevators, &group, &manifest, &world).decisions;
 
     // elev_b is at stop 2 (distance 0), elev_a is 20 away.
     // Even with rider delay, elev_b should win because wait_weight is high
@@ -833,7 +830,7 @@ fn etd_zero_max_speed_infinite_cost() {
 
     let mut etd = EtdDispatch::new();
     let elevators = vec![(elev_a, 0.0), (elev_b, 20.0)];
-    let decisions = etd.decide_all(&elevators, &group, &manifest, &world);
+    let decisions = dispatch::assign(&mut etd, &elevators, &group, &manifest, &world).decisions;
 
     // elev_a with max_speed=0 should NOT be assigned.
     let a_dec = decisions.iter().find(|(e, _)| *e == elev_a).unwrap();

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -353,19 +353,28 @@ for (id, vip) in world.query::<(EntityId, &Ext<VipTag>)>().iter() {
 
 ```rust
 pub trait DispatchStrategy: Send + Sync {
-    fn decide(
+    // Required: cost of sending `car` to `stop`. None excludes the pair.
+    fn rank(
         &mut self,
-        elevator: EntityId,
-        elevator_position: f64,
+        car: EntityId,
+        car_position: f64,
+        stop: EntityId,
+        stop_position: f64,
         group: &ElevatorGroup,
         manifest: &DispatchManifest,
         world: &World,
-    ) -> DispatchDecision;
+    ) -> Option<f64>;
 
-    // Optional: batch decision for all idle elevators (default calls decide per elevator)
-    fn decide_all(...) -> Vec<(EntityId, DispatchDecision)>;
+    // Optional: per-group pre-pass with mutable world access.
+    fn pre_dispatch(&mut self, group: &ElevatorGroup, manifest: &DispatchManifest, world: &mut World);
 
-    // Optional: cleanup when an elevator is removed (default no-op)
+    // Optional: per-car setup called before the car's rank loop.
+    fn prepare_car(&mut self, car: EntityId, car_position: f64, group: &ElevatorGroup, manifest: &DispatchManifest, world: &World);
+
+    // Optional: policy for cars left unassigned after the Hungarian match.
+    fn fallback(&mut self, car: EntityId, car_position: f64, group: &ElevatorGroup, manifest: &DispatchManifest, world: &World) -> DispatchDecision;
+
+    // Optional: cleanup when an elevator is removed (default no-op).
     fn notify_removed(&mut self, elevator: EntityId);
 }
 ```

--- a/docs/src/custom-dispatch.md
+++ b/docs/src/custom-dispatch.md
@@ -6,134 +6,109 @@ This chapter is a narrative tutorial that walks from a minimal strategy to a pro
 
 ## The trait surface
 
+Strategies express preference as a cost on each `(car, stop)` pair. The dispatch system collects those costs into a matrix and runs an optimal bipartite matching (Hungarian / Kuhn–Munkres) across the whole group, guaranteeing that two cars can never be sent to the same hall call. Cars left unassigned fall through to `fallback` for per-car policy (idle, park, etc.).
+
 ```rust,ignore
 pub trait DispatchStrategy: Send + Sync {
-    /// Decide where one idle elevator should go.
-    fn decide(
+    /// Pre-pass hook with mutable world access. Used by sticky strategies
+    /// (e.g. destination dispatch) to commit rider → car assignments.
+    fn pre_dispatch(
         &mut self,
-        elevator: EntityId,
-        elevator_position: f64,
+        _group: &ElevatorGroup,
+        _manifest: &DispatchManifest,
+        _world: &mut World,
+    ) { /* default: no-op */ }
+
+    /// Per-car setup called once before any `rank` calls for this car.
+    /// Strategies with per-car state (sweep direction, queue pointers)
+    /// refresh it here so `rank` is order-independent over stops.
+    fn prepare_car(
+        &mut self,
+        _car: EntityId,
+        _car_position: f64,
+        _group: &ElevatorGroup,
+        _manifest: &DispatchManifest,
+        _world: &World,
+    ) { /* default: no-op */ }
+
+    /// Score sending `car` to `stop`. Lower is better. `None` marks
+    /// the pair unavailable (capacity limits, wrong-direction, sticky).
+    /// Must return a finite, non-negative value when `Some`.
+    fn rank(
+        &mut self,
+        car: EntityId,
+        car_position: f64,
+        stop: EntityId,
+        stop_position: f64,
         group: &ElevatorGroup,
         manifest: &DispatchManifest,
         world: &World,
-    ) -> DispatchDecision;
+    ) -> Option<f64>;
 
-    /// Decide for all idle elevators in one pass (optional).
-    ///
-    /// Default implementation calls `decide` once per elevator.
-    /// Override when the strategy must coordinate across elevators —
-    /// for example, to prevent two cars from being sent to the same
-    /// hall call.
-    fn decide_all(
+    /// Decide what a car should do when the assignment phase couldn't
+    /// give it a stop (no demand or all candidate ranks were `None`).
+    fn fallback(
         &mut self,
-        elevators: &[(EntityId, f64)],
-        group: &ElevatorGroup,
-        manifest: &DispatchManifest,
-        world: &World,
-    ) -> Vec<(EntityId, DispatchDecision)> { /* default: per-elevator */ }
+        _car: EntityId,
+        _car_position: f64,
+        _group: &ElevatorGroup,
+        _manifest: &DispatchManifest,
+        _world: &World,
+    ) -> DispatchDecision { DispatchDecision::Idle }
 
-    /// Clean up per-elevator state when an elevator is removed.
-    ///
+    /// Clean up per-elevator state when a car leaves the group.
     /// Strategies with internal `HashMap<EntityId, _>` state must
-    /// remove the entry here — otherwise the map grows unbounded
-    /// and cross-group reassignments leave stale entries.
+    /// remove the entry here — otherwise the map grows unbounded.
     fn notify_removed(&mut self, _elevator: EntityId) { /* default: no-op */ }
 }
 ```
 
-Three methods, three clear responsibilities. Everything else you need comes from `DispatchManifest` and `ElevatorGroup`.
+Only `rank` is required. The default `fallback` returns `Idle`; the other hooks exist for strategies that need them.
 
 ## Step 1 — The simplest possible strategy
 
-"Always send idle elevators to the stop with the most waiting riders."
+"Nearest-car by distance, favoring stops with more waiting riders."
 
 ```rust,ignore
-use elevator_core::dispatch::{
-    DispatchDecision, DispatchManifest, DispatchStrategy, ElevatorGroup,
-};
+use elevator_core::dispatch::{DispatchManifest, DispatchStrategy, ElevatorGroup};
 use elevator_core::entity::EntityId;
 use elevator_core::world::World;
 
-struct BusiestStopFirst;
+struct BusyStopNearest;
 
-impl DispatchStrategy for BusiestStopFirst {
-    fn decide(
+impl DispatchStrategy for BusyStopNearest {
+    fn rank(
         &mut self,
-        _elevator: EntityId,
-        _position: f64,
-        group: &ElevatorGroup,
-        manifest: &DispatchManifest,
-        _world: &World,
-    ) -> DispatchDecision {
-        group
-            .stop_entities()
-            .iter()
-            .filter(|&&s| manifest.has_demand(s))
-            .max_by_key(|&&s| manifest.waiting_count_at(s))
-            .copied()
-            .map_or(DispatchDecision::Idle, DispatchDecision::GoToStop)
-    }
-}
-```
-
-What this gets you:
-- The simulation drives direction indicators automatically based on `GoToStop` vs. `Idle`.
-- `DestinationQueue` management happens in the `AdvanceQueue` phase — you don't touch it.
-- The dispatch phase events (`ElevatorAssigned`, `ElevatorIdle`, `DirectionIndicatorChanged`) emit automatically.
-
-What this strategy *doesn't* handle: two idle elevators will both be sent to the same stop. For that, you need `decide_all`.
-
-## Step 2 — Coordinating across elevators with `decide_all`
-
-The problem: `decide` runs independently per elevator. If stops A and B both have demand and elevators E1 and E2 are both idle, calling `decide` twice may return `GoToStop(A)` both times — one elevator goes unused.
-
-Override `decide_all` to pair elevators with stops exactly once:
-
-```rust,ignore
-impl DispatchStrategy for BusiestStopFirst {
-    fn decide(
-        &mut self,
-        _elevator: EntityId,
-        _position: f64,
+        _car: EntityId,
+        car_position: f64,
+        stop: EntityId,
+        stop_position: f64,
         _group: &ElevatorGroup,
-        _manifest: &DispatchManifest,
-        _world: &World,
-    ) -> DispatchDecision {
-        // Required by the trait. When `decide_all` is overridden, this
-        // is unreachable on the dispatch path.
-        DispatchDecision::Idle
-    }
-
-    fn decide_all(
-        &mut self,
-        elevators: &[(EntityId, f64)],
-        group: &ElevatorGroup,
         manifest: &DispatchManifest,
         _world: &World,
-    ) -> Vec<(EntityId, DispatchDecision)> {
-        let mut stops: Vec<EntityId> = group
-            .stop_entities()
-            .iter()
-            .copied()
-            .filter(|&s| manifest.has_demand(s))
-            .collect();
-        stops.sort_by_key(|&s| std::cmp::Reverse(manifest.waiting_count_at(s)));
-
-        let mut results = Vec::with_capacity(elevators.len());
-        let mut stops_iter = stops.into_iter();
-
-        for &(eid, _) in elevators {
-            match stops_iter.next() {
-                Some(stop) => results.push((eid, DispatchDecision::GoToStop(stop))),
-                None => results.push((eid, DispatchDecision::Idle)),
-            }
-        }
-        results
+    ) -> Option<f64> {
+        let distance = (car_position - stop_position).abs();
+        let waiting = manifest.waiting_count_at(stop) as f64;
+        // Subtract a crowding bonus so busier stops look cheaper. Clamp
+        // so Hungarian never sees a negative cost.
+        Some((distance - waiting).max(0.0))
     }
 }
 ```
 
-`NearestCarDispatch` and `EtdDispatch` both use this pattern internally.
+What this gets you automatically:
+- Coordination across cars — the Hungarian solver never sends two cars to the same hall call.
+- Direction indicators driven by the `GoToStop` decision vs. car position.
+- `DestinationQueue` management handled by later phases — you don't touch it.
+- Dispatch events (`ElevatorAssigned`, `ElevatorIdle`, `DirectionIndicatorChanged`) emit automatically.
+
+Returning `None` from `rank` excludes a `(car, stop)` pair entirely — use it for capacity limits, wrong-direction stops, or restricted stops. When every candidate stop returns `None` (or there are no demanded stops at all), the dispatcher calls `fallback`, which defaults to `Idle`.
+
+## Step 2 — Per-car state with `prepare_car`
+
+Strategies whose ranking depends on per-car state (a sweep direction, a queue pointer, a cached priority) should refresh that state in `prepare_car`. The framework calls it once per car per pass, before any `rank` calls for that car, so the subsequent `rank` results are independent of the order the dispatcher iterates stops.
+
+The built-in `ScanDispatch` uses this hook to decide whether the car's sweep direction should flip for the current pass. That decision depends on whole-group demand, so doing it inside `rank` would give different answers depending on which stop was scored first.
 
 ## Step 3 — Carrying state, and the `notify_removed` contract
 
@@ -158,7 +133,7 @@ struct PriorityDispatch {
 }
 
 impl DispatchStrategy for PriorityDispatch {
-    fn decide(/* ... */) -> DispatchDecision { /* ... */ }
+    fn rank(/* ... */) -> Option<f64> { /* ... */ }
 
     fn notify_removed(&mut self, elevator: EntityId) {
         // CRITICAL: keeps the map from growing unbounded under churn.
@@ -216,34 +191,16 @@ The name is opaque to the library. Keep it stable across releases — changing t
 
 Two levels of test coverage:
 
-**Unit-test `decide` in isolation.** Construct a minimal `World`, an `ElevatorGroup`, and a `DispatchManifest`, then call your strategy's `decide` directly. This is how the built-in strategies are tested; see `crates/elevator-core/src/tests/dispatch_tests.rs` for the helper pattern (`test_world()`, `test_group()`, `spawn_elevator()`, `add_demand()`).
+**Unit-test through `dispatch::assign` in isolation.** Construct a minimal `World`, an `ElevatorGroup`, and a `DispatchManifest`, then run one assignment pass. This exercises the Hungarian matching and `fallback` path end-to-end, so the test reflects real runtime behavior. See `crates/elevator-core/src/tests/dispatch_tests.rs` for the helper pattern (`test_world()`, `test_group()`, `spawn_elevator()`, `add_demand()`).
 
-```rust,ignore
-#[test]
-fn busiest_stop_wins() {
-    let (mut world, stops) = test_world();              // 4 stops at 0/4/8/12
-    let elev = spawn_elevator(&mut world, 0.0);
-    let group = test_group(&stops, vec![elev]);
-
-    let mut manifest = DispatchManifest::default();
-    add_demand(&mut manifest, &mut world, stops[1], 70.0);
-    add_demand(&mut manifest, &mut world, stops[2], 70.0);
-    add_demand(&mut manifest, &mut world, stops[2], 70.0);  // 2 riders at stops[2]
-
-    let mut strategy = BusiestStopFirst;
-    let decision = strategy.decide(elev, 0.0, &group, &manifest, &world);
-    assert_eq!(decision, DispatchDecision::GoToStop(stops[2]));
-}
-```
-
-**Integration-test via a full `Simulation`.** Spawn riders, step the loop, assert on events (`ElevatorAssigned`, `RiderBoarded`, etc.). This catches bugs that only surface through the 8-phase interaction — e.g., a strategy that pushes duplicate targets, or one that produces decisions that the `AdvanceQueue` phase later undoes.
+**Integration-test via a full `Simulation`.** Spawn riders, step the loop, assert on events (`ElevatorAssigned`, `RiderBoarded`, etc.). This catches bugs that only surface through the 8-phase interaction — e.g., a strategy that excludes every `(car, stop)` pair it shouldn't, or one whose `prepare_car` mutation leaves stale state between passes.
 
 ## Performance considerations
 
-- `decide` / `decide_all` run once per tick per group. At 60 ticks/second and a realistic group size (20 elevators, 50 stops), that's tens of thousands of calls per simulated minute. Keep the hot path allocation-free where possible.
-- `SmallVec<[T; N]>` is already the storage choice in the built-in strategies for the "ahead" / "behind" partitions. If you partition elevators or stops, consider the same.
-- The `DispatchManifest` is immutable — never try to mutate demand from inside `decide`. If you need to track per-rider state across ticks, store it in your strategy.
-- Avoid `HashMap<EntityId, _>` iteration in the hot path — it's nondeterministic. Use `BTreeMap` or sort the keys.
+- `rank` runs O(cars × stops) per tick per group, and the Hungarian solver itself is O(n³) in the group size. At 60 ticks/second and a realistic group (20 cars, 50 stops), that's millions of `rank` calls per simulated minute — keep the hot path allocation-free and `manifest` lookups cheap.
+- `SmallVec<[T; N]>` is already the storage choice in the built-in strategies for intermediate partitions. If your strategy partitions cars or stops, consider the same.
+- The `DispatchManifest` is immutable — never try to mutate demand from inside `rank`. If you need per-rider state across ticks, store it in your strategy.
+- Avoid iterating `HashMap<EntityId, _>` in the hot path — order is nondeterministic. Use `BTreeMap` or sort keys before iteration.
 
 ## Putting it together: a runnable example
 

--- a/docs/src/dispatch.md
+++ b/docs/src/dispatch.md
@@ -135,49 +135,29 @@ fn main() -> Result<(), SimError> {
 
 ## Writing a custom strategy
 
-To implement your own dispatch algorithm, implement the `DispatchStrategy` trait:
+Strategies express preferences as costs on `(car, stop)` pairs; the dispatch system runs an optimal bipartite matching across the whole group, so no two cars can be sent to the same hall call. See [Writing a Custom Dispatch Strategy](custom-dispatch.md) for the full tutorial.
 
 ```rust,no_run
 use elevator_core::prelude::*;
 use elevator_core::world::World;
 
-/// Always sends the elevator to the highest stop that has waiting riders.
+/// Prefer the highest demanded stop — cost decreases with position.
 struct HighestFirstDispatch;
 
 impl DispatchStrategy for HighestFirstDispatch {
-    fn decide(
+    fn rank(
         &mut self,
-        elevator: EntityId,
-        elevator_position: f64,
-        group: &ElevatorGroup,
-        manifest: &DispatchManifest,
-        world: &World,
-    ) -> DispatchDecision {
-        // Find the highest stop (by position) with waiting riders.
-        let mut best: Option<(EntityId, f64)> = None;
-
-        for &stop_eid in group.stop_entities() {
-            if manifest.waiting_count_at(stop_eid) == 0 {
-                continue;
-            }
-
-            if let Some(stop) = world.stop(stop_eid) {
-                match best {
-                    Some((_, best_pos)) if stop.position() > best_pos => {
-                        best = Some((stop_eid, stop.position()));
-                    }
-                    None => {
-                        best = Some((stop_eid, stop.position()));
-                    }
-                    _ => {}
-                }
-            }
-        }
-
-        match best {
-            Some((stop_eid, _)) => DispatchDecision::GoToStop(stop_eid),
-            None => DispatchDecision::Idle,
-        }
+        _car: EntityId,
+        _car_position: f64,
+        _stop: EntityId,
+        stop_position: f64,
+        _group: &ElevatorGroup,
+        _manifest: &DispatchManifest,
+        _world: &World,
+    ) -> Option<f64> {
+        // Use position as a negative score: higher stops are cheaper.
+        // Clamp to keep costs non-negative for the Hungarian solver.
+        Some((1000.0 - stop_position).max(0.0))
     }
 }
 ```
@@ -188,9 +168,10 @@ Then plug it into the builder:
 # use elevator_core::prelude::*;
 # use elevator_core::config::ElevatorConfig;
 # use elevator_core::stop::StopId;
+# use elevator_core::world::World;
 # struct HighestFirstDispatch;
 # impl DispatchStrategy for HighestFirstDispatch {
-#     fn decide(&mut self, _: EntityId, _: f64, _: &elevator_core::dispatch::ElevatorGroup, _: &DispatchManifest, _: &elevator_core::world::World) -> DispatchDecision { DispatchDecision::Idle }
+#     fn rank(&mut self, _: EntityId, _: f64, _: EntityId, _: f64, _: &elevator_core::dispatch::ElevatorGroup, _: &DispatchManifest, _: &World) -> Option<f64> { Some(0.0) }
 # }
 fn main() -> Result<(), SimError> {
     let sim = SimulationBuilder::new()
@@ -220,45 +201,11 @@ For more advanced dispatch (priority-aware, weight-aware, VIP-first), you can it
 
 For strategies that want to consider stopping at a passing floor only if the elevator can brake in time, `sim.braking_distance(elev)` and `sim.future_stop_position(elev)` expose the kinematic answer directly — no need to reimplement the trapezoidal physics. The free function `elevator_core::movement::braking_distance(velocity, deceleration)` is also available for pure computation off a `Simulation`.
 
-### Group-aware dispatch with `decide_all`
+### Group-aware coordination is automatic
 
-The default `DispatchStrategy` trait calls `decide()` once per idle elevator. If your strategy needs to coordinate across all elevators in a group (to avoid sending two elevators to the same stop), override `decide_all()` instead:
+Coordination across cars is a library invariant: the dispatch system collects every strategy's `(car, stop)` scores into a cost matrix and solves it with the Hungarian / Kuhn–Munkres algorithm. As long as your strategy's `rank` reflects the cost you want to minimize, you can't accidentally send two cars to the same hall call.
 
-```rust,no_run
-# use elevator_core::prelude::*;
-# use elevator_core::world::World;
-# struct MyStrategy;
-impl DispatchStrategy for MyStrategy {
-    fn decide(
-        &mut self,
-        _elevator: EntityId,
-        _pos: f64,
-        _group: &ElevatorGroup,
-        _manifest: &DispatchManifest,
-        _world: &World,
-    ) -> DispatchDecision {
-        // Required by the trait. When decide_all is overridden, the
-        // default trait impl calls decide_all instead of this method.
-        DispatchDecision::Idle
-    }
-
-    fn decide_all(
-        &mut self,
-        elevators: &[(EntityId, f64)],
-        group: &ElevatorGroup,
-        manifest: &DispatchManifest,
-        world: &World,
-    ) -> Vec<(EntityId, DispatchDecision)> {
-        // Your group-level coordination logic here.
-        elevators
-            .iter()
-            .map(|(eid, _)| (*eid, DispatchDecision::Idle))
-            .collect()
-    }
-}
-```
-
-Both `NearestCarDispatch` and `EtdDispatch` use this pattern internally to prevent duplicate assignments.
+Strategies with per-car state that depends on whole-group demand (for example the sweep direction used by SCAN/LOOK) set that state in `prepare_car`, which runs once per car before any `rank` calls for that car.
 
 ## Next steps
 

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -9,9 +9,8 @@ Let `E` = elevators, `R` = riders, `S` = stops. Per `sim.step()`:
 | Phase | Cost | Notes |
 |---|---|---|
 | Advance transient | O(R) worst-case, O(transitioning riders) typical | Only touches riders in `Boarding`/`Exiting`. |
-| Dispatch (SCAN/LOOK) | O(E · S) | Constant work per elevator per stop in the group. |
-| Dispatch (NearestCar) | O(E · S) | Uses `decide_all` to coordinate. |
-| Dispatch (ETD) | O(E · S · R_waiting) | Estimates per-rider delays; heaviest built-in. |
+| Dispatch (scoring) | O(E · S) per strategy | Cost-matrix build: one `rank` call per `(car, stop)` pair. ETD scales further with aboard riders. |
+| Dispatch (assignment) | O(max(E, S)³) | Hungarian / Kuhn–Munkres matching over the cost matrix. |
 | Reposition | O(E · S) | Only runs if configured. |
 | Movement | O(E) | Pure arithmetic per elevator. |
 | Doors | O(E) | Door FSM per elevator. |

--- a/docs/src/snapshots-and-determinism.md
+++ b/docs/src/snapshots-and-determinism.md
@@ -71,7 +71,7 @@ Built-in strategies (`Scan`, `Look`, `NearestCar`, `Etd`) are auto-restored by n
 # use elevator_core::world::World;
 # struct HighestFirstDispatch;
 # impl DispatchStrategy for HighestFirstDispatch {
-#   fn decide(&mut self, _: EntityId, _: f64, _: &elevator_core::dispatch::ElevatorGroup, _: &DispatchManifest, _: &World) -> DispatchDecision { DispatchDecision::Idle }
+#   fn rank(&mut self, _: EntityId, _: f64, _: EntityId, _: f64, _: &elevator_core::dispatch::ElevatorGroup, _: &DispatchManifest, _: &World) -> Option<f64> { Some(0.0) }
 # }
 # fn run(snapshot: WorldSnapshot) {
 let sim = snapshot.restore(Some(&|name: &str| match name {


### PR DESCRIPTION
## Summary

Fixes the \"one hall call summons every elevator\" behavior in the Bevy sim. `ScanDispatch` (and `LookDispatch`) relied on the default `decide_all()` — a naive per-car loop — so when multiple cars were idle they all ran `decide()` independently, picked the same nearest demanded stop, and were all dispatched to it.

The fix moves coordination from strategies into the dispatch system itself, so \"one car per hall call\" becomes a library invariant rather than a per-strategy convention.

### New trait surface

Strategies now implement `rank(car, stop) -> Option<f64>` (the cost of sending a car to a stop, or `None` to exclude the pair). The dispatch system builds a cost matrix from the ranks and runs `pathfinding::kuhn_munkres_min` for an optimal bipartite matching. Cars left unassigned fall through to `fallback` for per-car policy (idle, park, etc.).

Optional hooks:
- `pre_dispatch` — per-group mutable-world hook (used by sticky strategies).
- `prepare_car` — per-car setup before the car's `rank` loop, so strategies with whole-group state (SCAN/LOOK sweep direction) stay order-independent over stops.

### Ported strategies

All five built-ins are ported: NearestCar, SCAN, LOOK, ETD, Destination. SCAN/LOOK use `prepare_car` to decide their sweep direction once per pass.

### Breaking changes

- `DispatchStrategy::decide` and `decide_all` are removed.
- Custom strategies must migrate to `rank` + `fallback`.
- `pathfinding` added as a dependency.

## Test plan

- [ ] `cargo test --workspace --all-targets` (529 lib tests green)
- [ ] `cargo clippy --workspace --all-targets` clean
- [ ] `cargo run -p elevator-core --example custom_dispatch` runs and delivers riders
- [ ] `cargo run` the Bevy sim and verify only one elevator responds per hall call
- [ ] mdBook chapters render (api-reference, custom-dispatch, dispatch, performance, snapshots-and-determinism)