### PR TITLE
feat: gate DestinationDispatch on HallCallMode::Destination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "8.0.0"
+version = "8.1.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -94,6 +94,17 @@ impl DispatchStrategy for DestinationDispatch {
         manifest: &DispatchManifest,
         world: &mut World,
     ) {
+        // DCS requires the group to be in `HallCallMode::Destination` — that
+        // mode is what makes the kiosk-style "rider announces destination
+        // at press time" assumption hold. In Classic collective-control
+        // mode destinations aren't known until riders board, so running
+        // DCS there would commit assignments based on information a real
+        // controller wouldn't have. Early-return makes DCS a no-op for
+        // misconfigured groups; pair it with the right mode to activate.
+        if group.hall_call_mode() != super::HallCallMode::Destination {
+            return;
+        }
+
         // Candidate cars in this group that are operable for dispatch.
         let candidate_cars: Vec<EntityId> = group
             .elevator_entities()

--- a/crates/elevator-core/src/tests/destination_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/destination_dispatch_tests.rs
@@ -139,7 +139,7 @@ fn two_cars_same_group_config() -> SimConfig {
                 lines: vec![1],
                 dispatch: crate::dispatch::BuiltinStrategy::Destination,
                 reposition: None,
-                hall_call_mode: None,
+                hall_call_mode: Some(crate::dispatch::HallCallMode::Destination),
                 ack_latency_ticks: None,
             }]),
         },
@@ -159,6 +159,11 @@ fn two_cars_same_group_config() -> SimConfig {
 #[test]
 fn sticky_assignment_persists_across_ticks() {
     let mut sim = Simulation::new(&single_car_config(), DestinationDispatch::new()).unwrap();
+    // single_car_config has no explicit groups, so Simulation::new creates
+    // a default group in Classic mode. DCS requires Destination.
+    for g in sim.groups_mut() {
+        g.set_hall_call_mode(crate::dispatch::HallCallMode::Destination);
+    }
     sim.world_mut()
         .register_ext::<AssignedCar>(ASSIGNED_CAR_EXT_NAME);
 
@@ -269,6 +274,9 @@ fn unassigned_manual_board_riders_still_work() {
     // (attach rider via `build_rider_by_stop_id` with no destination) must
     // be preserved.
     let mut sim = Simulation::new(&single_car_config(), DestinationDispatch::new()).unwrap();
+    for g in sim.groups_mut() {
+        g.set_hall_call_mode(crate::dispatch::HallCallMode::Destination);
+    }
     sim.world_mut()
         .register_ext::<AssignedCar>(ASSIGNED_CAR_EXT_NAME);
 
@@ -377,4 +385,36 @@ fn up_peak_scenario_delivers_all_riders() {
         );
     }
     assert_eq!(sim.metrics().total_delivered(), 20);
+}
+
+/// `DestinationDispatch` must be a no-op when the group is in
+/// `HallCallMode::Classic` — running DCS there would commit
+/// assignments based on post-board destinations a real collective-
+/// control controller wouldn't yet know. Regression guard against
+/// accidentally re-enabling DCS in Classic groups.
+#[test]
+fn dcs_gated_to_destination_mode() {
+    let mut sim = Simulation::new(&single_car_config(), DestinationDispatch::new()).unwrap();
+    // Leave the group in its default Classic mode — DCS should skip.
+    assert_eq!(
+        sim.groups()[0].hall_call_mode(),
+        crate::dispatch::HallCallMode::Classic,
+        "default group mode should still be Classic for this test",
+    );
+    sim.world_mut()
+        .register_ext::<AssignedCar>(ASSIGNED_CAR_EXT_NAME);
+
+    let rid = sim
+        .spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
+        .unwrap();
+
+    // Step enough ticks that DCS would have assigned by now in Destination
+    // mode. In Classic it stays None because pre_dispatch early-returns.
+    for _ in 0..10 {
+        sim.step();
+    }
+    assert!(
+        sim.world().get_ext::<AssignedCar>(rid).is_none(),
+        "DCS must not assign when group is in Classic mode",
+    );
 }


### PR DESCRIPTION
## Summary

DCS previously ran regardless of the group's \`HallCallMode\`, committing sticky rider → car assignments based on rider **route** destinations that a Classic collective-control controller wouldn't actually know at press time. The group-mode knob existed but was decorative for DCS.

## Change

Gate \`DestinationDispatch::pre_dispatch\` on \`group.hall_call_mode() == HallCallMode::Destination\`. DCS becomes a no-op for Classic groups. Misconfigured \`Destination\` strategy + Classic mode pairs now intentionally fall through to empty destination queues — operators discover the misconfiguration via "nobody's being picked up" rather than via subtly-wrong assignments.

## Tests

- Existing DCS tests updated to enable Destination mode: \`single_car_config\` uses \`groups_mut\` post-construction (the config has no explicit groups, so the auto-built group inherits the gate); \`two_cars_same_group_config\`'s \`GroupConfig\` now sets \`hall_call_mode: Some(Destination)\`.
- **New** \`dcs_gated_to_destination_mode\`: leaves the group in Classic, spawns a rider with a \`DestinationDispatch\` strategy, asserts no \`AssignedCar\` extension is inserted even after 10 ticks.

## Why this is the right scope

Two implementation paths were considered:

1. **Gate on mode** (this PR) — behavior-preserving for correctly-configured \`Destination\`-mode groups; fails loudly for misconfigured Classic groups.
2. **Rewire DCS to read \`HallCall::destination\` via the manifest** (broader) — would be a bigger behavior change. \`HallCall::destination\` and \`info.destination\` (rider route) currently carry the same value, so switching sources has no observable effect unless we also start scrubbing route destinations from the manifest in Classic mode, which is a separate question.

Option 1 addresses #99's stated gap without rippling further. The manifest already exposes hall-call destinations (#108), so a follow-up can swap the source if it's worth the test churn.

## Test plan

- [x] \`cargo test -p elevator-core\` (560 lib tests green, 1 new)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [ ] Greptile review

Fixes #99