### PR TITLE
refactor!: rename FloorPosition to SpatialPosition

### DIFF
--- a/crates/elevator-core/ARCHITECTURE.md
+++ b/crates/elevator-core/ARCHITECTURE.md
@@ -55,7 +55,7 @@ concrete struct definition.
 |--------------------|-------------------|------------------------------------------------------------------|
 | `Position`         | Elevator, Stop    | Shaft-axis position (`f64`). Stops use it for lookup.            |
 | `Velocity`         | Elevator          | Shaft-axis velocity (`f64`, signed).                             |
-| `FloorPosition`    | Line              | Optional floor-plan position for rendering.                      |
+| `SpatialPosition`    | Line              | Optional floor-plan position for rendering.                      |
 | `Elevator`         | Elevator          | Phase, door FSM, riders, capacity, physics, direction lamps.     |
 | `Rider`            | Rider             | Phase, weight, spawn/board tick.                                 |
 | `Stop`             | Stop              | Name + position pair.                                            |

--- a/crates/elevator-core/ARCHITECTURE.md
+++ b/crates/elevator-core/ARCHITECTURE.md
@@ -30,7 +30,7 @@ pub struct World {
     alive:       SlotMap<EntityId, ()>,
 
     // Built-in component storages (one SecondaryMap per component type)
-    positions, velocities, floor_positions,
+    positions, velocities, spatial_positions,
     elevators, riders, stops, routes, lines,
     patience, preferences, access_control,
     destination_queues, service_modes,

--- a/crates/elevator-core/src/components/line.rs
+++ b/crates/elevator-core/src/components/line.rs
@@ -25,7 +25,7 @@ pub enum Orientation {
 
 /// 2D position on a floor plan (for spatial queries and rendering).
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
-pub struct FloorPosition {
+pub struct SpatialPosition {
     /// X coordinate on the floor plan.
     pub x: f64,
     /// Y coordinate on the floor plan.
@@ -53,7 +53,7 @@ pub struct Line {
     /// Physical orientation (metadata for rendering).
     pub(crate) orientation: Orientation,
     /// Optional floor-plan position (for spatial queries).
-    pub(crate) position: Option<FloorPosition>,
+    pub(crate) position: Option<SpatialPosition>,
     /// Lowest reachable position along the line axis.
     pub(crate) min_position: f64,
     /// Highest reachable position along the line axis.
@@ -83,7 +83,7 @@ impl Line {
 
     /// Optional floor-plan position.
     #[must_use]
-    pub const fn position(&self) -> Option<&FloorPosition> {
+    pub const fn position(&self) -> Option<&SpatialPosition> {
         self.position.as_ref()
     }
 

--- a/crates/elevator-core/src/components/mod.rs
+++ b/crates/elevator-core/src/components/mod.rs
@@ -30,7 +30,7 @@ pub use car_call::CarCall;
 pub use destination_queue::DestinationQueue;
 pub use elevator::{DOOR_COMMAND_QUEUE_CAP, Direction, Elevator, ElevatorPhase};
 pub use hall_call::{CallDirection, HallCall};
-pub use line::{FloorPosition, Line, Orientation};
+pub use line::{Line, Orientation, SpatialPosition};
 pub use patience::{Patience, Preferences};
 pub use position::{Position, Velocity};
 pub use rider::{Rider, RiderPhase};

--- a/crates/elevator-core/src/config.rs
+++ b/crates/elevator-core/src/config.rs
@@ -1,6 +1,6 @@
 //! Building and elevator configuration (RON-deserializable).
 
-use crate::components::{FloorPosition, Orientation};
+use crate::components::{Orientation, SpatialPosition};
 use crate::dispatch::{BuiltinReposition, BuiltinStrategy, HallCallMode};
 use crate::stop::{StopConfig, StopId};
 use serde::{Deserialize, Serialize};
@@ -236,7 +236,7 @@ pub struct LineConfig {
     pub orientation: Orientation,
     /// Optional floor-plan position.
     #[serde(default)]
-    pub position: Option<FloorPosition>,
+    pub position: Option<SpatialPosition>,
     /// Lowest reachable position (auto-computed from stops if `None`).
     #[serde(default)]
     pub min_position: Option<f64>,

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -59,7 +59,7 @@
 //! | [`sim`] | Top-level [`Simulation`](sim::Simulation) runner and tick loop |
 //! | [`dispatch`] | Dispatch strategies and the [`DispatchStrategy`](dispatch::DispatchStrategy) trait |
 //! | [`world`] | ECS-style [`World`](world::World) with typed component storage |
-//! | [`components`] | Entity data types: [`Rider`](components::Rider), [`Elevator`](components::Elevator), [`Stop`](components::Stop), [`Line`](components::Line), [`Route`](components::Route), [`Patience`](components::Patience), [`Preferences`](components::Preferences), [`AccessControl`](components::AccessControl), [`DestinationQueue`](components::DestinationQueue), [`ServiceMode`](components::ServiceMode), [`Orientation`](components::Orientation), [`Position`](components::Position), [`Velocity`](components::Velocity), [`FloorPosition`](components::FloorPosition) |
+//! | [`components`] | Entity data types: [`Rider`](components::Rider), [`Elevator`](components::Elevator), [`Stop`](components::Stop), [`Line`](components::Line), [`Route`](components::Route), [`Patience`](components::Patience), [`Preferences`](components::Preferences), [`AccessControl`](components::AccessControl), [`DestinationQueue`](components::DestinationQueue), [`ServiceMode`](components::ServiceMode), [`Orientation`](components::Orientation), [`Position`](components::Position), [`Velocity`](components::Velocity), [`SpatialPosition`](components::SpatialPosition) |
 //! | [`config`] | RON-deserializable [`SimConfig`](config::SimConfig), [`GroupConfig`](config::GroupConfig), [`LineConfig`](config::LineConfig) |
 //! | [`events`] | [`Event`](events::Event) variants and the [`EventBus`](events::EventBus) |
 //! | [`metrics`] | Aggregate [`Metrics`](metrics::Metrics) (wait time, throughput, etc.) |
@@ -435,7 +435,7 @@ macro_rules! register_extensions {
 ///   [`Stop`](crate::components::Stop), [`Line`](crate::components::Line),
 ///   [`Position`](crate::components::Position),
 ///   [`Velocity`](crate::components::Velocity),
-///   [`FloorPosition`](crate::components::FloorPosition),
+///   [`SpatialPosition`](crate::components::SpatialPosition),
 ///   [`Route`](crate::components::Route),
 ///   [`Patience`](crate::components::Patience),
 ///   [`Preferences`](crate::components::Preferences),
@@ -475,9 +475,9 @@ macro_rules! register_extensions {
 pub mod prelude {
     pub use crate::builder::SimulationBuilder;
     pub use crate::components::{
-        AccessControl, DestinationQueue, Direction, Elevator, ElevatorPhase, FloorPosition, Line,
-        Orientation, Patience, Position, Preferences, Rider, RiderPhase, Route, ServiceMode, Stop,
-        Velocity,
+        AccessControl, DestinationQueue, Direction, Elevator, ElevatorPhase, Line, Orientation,
+        Patience, Position, Preferences, Rider, RiderPhase, Route, ServiceMode, SpatialPosition,
+        Stop, Velocity,
     };
     pub use crate::config::{GroupConfig, LineConfig, SimConfig};
     pub use crate::dispatch::reposition::{

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -68,7 +68,7 @@ mod lifecycle;
 mod topology;
 
 use crate::components::{
-    AccessControl, FloorPosition, Orientation, Patience, Preferences, Rider, RiderPhase, Route,
+    AccessControl, Orientation, Patience, Preferences, Rider, RiderPhase, Route, SpatialPosition,
     Velocity,
 };
 use crate::dispatch::{BuiltinReposition, DispatchStrategy, ElevatorGroup, RepositionStrategy};
@@ -139,7 +139,7 @@ pub struct LineParams {
     /// Highest reachable position on the line axis.
     pub max_position: f64,
     /// Optional floor-plan position.
-    pub position: Option<FloorPosition>,
+    pub position: Option<SpatialPosition>,
     /// Maximum cars on this line (None = unlimited).
     pub max_cars: Option<usize>,
 }

--- a/crates/elevator-core/src/systems/energy.rs
+++ b/crates/elevator-core/src/systems/energy.rs
@@ -1,6 +1,5 @@
 //! Energy system: compute per-tick energy consumption and regeneration.
 
-use crate::components::ElevatorPhase;
 use crate::energy::compute_tick_energy;
 use crate::entity::EntityId;
 use crate::events::{Event, EventBus};

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -11,7 +11,7 @@ This chapter is a quick-reference for the public API of the `elevator-core` crat
 | Category | Items |
 |---|---|
 | Builder & sim | `SimulationBuilder`, `Simulation`, `RiderBuilder` |
-| Components | `Rider`, `RiderPhase`, `Elevator`, `ElevatorPhase`, `Stop`, `Line`, `Position`, `Velocity`, `FloorPosition`, `Route`, `Patience`, `Preferences`, `AccessControl`, `Orientation`, `ServiceMode` |
+| Components | `Rider`, `RiderPhase`, `Elevator`, `ElevatorPhase`, `Stop`, `Line`, `Position`, `Velocity`, `SpatialPosition`, `Route`, `Patience`, `Preferences`, `AccessControl`, `Orientation`, `ServiceMode` |
 | Config | `SimConfig`, `GroupConfig`, `LineConfig` |
 | Dispatch traits | `DispatchStrategy`, `RepositionStrategy` |
 | Reposition strategies | `NearestIdle`, `ReturnToLobby`, `SpreadEvenly`, `DemandWeighted` |
@@ -220,7 +220,7 @@ Parameters for `add_line` at runtime. All fields are public.
 | `orientation` | `Orientation` | Physical orientation (defaults to `Vertical`) |
 | `min_position` | `f64` | Lowest reachable position on the line axis |
 | `max_position` | `f64` | Highest reachable position on the line axis |
-| `position` | `Option<FloorPosition>` | Optional floor-plan position |
+| `position` | `Option<SpatialPosition>` | Optional floor-plan position |
 | `max_cars` | `Option<usize>` | Maximum cars on this line (`None` = unlimited) |
 
 Constructor: `LineParams::new(name, group)` — defaults orientation to `Vertical`, positions to `0.0`, no floor-plan position, unlimited cars.
@@ -650,7 +650,7 @@ All config types derive `Serialize + Deserialize` and are loadable from RON file
 | `serves` | `Vec<StopId>` | Stops served by this line |
 | `elevators` | `Vec<ElevatorConfig>` | Elevators on this line |
 | `orientation` | `Orientation` | Physical orientation (defaults to `Vertical`) |
-| `position` | `Option<FloorPosition>` | Optional floor-plan position |
+| `position` | `Option<SpatialPosition>` | Optional floor-plan position |
 | `min_position` | `Option<f64>` | Lowest reachable position (auto-computed from stops if `None`) |
 | `max_position` | `Option<f64>` | Highest reachable position (auto-computed from stops if `None`) |
 | `max_cars` | `Option<usize>` | Max cars on this line (`None` = unlimited) |
@@ -722,7 +722,7 @@ Entity components are the data attached to simulation entities. Built-in compone
 | `name()` | `&str` | Human-readable name |
 | `group()` | `GroupId` | Dispatch group this line belongs to |
 | `orientation()` | `Orientation` | Physical orientation |
-| `position()` | `Option<&FloorPosition>` | Optional floor-plan position |
+| `position()` | `Option<&SpatialPosition>` | Optional floor-plan position |
 | `min_position()` | `f64` | Lowest reachable position along the line axis |
 | `max_position()` | `f64` | Highest reachable position along the line axis |
 | `max_cars()` | `Option<usize>` | Maximum number of cars allowed on this line |

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -21,7 +21,7 @@ This brings in, at a glance:
 | Group | Items |
 |---|---|
 | Builder & sim | `SimulationBuilder`, `Simulation`, `RiderBuilder` |
-| Components | `Rider`, `RiderPhase`, `Elevator`, `ElevatorPhase`, `Stop`, `Line`, `Position`, `Velocity`, `FloorPosition`, `Route`, `Patience`, `Preferences`, `AccessControl`, `Orientation`, `ServiceMode` |
+| Components | `Rider`, `RiderPhase`, `Elevator`, `ElevatorPhase`, `Stop`, `Line`, `Position`, `Velocity`, `SpatialPosition`, `Route`, `Patience`, `Preferences`, `AccessControl`, `Orientation`, `ServiceMode` |
 | Config | `SimConfig`, `GroupConfig`, `LineConfig` |
 | Dispatch traits | `DispatchStrategy`, `RepositionStrategy` |
 | Reposition strategies | `NearestIdle`, `ReturnToLobby`, `SpreadEvenly`, `DemandWeighted` |


### PR DESCRIPTION
## Summary

BREAKING CHANGE: `FloorPosition` struct renamed to `SpatialPosition`.

The crate models stops at arbitrary distances, not uniform floors. `FloorPosition` contradicted this core design principle. `SpatialPosition` is neutral enough for both `Stop` and `Line` usage.

Updated across: components, config, sim, prelude, ARCHITECTURE.md, api-reference.md, getting-started.md.

Snapshot format: covered by the existing exact-string version check at `snapshot.rs:737` — any crate version change cleanly rejects old snapshots.

Part 7/9 of the API ergonomics overhaul.

## Test plan

- [x] `cargo test -p elevator-core --all-features` all green
- [x] `cargo clippy -p elevator-core --all-features -- -D warnings` clean
- [x] No stale `FloorPosition` references (`grep -r FloorPosition` = 0)
- [ ] CI green
- [ ] Greptile review clean