### PR TITLE
feat!: typed ExtKey<T> for compile-time extension safety

### DIFF
--- a/crates/elevator-core/examples/dispatch_comparison.rs
+++ b/crates/elevator-core/examples/dispatch_comparison.rs
@@ -129,7 +129,7 @@ fn run_one<S: DispatchStrategy + 'static>(
     let config = make_config();
     let mut sim = Simulation::new(&config, strategy).unwrap();
     sim.world_mut()
-        .register_ext::<AssignedCar>(ExtKey::from_type_name());
+        .register_ext::<AssignedCar>(ExtKey::new("assigned_car"));
 
     let mut source = make_source(pattern, seed, mean_interval);
     let mut spawned = 0u64;

--- a/crates/elevator-core/examples/dispatch_comparison.rs
+++ b/crates/elevator-core/examples/dispatch_comparison.rs
@@ -128,7 +128,8 @@ fn run_one<S: DispatchStrategy + 'static>(
 ) -> ScenarioResult {
     let config = make_config();
     let mut sim = Simulation::new(&config, strategy).unwrap();
-    sim.world_mut().register_ext::<AssignedCar>("assigned_car");
+    sim.world_mut()
+        .register_ext::<AssignedCar>(ExtKey::from_type_name());
 
     let mut source = make_source(pattern, seed, mean_interval);
     let mut spawned = 0u64;

--- a/crates/elevator-core/examples/extensions.rs
+++ b/crates/elevator-core/examples/extensions.rs
@@ -13,7 +13,7 @@ struct VipTag {
 
 fn main() {
     let mut sim = SimulationBuilder::demo()
-        .with_ext::<VipTag>("vip_tag")
+        .with_ext::<VipTag>()
         .build()
         .unwrap();
 
@@ -22,7 +22,7 @@ fn main() {
         .spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
         .unwrap();
     sim.world_mut()
-        .insert_ext(rider, VipTag { level: 5 }, "vip_tag");
+        .insert_ext(rider, VipTag { level: 5 }, ExtKey::from_type_name());
 
     // Query extension components.
     for (id, vip) in sim.world().query::<(EntityId, &Ext<VipTag>)>().iter() {

--- a/crates/elevator-core/examples/showcase.rs
+++ b/crates/elevator-core/examples/showcase.rs
@@ -216,7 +216,7 @@ fn part3_extensions() {
                 position: 12.0,
             },
         ])
-        .with_ext::<VipTag>("vip_tag")
+        .with_ext::<VipTag>()
         .build()
         .unwrap();
 
@@ -225,7 +225,7 @@ fn part3_extensions() {
         .spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
         .unwrap();
     sim.world_mut()
-        .insert_ext::<VipTag>(rider, VipTag { level: 3 }, "vip_tag");
+        .insert_ext(rider, VipTag { level: 3 }, ExtKey::from_type_name());
 
     // Read the extension back.
     let vip: Option<VipTag> = sim.world().get_ext::<VipTag>(rider);

--- a/crates/elevator-core/src/builder.rs
+++ b/crates/elevator-core/src/builder.rs
@@ -394,14 +394,10 @@ impl SimulationBuilder {
     /// Extensions registered here will be available immediately after [`build()`](Self::build)
     /// without needing to call `register_ext` manually.
     #[must_use]
-    pub fn with_ext<T: 'static + Send + Sync + Serialize + DeserializeOwned>(
-        mut self,
-        name: &str,
-    ) -> Self {
-        let name = name.to_owned();
+    pub fn with_ext<T: 'static + Send + Sync + Serialize + DeserializeOwned>(mut self) -> Self {
         self.ext_registrations
             .push(Box::new(move |world: &mut World| {
-                world.register_ext::<T>(&name);
+                world.register_ext::<T>(crate::world::ExtKey::from_type_name());
             }));
         self
     }

--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -28,22 +28,20 @@ use serde::{Deserialize, Serialize};
 
 use crate::components::{DestinationQueue, Direction, ElevatorPhase, TransportMode};
 use crate::entity::EntityId;
-use crate::world::World;
+use crate::world::{ExtKey, World};
 
 use super::{DispatchManifest, DispatchStrategy, ElevatorGroup};
 
 /// Sticky rider → car assignment produced by [`DestinationDispatch`].
 ///
-/// Stored as an extension component on the rider entity under the key
-/// `"assigned_car"`. Once set, the assignment is never mutated; the
-/// loading phase uses it to enforce that only the assigned car may board
-/// the rider.
+/// Stored as an extension component on the rider entity. Once set, the
+/// assignment is never mutated; the loading phase uses it to enforce
+/// that only the assigned car may board the rider.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AssignedCar(pub EntityId);
 
-/// Extension component name used when inserting [`AssignedCar`] into the
-/// world's extension storage.
-pub const ASSIGNED_CAR_EXT_NAME: &str = "assigned_car";
+/// Typed extension key for [`AssignedCar`] storage.
+pub const ASSIGNED_CAR_KEY: ExtKey<AssignedCar> = ExtKey::new("assigned_car");
 
 /// Hall-call destination dispatch (DCS).
 ///
@@ -202,7 +200,7 @@ impl DispatchStrategy for DestinationDispatch {
             let Some(car_eid) = best else {
                 continue;
             };
-            world.insert_ext(rid, AssignedCar(car_eid), ASSIGNED_CAR_EXT_NAME);
+            world.insert_ext(rid, AssignedCar(car_eid), ASSIGNED_CAR_KEY);
             *committed_load.entry(car_eid).or_insert(0.0) += weight;
         }
 

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -151,7 +151,7 @@
 //!
 //! ```rust,ignore
 //! // Attach a VIP flag to a rider.
-//! world.insert_ext(rider_id, VipTag { priority: 1 }, "vip_tag");
+//! world.insert_ext(rider_id, VipTag { priority: 1 }, ExtKey::from_type_name());
 //!
 //! // Query it alongside built-in components.
 //! for (id, rider, vip) in world.query::<(EntityId, &Rider, &Ext<VipTag>)>().iter() {
@@ -160,14 +160,14 @@
 //! ```
 //!
 //! Extensions participate in snapshots via `serialize_extensions()` /
-//! `register_ext::<T>(name)` + `load_extensions()`.
+//! `register_ext::<T>(key)` + `load_extensions()`.
 //!
 //! ### Snapshot lifecycle
 //!
 //! 1. Capture: `sim.snapshot()` → [`WorldSnapshot`](snapshot::WorldSnapshot)
 //! 2. Serialize: serde (RON, JSON, bincode, etc.)
 //! 3. Deserialize + restore: `snapshot.restore(factory)` → new `Simulation`
-//! 4. Re-register extensions: `world.register_ext::<T>(name)` per type
+//! 4. Re-register extensions: `world.register_ext::<T>(key)` per type
 //! 5. Load extension data: `sim.load_extensions()`
 //!
 //! For the common case (save-to-disk, load-from-disk), skip the format choice
@@ -394,7 +394,9 @@ pub mod traffic;
 ///
 /// Eliminates the manual `register_ext` ceremony after snapshot restore.
 ///
-/// # Example
+/// # Examples
+///
+/// Name-less form (uses `type_name` automatically):
 ///
 /// ```
 /// use elevator_core::prelude::*;
@@ -408,12 +410,29 @@ pub mod traffic;
 /// struct Priority { rank: u8 }
 ///
 /// let mut sim = SimulationBuilder::demo().build().unwrap();
-/// register_extensions!(sim.world_mut(), VipTag => "vip_tag", Priority => "priority");
+/// register_extensions!(sim.world_mut(), VipTag, Priority);
+/// ```
+///
+/// Named form (explicit storage name per type):
+///
+/// ```
+/// use elevator_core::prelude::*;
+/// use elevator_core::register_extensions;
+/// use serde::{Deserialize, Serialize};
+///
+/// #[derive(Clone, Debug, Serialize, Deserialize)]
+/// struct VipTag { level: u32 }
+///
+/// let mut sim = SimulationBuilder::demo().build().unwrap();
+/// register_extensions!(sim.world_mut(), VipTag => "vip_tag");
 /// ```
 #[macro_export]
 macro_rules! register_extensions {
+    ($world:expr, $($ty:ty),+ $(,)?) => {
+        $( $world.register_ext::<$ty>($crate::world::ExtKey::<$ty>::from_type_name()); )+
+    };
     ($world:expr, $($ty:ty => $name:expr),+ $(,)?) => {
-        $( $world.register_ext::<$ty>($name); )+
+        $( $world.register_ext::<$ty>($crate::world::ExtKey::<$ty>::new($name)); )+
     };
 }
 
@@ -494,6 +513,7 @@ pub mod prelude {
     pub use crate::sim::{RiderBuilder, Simulation};
     pub use crate::stop::{StopId, StopRef};
     pub use crate::time::TimeAdapter;
+    pub use crate::world::ExtKey;
 }
 
 #[cfg(test)]

--- a/crates/elevator-core/src/query/mod.rs
+++ b/crates/elevator-core/src/query/mod.rs
@@ -15,7 +15,7 @@
 //! let rider_eid = sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 75.0).unwrap();
 //!
 //! // Attach an extension component.
-//! sim.world_mut().insert_ext(rider_eid, VipTag { level: 5 }, "vip_tag");
+//! sim.world_mut().insert_ext(rider_eid, VipTag { level: 5 }, ExtKey::from_type_name());
 //!
 //! let world = sim.world();
 //!

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -20,11 +20,11 @@ impl Simulation {
     /// Deserialize extension components from a snapshot.
     ///
     /// Call this after restoring from a snapshot and registering all
-    /// extension types via `world.register_ext::<T>(name)`.
+    /// extension types via `world.register_ext::<T>(key)`.
     ///
     /// ```ignore
     /// let mut sim = snapshot.restore(None);
-    /// sim.world_mut().register_ext::<VipTag>("vip_tag");
+    /// sim.world_mut().register_ext::<VipTag>(ExtKey::from_type_name());
     /// sim.load_extensions();
     /// ```
     pub fn load_extensions(&mut self) {

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -157,7 +157,7 @@ impl WorldSnapshot {
     /// For `Custom` strategies, provide a factory function that maps strategy
     /// names to instances. Pass `None` if only using built-in strategies.
     ///
-    /// To restore extension components, call `world.register_ext::<T>(name)`
+    /// To restore extension components, call `world.register_ext::<T>(key)`
     /// on the returned simulation's world for each extension type, then call
     /// [`Simulation::load_extensions()`](crate::sim::Simulation::load_extensions)
     /// with this snapshot's `extensions` data.
@@ -683,7 +683,7 @@ impl crate::sim::Simulation {
     ///
     /// Extension component *data* is serialized (identical to
     /// [`Simulation::snapshot`]); after restore you must still call
-    /// `world.register_ext::<T>(name)` for each extension type and then
+    /// `world.register_ext::<T>(key)` for each extension type and then
     /// [`Simulation::load_extensions`] to materialize them. Custom
     /// dispatch strategies and arbitrary `World` resources are not
     /// included.

--- a/crates/elevator-core/src/tests/destination_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/destination_dispatch_tests.rs
@@ -5,7 +5,7 @@ use crate::config::{
     BuildingConfig, ElevatorConfig, GroupConfig, LineConfig, PassengerSpawnConfig, SimConfig,
     SimulationParams,
 };
-use crate::dispatch::destination::{ASSIGNED_CAR_EXT_NAME, AssignedCar, DestinationDispatch};
+use crate::dispatch::destination::{ASSIGNED_CAR_KEY, AssignedCar, DestinationDispatch};
 use crate::sim::Simulation;
 use crate::stop::{StopConfig, StopId};
 
@@ -165,7 +165,7 @@ fn sticky_assignment_persists_across_ticks() {
         g.set_hall_call_mode(crate::dispatch::HallCallMode::Destination);
     }
     sim.world_mut()
-        .register_ext::<AssignedCar>(ASSIGNED_CAR_EXT_NAME);
+        .register_ext::<AssignedCar>(ASSIGNED_CAR_KEY);
 
     let rid = sim
         .spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
@@ -203,7 +203,7 @@ fn loading_respects_assignment_other_car_skips() {
     .unwrap();
 
     sim.world_mut()
-        .register_ext::<AssignedCar>(ASSIGNED_CAR_EXT_NAME);
+        .register_ext::<AssignedCar>(ASSIGNED_CAR_KEY);
 
     // Identify the two elevators.
     let elevs: Vec<_> = sim
@@ -233,7 +233,7 @@ fn loading_respects_assignment_other_car_skips() {
     // and seed B's queue with the rider's pickup + drop-off so DCS's normal
     // queue-driven movement applies to the forced assignment too.
     sim.world_mut()
-        .insert_ext(rid, AssignedCar(car_b), ASSIGNED_CAR_EXT_NAME);
+        .insert_ext(rid, AssignedCar(car_b), ASSIGNED_CAR_KEY);
     let f2 = sim.stop_entity(StopId(1)).unwrap();
     let f3 = sim.stop_entity(StopId(2)).unwrap();
     sim.push_destination(car_b, f2).unwrap();
@@ -278,7 +278,7 @@ fn unassigned_manual_board_riders_still_work() {
         g.set_hall_call_mode(crate::dispatch::HallCallMode::Destination);
     }
     sim.world_mut()
-        .register_ext::<AssignedCar>(ASSIGNED_CAR_EXT_NAME);
+        .register_ext::<AssignedCar>(ASSIGNED_CAR_KEY);
 
     // Standard spawn: has a Route → DCS should assign.
     let routed = sim
@@ -320,7 +320,7 @@ fn closer_car_is_preferred_when_matching_direction() {
     let mut sim =
         Simulation::new(&two_cars_same_group_config(), DestinationDispatch::new()).unwrap();
     sim.world_mut()
-        .register_ext::<AssignedCar>(ASSIGNED_CAR_EXT_NAME);
+        .register_ext::<AssignedCar>(ASSIGNED_CAR_KEY);
 
     let elevs: Vec<_> = sim
         .world()
@@ -351,7 +351,7 @@ fn up_peak_scenario_delivers_all_riders() {
     let mut sim =
         Simulation::new(&two_cars_same_group_config(), DestinationDispatch::new()).unwrap();
     sim.world_mut()
-        .register_ext::<AssignedCar>(ASSIGNED_CAR_EXT_NAME);
+        .register_ext::<AssignedCar>(ASSIGNED_CAR_KEY);
 
     // 20 riders from the lobby (StopId(0)) to upper floors, alternating.
     let mut riders = Vec::new();
@@ -402,7 +402,7 @@ fn dcs_gated_to_destination_mode() {
         "default group mode should still be Classic for this test",
     );
     sim.world_mut()
-        .register_ext::<AssignedCar>(ASSIGNED_CAR_EXT_NAME);
+        .register_ext::<AssignedCar>(ASSIGNED_CAR_KEY);
 
     let rid = sim
         .spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)

--- a/crates/elevator-core/src/tests/query_tests.rs
+++ b/crates/elevator-core/src/tests/query_tests.rs
@@ -4,7 +4,7 @@ use crate::components::{Elevator, ElevatorPhase, Position, Rider, RiderPhase, St
 use crate::door::DoorState;
 use crate::entity::EntityId;
 use crate::query::Ext;
-use crate::world::World;
+use crate::world::{ExtKey, World};
 
 fn test_world() -> (World, EntityId, EntityId, EntityId) {
     let mut w = World::new();
@@ -157,7 +157,7 @@ fn query_extension_component() {
     }
 
     let (mut w, a, b, _c) = test_world();
-    w.insert_ext(a, VipTag { level: 3 }, "vip_tag");
+    w.insert_ext(a, VipTag { level: 3 }, ExtKey::from_type_name());
 
     // Query for entities with Rider and VipTag extension.
     let results: Vec<_> = w
@@ -179,8 +179,8 @@ fn query_ext_with_filter() {
     struct Priority(#[allow(dead_code)] u32);
 
     let (mut w, a, b, c) = test_world();
-    w.insert_ext(a, Priority(1), "priority");
-    w.insert_ext(c, Priority(2), "priority");
+    w.insert_ext(a, Priority(1), ExtKey::from_type_name());
+    w.insert_ext(c, Priority(2), ExtKey::from_type_name());
 
     // Entities with Position that have Priority extension.
     let results: Vec<_> = w
@@ -201,7 +201,7 @@ fn query_ext_without_filter() {
     struct Marked;
 
     let (mut w, a, _b, _c) = test_world();
-    w.insert_ext(a, Marked, "marked");
+    w.insert_ext(a, Marked, ExtKey::from_type_name());
 
     // Riders without Marked extension.
     let count = w

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -1,6 +1,7 @@
 use crate::components::RiderPhase;
 use crate::stop::StopId;
 use crate::tests::helpers;
+use crate::world::ExtKey;
 use serde::{Deserialize, Serialize};
 
 #[test]
@@ -233,13 +234,15 @@ fn snapshot_preserves_extension_components() {
         .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
         .unwrap();
     sim.world_mut()
-        .insert_ext(rider, VipTag { level: 5 }, "vip_tag");
+        .insert_ext(rider, VipTag { level: 5 }, ExtKey::from_type_name());
 
     let snap = sim.snapshot();
     let mut restored = snap.restore(None);
 
     // Register the extension type on the restored world, then load.
-    restored.world_mut().register_ext::<VipTag>("vip_tag");
+    restored
+        .world_mut()
+        .register_ext::<VipTag>(ExtKey::from_type_name());
     restored.load_extensions();
 
     // Find the rider in the restored world and check the extension.

--- a/crates/elevator-core/src/tests/world_tests.rs
+++ b/crates/elevator-core/src/tests/world_tests.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::components::*;
 use crate::door::DoorState;
-use crate::world::World;
+use crate::world::{ExtKey, World};
 
 #[test]
 fn spawn_and_check_alive() {
@@ -176,7 +176,7 @@ fn extension_components() {
     let e = world.spawn();
 
     // Insert, get, mutate.
-    world.insert_ext(e, VipTag { level: 3 }, "vip_tag");
+    world.insert_ext(e, VipTag { level: 3 }, ExtKey::from_type_name());
     assert_eq!(world.get_ext::<VipTag>(e), Some(VipTag { level: 3 }));
 
     world.get_ext_mut::<VipTag>(e).unwrap().level = 5;

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -2,6 +2,7 @@
 
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
+use std::marker::PhantomData;
 
 use slotmap::{SecondaryMap, SlotMap};
 
@@ -13,6 +14,57 @@ use crate::components::{
 use crate::energy::{EnergyMetrics, EnergyProfile};
 use crate::entity::EntityId;
 use crate::query::storage::AnyExtMap;
+
+/// Typed handle for extension component storage.
+///
+/// Constructed via [`ExtKey::new`] with an explicit name, or
+/// [`ExtKey::from_type_name`] which uses `std::any::type_name::<T>()`.
+#[derive(Debug)]
+pub struct ExtKey<T> {
+    /// Human-readable storage name, used for serialization roundtrips.
+    name: &'static str,
+    /// Binds this key to the extension component type `T`.
+    _marker: PhantomData<T>,
+}
+
+impl<T> Clone for ExtKey<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<T> Copy for ExtKey<T> {}
+
+impl<T> ExtKey<T> {
+    /// Create a key with an explicit storage name.
+    #[must_use]
+    pub const fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Create a key using `std::any::type_name::<T>()` as the storage name.
+    #[must_use]
+    pub fn from_type_name() -> Self {
+        Self {
+            name: std::any::type_name::<T>(),
+            _marker: PhantomData,
+        }
+    }
+
+    /// The storage name for this key.
+    #[must_use]
+    pub const fn name(&self) -> &'static str {
+        self.name
+    }
+}
+
+impl<T> Default for ExtKey<T> {
+    fn default() -> Self {
+        Self::from_type_name()
+    }
+}
 
 /// Central storage for all simulation entities and their components.
 ///
@@ -664,11 +716,11 @@ impl World {
     ///
     /// Games use this to attach their own typed data to simulation entities.
     /// Extension components must be `Serialize + DeserializeOwned` to support
-    /// snapshot save/load. A `name` string is required for serialization roundtrips.
+    /// snapshot save/load. An [`ExtKey`] is required for serialization roundtrips.
     /// Extension components are automatically cleaned up on `despawn()`.
     ///
     /// ```
-    /// use elevator_core::world::World;
+    /// use elevator_core::world::{ExtKey, World};
     /// use serde::{Serialize, Deserialize};
     ///
     /// #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -676,13 +728,13 @@ impl World {
     ///
     /// let mut world = World::new();
     /// let entity = world.spawn();
-    /// world.insert_ext(entity, VipTag { level: 3 }, "vip_tag");
+    /// world.insert_ext(entity, VipTag { level: 3 }, ExtKey::from_type_name());
     /// ```
     pub fn insert_ext<T: 'static + Send + Sync + serde::Serialize + serde::de::DeserializeOwned>(
         &mut self,
         id: EntityId,
         value: T,
-        name: &str,
+        key: ExtKey<T>,
     ) {
         let type_id = TypeId::of::<T>();
         let map = self
@@ -692,7 +744,7 @@ impl World {
         if let Some(m) = map.as_any_mut().downcast_mut::<SecondaryMap<EntityId, T>>() {
             m.insert(id, value);
         }
-        self.ext_names.insert(type_id, name.to_owned());
+        self.ext_names.insert(type_id, key.name().to_owned());
     }
 
     /// Get a clone of a custom component for an entity.
@@ -768,18 +820,19 @@ impl World {
     /// Register an extension type for deserialization (creates empty storage).
     ///
     /// Must be called before `restore()` for each extension type that was
-    /// present in the original simulation.
+    /// present in the original simulation. Returns the key for convenience.
     pub fn register_ext<
         T: 'static + Send + Sync + serde::Serialize + serde::de::DeserializeOwned,
     >(
         &mut self,
-        name: &str,
-    ) {
+        key: ExtKey<T>,
+    ) -> ExtKey<T> {
         let type_id = TypeId::of::<T>();
         self.extensions
             .entry(type_id)
             .or_insert_with(|| Box::new(SecondaryMap::<EntityId, T>::new()));
-        self.ext_names.insert(type_id, name.to_owned());
+        self.ext_names.insert(type_id, key.name().to_owned());
+        key
     }
 
     // ── Disabled entity management ──────────────────────────────────


### PR DESCRIPTION
## Summary

BREAKING CHANGE: extension component registration and insertion now use `ExtKey<T>` instead of bare `&str` names.

- `insert_ext(id, val, "name")` → `insert_ext(id, val, ExtKey::from_type_name())`
- `with_ext::<T>("name")` → `with_ext::<T>()`
- `register_ext::<T>("name")` → `register_ext::<T>(ExtKey::from_type_name())`

`ExtKey<T>` carries `PhantomData<T>` ensuring compile-time type safety — a typo in the extension name string is now impossible since `type_name::<T>()` is the default. `ExtKey::new("explicit_name")` is available for migration or custom naming.

Internal `ASSIGNED_CAR_EXT_NAME` const replaced with typed `ASSIGNED_CAR_KEY: ExtKey<AssignedCar>`. `register_extensions!` macro gains a name-less arm.

Part 4/9 of the API ergonomics overhaul.

## Test plan

- [x] `cargo test --workspace --all-features` all green (567 core + 5 FFI)
- [x] `cargo clippy -p elevator-core --all-features -- -D warnings` clean
- [x] Examples (`extensions.rs`, `showcase.rs`, `dispatch_comparison.rs`) updated and run clean
- [ ] CI green
- [ ] Greptile review clean