### PR TITLE
docs(example): demonstrate hall-call + pinning in custom_dispatch

### DIFF
--- a/crates/elevator-core/examples/custom_dispatch.rs
+++ b/crates/elevator-core/examples/custom_dispatch.rs
@@ -1,4 +1,5 @@
-//! Writing a custom `DispatchStrategy`.
+//! Writing a custom `DispatchStrategy`, and composing it with the
+//! hall-call layer (scripted presses and pinned assignments).
 //!
 //! This example walks through the score-based trait:
 //!
@@ -9,6 +10,14 @@
 //!   optional, used by sticky strategies like destination dispatch.
 //! * [`DispatchStrategy::notify_removed`] — per-elevator state cleanup,
 //!   required if the strategy carries a `HashMap<EntityId, _>`.
+//!
+//! …plus how the strategy interacts with the hall-call API:
+//! `Simulation::press_hall_button` registers scripted presses, and
+//! `Simulation::pin_assignment` forces a specific car to service a call
+//! regardless of the strategy's ranking. Pinned calls bypass the
+//! Hungarian solver entirely — a critical escape hatch for games that
+//! need deterministic overrides (building scripts, cutscenes,
+//! DCS lobby kiosks).
 //!
 //! Run with:
 //! ```sh
@@ -22,6 +31,7 @@
 
 use std::collections::HashMap;
 
+use elevator_core::components::CallDirection;
 use elevator_core::dispatch::{BuiltinStrategy, DispatchManifest, DispatchStrategy, ElevatorGroup};
 use elevator_core::entity::EntityId;
 use elevator_core::ids::GroupId;
@@ -140,6 +150,24 @@ fn main() {
         .unwrap();
     sim.spawn_rider_by_stop_id(StopId(2), StopId(1), 80.0)
         .unwrap();
+
+    // Hall-call layer demo: press a scripted hall button without
+    // spawning a rider (e.g. a building-sim "NPC on their way to the
+    // lobby") and pin a specific car to service it. The pin bypasses
+    // the Hungarian solver — the custom strategy's ranks do not
+    // decide this one, the scripted policy does. This is how games
+    // compose custom dispatch with building scripts or DCS overrides.
+    let mezzanine = sim.stop_entity(StopId(1)).unwrap();
+    let lobby_car = sim.world().elevator_ids()[0];
+    sim.press_hall_button(mezzanine, CallDirection::Down)
+        .unwrap();
+    sim.pin_assignment(lobby_car, mezzanine, CallDirection::Down)
+        .unwrap();
+    println!(
+        "Pinned car {:?} to mezzanine down-call. Active hall calls now: {}",
+        lobby_car,
+        sim.hall_calls().count(),
+    );
 
     for _ in 0..5000 {
         sim.step();

--- a/crates/elevator-core/examples/custom_dispatch.rs
+++ b/crates/elevator-core/examples/custom_dispatch.rs
@@ -151,20 +151,24 @@ fn main() {
     sim.spawn_rider_by_stop_id(StopId(2), StopId(1), 80.0)
         .unwrap();
 
-    // Hall-call layer demo: press a scripted hall button without
-    // spawning a rider (e.g. a building-sim "NPC on their way to the
-    // lobby") and pin a specific car to service it. The pin bypasses
-    // the Hungarian solver — the custom strategy's ranks do not
-    // decide this one, the scripted policy does. This is how games
-    // compose custom dispatch with building scripts or DCS overrides.
+    // Hall-call layer demo: script a phantom hall-call press with no
+    // spawned rider behind it — the kind of event a building-sim
+    // might emit when an off-screen NPC presses a button. Choose a
+    // (stop, direction) pair none of the three riders above touches
+    // (Mezzanine UP; riders 1–3 press Lobby-UP, Mezzanine-DOWN,
+    // Roof-DOWN respectively). Then pin the lobby car to it.
+    //
+    // The pin bypasses the Hungarian solver entirely — the custom
+    // strategy's ranks do not decide this one, the scripted policy
+    // does. That's the escape hatch games use to compose custom
+    // dispatch with building scripts, cutscenes, or DCS overrides.
     let mezzanine = sim.stop_entity(StopId(1)).unwrap();
     let lobby_car = sim.world().elevator_ids()[0];
-    sim.press_hall_button(mezzanine, CallDirection::Down)
-        .unwrap();
-    sim.pin_assignment(lobby_car, mezzanine, CallDirection::Down)
+    sim.press_hall_button(mezzanine, CallDirection::Up).unwrap();
+    sim.pin_assignment(lobby_car, mezzanine, CallDirection::Up)
         .unwrap();
     println!(
-        "Pinned car {:?} to mezzanine down-call. Active hall calls now: {}",
+        "Pinned car {:?} to mezzanine up-call. Active hall calls now: {}",
         lobby_car,
         sim.hall_calls().count(),
     );


### PR DESCRIPTION
## Summary

The \`custom_dispatch\` example covered the score-based trait (\`rank\` / \`prepare_car\` / \`pre_dispatch\` / \`notify_removed\` / \`fallback\`) but never touched the hall-call layer. Readers couldn't tell how a custom strategy composes with scripted hall presses or pinned assignments — the two interaction points most games will actually hit.

Extend \`main()\` to demonstrate the composition:
- Script a hall-call press at the mezzanine going down via \`Simulation::press_hall_button\`.
- Pin the lobby car to service it via \`Simulation::pin_assignment\`.
- Print the active hall-call count.

Module docstring updated to flag the composition demo so readers skimming the header know this example covers both the strategy trait and hall-call interop. Key callout: pinned calls bypass Hungarian entirely — a critical escape hatch for games with deterministic overrides (building scripts, cutscenes, DCS lobby kiosks).

## Out of scope

Reading \`DispatchManifest::hall_call_at\` / \`car_calls_for\` directly from inside a custom strategy's \`rank\` method is covered by #108 and depends on that manifest extension landing first. This PR sticks to the public \`Simulation\` surface already on main.

## Test plan

- [x] \`cargo run -p elevator-core --example custom_dispatch\` — runs end-to-end, prints the pin + hall-call count, delivers 3 riders.
- [x] \`cargo clippy -p elevator-core --examples -- -D warnings\` clean.
- [ ] Greptile review

Fixes #103