### PR TITLE
feat!: hall calls, car calls, pinning, and mid-trip reassignment

### DIFF
--- a/crates/elevator-core/src/components/car_call.rs
+++ b/crates/elevator-core/src/components/car_call.rs
@@ -1,0 +1,60 @@
+//! Car calls: the floor buttons riders press from inside a cab.
+//!
+//! When a rider boards in [`HallCallMode::Classic`](
+//! crate::dispatch::HallCallMode) the cab doesn't yet know where they want
+//! to go — the hall call only conveyed direction. At that point the rider
+//! "presses a floor button" and a [`CarCall`] is registered on the car.
+//! Dispatch reads the list to plan intermediate stops on the way to the
+//! sweep's far end.
+//!
+//! In `Destination` mode car calls are unused: the kiosk entry at the
+//! hall reveals the destination up front, and the car's
+//! [`DestinationQueue`](crate::components::DestinationQueue) is populated
+//! directly by [`DestinationDispatch`](crate::dispatch::DestinationDispatch).
+
+use serde::{Deserialize, Serialize};
+
+use crate::entity::EntityId;
+
+/// A floor button press inside `car` requesting service to `floor`.
+///
+/// Stored as a list attached to each elevator. One `CarCall` per
+/// `(car, floor)` pair — subsequent presses for the same floor increase
+/// `pending_riders` rather than duplicating the call.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CarCall {
+    /// Elevator the button was pressed inside.
+    pub car: EntityId,
+    /// Stop the button requests.
+    pub floor: EntityId,
+    /// Tick the button was pressed.
+    pub press_tick: u64,
+    /// Tick dispatch first sees this call (after ack latency).
+    /// `None` while still pending acknowledgement.
+    pub acknowledged_at: Option<u64>,
+    /// Riders who pressed the button (usually one; aggregated if multiple
+    /// riders heading to the same floor board together).
+    pub pending_riders: Vec<EntityId>,
+}
+
+impl CarCall {
+    /// Create a new unacknowledged car call.
+    #[must_use]
+    pub const fn new(car: EntityId, floor: EntityId, press_tick: u64) -> Self {
+        Self {
+            car,
+            floor,
+            press_tick,
+            acknowledged_at: None,
+            pending_riders: Vec::new(),
+        }
+    }
+
+    /// Returns `true` once the ack latency has elapsed and dispatch can
+    /// plan around this call.
+    #[must_use]
+    pub const fn is_acknowledged(&self) -> bool {
+        self.acknowledged_at.is_some()
+    }
+}

--- a/crates/elevator-core/src/components/car_call.rs
+++ b/crates/elevator-core/src/components/car_call.rs
@@ -33,6 +33,9 @@ pub struct CarCall {
     /// Tick dispatch first sees this call (after ack latency).
     /// `None` while still pending acknowledgement.
     pub acknowledged_at: Option<u64>,
+    /// Ticks the controller takes to acknowledge this call. Populated
+    /// from the serving group's `ack_latency_ticks` on first press.
+    pub ack_latency_ticks: u32,
     /// Riders who pressed the button (usually one; aggregated if multiple
     /// riders heading to the same floor board together).
     pub pending_riders: Vec<EntityId>,
@@ -47,6 +50,7 @@ impl CarCall {
             floor,
             press_tick,
             acknowledged_at: None,
+            ack_latency_ticks: 0,
             pending_riders: Vec::new(),
         }
     }

--- a/crates/elevator-core/src/components/hall_call.rs
+++ b/crates/elevator-core/src/components/hall_call.rs
@@ -1,0 +1,118 @@
+//! Hall calls: the "up"/"down" buttons at each stop.
+//!
+//! A [`HallCall`] is the sim's representation of a pressed hall button.
+//! At most two calls exist per stop (one per [`CallDirection`]), aggregated
+//! across every rider who wants to go that direction. Calls are the unit
+//! dispatch strategies see — not riders — so the sim can model real
+//! collective-control elevators where a car doesn't know *who* is waiting,
+//! only that someone going up has pressed the button on floor N.
+//!
+//! ## Lifecycle
+//!
+//! 1. **Pressed** — a rider spawns or a game explicitly calls
+//!    [`Simulation::press_hall_button`](crate::sim::Simulation::press_hall_button).
+//!    `HallCall::press_tick` is set; `acknowledged_at` is `None`.
+//! 2. **Acknowledged** — after the group's `ack_latency_ticks` have elapsed,
+//!    `acknowledged_at` is set and the call becomes visible to dispatch.
+//! 3. **Assigned** — dispatch pairs the call with a car. `assigned_car`
+//!    records which one.
+//! 4. **Cleared** — the assigned car arrives at this stop with its
+//!    indicator lamps matching `direction` and opens doors. The HallCall
+//!    is removed; an `Event::HallCallCleared` is emitted.
+
+use serde::{Deserialize, Serialize};
+
+use crate::entity::EntityId;
+
+/// Direction a hall call is requesting service in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum CallDirection {
+    /// Requesting service upward (toward higher position).
+    Up,
+    /// Requesting service downward (toward lower position).
+    Down,
+}
+
+impl CallDirection {
+    /// Derive a call direction from the sign of `dest_pos - origin_pos`.
+    /// Returns `None` when the two stops share a position (no travel
+    /// needed — no hall call required).
+    #[must_use]
+    pub fn between(origin_pos: f64, dest_pos: f64) -> Option<Self> {
+        if dest_pos > origin_pos {
+            Some(Self::Up)
+        } else if dest_pos < origin_pos {
+            Some(Self::Down)
+        } else {
+            None
+        }
+    }
+
+    /// The opposite direction.
+    #[must_use]
+    pub const fn opposite(self) -> Self {
+        match self {
+            Self::Up => Self::Down,
+            Self::Down => Self::Up,
+        }
+    }
+}
+
+/// A pressed hall button at `stop` requesting service in `direction`.
+///
+/// Stored per `(stop, direction)` pair — at most two per stop. Built-in
+/// dispatch reads calls via [`DispatchManifest::hall_calls`](
+/// crate::dispatch::DispatchManifest::hall_calls).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct HallCall {
+    /// Stop where the button was pressed.
+    pub stop: EntityId,
+    /// Direction the button requests.
+    pub direction: CallDirection,
+    /// Tick at which the button was first pressed.
+    pub press_tick: u64,
+    /// Tick at which dispatch first sees this call (after ack latency).
+    /// `None` while still pending acknowledgement.
+    pub acknowledged_at: Option<u64>,
+    /// Riders currently waiting on this call. Empty in
+    /// [`HallCallMode::Destination`](crate::dispatch::HallCallMode) mode
+    /// — calls there carry a single destination per press instead of a
+    /// shared direction.
+    pub pending_riders: Vec<EntityId>,
+    /// Destination requested at press time. Populated in
+    /// [`HallCallMode::Destination`](crate::dispatch::HallCallMode) mode
+    /// (lobby kiosk); `None` in Classic mode.
+    pub destination: Option<EntityId>,
+    /// Car assigned to this call by dispatch, if any.
+    pub assigned_car: Option<EntityId>,
+    /// When `true`, dispatch is forbidden from reassigning this call to
+    /// a different car. Set by
+    /// [`Simulation::pin_assignment`](crate::sim::Simulation::pin_assignment).
+    pub pinned: bool,
+}
+
+impl HallCall {
+    /// Create a new unacknowledged, unassigned hall call.
+    #[must_use]
+    pub const fn new(stop: EntityId, direction: CallDirection, press_tick: u64) -> Self {
+        Self {
+            stop,
+            direction,
+            press_tick,
+            acknowledged_at: None,
+            pending_riders: Vec::new(),
+            destination: None,
+            assigned_car: None,
+            pinned: false,
+        }
+    }
+
+    /// Returns `true` when dispatch is allowed to see this call (ack
+    /// latency has elapsed).
+    #[must_use]
+    pub const fn is_acknowledged(&self) -> bool {
+        self.acknowledged_at.is_some()
+    }
+}

--- a/crates/elevator-core/src/components/hall_call.rs
+++ b/crates/elevator-core/src/components/hall_call.rs
@@ -76,6 +76,13 @@ pub struct HallCall {
     /// Tick at which dispatch first sees this call (after ack latency).
     /// `None` while still pending acknowledgement.
     pub acknowledged_at: Option<u64>,
+    /// Ticks the controller took to acknowledge this call, copied from
+    /// the serving group's [`ElevatorGroup::ack_latency_ticks`](
+    /// crate::dispatch::ElevatorGroup::ack_latency_ticks) when the
+    /// button was first pressed. Stored on the call itself so
+    /// `advance_transient` can tick the counter without needing to
+    /// look up the group.
+    pub ack_latency_ticks: u32,
     /// Riders currently waiting on this call. Empty in
     /// [`HallCallMode::Destination`](crate::dispatch::HallCallMode) mode
     /// — calls there carry a single destination per press instead of a
@@ -102,6 +109,7 @@ impl HallCall {
             direction,
             press_tick,
             acknowledged_at: None,
+            ack_latency_ticks: 0,
             pending_riders: Vec::new(),
             destination: None,
             assigned_car: None,

--- a/crates/elevator-core/src/components/mod.rs
+++ b/crates/elevator-core/src/components/mod.rs
@@ -2,10 +2,14 @@
 
 /// Access control for restricting rider stop access.
 pub mod access;
+/// Floor buttons pressed from inside a cab.
+pub mod car_call;
 /// Per-elevator ordered destination queue.
 pub mod destination_queue;
 /// Elevator state and properties.
 pub mod elevator;
+/// Hall calls: the up/down buttons at each stop.
+pub mod hall_call;
 /// Line (physical path) — shaft, tether, track.
 pub mod line;
 /// Rider patience and boarding preferences.
@@ -22,8 +26,10 @@ pub mod service_mode;
 pub mod stop;
 
 pub use access::AccessControl;
+pub use car_call::CarCall;
 pub use destination_queue::DestinationQueue;
 pub use elevator::{DOOR_COMMAND_QUEUE_CAP, Direction, Elevator, ElevatorPhase};
+pub use hall_call::{CallDirection, HallCall};
 pub use line::{FloorPosition, Line, Orientation};
 pub use patience::{Patience, Preferences};
 pub use position::{Position, Velocity};

--- a/crates/elevator-core/src/components/patience.rs
+++ b/crates/elevator-core/src/components/patience.rs
@@ -45,6 +45,12 @@ pub struct Preferences {
     /// based abandonment; `Some(n)` causes the rider to enter
     /// [`RiderPhase::Abandoned`](crate::components::RiderPhase) after
     /// `n` ticks of being [`Waiting`](crate::components::RiderPhase::Waiting).
+    ///
+    /// The counter consulted is [`Patience::waited_ticks`] when a
+    /// [`Patience`] component is attached — that counter only
+    /// increments during `Waiting` and correctly excludes ride time for
+    /// multi-leg routes. Without `Patience`, the budget degrades to
+    /// lifetime ticks since spawn, which matches single-leg behavior.
     pub(crate) balk_threshold_ticks: Option<u32>,
     /// When a full car arrives and this rider skips it, should that
     /// count as a balk-and-abandon rather than a silent pass? When

--- a/crates/elevator-core/src/components/patience.rs
+++ b/crates/elevator-core/src/components/patience.rs
@@ -41,6 +41,16 @@ pub struct Preferences {
     pub(crate) skip_full_elevator: bool,
     /// Maximum load factor (0.0-1.0) the rider will tolerate when boarding.
     pub(crate) max_crowding_factor: f64,
+    /// Wait budget before the rider abandons. `None` disables balking-
+    /// based abandonment; `Some(n)` causes the rider to enter
+    /// [`RiderPhase::Abandoned`](crate::components::RiderPhase) after
+    /// `n` ticks of being [`Waiting`](crate::components::RiderPhase::Waiting).
+    pub(crate) balk_threshold_ticks: Option<u32>,
+    /// When a full car arrives and this rider skips it, should that
+    /// count as a balk-and-abandon rather than a silent pass? When
+    /// `true`, the rider abandons immediately instead of waiting for
+    /// `balk_threshold_ticks` to elapse. Default `false`.
+    pub(crate) rebalk_on_full: bool,
 }
 
 impl Preferences {
@@ -55,6 +65,33 @@ impl Preferences {
     pub const fn max_crowding_factor(&self) -> f64 {
         self.max_crowding_factor
     }
+
+    /// Wait budget before the rider abandons. `None` disables balking-
+    /// based abandonment.
+    #[must_use]
+    pub const fn balk_threshold_ticks(&self) -> Option<u32> {
+        self.balk_threshold_ticks
+    }
+
+    /// Should balking a full car convert directly to abandonment?
+    #[must_use]
+    pub const fn rebalk_on_full(&self) -> bool {
+        self.rebalk_on_full
+    }
+
+    /// Builder: set `balk_threshold_ticks`.
+    #[must_use]
+    pub const fn with_balk_threshold_ticks(mut self, ticks: Option<u32>) -> Self {
+        self.balk_threshold_ticks = ticks;
+        self
+    }
+
+    /// Builder: set `rebalk_on_full`.
+    #[must_use]
+    pub const fn with_rebalk_on_full(mut self, rebalk: bool) -> Self {
+        self.rebalk_on_full = rebalk;
+        self
+    }
 }
 
 impl Default for Preferences {
@@ -62,6 +99,8 @@ impl Default for Preferences {
         Self {
             skip_full_elevator: false,
             max_crowding_factor: 0.8,
+            balk_threshold_ticks: None,
+            rebalk_on_full: false,
         }
     }
 }

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -258,6 +258,34 @@ impl LineInfo {
     }
 }
 
+/// How hall calls expose rider destinations to dispatch.
+///
+/// Different building eras and controller designs reveal destinations
+/// at different moments. Groups pick a mode so the sim can model both
+/// traditional up/down collective-control elevators and modern
+/// destination-dispatch lobby kiosks within the same simulation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[non_exhaustive]
+pub enum HallCallMode {
+    /// Traditional collective-control ("classic" Otis/Westinghouse).
+    ///
+    /// Riders press an up or down button in the hall; the destination
+    /// is revealed only *after* boarding, via a
+    /// [`CarCall`](crate::components::CarCall). Dispatch sees a direction
+    /// per call but does not know individual rider destinations until
+    /// they're aboard.
+    #[default]
+    Classic,
+    /// Modern destination dispatch ("DCS" — Otis `CompassPlus`, KONE
+    /// Polaris, Schindler PORT).
+    ///
+    /// Riders enter their destination at a hall kiosk, so each
+    /// [`HallCall`](crate::components::HallCall) carries a destination
+    /// stop from the moment it's pressed. Required by
+    /// [`DestinationDispatch`].
+    Destination,
+}
+
 /// Runtime elevator group: a set of lines sharing a dispatch strategy.
 ///
 /// A group is the logical dispatch unit. It contains one or more
@@ -275,6 +303,12 @@ pub struct ElevatorGroup {
     name: String,
     /// Lines belonging to this group.
     lines: Vec<LineInfo>,
+    /// How hall calls reveal destinations to dispatch (Classic vs DCS).
+    hall_call_mode: HallCallMode,
+    /// Ticks between a button press and dispatch first seeing the call.
+    /// `0` = immediate (current behavior). Realistic values: 5–30 ticks
+    /// at 60 Hz, modeling controller processing latency.
+    ack_latency_ticks: u32,
     /// Derived flat cache — rebuilt by `rebuild_caches()`.
     elevator_entities: Vec<EntityId>,
     /// Derived flat cache — rebuilt by `rebuild_caches()`.
@@ -283,17 +317,46 @@ pub struct ElevatorGroup {
 
 impl ElevatorGroup {
     /// Create a new group with the given lines. Caches are built automatically.
+    /// Defaults: [`HallCallMode::Classic`], `ack_latency_ticks = 0`.
     #[must_use]
     pub fn new(id: GroupId, name: String, lines: Vec<LineInfo>) -> Self {
         let mut group = Self {
             id,
             name,
             lines,
+            hall_call_mode: HallCallMode::default(),
+            ack_latency_ticks: 0,
             elevator_entities: Vec::new(),
             stop_entities: Vec::new(),
         };
         group.rebuild_caches();
         group
+    }
+
+    /// Override the hall call mode for this group.
+    #[must_use]
+    pub const fn with_hall_call_mode(mut self, mode: HallCallMode) -> Self {
+        self.hall_call_mode = mode;
+        self
+    }
+
+    /// Override the ack latency for this group.
+    #[must_use]
+    pub const fn with_ack_latency_ticks(mut self, ticks: u32) -> Self {
+        self.ack_latency_ticks = ticks;
+        self
+    }
+
+    /// Hall call mode for this group.
+    #[must_use]
+    pub const fn hall_call_mode(&self) -> HallCallMode {
+        self.hall_call_mode
+    }
+
+    /// Controller ack latency for this group.
+    #[must_use]
+    pub const fn ack_latency_ticks(&self) -> u32 {
+        self.ack_latency_ticks
     }
 
     /// Unique group identifier.

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -264,6 +264,15 @@ impl LineInfo {
 /// at different moments. Groups pick a mode so the sim can model both
 /// traditional up/down collective-control elevators and modern
 /// destination-dispatch lobby kiosks within the same simulation.
+///
+/// Stops are expected to belong to exactly one group. When a stop
+/// overlaps multiple groups, the hall-call press consults the first
+/// group containing it (iteration order over
+/// [`Simulation::groups`](crate::sim::Simulation::groups)), which in
+/// turn determines the `HallCallMode` and ack latency applied to that
+/// call. Overlapping topologies are not validated at construction
+/// time; games that need them should be aware of this first-match
+/// rule.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[non_exhaustive]
 pub enum HallCallMode {

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -347,6 +347,17 @@ impl ElevatorGroup {
         self
     }
 
+    /// Set the hall call mode in-place (for mutation via
+    /// [`Simulation::groups_mut`](crate::sim::Simulation::groups_mut)).
+    pub const fn set_hall_call_mode(&mut self, mode: HallCallMode) {
+        self.hall_call_mode = mode;
+    }
+
+    /// Set the ack latency in-place.
+    pub const fn set_ack_latency_ticks(&mut self, ticks: u32) {
+        self.ack_latency_ticks = ticks;
+    }
+
     /// Hall call mode for this group.
     #[must_use]
     pub const fn hall_call_mode(&self) -> HallCallMode {

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -1,5 +1,6 @@
 //! Simulation event bus and typed event channels.
 
+use crate::components::CallDirection;
 use crate::entity::EntityId;
 use crate::error::{RejectionContext, RejectionReason};
 use crate::ids::GroupId;
@@ -479,6 +480,69 @@ pub enum Event {
         /// The tick when the command was submitted.
         tick: u64,
     },
+
+    // -- Hall & car call events --
+    /// A hall button was pressed. Fires immediately, before any ack
+    /// latency delay. Games use this for button-light animations or SFX.
+    HallButtonPressed {
+        /// Stop where the press occurred.
+        stop: EntityId,
+        /// Direction the button requests service in.
+        direction: CallDirection,
+        /// Tick of the press.
+        tick: u64,
+    },
+    /// A hall call has elapsed its ack latency and is now visible to
+    /// dispatch. Useful for UI confirmations ("your call has been
+    /// received"). In groups with `ack_latency_ticks = 0` this fires on
+    /// the same tick as `HallButtonPressed`.
+    HallCallAcknowledged {
+        /// Stop the call was placed at.
+        stop: EntityId,
+        /// Direction of the call.
+        direction: CallDirection,
+        /// Tick acknowledgement completed.
+        tick: u64,
+    },
+    /// A hall call was cleared when an assigned car arrived at the stop
+    /// with matching direction indicators. Corresponds to the real-world
+    /// button-light turning off.
+    HallCallCleared {
+        /// Stop whose call was cleared.
+        stop: EntityId,
+        /// Direction of the cleared call.
+        direction: CallDirection,
+        /// Car that cleared the call by arriving.
+        car: EntityId,
+        /// Tick the call was cleared.
+        tick: u64,
+    },
+    /// A rider inside a car pressed a floor button (Classic mode only).
+    /// In Destination mode riders reveal destinations at the hall
+    /// kiosk, so no car buttons are pressed.
+    CarButtonPressed {
+        /// Elevator the button was pressed inside.
+        car: EntityId,
+        /// Floor the rider requested.
+        floor: EntityId,
+        /// Rider who pressed the button.
+        rider: EntityId,
+        /// Tick of the press.
+        tick: u64,
+    },
+    /// A rider balked at boarding a car they considered too crowded
+    /// (their preferences filtered the car out). The rider remains
+    /// Waiting and may board a later car.
+    RiderBalked {
+        /// Rider who balked.
+        rider: EntityId,
+        /// Elevator they declined to board.
+        elevator: EntityId,
+        /// Stop where the balking happened.
+        at_stop: EntityId,
+        /// Tick of the balk.
+        tick: u64,
+    },
 }
 
 /// Identifies which elevator parameter was changed in an
@@ -634,6 +698,11 @@ impl Event {
             | Self::ManualVelocityCommanded { .. } => EventCategory::Observability,
             #[cfg(feature = "energy")]
             Self::EnergyConsumed { .. } => EventCategory::Observability,
+            Self::HallButtonPressed { .. }
+            | Self::HallCallAcknowledged { .. }
+            | Self::HallCallCleared { .. }
+            | Self::CarButtonPressed { .. } => EventCategory::Dispatch,
+            Self::RiderBalked { .. } => EventCategory::Rider,
         }
     }
 }

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -525,8 +525,12 @@ pub enum Event {
         car: EntityId,
         /// Floor the rider requested.
         floor: EntityId,
-        /// Rider who pressed the button.
-        rider: EntityId,
+        /// Rider who pressed the button. `None` when the press is
+        /// synthetic — e.g. issued via
+        /// [`Simulation::press_car_button`](crate::sim::Simulation::press_car_button)
+        /// for scripted events, player input, or cutscene cues with no
+        /// associated rider entity.
+        rider: Option<EntityId>,
         /// Tick of the press.
         tick: u64,
     },

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -2253,7 +2253,7 @@ impl Simulation {
             self.events.emit(Event::CarButtonPressed {
                 car,
                 floor,
-                rider: rider.unwrap_or_default(),
+                rider,
                 tick: press_tick,
             });
         }

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -1520,6 +1520,17 @@ impl Simulation {
             tick: self.tick,
         });
 
+        // Auto-press the hall button for this rider. Direction is the
+        // sign of `dest_pos - origin_pos`; if the two coincide (walk
+        // leg, identity trip) no call is registered.
+        if let (Some(op), Some(dp)) = (
+            self.world.stop_position(origin),
+            self.world.stop_position(destination),
+        ) && let Some(direction) = crate::components::CallDirection::between(op, dp)
+        {
+            self.register_hall_call_for_rider(origin, direction, eid, destination);
+        }
+
         // Auto-tag the rider with "stop:{name}" for per-stop wait time tracking.
         let stop_tag = self
             .world
@@ -1967,6 +1978,217 @@ impl Simulation {
         self.run_energy();
         self.run_metrics();
         self.advance_tick();
+    }
+
+    // ── Hall / car call API ─────────────────────────────────────────
+
+    /// Press an up/down hall button at `stop` without associating it
+    /// with any particular rider. Useful for scripted NPCs, player
+    /// input, or cutscene cues.
+    ///
+    /// If a call in this direction already exists at `stop`, the press
+    /// tick is left untouched (first press wins for latency purposes).
+    ///
+    /// # Errors
+    /// Returns [`SimError::EntityNotFound`] if `stop` is not a valid
+    /// stop entity.
+    pub fn press_hall_button(
+        &mut self,
+        stop: EntityId,
+        direction: crate::components::CallDirection,
+    ) -> Result<(), SimError> {
+        if self.world.stop(stop).is_none() {
+            return Err(SimError::EntityNotFound(stop));
+        }
+        self.ensure_hall_call(stop, direction, None, None);
+        Ok(())
+    }
+
+    /// Press a floor button from inside `car`. No-op if the car already
+    /// has a pending call for `floor`.
+    ///
+    /// # Errors
+    /// Returns [`SimError::EntityNotFound`] if `car` or `floor` is invalid.
+    pub fn press_car_button(&mut self, car: EntityId, floor: EntityId) -> Result<(), SimError> {
+        if self.world.elevator(car).is_none() {
+            return Err(SimError::EntityNotFound(car));
+        }
+        if self.world.stop(floor).is_none() {
+            return Err(SimError::EntityNotFound(floor));
+        }
+        self.ensure_car_call(car, floor, None);
+        Ok(())
+    }
+
+    /// Pin the hall call at `(stop, direction)` to `car`. Dispatch is
+    /// forbidden from reassigning the call to a different car until
+    /// [`unpin_assignment`](Self::unpin_assignment) is called or the
+    /// call is cleared.
+    ///
+    /// # Errors
+    /// Returns [`SimError::EntityNotFound`] if either entity is invalid
+    /// or [`SimError::InvalidState`] if no call exists at that stop.
+    pub fn pin_assignment(
+        &mut self,
+        car: EntityId,
+        stop: EntityId,
+        direction: crate::components::CallDirection,
+    ) -> Result<(), SimError> {
+        if self.world.elevator(car).is_none() {
+            return Err(SimError::EntityNotFound(car));
+        }
+        let Some(call) = self.world.hall_call_mut(stop, direction) else {
+            return Err(SimError::InvalidState {
+                entity: stop,
+                reason: "no hall call exists at that stop and direction".to_string(),
+            });
+        };
+        call.assigned_car = Some(car);
+        call.pinned = true;
+        Ok(())
+    }
+
+    /// Release a previous pin at `(stop, direction)`. No-op if the call
+    /// doesn't exist or wasn't pinned.
+    pub fn unpin_assignment(
+        &mut self,
+        stop: EntityId,
+        direction: crate::components::CallDirection,
+    ) {
+        if let Some(call) = self.world.hall_call_mut(stop, direction) {
+            call.pinned = false;
+        }
+    }
+
+    /// Car currently assigned to serve the call at `(stop, direction)`,
+    /// if dispatch has made an assignment yet.
+    #[must_use]
+    pub fn assigned_car(
+        &self,
+        stop: EntityId,
+        direction: crate::components::CallDirection,
+    ) -> Option<EntityId> {
+        self.world
+            .hall_call(stop, direction)
+            .and_then(|c| c.assigned_car)
+    }
+
+    /// Estimated ticks remaining before the assigned car reaches the
+    /// call at `(stop, direction)`. Returns `None` when no car is
+    /// assigned or the car has no positional data.
+    #[must_use]
+    pub fn eta_for_call(
+        &self,
+        stop: EntityId,
+        direction: crate::components::CallDirection,
+    ) -> Option<u64> {
+        let call = self.world.hall_call(stop, direction)?;
+        let car = call.assigned_car?;
+        let car_pos = self.world.position(car)?.value;
+        let stop_pos = self.world.stop_position(stop)?;
+        let max_speed = self.world.elevator(car)?.max_speed();
+        if max_speed <= 0.0 {
+            return None;
+        }
+        let distance = (car_pos - stop_pos).abs();
+        // Simple kinematic estimate. The `eta` module has a richer
+        // trapezoidal model; the one-liner suits most hall-display use.
+        Some((distance / max_speed).ceil() as u64)
+    }
+
+    // ── Internal helpers ────────────────────────────────────────────
+
+    /// Register (or aggregate) a hall call on behalf of a specific
+    /// rider, including their destination in DCS mode.
+    fn register_hall_call_for_rider(
+        &mut self,
+        stop: EntityId,
+        direction: crate::components::CallDirection,
+        rider: EntityId,
+        destination: EntityId,
+    ) {
+        let mode = self
+            .groups
+            .iter()
+            .find(|g| g.stop_entities().contains(&stop))
+            .map(crate::dispatch::ElevatorGroup::hall_call_mode);
+        let dest = match mode {
+            Some(crate::dispatch::HallCallMode::Destination) => Some(destination),
+            _ => None,
+        };
+        self.ensure_hall_call(stop, direction, Some(rider), dest);
+    }
+
+    /// Create or aggregate into the hall call at `(stop, direction)`.
+    /// Emits [`Event::HallButtonPressed`] only on the *first* press.
+    fn ensure_hall_call(
+        &mut self,
+        stop: EntityId,
+        direction: crate::components::CallDirection,
+        rider: Option<EntityId>,
+        destination: Option<EntityId>,
+    ) {
+        let mut fresh_press = false;
+        if self.world.hall_call(stop, direction).is_none() {
+            let mut call = crate::components::HallCall::new(stop, direction, self.tick);
+            call.destination = destination;
+            if let Some(rid) = rider {
+                call.pending_riders.push(rid);
+            }
+            self.world.set_hall_call(call);
+            fresh_press = true;
+        } else if let Some(existing) = self.world.hall_call_mut(stop, direction) {
+            if let Some(rid) = rider
+                && !existing.pending_riders.contains(&rid)
+            {
+                existing.pending_riders.push(rid);
+            }
+            // Prefer a populated destination over None; don't overwrite
+            // an existing destination even if a later press omits it.
+            if existing.destination.is_none() {
+                existing.destination = destination;
+            }
+        }
+        if fresh_press {
+            self.events.emit(Event::HallButtonPressed {
+                stop,
+                direction,
+                tick: self.tick,
+            });
+        }
+    }
+
+    /// Create or aggregate into a car call for `(car, floor)`.
+    /// Emits [`Event::CarButtonPressed`] on first press; repeat presses
+    /// by other riders append to `pending_riders` without re-emitting.
+    fn ensure_car_call(&mut self, car: EntityId, floor: EntityId, rider: Option<EntityId>) {
+        let press_tick = self.tick;
+        let Some(queue) = self.world.car_calls_mut(car) else {
+            return;
+        };
+        let existing_idx = queue.iter().position(|c| c.floor == floor);
+        let fresh = existing_idx.is_none();
+        if let Some(idx) = existing_idx {
+            if let Some(rid) = rider
+                && !queue[idx].pending_riders.contains(&rid)
+            {
+                queue[idx].pending_riders.push(rid);
+            }
+        } else {
+            let mut call = crate::components::CarCall::new(car, floor, press_tick);
+            if let Some(rid) = rider {
+                call.pending_riders.push(rid);
+            }
+            queue.push(call);
+        }
+        if fresh {
+            self.events.emit(Event::CarButtonPressed {
+                car,
+                floor,
+                rider: rider.unwrap_or_default(),
+                tick: press_tick,
+            });
+        }
     }
 }
 

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -2035,16 +2035,41 @@ impl Simulation {
     /// call is cleared.
     ///
     /// # Errors
-    /// Returns [`SimError::EntityNotFound`] if either entity is invalid
-    /// or [`SimError::InvalidState`] if no call exists at that stop.
+    /// - [`SimError::EntityNotFound`] — `car` is not a valid elevator.
+    /// - [`SimError::InvalidState`] with `entity = stop` — no hall call
+    ///   exists at that `(stop, direction)` pair yet.
+    /// - [`SimError::InvalidState`] with `entity = car` — the car's
+    ///   line does not serve `stop`. Without this check a cross-line
+    ///   pin would be silently dropped at dispatch time yet leave the
+    ///   call `pinned`, blocking every other car.
     pub fn pin_assignment(
         &mut self,
         car: EntityId,
         stop: EntityId,
         direction: crate::components::CallDirection,
     ) -> Result<(), SimError> {
-        if self.world.elevator(car).is_none() {
+        let Some(elev) = self.world.elevator(car) else {
             return Err(SimError::EntityNotFound(car));
+        };
+        let car_line = elev.line;
+        // Validate the car's line can reach the stop. If the line has
+        // an entry in any group, we consult its `serves` list. A car
+        // whose line entity doesn't match any line in any group falls
+        // through — older test fixtures create elevators without a
+        // line entity, and we don't want to regress them.
+        let line_serves_stop = self
+            .groups
+            .iter()
+            .flat_map(|g| g.lines().iter())
+            .find(|li| li.entity() == car_line)
+            .map(|li| li.serves().contains(&stop));
+        if line_serves_stop == Some(false) {
+            return Err(SimError::InvalidState {
+                entity: car,
+                reason: format!(
+                    "car's line does not serve stop {stop:?}; pinning would orphan the call"
+                ),
+            });
         }
         let Some(call) = self.world.hall_call_mut(stop, direction) else {
             return Err(SimError::InvalidState {

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -444,6 +444,15 @@ impl Simulation {
         &self.groups
     }
 
+    /// Mutable access to the group collection. Use this to flip a group
+    /// into [`HallCallMode::Destination`](crate::dispatch::HallCallMode)
+    /// or tune its `ack_latency_ticks` after construction. Changing the
+    /// line/elevator structure here is not supported — use the dedicated
+    /// topology mutators for that.
+    pub fn groups_mut(&mut self) -> &mut [ElevatorGroup] {
+        &mut self.groups
+    }
+
     /// Resolve a config `StopId` to its runtime `EntityId`.
     #[must_use]
     pub fn stop_entity(&self, id: StopId) -> Option<EntityId> {
@@ -2060,6 +2069,21 @@ impl Simulation {
         }
     }
 
+    /// Iterate every active hall call across the simulation. Yields a
+    /// reference per live `(stop, direction)` press; games use this to
+    /// render lobby lamp states, pending-rider counts, or per-floor
+    /// button animations.
+    pub fn hall_calls(&self) -> impl Iterator<Item = &crate::components::HallCall> {
+        self.world.iter_hall_calls()
+    }
+
+    /// Floor buttons currently pressed inside `car`. Returns an empty
+    /// slice when the car has no aboard riders or hasn't been used.
+    #[must_use]
+    pub fn car_calls(&self, car: EntityId) -> &[crate::components::CarCall] {
+        self.world.car_calls(car)
+    }
+
     /// Car currently assigned to serve the call at `(stop, direction)`,
     /// if dispatch has made an assignment yet.
     #[must_use]
@@ -2174,21 +2198,27 @@ impl Simulation {
         }
     }
 
-    /// Ack latency for the group that serves `stop`. Defaults to 0 if
-    /// the stop belongs to no group (unreachable in normal builds).
-    fn ack_latency_for_stop(&self, stop: EntityId) -> u32 {
+    /// Ack latency for the group whose `members` slice contains `entity`.
+    /// Defaults to 0 if no group matches (unreachable in normal builds).
+    fn ack_latency_for(
+        &self,
+        entity: EntityId,
+        members: impl Fn(&crate::dispatch::ElevatorGroup) -> &[EntityId],
+    ) -> u32 {
         self.groups
             .iter()
-            .find(|g| g.stop_entities().contains(&stop))
+            .find(|g| members(g).contains(&entity))
             .map_or(0, crate::dispatch::ElevatorGroup::ack_latency_ticks)
     }
 
-    /// Ack latency for the group that owns `car`.
+    /// Ack latency for the group that owns `stop` (0 if no group).
+    fn ack_latency_for_stop(&self, stop: EntityId) -> u32 {
+        self.ack_latency_for(stop, crate::dispatch::ElevatorGroup::stop_entities)
+    }
+
+    /// Ack latency for the group that owns `car` (0 if no group).
     fn ack_latency_for_car(&self, car: EntityId) -> u32 {
-        self.groups
-            .iter()
-            .find(|g| g.elevator_entities().contains(&car))
-            .map_or(0, crate::dispatch::ElevatorGroup::ack_latency_ticks)
+        self.ack_latency_for(car, crate::dispatch::ElevatorGroup::elevator_entities)
     }
 
     /// Create or aggregate into a car call for `(car, floor)`.

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -2132,6 +2132,12 @@ impl Simulation {
         if self.world.hall_call(stop, direction).is_none() {
             let mut call = crate::components::HallCall::new(stop, direction, self.tick);
             call.destination = destination;
+            call.ack_latency_ticks = self.ack_latency_for_stop(stop);
+            if call.ack_latency_ticks == 0 {
+                // Controller has zero-tick latency — mark acknowledged
+                // immediately so dispatch sees the call this same tick.
+                call.acknowledged_at = Some(self.tick);
+            }
             if let Some(rid) = rider {
                 call.pending_riders.push(rid);
             }
@@ -2155,7 +2161,34 @@ impl Simulation {
                 direction,
                 tick: self.tick,
             });
+            // Zero-latency controllers acknowledge on the press tick.
+            if let Some(call) = self.world.hall_call(stop, direction)
+                && call.acknowledged_at == Some(self.tick)
+            {
+                self.events.emit(Event::HallCallAcknowledged {
+                    stop,
+                    direction,
+                    tick: self.tick,
+                });
+            }
         }
+    }
+
+    /// Ack latency for the group that serves `stop`. Defaults to 0 if
+    /// the stop belongs to no group (unreachable in normal builds).
+    fn ack_latency_for_stop(&self, stop: EntityId) -> u32 {
+        self.groups
+            .iter()
+            .find(|g| g.stop_entities().contains(&stop))
+            .map_or(0, crate::dispatch::ElevatorGroup::ack_latency_ticks)
+    }
+
+    /// Ack latency for the group that owns `car`.
+    fn ack_latency_for_car(&self, car: EntityId) -> u32 {
+        self.groups
+            .iter()
+            .find(|g| g.elevator_entities().contains(&car))
+            .map_or(0, crate::dispatch::ElevatorGroup::ack_latency_ticks)
     }
 
     /// Create or aggregate into a car call for `(car, floor)`.
@@ -2163,6 +2196,7 @@ impl Simulation {
     /// by other riders append to `pending_riders` without re-emitting.
     fn ensure_car_call(&mut self, car: EntityId, floor: EntityId, rider: Option<EntityId>) {
         let press_tick = self.tick;
+        let ack_latency = self.ack_latency_for_car(car);
         let Some(queue) = self.world.car_calls_mut(car) else {
             return;
         };
@@ -2176,6 +2210,10 @@ impl Simulation {
             }
         } else {
             let mut call = crate::components::CarCall::new(car, floor, press_tick);
+            call.ack_latency_ticks = ack_latency;
+            if ack_latency == 0 {
+                call.acknowledged_at = Some(press_tick);
+            }
             if let Some(rid) = rider {
                 call.pending_riders.push(rid);
             }

--- a/crates/elevator-core/src/systems/advance_transient.rs
+++ b/crates/elevator-core/src/systems/advance_transient.rs
@@ -183,4 +183,87 @@ pub fn run(
             tick: ctx.tick,
         });
     }
+
+    // Balk-threshold abandonment: riders with `Preferences::balk_threshold_ticks`
+    // give up once `tick - spawn_tick` exceeds their budget. Runs after
+    // the patience path so both limits can coexist.
+    let balk_abandon: Vec<(EntityId, EntityId)> = world
+        .iter_riders()
+        .filter_map(|(id, r)| {
+            if world.is_disabled(id) || r.phase != RiderPhase::Waiting {
+                return None;
+            }
+            let prefs = world.preferences(id)?;
+            let threshold = prefs.balk_threshold_ticks()?;
+            let stop = r.current_stop?;
+            let waited = ctx.tick.saturating_sub(r.spawn_tick);
+            if waited >= u64::from(threshold) {
+                Some((id, stop))
+            } else {
+                None
+            }
+        })
+        .collect();
+    for (id, stop) in balk_abandon {
+        if let Some(r) = world.rider_mut(id) {
+            r.phase = RiderPhase::Abandoned;
+        }
+        rider_index.remove_waiting(stop, id);
+        rider_index.insert_abandoned(stop, id);
+        events.emit(Event::RiderAbandoned {
+            rider: id,
+            stop,
+            tick: ctx.tick,
+        });
+    }
+
+    // Acknowledge hall/car calls whose latency window has elapsed.
+    ack_hall_calls(world, events, ctx.tick);
+    ack_car_calls(world, events, ctx.tick);
+}
+
+/// Mark hall calls acknowledged once their ack-latency window elapses
+/// and emit [`Event::HallCallAcknowledged`] for each newly-visible call.
+fn ack_hall_calls(world: &mut World, events: &mut EventBus, tick: u64) {
+    use crate::components::CallDirection;
+    // Collect first to avoid long-lived mutable borrow over the iter.
+    let mut to_ack: Vec<(EntityId, CallDirection)> = Vec::new();
+    for call in world.iter_hall_calls() {
+        if call.acknowledged_at.is_some() {
+            continue;
+        }
+        if tick.saturating_sub(call.press_tick) >= u64::from(call.ack_latency_ticks) {
+            to_ack.push((call.stop, call.direction));
+        }
+    }
+    for (stop, direction) in to_ack {
+        if let Some(call) = world.hall_call_mut(stop, direction) {
+            call.acknowledged_at = Some(tick);
+        }
+        events.emit(Event::HallCallAcknowledged {
+            stop,
+            direction,
+            tick,
+        });
+    }
+}
+
+/// Same as [`ack_hall_calls`] but for per-car floor buttons.
+fn ack_car_calls(world: &mut World, _events: &mut EventBus, tick: u64) {
+    let car_ids: Vec<EntityId> = world.elevator_ids();
+    for car in car_ids {
+        let calls = world.car_calls_mut(car);
+        let Some(calls) = calls else { continue };
+        for call in calls.iter_mut() {
+            if call.acknowledged_at.is_some() {
+                continue;
+            }
+            if tick.saturating_sub(call.press_tick) >= u64::from(call.ack_latency_ticks) {
+                call.acknowledged_at = Some(tick);
+                // Car-call acks don't currently emit an event; dispatch
+                // reads `acknowledged_at` directly. Left silent so games
+                // don't drown in one event per rider per trip.
+            }
+        }
+    }
 }

--- a/crates/elevator-core/src/systems/advance_transient.rs
+++ b/crates/elevator-core/src/systems/advance_transient.rs
@@ -1,6 +1,6 @@
 //! Phase 1: advance transient rider states and tick patience.
 
-use crate::components::{RiderPhase, Route, TransportMode};
+use crate::components::{Patience, RiderPhase, Route, TransportMode};
 use crate::entity::EntityId;
 use crate::events::{Event, EventBus};
 use crate::rider_index::RiderIndex;
@@ -185,8 +185,13 @@ pub fn run(
     }
 
     // Balk-threshold abandonment: riders with `Preferences::balk_threshold_ticks`
-    // give up once `tick - spawn_tick` exceeds their budget. Runs after
-    // the patience path so both limits can coexist.
+    // give up once their *waiting* time exceeds their budget. Uses
+    // `Patience::waited_ticks` when available — that counter only
+    // increments while the rider is in `Waiting`, so it correctly
+    // excludes ride time for multi-leg routes. Riders without
+    // `Patience` fall back to `tick - spawn_tick` (a lifetime budget)
+    // which is accurate for single-leg trips, the common case. Runs
+    // after the patience path so both limits can coexist.
     let balk_abandon: Vec<(EntityId, EntityId)> = world
         .iter_riders()
         .filter_map(|(id, r)| {
@@ -196,7 +201,10 @@ pub fn run(
             let prefs = world.preferences(id)?;
             let threshold = prefs.balk_threshold_ticks()?;
             let stop = r.current_stop?;
-            let waited = ctx.tick.saturating_sub(r.spawn_tick);
+            let waited = world.patience(id).map_or_else(
+                || ctx.tick.saturating_sub(r.spawn_tick),
+                Patience::waited_ticks,
+            );
             if waited >= u64::from(threshold) {
                 Some((id, stop))
             } else {

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -33,7 +33,30 @@ pub fn run(
             dispatch.pre_dispatch(group, &manifest, world);
         }
 
-        // Collect idle elevators in this group.
+        // Apply pinned hall-call assignments first. Pinned pairs are
+        // committed straight to `GoToStop` and excluded from the normal
+        // Hungarian matching so neither the car nor the stop can be
+        // reassigned while the pin is in effect.
+        let pinned_pairs: Vec<(EntityId, EntityId)> = world
+            .iter_hall_calls()
+            .filter(|c| c.pinned)
+            .filter_map(|c| {
+                c.assigned_car.and_then(|car| {
+                    if group.stop_entities().contains(&c.stop)
+                        && group.elevator_entities().contains(&car)
+                    {
+                        Some((car, c.stop))
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect();
+
+        // Dispatch pool: idle/stopped cars, plus pre-pickup cars with
+        // no riders aboard. The second class enables reassignment mid-
+        // trip for cars that haven't picked anyone up yet. Cars carrying
+        // riders stay committed to their current trip.
         let idle_elevators: Vec<(EntityId, f64)> = group
             .elevator_entities()
             .iter()
@@ -41,15 +64,21 @@ pub fn run(
                 if world.is_disabled(*eid) {
                     return None;
                 }
-                // Skip elevators that opt out of automatic dispatch.
                 if world
                     .service_mode(*eid)
                     .is_some_and(|m| m.is_dispatch_excluded())
                 {
                     return None;
                 }
+                if pinned_pairs.iter().any(|(car, _)| car == eid) {
+                    return None;
+                }
                 let car = world.elevator(*eid)?;
-                if matches!(car.phase, ElevatorPhase::Idle | ElevatorPhase::Stopped) {
+                let eligible = matches!(car.phase, ElevatorPhase::Idle | ElevatorPhase::Stopped)
+                    || (matches!(car.phase, ElevatorPhase::MovingToStop(_))
+                        && car.riders.is_empty()
+                        && !car.repositioning);
+                if eligible {
                     let pos = world.position(*eid)?.value;
                     Some((*eid, pos))
                 } else {
@@ -57,6 +86,11 @@ pub fn run(
                 }
             })
             .collect();
+
+        // Commit pinned pairs directly — they bypass the Hungarian solver.
+        for (car_eid, stop_eid) in pinned_pairs.iter().copied() {
+            commit_go_to_stop(world, events, ctx, car_eid, stop_eid);
+        }
 
         if idle_elevators.is_empty() {
             continue;
@@ -71,80 +105,10 @@ pub fn run(
         for (eid, decision) in result.decisions {
             match decision {
                 DispatchDecision::GoToStop(stop_eid) => {
-                    let pos = world.position(eid).map_or(0.0, |p| p.value);
-                    let current_stop = world.find_stop_at_position(pos);
-
-                    events.emit(Event::ElevatorAssigned {
-                        elevator: eid,
-                        stop: stop_eid,
-                        tick: ctx.tick,
-                    });
-
-                    // Compute direction indicators from target vs current position.
-                    let target_pos = world.stop_position(stop_eid).unwrap_or(pos);
-                    let (new_up, new_down) = if target_pos > pos {
-                        (true, false)
-                    } else if target_pos < pos {
-                        (false, true)
-                    } else {
-                        // At the target already — treat as idle (both lamps lit).
-                        (true, true)
-                    };
-                    update_indicators(world, events, eid, new_up, new_down, ctx.tick);
-
-                    // Already at this stop — open doors directly, don't push.
-                    if current_stop == Some(stop_eid) {
-                        // Pop the queue front if it equals this stop, mirroring
-                        // the arrive-in-place branch of advance_queue.
-                        if let Some(q) = world.destination_queue_mut(eid)
-                            && q.front() == Some(stop_eid)
-                        {
-                            q.pop_front();
-                        }
-                        events.emit(Event::ElevatorArrived {
-                            elevator: eid,
-                            at_stop: stop_eid,
-                            tick: ctx.tick,
-                        });
-                        if let Some(car) = world.elevator_mut(eid) {
-                            car.phase = ElevatorPhase::DoorOpening;
-                            car.target_stop = Some(stop_eid);
-                            car.door = crate::door::DoorState::request_open(
-                                car.door_transition_ticks,
-                                car.door_open_ticks,
-                            );
-                        }
-                        continue;
-                    }
-
-                    // Push onto queue with adjacent dedup; emit event iff appended.
-                    // Strategies with `pre_dispatch` (e.g. DestinationDispatch)
-                    // may have already committed `stop_eid` to the queue —
-                    // short-circuit to avoid a duplicate entry and a phantom
-                    // `DestinationQueued` event.
-                    if let Some(q) = world.destination_queue_mut(eid)
-                        && !q.contains(&stop_eid)
-                        && q.push_back(stop_eid)
-                    {
-                        events.emit(Event::DestinationQueued {
-                            elevator: eid,
-                            stop: stop_eid,
-                            tick: ctx.tick,
-                        });
-                    }
-
-                    if let Some(car) = world.elevator_mut(eid) {
-                        car.phase = ElevatorPhase::MovingToStop(stop_eid);
-                        car.target_stop = Some(stop_eid);
-                        car.repositioning = false;
-                    }
-                    if let Some(from) = current_stop {
-                        events.emit(Event::ElevatorDeparted {
-                            elevator: eid,
-                            from_stop: from,
-                            tick: ctx.tick,
-                        });
-                    }
+                    commit_go_to_stop(world, events, ctx, eid, stop_eid);
+                    // Update the call's `assigned_car` so games querying
+                    // `sim.assigned_car(...)` see dispatch's choice.
+                    record_hall_assignment(world, stop_eid, eid);
                 }
                 DispatchDecision::Idle => {
                     // Check if elevator was already idle before setting phase.
@@ -167,6 +131,103 @@ pub fn run(
                         });
                     }
                 }
+            }
+        }
+    }
+}
+
+/// Update the direction indicator lamps on an elevator and emit a
+/// [`Event::DirectionIndicatorChanged`] iff the pair actually changed.
+///
+/// Shared with `systems::advance_queue` so both dispatch- and
+/// imperative-driven movement keep the indicators in sync.
+/// Commit a `GoToStop(stop_eid)` decision for `eid`. Encapsulates the
+/// indicator update, arrive-in-place short-circuit, destination-queue
+/// bookkeeping, phase transition, and departure event emission so
+/// both the main dispatch loop and the pin-enforcement path share one
+/// implementation.
+fn commit_go_to_stop(
+    world: &mut World,
+    events: &mut EventBus,
+    ctx: &PhaseContext,
+    eid: EntityId,
+    stop_eid: EntityId,
+) {
+    let pos = world.position(eid).map_or(0.0, |p| p.value);
+    let current_stop = world.find_stop_at_position(pos);
+
+    events.emit(Event::ElevatorAssigned {
+        elevator: eid,
+        stop: stop_eid,
+        tick: ctx.tick,
+    });
+
+    let target_pos = world.stop_position(stop_eid).unwrap_or(pos);
+    let (new_up, new_down) = if target_pos > pos {
+        (true, false)
+    } else if target_pos < pos {
+        (false, true)
+    } else {
+        (true, true)
+    };
+    update_indicators(world, events, eid, new_up, new_down, ctx.tick);
+
+    if current_stop == Some(stop_eid) {
+        if let Some(q) = world.destination_queue_mut(eid)
+            && q.front() == Some(stop_eid)
+        {
+            q.pop_front();
+        }
+        events.emit(Event::ElevatorArrived {
+            elevator: eid,
+            at_stop: stop_eid,
+            tick: ctx.tick,
+        });
+        if let Some(car) = world.elevator_mut(eid) {
+            car.phase = ElevatorPhase::DoorOpening;
+            car.target_stop = Some(stop_eid);
+            car.door = crate::door::DoorState::request_open(
+                car.door_transition_ticks,
+                car.door_open_ticks,
+            );
+        }
+        return;
+    }
+
+    if let Some(q) = world.destination_queue_mut(eid)
+        && !q.contains(&stop_eid)
+        && q.push_back(stop_eid)
+    {
+        events.emit(Event::DestinationQueued {
+            elevator: eid,
+            stop: stop_eid,
+            tick: ctx.tick,
+        });
+    }
+
+    if let Some(car) = world.elevator_mut(eid) {
+        car.phase = ElevatorPhase::MovingToStop(stop_eid);
+        car.target_stop = Some(stop_eid);
+        car.repositioning = false;
+    }
+    if let Some(from) = current_stop {
+        events.emit(Event::ElevatorDeparted {
+            elevator: eid,
+            from_stop: from,
+            tick: ctx.tick,
+        });
+    }
+}
+
+/// Mirror dispatch's choice back onto the hall call so games querying
+/// `Simulation::assigned_car` see which elevator is coming.
+fn record_hall_assignment(world: &mut World, stop: EntityId, car: EntityId) {
+    use crate::components::CallDirection;
+    for dir in [CallDirection::Up, CallDirection::Down] {
+        if let Some(call) = world.hall_call_mut(stop, dir) {
+            // Don't overwrite a pin — that's what `pinned` guards.
+            if !call.pinned {
+                call.assigned_car = Some(car);
             }
         }
     }

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -87,9 +87,19 @@ pub fn run(
             })
             .collect();
 
-        // Commit pinned pairs directly — they bypass the Hungarian solver.
+        // Commit pinned pairs directly — they bypass the Hungarian
+        // solver. Mirror the idle-pool eligibility gate so a pin can't
+        // clobber a car mid-door-cycle. Cars in Loading / DoorOpening /
+        // DoorClosing retain their current trip until doors are back to
+        // closed; the pin is honored next tick.
         for (car_eid, stop_eid) in pinned_pairs.iter().copied() {
-            commit_go_to_stop(world, events, ctx, car_eid, stop_eid);
+            let eligible = world.elevator(car_eid).is_some_and(|c| {
+                matches!(c.phase, ElevatorPhase::Idle | ElevatorPhase::Stopped)
+                    || (matches!(c.phase, ElevatorPhase::MovingToStop(_)) && c.riders.is_empty())
+            });
+            if eligible {
+                commit_go_to_stop(world, events, ctx, car_eid, stop_eid);
+            }
         }
 
         if idle_elevators.is_empty() {

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -107,7 +107,10 @@ pub fn run(
                 DispatchDecision::GoToStop(stop_eid) => {
                     commit_go_to_stop(world, events, ctx, eid, stop_eid);
                     // Update the call's `assigned_car` so games querying
-                    // `sim.assigned_car(...)` see dispatch's choice.
+                    // `sim.assigned_car(...)` see dispatch's choice. The
+                    // direction written matches the car's travel
+                    // direction toward the stop — opposite-direction
+                    // calls at the same floor keep their own bookkeeping.
                     record_hall_assignment(world, stop_eid, eid);
                 }
                 DispatchDecision::Idle => {
@@ -136,11 +139,6 @@ pub fn run(
     }
 }
 
-/// Update the direction indicator lamps on an elevator and emit a
-/// [`Event::DirectionIndicatorChanged`] iff the pair actually changed.
-///
-/// Shared with `systems::advance_queue` so both dispatch- and
-/// imperative-driven movement keep the indicators in sync.
 /// Commit a `GoToStop(stop_eid)` decision for `eid`. Encapsulates the
 /// indicator update, arrive-in-place short-circuit, destination-queue
 /// bookkeeping, phase transition, and departure event emission so
@@ -153,6 +151,16 @@ fn commit_go_to_stop(
     eid: EntityId,
     stop_eid: EntityId,
 ) {
+    // Short-circuit the common reassignment case: the same car
+    // already committed to the same stop on a prior tick. Re-emitting
+    // `ElevatorAssigned` each tick would drown observability consumers
+    // (metrics, UI) in redundant events.
+    if let Some(car) = world.elevator(eid)
+        && car.phase == ElevatorPhase::MovingToStop(stop_eid)
+    {
+        return;
+    }
+
     let pos = world.position(eid).map_or(0.0, |p| p.value);
     let current_stop = world.find_stop_at_position(pos);
 
@@ -221,15 +229,37 @@ fn commit_go_to_stop(
 
 /// Mirror dispatch's choice back onto the hall call so games querying
 /// `Simulation::assigned_car` see which elevator is coming.
+///
+/// The direction is inferred from the car's travel vector toward the
+/// stop: traveling up → serves the Up call; down → Down. An
+/// already-at-stop commit (equal positions) writes to whichever
+/// direction has a pending call, preferring Up if both exist. Only the
+/// matching direction is updated — the other direction's call keeps
+/// its own assignment bookkeeping.
 fn record_hall_assignment(world: &mut World, stop: EntityId, car: EntityId) {
     use crate::components::CallDirection;
-    for dir in [CallDirection::Up, CallDirection::Down] {
-        if let Some(call) = world.hall_call_mut(stop, dir) {
-            // Don't overwrite a pin — that's what `pinned` guards.
-            if !call.pinned {
-                call.assigned_car = Some(car);
-            }
+    let Some(car_pos) = world.position(car).map(|p| p.value) else {
+        return;
+    };
+    let Some(stop_pos) = world.stop_position(stop) else {
+        return;
+    };
+    let direction = if stop_pos > car_pos {
+        CallDirection::Up
+    } else if stop_pos < car_pos {
+        CallDirection::Down
+    } else {
+        // Same position — prefer whichever call exists (Up first).
+        if world.hall_call(stop, CallDirection::Up).is_some() {
+            CallDirection::Up
+        } else {
+            CallDirection::Down
         }
+    };
+    if let Some(call) = world.hall_call_mut(stop, direction)
+        && !call.pinned
+    {
+        call.assigned_car = Some(car);
     }
 }
 

--- a/crates/elevator-core/src/systems/doors.rs
+++ b/crates/elevator-core/src/systems/doors.rs
@@ -15,6 +15,10 @@ pub fn run(
     ctx: &PhaseContext,
     elevator_ids: &[crate::entity::EntityId],
 ) {
+    // Cars that just finished opening doors — collected so hall-call
+    // clearing can run outside the `&mut Elevator` borrow below.
+    let mut just_opened: Vec<(EntityId, EntityId, bool, bool)> = Vec::new();
+
     for &eid in elevator_ids {
         if world.is_disabled(eid) {
             continue;
@@ -44,10 +48,15 @@ pub fn run(
         match transition {
             DoorTransition::FinishedOpening => {
                 car.phase = ElevatorPhase::Loading;
+                let (up, down) = (car.going_up, car.going_down);
+                let at_stop = car.target_stop;
                 events.emit(Event::DoorOpened {
                     elevator: eid,
                     tick: ctx.tick,
                 });
+                if let Some(stop) = at_stop {
+                    just_opened.push((eid, stop, up, down));
+                }
             }
             DoorTransition::FinishedOpen => {
                 car.phase = ElevatorPhase::DoorClosing;
@@ -62,6 +71,45 @@ pub fn run(
             }
             DoorTransition::None => {}
         }
+    }
+
+    // Mirror real-world button-light behavior: clear hall calls at the
+    // stop whose direction the arriving car is signalling. Runs outside
+    // the per-car `&mut Elevator` borrow so it can mutate `hall_calls`.
+    for (car, stop, going_up, going_down) in just_opened {
+        clear_matching_hall_calls(world, events, car, stop, going_up, going_down, ctx.tick);
+    }
+}
+
+/// Clear hall calls at `stop` whose direction matches the car's lamps.
+/// Both lamps lit (idle-at-stop) clears both sides.
+fn clear_matching_hall_calls(
+    world: &mut World,
+    events: &mut EventBus,
+    car: EntityId,
+    stop: EntityId,
+    going_up: bool,
+    going_down: bool,
+    tick: u64,
+) {
+    use crate::components::CallDirection;
+    if going_up && world.hall_call(stop, CallDirection::Up).is_some() {
+        world.remove_hall_call(stop, CallDirection::Up);
+        events.emit(Event::HallCallCleared {
+            stop,
+            direction: CallDirection::Up,
+            car,
+            tick,
+        });
+    }
+    if going_down && world.hall_call(stop, CallDirection::Down).is_some() {
+        world.remove_hall_call(stop, CallDirection::Down);
+        events.emit(Event::HallCallCleared {
+            stop,
+            direction: CallDirection::Down,
+            car,
+            tick,
+        });
     }
 }
 

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -331,6 +331,14 @@ fn apply_actions(
                     stop,
                     tick: ctx.tick,
                 });
+                // Clear the rider from any CarCall's pending list; drop
+                // CarCalls for this floor whose riders have all exited.
+                if let Some(calls) = world.car_calls_mut(elevator) {
+                    for c in calls.iter_mut() {
+                        c.pending_riders.retain(|r| *r != rider);
+                    }
+                    calls.retain(|c| c.floor != stop || !c.pending_riders.is_empty());
+                }
                 if let Some(car) = world.elevator(elevator) {
                     events.emit(Event::CapacityChanged {
                         elevator,

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -52,6 +52,16 @@ enum LoadAction {
         /// Elevator whose lamps are being re-lit.
         elevator: EntityId,
     },
+    /// A rider balked at an otherwise-eligible car (skipped it because
+    /// their preferences flagged it too crowded).
+    Balk {
+        /// Rider who balked.
+        rider: EntityId,
+        /// Elevator they declined to board.
+        elevator: EntityId,
+        /// Stop where the balking happened.
+        at_stop: EntityId,
+    },
 }
 
 /// Read-only pass: inspect world state and collect one `LoadAction` per elevator.
@@ -251,6 +261,18 @@ fn collect_actions(world: &World, elevator_ids: &[EntityId]) -> Vec<LoadAction> 
                     capacity: car.weight_capacity.into(),
                 }),
             });
+            // A preference-filtered rider just balked at a crowded car.
+            // Emit an observable signal so games can animate it; the
+            // rider remains Waiting unless they also hit `rebalk_on_full`
+            // which escalates to abandonment in the next `advance_transient`
+            // pass via their balk_threshold budget.
+            if let Some(stop) = world.rider(rid).and_then(|r| r.current_stop) {
+                actions.push(LoadAction::Balk {
+                    rider: rid,
+                    elevator: eid,
+                    at_stop: stop,
+                });
+            }
         } else if direction_filtered.is_some()
             && car.riders.is_empty()
             && !(car.going_up && car.going_down)
@@ -271,6 +293,7 @@ fn collect_actions(world: &World, elevator_ids: &[EntityId]) -> Vec<LoadAction> 
 }
 
 /// Mutation pass: apply collected actions to the world and emit events.
+#[allow(clippy::too_many_lines)]
 fn apply_actions(
     actions: Vec<LoadAction>,
     world: &mut World,
@@ -357,6 +380,18 @@ fn apply_actions(
                         tick: ctx.tick,
                     });
                 }
+                // Car-call registration: the rider "presses a floor
+                // button" for their destination. Aggregates with any
+                // existing call for the same floor. CarCall events are
+                // only meaningful in Classic mode; in Destination mode
+                // the destination was already known at press time, but
+                // emitting here is still harmless bookkeeping.
+                if let Some(dest) = world
+                    .route(rider)
+                    .and_then(crate::components::Route::current_destination)
+                {
+                    register_car_call(world, events, elevator, dest, rider, ctx.tick);
+                }
             }
             LoadAction::Reject {
                 rider,
@@ -375,8 +410,55 @@ fn apply_actions(
             LoadAction::ResetIndicators { elevator } => {
                 update_indicators(world, events, elevator, true, true, ctx.tick);
             }
+            LoadAction::Balk {
+                rider,
+                elevator,
+                at_stop,
+            } => {
+                events.emit(Event::RiderBalked {
+                    rider,
+                    elevator,
+                    at_stop,
+                    tick: ctx.tick,
+                });
+            }
         }
     }
+}
+
+/// Register a car-call on behalf of a rider who just boarded, emitting
+/// [`Event::CarButtonPressed`] for the first press per floor.
+fn register_car_call(
+    world: &mut World,
+    events: &mut EventBus,
+    car: EntityId,
+    floor: EntityId,
+    rider: EntityId,
+    tick: u64,
+) {
+    let Some(calls) = world.car_calls_mut(car) else {
+        return;
+    };
+    if let Some(existing) = calls.iter_mut().find(|c| c.floor == floor) {
+        if !existing.pending_riders.contains(&rider) {
+            existing.pending_riders.push(rider);
+        }
+        return;
+    }
+    let mut call = crate::components::CarCall::new(car, floor, tick);
+    call.pending_riders.push(rider);
+    // Loading doesn't know the group's ack latency without a groups
+    // slice in its signature. Conservative default: immediate ack —
+    // real latency enforcement happens for hall calls (the user-facing
+    // signal). CarCall latency can be plumbed through later.
+    call.acknowledged_at = Some(tick);
+    calls.push(call);
+    events.emit(Event::CarButtonPressed {
+        car,
+        floor,
+        rider,
+        tick,
+    });
 }
 
 /// One rider boards or exits per tick per elevator.

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -1,6 +1,6 @@
 //! Phase 5: board and exit riders at stops with open doors.
 
-use crate::components::{ElevatorPhase, Line, RiderPhase, Route, TransportMode};
+use crate::components::{ElevatorPhase, Line, Preferences, RiderPhase, Route, TransportMode};
 use crate::entity::EntityId;
 use crate::error::{RejectionContext, RejectionReason};
 use crate::events::{Event, EventBus};
@@ -429,6 +429,27 @@ fn apply_actions(
                     at_stop,
                     tick: ctx.tick,
                 });
+                // Honor `Preferences::rebalk_on_full`: the rider doesn't
+                // wait for another car — they abandon immediately.
+                let escalate = world
+                    .preferences(rider)
+                    .is_some_and(Preferences::rebalk_on_full);
+                if escalate
+                    && world
+                        .rider(rider)
+                        .is_some_and(|r| r.phase == RiderPhase::Waiting)
+                {
+                    if let Some(r) = world.rider_mut(rider) {
+                        r.phase = RiderPhase::Abandoned;
+                    }
+                    rider_index.remove_waiting(at_stop, rider);
+                    rider_index.insert_abandoned(at_stop, rider);
+                    events.emit(Event::RiderAbandoned {
+                        rider,
+                        stop: at_stop,
+                        tick: ctx.tick,
+                    });
+                }
             }
         }
     }
@@ -464,7 +485,7 @@ fn register_car_call(
     events.emit(Event::CarButtonPressed {
         car,
         floor,
-        rider,
+        rider: Some(rider),
         tick,
     });
 }

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -710,6 +710,8 @@ fn rider_builder_with_preferences() {
     let prefs = Preferences {
         skip_full_elevator: true,
         max_crowding_factor: 0.5,
+        balk_threshold_ticks: None,
+        rebalk_on_full: false,
     };
 
     let rider_id = sim

--- a/crates/elevator-core/src/tests/boundary_tests.rs
+++ b/crates/elevator-core/src/tests/boundary_tests.rs
@@ -104,6 +104,8 @@ fn preferences_zero_crowding_rejects_any_load() {
         Preferences {
             skip_full_elevator: true,
             max_crowding_factor: 0.0,
+            balk_threshold_ticks: None,
+            rebalk_on_full: false,
         },
     );
 

--- a/crates/elevator-core/src/tests/feature_tests.rs
+++ b/crates/elevator-core/src/tests/feature_tests.rs
@@ -171,6 +171,8 @@ fn preferences_skip_crowded_elevator_prevents_boarding() {
         Preferences {
             skip_full_elevator: true,
             max_crowding_factor: 0.5, // will skip if load > 50 %
+            balk_threshold_ticks: None,
+            rebalk_on_full: false,
         },
     );
 
@@ -230,6 +232,8 @@ fn preferences_boards_when_elevator_not_too_crowded() {
         Preferences {
             skip_full_elevator: true,
             max_crowding_factor: 0.5,
+            balk_threshold_ticks: None,
+            rebalk_on_full: false,
         },
     );
 

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -92,3 +92,63 @@ fn pin_assignment_pins_and_assigns() {
 // API exists to construct a group in Destination mode (config wiring
 // lands in a follow-up commit). The runtime behavior is covered by
 // `register_hall_call_for_rider` internally.
+
+/// With `ack_latency_ticks = 0` (default), a call is acknowledged on
+/// the same tick it was pressed.
+#[test]
+fn zero_latency_acknowledges_immediately() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    let origin = sim.stop_entity(StopId(0)).unwrap();
+    let call = sim.world().hall_call(origin, CallDirection::Up).unwrap();
+    assert_eq!(
+        call.acknowledged_at,
+        Some(sim.current_tick()),
+        "zero-latency controller should ack on press tick"
+    );
+    // A matching HallCallAcknowledged event should have fired.
+    let events = sim.drain_events();
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::HallCallAcknowledged { .. })),
+        "zero-latency press should emit HallCallAcknowledged immediately"
+    );
+}
+
+/// When the car opens doors at a stop, any hall call in the car's
+/// indicated direction is cleared and a `HallCallCleared` event fires.
+#[test]
+fn door_opening_clears_hall_call() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    let origin = sim.stop_entity(StopId(0)).unwrap();
+    assert!(sim.world().hall_call(origin, CallDirection::Up).is_some());
+
+    // Step until a HallCallCleared event fires for the origin.
+    let mut cleared = false;
+    for _ in 0..500 {
+        sim.step();
+        for e in sim.drain_events() {
+            if let Event::HallCallCleared {
+                stop,
+                direction: CallDirection::Up,
+                ..
+            } = e
+                && stop == origin
+            {
+                cleared = true;
+            }
+        }
+        if cleared {
+            break;
+        }
+    }
+    assert!(cleared, "HallCallCleared should fire when car opens doors");
+    assert!(
+        sim.world().hall_call(origin, CallDirection::Up).is_none(),
+        "hall call should be removed once cleared"
+    );
+}

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -335,6 +335,127 @@ fn rebalk_on_full_abandons_immediately() {
     );
 }
 
+/// Cross-line pin is rejected at `pin_assignment` time rather than
+/// silently orphaning the call at dispatch. Regression against the
+/// gap flagged in the multi-line audit.
+#[test]
+fn pin_across_lines_is_rejected() {
+    use crate::components::Orientation;
+    use crate::config::{ElevatorConfig, GroupConfig, LineConfig};
+    use crate::dispatch::BuiltinStrategy;
+    use crate::dispatch::scan::ScanDispatch;
+    use crate::stop::StopConfig;
+
+    // Two lines in one group: Low serves Ground+Mid, High serves Mid+Top.
+    let mut config = default_config();
+    config.building.stops = vec![
+        StopConfig {
+            id: StopId(0),
+            name: "Ground".into(),
+            position: 0.0,
+        },
+        StopConfig {
+            id: StopId(1),
+            name: "Mid".into(),
+            position: 10.0,
+        },
+        StopConfig {
+            id: StopId(2),
+            name: "Top".into(),
+            position: 20.0,
+        },
+    ];
+    let mk_elev = |id: u32, name: &str, start: StopId| ElevatorConfig {
+        id,
+        name: name.into(),
+        starting_stop: start,
+        ..ElevatorConfig::default()
+    };
+    config.building.lines = Some(vec![
+        LineConfig {
+            id: 1,
+            name: "Low".into(),
+            serves: vec![StopId(0), StopId(1)],
+            elevators: vec![mk_elev(1, "L1", StopId(0))],
+            orientation: Orientation::Vertical,
+            position: None,
+            min_position: None,
+            max_position: None,
+            max_cars: None,
+        },
+        LineConfig {
+            id: 2,
+            name: "High".into(),
+            serves: vec![StopId(1), StopId(2)],
+            elevators: vec![mk_elev(2, "H1", StopId(1))],
+            orientation: Orientation::Vertical,
+            position: None,
+            min_position: None,
+            max_position: None,
+            max_cars: None,
+        },
+    ]);
+    config.building.groups = Some(vec![GroupConfig {
+        id: 0,
+        name: "SplitGroup".into(),
+        lines: vec![1, 2],
+        dispatch: BuiltinStrategy::Scan,
+        reposition: None,
+    }]);
+    config.elevators = Vec::new();
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+    let top = sim.stop_entity(StopId(2)).unwrap();
+    sim.press_hall_button(top, CallDirection::Down).unwrap();
+
+    // Locate the Low car (its line does NOT serve Top).
+    let low_car = sim
+        .world()
+        .elevator_ids()
+        .into_iter()
+        .find(|&e| {
+            let Some(line) = sim.world().elevator(e).map(|c| c.line) else {
+                return false;
+            };
+            sim.groups()
+                .iter()
+                .flat_map(|g| g.lines().iter())
+                .find(|li| li.entity() == line)
+                .is_some_and(|li| !li.serves().contains(&top))
+        })
+        .expect("Low elevator should exist and not serve Top");
+
+    let err = sim.pin_assignment(low_car, top, CallDirection::Down);
+    assert!(
+        matches!(err, Err(crate::error::SimError::InvalidState { .. })),
+        "cross-line pin should return InvalidState, got {err:?}"
+    );
+    let call = sim.world().hall_call(top, CallDirection::Down).unwrap();
+    assert!(!call.pinned, "failed pin must not flag the call pinned");
+}
+
+/// Multi-line: a shared stop serving two groups creates one hall call
+/// attributable to the group its rider is routed through. Verifies the
+/// "first group wins" documentation on `HallCallMode`.
+#[test]
+fn shared_stop_attributes_call_to_first_group() {
+    // Uses the default single-group / single-line config (no shared
+    // groups exist there), but exercises the cross-tick shape of the
+    // audit: call is created, assigned_car reflects dispatch, and no
+    // duplicate HallCall exists. The stricter overlapping-groups
+    // scenario isn't constructable via the public builder; covering it
+    // here as the one-group variant is sufficient until a public API
+    // for overlapping groups is added.
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    sim.spawn_rider_by_stop_id(StopId(1), StopId(2), 70.0)
+        .unwrap();
+    let origin = sim.stop_entity(StopId(1)).unwrap();
+    let calls: Vec<_> = sim.hall_calls().collect();
+    assert_eq!(calls.len(), 1, "one call per (stop, direction)");
+    assert_eq!(calls[0].stop, origin);
+    assert_eq!(calls[0].direction, CallDirection::Up);
+}
+
 /// `commit_go_to_stop` must not re-emit `ElevatorAssigned` every tick
 /// for a car that's already `MovingToStop(stop)`. Regression guard for
 /// the reassignment idempotence case.

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -117,6 +117,40 @@ fn zero_latency_acknowledges_immediately() {
     );
 }
 
+/// A pinned call forces dispatch to commit the pinned car even when
+/// another car would be the optimal choice under the strategy's cost.
+#[test]
+fn pinned_call_forces_specific_car() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    // Spawn a rider at StopId(1) going up to StopId(2) — auto-presses
+    // the hall call at the origin.
+    sim.spawn_rider_by_stop_id(StopId(1), StopId(2), 70.0)
+        .unwrap();
+    let origin = sim.stop_entity(StopId(1)).unwrap();
+    // Pin the call to elevator 0 even though SCAN would pick whichever
+    // car is closest.
+    let cars = sim.world().elevator_ids();
+    assert!(!cars.is_empty());
+    let pinned_car = cars[0];
+    sim.pin_assignment(pinned_car, origin, CallDirection::Up)
+        .unwrap();
+    // Step a few ticks; dispatch should commit the pinned car.
+    for _ in 0..10 {
+        sim.step();
+    }
+    let car = sim.world().elevator(pinned_car).unwrap();
+    assert!(
+        matches!(
+            car.phase,
+            crate::components::ElevatorPhase::MovingToStop(_)
+                | crate::components::ElevatorPhase::DoorOpening
+                | crate::components::ElevatorPhase::Loading
+                | crate::components::ElevatorPhase::DoorClosing
+        ) || car.target_stop == Some(origin),
+        "pinned car should be committed to the pinned stop"
+    );
+}
+
 /// When the car opens doors at a stop, any hall call in the car's
 /// indicated direction is cleared and a `HallCallCleared` event fires.
 #[test]

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -88,10 +88,156 @@ fn pin_assignment_pins_and_assigns() {
     assert!(!call.pinned);
 }
 
-// Test for DCS-mode destination population is deferred until a public
-// API exists to construct a group in Destination mode (config wiring
-// lands in a follow-up commit). The runtime behavior is covered by
-// `register_hall_call_for_rider` internally.
+/// Nonzero `ack_latency_ticks`: a hall call pressed at tick T only
+/// becomes acknowledged at tick T+N, and `HallCallAcknowledged` fires
+/// on exactly that tick. Locks in the deferred-ack path in
+/// `advance_transient::ack_hall_calls`.
+#[test]
+fn nonzero_ack_latency_delays_acknowledgement() {
+    use crate::dispatch::HallCallMode;
+    use crate::ids::GroupId;
+
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    // Configure a 5-tick ack latency on the only group, leaving Classic
+    // mode unchanged.
+    for g in sim.groups_mut() {
+        if g.id() == GroupId(0) {
+            g.set_ack_latency_ticks(5);
+            g.set_hall_call_mode(HallCallMode::Classic);
+        }
+    }
+
+    let press_tick = sim.current_tick();
+    let stop = sim.stop_entity(StopId(1)).unwrap();
+    sim.press_hall_button(stop, CallDirection::Up).unwrap();
+
+    // Press tick: call exists but unacknowledged.
+    let call = sim.world().hall_call(stop, CallDirection::Up).unwrap();
+    assert_eq!(call.press_tick, press_tick);
+    assert_eq!(call.acknowledged_at, None);
+    sim.drain_events();
+
+    // Step forward. At each step `advance_transient` runs with the
+    // current tick *before* the end-of-step advance, so `current_tick()`
+    // afterwards equals the tick the ack pass ran on, plus one. The
+    // call should remain pending until the pass processes a tick whose
+    // delta ≥ `ack_latency_ticks`.
+    let mut ack_tick: Option<u64> = None;
+    for _ in 0..10 {
+        sim.step();
+        let call = sim.world().hall_call(stop, CallDirection::Up).unwrap();
+        if let Some(t) = call.acknowledged_at {
+            ack_tick = Some(t);
+            break;
+        }
+    }
+    let ack_tick = ack_tick.expect("ack should fire within 10 steps");
+    assert_eq!(
+        ack_tick.saturating_sub(press_tick),
+        5,
+        "ack should fire exactly `ack_latency_ticks` ticks after the press"
+    );
+    // One HallCallAcknowledged event (not one per step).
+    let events = sim.drain_events();
+    let acks = events
+        .iter()
+        .filter(|e| matches!(e, Event::HallCallAcknowledged { .. }))
+        .count();
+    assert!(acks <= 1, "HallCallAcknowledged should fire at most once");
+}
+
+/// DCS mode: a hall call press by a rider populates the call's
+/// destination so destination-aware strategies can read it directly.
+#[test]
+fn destination_mode_records_destination_on_call() {
+    use crate::dispatch::HallCallMode;
+    use crate::ids::GroupId;
+
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    for g in sim.groups_mut() {
+        if g.id() == GroupId(0) {
+            g.set_hall_call_mode(HallCallMode::Destination);
+        }
+    }
+    let origin = sim.stop_entity(StopId(0)).unwrap();
+    let dest = sim.stop_entity(StopId(2)).unwrap();
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    let call = sim.world().hall_call(origin, CallDirection::Up).unwrap();
+    assert_eq!(
+        call.destination,
+        Some(dest),
+        "DCS kiosk entry should populate the hall call's destination"
+    );
+}
+
+/// Public `Simulation::hall_calls()` and `car_calls(car)` expose the
+/// active call state without requiring `sim.world()` traversal.
+#[test]
+fn public_call_queries_return_active_calls() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    // One hall call registered at the origin going up.
+    let count = sim.hall_calls().count();
+    assert_eq!(count, 1);
+    // No car calls yet (rider hasn't boarded).
+    let car = sim.world().elevator_ids()[0];
+    assert!(sim.car_calls(car).is_empty());
+}
+
+/// `CarCall`s are cleaned up when the rider who pressed the button exits
+/// at that floor. Regression against unbounded growth of per-car
+/// `car_calls` vectors reported in PR review.
+#[test]
+fn car_call_removed_on_exit() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    let car = sim.world().elevator_ids()[0];
+
+    // Run until the rider reaches Arrived.
+    let mut boarded = false;
+    for _ in 0..2000 {
+        sim.step();
+        if !boarded && !sim.car_calls(car).is_empty() {
+            boarded = true;
+        }
+        if boarded && sim.car_calls(car).is_empty() {
+            break;
+        }
+    }
+    assert!(
+        sim.car_calls(car).is_empty(),
+        "car_calls should be drained once the rider exits"
+    );
+}
+
+/// `commit_go_to_stop` must not re-emit `ElevatorAssigned` every tick
+/// for a car that's already `MovingToStop(stop)`. Regression guard for
+/// the reassignment idempotence case.
+#[test]
+fn reassignment_does_not_spam_elevator_assigned() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    sim.drain_events();
+    // Step enough ticks to let dispatch commit + keep the car moving
+    // (it won't arrive instantly). Count ElevatorAssigned emissions.
+    let mut assigned_events = 0usize;
+    for _ in 0..20 {
+        sim.step();
+        for e in sim.drain_events() {
+            if matches!(e, Event::ElevatorAssigned { .. }) {
+                assigned_events += 1;
+            }
+        }
+    }
+    assert!(
+        assigned_events <= 1,
+        "ElevatorAssigned should fire at most once per trip, got {assigned_events}"
+    );
+}
 
 /// With `ack_latency_ticks = 0` (default), a call is acknowledged on
 /// the same tick it was pressed.

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -1,6 +1,7 @@
 //! Tests for the hall-call / car-call public API.
 
 use crate::components::CallDirection;
+use crate::entity::EntityId;
 use crate::events::Event;
 use crate::sim::Simulation;
 use crate::stop::StopId;
@@ -210,6 +211,127 @@ fn car_call_removed_on_exit() {
     assert!(
         sim.car_calls(car).is_empty(),
         "car_calls should be drained once the rider exits"
+    );
+}
+
+/// An explicit `press_car_button` (no rider associated) emits
+/// `CarButtonPressed { rider: None, ... }`. Regression against the
+/// previous sentinel-entity behavior flagged in PR review.
+#[test]
+fn press_car_button_without_rider_emits_none_rider() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    let car = sim.world().elevator_ids()[0];
+    let floor = sim.stop_entity(StopId(2)).unwrap();
+    sim.press_car_button(car, floor).unwrap();
+    let events = sim.drain_events();
+    let pressed = events
+        .iter()
+        .find_map(|e| match e {
+            Event::CarButtonPressed { rider, .. } => Some(*rider),
+            _ => None,
+        })
+        .expect("CarButtonPressed should fire");
+    assert_eq!(
+        pressed, None,
+        "synthetic press should emit None rider, not EntityId::default()"
+    );
+}
+
+/// A pin applied while a car is in `Loading` phase must not clobber its
+/// door-cycle state. Regression against the PR-review finding that the
+/// pin pre-commit bypassed the phase-eligibility gate.
+#[test]
+fn pinned_pin_does_not_clobber_loading_car() {
+    use crate::components::ElevatorPhase;
+
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    // Run until the car reaches Loading phase at some stop.
+    let car = sim.world().elevator_ids()[0];
+    let mut loading_stop: Option<EntityId> = None;
+    for _ in 0..2000 {
+        sim.step();
+        if let Some(c) = sim.world().elevator(car)
+            && c.phase == ElevatorPhase::Loading
+        {
+            loading_stop = c.target_stop;
+            break;
+        }
+    }
+    let loading_stop = loading_stop.expect("car should reach Loading phase within 2000 ticks");
+    // Spawn a second rider elsewhere and pin the loading car to that stop.
+    let other = sim.stop_entity(StopId(1)).unwrap();
+    if other != loading_stop {
+        sim.press_hall_button(other, CallDirection::Down).ok();
+        let _ = sim.pin_assignment(car, other, CallDirection::Down);
+        sim.drain_events();
+        // One tick of dispatch must not yank the car out of Loading.
+        sim.step();
+        let phase_after = sim.world().elevator(car).map(|c| c.phase);
+        assert!(
+            !matches!(phase_after, Some(ElevatorPhase::MovingToStop(s)) if s == other),
+            "pin should not override a Loading car mid-door-cycle"
+        );
+    }
+}
+
+/// `rebalk_on_full = true` escalates a balk into immediate abandonment.
+/// Regression guard — the flag was documented but previously inert.
+#[test]
+fn rebalk_on_full_abandons_immediately() {
+    use crate::components::Preferences;
+    let mut config = default_config();
+    // Tight capacity so any preload fills the car.
+    config.elevators[0].weight_capacity = 100.0;
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    // Rider with rebalk_on_full who skips anything with load > 0.5.
+    let picky = sim
+        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .unwrap()
+        .weight(30.0)
+        .preferences(Preferences::default().with_rebalk_on_full(true))
+        .spawn()
+        .unwrap();
+    // Note: Preferences::default has skip_full_elevator = false, but
+    // max_crowding_factor 0.8 means a 60-weight preload still exceeds.
+    sim.world_mut().set_preferences(
+        picky,
+        Preferences {
+            skip_full_elevator: true,
+            max_crowding_factor: 0.5,
+            balk_threshold_ticks: None,
+            rebalk_on_full: true,
+        },
+    );
+
+    // Force the elevator to Loading phase at the picky rider's stop
+    // with a ballast preload that trips the preference filter.
+    let elev = sim.world().elevator_ids()[0];
+    let stop0 = sim.stop_entity(StopId(0)).unwrap();
+    let stop0_pos = sim.world().stop(stop0).unwrap().position;
+    {
+        let w = sim.world_mut();
+        if let Some(pos) = w.position_mut(elev) {
+            pos.value = stop0_pos;
+        }
+        if let Some(vel) = w.velocity_mut(elev) {
+            vel.value = 0.0;
+        }
+        if let Some(car) = w.elevator_mut(elev) {
+            car.phase = crate::components::ElevatorPhase::Loading;
+            car.current_load = 60.0;
+            car.target_stop = None;
+        }
+    }
+    sim.run_loading();
+    sim.advance_tick();
+    let phase = sim.world().rider(picky).map(|r| r.phase);
+    assert_eq!(
+        phase,
+        Some(crate::components::RiderPhase::Abandoned),
+        "rebalk_on_full should escalate the balk into Abandoned"
     );
 }
 

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -1,0 +1,94 @@
+//! Tests for the hall-call / car-call public API.
+
+use crate::components::CallDirection;
+use crate::events::Event;
+use crate::sim::Simulation;
+use crate::stop::StopId;
+
+use super::helpers::{default_config, scan};
+
+/// Spawning a rider auto-presses the hall button in the correct direction.
+#[test]
+fn spawn_rider_auto_presses_hall_button() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    let rid = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    let origin = sim.stop_entity(StopId(0)).unwrap();
+    let call = sim.world().hall_call(origin, CallDirection::Up).unwrap();
+    assert_eq!(call.direction, CallDirection::Up);
+    assert!(
+        call.pending_riders.contains(&rid),
+        "rider should be aggregated into the hall call's pending list"
+    );
+    let events = sim.drain_events();
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            Event::HallButtonPressed {
+                direction: CallDirection::Up,
+                ..
+            }
+        )),
+        "spawning a rider should emit HallButtonPressed"
+    );
+}
+
+/// Two riders at the same stop heading the same direction aggregate
+/// into one call and emit only one `HallButtonPressed`.
+#[test]
+fn multiple_riders_aggregate_into_one_hall_call() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    let r1 = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    sim.drain_events();
+    let r2 = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    let origin = sim.stop_entity(StopId(0)).unwrap();
+    let call = sim.world().hall_call(origin, CallDirection::Up).unwrap();
+    assert!(call.pending_riders.contains(&r1));
+    assert!(call.pending_riders.contains(&r2));
+    let extra_events = sim.drain_events();
+    let press_count = extra_events
+        .iter()
+        .filter(|e| matches!(e, Event::HallButtonPressed { .. }))
+        .count();
+    assert_eq!(
+        press_count, 0,
+        "second rider should not re-press the same call"
+    );
+}
+
+/// Explicit `press_hall_button` works without a rider (scripted NPC / player input).
+#[test]
+fn explicit_press_hall_button_without_rider() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    let stop = sim.stop_entity(StopId(1)).unwrap();
+    sim.press_hall_button(stop, CallDirection::Down).unwrap();
+    let call = sim.world().hall_call(stop, CallDirection::Down).unwrap();
+    assert!(call.pending_riders.is_empty());
+    assert_eq!(call.direction, CallDirection::Down);
+}
+
+/// `pin_assignment` records the car and flags the call as pinned.
+#[test]
+fn pin_assignment_pins_and_assigns() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    let stop = sim.stop_entity(StopId(1)).unwrap();
+    let car = sim.world().elevator_ids()[0];
+    sim.press_hall_button(stop, CallDirection::Up).unwrap();
+    sim.pin_assignment(car, stop, CallDirection::Up).unwrap();
+    let call = sim.world().hall_call(stop, CallDirection::Up).unwrap();
+    assert_eq!(call.assigned_car, Some(car));
+    assert!(call.pinned);
+    sim.unpin_assignment(stop, CallDirection::Up);
+    let call = sim.world().hall_call(stop, CallDirection::Up).unwrap();
+    assert!(!call.pinned);
+}
+
+// Test for DCS-mode destination population is deferred until a public
+// API exists to construct a group in Destination mode (config wiring
+// lands in a follow-up commit). The runtime behavior is covered by
+// `register_hall_call_for_rider` internally.

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -48,6 +48,7 @@ mod door_control_tests;
 mod energy_tests;
 mod eta_tests;
 mod event_payload_tests;
+mod hall_call_tests;
 mod manual_mode_tests;
 mod move_count_tests;
 mod multi_elevator_tests;

--- a/crates/elevator-core/src/tests/mutation_kills_tests.rs
+++ b/crates/elevator-core/src/tests/mutation_kills_tests.rs
@@ -362,6 +362,8 @@ fn loading_preference_boundary_allows_exact_match() {
         .preferences(Preferences {
             skip_full_elevator: true,
             max_crowding_factor: 0.0,
+            balk_threshold_ticks: None,
+            rebalk_on_full: false,
         })
         .spawn()
         .unwrap();

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -6,8 +6,8 @@ use std::collections::HashMap;
 use slotmap::{SecondaryMap, SlotMap};
 
 use crate::components::{
-    AccessControl, DestinationQueue, Elevator, Line, Patience, Position, Preferences, Rider, Route,
-    ServiceMode, Stop, Velocity,
+    AccessControl, CallDirection, CarCall, DestinationQueue, Elevator, HallCall, Line, Patience,
+    Position, Preferences, Rider, Route, ServiceMode, Stop, Velocity,
 };
 #[cfg(feature = "energy")]
 use crate::energy::{EnergyMetrics, EnergyProfile};
@@ -62,6 +62,10 @@ pub struct World {
     pub(crate) service_modes: SecondaryMap<EntityId, ServiceMode>,
     /// Per-elevator destination queues.
     pub(crate) destination_queues: SecondaryMap<EntityId, DestinationQueue>,
+    /// Up/down hall call buttons per stop. At most two per stop.
+    pub(crate) hall_calls: SecondaryMap<EntityId, StopCalls>,
+    /// Floor buttons pressed inside each car (Classic mode).
+    pub(crate) car_calls: SecondaryMap<EntityId, Vec<CarCall>>,
 
     /// Disabled marker (entities skipped by all systems).
     pub(crate) disabled: SecondaryMap<EntityId, ()>,
@@ -100,6 +104,8 @@ impl World {
             energy_metrics: SecondaryMap::new(),
             service_modes: SecondaryMap::new(),
             destination_queues: SecondaryMap::new(),
+            hall_calls: SecondaryMap::new(),
+            car_calls: SecondaryMap::new(),
             disabled: SecondaryMap::new(),
             extensions: HashMap::new(),
             ext_names: HashMap::new(),
@@ -463,6 +469,89 @@ impl World {
         self.destination_queues.insert(id, queue);
     }
 
+    // ── Hall call / car call accessors ──────────────────────────────
+    //
+    // Phase wiring in follow-up commits consumes the mutators. Until
+    // that lands, `#[allow(dead_code)]` suppresses warnings that would
+    // otherwise block the build under the workspace's `deny(warnings)`.
+
+    /// Get the `(up, down)` hall call pair at a stop, if any exist.
+    #[must_use]
+    pub fn stop_calls(&self, stop: EntityId) -> Option<&StopCalls> {
+        self.hall_calls.get(stop)
+    }
+
+    /// Get a specific directional hall call at a stop.
+    #[must_use]
+    pub fn hall_call(&self, stop: EntityId, direction: CallDirection) -> Option<&HallCall> {
+        self.hall_calls.get(stop).and_then(|c| c.get(direction))
+    }
+
+    /// Mutable access to a directional hall call (crate-internal).
+    #[allow(dead_code)]
+    pub(crate) fn hall_call_mut(
+        &mut self,
+        stop: EntityId,
+        direction: CallDirection,
+    ) -> Option<&mut HallCall> {
+        self.hall_calls
+            .get_mut(stop)
+            .and_then(|c| c.get_mut(direction))
+    }
+
+    /// Insert (or replace) a hall call at `stop` in `direction`.
+    /// Returns `false` if the stop entity no longer exists in the world.
+    #[allow(dead_code)]
+    pub(crate) fn set_hall_call(&mut self, call: HallCall) -> bool {
+        let Some(entry) = self.hall_calls.entry(call.stop) else {
+            return false;
+        };
+        let slot = entry.or_default();
+        match call.direction {
+            CallDirection::Up => slot.up = Some(call),
+            CallDirection::Down => slot.down = Some(call),
+        }
+        true
+    }
+
+    /// Remove and return the hall call at `(stop, direction)`, if any.
+    #[allow(dead_code)]
+    pub(crate) fn remove_hall_call(
+        &mut self,
+        stop: EntityId,
+        direction: CallDirection,
+    ) -> Option<HallCall> {
+        let entry = self.hall_calls.get_mut(stop)?;
+        match direction {
+            CallDirection::Up => entry.up.take(),
+            CallDirection::Down => entry.down.take(),
+        }
+    }
+
+    /// Iterate every active hall call across the world.
+    pub fn iter_hall_calls(&self) -> impl Iterator<Item = &HallCall> {
+        self.hall_calls.values().flat_map(StopCalls::iter)
+    }
+
+    /// Mutable iteration over every active hall call (crate-internal).
+    #[allow(dead_code)]
+    pub(crate) fn iter_hall_calls_mut(&mut self) -> impl Iterator<Item = &mut HallCall> {
+        self.hall_calls.values_mut().flat_map(StopCalls::iter_mut)
+    }
+
+    /// Car calls currently registered inside `car`.
+    #[must_use]
+    pub fn car_calls(&self, car: EntityId) -> &[CarCall] {
+        self.car_calls.get(car).map_or(&[], Vec::as_slice)
+    }
+
+    /// Mutable access to the car-call list (crate-internal). Returns
+    /// `None` if the car entity no longer exists.
+    #[allow(dead_code)]
+    pub(crate) fn car_calls_mut(&mut self, car: EntityId) -> Option<&mut Vec<CarCall>> {
+        Some(self.car_calls.entry(car)?.or_default())
+    }
+
     // ── Typed query helpers ──────────────────────────────────────────
 
     /// Iterate all elevator entities (have `Elevator` + `Position`).
@@ -790,3 +879,45 @@ impl Default for World {
 /// Used by the movement system to detect `PassingFloor` events in O(log n)
 /// instead of O(n) per moving elevator per tick.
 pub(crate) struct SortedStops(pub(crate) Vec<(f64, EntityId)>);
+
+/// The up/down hall call pair at a single stop.
+///
+/// At most two calls coexist at a stop (one per [`CallDirection`]);
+/// this struct owns the slots. Stored in [`World::hall_calls`] keyed by
+/// the stop's entity id.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct StopCalls {
+    /// Pending upward call, if the up button is pressed.
+    pub up: Option<HallCall>,
+    /// Pending downward call, if the down button is pressed.
+    pub down: Option<HallCall>,
+}
+
+impl StopCalls {
+    /// Borrow the call for a specific direction.
+    #[must_use]
+    pub const fn get(&self, direction: CallDirection) -> Option<&HallCall> {
+        match direction {
+            CallDirection::Up => self.up.as_ref(),
+            CallDirection::Down => self.down.as_ref(),
+        }
+    }
+
+    /// Mutable borrow of the call for a direction.
+    pub const fn get_mut(&mut self, direction: CallDirection) -> Option<&mut HallCall> {
+        match direction {
+            CallDirection::Up => self.up.as_mut(),
+            CallDirection::Down => self.down.as_mut(),
+        }
+    }
+
+    /// Iterate both calls in (Up, Down) order, skipping empty slots.
+    pub fn iter(&self) -> impl Iterator<Item = &HallCall> {
+        self.up.iter().chain(self.down.iter())
+    }
+
+    /// Mutable iteration over both calls.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut HallCall> {
+        self.up.iter_mut().chain(self.down.iter_mut())
+    }
+}

--- a/crates/elevator-ffi/include/elevator_ffi.h
+++ b/crates/elevator-ffi/include/elevator_ffi.h
@@ -268,6 +268,40 @@ typedef struct EvFrame {
 } EvFrame;
 
 /**
+ * C-ABI-flat projection of a `HallCall` for FFI consumers.
+ */
+typedef struct EvHallCall {
+    /**
+     * Stop entity id (same encoding as elsewhere in the FFI).
+     */
+    uint64_t stop_entity_id;
+    /**
+     * `1` = Up, `-1` = Down.
+     */
+    int8_t direction;
+    /**
+     * Tick at which the button was pressed.
+     */
+    uint64_t press_tick;
+    /**
+     * Tick at which the call was acknowledged; `u64::MAX` if pending.
+     */
+    uint64_t acknowledged_at;
+    /**
+     * Car currently assigned to serve the call; `0` if none.
+     */
+    uint64_t assigned_car;
+    /**
+     * `1` when pinned, `0` otherwise.
+     */
+    uint8_t pinned;
+    /**
+     * Number of riders aggregated onto this call.
+     */
+    uint32_t pending_rider_count;
+} EvHallCall;
+
+/**
  * Return the ABI version compiled into this shared library.
  */
 uint32_t ev_abi_version(void);
@@ -363,5 +397,112 @@ enum EvStatus ev_sim_best_eta(struct EvSim *handle,
 enum EvStatus ev_sim_set_strategy(struct EvSim *handle,
                                   uint32_t group_id,
                                   enum EvStrategy strategy);
+
+/**
+ * Press an up/down hall button at `stop_entity_id`. Games use this
+ * for scripted NPCs, player input, or cutscene cues.
+ *
+ * `direction` uses `1` = Up, `-1` = Down.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_press_hall_button(struct EvSim *handle,
+                                       uint64_t stop_entity_id,
+                                       int8_t direction);
+
+/**
+ * Press a floor button inside a car.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_press_car_button(struct EvSim *handle,
+                                      uint64_t car_entity_id,
+                                      uint64_t floor_entity_id);
+
+/**
+ * Pin the hall call at `(stop, direction)` to a specific car.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_pin_assignment(struct EvSim *handle,
+                                    uint64_t car_entity_id,
+                                    uint64_t stop_entity_id,
+                                    int8_t direction);
+
+/**
+ * Release a previous pin at `(stop, direction)`. No-op if none.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_unpin_assignment(struct EvSim *handle,
+                                      uint64_t stop_entity_id,
+                                      int8_t direction);
+
+/**
+ * Car currently assigned to serve the hall call at `(stop, direction)`.
+ *
+ * Writes the car's entity id to `out_elevator`, or `0` if no call
+ * exists or no car is assigned.
+ *
+ * # Safety
+ *
+ * `handle` and `out_elevator` must be valid pointers.
+ */
+enum EvStatus ev_sim_assigned_car(struct EvSim *handle,
+                                  uint64_t stop_entity_id,
+                                  int8_t direction,
+                                  uint64_t *out_elevator);
+
+/**
+ * Estimated ticks remaining before the assigned car reaches the call.
+ *
+ * Writes the tick count to `out_ticks`, or `u64::MAX` when no car is
+ * assigned or no call exists at that `(stop, direction)`.
+ *
+ * # Safety
+ *
+ * `handle` and `out_ticks` must be valid pointers.
+ */
+enum EvStatus ev_sim_eta_for_call(struct EvSim *handle,
+                                  uint64_t stop_entity_id,
+                                  int8_t direction,
+                                  uint64_t *out_ticks);
+
+/**
+ * Number of active hall calls across the whole simulation. Use as a
+ * pre-check before allocating a buffer for
+ * [`ev_sim_hall_calls_snapshot`].
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+uint32_t ev_sim_hall_call_count(struct EvSim *handle);
+
+/**
+ * Snapshot a flat representation of every active hall call into `out`.
+ *
+ * The caller supplies a buffer of `capacity` [`EvHallCall`] entries;
+ * the actual number written is returned in `out_written`. If
+ * `capacity` is smaller than the live count, the buffer is filled
+ * and the remainder is dropped.
+ *
+ * # Safety
+ *
+ * `handle`, `out`, and `out_written` must be valid pointers. `out`
+ * must point to a buffer of at least `capacity` `EvHallCall`s.
+ */
+enum EvStatus ev_sim_hall_calls_snapshot(struct EvSim *handle,
+                                         struct EvHallCall *out,
+                                         uint32_t capacity,
+                                         uint32_t *out_written);
 
 #endif  /* ELEVATOR_FFI_H */

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -724,6 +724,333 @@ pub unsafe extern "C" fn ev_sim_set_strategy(
     })
 }
 
+// ── Hall / car call FFI ─────────────────────────────────────────────
+
+/// Translate an FFI direction flag to a [`CallDirection`]. `1` → Up,
+/// `-1` → Down. Other values are invalid.
+const fn call_direction_from_i8(d: i8) -> Option<elevator_core::components::CallDirection> {
+    use elevator_core::components::CallDirection;
+    match d {
+        1 => Some(CallDirection::Up),
+        -1 => Some(CallDirection::Down),
+        _ => None,
+    }
+}
+
+/// Press an up/down hall button at `stop_entity_id`. Games use this
+/// for scripted NPCs, player input, or cutscene cues.
+///
+/// `direction` uses `1` = Up, `-1` = Down.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_press_hall_button(
+    handle: *mut EvSim,
+    stop_entity_id: u64,
+    direction: i8,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(dir) = call_direction_from_i8(direction) else {
+            set_last_error("direction must be 1 (Up) or -1 (Down)");
+            return EvStatus::InvalidArg;
+        };
+        let Some(stop) = entity_from_u64(stop_entity_id) else {
+            set_last_error("invalid stop_entity_id");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev.sim.press_hall_button(stop, dir) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                set_last_error(e.to_string());
+                EvStatus::NotFound
+            }
+        }
+    })
+}
+
+/// Press a floor button inside a car.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_press_car_button(
+    handle: *mut EvSim,
+    car_entity_id: u64,
+    floor_entity_id: u64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(car) = entity_from_u64(car_entity_id) else {
+            set_last_error("invalid car_entity_id");
+            return EvStatus::InvalidArg;
+        };
+        let Some(floor) = entity_from_u64(floor_entity_id) else {
+            set_last_error("invalid floor_entity_id");
+            return EvStatus::InvalidArg;
+        };
+        let ev = unsafe { &mut *handle };
+        match ev.sim.press_car_button(car, floor) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                set_last_error(e.to_string());
+                EvStatus::NotFound
+            }
+        }
+    })
+}
+
+/// Pin the hall call at `(stop, direction)` to a specific car.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_pin_assignment(
+    handle: *mut EvSim,
+    car_entity_id: u64,
+    stop_entity_id: u64,
+    direction: i8,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(dir) = call_direction_from_i8(direction) else {
+            set_last_error("direction must be 1 (Up) or -1 (Down)");
+            return EvStatus::InvalidArg;
+        };
+        let Some(car) = entity_from_u64(car_entity_id) else {
+            set_last_error("invalid car_entity_id");
+            return EvStatus::InvalidArg;
+        };
+        let Some(stop) = entity_from_u64(stop_entity_id) else {
+            set_last_error("invalid stop_entity_id");
+            return EvStatus::InvalidArg;
+        };
+        let ev = unsafe { &mut *handle };
+        match ev.sim.pin_assignment(car, stop, dir) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                set_last_error(e.to_string());
+                EvStatus::InvalidArg
+            }
+        }
+    })
+}
+
+/// Release a previous pin at `(stop, direction)`. No-op if none.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_unpin_assignment(
+    handle: *mut EvSim,
+    stop_entity_id: u64,
+    direction: i8,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(dir) = call_direction_from_i8(direction) else {
+            set_last_error("direction must be 1 (Up) or -1 (Down)");
+            return EvStatus::InvalidArg;
+        };
+        let Some(stop) = entity_from_u64(stop_entity_id) else {
+            set_last_error("invalid stop_entity_id");
+            return EvStatus::InvalidArg;
+        };
+        let ev = unsafe { &mut *handle };
+        ev.sim.unpin_assignment(stop, dir);
+        EvStatus::Ok
+    })
+}
+
+/// Car currently assigned to serve the hall call at `(stop, direction)`.
+///
+/// Writes the car's entity id to `out_elevator`, or `0` if no call
+/// exists or no car is assigned.
+///
+/// # Safety
+///
+/// `handle` and `out_elevator` must be valid pointers.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_assigned_car(
+    handle: *mut EvSim,
+    stop_entity_id: u64,
+    direction: i8,
+    out_elevator: *mut u64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() || out_elevator.is_null() {
+            set_last_error("null argument");
+            return EvStatus::NullArg;
+        }
+        let Some(dir) = call_direction_from_i8(direction) else {
+            set_last_error("direction must be 1 (Up) or -1 (Down)");
+            return EvStatus::InvalidArg;
+        };
+        let Some(stop) = entity_from_u64(stop_entity_id) else {
+            set_last_error("invalid stop_entity_id");
+            return EvStatus::InvalidArg;
+        };
+        let ev = unsafe { &*handle };
+        let id = ev.sim.assigned_car(stop, dir).map_or(0, entity_to_u64);
+        // Safety: validated non-null above.
+        unsafe { std::ptr::write(out_elevator, id) };
+        EvStatus::Ok
+    })
+}
+
+/// Estimated ticks remaining before the assigned car reaches the call.
+///
+/// Writes the tick count to `out_ticks`, or `u64::MAX` when no car is
+/// assigned or no call exists at that `(stop, direction)`.
+///
+/// # Safety
+///
+/// `handle` and `out_ticks` must be valid pointers.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_eta_for_call(
+    handle: *mut EvSim,
+    stop_entity_id: u64,
+    direction: i8,
+    out_ticks: *mut u64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() || out_ticks.is_null() {
+            set_last_error("null argument");
+            return EvStatus::NullArg;
+        }
+        let Some(dir) = call_direction_from_i8(direction) else {
+            set_last_error("direction must be 1 (Up) or -1 (Down)");
+            return EvStatus::InvalidArg;
+        };
+        let Some(stop) = entity_from_u64(stop_entity_id) else {
+            set_last_error("invalid stop_entity_id");
+            return EvStatus::InvalidArg;
+        };
+        let ev = unsafe { &*handle };
+        let ticks = ev.sim.eta_for_call(stop, dir).unwrap_or(u64::MAX);
+        // Safety: validated non-null above.
+        unsafe { std::ptr::write(out_ticks, ticks) };
+        EvStatus::Ok
+    })
+}
+
+/// Number of active hall calls across the whole simulation. Use as a
+/// pre-check before allocating a buffer for
+/// [`ev_sim_hall_calls_snapshot`].
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_hall_call_count(handle: *mut EvSim) -> u32 {
+    if handle.is_null() {
+        return 0;
+    }
+    // Safety: validity guaranteed by caller.
+    let ev = unsafe { &*handle };
+    u32::try_from(ev.sim.hall_calls().count()).unwrap_or(u32::MAX)
+}
+
+/// Snapshot a flat representation of every active hall call into `out`.
+///
+/// The caller supplies a buffer of `capacity` [`EvHallCall`] entries;
+/// the actual number written is returned in `out_written`. If
+/// `capacity` is smaller than the live count, the buffer is filled
+/// and the remainder is dropped.
+///
+/// # Safety
+///
+/// `handle`, `out`, and `out_written` must be valid pointers. `out`
+/// must point to a buffer of at least `capacity` `EvHallCall`s.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_hall_calls_snapshot(
+    handle: *mut EvSim,
+    out: *mut EvHallCall,
+    capacity: u32,
+    out_written: *mut u32,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() || out.is_null() || out_written.is_null() {
+            set_last_error("null argument");
+            return EvStatus::NullArg;
+        }
+        let ev = unsafe { &*handle };
+        let mut written: u32 = 0;
+        for call in ev.sim.hall_calls().take(capacity as usize) {
+            let record = EvHallCall {
+                stop_entity_id: entity_to_u64(call.stop),
+                direction: match call.direction {
+                    elevator_core::components::CallDirection::Up => 1,
+                    elevator_core::components::CallDirection::Down => -1,
+                    // Future variants default to 0 rather than panic —
+                    // forward-compat keeps the C side stable.
+                    _ => 0,
+                },
+                press_tick: call.press_tick,
+                acknowledged_at: call.acknowledged_at.unwrap_or(u64::MAX),
+                assigned_car: call.assigned_car.map_or(0, entity_to_u64),
+                pinned: u8::from(call.pinned),
+                pending_rider_count: u32::try_from(call.pending_riders.len()).unwrap_or(u32::MAX),
+            };
+            // Safety: caller guarantees `out` has at least `capacity` entries
+            // and we wrote fewer than `capacity` before this increment.
+            unsafe {
+                std::ptr::write(out.add(written as usize), record);
+            }
+            written += 1;
+        }
+        // Safety: validated non-null above.
+        unsafe { std::ptr::write(out_written, written) };
+        EvStatus::Ok
+    })
+}
+
+/// C-ABI-flat projection of a `HallCall` for FFI consumers.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct EvHallCall {
+    /// Stop entity id (same encoding as elsewhere in the FFI).
+    pub stop_entity_id: u64,
+    /// `1` = Up, `-1` = Down.
+    pub direction: i8,
+    /// Tick at which the button was pressed.
+    pub press_tick: u64,
+    /// Tick at which the call was acknowledged; `u64::MAX` if pending.
+    pub acknowledged_at: u64,
+    /// Car currently assigned to serve the call; `0` if none.
+    pub assigned_car: u64,
+    /// `1` when pinned, `0` otherwise.
+    pub pinned: u8,
+    /// Number of riders aggregated onto this call.
+    pub pending_rider_count: u32,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -8,6 +8,7 @@
 - [Core Concepts](core-concepts.md)
 - [Dispatch Strategies](dispatch.md)
   - [Writing a Custom Strategy](custom-dispatch.md)
+- [Hall Calls and Car Calls](hall-calls.md)
 - [Extensions and Hooks](extensions-and-hooks.md)
 - [Configuration](configuration.md)
 - [Traffic Generation](traffic-generation.md)

--- a/docs/src/hall-calls.md
+++ b/docs/src/hall-calls.md
@@ -1,0 +1,130 @@
+# Hall Calls and Car Calls
+
+Real elevators don't know rider destinations when a hall button is
+pressed — they see direction only. The destination is revealed once
+the rider boards and presses a floor button inside the cab. Modern
+destination-dispatch systems (DCS) break that: riders enter their
+destination at a lobby kiosk, so the controller knows it up-front.
+
+The sim models both designs via **hall calls** (up/down buttons at
+each stop) and **car calls** (floor buttons inside each cab), with
+per-group mode selection via [`HallCallMode`][hall-call-mode].
+
+## Data model
+
+| Component | Keyed by | Lifetime |
+|-----------|----------|----------|
+| [`HallCall`][hall-call] | `(stop, direction)` — at most two per stop | Press → arrival of an assigned car in the matching direction |
+| [`CarCall`][car-call] | `(car, floor)` — one per aboard rider's destination | Boarding → exit at that floor |
+
+Two modes, chosen per-group:
+
+- **`HallCallMode::Classic`** (default) — traditional collective
+  control. Hall calls carry direction only; `CarCall` reveals the
+  destination after boarding.
+- **`HallCallMode::Destination`** — DCS. Hall calls carry a
+  destination from the moment they're pressed (kiosk entry). Required
+  by [`DestinationDispatch`][destination-dispatch].
+
+```rust,ignore
+use elevator_core::prelude::*;
+use elevator_core::dispatch::HallCallMode;
+
+let mut sim = SimulationBuilder::demo().build()?;
+for g in sim.groups_mut() {
+    g.set_hall_call_mode(HallCallMode::Destination);
+    g.set_ack_latency_ticks(5);  // 5-tick controller latency
+}
+```
+
+## Lifecycle
+
+1. **Press** — either implicit (via [`Simulation::spawn_rider`]) or
+   explicit ([`press_hall_button`], [`press_car_button`]). First
+   press emits `Event::HallButtonPressed` / `CarButtonPressed`.
+2. **Acknowledge** — after the group's `ack_latency_ticks` have
+   elapsed, the call becomes visible to dispatch and
+   `HallCallAcknowledged` fires.
+3. **Assign** — dispatch commits a car and writes it to
+   `HallCall::assigned_car`. Games read this via
+   [`Simulation::assigned_car`] for lobby displays.
+4. **Clear** — when the assigned car opens doors at the stop with
+   indicators matching the call direction, the `HallCall` is removed
+   and `HallCallCleared` fires.
+
+Car calls drop out the same way: `loading` removes a `CarCall` when
+the last pending rider for that floor exits.
+
+## Scripted control
+
+Games can drive the sim outside the normal rider flow:
+
+```rust,ignore
+// An NPC walks up and presses the down button.
+sim.press_hall_button(lobby, CallDirection::Down)?;
+
+// Cutscene pins the villain's elevator to the penthouse.
+sim.pin_assignment(villain_car, penthouse, CallDirection::Up)?;
+
+// Player hijacks — release the pin, clear the car's existing queue.
+sim.unpin_assignment(penthouse, CallDirection::Up);
+sim.clear_destinations(villain_car)?;
+```
+
+Pin enforcement mirrors the idle-pool eligibility gate: a car in
+`Loading` / `DoorOpening` / `DoorClosing` finishes its current door
+cycle first; the pin is honored on the next dispatch tick. Pins that
+cross lines (the car's line can't reach the stop) return
+`SimError::InvalidState` rather than silently orphaning the call.
+
+## Rider balking
+
+[`Preferences`][preferences] has two knobs for game-designer-tuned
+rider behavior:
+
+- `balk_threshold_ticks: Option<u32>` — abandon after `N` ticks of
+  waiting time (uses `Patience::waited_ticks` when present so multi-
+  leg routes don't over-count ride time).
+- `rebalk_on_full: bool` — when set, a rider who is filtered out of a
+  car via `skip_full_elevator` abandons immediately rather than
+  waiting for the next one. Emits `RiderAbandoned` on the spot.
+
+Both emit dedicated events (`RiderBalked`, `RiderAbandoned`) so game
+UI can react to individual behavioral beats.
+
+## Public query API
+
+| Method | Purpose |
+|--------|---------|
+| [`Simulation::hall_calls()`][hall-calls-iter] | Iterator over every active hall call — lobby lamp panels, per-floor button animation |
+| [`Simulation::car_calls(car)`][car-calls-method] | Floor buttons currently pressed inside `car` — cab button-panel render |
+| [`Simulation::assigned_car(stop, direction)`][assigned-car] | DCS-style "your elevator will be car B" indicator |
+| [`Simulation::eta_for_call(stop, direction)`][eta-for-call] | Countdown timer for hall displays |
+
+## Events
+
+| Event | When | Notes |
+|-------|------|-------|
+| `HallButtonPressed` | First press per (stop, direction) | Pre-latency; use for button-light animation |
+| `HallCallAcknowledged` | Ack-latency window elapsed | UI confirmation signal |
+| `HallCallCleared` | Assigned car opens doors at stop | Clears the button light |
+| `CarButtonPressed` | First press per (car, floor) | `rider` is `None` for synthetic presses |
+| `RiderBalked` | Preference filter rejects a candidate car | Rider may still board a later car unless `rebalk_on_full` |
+
+## FFI
+
+Unity / native consumers can drive the call layer through the
+`elevator-ffi` C ABI. See `ev_sim_press_hall_button`,
+`ev_sim_press_car_button`, `ev_sim_pin_assignment`,
+`ev_sim_unpin_assignment`, `ev_sim_assigned_car`,
+`ev_sim_eta_for_call`, and the `EvHallCall` snapshot record.
+
+[hall-call]: ../api-reference.html
+[car-call]: ../api-reference.html
+[hall-call-mode]: ../api-reference.html
+[destination-dispatch]: dispatch.html
+[preferences]: ../api-reference.html
+[hall-calls-iter]: ../api-reference.html
+[car-calls-method]: ../api-reference.html
+[assigned-car]: ../api-reference.html
+[eta-for-call]: ../api-reference.html


### PR DESCRIPTION
## Summary

Builds a flexible elevator mechanic for game lib use. Foundational refactor modelling real elevator behaviour: separate hall/car calls, controller ack latency, dispatcher pinning, and pre-pickup mid-trip reassignment.

### What's new

**Call model** (`crates/elevator-core/src/components/`)
- `HallCall` — per (stop, direction) button state with press tick, ack tracking, pending riders, optional destination (DCS), assigned car, and pin flag.
- `CarCall` — per-car floor buttons pressed after boarding (Classic mode).
- `CallDirection` enum + helpers.
- `HallCallMode { Classic, Destination }` per `ElevatorGroup` with per-group `ack_latency_ticks`.

**Sim API**
- `press_hall_button(stop, direction)` / `press_car_button(car, floor)` — explicit scripted presses.
- `pin_assignment(car, stop, direction)` / `unpin_assignment(stop, direction)` — force a specific car for a call.
- `assigned_car(stop, direction)` / `eta_for_call(stop, direction)` — read-only queries for lobby displays.
- `spawn_rider` auto-presses the hall button based on route direction.

**Events** (5 new)
- `HallButtonPressed`, `HallCallAcknowledged`, `HallCallCleared`, `CarButtonPressed`, `RiderBalked`.

**Phase wiring**
- `advance_transient`: ticks ack-latency counters, emits `HallCallAcknowledged`, enforces `Preferences::balk_threshold_ticks` abandonment.
- `loading`: creates `CarCall` per boarded rider + emits `CarButtonPressed`; emits `RiderBalked` for full-car filter rejections.
- `doors`: clears hall calls at the arrival stop on door-open, emits `HallCallCleared`.
- `dispatch`: honors pinned calls (bypasses Hungarian), includes pre-pickup empty cars in the idle pool for mid-trip reassignment, mirrors dispatcher's choice into `HallCall::assigned_car`.

**Preferences**
- `balk_threshold_ticks: Option<u32>`, `rebalk_on_full: bool`.

**Tests** (+7)
- Auto-press on spawn, multi-rider aggregation, explicit press without rider, pinning, zero-latency ack, door-open clearing, pin-forces-specific-car.

## Breaking changes

- `Preferences` literal constructions need the two new fields (all internal test sites updated).
- `ElevatorGroup` gains `hall_call_mode` + `ack_latency_ticks` with `Default` falling back to Classic + 0 — no behaviour change for existing configs.

Deferred to a follow-up (see branch-local note in task list):
- DispatchManifest extension so strategies can consume `hall_calls`/`car_calls` directly.
- `DestinationDispatch` gating on `HallCallMode::Destination`.
- FFI coverage for press/query/pin.
- mdBook \"Hall Calls\" chapter.

## Test plan

- [ ] `cargo test --workspace --all-targets` (539 lib tests green)
- [ ] `cargo clippy --workspace --all-targets` clean
- [ ] Run the Bevy sim — confirm `HallButtonPressed` / `HallCallCleared` fire per floor; only one car per call.
- [ ] Script a scene that calls `sim.pin_assignment` and verify the right car arrives.