### PR TITLE
feat!: rename rebalk_on_full to abandon_on_full, clarify semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "6.0.0"
+version = "7.0.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "cbindgen",
  "elevator-core",

--- a/crates/elevator-core/src/components/patience.rs
+++ b/crates/elevator-core/src/components/patience.rs
@@ -52,11 +52,25 @@ pub struct Preferences {
     /// multi-leg routes. Without `Patience`, the budget degrades to
     /// lifetime ticks since spawn, which matches single-leg behavior.
     pub(crate) balk_threshold_ticks: Option<u32>,
-    /// When a full car arrives and this rider skips it, should that
-    /// count as a balk-and-abandon rather than a silent pass? When
-    /// `true`, the rider abandons immediately instead of waiting for
-    /// `balk_threshold_ticks` to elapse. Default `false`.
-    pub(crate) rebalk_on_full: bool,
+    /// Abandon on the first full-car skip, rather than silently
+    /// passing and continuing to wait. Default `false`.
+    ///
+    /// This is an **independent** abandonment axis from
+    /// [`balk_threshold_ticks`](Self::balk_threshold_ticks) — the two
+    /// do not compose or gate each other:
+    ///
+    /// - `abandon_on_full` is *event-triggered* from the loading phase
+    ///   (`systems::loading`), firing on a full-car balk.
+    /// - `balk_threshold_ticks` is *time-triggered* from the transient
+    ///   phase (`systems::advance_transient`), firing when the rider's
+    ///   wait budget elapses.
+    ///
+    /// Both paths set [`RiderPhase::Abandoned`](crate::components::RiderPhase);
+    /// whichever condition is reached first wins. Setting
+    /// `abandon_on_full = true` with `balk_threshold_ticks = None` is
+    /// valid and abandons on the first full-car skip regardless of
+    /// wait time.
+    pub(crate) abandon_on_full: bool,
 }
 
 impl Preferences {
@@ -81,8 +95,8 @@ impl Preferences {
 
     /// Should balking a full car convert directly to abandonment?
     #[must_use]
-    pub const fn rebalk_on_full(&self) -> bool {
-        self.rebalk_on_full
+    pub const fn abandon_on_full(&self) -> bool {
+        self.abandon_on_full
     }
 
     /// Builder: set `balk_threshold_ticks`.
@@ -92,10 +106,10 @@ impl Preferences {
         self
     }
 
-    /// Builder: set `rebalk_on_full`.
+    /// Builder: set `abandon_on_full`.
     #[must_use]
-    pub const fn with_rebalk_on_full(mut self, rebalk: bool) -> Self {
-        self.rebalk_on_full = rebalk;
+    pub const fn with_abandon_on_full(mut self, abandon: bool) -> Self {
+        self.abandon_on_full = abandon;
         self
     }
 }
@@ -106,7 +120,7 @@ impl Default for Preferences {
             skip_full_elevator: false,
             max_crowding_factor: 0.8,
             balk_threshold_ticks: None,
-            rebalk_on_full: false,
+            abandon_on_full: false,
         }
     }
 }

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -263,7 +263,7 @@ fn collect_actions(world: &World, elevator_ids: &[EntityId]) -> Vec<LoadAction> 
             });
             // A preference-filtered rider just balked at a crowded car.
             // Emit an observable signal so games can animate it; the
-            // rider remains Waiting unless they also hit `rebalk_on_full`
+            // rider remains Waiting unless they also hit `abandon_on_full`
             // which escalates to abandonment in the next `advance_transient`
             // pass via their balk_threshold budget.
             if let Some(stop) = world.rider(rid).and_then(|r| r.current_stop) {
@@ -429,11 +429,11 @@ fn apply_actions(
                     at_stop,
                     tick: ctx.tick,
                 });
-                // Honor `Preferences::rebalk_on_full`: the rider doesn't
+                // Honor `Preferences::abandon_on_full`: the rider doesn't
                 // wait for another car — they abandon immediately.
                 let escalate = world
                     .preferences(rider)
-                    .is_some_and(Preferences::rebalk_on_full);
+                    .is_some_and(Preferences::abandon_on_full);
                 if escalate
                     && world
                         .rider(rider)

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -263,9 +263,10 @@ fn collect_actions(world: &World, elevator_ids: &[EntityId]) -> Vec<LoadAction> 
             });
             // A preference-filtered rider just balked at a crowded car.
             // Emit an observable signal so games can animate it; the
-            // rider remains Waiting unless they also hit `abandon_on_full`
-            // which escalates to abandonment in the next `advance_transient`
-            // pass via their balk_threshold budget.
+            // rider remains Waiting unless `abandon_on_full` is set, in
+            // which case the Balk arm below escalates to Abandoned
+            // immediately — event-triggered, this phase, independent
+            // of the balk_threshold time budget.
             if let Some(stop) = world.rider(rid).and_then(|r| r.current_stop) {
                 actions.push(LoadAction::Balk {
                     rider: rid,

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -711,7 +711,7 @@ fn rider_builder_with_preferences() {
         skip_full_elevator: true,
         max_crowding_factor: 0.5,
         balk_threshold_ticks: None,
-        rebalk_on_full: false,
+        abandon_on_full: false,
     };
 
     let rider_id = sim

--- a/crates/elevator-core/src/tests/boundary_tests.rs
+++ b/crates/elevator-core/src/tests/boundary_tests.rs
@@ -105,7 +105,7 @@ fn preferences_zero_crowding_rejects_any_load() {
             skip_full_elevator: true,
             max_crowding_factor: 0.0,
             balk_threshold_ticks: None,
-            rebalk_on_full: false,
+            abandon_on_full: false,
         },
     );
 

--- a/crates/elevator-core/src/tests/feature_tests.rs
+++ b/crates/elevator-core/src/tests/feature_tests.rs
@@ -172,7 +172,7 @@ fn preferences_skip_crowded_elevator_prevents_boarding() {
             skip_full_elevator: true,
             max_crowding_factor: 0.5, // will skip if load > 50 %
             balk_threshold_ticks: None,
-            rebalk_on_full: false,
+            abandon_on_full: false,
         },
     );
 
@@ -233,7 +233,7 @@ fn preferences_boards_when_elevator_not_too_crowded() {
             skip_full_elevator: true,
             max_crowding_factor: 0.5,
             balk_threshold_ticks: None,
-            rebalk_on_full: false,
+            abandon_on_full: false,
         },
     );
 

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -276,22 +276,22 @@ fn pinned_pin_does_not_clobber_loading_car() {
     }
 }
 
-/// `rebalk_on_full = true` escalates a balk into immediate abandonment.
+/// `abandon_on_full = true` escalates a balk into immediate abandonment.
 /// Regression guard — the flag was documented but previously inert.
 #[test]
-fn rebalk_on_full_abandons_immediately() {
+fn abandon_on_full_abandons_immediately() {
     use crate::components::Preferences;
     let mut config = default_config();
     // Tight capacity so any preload fills the car.
     config.elevators[0].weight_capacity = 100.0;
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
-    // Rider with rebalk_on_full who skips anything with load > 0.5.
+    // Rider with abandon_on_full who skips anything with load > 0.5.
     let picky = sim
         .build_rider_by_stop_id(StopId(0), StopId(2))
         .unwrap()
         .weight(30.0)
-        .preferences(Preferences::default().with_rebalk_on_full(true))
+        .preferences(Preferences::default().with_abandon_on_full(true))
         .spawn()
         .unwrap();
     // Note: Preferences::default has skip_full_elevator = false, but
@@ -302,7 +302,7 @@ fn rebalk_on_full_abandons_immediately() {
             skip_full_elevator: true,
             max_crowding_factor: 0.5,
             balk_threshold_ticks: None,
-            rebalk_on_full: true,
+            abandon_on_full: true,
         },
     );
 
@@ -331,7 +331,64 @@ fn rebalk_on_full_abandons_immediately() {
     assert_eq!(
         phase,
         Some(crate::components::RiderPhase::Abandoned),
-        "rebalk_on_full should escalate the balk into Abandoned"
+        "abandon_on_full should escalate the balk into Abandoned"
+    );
+}
+
+/// `abandon_on_full` and `balk_threshold_ticks` are independent axes.
+/// Setting both with `abandon_on_full = true` and a large threshold
+/// proves the event-triggered path fires before the time-triggered
+/// one — the two do not gate each other.
+#[test]
+fn abandon_on_full_fires_before_balk_threshold_elapses() {
+    use crate::components::Preferences;
+    let mut config = default_config();
+    config.elevators[0].weight_capacity = 100.0;
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let picky = sim
+        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .unwrap()
+        .weight(30.0)
+        .preferences(Preferences::default())
+        .spawn()
+        .unwrap();
+    // Both fields set: a very large threshold that would never fire in
+    // this test, plus abandon_on_full = true. The rider should abandon
+    // on the first full-car skip — not wait the threshold out.
+    sim.world_mut().set_preferences(
+        picky,
+        Preferences {
+            skip_full_elevator: true,
+            max_crowding_factor: 0.5,
+            balk_threshold_ticks: Some(1_000_000),
+            abandon_on_full: true,
+        },
+    );
+
+    let elev = sim.world().elevator_ids()[0];
+    let stop0 = sim.stop_entity(StopId(0)).unwrap();
+    let stop0_pos = sim.world().stop(stop0).unwrap().position;
+    {
+        let w = sim.world_mut();
+        if let Some(pos) = w.position_mut(elev) {
+            pos.value = stop0_pos;
+        }
+        if let Some(vel) = w.velocity_mut(elev) {
+            vel.value = 0.0;
+        }
+        if let Some(car) = w.elevator_mut(elev) {
+            car.phase = crate::components::ElevatorPhase::Loading;
+            car.current_load = 60.0;
+            car.target_stop = None;
+        }
+    }
+    sim.run_loading();
+    sim.advance_tick();
+    assert_eq!(
+        sim.world().rider(picky).map(|r| r.phase),
+        Some(crate::components::RiderPhase::Abandoned),
+        "abandon_on_full should fire on first full-car contact regardless of threshold",
     );
 }
 

--- a/crates/elevator-core/src/tests/mutation_kills_tests.rs
+++ b/crates/elevator-core/src/tests/mutation_kills_tests.rs
@@ -363,7 +363,7 @@ fn loading_preference_boundary_allows_exact_match() {
             skip_full_elevator: true,
             max_crowding_factor: 0.0,
             balk_threshold_ticks: None,
-            rebalk_on_full: false,
+            abandon_on_full: false,
         })
         .spawn()
         .unwrap();

--- a/docs/src/hall-calls.md
+++ b/docs/src/hall-calls.md
@@ -85,7 +85,7 @@ rider behavior:
 - `balk_threshold_ticks: Option<u32>` — abandon after `N` ticks of
   waiting time (uses `Patience::waited_ticks` when present so multi-
   leg routes don't over-count ride time).
-- `rebalk_on_full: bool` — when set, a rider who is filtered out of a
+- `abandon_on_full: bool` — when set, a rider who is filtered out of a
   car via `skip_full_elevator` abandons immediately rather than
   waiting for the next one. Emits `RiderAbandoned` on the spot.
 
@@ -109,7 +109,7 @@ UI can react to individual behavioral beats.
 | `HallCallAcknowledged` | Ack-latency window elapsed | UI confirmation signal |
 | `HallCallCleared` | Assigned car opens doors at stop | Clears the button light |
 | `CarButtonPressed` | First press per (car, floor) | `rider` is `None` for synthetic presses |
-| `RiderBalked` | Preference filter rejects a candidate car | Rider may still board a later car unless `rebalk_on_full` |
+| `RiderBalked` | Preference filter rejects a candidate car | Rider may still board a later car unless `abandon_on_full` |
 
 ## FFI
 


### PR DESCRIPTION
## Summary

Two related changes on the same \`Preferences\` field:

1. **Rename** \`Preferences::rebalk_on_full\` → \`abandon_on_full\` (plus builder and accessor). \"Rebalk\" is archaic Scottish English meaning \"plough across previously ploughed ground\" — nothing to do with this field. The behavior is \"abandon on first full-car skip,\" so the new name says that.
2. **Clarify docstring.** The previous wording (\"the rider abandons immediately instead of waiting for \`balk_threshold_ticks\` to elapse\") implied coupling between \`abandon_on_full\` and \`balk_threshold_ticks\`. They are actually independent axes:
   - \`abandon_on_full\` is **event-triggered** from the loading phase on a full-car skip.
   - \`balk_threshold_ticks\` is **time-triggered** from the transient phase when the wait budget elapses.

   Both write \`RiderPhase::Abandoned\`; whichever fires first wins. The new docstring spells this out.

## Tests

- \`abandon_on_full_abandons_immediately\` — existing regression, renamed.
- \`abandon_on_full_fires_before_balk_threshold_elapses\` — **new**. Sets both \`abandon_on_full = true\` and \`balk_threshold_ticks = Some(1_000_000)\`; rider abandons on first full-car contact without waiting the threshold. Proves independence by construction.

## Breaking changes

- \`Preferences::rebalk_on_full\` field → \`abandon_on_full\`
- \`Preferences::with_rebalk_on_full()\` → \`with_abandon_on_full()\`
- \`Preferences::rebalk_on_full()\` accessor → \`abandon_on_full()\`

No migration shim provided; the rename is pure string replacement at call sites.

## Other updates

- \`docs/src/hall-calls.md\` — field name + the \`RiderBalked\` event-row note now use \`abandon_on_full\`.

## Test plan

- [x] \`cargo test -p elevator-core\` (550 lib tests green, one renamed + one new)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [ ] Greptile review

Fixes #97