### PR TITLE
feat!: complete SimError::InvalidState split and delete variant

### DIFF
--- a/crates/elevator-core/src/components/mod.rs
+++ b/crates/elevator-core/src/components/mod.rs
@@ -33,7 +33,7 @@ pub use hall_call::{CallDirection, HallCall};
 pub use line::{Line, Orientation, SpatialPosition};
 pub use patience::{Patience, Preferences};
 pub use position::{Position, Velocity};
-pub use rider::{Rider, RiderPhase};
+pub use rider::{Rider, RiderPhase, RiderPhaseKind};
 pub use route::{Route, RouteLeg, TransportMode};
 pub use service_mode::ServiceMode;
 pub use stop::Stop;

--- a/crates/elevator-core/src/components/rider.rs
+++ b/crates/elevator-core/src/components/rider.rs
@@ -41,6 +41,61 @@ impl RiderPhase {
     }
 }
 
+/// Data-less companion to [`RiderPhase`] for error messages and pattern matching
+/// without requiring the inner `EntityId`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum RiderPhaseKind {
+    /// Waiting at a stop.
+    Waiting,
+    /// Boarding an elevator.
+    Boarding,
+    /// Riding in an elevator.
+    Riding,
+    /// Exiting an elevator.
+    Exiting,
+    /// Walking between transfer stops.
+    Walking,
+    /// Reached final destination.
+    Arrived,
+    /// Gave up waiting.
+    Abandoned,
+    /// Parked at a stop.
+    Resident,
+}
+
+impl RiderPhase {
+    /// Return the data-less kind of this phase.
+    #[must_use]
+    pub const fn kind(&self) -> RiderPhaseKind {
+        match self {
+            Self::Waiting => RiderPhaseKind::Waiting,
+            Self::Boarding(_) => RiderPhaseKind::Boarding,
+            Self::Riding(_) => RiderPhaseKind::Riding,
+            Self::Exiting(_) => RiderPhaseKind::Exiting,
+            Self::Walking => RiderPhaseKind::Walking,
+            Self::Arrived => RiderPhaseKind::Arrived,
+            Self::Abandoned => RiderPhaseKind::Abandoned,
+            Self::Resident => RiderPhaseKind::Resident,
+        }
+    }
+}
+
+impl std::fmt::Display for RiderPhaseKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Waiting => write!(f, "Waiting"),
+            Self::Boarding => write!(f, "Boarding"),
+            Self::Riding => write!(f, "Riding"),
+            Self::Exiting => write!(f, "Exiting"),
+            Self::Walking => write!(f, "Walking"),
+            Self::Arrived => write!(f, "Arrived"),
+            Self::Abandoned => write!(f, "Abandoned"),
+            Self::Resident => write!(f, "Resident"),
+        }
+    }
+}
+
 impl std::fmt::Display for RiderPhase {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/crates/elevator-core/src/error.rs
+++ b/crates/elevator-core/src/error.rs
@@ -1,6 +1,6 @@
 //! Error types for configuration validation and runtime failures.
 
-use crate::components::ServiceMode;
+use crate::components::{CallDirection, RiderPhaseKind, ServiceMode};
 use crate::entity::EntityId;
 use crate::ids::GroupId;
 use crate::stop::StopId;
@@ -24,13 +24,40 @@ pub enum SimError {
     StopNotFound(StopId),
     /// A referenced group does not exist.
     GroupNotFound(GroupId),
-    /// An operation was attempted on an entity in an invalid state.
-    InvalidState {
-        /// The entity in the wrong state.
-        entity: EntityId,
-        /// Human-readable explanation.
-        reason: String,
+    /// The route's origin does not match the expected origin.
+    RouteOriginMismatch {
+        /// The expected origin entity.
+        expected_origin: EntityId,
+        /// The origin recorded in the route.
+        route_origin: EntityId,
     },
+    /// An elevator's line does not serve the target stop.
+    LineDoesNotServeStop {
+        /// The elevator (or line) entity.
+        line_or_car: EntityId,
+        /// The stop that is not served.
+        stop: EntityId,
+    },
+    /// No hall call exists at the given stop and direction.
+    HallCallNotFound {
+        /// The stop entity.
+        stop: EntityId,
+        /// The call direction.
+        direction: CallDirection,
+    },
+    /// A rider is in the wrong lifecycle phase for the attempted operation.
+    WrongRiderPhase {
+        /// The rider entity.
+        rider: EntityId,
+        /// The phase required by the operation.
+        expected: RiderPhaseKind,
+        /// The rider's current phase.
+        actual: RiderPhaseKind,
+    },
+    /// A rider has no current stop when one is required.
+    RiderHasNoStop(EntityId),
+    /// A route has no legs.
+    EmptyRoute,
     /// The entity is not an elevator.
     NotAnElevator(EntityId),
     /// The elevator is disabled.
@@ -88,9 +115,33 @@ impl fmt::Display for SimError {
             Self::EntityNotFound(id) => write!(f, "entity not found: {id:?}"),
             Self::StopNotFound(id) => write!(f, "stop not found: {id}"),
             Self::GroupNotFound(id) => write!(f, "group not found: {id}"),
-            Self::InvalidState { entity, reason } => {
-                write!(f, "invalid state for {entity:?}: {reason}")
+            Self::RouteOriginMismatch {
+                expected_origin,
+                route_origin,
+            } => {
+                write!(
+                    f,
+                    "route origin {route_origin:?} does not match expected origin {expected_origin:?}"
+                )
             }
+            Self::LineDoesNotServeStop { line_or_car, stop } => {
+                write!(f, "line/car {line_or_car:?} does not serve stop {stop:?}")
+            }
+            Self::HallCallNotFound { stop, direction } => {
+                write!(f, "no hall call at stop {stop:?} direction {direction:?}")
+            }
+            Self::WrongRiderPhase {
+                rider,
+                expected,
+                actual,
+            } => {
+                write!(
+                    f,
+                    "rider {rider:?} is in {actual} phase, expected {expected}"
+                )
+            }
+            Self::RiderHasNoStop(id) => write!(f, "rider {id:?} has no current stop"),
+            Self::EmptyRoute => write!(f, "route has no legs"),
             Self::NotAnElevator(id) => write!(f, "entity {id:?} is not an elevator"),
             Self::ElevatorDisabled(id) => write!(f, "elevator {id:?} is disabled"),
             Self::WrongServiceMode {

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -476,8 +476,8 @@ pub mod prelude {
     pub use crate::builder::SimulationBuilder;
     pub use crate::components::{
         AccessControl, DestinationQueue, Direction, Elevator, ElevatorPhase, Line, Orientation,
-        Patience, Position, Preferences, Rider, RiderPhase, Route, ServiceMode, SpatialPosition,
-        Stop, Velocity,
+        Patience, Position, Preferences, Rider, RiderPhase, RiderPhaseKind, Route, ServiceMode,
+        SpatialPosition, Stop, Velocity,
     };
     pub use crate::config::{GroupConfig, LineConfig, SimConfig};
     pub use crate::dispatch::reposition::{

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -1505,8 +1505,8 @@ impl Simulation {
     /// # Errors
     ///
     /// Returns [`SimError::EntityNotFound`] if origin does not exist.
-    /// Returns [`SimError::InvalidState`] if origin doesn't match the route's
-    /// first leg `from`.
+    /// Returns [`SimError::RouteOriginMismatch`] if origin doesn't match the
+    /// route's first leg `from`.
     pub fn spawn_rider_with_route(
         &mut self,
         origin: impl Into<StopRef>,
@@ -1522,12 +1522,9 @@ impl Simulation {
         if let Some(leg) = route.current()
             && leg.from != origin
         {
-            return Err(SimError::InvalidState {
-                entity: origin,
-                reason: format!(
-                    "origin {origin:?} does not match route first leg from {:?}",
-                    leg.from
-                ),
+            return Err(SimError::RouteOriginMismatch {
+                expected_origin: origin,
+                route_origin: leg.from,
             });
         }
         Ok(self.spawn_rider_inner(origin, destination, weight, route))
@@ -2076,12 +2073,12 @@ impl Simulation {
     ///
     /// # Errors
     /// - [`SimError::EntityNotFound`] — `car` is not a valid elevator.
-    /// - [`SimError::InvalidState`] with `entity = stop` — no hall call
-    ///   exists at that `(stop, direction)` pair yet.
-    /// - [`SimError::InvalidState`] with `entity = car` — the car's
-    ///   line does not serve `stop`. Without this check a cross-line
-    ///   pin would be silently dropped at dispatch time yet leave the
-    ///   call `pinned`, blocking every other car.
+    /// - [`SimError::HallCallNotFound`] — no hall call exists at that
+    ///   `(stop, direction)` pair yet.
+    /// - [`SimError::LineDoesNotServeStop`] — the car's line does not
+    ///   serve `stop`. Without this check a cross-line pin would be
+    ///   silently dropped at dispatch time yet leave the call `pinned`,
+    ///   blocking every other car.
     pub fn pin_assignment(
         &mut self,
         car: EntityId,
@@ -2104,18 +2101,13 @@ impl Simulation {
             .find(|li| li.entity() == car_line)
             .map(|li| li.serves().contains(&stop));
         if line_serves_stop == Some(false) {
-            return Err(SimError::InvalidState {
-                entity: car,
-                reason: format!(
-                    "car's line does not serve stop {stop:?}; pinning would orphan the call"
-                ),
+            return Err(SimError::LineDoesNotServeStop {
+                line_or_car: car,
+                stop,
             });
         }
         let Some(call) = self.world.hall_call_mut(stop, direction) else {
-            return Err(SimError::InvalidState {
-                entity: stop,
-                reason: "no hall call exists at that stop and direction".to_string(),
-            });
+            return Err(SimError::HallCallNotFound { stop, direction });
         };
         call.assigned_car = Some(car);
         call.pinned = true;

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashSet;
 
-use crate::components::{Elevator, ElevatorPhase, RiderPhase, Route};
+use crate::components::{Elevator, ElevatorPhase, RiderPhase, RiderPhaseKind, Route};
 use crate::entity::EntityId;
 use crate::error::SimError;
 use crate::events::Event;
@@ -73,8 +73,9 @@ impl Simulation {
     /// # Errors
     ///
     /// Returns [`SimError::EntityNotFound`] if `rider` does not exist.
-    /// Returns [`SimError::InvalidState`] if the rider is not in
-    /// [`RiderPhase::Waiting`] or has no current stop.
+    /// Returns [`SimError::WrongRiderPhase`] if the rider is not in
+    /// [`RiderPhase::Waiting`], or [`SimError::RiderHasNoStop`] if the
+    /// rider has no current stop.
     pub fn reroute(&mut self, rider: EntityId, new_destination: EntityId) -> Result<(), SimError> {
         let r = self
             .world
@@ -82,16 +83,14 @@ impl Simulation {
             .ok_or(SimError::EntityNotFound(rider))?;
 
         if r.phase != RiderPhase::Waiting {
-            return Err(SimError::InvalidState {
-                entity: rider,
-                reason: "can only reroute riders in Waiting phase".into(),
+            return Err(SimError::WrongRiderPhase {
+                rider,
+                expected: RiderPhaseKind::Waiting,
+                actual: r.phase.kind(),
             });
         }
 
-        let origin = r.current_stop.ok_or_else(|| SimError::InvalidState {
-            entity: rider,
-            reason: "rider has no current stop for reroute".into(),
-        })?;
+        let origin = r.current_stop.ok_or(SimError::RiderHasNoStop(rider))?;
 
         let group = self.group_from_route(self.world.route(rider));
         self.world
@@ -131,8 +130,9 @@ impl Simulation {
     /// # Errors
     ///
     /// Returns [`SimError::EntityNotFound`] if `id` does not exist.
-    /// Returns [`SimError::InvalidState`] if the rider is not in
-    /// `Arrived` or `Abandoned` phase, or has no current stop.
+    /// Returns [`SimError::WrongRiderPhase`] if the rider is not in
+    /// `Arrived` or `Abandoned` phase, or [`SimError::RiderHasNoStop`]
+    /// if the rider has no current stop.
     pub fn settle_rider(&mut self, id: EntityId) -> Result<(), SimError> {
         let rider = self.world.rider(id).ok_or(SimError::EntityNotFound(id))?;
 
@@ -140,19 +140,15 @@ impl Simulation {
         match old_phase {
             RiderPhase::Arrived | RiderPhase::Abandoned => {}
             _ => {
-                return Err(SimError::InvalidState {
-                    entity: id,
-                    reason: format!(
-                        "cannot settle rider in {old_phase} phase, expected Arrived or Abandoned"
-                    ),
+                return Err(SimError::WrongRiderPhase {
+                    rider: id,
+                    expected: RiderPhaseKind::Arrived,
+                    actual: old_phase.kind(),
                 });
             }
         }
 
-        let stop = rider.current_stop.ok_or_else(|| SimError::InvalidState {
-            entity: id,
-            reason: "rider has no current_stop".into(),
-        })?;
+        let stop = rider.current_stop.ok_or(SimError::RiderHasNoStop(id))?;
 
         // Update index: remove from old partition (only Abandoned is indexed).
         if old_phase == RiderPhase::Abandoned {
@@ -183,44 +179,32 @@ impl Simulation {
     /// # Errors
     ///
     /// Returns [`SimError::EntityNotFound`] if `id` does not exist.
-    /// Returns [`SimError::InvalidState`] if the rider is not in `Resident` phase,
-    /// the route has no legs, or the route's first leg origin does not match the
-    /// rider's current stop.
+    /// Returns [`SimError::WrongRiderPhase`] if the rider is not in `Resident`
+    /// phase, [`SimError::EmptyRoute`] if the route has no legs, or
+    /// [`SimError::RouteOriginMismatch`] if the route's first leg origin does
+    /// not match the rider's current stop.
     pub fn reroute_rider(&mut self, id: EntityId, route: Route) -> Result<(), SimError> {
         let rider = self.world.rider(id).ok_or(SimError::EntityNotFound(id))?;
 
         if rider.phase != RiderPhase::Resident {
-            return Err(SimError::InvalidState {
-                entity: id,
-                reason: format!(
-                    "cannot reroute rider in {} phase, expected Resident",
-                    rider.phase
-                ),
+            return Err(SimError::WrongRiderPhase {
+                rider: id,
+                expected: RiderPhaseKind::Resident,
+                actual: rider.phase.kind(),
             });
         }
 
-        let stop = rider.current_stop.ok_or_else(|| SimError::InvalidState {
-            entity: id,
-            reason: "resident rider has no current_stop".into(),
-        })?;
+        let stop = rider.current_stop.ok_or(SimError::RiderHasNoStop(id))?;
 
-        let new_destination = route
-            .final_destination()
-            .ok_or_else(|| SimError::InvalidState {
-                entity: id,
-                reason: "route has no legs".into(),
-            })?;
+        let new_destination = route.final_destination().ok_or(SimError::EmptyRoute)?;
 
         // Validate that the route departs from the rider's current stop.
         if let Some(leg) = route.current()
             && leg.from != stop
         {
-            return Err(SimError::InvalidState {
-                entity: id,
-                reason: format!(
-                    "route origin {:?} does not match rider current_stop {:?}",
-                    leg.from, stop
-                ),
+            return Err(SimError::RouteOriginMismatch {
+                expected_origin: stop,
+                route_origin: leg.from,
             });
         }
 

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -486,8 +486,11 @@ fn pin_across_lines_is_rejected() {
 
     let err = sim.pin_assignment(low_car, top, CallDirection::Down);
     assert!(
-        matches!(err, Err(crate::error::SimError::InvalidState { .. })),
-        "cross-line pin should return InvalidState, got {err:?}"
+        matches!(
+            err,
+            Err(crate::error::SimError::LineDoesNotServeStop { .. })
+        ),
+        "cross-line pin should return LineDoesNotServeStop, got {err:?}"
     );
     let call = sim.world().hall_call(top, CallDirection::Down).unwrap();
     assert!(!call.pinned, "failed pin must not flag the call pinned");

--- a/crates/elevator-core/src/tests/reroute_tests.rs
+++ b/crates/elevator-core/src/tests/reroute_tests.rs
@@ -261,7 +261,10 @@ fn reroute_rejects_non_waiting_rider() {
     let phase = sim.world().rider(rider).unwrap().phase;
     if phase != RiderPhase::Waiting {
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), SimError::InvalidState { .. }));
+        assert!(matches!(
+            result.unwrap_err(),
+            SimError::WrongRiderPhase { .. }
+        ));
     }
 }
 

--- a/crates/elevator-core/src/tests/resident_tests.rs
+++ b/crates/elevator-core/src/tests/resident_tests.rs
@@ -103,7 +103,7 @@ fn settle_wrong_phase_returns_error() {
 
     // Rider is Waiting — should fail.
     let result = sim.settle_rider(rider);
-    assert!(matches!(result, Err(SimError::InvalidState { .. })));
+    assert!(matches!(result, Err(SimError::WrongRiderPhase { .. })));
 }
 
 #[test]
@@ -155,7 +155,7 @@ fn reroute_wrong_phase_returns_error() {
 
     // Rider is Waiting — should fail.
     let result = sim.reroute_rider(rider, route);
-    assert!(matches!(result, Err(SimError::InvalidState { .. })));
+    assert!(matches!(result, Err(SimError::WrongRiderPhase { .. })));
 }
 
 #[test]

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -810,7 +810,12 @@ Method: `reversed()` returns the opposite direction.
 | `EntityNotFound` | `EntityId` | A referenced entity does not exist |
 | `StopNotFound` | `StopId` | A referenced stop ID does not exist |
 | `GroupNotFound` | `GroupId` | A referenced group does not exist |
-| `InvalidState` | `entity: EntityId`, `reason: String` | Operation attempted on entity in wrong state |
+| `RouteOriginMismatch` | `expected_origin: EntityId`, `route_origin: EntityId` | Route origin does not match expected origin |
+| `LineDoesNotServeStop` | `line_or_car: EntityId`, `stop: EntityId` | Elevator's line does not serve the target stop |
+| `HallCallNotFound` | `stop: EntityId`, `direction: CallDirection` | No hall call at that stop and direction |
+| `WrongRiderPhase` | `rider: EntityId`, `expected: RiderPhaseKind`, `actual: RiderPhaseKind` | Rider in wrong lifecycle phase for operation |
+| `RiderHasNoStop` | `EntityId` | Rider has no current stop when one is required |
+| `EmptyRoute` | — | Route has no legs |
 | `LineNotFound` | `EntityId` | A referenced line entity does not exist |
 | `NoRoute` | `origin: EntityId`, `destination: EntityId` | No route exists between origin and destination across any group |
 | `AmbiguousRoute` | `origin: EntityId`, `destination: EntityId` | Multiple groups serve both origin and destination — caller must specify |

--- a/docs/src/hall-calls.md
+++ b/docs/src/hall-calls.md
@@ -75,7 +75,7 @@ Pin enforcement mirrors the idle-pool eligibility gate: a car in
 `Loading` / `DoorOpening` / `DoorClosing` finishes its current door
 cycle first; the pin is honored on the next dispatch tick. Pins that
 cross lines (the car's line can't reach the stop) return
-`SimError::InvalidState` rather than silently orphaning the call.
+`SimError::LineDoesNotServeStop` rather than silently orphaning the call.
 
 ## Rider balking
 


### PR DESCRIPTION
## Summary

BREAKING CHANGE: `SimError::InvalidState` removed entirely. All 22 former call sites now use concrete, matchable variants.

New types:
- `RiderPhaseKind` — data-less companion to `RiderPhase` for error contexts

New `SimError` variants (6):
- `RouteOriginMismatch { expected_origin, route_origin }`
- `LineDoesNotServeStop { line_or_car, stop }`
- `HallCallNotFound { stop, direction: CallDirection }`
- `WrongRiderPhase { rider, expected: RiderPhaseKind, actual: RiderPhaseKind }`
- `RiderHasNoStop(EntityId)`
- `EmptyRoute`

Combined with PR 3a's four variants, consumers can now pattern-match on every operational failure mode without parsing strings.

Part 3b/9 of the API ergonomics overhaul.

## Test plan

- [x] `cargo test -p elevator-core --all-features` all green
- [x] `cargo clippy -p elevator-core --all-features -- -D warnings` clean
- [x] `grep -rn InvalidState crates/elevator-core/src/` returns zero matches
- [x] Test assertions tightened to match concrete variants
- [ ] CI green
- [ ] Greptile review clean