### PR TITLE
feat!: return Result from eta() and tag_entity()

### DIFF
--- a/crates/elevator-core/examples/showcase.rs
+++ b/crates/elevator-core/examples/showcase.rs
@@ -324,7 +324,7 @@ fn part5_metrics_deep_dive() {
 
     // Tag the lobby stop — riders spawned there inherit the tag automatically.
     let lobby_entity = sim.stop_entity(StopId(0)).unwrap();
-    sim.tag_entity(lobby_entity, "zone:lobby");
+    sim.tag_entity(lobby_entity, "zone:lobby").unwrap();
 
     // Spawn riders from the tagged lobby.
     for _ in 0..5 {
@@ -337,7 +337,7 @@ fn part5_metrics_deep_dive() {
     let special = sim
         .spawn_rider_by_stop_id(StopId(0), StopId(1), 60.0)
         .unwrap();
-    sim.tag_entity(special, "priority:express");
+    sim.tag_entity(special, "priority:express").unwrap();
 
     // Run enough ticks for deliveries.
     for _ in 0..600 {

--- a/crates/elevator-core/src/error.rs
+++ b/crates/elevator-core/src/error.rs
@@ -136,6 +136,8 @@ pub enum EtaError {
     ServiceModeExcluded(EntityId),
     /// A stop in the route vanished during calculation.
     StopVanished(EntityId),
+    /// No car has been assigned to serve the hall call at this stop.
+    NoCarAssigned(EntityId),
 }
 
 impl fmt::Display for EtaError {
@@ -150,6 +152,9 @@ impl fmt::Display for EtaError {
                 write!(f, "elevator {id:?} is in a dispatch-excluded service mode")
             }
             Self::StopVanished(id) => write!(f, "stop {id:?} vanished during ETA calculation"),
+            Self::NoCarAssigned(id) => {
+                write!(f, "no car assigned to serve hall call at stop {id:?}")
+            }
         }
     }
 }

--- a/crates/elevator-core/src/error.rs
+++ b/crates/elevator-core/src/error.rs
@@ -117,6 +117,49 @@ impl std::error::Error for SimError {
     }
 }
 
+/// Failure modes for [`Simulation::eta`](crate::sim::Simulation::eta) queries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum EtaError {
+    /// The entity is not an elevator.
+    NotAnElevator(EntityId),
+    /// The entity is not a stop.
+    NotAStop(EntityId),
+    /// The stop is not in the elevator's destination queue.
+    StopNotQueued {
+        /// The queried elevator.
+        elevator: EntityId,
+        /// The queried stop.
+        stop: EntityId,
+    },
+    /// The elevator's service mode excludes it from dispatch-based queries.
+    ServiceModeExcluded(EntityId),
+    /// A stop in the route vanished during calculation.
+    StopVanished(EntityId),
+}
+
+impl fmt::Display for EtaError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotAnElevator(id) => write!(f, "entity {id:?} is not an elevator"),
+            Self::NotAStop(id) => write!(f, "entity {id:?} is not a stop"),
+            Self::StopNotQueued { elevator, stop } => {
+                write!(f, "stop {stop:?} is not in elevator {elevator:?}'s queue")
+            }
+            Self::ServiceModeExcluded(id) => {
+                write!(f, "elevator {id:?} is in a dispatch-excluded service mode")
+            }
+            Self::StopVanished(id) => write!(f, "stop {id:?} vanished during ETA calculation"),
+        }
+    }
+}
+
+impl std::error::Error for EtaError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}
+
 /// Format a list of `GroupId`s as `[GroupId(0), GroupId(1)]` or `[]` if empty.
 fn format_group_list(groups: &[GroupId]) -> String {
     if groups.is_empty() {

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -487,7 +487,7 @@ pub mod prelude {
         AssignedCar, DestinationDispatch, DispatchStrategy, RepositionStrategy,
     };
     pub use crate::entity::EntityId;
-    pub use crate::error::{RejectionContext, RejectionReason, SimError};
+    pub use crate::error::{EtaError, RejectionContext, RejectionReason, SimError};
     pub use crate::events::{Event, EventBus, EventCategory};
     pub use crate::ids::GroupId;
     pub use crate::metrics::Metrics;

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -73,7 +73,7 @@ use crate::components::{
 };
 use crate::dispatch::{BuiltinReposition, DispatchStrategy, ElevatorGroup, RepositionStrategy};
 use crate::entity::EntityId;
-use crate::error::SimError;
+use crate::error::{EtaError, SimError};
 use crate::events::{Event, EventBus};
 use crate::hooks::{Phase, PhaseHooks};
 use crate::ids::GroupId;
@@ -621,25 +621,32 @@ impl Simulation {
     /// at `stop` itself is **not** added; door time at earlier stops along
     /// the route **is**.
     ///
-    /// Returns `None` if:
-    /// - `elev` is not an elevator or `stop` is not a stop,
-    /// - the elevator's [`ServiceMode`](crate::components::ServiceMode) is
-    ///   dispatch-excluded (`Manual` / `Independent`), or
-    /// - `stop` is neither the elevator's current movement target nor anywhere
-    ///   in its [`destination_queue`](Self::destination_queue).
+    /// # Errors
+    ///
+    /// - [`EtaError::NotAnElevator`] if `elev` is not an elevator entity.
+    /// - [`EtaError::NotAStop`] if `stop` is not a stop entity.
+    /// - [`EtaError::ServiceModeExcluded`] if the elevator's
+    ///   [`ServiceMode`](crate::components::ServiceMode) is dispatch-excluded
+    ///   (`Manual` / `Independent`).
+    /// - [`EtaError::StopNotQueued`] if `stop` is neither the elevator's
+    ///   current movement target nor anywhere in its
+    ///   [`destination_queue`](Self::destination_queue).
+    /// - [`EtaError::StopVanished`] if a stop in the route lost its position
+    ///   during calculation.
     ///
     /// The estimate is best-effort. It assumes the queue is served in order
     /// with no mid-trip insertions; dispatch decisions, manual door commands,
     /// and rider boarding/exiting beyond the configured dwell will perturb
     /// the actual arrival.
-    #[must_use]
-    pub fn eta(&self, elev: EntityId, stop: impl Into<StopRef>) -> Option<Duration> {
-        let stop = self.resolve_stop(stop.into()).ok()?;
-        let elevator = self.world.elevator(elev)?;
-        self.world.stop(stop)?;
+    pub fn eta(&self, elev: EntityId, stop: EntityId) -> Result<Duration, EtaError> {
+        let elevator = self
+            .world
+            .elevator(elev)
+            .ok_or(EtaError::NotAnElevator(elev))?;
+        self.world.stop(stop).ok_or(EtaError::NotAStop(stop))?;
         let svc = self.world.service_mode(elev).copied().unwrap_or_default();
         if svc.is_dispatch_excluded() {
-            return None;
+            return Err(EtaError::ServiceModeExcluded(elev));
         }
 
         // Build the route in service order: current target first (if any),
@@ -656,7 +663,10 @@ impl Simulation {
             }
         }
         if !route.contains(&stop) {
-            return None;
+            return Err(EtaError::StopNotQueued {
+                elevator: elev,
+                stop,
+            });
         }
 
         let max_speed = elevator.max_speed();
@@ -686,17 +696,18 @@ impl Simulation {
         };
 
         let in_door_cycle = !matches!(elevator.door(), crate::door::DoorState::Closed);
-        let mut pos = self.world.position(elev)?.value;
+        let mut pos = self
+            .world
+            .position(elev)
+            .ok_or(EtaError::NotAnElevator(elev))?
+            .value;
         let vel_signed = self.world.velocity(elev).map_or(0.0, Velocity::value);
 
         for (idx, &s) in route.iter().enumerate() {
-            let Some(s_pos) = self.world.stop_position(s) else {
-                // A queued entry without a position can only mean the stop
-                // entity was despawned out from under us. Bail rather than
-                // returning a partial accumulation that would silently
-                // understate the ETA.
-                return None;
-            };
+            let s_pos = self
+                .world
+                .stop_position(s)
+                .ok_or(EtaError::StopVanished(s))?;
             let dist = (s_pos - pos).abs();
             // Only the first leg can carry initial velocity, and only if
             // the car is already moving toward this stop and not stuck in
@@ -713,14 +724,17 @@ impl Simulation {
             };
             total += crate::eta::travel_time(dist, v0, max_speed, accel, decel);
             if s == stop {
-                return Some(Duration::from_secs_f64(total.max(0.0)));
+                return Ok(Duration::from_secs_f64(total.max(0.0)));
             }
             total += door_cycle_secs;
             pos = s_pos;
         }
         // `route.contains(&stop)` was true above, so the loop must hit `stop`.
-        // Fall through to `None` as a defensive backstop.
-        None
+        // Fall through as a defensive backstop.
+        Err(EtaError::StopNotQueued {
+            elevator: elev,
+            stop,
+        })
     }
 
     /// Best ETA to `stop` across all dispatch-eligible elevators, optionally
@@ -752,7 +766,7 @@ impl Simulation {
                 if !direction_ok {
                     return None;
                 }
-                self.eta(eid, stop).map(|d| (eid, d))
+                self.eta(eid, stop).ok().map(|d| (eid, d))
             })
             .min_by_key(|(_, d)| *d)
     }
@@ -1320,13 +1334,22 @@ impl Simulation {
     ///
     /// Tags enable per-tag metric breakdowns. An entity can have multiple tags.
     /// Riders automatically inherit tags from their origin stop when spawned.
-    pub fn tag_entity(&mut self, id: EntityId, tag: impl Into<String>) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SimError::EntityNotFound`] if the entity does not exist in
+    /// the world.
+    pub fn tag_entity(&mut self, id: EntityId, tag: impl Into<String>) -> Result<(), SimError> {
+        if !self.world.is_alive(id) {
+            return Err(SimError::EntityNotFound(id));
+        }
         if let Some(tags) = self
             .world
             .resource_mut::<crate::tagged_metrics::MetricTags>()
         {
             tags.tag(id, tag);
         }
+        Ok(())
     }
 
     /// Remove a metric tag from an entity.
@@ -2155,26 +2178,48 @@ impl Simulation {
     }
 
     /// Estimated ticks remaining before the assigned car reaches the
-    /// call at `(stop, direction)`. Returns `None` when no car is
-    /// assigned or the car has no positional data.
-    #[must_use]
+    /// call at `(stop, direction)`.
+    ///
+    /// # Errors
+    ///
+    /// - [`EtaError::NotAStop`] if no hall call exists at `(stop, direction)`.
+    /// - [`EtaError::StopNotQueued`] if no car is assigned to the call.
+    /// - [`EtaError::NotAnElevator`] if the assigned car has no positional
+    ///   data or is not a valid elevator.
     pub fn eta_for_call(
         &self,
         stop: EntityId,
         direction: crate::components::CallDirection,
-    ) -> Option<u64> {
-        let call = self.world.hall_call(stop, direction)?;
-        let car = call.assigned_car?;
-        let car_pos = self.world.position(car)?.value;
-        let stop_pos = self.world.stop_position(stop)?;
-        let max_speed = self.world.elevator(car)?.max_speed();
+    ) -> Result<u64, EtaError> {
+        let call = self
+            .world
+            .hall_call(stop, direction)
+            .ok_or(EtaError::NotAStop(stop))?;
+        let car = call.assigned_car.ok_or_else(|| EtaError::StopNotQueued {
+            elevator: EntityId::default(),
+            stop,
+        })?;
+        let car_pos = self
+            .world
+            .position(car)
+            .ok_or(EtaError::NotAnElevator(car))?
+            .value;
+        let stop_pos = self
+            .world
+            .stop_position(stop)
+            .ok_or(EtaError::StopVanished(stop))?;
+        let max_speed = self
+            .world
+            .elevator(car)
+            .ok_or(EtaError::NotAnElevator(car))?
+            .max_speed();
         if max_speed <= 0.0 {
-            return None;
+            return Err(EtaError::NotAnElevator(car));
         }
         let distance = (car_pos - stop_pos).abs();
         // Simple kinematic estimate. The `eta` module has a richer
         // trapezoidal model; the one-liner suits most hall-display use.
-        Some((distance / max_speed).ceil() as u64)
+        Ok((distance / max_speed).ceil() as u64)
     }
 
     // ── Internal helpers ────────────────────────────────────────────

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -2195,10 +2195,7 @@ impl Simulation {
             .world
             .hall_call(stop, direction)
             .ok_or(EtaError::NotAStop(stop))?;
-        let car = call.assigned_car.ok_or_else(|| EtaError::StopNotQueued {
-            elevator: EntityId::default(),
-            stop,
-        })?;
+        let car = call.assigned_car.ok_or(EtaError::NoCarAssigned(stop))?;
         let car_pos = self
             .world
             .position(car)

--- a/crates/elevator-core/src/tests/eta_tests.rs
+++ b/crates/elevator-core/src/tests/eta_tests.rs
@@ -1,4 +1,5 @@
 use crate::components::{Direction, ServiceMode};
+use crate::error::EtaError;
 use crate::eta::travel_time;
 use crate::stop::StopId;
 use crate::tests::helpers;
@@ -52,8 +53,8 @@ fn eta_returns_none_for_unqueued_stop() {
     let sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
     let elev = sim.world().iter_elevators().next().unwrap().0;
     let stop1 = sim.stop_entity(StopId(1)).unwrap();
-    // Empty queue, no movement target → None.
-    assert!(sim.eta(elev, stop1).is_none());
+    // Empty queue, no movement target → Err.
+    assert!(sim.eta(elev, stop1).is_err());
 }
 
 #[test]
@@ -168,7 +169,10 @@ fn eta_returns_none_for_manual_mode() {
     sim.push_destination(elev, stop1).unwrap();
 
     sim.set_service_mode(elev, ServiceMode::Manual).unwrap();
-    assert!(sim.eta(elev, stop1).is_none());
+    assert!(matches!(
+        sim.eta(elev, stop1),
+        Err(EtaError::ServiceModeExcluded(_))
+    ));
 }
 
 #[test]
@@ -181,7 +185,10 @@ fn eta_returns_none_for_independent_mode() {
 
     sim.set_service_mode(elev, ServiceMode::Independent)
         .unwrap();
-    assert!(sim.eta(elev, stop1).is_none());
+    assert!(matches!(
+        sim.eta(elev, stop1),
+        Err(EtaError::ServiceModeExcluded(_))
+    ));
 }
 
 #[test]
@@ -191,8 +198,11 @@ fn eta_rejects_non_elevator_and_non_stop() {
     let elev = sim.world().iter_elevators().next().unwrap().0;
     let stop1 = sim.stop_entity(StopId(1)).unwrap();
     // Swap arguments: stop is not an elevator, elevator is not a stop.
-    assert!(sim.eta(stop1, stop1).is_none());
-    assert!(sim.eta(elev, elev).is_none());
+    assert!(matches!(
+        sim.eta(stop1, stop1),
+        Err(EtaError::NotAnElevator(_))
+    ));
+    assert!(matches!(sim.eta(elev, elev), Err(EtaError::NotAStop(_))));
 }
 
 #[test]

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -197,7 +197,7 @@ fn snapshot_preserves_metric_tags() {
 
     // Tag stop 0 and spawn a rider.
     let stop0 = sim.stop_entity(StopId(0)).unwrap();
-    sim.tag_entity(stop0, "zone:lobby");
+    sim.tag_entity(stop0, "zone:lobby").unwrap();
     sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
         .unwrap();
     for _ in 0..500 {

--- a/crates/elevator-core/src/tests/tagged_metrics_tests.rs
+++ b/crates/elevator-core/src/tests/tagged_metrics_tests.rs
@@ -8,7 +8,7 @@ fn tagged_stop_metrics_track_riders() {
 
     // Tag stop 0 (Ground) with "zone:lobby".
     let stop0 = sim.stop_entity(StopId(0)).unwrap();
-    sim.tag_entity(stop0, "zone:lobby");
+    sim.tag_entity(stop0, "zone:lobby").unwrap();
 
     // Spawn riders from stop 0 → stop 2 (they inherit "zone:lobby" tag).
     sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
@@ -39,7 +39,7 @@ fn untagged_riders_dont_affect_tagged_metrics() {
 
     // Only tag stop 0.
     let stop0 = sim.stop_entity(StopId(0)).unwrap();
-    sim.tag_entity(stop0, "zone:ground");
+    sim.tag_entity(stop0, "zone:ground").unwrap();
 
     // Spawn a rider from stop 1 (not tagged).
     sim.spawn_rider_by_stop_id(StopId(1), StopId(2), 70.0)
@@ -64,8 +64,8 @@ fn multiple_tags_per_entity() {
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
 
     let stop0 = sim.stop_entity(StopId(0)).unwrap();
-    sim.tag_entity(stop0, "zone:lobby");
-    sim.tag_entity(stop0, "floor:ground");
+    sim.tag_entity(stop0, "zone:lobby").unwrap();
+    sim.tag_entity(stop0, "floor:ground").unwrap();
 
     sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
         .unwrap();
@@ -87,8 +87,8 @@ fn all_tags_lists_registered_tags() {
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
 
     let stop0 = sim.stop_entity(StopId(0)).unwrap();
-    sim.tag_entity(stop0, "alpha");
-    sim.tag_entity(stop0, "beta");
+    sim.tag_entity(stop0, "alpha").unwrap();
+    sim.tag_entity(stop0, "beta").unwrap();
 
     let tags = sim.all_tags();
     assert!(tags.contains(&"alpha"));

--- a/docs/src/metrics-and-events.md
+++ b/docs/src/metrics-and-events.md
@@ -265,14 +265,14 @@ For per-zone or per-label breakdowns, you can tag entities with string labels an
 #     .build()?;
 // Tag a stop.
 let lobby = sim.stop_entity(StopId(0)).unwrap();
-sim.tag_entity(lobby, "zone:lobby");
+sim.tag_entity(lobby, "zone:lobby")?;
 
 // Tag a rider (riders auto-inherit tags from their origin stop when spawned).
 let rider = sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 75.0)?;
 // rider automatically has "zone:lobby" because it was spawned at StopId(0).
 
 // You can also tag manually.
-sim.tag_entity(rider, "priority:vip");
+sim.tag_entity(rider, "priority:vip")?;
 # Ok(())
 # }
 ```
@@ -312,7 +312,7 @@ fn main() -> Result<(), SimError> {
     // Tag stops by zone.
     for (id, tag) in [(0, "zone:low"), (1, "zone:low"), (2, "zone:high"), (3, "zone:high")] {
         if let Some(eid) = sim.stop_entity(StopId(id)) {
-            sim.tag_entity(eid, tag);
+            sim.tag_entity(eid, tag)?;
         }
     }
 


### PR DESCRIPTION
## Summary

BREAKING CHANGE: Return types changed for three public methods:

- `eta()`: `Option<Duration>` → `Result<Duration, EtaError>`
- `eta_for_call()`: `Option<u64>` → `Result<u64, EtaError>`
- `tag_entity()`: `()` → `Result<(), SimError>`

New `EtaError` enum with five variants: `NotAnElevator`, `NotAStop`, `StopNotQueued`, `ServiceModeExcluded`, `StopVanished`. Consumers can now distinguish *why* an ETA is unavailable.

`best_eta()` stays `Option<(EntityId, Duration)>` — internally swallows `EtaError`.

`tag_entity()` returns `SimError::EntityNotFound` if the entity doesn't exist, instead of silently no-oping.

FFI bridge: `ev_sim_eta_for_call` handles new `Result` via existing `.unwrap_or(u64::MAX)` — no ABI change.

Part 2/9 of the API ergonomics overhaul.

## Test plan

- [x] `cargo test --workspace --all-features` all green (567 core + 5 FFI)
- [x] `cargo clippy -p elevator-core --all-features -- -D warnings` clean
- [x] ETA test assertions tightened to match specific `EtaError` variants
- [ ] CI green
- [ ] Greptile review clean