### PR TITLE
ci: run ffi-harness on windows-latest and macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,12 @@ jobs:
           - os: windows-latest
             rid: win-x64
             lib_name: elevator_ffi.dll
-          - os: macos-latest
+          # Pin to macos-15 rather than macos-latest: the alias currently
+          # resolves to Apple Silicon (matching osx-arm64), but if GitHub
+          # ever remaps macos-latest to an x86-64 runner the dylib would
+          # land in the wrong runtime-id directory and fail with a
+          # confusing DllNotFoundException. Explicit = self-documenting.
+          - os: macos-15
             rid: osx-arm64
             lib_name: libelevator_ffi.dylib
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,12 +69,28 @@ jobs:
           arg: --workspace
 
   ffi-harness:
-    name: FFI smoke test (C# harness)
+    name: FFI smoke test (${{ matrix.os }})
     if: |
       github.event_name != 'pull_request' ||
       github.event.pull_request.user.login != 'release-kun[bot]' ||
       !startsWith(github.event.pull_request.title, 'chore(main): release')
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            rid: linux-x64
+            lib_name: libelevator_ffi.so
+          - os: windows-latest
+            rid: win-x64
+            lib_name: elevator_ffi.dll
+          - os: macos-latest
+            rid: osx-arm64
+            lib_name: libelevator_ffi.dylib
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -83,13 +99,15 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
-      - name: Install system dependencies
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libudev-dev libasound2-dev
 
       - name: Build elevator-ffi cdylib
         run: cargo build -p elevator-ffi --release
 
       - name: Verify generated header is up to date
+        if: runner.os == 'Linux'
         run: |
           cargo build -p elevator-ffi
           if ! git diff --exit-code crates/elevator-ffi/include/elevator_ffi.h; then
@@ -98,9 +116,12 @@ jobs:
           fi
 
       - name: Stage cdylib for harness
+        env:
+          RID: ${{ matrix.rid }}
+          LIB_NAME: ${{ matrix.lib_name }}
         run: |
-          mkdir -p examples/csharp-harness/runtimes/linux-x64/native
-          cp target/release/libelevator_ffi.so examples/csharp-harness/runtimes/linux-x64/native/
+          mkdir -p "examples/csharp-harness/runtimes/$RID/native"
+          cp "target/release/$LIB_NAME" "examples/csharp-harness/runtimes/$RID/native/"
 
       - name: Build C# harness
         working-directory: examples/csharp-harness

--- a/crates/elevator-ffi/README.md
+++ b/crates/elevator-ffi/README.md
@@ -83,3 +83,18 @@ cargo build -p elevator-ffi --release
 ```
 
 The header is regenerated on every build via `build.rs` and checked in.
+
+## CI coverage
+
+The `ffi-harness` job in `.github/workflows/ci.yml` runs the C# smoke
+harness against the compiled cdylib on three host platforms:
+
+| Host                  | Runner           | Runtime ID  | Artefact                |
+|-----------------------|------------------|-------------|-------------------------|
+| Linux (x86-64)        | `ubuntu-latest`  | `linux-x64` | `libelevator_ffi.so`    |
+| Windows (x86-64)      | `windows-latest` | `win-x64`   | `elevator_ffi.dll`      |
+| macOS (Apple Silicon) | `macos-latest`   | `osx-arm64` | `libelevator_ffi.dylib` |
+
+The header-diff check runs only on Linux (all three produce identical
+output). `fail-fast: false` is set so a regression on one platform
+doesn't hide issues on the others.

--- a/crates/elevator-ffi/README.md
+++ b/crates/elevator-ffi/README.md
@@ -93,7 +93,7 @@ harness against the compiled cdylib on three host platforms:
 |-----------------------|------------------|-------------|-------------------------|
 | Linux (x86-64)        | `ubuntu-latest`  | `linux-x64` | `libelevator_ffi.so`    |
 | Windows (x86-64)      | `windows-latest` | `win-x64`   | `elevator_ffi.dll`      |
-| macOS (Apple Silicon) | `macos-latest`   | `osx-arm64` | `libelevator_ffi.dylib` |
+| macOS (Apple Silicon) | `macos-15`       | `osx-arm64` | `libelevator_ffi.dylib` |
 
 The header-diff check runs only on Linux (all three produce identical
 output). `fail-fast: false` is set so a regression on one platform


### PR DESCRIPTION
## Summary

The FFI smoke harness was ubuntu-only, so any endian / alignment / \`c_char\`-signedness regression on Windows or macOS would only surface when a downstream consumer (Unity / C#) hit it. PR #87 explicitly deferred the matrix expansion as a follow-up.

## Change

Convert the \`ffi-harness\` job into a 3-way matrix:

| Host | Runner | Runtime ID | Artefact |
|------|--------|------------|----------|
| Linux (x86-64) | \`ubuntu-latest\` | \`linux-x64\` | \`libelevator_ffi.so\` |
| Windows (x86-64) | \`windows-latest\` | \`win-x64\` | \`elevator_ffi.dll\` |
| macOS (Apple Silicon) | \`macos-latest\` | \`osx-arm64\` | \`libelevator_ffi.dylib\` |

Platform-specific pieces:
- Linux-only system deps (\`libudev\`, \`libasound\`) install only on Linux.
- The header-diff check runs only on Linux — all three platforms produce identical headers; duplicating the check would waste CI time without catching anything new.
- Matrix values flow into shell via \`env: RID / LIB_NAME\` rather than inline \`\${{ matrix.* }}\` in \`run:\` lines, per the workflow-injection guidance.
- \`fail-fast: false\` so a regression on one platform doesn't hide issues on the others.

Also document the CI matrix in \`crates/elevator-ffi/README.md\`.

## Test plan

- [ ] All three matrix jobs pass on this PR (this is the validation)
- [x] YAML validates locally; job name renders as \`FFI smoke test (ubuntu-latest)\` etc.
- [ ] Greptile review

Fixes #96