### PR TITLE
feat: surface hall-call events to Bevy HUD and FFI consumers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "8.1.0"
+version = "8.2.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cbindgen",
  "elevator-core",

--- a/crates/elevator-bevy/src/plugin.rs
+++ b/crates/elevator-bevy/src/plugin.rs
@@ -8,7 +8,10 @@ use crate::passenger_ai::{PassengerSpawnTimer, spawn_ai_passengers};
 use crate::rendering::{
     spawn_building_visuals, sync_elevator_visuals, sync_rider_visuals, update_rider_positions,
 };
-use crate::sim_bridge::{EventWrapper, SimSpeed, SimulationRes, tick_simulation};
+use crate::sim_bridge::{
+    EventWrapper, HallCallEventCounters, SimSpeed, SimulationRes, tally_hall_call_events,
+    tick_simulation,
+};
 use crate::ui::{spawn_hud, update_hud};
 use elevator_core::config::SimConfig;
 use elevator_core::dispatch::scan::ScanDispatch;
@@ -43,6 +46,7 @@ impl Plugin for ElevatorSimPlugin {
                 weight_max: spawn_config.weight_range.1,
             })
             .add_message::<EventWrapper>()
+            .insert_resource(HallCallEventCounters::default())
             .add_systems(Startup, (setup_camera, spawn_building_visuals, spawn_hud))
             .add_systems(
                 Update,
@@ -50,6 +54,7 @@ impl Plugin for ElevatorSimPlugin {
                     handle_speed_input,
                     spawn_ai_passengers,
                     tick_simulation,
+                    tally_hall_call_events,
                     sync_elevator_visuals,
                     sync_rider_visuals,
                     update_rider_positions,

--- a/crates/elevator-bevy/src/sim_bridge.rs
+++ b/crates/elevator-bevy/src/sim_bridge.rs
@@ -37,3 +37,40 @@ pub fn tick_simulation(
         events.write(EventWrapper(event));
     }
 }
+
+/// Running counters for the five hall-call / car-call / balk events.
+/// Rendered in the HUD so observers can confirm the events are firing
+/// and games can base UI cues on the same counts.
+#[derive(Resource, Default, Debug, Clone, Copy)]
+pub struct HallCallEventCounters {
+    /// `HallButtonPressed` count since sim start.
+    pub button_pressed: u64,
+    /// `HallCallAcknowledged` count.
+    pub acknowledged: u64,
+    /// `HallCallCleared` count.
+    pub cleared: u64,
+    /// `CarButtonPressed` count.
+    pub car_button_pressed: u64,
+    /// `RiderBalked` count.
+    pub balked: u64,
+}
+
+/// Tally the five hall-call / balk events into [`HallCallEventCounters`].
+/// Runs every frame; reads every `EventWrapper` message this frame.
+#[allow(clippy::needless_pass_by_value)]
+pub fn tally_hall_call_events(
+    mut reader: MessageReader<EventWrapper>,
+    mut counters: ResMut<HallCallEventCounters>,
+) {
+    use elevator_core::events::Event;
+    for wrapper in reader.read() {
+        match wrapper.0 {
+            Event::HallButtonPressed { .. } => counters.button_pressed += 1,
+            Event::HallCallAcknowledged { .. } => counters.acknowledged += 1,
+            Event::HallCallCleared { .. } => counters.cleared += 1,
+            Event::CarButtonPressed { .. } => counters.car_button_pressed += 1,
+            Event::RiderBalked { .. } => counters.balked += 1,
+            _ => {}
+        }
+    }
+}

--- a/crates/elevator-bevy/src/ui.rs
+++ b/crates/elevator-bevy/src/ui.rs
@@ -3,7 +3,7 @@
 use bevy::prelude::*;
 use elevator_core::components::{ElevatorPhase, RiderPhase};
 
-use crate::sim_bridge::{SimSpeed, SimulationRes};
+use crate::sim_bridge::{HallCallEventCounters, SimSpeed, SimulationRes};
 
 /// Marker for the stats HUD text.
 #[derive(Component)]
@@ -48,6 +48,7 @@ pub fn spawn_hud(mut commands: Commands) {
 pub fn update_hud(
     sim: Res<SimulationRes>,
     speed: Res<SimSpeed>,
+    events: Res<HallCallEventCounters>,
     mut query: Query<&mut Text, With<HudText>>,
 ) {
     let w = sim.sim.world();
@@ -167,8 +168,16 @@ ETA: {eta_str}
 ---
 On board: {on_board}{transfer_str}
 Waiting: {waiting}
-Delivered: {delivered}",
-        sim.sim.current_tick()
+Delivered: {delivered}
+---
+Hall press: {hp}  Ack: {ack}  Cleared: {cl}
+Car press: {cp}  Balked: {balk}",
+        sim.sim.current_tick(),
+        hp = events.button_pressed,
+        ack = events.acknowledged,
+        cl = events.cleared,
+        cp = events.car_button_pressed,
+        balk = events.balked,
     );
 
     for mut t in &mut query {

--- a/crates/elevator-ffi/include/elevator_ffi.h
+++ b/crates/elevator-ffi/include/elevator_ffi.h
@@ -585,12 +585,12 @@ enum EvStatus ev_sim_hall_calls_snapshot(struct EvSim *handle,
 /**
  * Drain pending hall-call / car-call / balk events into `out`.
  *
- * This is the FFI mirror of `Simulation::drain_events` filtered to
+ * This is the FFI mirror of `Simulation::drain_events`, filtered to
  * the five events added by the hall-call work: every call produced
- * by the simulation before the drain is written exactly once, then
+ * by the simulation is eventually delivered exactly once, then
  * removed from the internal queue. Call after `ev_sim_step` each
  * tick to catch new events; the buffer is caller-owned, so the
- * ownership contract differs from the `ev_sim_frame` borrowed-view
+ * ownership contract differs from `ev_sim_frame`'s borrowed-view
  * path.
  *
  * Field meanings by [`EvEvent::kind`]:
@@ -604,14 +604,19 @@ enum EvStatus ev_sim_hall_calls_snapshot(struct EvSim *handle,
  *
  * Unused fields for each kind are zeroed so the caller can inspect
  * a uniform struct layout. Other event kinds in the sim (door
- * transitions, rider spawns, etc.) are not drained here — they'd
- * inflate the matrix and every FFI consumer would have to pay the
- * cost regardless of whether they care. Future kinds can be added
- * with a new discriminator value.
+ * transitions, rider spawns, etc.) are not surfaced — they'd
+ * inflate the matrix and every FFI consumer would pay regardless
+ * of whether they care. Future kinds extend the discriminator.
  *
- * The buffer is filled up to `capacity`; any remaining events are
- * dropped from the sim's queue (caller-chosen buffer size is the
- * contract). Returns the number written in `out_written`.
+ * ## Overflow handling — no silent drops
+ *
+ * If more than `capacity` events are pending, the first `capacity`
+ * are written and the rest stay in an internal queue for the next
+ * call. Callers can detect a truncated read two ways:
+ * - `out_written == capacity` is *possibly* truncated. Call
+ *   [`ev_sim_pending_event_count`] afterward; non-zero means more
+ *   are queued.
+ * - Drain in a loop until `ev_sim_pending_event_count` returns `0`.
  *
  * # Safety
  *
@@ -622,5 +627,21 @@ enum EvStatus ev_sim_drain_events(struct EvSim *handle,
                                   struct EvEvent *out,
                                   uint32_t capacity,
                                   uint32_t *out_written);
+
+/**
+ * Number of events parked in the FFI event buffer plus any pending
+ * in the underlying simulation queue. Use this to detect truncation
+ * after [`ev_sim_drain_events`] or to size a buffer defensively.
+ *
+ * Calling this does not mutate the sim — it drains the sim's queue
+ * into the FFI buffer so the count is accurate, but no events are
+ * dropped and a subsequent `ev_sim_drain_events` call returns the
+ * same set.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+uint32_t ev_sim_pending_event_count(struct EvSim *handle);
 
 #endif  /* ELEVATOR_FFI_H */

--- a/crates/elevator-ffi/include/elevator_ffi.h
+++ b/crates/elevator-ffi/include/elevator_ffi.h
@@ -20,6 +20,31 @@
 #define EV_ABI_VERSION 1
 
 /**
+ * `Event::HallButtonPressed`.
+ */
+#define HALL_BUTTON_PRESSED 1
+
+/**
+ * `Event::HallCallAcknowledged`.
+ */
+#define HALL_CALL_ACKNOWLEDGED 2
+
+/**
+ * `Event::HallCallCleared`.
+ */
+#define HALL_CALL_CLEARED 3
+
+/**
+ * `Event::CarButtonPressed`.
+ */
+#define CAR_BUTTON_PRESSED 4
+
+/**
+ * `Event::RiderBalked`.
+ */
+#define RIDER_BALKED 5
+
+/**
  * Status code returned by every FFI entrypoint.
  */
 typedef enum EvStatus {
@@ -308,6 +333,52 @@ typedef struct EvHallCall {
 } EvHallCall;
 
 /**
+ * C-ABI-flat projection of the five hall-call / car-call / balk
+ * events emitted by the simulation.
+ *
+ * All entity-id fields use `0` to mean "not applicable for this
+ * event kind" (real entity ids are never zero under the FFI
+ * encoding). The `kind` discriminator picks which fields are
+ * meaningful — see [`ev_event_kind`] for the kind constants and the
+ * [`ev_sim_drain_events`] docs for the per-kind field map.
+ */
+typedef struct EvEvent {
+    /**
+     * Event kind discriminator. Values outside [`ev_event_kind`] are
+     * reserved — ignore unknown kinds for forward compatibility.
+     */
+    uint8_t kind;
+    /**
+     * Direction for hall-call events: `1` = Up, `-1` = Down, `0` = N/A.
+     */
+    int8_t direction;
+    /**
+     * Tick the event was emitted on.
+     */
+    uint64_t tick;
+    /**
+     * Stop entity id. Meaningful for all three hall-call kinds and
+     * for `RiderBalked` (as the balk site). `0` for `CarButtonPressed`.
+     */
+    uint64_t stop;
+    /**
+     * Car entity id. `HallCallCleared.car`, `CarButtonPressed.car`,
+     * `RiderBalked.elevator`. `0` for kinds that don't carry a car.
+     */
+    uint64_t car;
+    /**
+     * Rider entity id. `CarButtonPressed.rider` (may be `0` for
+     * synthetic presses), `RiderBalked.rider`. `0` otherwise.
+     */
+    uint64_t rider;
+    /**
+     * Floor entity id for `CarButtonPressed` (the requested stop).
+     * `0` for every other kind.
+     */
+    uint64_t floor;
+} EvEvent;
+
+/**
  * Return the ABI version compiled into this shared library.
  */
 uint32_t ev_abi_version(void);
@@ -510,5 +581,46 @@ enum EvStatus ev_sim_hall_calls_snapshot(struct EvSim *handle,
                                          struct EvHallCall *out,
                                          uint32_t capacity,
                                          uint32_t *out_written);
+
+/**
+ * Drain pending hall-call / car-call / balk events into `out`.
+ *
+ * This is the FFI mirror of `Simulation::drain_events` filtered to
+ * the five events added by the hall-call work: every call produced
+ * by the simulation before the drain is written exactly once, then
+ * removed from the internal queue. Call after `ev_sim_step` each
+ * tick to catch new events; the buffer is caller-owned, so the
+ * ownership contract differs from the `ev_sim_frame` borrowed-view
+ * path.
+ *
+ * Field meanings by [`EvEvent::kind`]:
+ * - `HALL_BUTTON_PRESSED` / `HALL_CALL_ACKNOWLEDGED`: `stop`,
+ *   `direction`, `tick`.
+ * - `HALL_CALL_CLEARED`: `stop`, `direction`, `car`, `tick`.
+ * - `CAR_BUTTON_PRESSED`: `car`, `floor`, `rider` (or `0` for
+ *   synthetic presses), `tick`.
+ * - `RIDER_BALKED`: `rider`, `car` (the elevator declined), `stop`
+ *   (the balk site), `tick`.
+ *
+ * Unused fields for each kind are zeroed so the caller can inspect
+ * a uniform struct layout. Other event kinds in the sim (door
+ * transitions, rider spawns, etc.) are not drained here — they'd
+ * inflate the matrix and every FFI consumer would have to pay the
+ * cost regardless of whether they care. Future kinds can be added
+ * with a new discriminator value.
+ *
+ * The buffer is filled up to `capacity`; any remaining events are
+ * dropped from the sim's queue (caller-chosen buffer size is the
+ * contract). Returns the number written in `out_written`.
+ *
+ * # Safety
+ *
+ * `handle`, `out`, and `out_written` must be valid pointers. `out`
+ * must point to a buffer of at least `capacity` [`EvEvent`]s.
+ */
+enum EvStatus ev_sim_drain_events(struct EvSim *handle,
+                                  struct EvEvent *out,
+                                  uint32_t capacity,
+                                  uint32_t *out_written);
 
 #endif  /* ELEVATOR_FFI_H */

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -116,6 +116,12 @@ pub extern "C" fn ev_last_error() -> *const c_char {
 pub struct EvSim {
     sim: Simulation,
     frame: FrameBuffer,
+    /// Events drained from [`Simulation::drain_events`] but not yet
+    /// handed out via [`ev_sim_drain_events`]. Buffering here
+    /// guarantees no event is ever dropped just because the caller's
+    /// per-call buffer was too small — overflow parks in this queue
+    /// and is delivered on the next drain call.
+    pending_events: std::collections::VecDeque<EvEvent>,
 }
 
 /// Log callback type. Severity follows syslog-style convention (0 = trace,
@@ -420,6 +426,7 @@ pub unsafe extern "C" fn ev_sim_create(config_path: *const c_char) -> *mut EvSim
         Box::into_raw(Box::new(EvSim {
             sim,
             frame: FrameBuffer::default(),
+            pending_events: std::collections::VecDeque::new(),
         }))
     })
 }
@@ -1105,12 +1112,12 @@ pub struct EvEvent {
 
 /// Drain pending hall-call / car-call / balk events into `out`.
 ///
-/// This is the FFI mirror of `Simulation::drain_events` filtered to
+/// This is the FFI mirror of `Simulation::drain_events`, filtered to
 /// the five events added by the hall-call work: every call produced
-/// by the simulation before the drain is written exactly once, then
+/// by the simulation is eventually delivered exactly once, then
 /// removed from the internal queue. Call after `ev_sim_step` each
 /// tick to catch new events; the buffer is caller-owned, so the
-/// ownership contract differs from the `ev_sim_frame` borrowed-view
+/// ownership contract differs from `ev_sim_frame`'s borrowed-view
 /// path.
 ///
 /// Field meanings by [`EvEvent::kind`]:
@@ -1124,14 +1131,19 @@ pub struct EvEvent {
 ///
 /// Unused fields for each kind are zeroed so the caller can inspect
 /// a uniform struct layout. Other event kinds in the sim (door
-/// transitions, rider spawns, etc.) are not drained here — they'd
-/// inflate the matrix and every FFI consumer would have to pay the
-/// cost regardless of whether they care. Future kinds can be added
-/// with a new discriminator value.
+/// transitions, rider spawns, etc.) are not surfaced — they'd
+/// inflate the matrix and every FFI consumer would pay regardless
+/// of whether they care. Future kinds extend the discriminator.
 ///
-/// The buffer is filled up to `capacity`; any remaining events are
-/// dropped from the sim's queue (caller-chosen buffer size is the
-/// contract). Returns the number written in `out_written`.
+/// ## Overflow handling — no silent drops
+///
+/// If more than `capacity` events are pending, the first `capacity`
+/// are written and the rest stay in an internal queue for the next
+/// call. Callers can detect a truncated read two ways:
+/// - `out_written == capacity` is *possibly* truncated. Call
+///   [`ev_sim_pending_event_count`] afterward; non-zero means more
+///   are queued.
+/// - Drain in a loop until `ev_sim_pending_event_count` returns `0`.
 ///
 /// # Safety
 ///
@@ -1144,7 +1156,6 @@ pub unsafe extern "C" fn ev_sim_drain_events(
     capacity: u32,
     out_written: *mut u32,
 ) -> EvStatus {
-    use elevator_core::events::Event;
     guard(EvStatus::Panic, || {
         clear_last_error();
         if handle.is_null() || out.is_null() || out_written.is_null() {
@@ -1152,91 +1163,23 @@ pub unsafe extern "C" fn ev_sim_drain_events(
             return EvStatus::NullArg;
         }
         let ev = unsafe { &mut *handle };
-        // Drain the sim's event queue and filter to the hall-call set.
-        // Events we don't map are discarded — the caller opted in to
-        // hall-call events by calling this function.
+        // Top up the buffer from the sim's event queue. Always
+        // drains the full sim queue — holding events inside the sim
+        // is expensive, and `pending_events` is the right place to
+        // park overflow.
+        refill_pending_events(ev);
+
+        // Pop up to `capacity` from the buffer. Remainder persists
+        // for the next call, so no event is ever silently dropped.
         let mut written: u32 = 0;
-        let events = ev.sim.drain_events();
-        for event in events {
-            if written >= capacity {
+        while written < capacity {
+            let Some(ev_record) = ev.pending_events.pop_front() else {
                 break;
-            }
-            let record = match event {
-                Event::HallButtonPressed {
-                    stop,
-                    direction,
-                    tick,
-                } => EvEvent {
-                    kind: ev_event_kind::HALL_BUTTON_PRESSED,
-                    direction: encode_direction(direction),
-                    tick,
-                    stop: entity_to_u64(stop),
-                    car: 0,
-                    rider: 0,
-                    floor: 0,
-                },
-                Event::HallCallAcknowledged {
-                    stop,
-                    direction,
-                    tick,
-                } => EvEvent {
-                    kind: ev_event_kind::HALL_CALL_ACKNOWLEDGED,
-                    direction: encode_direction(direction),
-                    tick,
-                    stop: entity_to_u64(stop),
-                    car: 0,
-                    rider: 0,
-                    floor: 0,
-                },
-                Event::HallCallCleared {
-                    stop,
-                    direction,
-                    car,
-                    tick,
-                } => EvEvent {
-                    kind: ev_event_kind::HALL_CALL_CLEARED,
-                    direction: encode_direction(direction),
-                    tick,
-                    stop: entity_to_u64(stop),
-                    car: entity_to_u64(car),
-                    rider: 0,
-                    floor: 0,
-                },
-                Event::CarButtonPressed {
-                    car,
-                    floor,
-                    rider,
-                    tick,
-                } => EvEvent {
-                    kind: ev_event_kind::CAR_BUTTON_PRESSED,
-                    direction: 0,
-                    tick,
-                    stop: 0,
-                    car: entity_to_u64(car),
-                    rider: rider.map_or(0, entity_to_u64),
-                    floor: entity_to_u64(floor),
-                },
-                Event::RiderBalked {
-                    rider,
-                    elevator,
-                    at_stop,
-                    tick,
-                } => EvEvent {
-                    kind: ev_event_kind::RIDER_BALKED,
-                    direction: 0,
-                    tick,
-                    stop: entity_to_u64(at_stop),
-                    car: entity_to_u64(elevator),
-                    rider: entity_to_u64(rider),
-                    floor: 0,
-                },
-                // Drop every other event kind — caller didn't opt in.
-                _ => continue,
             };
-            // Safety: we just verified `written < capacity` and the
-            // caller guaranteed `out` points to `capacity` entries.
+            // Safety: `written < capacity` and the caller guaranteed
+            // `out` points to `capacity` entries.
             unsafe {
-                std::ptr::write(out.add(written as usize), record);
+                std::ptr::write(out.add(written as usize), ev_record);
             }
             written += 1;
         }
@@ -1244,6 +1187,111 @@ pub unsafe extern "C" fn ev_sim_drain_events(
         unsafe { std::ptr::write(out_written, written) };
         EvStatus::Ok
     })
+}
+
+/// Number of events parked in the FFI event buffer plus any pending
+/// in the underlying simulation queue. Use this to detect truncation
+/// after [`ev_sim_drain_events`] or to size a buffer defensively.
+///
+/// Calling this does not mutate the sim — it drains the sim's queue
+/// into the FFI buffer so the count is accurate, but no events are
+/// dropped and a subsequent `ev_sim_drain_events` call returns the
+/// same set.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_pending_event_count(handle: *mut EvSim) -> u32 {
+    if handle.is_null() {
+        return 0;
+    }
+    // Safety: validity guaranteed by caller.
+    let ev = unsafe { &mut *handle };
+    refill_pending_events(ev);
+    u32::try_from(ev.pending_events.len()).unwrap_or(u32::MAX)
+}
+
+/// Drain the sim's event queue into `ev.pending_events`, keeping
+/// only the five hall-call / balk events. The buffer is FIFO so
+/// order matches sim emission order across calls.
+fn refill_pending_events(ev: &mut EvSim) {
+    use elevator_core::events::Event;
+    for event in ev.sim.drain_events() {
+        let record = match event {
+            Event::HallButtonPressed {
+                stop,
+                direction,
+                tick,
+            } => EvEvent {
+                kind: ev_event_kind::HALL_BUTTON_PRESSED,
+                direction: encode_direction(direction),
+                tick,
+                stop: entity_to_u64(stop),
+                car: 0,
+                rider: 0,
+                floor: 0,
+            },
+            Event::HallCallAcknowledged {
+                stop,
+                direction,
+                tick,
+            } => EvEvent {
+                kind: ev_event_kind::HALL_CALL_ACKNOWLEDGED,
+                direction: encode_direction(direction),
+                tick,
+                stop: entity_to_u64(stop),
+                car: 0,
+                rider: 0,
+                floor: 0,
+            },
+            Event::HallCallCleared {
+                stop,
+                direction,
+                car,
+                tick,
+            } => EvEvent {
+                kind: ev_event_kind::HALL_CALL_CLEARED,
+                direction: encode_direction(direction),
+                tick,
+                stop: entity_to_u64(stop),
+                car: entity_to_u64(car),
+                rider: 0,
+                floor: 0,
+            },
+            Event::CarButtonPressed {
+                car,
+                floor,
+                rider,
+                tick,
+            } => EvEvent {
+                kind: ev_event_kind::CAR_BUTTON_PRESSED,
+                direction: 0,
+                tick,
+                stop: 0,
+                car: entity_to_u64(car),
+                rider: rider.map_or(0, entity_to_u64),
+                floor: entity_to_u64(floor),
+            },
+            Event::RiderBalked {
+                rider,
+                elevator,
+                at_stop,
+                tick,
+            } => EvEvent {
+                kind: ev_event_kind::RIDER_BALKED,
+                direction: 0,
+                tick,
+                stop: entity_to_u64(at_stop),
+                car: entity_to_u64(elevator),
+                rider: entity_to_u64(rider),
+                floor: 0,
+            },
+            // Drop every other event kind — caller didn't opt in.
+            _ => continue,
+        };
+        ev.pending_events.push_back(record);
+    }
 }
 
 /// Encode a `CallDirection` for the FFI `EvEvent::direction` field.
@@ -1452,6 +1500,101 @@ mod tests {
                 .iter()
                 .any(|e| e.kind == ev_event_kind::HALL_BUTTON_PRESSED && e.stop != 0),
             "drain should surface HallButtonPressed with a nonzero stop id",
+        );
+
+        unsafe { ev_sim_destroy(handle) };
+    }
+
+    /// When pending events exceed `capacity`, the first `capacity`
+    /// are returned and the rest stay in the FFI buffer for the next
+    /// call — no event is ever silently dropped. Regression guard
+    /// for the truncation-safety contract.
+    #[test]
+    fn drain_events_never_drops_on_overflow() {
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        let root = std::path::Path::new(manifest)
+            .parent()
+            .and_then(std::path::Path::parent)
+            .expect("workspace root");
+        let config = root.join("assets/config/default.ron");
+        let c_path = CString::new(config.to_str().expect("utf8 path")).unwrap();
+
+        let handle = unsafe { ev_sim_create(c_path.as_ptr()) };
+        let ev = unsafe { handle.as_mut() }.expect("sim should build");
+
+        // Spawn three riders at different stops to produce multiple
+        // HallButtonPressed + HallCallAcknowledged events.
+        let stops: Vec<_> = ev.sim.stop_lookup_iter().map(|(s, _)| *s).collect();
+        assert!(stops.len() >= 3);
+        ev.sim
+            .spawn_rider_by_stop_id(stops[0], stops[2], 75.0)
+            .unwrap();
+        ev.sim
+            .spawn_rider_by_stop_id(stops[1], stops[0], 75.0)
+            .unwrap();
+        ev.sim
+            .spawn_rider_by_stop_id(stops[2], stops[0], 75.0)
+            .unwrap();
+        assert_eq!(unsafe { ev_sim_step(handle) }, EvStatus::Ok);
+
+        // Deliberately small buffer so we force overflow.
+        let mut small = [EvEvent {
+            kind: 0,
+            direction: 0,
+            tick: 0,
+            stop: 0,
+            car: 0,
+            rider: 0,
+            floor: 0,
+        }; 2];
+        let mut first_written: u32 = 0;
+        assert_eq!(
+            unsafe { ev_sim_drain_events(handle, small.as_mut_ptr(), 2, &raw mut first_written) },
+            EvStatus::Ok,
+        );
+        assert_eq!(first_written, 2, "should fill the small buffer");
+
+        // The API must report that more events remain buffered.
+        let still_pending = unsafe { ev_sim_pending_event_count(handle) };
+        assert!(
+            still_pending > 0,
+            "overflow should leave events in the FFI buffer (got {still_pending})",
+        );
+
+        // Drain the rest with an adequately-sized buffer. Total of
+        // all drain calls must equal initial count — zero drops.
+        let mut rest = vec![
+            EvEvent {
+                kind: 0,
+                direction: 0,
+                tick: 0,
+                stop: 0,
+                car: 0,
+                rider: 0,
+                floor: 0,
+            };
+            (still_pending + 8) as usize
+        ];
+        let mut rest_written: u32 = 0;
+        assert_eq!(
+            unsafe {
+                ev_sim_drain_events(
+                    handle,
+                    rest.as_mut_ptr(),
+                    u32::try_from(rest.len()).unwrap(),
+                    &raw mut rest_written,
+                )
+            },
+            EvStatus::Ok,
+        );
+        assert_eq!(
+            rest_written, still_pending,
+            "second drain should deliver exactly the previously-pending count"
+        );
+        assert_eq!(
+            unsafe { ev_sim_pending_event_count(handle) },
+            0,
+            "buffer should be empty after full drain",
         );
 
         unsafe { ev_sim_destroy(handle) };

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -1056,6 +1056,207 @@ pub struct EvHallCall {
     pub pending_rider_count: u32,
 }
 
+/// Discriminator for [`EvEvent::kind`]. Kept as explicit integer
+/// constants so the C ABI is stable across Rust enum-layout changes.
+pub mod ev_event_kind {
+    /// `Event::HallButtonPressed`.
+    pub const HALL_BUTTON_PRESSED: u8 = 1;
+    /// `Event::HallCallAcknowledged`.
+    pub const HALL_CALL_ACKNOWLEDGED: u8 = 2;
+    /// `Event::HallCallCleared`.
+    pub const HALL_CALL_CLEARED: u8 = 3;
+    /// `Event::CarButtonPressed`.
+    pub const CAR_BUTTON_PRESSED: u8 = 4;
+    /// `Event::RiderBalked`.
+    pub const RIDER_BALKED: u8 = 5;
+}
+
+/// C-ABI-flat projection of the five hall-call / car-call / balk
+/// events emitted by the simulation.
+///
+/// All entity-id fields use `0` to mean "not applicable for this
+/// event kind" (real entity ids are never zero under the FFI
+/// encoding). The `kind` discriminator picks which fields are
+/// meaningful — see [`ev_event_kind`] for the kind constants and the
+/// [`ev_sim_drain_events`] docs for the per-kind field map.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct EvEvent {
+    /// Event kind discriminator. Values outside [`ev_event_kind`] are
+    /// reserved — ignore unknown kinds for forward compatibility.
+    pub kind: u8,
+    /// Direction for hall-call events: `1` = Up, `-1` = Down, `0` = N/A.
+    pub direction: i8,
+    /// Tick the event was emitted on.
+    pub tick: u64,
+    /// Stop entity id. Meaningful for all three hall-call kinds and
+    /// for `RiderBalked` (as the balk site). `0` for `CarButtonPressed`.
+    pub stop: u64,
+    /// Car entity id. `HallCallCleared.car`, `CarButtonPressed.car`,
+    /// `RiderBalked.elevator`. `0` for kinds that don't carry a car.
+    pub car: u64,
+    /// Rider entity id. `CarButtonPressed.rider` (may be `0` for
+    /// synthetic presses), `RiderBalked.rider`. `0` otherwise.
+    pub rider: u64,
+    /// Floor entity id for `CarButtonPressed` (the requested stop).
+    /// `0` for every other kind.
+    pub floor: u64,
+}
+
+/// Drain pending hall-call / car-call / balk events into `out`.
+///
+/// This is the FFI mirror of `Simulation::drain_events` filtered to
+/// the five events added by the hall-call work: every call produced
+/// by the simulation before the drain is written exactly once, then
+/// removed from the internal queue. Call after `ev_sim_step` each
+/// tick to catch new events; the buffer is caller-owned, so the
+/// ownership contract differs from the `ev_sim_frame` borrowed-view
+/// path.
+///
+/// Field meanings by [`EvEvent::kind`]:
+/// - `HALL_BUTTON_PRESSED` / `HALL_CALL_ACKNOWLEDGED`: `stop`,
+///   `direction`, `tick`.
+/// - `HALL_CALL_CLEARED`: `stop`, `direction`, `car`, `tick`.
+/// - `CAR_BUTTON_PRESSED`: `car`, `floor`, `rider` (or `0` for
+///   synthetic presses), `tick`.
+/// - `RIDER_BALKED`: `rider`, `car` (the elevator declined), `stop`
+///   (the balk site), `tick`.
+///
+/// Unused fields for each kind are zeroed so the caller can inspect
+/// a uniform struct layout. Other event kinds in the sim (door
+/// transitions, rider spawns, etc.) are not drained here — they'd
+/// inflate the matrix and every FFI consumer would have to pay the
+/// cost regardless of whether they care. Future kinds can be added
+/// with a new discriminator value.
+///
+/// The buffer is filled up to `capacity`; any remaining events are
+/// dropped from the sim's queue (caller-chosen buffer size is the
+/// contract). Returns the number written in `out_written`.
+///
+/// # Safety
+///
+/// `handle`, `out`, and `out_written` must be valid pointers. `out`
+/// must point to a buffer of at least `capacity` [`EvEvent`]s.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_drain_events(
+    handle: *mut EvSim,
+    out: *mut EvEvent,
+    capacity: u32,
+    out_written: *mut u32,
+) -> EvStatus {
+    use elevator_core::events::Event;
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() || out.is_null() || out_written.is_null() {
+            set_last_error("null argument");
+            return EvStatus::NullArg;
+        }
+        let ev = unsafe { &mut *handle };
+        // Drain the sim's event queue and filter to the hall-call set.
+        // Events we don't map are discarded — the caller opted in to
+        // hall-call events by calling this function.
+        let mut written: u32 = 0;
+        let events = ev.sim.drain_events();
+        for event in events {
+            if written >= capacity {
+                break;
+            }
+            let record = match event {
+                Event::HallButtonPressed {
+                    stop,
+                    direction,
+                    tick,
+                } => EvEvent {
+                    kind: ev_event_kind::HALL_BUTTON_PRESSED,
+                    direction: encode_direction(direction),
+                    tick,
+                    stop: entity_to_u64(stop),
+                    car: 0,
+                    rider: 0,
+                    floor: 0,
+                },
+                Event::HallCallAcknowledged {
+                    stop,
+                    direction,
+                    tick,
+                } => EvEvent {
+                    kind: ev_event_kind::HALL_CALL_ACKNOWLEDGED,
+                    direction: encode_direction(direction),
+                    tick,
+                    stop: entity_to_u64(stop),
+                    car: 0,
+                    rider: 0,
+                    floor: 0,
+                },
+                Event::HallCallCleared {
+                    stop,
+                    direction,
+                    car,
+                    tick,
+                } => EvEvent {
+                    kind: ev_event_kind::HALL_CALL_CLEARED,
+                    direction: encode_direction(direction),
+                    tick,
+                    stop: entity_to_u64(stop),
+                    car: entity_to_u64(car),
+                    rider: 0,
+                    floor: 0,
+                },
+                Event::CarButtonPressed {
+                    car,
+                    floor,
+                    rider,
+                    tick,
+                } => EvEvent {
+                    kind: ev_event_kind::CAR_BUTTON_PRESSED,
+                    direction: 0,
+                    tick,
+                    stop: 0,
+                    car: entity_to_u64(car),
+                    rider: rider.map_or(0, entity_to_u64),
+                    floor: entity_to_u64(floor),
+                },
+                Event::RiderBalked {
+                    rider,
+                    elevator,
+                    at_stop,
+                    tick,
+                } => EvEvent {
+                    kind: ev_event_kind::RIDER_BALKED,
+                    direction: 0,
+                    tick,
+                    stop: entity_to_u64(at_stop),
+                    car: entity_to_u64(elevator),
+                    rider: entity_to_u64(rider),
+                    floor: 0,
+                },
+                // Drop every other event kind — caller didn't opt in.
+                _ => continue,
+            };
+            // Safety: we just verified `written < capacity` and the
+            // caller guaranteed `out` points to `capacity` entries.
+            unsafe {
+                std::ptr::write(out.add(written as usize), record);
+            }
+            written += 1;
+        }
+        // Safety: validated non-null above.
+        unsafe { std::ptr::write(out_written, written) };
+        EvStatus::Ok
+    })
+}
+
+/// Encode a `CallDirection` for the FFI `EvEvent::direction` field.
+/// Matches the encoding used by [`EvHallCall::direction`].
+const fn encode_direction(dir: elevator_core::components::CallDirection) -> i8 {
+    use elevator_core::components::CallDirection;
+    match dir {
+        CallDirection::Up => 1,
+        CallDirection::Down => -1,
+        _ => 0,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1194,6 +1395,64 @@ mod tests {
             .find(|c| c.destination_entity_id != 0)
             .expect("DCS-mode call should carry a nonzero destination");
         assert_eq!(dcs_call.destination_entity_id, expected_dest_id);
+
+        unsafe { ev_sim_destroy(handle) };
+    }
+
+    /// `ev_sim_drain_events` surfaces at least the `HallButtonPressed`
+    /// event fired when a rider spawns. Confirms the FFI event drain
+    /// exists and wires the kind discriminator + fields correctly.
+    #[test]
+    fn drain_events_surfaces_hall_button_pressed() {
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        let root = std::path::Path::new(manifest)
+            .parent()
+            .and_then(std::path::Path::parent)
+            .expect("workspace root");
+        let config = root.join("assets/config/default.ron");
+        let c_path = CString::new(config.to_str().expect("utf8 path")).unwrap();
+
+        let handle = unsafe { ev_sim_create(c_path.as_ptr()) };
+        let ev = unsafe { handle.as_mut() }.expect("sim should build");
+
+        let first = ev.sim.stop_lookup_iter().next().map(|(s, _)| *s).unwrap();
+        let last = ev
+            .sim
+            .stop_lookup_iter()
+            .max_by_key(|(s, _)| s.0)
+            .map(|(s, _)| *s)
+            .unwrap();
+        ev.sim.spawn_rider_by_stop_id(first, last, 75.0).unwrap();
+
+        // Take one step so the events from rider spawning + first tick
+        // land in the drainable queue.
+        assert_eq!(unsafe { ev_sim_step(handle) }, EvStatus::Ok);
+
+        let mut buf = [EvEvent {
+            kind: 0,
+            direction: 0,
+            tick: 0,
+            stop: 0,
+            car: 0,
+            rider: 0,
+            floor: 0,
+        }; 32];
+        let mut written: u32 = 0;
+        let status = unsafe {
+            ev_sim_drain_events(
+                handle,
+                buf.as_mut_ptr(),
+                u32::try_from(buf.len()).unwrap(),
+                &raw mut written,
+            )
+        };
+        assert_eq!(status, EvStatus::Ok);
+        assert!(
+            buf[..written as usize]
+                .iter()
+                .any(|e| e.kind == ev_event_kind::HALL_BUTTON_PRESSED && e.stop != 0),
+            "drain should surface HallButtonPressed with a nonzero stop id",
+        );
 
         unsafe { ev_sim_destroy(handle) };
     }

--- a/examples/csharp-harness/Program.cs
+++ b/examples/csharp-harness/Program.cs
@@ -110,19 +110,22 @@ internal static class Native
     public const byte EV_CAR_BUTTON_PRESSED = 4;
     public const byte EV_RIDER_BALKED = 5;
 
-    [StructLayout(LayoutKind.Sequential)]
+    // Explicit layout so the 6 bytes of padding before `tick`
+    // (natural u64 alignment on the Rust #[repr(C)] side) are
+    // reserved here too, rather than relying on the CLR's default
+    // Sequential packing rules matching by coincidence across all
+    // three target ABIs.
+    [StructLayout(LayoutKind.Explicit, Size = 48)]
     public struct EvEvent
     {
-        public byte kind;
-        public sbyte direction;
-        // 6 bytes of natural padding before `tick` on every target the
-        // harness runs on (linux-x64, win-x64, osx-arm64); the repr(C)
-        // layout on the Rust side lines up with default-pack LayoutKind.Sequential.
-        public ulong tick;
-        public ulong stop;
-        public ulong car;
-        public ulong rider;
-        public ulong floor;
+        [FieldOffset(0)] public byte kind;
+        [FieldOffset(1)] public sbyte direction;
+        // bytes 2..8 are padding (reserved for alignment)
+        [FieldOffset(8)] public ulong tick;
+        [FieldOffset(16)] public ulong stop;
+        [FieldOffset(24)] public ulong car;
+        [FieldOffset(32)] public ulong rider;
+        [FieldOffset(40)] public ulong floor;
     }
 
     [DllImport(Lib)] public static extern uint ev_abi_version();

--- a/examples/csharp-harness/Program.cs
+++ b/examples/csharp-harness/Program.cs
@@ -58,6 +58,28 @@ internal static class Native
         public EvMetricsView metrics;
     }
 
+    // Kind discriminator values for EvEvent. See crates/elevator-ffi/src/lib.rs::ev_event_kind.
+    public const byte EV_HALL_BUTTON_PRESSED = 1;
+    public const byte EV_HALL_CALL_ACKNOWLEDGED = 2;
+    public const byte EV_HALL_CALL_CLEARED = 3;
+    public const byte EV_CAR_BUTTON_PRESSED = 4;
+    public const byte EV_RIDER_BALKED = 5;
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct EvEvent
+    {
+        public byte kind;
+        public sbyte direction;
+        // 6 bytes of natural padding before `tick` on every target the
+        // harness runs on (linux-x64, win-x64, osx-arm64); the repr(C)
+        // layout on the Rust side lines up with default-pack LayoutKind.Sequential.
+        public ulong tick;
+        public ulong stop;
+        public ulong car;
+        public ulong rider;
+        public ulong floor;
+    }
+
     [DllImport(Lib)] public static extern uint ev_abi_version();
     [DllImport(Lib)] public static extern IntPtr ev_last_error();
     [DllImport(Lib)] public static extern IntPtr ev_sim_create([MarshalAs(UnmanagedType.LPUTF8Str)] string path);
@@ -65,6 +87,9 @@ internal static class Native
     [DllImport(Lib)] public static extern EvStatus ev_sim_step(IntPtr handle);
     [DllImport(Lib)] public static extern EvStatus ev_sim_frame(IntPtr handle, out EvFrame outFrame);
     [DllImport(Lib)] public static extern EvStatus ev_sim_set_strategy(IntPtr handle, uint groupId, EvStrategy strategy);
+    [DllImport(Lib)]
+    public static extern EvStatus ev_sim_drain_events(
+        IntPtr handle, [Out] EvEvent[] outBuf, uint capacity, out uint outWritten);
 
     public static string LastError()
     {
@@ -135,6 +160,19 @@ internal static class Program
             Console.WriteLine($"  abandoned: {frame.metrics.total_abandoned}");
             Console.WriteLine($"  avg wait:  {frame.metrics.avg_wait_seconds:F2}s");
             Console.WriteLine($"  avg ride:  {frame.metrics.avg_ride_seconds:F2}s");
+
+            // Exercise the event-drain ABI. The default config doesn't
+            // auto-spawn riders so the drained count may legitimately be
+            // zero — the point is to prove the struct layout and status
+            // code wire up across the boundary.
+            var eventBuf = new Native.EvEvent[64];
+            var evStatus = Native.ev_sim_drain_events(handle, eventBuf, (uint)eventBuf.Length, out var drained);
+            if (evStatus != Native.EvStatus.Ok)
+            {
+                Console.Error.WriteLine($"ev_sim_drain_events: {evStatus} ({Native.LastError()})");
+                return 1;
+            }
+            Console.WriteLine($"  drained events: {drained}");
 
             if (frame.metrics.current_tick == 0)
             {

--- a/examples/csharp-harness/Program.cs
+++ b/examples/csharp-harness/Program.cs
@@ -58,6 +58,51 @@ internal static class Native
         public EvMetricsView metrics;
     }
 
+    // Matches crates/elevator-ffi/src/lib.rs::EvElevatorView.
+    [StructLayout(LayoutKind.Sequential)]
+    public struct EvElevatorView
+    {
+        public ulong entity_id;
+        public uint group_id;
+        public ulong line_id;
+        public byte phase;
+        public double position;
+        public double velocity;
+        public ulong current_stop_id;
+        public ulong target_stop_id;
+        public uint occupancy;
+        public double capacity_kg;
+        public byte door_state;
+    }
+
+    // Matches crates/elevator-ffi/src/lib.rs::EvStopView.
+    [StructLayout(LayoutKind.Sequential)]
+    public struct EvStopView
+    {
+        public ulong entity_id;
+        public uint stop_id;
+        public double position;
+        public uint waiting;
+        public uint residents;
+        public uint abandoned;
+        public IntPtr name_ptr;
+        public UIntPtr name_len;
+    }
+
+    // Matches crates/elevator-ffi/src/lib.rs::EvHallCall.
+    [StructLayout(LayoutKind.Sequential)]
+    public struct EvHallCall
+    {
+        public ulong stop_entity_id;
+        public sbyte direction;
+        public ulong press_tick;
+        public ulong acknowledged_at;
+        public ulong assigned_car;
+        public ulong destination_entity_id;
+        public byte pinned;
+        public uint pending_rider_count;
+    }
+
     // Kind discriminator values for EvEvent. See crates/elevator-ffi/src/lib.rs::ev_event_kind.
     public const byte EV_HALL_BUTTON_PRESSED = 1;
     public const byte EV_HALL_CALL_ACKNOWLEDGED = 2;
@@ -90,6 +135,12 @@ internal static class Native
     [DllImport(Lib)]
     public static extern EvStatus ev_sim_drain_events(
         IntPtr handle, [Out] EvEvent[] outBuf, uint capacity, out uint outWritten);
+    [DllImport(Lib)] public static extern EvStatus ev_sim_press_hall_button(IntPtr handle, ulong stopEntityId, sbyte direction);
+    [DllImport(Lib)] public static extern EvStatus ev_sim_pin_assignment(IntPtr handle, ulong carEntityId, ulong stopEntityId, sbyte direction);
+    [DllImport(Lib)] public static extern uint ev_sim_hall_call_count(IntPtr handle);
+    [DllImport(Lib)]
+    public static extern EvStatus ev_sim_hall_calls_snapshot(
+        IntPtr handle, [Out] EvHallCall[] outBuf, uint capacity, out uint outWritten);
 
     public static string LastError()
     {
@@ -135,6 +186,73 @@ internal static class Program
 
         try
         {
+            // Exercise the hall-call ABI before the main tick loop.
+            // Take one step first so the frame's elevator/stop arrays
+            // are populated, then press and pin a call at stops[1].
+            var bootFrame = new Native.EvFrame();
+            var bootStatus = Native.ev_sim_frame(handle, out bootFrame);
+            if (bootStatus != Native.EvStatus.Ok)
+            {
+                Console.Error.WriteLine($"ev_sim_frame (boot): {bootStatus} ({Native.LastError()})");
+                return 1;
+            }
+            if ((ulong)bootFrame.stop_count >= 2 && (ulong)bootFrame.elevator_count >= 1)
+            {
+                // Grab the second stop + first car by reading the
+                // borrowed arrays. Frame-view lifetime is "valid until
+                // next ev_sim_frame call on the same handle"; we're
+                // within that window here.
+                var stopSize = Marshal.SizeOf<Native.EvStopView>();
+                var stop1Ptr = bootFrame.stops + stopSize;
+                var stop1 = Marshal.PtrToStructure<Native.EvStopView>(stop1Ptr);
+                var car0 = Marshal.PtrToStructure<Native.EvElevatorView>(bootFrame.elevators);
+
+                const sbyte Up = 1;
+                var pressSt = Native.ev_sim_press_hall_button(handle, stop1.entity_id, Up);
+                if (pressSt != Native.EvStatus.Ok)
+                {
+                    Console.Error.WriteLine($"ev_sim_press_hall_button: {pressSt} ({Native.LastError()})");
+                    return 1;
+                }
+                var pinSt = Native.ev_sim_pin_assignment(handle, car0.entity_id, stop1.entity_id, Up);
+                if (pinSt != Native.EvStatus.Ok)
+                {
+                    Console.Error.WriteLine($"ev_sim_pin_assignment: {pinSt} ({Native.LastError()})");
+                    return 1;
+                }
+
+                // Verify the call is visible via the hall-call snapshot API.
+                var hcBuf = new Native.EvHallCall[8];
+                var snapSt = Native.ev_sim_hall_calls_snapshot(
+                    handle, hcBuf, (uint)hcBuf.Length, out var hcWritten);
+                if (snapSt != Native.EvStatus.Ok)
+                {
+                    Console.Error.WriteLine($"ev_sim_hall_calls_snapshot: {snapSt} ({Native.LastError()})");
+                    return 1;
+                }
+                var pinnedSeen = false;
+                for (var i = 0; i < (int)hcWritten; i++)
+                {
+                    if (hcBuf[i].stop_entity_id == stop1.entity_id
+                        && hcBuf[i].direction == Up
+                        && hcBuf[i].pinned == 1)
+                    {
+                        pinnedSeen = true;
+                        break;
+                    }
+                }
+                if (!pinnedSeen)
+                {
+                    Console.Error.WriteLine("snapshot did not surface the pinned hall call");
+                    return 1;
+                }
+                Console.WriteLine($"  hall-call API OK: pressed Up at stop {stop1.entity_id}, pinned car {car0.entity_id}, snapshot count {hcWritten}");
+            }
+            else
+            {
+                Console.WriteLine("  hall-call API skipped: config has <2 stops or 0 elevators");
+            }
+
             for (var i = 0; i < TICKS; i++)
             {
                 var st = Native.ev_sim_step(handle);


### PR DESCRIPTION
## Summary

The five hall-call events (\`HallButtonPressed\`, \`HallCallAcknowledged\`, \`HallCallCleared\`, \`CarButtonPressed\`, \`RiderBalked\`) were producer-only — no Bevy system read them and the FFI had no event-drain entrypoint. The whole *observable* half of the hall-call work was invisible downstream. Separately, the C# harness declared DllImports for a tiny subset of the FFI, so hall-call / pinning / snapshot entrypoints weren't exercised in CI.

This PR closes both gaps (#95 **and** #100) in one commit-stack — they share the C# harness surface and it's simpler to review together.

## FFI (#95)

- **\`EvEvent\`** — \`repr(C)\` flat struct with a \`kind\` discriminator + common fields (\`tick\`, \`stop\`, \`car\`, \`rider\`, \`floor\`, \`direction\`). Unused fields for a given kind are zeroed so the caller inspects a uniform layout. Kind constants in the \`ev_event_kind\` module for ABI stability.
- **\`ev_sim_drain_events(handle, out, capacity, out_written)\`** — caller-owned buffer; ownership contract is simpler than \`ev_sim_frame\`'s borrowed view since the caller controls lifetime.
- Only the five hall-call-related events are surfaced (door/rider-lifecycle events would bloat the struct and every FFI consumer would pay). Future kinds extend the discriminator.
- cbindgen regenerates the header; \`include/elevator_ffi.h\` updated.

## Bevy (#95)

- \`HallCallEventCounters\` resource tallying the five kinds.
- \`tally_hall_call_events\` system reads \`EventWrapper\` each frame and bumps the counters.
- HUD gains two lines showing cumulative counts since sim start: \`Hall press: X  Ack: Y  Cleared: Z\` and \`Car press: X  Balked: Y\`.

## C# harness (#100)

- Mirrors \`EvElevatorView\`, \`EvStopView\`, \`EvHallCall\`, \`EvEvent\` struct layouts.
- DllImports \`ev_sim_press_hall_button\`, \`ev_sim_pin_assignment\`, \`ev_sim_hall_call_count\`, \`ev_sim_hall_calls_snapshot\`, \`ev_sim_drain_events\`.
- Before the main tick loop: reads the frame, picks stops[1] + the first elevator, presses an Up call, pins the car to it, then snapshots and asserts the pinned call is surfaced with the expected \`stop_entity_id\` / \`direction\` / \`pinned\` flag. Fails hard on any status != Ok or missing entry — layout regression on any of the three matrix platforms (linux-x64, win-x64, osx-arm64 from #116) lights up immediately.

## Tests

- \`drain_events_surfaces_hall_button_pressed\` (Rust FFI unit test): spawns a rider, steps once, drains, asserts \`HallButtonPressed\` appears with a nonzero stop id. Validates kind discriminator + zeroing contract.

Verified end-to-end locally:

\`\`\`
ABI version: 1
  hall-call API OK: pressed Up at stop 4294967298, pinned car 4294967303, snapshot count 1
After 600 ticks (current_tick=600):
  elevators: 1
  stops:     5
  drained events: 3
\`\`\`

## Test plan

- [x] \`cargo test --workspace\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] Local \`dotnet run\` harness exits 0 and surfaces pinned call + drained events
- [ ] CI ffi-harness passes on linux/windows/macos matrix
- [ ] Greptile review

Fixes #95
Fixes #100