### PR TITLE
feat: expose hall_calls and car_calls on DispatchManifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "7.0.0"
+version = "8.0.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -154,6 +154,10 @@ impl DispatchManifest {
     }
 
     /// All hall calls across every stop in the group (flattened iterator).
+    ///
+    /// No `#[must_use]` needed: `impl Iterator` already carries that
+    /// annotation, and adding our own triggers clippy's
+    /// `double_must_use` lint.
     pub fn iter_hall_calls(&self) -> impl Iterator<Item = &HallCall> {
         self.hall_calls_at_stop.values().flatten()
     }

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -66,6 +66,7 @@ pub use scan::ScanDispatch;
 
 use serde::{Deserialize, Serialize};
 
+use crate::components::{CallDirection, CarCall, HallCall};
 use crate::entity::EntityId;
 use crate::ids::GroupId;
 use crate::world::World;
@@ -99,6 +100,15 @@ pub struct DispatchManifest {
     pub riding_to_stop: BTreeMap<EntityId, Vec<RiderInfo>>,
     /// Number of residents at each stop (read-only hint for dispatch strategies).
     pub resident_count_at_stop: BTreeMap<EntityId, usize>,
+    /// Pending hall calls at each stop — at most two entries per stop
+    /// (one per [`CallDirection`]). Populated only for stops served by
+    /// the group being dispatched. Strategies read this to rank based on
+    /// call age, pending-rider count, pin flags, or DCS destinations.
+    pub hall_calls_at_stop: BTreeMap<EntityId, Vec<HallCall>>,
+    /// Floor buttons pressed inside each car in the group. Keyed by car
+    /// entity. Strategies read this to plan intermediate stops without
+    /// poking into `World` directly.
+    pub car_calls_by_car: BTreeMap<EntityId, Vec<CarCall>>,
 }
 
 impl DispatchManifest {
@@ -132,6 +142,27 @@ impl DispatchManifest {
     #[must_use]
     pub fn resident_count_at(&self, stop: EntityId) -> usize {
         self.resident_count_at_stop.get(&stop).copied().unwrap_or(0)
+    }
+
+    /// The hall call at `(stop, direction)`, if pressed.
+    #[must_use]
+    pub fn hall_call_at(&self, stop: EntityId, direction: CallDirection) -> Option<&HallCall> {
+        self.hall_calls_at_stop
+            .get(&stop)?
+            .iter()
+            .find(|c| c.direction == direction)
+    }
+
+    /// All hall calls across every stop in the group (flattened iterator).
+    pub fn iter_hall_calls(&self) -> impl Iterator<Item = &HallCall> {
+        self.hall_calls_at_stop.values().flatten()
+    }
+
+    /// Floor buttons currently pressed inside `car`. Empty slice if the
+    /// car has no aboard riders or no outstanding presses.
+    #[must_use]
+    pub fn car_calls_for(&self, car: EntityId) -> &[CarCall] {
+        self.car_calls_by_car.get(&car).map_or(&[], Vec::as_slice)
     }
 }
 

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -390,20 +390,36 @@ fn build_manifest(
 
     // Populate hall calls at group's stops. Strategies read these for
     // call age, pending-rider count, pin flags, and DCS destinations.
+    //
+    // Filter on `is_acknowledged()` so nonzero `ack_latency_ticks`
+    // actually hides calls from dispatch until the controller has
+    // surfaced them — matches `HallCall::is_acknowledged`'s contract
+    // ("when dispatch is allowed to see this call").
     for &stop in group.stop_entities() {
         if let Some(stop_calls) = world.stop_calls(stop) {
-            let calls: Vec<_> = stop_calls.iter().cloned().collect();
+            let calls: Vec<_> = stop_calls
+                .iter()
+                .filter(|c| c.is_acknowledged())
+                .cloned()
+                .collect();
             if !calls.is_empty() {
                 manifest.hall_calls_at_stop.insert(stop, calls);
             }
         }
     }
 
-    // Populate car calls for each car in the group.
+    // Populate car calls for each car in the group. Same ack filter —
+    // a car call pressed under latency shouldn't be planned against
+    // until the controller has registered it.
     for &car in group.elevator_entities() {
-        let calls = world.car_calls(car);
+        let calls: Vec<_> = world
+            .car_calls(car)
+            .iter()
+            .filter(|c| c.is_acknowledged())
+            .cloned()
+            .collect();
         if !calls.is_empty() {
-            manifest.car_calls_by_car.insert(car, calls.to_vec());
+            manifest.car_calls_by_car.insert(car, calls);
         }
     }
 

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -388,5 +388,24 @@ fn build_manifest(
         }
     }
 
+    // Populate hall calls at group's stops. Strategies read these for
+    // call age, pending-rider count, pin flags, and DCS destinations.
+    for &stop in group.stop_entities() {
+        if let Some(stop_calls) = world.stop_calls(stop) {
+            let calls: Vec<_> = stop_calls.iter().cloned().collect();
+            if !calls.is_empty() {
+                manifest.hall_calls_at_stop.insert(stop, calls);
+            }
+        }
+    }
+
+    // Populate car calls for each car in the group.
+    for &car in group.elevator_entities() {
+        let calls = world.car_calls(car);
+        if !calls.is_empty() {
+            manifest.car_calls_by_car.insert(car, calls.to_vec());
+        }
+    }
+
     manifest
 }

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -704,3 +704,122 @@ fn group_config_ron_defaults_to_classic_zero_latency() {
     assert_eq!(gc2.hall_call_mode, Some(HallCallMode::Destination));
     assert_eq!(gc2.ack_latency_ticks, Some(10));
 }
+
+/// A custom dispatch strategy can observe hall-call state via
+/// `DispatchManifest::hall_call_at(...)` without reaching into `World`
+/// directly. This exercises the #102 contract end-to-end.
+#[test]
+fn custom_strategy_reads_hall_calls_from_manifest() {
+    use crate::dispatch::{DispatchManifest, DispatchStrategy, ElevatorGroup};
+    use crate::world::World;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Records how many times `rank` observed the pressed up-call at
+    /// the target stop through the manifest.
+    struct Observer {
+        target_stop: Arc<std::sync::Mutex<Option<EntityId>>>,
+        saw_call: Arc<AtomicUsize>,
+    }
+
+    impl DispatchStrategy for Observer {
+        fn rank(
+            &mut self,
+            _car: EntityId,
+            car_pos: f64,
+            stop: EntityId,
+            stop_pos: f64,
+            _group: &ElevatorGroup,
+            manifest: &DispatchManifest,
+            _world: &World,
+        ) -> Option<f64> {
+            let target = *self.target_stop.lock().unwrap();
+            if Some(stop) == target && manifest.hall_call_at(stop, CallDirection::Up).is_some() {
+                self.saw_call.fetch_add(1, Ordering::Relaxed);
+            }
+            Some((car_pos - stop_pos).abs())
+        }
+    }
+
+    let saw_call = Arc::new(AtomicUsize::new(0));
+    let target_stop = Arc::new(std::sync::Mutex::new(None));
+    let observer = Observer {
+        target_stop: Arc::clone(&target_stop),
+        saw_call: Arc::clone(&saw_call),
+    };
+    let mut sim = Simulation::new(&default_config(), observer).unwrap();
+    let stop = sim.stop_entity(StopId(0)).unwrap();
+    *target_stop.lock().unwrap() = Some(stop);
+    // Spawning a rider auto-presses the up-button at stop 0 AND
+    // registers waiting demand there, so `dispatch::assign` will
+    // consider stop 0 a candidate and call `rank` for it.
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+
+    // One tick runs dispatch, building the manifest with the pressed
+    // hall call at stop 0 and calling `rank(car, stop)` for every
+    // (car, stop) pair with demand. The observer fires whenever it
+    // sees a hall call at the target stop through the manifest.
+    sim.step();
+    assert!(
+        saw_call.load(Ordering::Relaxed) > 0,
+        "strategy should see the pressed hall call through DispatchManifest::hall_call_at",
+    );
+}
+
+/// Car calls are exposed to dispatch strategies via
+/// `DispatchManifest::car_calls_for(car)`. After a rider boards, the
+/// car's in-cab floor button press is visible without reaching into
+/// `World`.
+#[test]
+fn custom_strategy_reads_car_calls_from_manifest() {
+    use crate::dispatch::{DispatchManifest, DispatchStrategy, ElevatorGroup};
+    use crate::world::World;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct Observer {
+        saw_car_call: Arc<AtomicUsize>,
+    }
+    impl DispatchStrategy for Observer {
+        fn rank(
+            &mut self,
+            car: EntityId,
+            car_pos: f64,
+            _stop: EntityId,
+            stop_pos: f64,
+            _group: &ElevatorGroup,
+            manifest: &DispatchManifest,
+            _world: &World,
+        ) -> Option<f64> {
+            if !manifest.car_calls_for(car).is_empty() {
+                self.saw_car_call.fetch_add(1, Ordering::Relaxed);
+            }
+            Some((car_pos - stop_pos).abs())
+        }
+    }
+
+    let saw = Arc::new(AtomicUsize::new(0));
+    let observer = Observer {
+        saw_car_call: Arc::clone(&saw),
+    };
+    let mut sim = Simulation::new(&default_config(), observer).unwrap();
+    // Spawn a rider — they press the hall call (creating dispatch demand)
+    // and on boarding will press a car button, which the strategy sees
+    // through `car_calls_for` as soon as dispatch runs next.
+    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .unwrap();
+    // Step until the rider boards and a car call exists; then one
+    // further step triggers a dispatch pass with the car call visible.
+    let car = sim.world().elevator_ids()[0];
+    for _ in 0..200 {
+        sim.step();
+        if !sim.car_calls(car).is_empty() && saw.load(Ordering::Relaxed) > 0 {
+            break;
+        }
+    }
+    assert!(
+        saw.load(Ordering::Relaxed) > 0,
+        "strategy should see car calls via DispatchManifest::car_calls_for once the rider boards",
+    );
+}

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -823,3 +823,107 @@ fn custom_strategy_reads_car_calls_from_manifest() {
         "strategy should see car calls via DispatchManifest::car_calls_for once the rider boards",
     );
 }
+
+/// Unacknowledged hall calls are filtered out of `DispatchManifest`.
+/// When `ack_latency_ticks > 0`, a freshly pressed call sits in the
+/// ack-pending window and must not yet be visible to strategies —
+/// otherwise the latency knob is inert for custom dispatch. Matches
+/// `HallCall::is_acknowledged`'s documented contract.
+#[test]
+fn unacknowledged_hall_calls_hidden_from_manifest() {
+    use crate::dispatch::{DispatchManifest, DispatchStrategy, ElevatorGroup, HallCallMode};
+    use crate::ids::GroupId;
+    use crate::world::World;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct Observer {
+        visible_call_count: Arc<AtomicUsize>,
+    }
+    impl DispatchStrategy for Observer {
+        fn rank(
+            &mut self,
+            _car: EntityId,
+            car_pos: f64,
+            _stop: EntityId,
+            stop_pos: f64,
+            _group: &ElevatorGroup,
+            manifest: &DispatchManifest,
+            _world: &World,
+        ) -> Option<f64> {
+            // Track running max so a later `rank` call observing zero
+            // calls (e.g. after the car arrived and cleared the call)
+            // doesn't overwrite a previous nonzero observation.
+            let count = manifest.iter_hall_calls().count();
+            self.visible_call_count.fetch_max(count, Ordering::Relaxed);
+            Some((car_pos - stop_pos).abs())
+        }
+    }
+
+    let visible = Arc::new(AtomicUsize::new(0));
+    let observer = Observer {
+        visible_call_count: Arc::clone(&visible),
+    };
+    let mut sim = Simulation::new(&default_config(), observer).unwrap();
+    // 10-tick ack latency; Classic mode so the call is direction-only.
+    for g in sim.groups_mut() {
+        if g.id() == GroupId(0) {
+            g.set_ack_latency_ticks(10);
+            g.set_hall_call_mode(HallCallMode::Classic);
+        }
+    }
+    // Spawn the rider at a stop the car isn't already parked at, so
+    // the car must travel — giving ack-latency time to elapse before
+    // the call is cleared on arrival.
+    sim.spawn_rider_by_stop_id(StopId(1), StopId(0), 70.0)
+        .unwrap();
+    // One tick: call exists under ack-latency, not yet acknowledged.
+    sim.step();
+    assert!(
+        !sim.world()
+            .iter_hall_calls()
+            .any(crate::components::HallCall::is_acknowledged),
+        "no hall call should be acknowledged yet",
+    );
+    assert_eq!(
+        visible.load(Ordering::Relaxed),
+        0,
+        "unacknowledged calls must be hidden from the manifest",
+    );
+
+    // Step past the latency window: once the advance_transient pass
+    // sets `acknowledged_at`, the call becomes visible to dispatch and
+    // therefore to the strategy's `rank`. Allow generous headroom —
+    // the phase order (advance_transient runs before dispatch each
+    // step) plus tick boundaries mean the exact step count is
+    // configuration-sensitive, not a contract.
+    let mut any_acknowledged = false;
+    for _ in 0..50 {
+        sim.step();
+        if sim
+            .world()
+            .iter_hall_calls()
+            .any(crate::components::HallCall::is_acknowledged)
+        {
+            any_acknowledged = true;
+        }
+        if visible.load(Ordering::Relaxed) > 0 {
+            break;
+        }
+    }
+    // If the call was briefly acknowledged and then cleared by the car
+    // arriving, we may have missed the rank-with-visible-call moment
+    // — but as long as acknowledgement did fire, the filter let the
+    // manifest reflect it. The assertion below catches both the "never
+    // acknowledged" case (filter never saw a visible call) and the
+    // "acknowledged but rank never ran while visible" case (fine,
+    // since visible > 0 is still the contract).
+    assert!(
+        any_acknowledged,
+        "ack-latency should have elapsed within 50 ticks"
+    );
+    assert!(
+        visible.load(Ordering::Relaxed) > 0,
+        "after ack-latency elapses, the call should appear in the manifest",
+    );
+}


### PR DESCRIPTION
## Summary

Custom dispatch strategies that want to rank based on hall-call age, pending-rider count, pin flags, or DCS destinations had to reach into \`&World\` directly, breaking the documented \`rank(car, stop, group, manifest, world)\` contract. The manifest was the intended interface but shipped without call-layer state.

## Changes

- \`DispatchManifest\` gains two maps:
  - \`hall_calls_at_stop: BTreeMap<EntityId, Vec<HallCall>>\` — at most two entries per stop (one per \`CallDirection\`); only populated for stops served by the group being dispatched.
  - \`car_calls_by_car: BTreeMap<EntityId, Vec<CarCall>>\` — per-car pending floor presses for every car in the group.
- Convenience accessors:
  - \`hall_call_at(stop, direction)\` — O(stop-calls) lookup (≤ 2 candidates).
  - \`iter_hall_calls()\` — flat iterator over every call visible to the group.
  - \`car_calls_for(car)\` — borrowed \`&[CarCall]\` slice, mirroring \`Simulation::car_calls\`.
- \`systems::dispatch::build_manifest\` is the single populate site; per-group filtering stays consistent.

## Tests

- \`custom_strategy_reads_hall_calls_from_manifest\` — custom strategy observes a pressed up-call at the rider's origin stop via \`hall_call_at\`.
- \`custom_strategy_reads_car_calls_from_manifest\` — strategy observes the in-cab floor press after the rider boards via \`car_calls_for(car)\`.

Both use the public \`Simulation::step\` path so the test drives the real Hungarian-assignment pipeline end-to-end, not a unit-level \`assign\` harness.

## Follow-up (intentionally out of scope)

\`dispatch::assign\` uses \`manifest.has_demand(stop)\` to filter to stops with active demand before calling \`rank\`. \`has_demand\` considers riders but not raw hall presses — so a scripted \`press_hall_button\` without a rider doesn't yet trigger Hungarian assignment. That's an additional gap worth filing separately (not a regression from this PR; it predates #102 and is orthogonal to manifest exposure).

## Breaking

Adding fields to the non-\`#[non_exhaustive]\` \`DispatchManifest\` is technically breaking for any external caller constructing it literally; in practice \`DispatchManifest\` has \`#[derive(Default)]\` and is only built by the dispatch system. No external construction sites in this repo.

## Test plan

- [x] \`cargo test -p elevator-core\` (555 lib tests green, 2 new)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [ ] Greptile review

Fixes #102