### PR TITLE
feat: add concrete SimError variants for elevator operations

### DIFF
--- a/crates/elevator-core/src/error.rs
+++ b/crates/elevator-core/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types for configuration validation and runtime failures.
 
+use crate::components::ServiceMode;
 use crate::entity::EntityId;
 use crate::ids::GroupId;
 use crate::stop::StopId;
@@ -30,6 +31,21 @@ pub enum SimError {
         /// Human-readable explanation.
         reason: String,
     },
+    /// The entity is not an elevator.
+    NotAnElevator(EntityId),
+    /// The elevator is disabled.
+    ElevatorDisabled(EntityId),
+    /// The elevator is in an incompatible service mode.
+    WrongServiceMode {
+        /// The elevator entity.
+        entity: EntityId,
+        /// The service mode required by the operation.
+        expected: ServiceMode,
+        /// The elevator's current service mode.
+        actual: ServiceMode,
+    },
+    /// The entity is not a stop.
+    NotAStop(EntityId),
     /// A line entity was not found.
     LineNotFound(EntityId),
     /// No route exists between origin and destination across any group.
@@ -75,6 +91,19 @@ impl fmt::Display for SimError {
             Self::InvalidState { entity, reason } => {
                 write!(f, "invalid state for {entity:?}: {reason}")
             }
+            Self::NotAnElevator(id) => write!(f, "entity {id:?} is not an elevator"),
+            Self::ElevatorDisabled(id) => write!(f, "elevator {id:?} is disabled"),
+            Self::WrongServiceMode {
+                entity,
+                expected,
+                actual,
+            } => {
+                write!(
+                    f,
+                    "elevator {entity:?} is in {actual} mode, expected {expected}"
+                )
+            }
+            Self::NotAStop(id) => write!(f, "entity {id:?} is not a stop"),
             Self::LineNotFound(id) => write!(f, "line entity {id:?} not found"),
             Self::NoRoute {
                 origin,

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -224,7 +224,7 @@
 //! door-FSM state) or queued on the elevator's
 //! [`door_command_queue`](components::Elevator::door_command_queue) and
 //! re-tried every tick until it can be applied. The only hard errors are
-//! "not an elevator" / "elevator disabled" and (for `hold_door`) a
+//! [`NotAnElevator`](error::SimError::NotAnElevator) / [`ElevatorDisabled`](error::SimError::ElevatorDisabled) and (for `hold_door`) a
 //! zero-tick argument — the rest return `Ok(())` and let the engine pick
 //! the right moment. A [`DoorCommand`](door::DoorCommand) can be:
 //!

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -513,8 +513,8 @@ impl Simulation {
     ///
     /// # Errors
     ///
-    /// - [`SimError::InvalidState`] if `elev` is not an elevator.
-    /// - [`SimError::InvalidState`] if `stop` is not a stop.
+    /// - [`SimError::NotAnElevator`] if `elev` is not an elevator.
+    /// - [`SimError::NotAStop`] if `stop` is not a stop.
     pub fn push_destination(
         &mut self,
         elev: EntityId,
@@ -548,8 +548,8 @@ impl Simulation {
     ///
     /// # Errors
     ///
-    /// - [`SimError::InvalidState`] if `elev` is not an elevator.
-    /// - [`SimError::InvalidState`] if `stop` is not a stop.
+    /// - [`SimError::NotAnElevator`] if `elev` is not an elevator.
+    /// - [`SimError::NotAStop`] if `stop` is not a stop.
     pub fn push_destination_front(
         &mut self,
         elev: EntityId,
@@ -580,13 +580,10 @@ impl Simulation {
     ///
     /// # Errors
     ///
-    /// Returns [`SimError::InvalidState`] if `elev` is not an elevator.
+    /// Returns [`SimError::NotAnElevator`] if `elev` is not an elevator.
     pub fn clear_destinations(&mut self, elev: EntityId) -> Result<(), SimError> {
         if self.world.elevator(elev).is_none() {
-            return Err(SimError::InvalidState {
-                entity: elev,
-                reason: "not an elevator".into(),
-            });
+            return Err(SimError::NotAnElevator(elev));
         }
         if let Some(q) = self.world.destination_queue_mut(elev) {
             q.clear();
@@ -597,16 +594,10 @@ impl Simulation {
     /// Validate that `elev` is an elevator and `stop` is a stop.
     fn validate_push_targets(&self, elev: EntityId, stop: EntityId) -> Result<(), SimError> {
         if self.world.elevator(elev).is_none() {
-            return Err(SimError::InvalidState {
-                entity: elev,
-                reason: "not an elevator".into(),
-            });
+            return Err(SimError::NotAnElevator(elev));
         }
         if self.world.stop(stop).is_none() {
-            return Err(SimError::InvalidState {
-                entity: stop,
-                reason: "not a stop".into(),
-            });
+            return Err(SimError::NotAStop(stop));
         }
         Ok(())
     }
@@ -791,7 +782,7 @@ impl Simulation {
     ///
     /// # Errors
     ///
-    /// - [`SimError::InvalidState`] if `elevator` is not an elevator entity.
+    /// - [`SimError::NotAnElevator`] if `elevator` is not an elevator entity.
     /// - [`SimError::InvalidConfig`] if `speed` is not a positive finite number.
     ///
     /// # Example
@@ -826,7 +817,7 @@ impl Simulation {
     ///
     /// # Errors
     ///
-    /// - [`SimError::InvalidState`] if `elevator` is not an elevator entity.
+    /// - [`SimError::NotAnElevator`] if `elevator` is not an elevator entity.
     /// - [`SimError::InvalidConfig`] if `accel` is not a positive finite number.
     ///
     /// # Example
@@ -861,7 +852,7 @@ impl Simulation {
     ///
     /// # Errors
     ///
-    /// - [`SimError::InvalidState`] if `elevator` is not an elevator entity.
+    /// - [`SimError::NotAnElevator`] if `elevator` is not an elevator entity.
     /// - [`SimError::InvalidConfig`] if `decel` is not a positive finite number.
     ///
     /// # Example
@@ -899,7 +890,7 @@ impl Simulation {
     ///
     /// # Errors
     ///
-    /// - [`SimError::InvalidState`] if `elevator` is not an elevator entity.
+    /// - [`SimError::NotAnElevator`] if `elevator` is not an elevator entity.
     /// - [`SimError::InvalidConfig`] if `capacity` is not a positive finite number.
     ///
     /// # Example
@@ -938,7 +929,7 @@ impl Simulation {
     ///
     /// # Errors
     ///
-    /// - [`SimError::InvalidState`] if `elevator` is not an elevator entity.
+    /// - [`SimError::NotAnElevator`] if `elevator` is not an elevator entity.
     /// - [`SimError::InvalidConfig`] if `ticks` is zero.
     ///
     /// # Example
@@ -978,7 +969,7 @@ impl Simulation {
     ///
     /// # Errors
     ///
-    /// - [`SimError::InvalidState`] if `elevator` is not an elevator entity.
+    /// - [`SimError::NotAnElevator`] if `elevator` is not an elevator entity.
     /// - [`SimError::InvalidConfig`] if `ticks` is zero.
     ///
     /// # Example
@@ -1026,8 +1017,8 @@ impl Simulation {
     ///
     /// # Errors
     ///
-    /// - [`SimError::InvalidState`] if `elevator` is not an elevator
-    ///   entity or is disabled.
+    /// - [`SimError::NotAnElevator`] if `elevator` is not an elevator entity.
+    /// - [`SimError::ElevatorDisabled`] if the elevator is disabled.
     ///
     /// # Example
     ///
@@ -1053,8 +1044,8 @@ impl Simulation {
     ///
     /// # Errors
     ///
-    /// - [`SimError::InvalidState`] if `elevator` is not an elevator
-    ///   entity or is disabled.
+    /// - [`SimError::NotAnElevator`] if `elevator` is not an elevator entity.
+    /// - [`SimError::ElevatorDisabled`] if the elevator is disabled.
     ///
     /// # Example
     ///
@@ -1079,8 +1070,8 @@ impl Simulation {
     ///
     /// # Errors
     ///
-    /// - [`SimError::InvalidState`] if `elevator` is not an elevator
-    ///   entity or is disabled.
+    /// - [`SimError::NotAnElevator`] if `elevator` is not an elevator entity.
+    /// - [`SimError::ElevatorDisabled`] if the elevator is disabled.
     /// - [`SimError::InvalidConfig`] if `ticks` is zero.
     ///
     /// # Example
@@ -1106,8 +1097,8 @@ impl Simulation {
     ///
     /// # Errors
     ///
-    /// - [`SimError::InvalidState`] if `elevator` is not an elevator
-    ///   entity or is disabled.
+    /// - [`SimError::NotAnElevator`] if `elevator` is not an elevator entity.
+    /// - [`SimError::ElevatorDisabled`] if the elevator is disabled.
     ///
     /// # Example
     ///
@@ -1134,9 +1125,10 @@ impl Simulation {
     /// values command upward travel, negative values command downward travel.
     ///
     /// # Errors
-    /// - Entity is not an elevator, or is disabled.
-    /// - Elevator is not in [`ServiceMode::Manual`].
-    /// - `velocity` is not finite (NaN or infinite).
+    /// - [`SimError::NotAnElevator`] if the entity is not an elevator.
+    /// - [`SimError::ElevatorDisabled`] if the elevator is disabled.
+    /// - [`SimError::WrongServiceMode`] if the elevator is not in [`ServiceMode::Manual`].
+    /// - [`SimError::InvalidConfig`] if `velocity` is not finite (NaN or infinite).
     ///
     /// [`ServiceMode::Manual`]: crate::components::ServiceMode::Manual
     pub fn set_target_velocity(
@@ -1195,14 +1187,16 @@ impl Simulation {
 
     /// Internal: require an elevator be in `ServiceMode::Manual`.
     fn require_manual_mode(&self, elevator: EntityId) -> Result<(), SimError> {
-        let is_manual = self
+        let actual = self
             .world
             .service_mode(elevator)
-            .is_some_and(|m| *m == crate::components::ServiceMode::Manual);
-        if !is_manual {
-            return Err(SimError::InvalidState {
+            .copied()
+            .unwrap_or_default();
+        if actual != crate::components::ServiceMode::Manual {
+            return Err(SimError::WrongServiceMode {
                 entity: elevator,
-                reason: "elevator is not in ServiceMode::Manual".into(),
+                expected: crate::components::ServiceMode::Manual,
+                actual,
             });
         }
         Ok(())
@@ -1239,16 +1233,10 @@ impl Simulation {
     /// Internal: resolve an elevator entity that is not disabled.
     fn require_enabled_elevator(&self, elevator: EntityId) -> Result<(), SimError> {
         if self.world.elevator(elevator).is_none() {
-            return Err(SimError::InvalidState {
-                entity: elevator,
-                reason: "not an elevator".into(),
-            });
+            return Err(SimError::NotAnElevator(elevator));
         }
         if self.world.is_disabled(elevator) {
-            return Err(SimError::InvalidState {
-                entity: elevator,
-                reason: "elevator is disabled".into(),
-            });
+            return Err(SimError::ElevatorDisabled(elevator));
         }
         Ok(())
     }
@@ -1260,10 +1248,7 @@ impl Simulation {
     ) -> Result<&crate::components::Elevator, SimError> {
         self.world
             .elevator(elevator)
-            .ok_or_else(|| SimError::InvalidState {
-                entity: elevator,
-                reason: "not an elevator".into(),
-            })
+            .ok_or(SimError::NotAnElevator(elevator))
     }
 
     /// Internal: positive-finite validator matching the construction-time

--- a/crates/elevator-core/src/tests/destination_queue_tests.rs
+++ b/crates/elevator-core/src/tests/destination_queue_tests.rs
@@ -4,6 +4,7 @@
 use crate::builder::SimulationBuilder;
 use crate::components::ElevatorPhase;
 use crate::dispatch::scan::ScanDispatch;
+use crate::error::SimError;
 use crate::events::Event;
 use crate::stop::StopId;
 
@@ -272,7 +273,7 @@ fn push_destination_errors_on_non_elevator() {
         .spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
         .unwrap();
     let result = sim.push_destination(rider, s1);
-    assert!(result.is_err());
+    assert!(matches!(result, Err(SimError::NotAnElevator(_))));
 }
 
 // 15
@@ -282,7 +283,7 @@ fn push_destination_errors_on_non_stop() {
     let elev = first_elevator(&sim);
     // Use the elevator entity as the target — not a stop.
     let result = sim.push_destination(elev, elev);
-    assert!(result.is_err());
+    assert!(matches!(result, Err(SimError::NotAStop(_))));
 }
 
 // Regression for greptile P1: when `advance_queue` redirects a moving

--- a/crates/elevator-core/src/tests/door_control_tests.rs
+++ b/crates/elevator-core/src/tests/door_control_tests.rs
@@ -340,7 +340,7 @@ fn command_queued_during_motion_fires_on_arrival() {
     );
 }
 
-/// 9. Unknown elevator: pass non-elevator eid → SimError::InvalidState.
+/// 9. Unknown elevator: pass non-elevator eid → SimError::NotAnElevator.
 #[test]
 fn unknown_elevator_errors() {
     let (mut sim, _elev) = make_sim();
@@ -349,19 +349,19 @@ fn unknown_elevator_errors() {
         .unwrap();
     assert!(matches!(
         sim.open_door(rider),
-        Err(SimError::InvalidState { .. })
+        Err(SimError::NotAnElevator(_))
     ));
     assert!(matches!(
         sim.close_door(rider),
-        Err(SimError::InvalidState { .. })
+        Err(SimError::NotAnElevator(_))
     ));
     assert!(matches!(
         sim.hold_door(rider, 10),
-        Err(SimError::InvalidState { .. })
+        Err(SimError::NotAnElevator(_))
     ));
     assert!(matches!(
         sim.cancel_door_hold(rider),
-        Err(SimError::InvalidState { .. })
+        Err(SimError::NotAnElevator(_))
     ));
 }
 

--- a/crates/elevator-core/src/tests/runtime_upgrades_tests.rs
+++ b/crates/elevator-core/src/tests/runtime_upgrades_tests.rs
@@ -203,7 +203,7 @@ fn set_on_non_elevator_returns_invalid_state() {
         .spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
         .unwrap();
     let err = sim.set_max_speed(rider, 4.0).unwrap_err();
-    assert!(matches!(err, SimError::InvalidState { .. }));
+    assert!(matches!(err, SimError::NotAnElevator(_)));
 }
 
 // ── Velocity preservation ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds four concrete `SimError` variants replacing stringly-typed `InvalidState` for elevator-specific failures:

- `NotAnElevator(EntityId)` — entity is not an elevator
- `ElevatorDisabled(EntityId)` — elevator is disabled
- `WrongServiceMode { entity, expected, actual }` — incompatible service mode
- `NotAStop(EntityId)` — entity is not a stop

Rewrites 7 of 22 total `InvalidState { reason: String }` call sites. `SimError` is `#[non_exhaustive]` so adding variants is non-breaking.

Remaining `InvalidState` sites (rider phase, route mismatch, hall call) are deferred to PR 3b.

**Non-breaking** (`feat:`). Part 3a/9 of the API ergonomics overhaul.

## Test plan

- [x] `cargo test -p elevator-core --all-features` all green
- [x] `cargo clippy -p elevator-core --all-features -- -D warnings` clean
- [x] Test assertions tightened to match concrete variants
- [ ] CI green
- [ ] Greptile review clean