### PR TITLE
ci: freeze release-please auto-merge during API overhaul

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,30 +36,36 @@ jobs:
           manifest-file: .release-please-manifest.json
           token: ${{ steps.app-token.outputs.token }}
 
-      # Inline approve + auto-merge in the same workflow run that
-      # opened the PR. Approval uses the default GITHUB_TOKEN
-      # (`github-actions[bot]` actor), which is distinct from the App
-      # that authored the PR — GitHub forbids self-review, so the two
-      # actors must differ. The merge call uses the App token so
-      # branch-protection rules requiring a PR approval are satisfied.
-      - name: Auto-approve release PR
-        if: steps.release.outputs.pr
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr review ${{ fromJSON(steps.release.outputs.pr).number }} \
-            --approve \
-            --body "Auto-approved by release pipeline." \
-            --repo ${{ github.repository }}
-
-      - name: Auto-merge release PR
-        if: steps.release.outputs.pr
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          gh pr merge ${{ fromJSON(steps.release.outputs.pr).number }} \
-            --auto --squash \
-            --repo ${{ github.repository }}
+      # Auto-approve and auto-merge are TEMPORARILY DISABLED during the
+      # API ergonomics overhaul stack. During the overhaul, every merge
+      # to main would otherwise produce a separate release (and a
+      # `SnapshotVersion` break for downstream consumers). With these
+      # steps disabled, release-please still opens/updates the release
+      # PR on every push — but the PR accumulates all stack commits
+      # into a single release. Manually approve and merge the release
+      # PR once the overhaul lands.
+      #
+      # TO RESTORE (final step of the overhaul): uncomment both steps
+      # below.
+      #
+      # - name: Auto-approve release PR
+      #   if: steps.release.outputs.pr
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     gh pr review ${{ fromJSON(steps.release.outputs.pr).number }} \
+      #       --approve \
+      #       --body "Auto-approved by release pipeline." \
+      #       --repo ${{ github.repository }}
+      #
+      # - name: Auto-merge release PR
+      #   if: steps.release.outputs.pr
+      #   env:
+      #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      #   run: |
+      #     gh pr merge ${{ fromJSON(steps.release.outputs.pr).number }} \
+      #       --auto --squash \
+      #       --repo ${{ github.repository }}
 
   publish:
     needs: release-please

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "8.2.0"
+version = "8.3.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cbindgen",
  "elevator-core",


### PR DESCRIPTION
## Summary

Temporarily comments out the `Auto-approve release PR` and `Auto-merge release PR` steps in `.github/workflows/release-please.yml`.

The upcoming API ergonomics overhaul lands as 9 stacked PRs. Each stack-PR merging to main would otherwise trigger release-please to auto-merge a release PR, producing 9 separate crates.io releases and 9 `SnapshotVersion` breaks for downstream consumers.

With the auto-* steps disabled, release-please still opens/updates a single accumulated release PR on every push to main. Once the overhaul lands, manually approve and merge the accumulated release PR, producing **one** release for the entire overhaul. The final PR in the stack will restore the auto-* steps.

## Context

See the overhaul plan in the session plan file. Ordered operations:
1. **This PR** (freeze) ← you are here
2. Wave A: PR 1 (additive), PR 6 (door rename), PR 7 (FloorPosition rename)
3. Wave B: PR 2 (eta/tag_entity Result), PR 3a (SimError elevator variants), PR 5a (StopRef)
4. Wave C: PR 3b (SimError rider variants) → PR 4 (ExtKey) → PR 5b (spawn_rider consolidation)
5. Unfreeze + single release

## Test plan

- [x] `cargo test -p elevator-core` passes locally (pre-commit hook ran 560 tests)
- [x] `cargo clippy -p elevator-core` clean (pre-commit hook)
- [ ] CI green
- [ ] Greptile review clean