### PR TITLE
feat: additive API ergonomics wins

### DIFF
--- a/crates/elevator-core/src/components/rider.rs
+++ b/crates/elevator-core/src/components/rider.rs
@@ -27,6 +27,20 @@ pub enum RiderPhase {
     Resident,
 }
 
+impl RiderPhase {
+    /// True when the rider is currently inside or transitioning through an
+    /// elevator cab — i.e., [`Boarding`](Self::Boarding),
+    /// [`Riding`](Self::Riding), or [`Exiting`](Self::Exiting).
+    ///
+    /// Useful for code that needs to treat all three mid-elevator phases
+    /// uniformly (rendering, per-elevator population counts, skipping
+    /// stop-queue updates) without writing a three-arm `match`.
+    #[must_use]
+    pub const fn is_aboard(&self) -> bool {
+        matches!(self, Self::Boarding(_) | Self::Riding(_) | Self::Exiting(_))
+    }
+}
+
 impl std::fmt::Display for RiderPhase {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -367,8 +367,14 @@ impl Simulation {
     // ── Accessors ────────────────────────────────────────────────────
 
     /// Get a shared reference to the world.
+    //
+    // Intentionally non-`const`: a `const` qualifier on a runtime accessor
+    // signals "usable in const context", which these methods are not in
+    // practice (the `World` is heap-allocated and mutated). Marking them
+    // `const` misleads readers without unlocking any call sites.
     #[must_use]
-    pub const fn world(&self) -> &World {
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn world(&self) -> &World {
         &self.world
     }
 
@@ -377,7 +383,8 @@ impl Simulation {
     /// Exposed for advanced use cases (manual rider management, custom
     /// component attachment). Prefer `spawn_rider` / `spawn_rider_by_stop_id`
     /// for standard operations.
-    pub const fn world_mut(&mut self) -> &mut World {
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn world_mut(&mut self) -> &mut World {
         &mut self.world
     }
 

--- a/crates/elevator-core/src/stop.rs
+++ b/crates/elevator-core/src/stop.rs
@@ -22,3 +22,37 @@ pub struct StopConfig {
     /// Absolute position along the shaft axis (distance units from origin).
     pub position: f64,
 }
+
+impl StopConfig {
+    /// Build a `Vec<StopConfig>` from a compact `(name, position)` slice.
+    ///
+    /// `StopId`s are assigned sequentially starting at 0. Useful for demos,
+    /// tests, and any sim whose stops don't need hand-picked identifiers.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use elevator_core::stop::StopConfig;
+    ///
+    /// let stops = StopConfig::linear(&[
+    ///     ("Ground", 0.0),
+    ///     ("Floor 2", 4.0),
+    ///     ("Floor 3", 8.0),
+    /// ]);
+    /// assert_eq!(stops.len(), 3);
+    /// assert_eq!(stops[0].name, "Ground");
+    /// assert_eq!(stops[2].position, 8.0);
+    /// ```
+    #[must_use]
+    pub fn linear(stops: &[(&str, f64)]) -> Vec<Self> {
+        stops
+            .iter()
+            .enumerate()
+            .map(|(i, (name, position))| Self {
+                id: StopId(u32::try_from(i).unwrap_or(u32::MAX)),
+                name: (*name).to_owned(),
+                position: *position,
+            })
+            .collect()
+    }
+}

--- a/crates/elevator-core/src/systems/energy.rs
+++ b/crates/elevator-core/src/systems/energy.rs
@@ -1,6 +1,5 @@
 //! Energy system: compute per-tick energy consumption and regeneration.
 
-use crate::components::ElevatorPhase;
 use crate::energy::compute_tick_energy;
 use crate::entity::EntityId;
 use crate::events::{Event, EventBus};

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -701,6 +701,16 @@ impl World {
         self.ext_map::<T>()?.get(id).cloned()
     }
 
+    /// Get a shared reference to a custom component for an entity.
+    ///
+    /// Zero-copy alternative to [`get_ext`](Self::get_ext): prefer this when
+    /// `T` is large or expensive to clone, or when the caller only needs a
+    /// borrow. Unlike `get_ext`, `T` does not need to implement `Clone`.
+    #[must_use]
+    pub fn get_ext_ref<T: 'static + Send + Sync>(&self, id: EntityId) -> Option<&T> {
+        self.ext_map::<T>()?.get(id)
+    }
+
     /// Get a mutable reference to a custom component for an entity.
     pub fn get_ext_mut<T: 'static + Send + Sync>(&mut self, id: EntityId) -> Option<&mut T> {
         self.ext_map_mut::<T>()?.get_mut(id)


### PR DESCRIPTION
## Summary

- `World::get_ext_ref<T>()` — zero-copy shared reference to extension components (no `Clone` bound)
- `RiderPhase::is_aboard()` — returns true for `Boarding`/`Riding`/`Exiting`, replacing repeated three-arm matches
- `StopConfig::linear(&[(name, pos)])` — shorthand constructor for sequential stops
- Drop `const` from `Simulation::world()` and `world_mut()` — misleading on `&mut self` accessors
- Drive-by: remove unused `ElevatorPhase` import in energy system (unmasked by `--all-features`)

**Non-breaking.** Part 1/9 of the API ergonomics overhaul.

## Test plan

- [x] `cargo test -p elevator-core --all-features` all green (pre-commit hook ran 560+ tests)
- [x] `cargo clippy -p elevator-core --all-features -- -D warnings` clean
- [ ] CI green
- [ ] Greptile review clean