### PR TITLE
fix: persist hall/car calls and group hall mode in snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ mutants.out/
 mutants.out.old/
 .claude/agent-memory-local/
 .claude/*.lock
+.claude/worktrees/
 .idea/
 .vscode/
 *.code-workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "5.10.0"
+version = "6.0.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -8,8 +8,8 @@
 //! own extensions separately and re-attach them after restoring.
 
 use crate::components::{
-    AccessControl, DestinationQueue, Elevator, Line, Patience, Position, Preferences, Rider, Route,
-    Stop, Velocity,
+    AccessControl, CarCall, DestinationQueue, Elevator, HallCall, Line, Patience, Position,
+    Preferences, Rider, Route, Stop, Velocity,
 };
 use crate::entity::EntityId;
 use crate::ids::GroupId;
@@ -62,6 +62,9 @@ pub struct EntitySnapshot {
     /// Destination queue (per-elevator; absent in legacy snapshots).
     #[serde(default)]
     pub destination_queue: Option<DestinationQueue>,
+    /// Car calls pressed inside this elevator (per-car; absent in legacy snapshots).
+    #[serde(default)]
+    pub car_calls: Vec<CarCall>,
 }
 
 /// Serializable snapshot of the entire simulation state.
@@ -93,6 +96,9 @@ pub struct WorldSnapshot {
     pub extensions: HashMap<String, HashMap<EntityId, String>>,
     /// Ticks per second (for `TimeAdapter` reconstruction).
     pub ticks_per_second: f64,
+    /// All pending hall calls across every stop. Absent in legacy snapshots.
+    #[serde(default)]
+    pub hall_calls: Vec<HallCall>,
 }
 
 /// Per-line snapshot info within a group.
@@ -125,6 +131,12 @@ pub struct GroupSnapshot {
     /// Optional repositioning strategy for idle elevators.
     #[serde(default)]
     pub reposition: Option<crate::dispatch::BuiltinReposition>,
+    /// Hall call mode for this group. Legacy snapshots default to `Classic`.
+    #[serde(default)]
+    pub hall_call_mode: crate::dispatch::HallCallMode,
+    /// Controller ack latency in ticks. Legacy snapshots default to `0`.
+    #[serde(default)]
+    pub ack_latency_ticks: u32,
 }
 
 /// Pending extension data from a snapshot, awaiting type registration.
@@ -163,6 +175,9 @@ impl WorldSnapshot {
 
         // Phase 2: attach components with remapped EntityIds.
         Self::attach_components(&mut world, &self.entities, &index_to_id, &id_remap);
+
+        // Phase 2b: re-register hall calls (cross-reference stops/cars/riders).
+        self.attach_hall_calls(&mut world, &id_remap);
 
         // Rebuild sorted stops index.
         let mut sorted: Vec<(f64, EntityId)> = world
@@ -362,6 +377,51 @@ impl WorldSnapshot {
                 }
                 world.set_destination_queue(eid, new_dq);
             }
+            Self::attach_car_calls(world, eid, &snap.car_calls, id_remap);
+        }
+    }
+
+    /// Re-register per-car floor button presses after entities are spawned.
+    fn attach_car_calls(
+        world: &mut crate::world::World,
+        car: EntityId,
+        car_calls: &[CarCall],
+        id_remap: &HashMap<EntityId, EntityId>,
+    ) {
+        if car_calls.is_empty() {
+            return;
+        }
+        let remap = |old: EntityId| -> EntityId { id_remap.get(&old).copied().unwrap_or(old) };
+        let Some(slot) = world.car_calls_mut(car) else {
+            return;
+        };
+        for cc in car_calls {
+            let mut c = cc.clone();
+            c.car = car;
+            c.floor = remap(c.floor);
+            c.pending_riders = c.pending_riders.iter().map(|&r| remap(r)).collect();
+            slot.push(c);
+        }
+    }
+
+    /// Re-register hall calls in the world after entities are spawned.
+    ///
+    /// `HallCall` cross-references stops, cars, riders, and optional
+    /// destinations — all `EntityId`s must be remapped through `id_remap`.
+    fn attach_hall_calls(
+        &self,
+        world: &mut crate::world::World,
+        id_remap: &HashMap<EntityId, EntityId>,
+    ) {
+        let remap = |old: EntityId| -> EntityId { id_remap.get(&old).copied().unwrap_or(old) };
+        let remap_opt = |old: Option<EntityId>| -> Option<EntityId> { old.map(&remap) };
+        for hc in &self.hall_calls {
+            let mut c = hc.clone();
+            c.stop = remap(c.stop);
+            c.destination = remap_opt(c.destination);
+            c.assigned_car = remap_opt(c.assigned_car);
+            c.pending_riders = c.pending_riders.iter().map(|&r| remap(r)).collect();
+            world.set_hall_call(c);
         }
     }
 
@@ -423,6 +483,8 @@ impl WorldSnapshot {
                 };
 
                 ElevatorGroup::new(gs.id, gs.name.clone(), lines)
+                    .with_hall_call_mode(gs.hall_call_mode)
+                    .with_ack_latency_ticks(gs.ack_latency_ticks)
             })
             .collect();
 
@@ -533,6 +595,7 @@ impl crate::sim::Simulation {
                 energy_metrics: world.energy_metrics(eid).cloned(),
                 service_mode: world.service_mode(eid).copied(),
                 destination_queue: world.destination_queue(eid).cloned(),
+                car_calls: world.car_calls(eid).to_vec(),
             })
             .collect();
 
@@ -580,6 +643,8 @@ impl crate::sim::Simulation {
                         .unwrap_or(crate::dispatch::BuiltinStrategy::Scan),
                     lines,
                     reposition: self.reposition_id(g.id()).cloned(),
+                    hall_call_mode: g.hall_call_mode(),
+                    ack_latency_ticks: g.ack_latency_ticks(),
                 }
             })
             .collect();
@@ -604,6 +669,7 @@ impl crate::sim::Simulation {
                 .unwrap_or_default(),
             extensions: self.world().serialize_extensions(),
             ticks_per_second: 1.0 / self.dt(),
+            hall_calls: world.iter_hall_calls().cloned().collect(),
         }
     }
 

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -413,9 +413,14 @@ fn snapshot_preserves_hall_calls_and_pinning() {
         .expect("hall call should survive snapshot/restore");
     assert_eq!(call.direction, CallDirection::Up);
     assert!(call.pinned, "pinning flag must round-trip");
+    let assigned = call
+        .assigned_car
+        .expect("assigned_car must round-trip through restore");
     assert!(
-        call.assigned_car.is_some(),
-        "assigned_car must round-trip (remapped to new EntityId)"
+        restored.world().elevator(assigned).is_some(),
+        "assigned_car must point to a live elevator in the restored \
+         world — a dangling (un-remapped) EntityId would slip past an \
+         is_some() check",
     );
 }
 

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -390,3 +390,109 @@ fn snapshot_bytes_midrun_determinism() {
         via_snapshot.metrics().total_moves(),
     );
 }
+
+#[test]
+fn snapshot_preserves_hall_calls_and_pinning() {
+    use crate::components::CallDirection;
+
+    let config = helpers::default_config();
+    let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+
+    let stop = sim.stop_entity(StopId(1)).unwrap();
+    let car = sim.world().elevator_ids()[0];
+    sim.press_hall_button(stop, CallDirection::Up).unwrap();
+    sim.pin_assignment(car, stop, CallDirection::Up).unwrap();
+
+    let snap = sim.snapshot();
+    let restored = snap.restore(None);
+
+    let restored_stop = restored.stop_entity(StopId(1)).unwrap();
+    let call = restored
+        .world()
+        .hall_call(restored_stop, CallDirection::Up)
+        .expect("hall call should survive snapshot/restore");
+    assert_eq!(call.direction, CallDirection::Up);
+    assert!(call.pinned, "pinning flag must round-trip");
+    assert!(
+        call.assigned_car.is_some(),
+        "assigned_car must round-trip (remapped to new EntityId)"
+    );
+}
+
+#[test]
+fn snapshot_preserves_car_calls() {
+    let config = helpers::default_config();
+    let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+
+    let car = sim.world().elevator_ids()[0];
+    let floor = sim.stop_entity(StopId(2)).unwrap();
+    sim.press_car_button(car, floor).unwrap();
+    assert_eq!(sim.car_calls(car).len(), 1);
+
+    let snap = sim.snapshot();
+    let restored = snap.restore(None);
+
+    let restored_car = restored.world().elevator_ids()[0];
+    let calls = restored.car_calls(restored_car);
+    assert_eq!(calls.len(), 1, "car call must round-trip");
+    // Floor reference must have been remapped to a valid stop entity.
+    assert!(restored.world().stop(calls[0].floor).is_some());
+}
+
+#[test]
+fn snapshot_preserves_group_hall_mode_and_ack_latency() {
+    use crate::dispatch::HallCallMode;
+
+    let config = helpers::default_config();
+    let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+    sim.groups_mut()[0].set_hall_call_mode(HallCallMode::Destination);
+    sim.groups_mut()[0].set_ack_latency_ticks(12);
+
+    let snap = sim.snapshot();
+    let restored = snap.restore(None);
+
+    assert_eq!(
+        restored.groups()[0].hall_call_mode(),
+        HallCallMode::Destination,
+    );
+    assert_eq!(restored.groups()[0].ack_latency_ticks(), 12);
+}
+
+#[test]
+fn snapshot_preserves_hall_call_ack_state_under_latency() {
+    use crate::components::CallDirection;
+    use crate::dispatch::HallCallMode;
+
+    let config = helpers::default_config();
+    let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+    sim.groups_mut()[0].set_hall_call_mode(HallCallMode::Destination);
+    sim.groups_mut()[0].set_ack_latency_ticks(10);
+
+    let stop = sim.stop_entity(StopId(1)).unwrap();
+    sim.press_hall_button(stop, CallDirection::Up).unwrap();
+    // Advance a few ticks so the ack-latency counter has started ticking
+    // but not yet expired — we must preserve the partial state.
+    for _ in 0..3 {
+        sim.step();
+    }
+    let original_press_tick = sim
+        .world()
+        .hall_call(stop, CallDirection::Up)
+        .unwrap()
+        .press_tick;
+
+    let snap = sim.snapshot();
+    let restored = snap.restore(None);
+
+    let restored_stop = restored.stop_entity(StopId(1)).unwrap();
+    let call = restored
+        .world()
+        .hall_call(restored_stop, CallDirection::Up)
+        .unwrap();
+    assert_eq!(call.press_tick, original_press_tick);
+    assert!(
+        !call.is_acknowledged(),
+        "call should still be pending ack after 3 of 10 latency ticks"
+    );
+    assert_eq!(call.ack_latency_ticks, 10);
+}


### PR DESCRIPTION
## Summary

Snapshot/restore was silently dropping every piece of state introduced by #91: pressed \`HallCall\`s, \`CarCall\`s, pin flags, ack-latency counters, and per-group \`HallCallMode\` / \`ack_latency_ticks\`. A save taken mid-scenario restored to a group running \`Classic\` mode with zero latency and no pending button presses — replays diverged on the first tick.

## Changes

- \`EntitySnapshot\` gains \`car_calls: Vec<CarCall>\` (per-car, \`#[serde(default)]\`).
- \`WorldSnapshot\` gains \`hall_calls: Vec<HallCall>\` — flat top-level list, since each \`HallCall\` already carries its \`stop\` and cross-references \`destination\` / \`assigned_car\` / \`pending_riders\` on *other* entities; flat keeps the remap simple.
- \`GroupSnapshot\` gains \`hall_call_mode\` + \`ack_latency_ticks\` with \`#[serde(default)]\` so pre-#91 snapshots continue to deserialize as \`Classic\` + \`0\` (no behavior change on legacy restores).

On \`restore()\`:
- Per-car \`CarCall\`s remap \`floor\` + \`pending_riders\` through the existing \`id_remap\` (extracted to \`attach_car_calls\` helper to keep \`attach_components\` under the clippy line limit).
- Hall calls are attached in a new \`attach_hall_calls\` phase after entity rebuild, remapping \`stop\`, \`destination\`, \`assigned_car\`, and \`pending_riders\`.
- \`ElevatorGroup\` builder chain picks up \`with_hall_call_mode\` + \`with_ack_latency_ticks\`.

## Tests

Four new roundtrip tests in \`snapshot_tests.rs\`:

1. \`snapshot_preserves_hall_calls_and_pinning\` — pressed call + pinned assignment survive; \`assigned_car\` is remapped to the new \`EntityId\`.
2. \`snapshot_preserves_car_calls\` — \`press_car_button\` state round-trips; \`floor\` is remapped.
3. \`snapshot_preserves_group_hall_mode_and_ack_latency\` — \`Destination\` mode + \`ack_latency_ticks = 12\` round-trip.
4. \`snapshot_preserves_hall_call_ack_state_under_latency\` — call pressed at tick T with 10-tick latency, ticked 3 times, snapshotted mid-ack: \`press_tick\`, \`ack_latency_ticks\`, and pending-ack status all preserve correctly (locks in the determinism invariant).

Wire format is additively backwards-compatible — pre-#93 snapshots still deserialize because every new field uses \`#[serde(default)]\`.

## Test plan

- [x] \`cargo test -p elevator-core\` (553 tests green, 4 new)
- [x] \`cargo clippy -p elevator-core --all-targets -- -D warnings\` clean
- [x] \`cargo check --workspace --all-targets\` clean (FFI + Bevy still build)
- [ ] Greptile review

Fixes #93