### PR TITLE
feat!: consolidate spawn_rider API and delete _by_stop_id twins

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ let mut sim = SimulationBuilder::new()
     .unwrap();
 
 // Spawn a 75 kg rider going from Ground to Floor 3.
-sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0).unwrap();
+sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
 
 // Run for 1000 ticks.
 for _ in 0..1000 {
@@ -109,7 +109,7 @@ let mut sim = SimulationBuilder::new()
     .build()
     .unwrap();
 
-sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 80.0).unwrap();
+sim.spawn_rider(StopId(0), StopId(2), 80.0).unwrap();
 
 for _ in 0..2000 {
     sim.step();
@@ -162,7 +162,7 @@ let mut sim = SimulationBuilder::new()
     .unwrap();
 
 // Spawn a rider and tag them as VIP.
-let rider_id = sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0).unwrap();
+let rider_id = sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
 sim.world_mut().insert_ext(rider_id, VipTag { level: 3 }, "vip_tag");
 
 // Later, read back the extension data.

--- a/crates/elevator-core/benches/dispatch_bench.rs
+++ b/crates/elevator-core/benches/dispatch_bench.rs
@@ -84,7 +84,7 @@ fn make_sim_with<S: DispatchStrategy + 'static>(
     for i in 0..num_riders {
         let origin = StopId(i % num_stops);
         let dest = StopId((i + 1) % num_stops);
-        sim.spawn_rider_by_stop_id(origin, dest, 75.0).unwrap();
+        sim.spawn_rider(origin, dest, 75.0).unwrap();
     }
 
     sim

--- a/crates/elevator-core/benches/multi_line_bench.rs
+++ b/crates/elevator-core/benches/multi_line_bench.rs
@@ -220,7 +220,11 @@ fn bench_multi_group_step(c: &mut Criterion) {
                     let base = g * unique_per_group;
                     let origin = StopId(base + (i / num_groups) % stops_per_line);
                     let dest = StopId(base + ((i / num_groups) + 1) % stops_per_line);
-                    sim.spawn_rider_in_group_by_stop_id(origin, dest, 75.0, GroupId(g))
+                    sim.build_rider(origin, dest)
+                        .unwrap()
+                        .weight(75.0)
+                        .group(GroupId(g))
+                        .spawn()
                         .unwrap();
                 }
                 sim
@@ -241,7 +245,7 @@ fn bench_multi_group_step(c: &mut Criterion) {
                 for i in 0..100u32 {
                     let origin = StopId(i % 50);
                     let dest = StopId((i + 25) % 50);
-                    sim.spawn_rider_by_stop_id(origin, dest, 75.0).unwrap();
+                    sim.spawn_rider(origin, dest, 75.0).unwrap();
                 }
                 sim
             },
@@ -276,7 +280,7 @@ fn bench_cross_group_routing(c: &mut Criterion) {
                     for i in 0..1000u32 {
                         let origin = StopId(i % total_stops);
                         let dest = StopId((i + 1) % total_stops);
-                        let _ = sim.spawn_rider_by_stop_id(origin, dest, 75.0);
+                        let _ = sim.spawn_rider(origin, dest, 75.0);
                     }
                 },
                 criterion::BatchSize::LargeInput,

--- a/crates/elevator-core/benches/query_bench.rs
+++ b/crates/elevator-core/benches/query_bench.rs
@@ -75,7 +75,7 @@ fn make_sim(num_stops: u32, num_elevators: u32, num_riders: u32) -> Simulation {
     for i in 0..num_riders {
         let origin = StopId(i % num_stops);
         let dest = StopId((i + 1) % num_stops);
-        sim.spawn_rider_by_stop_id(origin, dest, 75.0).unwrap();
+        sim.spawn_rider(origin, dest, 75.0).unwrap();
     }
 
     sim

--- a/crates/elevator-core/benches/scaling_bench.rs
+++ b/crates/elevator-core/benches/scaling_bench.rs
@@ -73,7 +73,7 @@ fn make_sim(num_stops: u32, num_elevators: u32, num_riders: u32) -> Simulation {
     for i in 0..num_riders {
         let origin = StopId(i % num_stops);
         let dest = StopId((i + 1) % num_stops);
-        sim.spawn_rider_by_stop_id(origin, dest, 75.0).unwrap();
+        sim.spawn_rider(origin, dest, 75.0).unwrap();
     }
 
     sim
@@ -140,7 +140,7 @@ fn bench_spawn_pressure(c: &mut Criterion) {
                 for i in 0..10_000u32 {
                     let origin = StopId(i % 200);
                     let dest = StopId((i + 1) % 200);
-                    sim.spawn_rider_by_stop_id(origin, dest, 75.0).unwrap();
+                    sim.spawn_rider(origin, dest, 75.0).unwrap();
                 }
             },
             criterion::BatchSize::LargeInput,

--- a/crates/elevator-core/benches/sim_bench.rs
+++ b/crates/elevator-core/benches/sim_bench.rs
@@ -77,7 +77,7 @@ fn make_sim(num_stops: u32, num_elevators: u32, num_riders: u32) -> Simulation {
     for i in 0..num_riders {
         let origin = StopId(i % num_stops);
         let dest = StopId((i + 1) % num_stops);
-        sim.spawn_rider_by_stop_id(origin, dest, 75.0).unwrap();
+        sim.spawn_rider(origin, dest, 75.0).unwrap();
     }
 
     sim

--- a/crates/elevator-core/examples/basic.rs
+++ b/crates/elevator-core/examples/basic.rs
@@ -28,7 +28,7 @@ fn main() {
 
     // Spawn 3 riders going up.
     for i in 0..3 {
-        sim.spawn_rider_by_stop_id(StopId(0), StopId(2), f64::from(i).mul_add(5.0, 70.0))
+        sim.spawn_rider(StopId(0), StopId(2), f64::from(i).mul_add(5.0, 70.0))
             .unwrap();
     }
 

--- a/crates/elevator-core/examples/config_file.rs
+++ b/crates/elevator-core/examples/config_file.rs
@@ -21,8 +21,7 @@ fn main() {
 
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(4), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(4), 75.0).unwrap();
 
     for _ in 0..1000 {
         sim.step();

--- a/crates/elevator-core/examples/custom_dispatch.rs
+++ b/crates/elevator-core/examples/custom_dispatch.rs
@@ -144,12 +144,9 @@ fn main() {
         BuiltinStrategy::Custom("idle_penalty".into()),
     );
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
-    sim.spawn_rider_by_stop_id(StopId(1), StopId(0), 72.0)
-        .unwrap();
-    sim.spawn_rider_by_stop_id(StopId(2), StopId(1), 80.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.spawn_rider(StopId(1), StopId(0), 72.0).unwrap();
+    sim.spawn_rider(StopId(2), StopId(1), 80.0).unwrap();
 
     // Hall-call layer demo: script a phantom hall-call press with no
     // spawned rider behind it — the kind of event a building-sim

--- a/crates/elevator-core/examples/dispatch_comparison.rs
+++ b/crates/elevator-core/examples/dispatch_comparison.rs
@@ -146,7 +146,7 @@ fn run_one<S: DispatchStrategy + 'static>(
         let reqs: Vec<SpawnRequest> = source.generate(tick);
         for req in reqs {
             if sim
-                .spawn_rider_by_stop_id(req.origin, req.destination, req.weight)
+                .spawn_rider(req.origin, req.destination, req.weight)
                 .is_ok()
             {
                 spawned += 1;

--- a/crates/elevator-core/examples/door_commands.rs
+++ b/crates/elevator-core/examples/door_commands.rs
@@ -45,9 +45,7 @@ fn main() {
     let elev = sim.world().iter_elevators().next().unwrap().0;
 
     // First rider heading up from the lobby.
-    let first = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
-        .unwrap();
+    let first = sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
 
     let mut held = false;
     let mut friend: Option<EntityId> = None;
@@ -67,9 +65,7 @@ fn main() {
             sim.hold_door(elev, 60).unwrap();
             held = true;
             // Spawn the friend at the lobby.
-            let f = sim
-                .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-                .unwrap();
+            let f = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
             println!("[t={tick:>3}] Friend spawned at lobby");
             friend = Some(f);
         }

--- a/crates/elevator-core/examples/extensions.rs
+++ b/crates/elevator-core/examples/extensions.rs
@@ -18,9 +18,7 @@ fn main() {
         .unwrap();
 
     // Spawn a rider and tag them as VIP.
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
     sim.world_mut()
         .insert_ext(rider, VipTag { level: 5 }, "vip_tag");
 

--- a/crates/elevator-core/examples/fp_player_rider.rs
+++ b/crates/elevator-core/examples/fp_player_rider.rs
@@ -24,8 +24,7 @@ fn main() {
     let elev = sim.world().iter_elevators().next().unwrap().0;
 
     // Give the car something to do.
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(1), 75.0).unwrap();
 
     println!("tick  alpha=0.00  alpha=0.50  alpha=1.00   vel");
     println!("----  ----------  ----------  ----------  -----");

--- a/crates/elevator-core/examples/headless_trace.rs
+++ b/crates/elevator-core/examples/headless_trace.rs
@@ -145,7 +145,7 @@ fn main() -> ExitCode {
     let mut sim = SimulationBuilder::from_config(config).build().unwrap();
     for i in 0..args.spawn {
         let weight = 70.0 + f64::from(u32::try_from(i).unwrap_or(0)) * 2.5;
-        sim.spawn_rider_by_stop_id(first, last, weight).unwrap();
+        sim.spawn_rider(first, last, weight).unwrap();
     }
 
     // Dispatch the output writer once. Both sinks go through BufWriter so

--- a/crates/elevator-core/examples/runtime_upgrades.rs
+++ b/crates/elevator-core/examples/runtime_upgrades.rs
@@ -54,7 +54,7 @@ fn spawn_wave(sim: &mut Simulation, tick: u64) {
     } else {
         (StopId(2), StopId(0))
     };
-    let _ = sim.spawn_rider_by_stop_id(o, d, 75.0);
+    let _ = sim.spawn_rider(o, d, 75.0);
 }
 
 fn run_baseline() -> (u64, f64) {

--- a/crates/elevator-core/examples/showcase.rs
+++ b/crates/elevator-core/examples/showcase.rs
@@ -63,9 +63,7 @@ fn part1_basic_simulation() {
         .unwrap();
 
     // Spawn a rider at Ground heading to Floor 3, weighing 75 kg.
-    let rider_id = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
-        .unwrap();
+    let rider_id = sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
     println!("Spawned rider: {rider_id:?}");
 
     // Step the simulation until the rider is delivered (or a safety cap).
@@ -146,15 +144,9 @@ fn part2_custom_dispatch() {
         .unwrap();
 
     // Spawn several riders to see ETD in action.
-    let _ = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
-    let _ = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(1), 80.0)
-        .unwrap();
-    let _ = sim
-        .spawn_rider_by_stop_id(StopId(2), StopId(0), 65.0)
-        .unwrap();
+    let _ = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    let _ = sim.spawn_rider(StopId(0), StopId(1), 80.0).unwrap();
+    let _ = sim.spawn_rider(StopId(2), StopId(0), 65.0).unwrap();
 
     // Run for enough ticks for the elevator to make full round trips.
     for _ in 0..900 {
@@ -221,9 +213,7 @@ fn part3_extensions() {
         .unwrap();
 
     // Spawn a rider and attach the VIP extension.
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
     sim.world_mut()
         .insert_ext::<VipTag>(rider, VipTag { level: 3 }, "vip_tag");
 
@@ -278,9 +268,7 @@ fn part4_lifecycle_hooks() {
         .build()
         .unwrap();
 
-    let _ = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(1), 60.0)
-        .unwrap();
+    let _ = sim.spawn_rider(StopId(0), StopId(1), 60.0).unwrap();
 
     for _ in 0..300 {
         sim.step();
@@ -328,15 +316,11 @@ fn part5_metrics_deep_dive() {
 
     // Spawn riders from the tagged lobby.
     for _ in 0..5 {
-        let _ = sim
-            .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-            .unwrap();
+        let _ = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     }
 
     // Tag a rider individually for a different dimension.
-    let special = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(1), 60.0)
-        .unwrap();
+    let special = sim.spawn_rider(StopId(0), StopId(1), 60.0).unwrap();
     sim.tag_entity(special, "priority:express").unwrap();
 
     // Run enough ticks for deliveries.
@@ -451,12 +435,8 @@ fn part6_configuration() {
         .unwrap();
 
     // Spawn riders and simulate.
-    let _ = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(1), 80.0)
-        .unwrap();
-    let _ = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 65.0)
-        .unwrap();
+    let _ = sim.spawn_rider(StopId(0), StopId(1), 80.0).unwrap();
+    let _ = sim.spawn_rider(StopId(0), StopId(2), 65.0).unwrap();
 
     for _ in 0..1800 {
         sim.step();

--- a/crates/elevator-core/examples/space_elevator.rs
+++ b/crates/elevator-core/examples/space_elevator.rs
@@ -60,13 +60,11 @@ fn main() {
     // 80 kg astronauts; the climber's 10 000 kg capacity is more than ample.
     let mut spawned = 0_u64;
     for weight in [70.0, 82.0, 95.0] {
-        sim.spawn_rider_by_stop_id(StopId(0), StopId(1), weight)
-            .unwrap();
+        sim.spawn_rider(StopId(0), StopId(1), weight).unwrap();
         spawned += 1;
     }
     for weight in [68.0, 74.0] {
-        sim.spawn_rider_by_stop_id(StopId(1), StopId(0), weight)
-            .unwrap();
+        sim.spawn_rider(StopId(1), StopId(0), weight).unwrap();
         spawned += 1;
     }
 

--- a/crates/elevator-core/fuzz/fuzz_targets/sim_step_random.rs
+++ b/crates/elevator-core/fuzz/fuzz_targets/sim_step_random.rs
@@ -94,7 +94,7 @@ fuzz_target!(|data: &[u8]| {
                     dest_raw
                 };
                 i += 2;
-                if let Ok(eid) = sim.spawn_rider_by_stop_id(
+                if let Ok(eid) = sim.spawn_rider(
                     StopId(origin),
                     StopId(dest),
                     75.0,

--- a/crates/elevator-core/src/builder.rs
+++ b/crates/elevator-core/src/builder.rs
@@ -441,7 +441,7 @@ impl SimulationBuilder {
     ///     .build()
     ///     .unwrap();
     ///
-    /// sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 75.0).unwrap();
+    /// sim.spawn_rider(StopId(0), StopId(1), 75.0).unwrap();
     ///
     /// for _ in 0..1000 {
     ///     sim.step();

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -42,7 +42,7 @@
 //!     .build()
 //!     .unwrap();
 //!
-//! sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0).unwrap();
+//! sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
 //!
 //! for _ in 0..1000 {
 //!     sim.step();

--- a/crates/elevator-core/src/query/mod.rs
+++ b/crates/elevator-core/src/query/mod.rs
@@ -12,7 +12,7 @@
 //! struct VipTag { level: u32 }
 //!
 //! let mut sim = SimulationBuilder::demo().build().unwrap();
-//! let rider_eid = sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 75.0).unwrap();
+//! let rider_eid = sim.spawn_rider(StopId(0), StopId(1), 75.0).unwrap();
 //!
 //! // Attach an extension component.
 //! sim.world_mut().insert_ext(rider_eid, VipTag { level: 5 }, "vip_tag");

--- a/crates/elevator-core/src/scenario.rs
+++ b/crates/elevator-core/src/scenario.rs
@@ -135,7 +135,7 @@ impl ScenarioRunner {
             // skipping invalid spawns is the correct replay behavior.
             let _ = self
                 .sim
-                .spawn_rider_by_stop_id(spawn.origin, spawn.destination, spawn.weight);
+                .spawn_rider(spawn.origin, spawn.destination, spawn.weight);
             self.spawn_cursor += 1;
         }
 

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -23,11 +23,11 @@
 //!
 //! ### Spawning and rerouting riders
 //!
-//! - [`Simulation::spawn_rider_by_stop_id()`](crate::sim::Simulation::spawn_rider_by_stop_id)
-//!   — simple origin/destination/weight spawn.
-//! - [`Simulation::build_rider_by_stop_id()`](crate::sim::Simulation::build_rider_by_stop_id)
+//! - [`Simulation::spawn_rider()`](crate::sim::Simulation::spawn_rider)
+//!   — simple origin/destination/weight spawn (accepts `EntityId` or `StopId`).
+//! - [`Simulation::build_rider()`](crate::sim::Simulation::build_rider)
 //!   — fluent [`RiderBuilder`](crate::sim::RiderBuilder) for patience, preferences, access
-//!   control, explicit groups, multi-leg routes.
+//!   control, explicit groups, multi-leg routes (accepts `EntityId` or `StopId`).
 //! - [`Simulation::reroute()`](crate::sim::Simulation::reroute) — change a waiting
 //!   rider's destination mid-trip.
 //! - [`Simulation::settle_rider()`](crate::sim::Simulation::settle_rider) /
@@ -162,13 +162,13 @@ impl LineParams {
 
 /// Fluent builder for spawning riders with optional configuration.
 ///
-/// Created via [`Simulation::build_rider`] or [`Simulation::build_rider_by_stop_id`].
+/// Created via [`Simulation::build_rider`].
 ///
 /// ```
 /// use elevator_core::prelude::*;
 ///
 /// let mut sim = SimulationBuilder::demo().build().unwrap();
-/// let rider = sim.build_rider_by_stop_id(StopId(0), StopId(1))
+/// let rider = sim.build_rider(StopId(0), StopId(1))
 ///     .unwrap()
 ///     .weight(80.0)
 ///     .spawn()
@@ -245,8 +245,19 @@ impl RiderBuilder<'_> {
     /// Returns [`SimError::NoRoute`] if no group serves both stops (when auto-detecting).
     /// Returns [`SimError::AmbiguousRoute`] if multiple groups serve both stops (when auto-detecting).
     /// Returns [`SimError::GroupNotFound`] if an explicit group does not exist.
+    /// Returns [`SimError::RouteOriginMismatch`] if an explicit route's first leg
+    /// does not start at `origin`.
     pub fn spawn(self) -> Result<EntityId, SimError> {
         let route = if let Some(route) = self.route {
+            // Validate route origin matches the spawn origin.
+            if let Some(leg) = route.current()
+                && leg.from != self.origin
+            {
+                return Err(SimError::RouteOriginMismatch {
+                    expected_origin: self.origin,
+                    route_origin: leg.from,
+                });
+            }
             route
         } else if let Some(group) = self.group {
             if !self.sim.groups.iter().any(|g| g.id() == group) {
@@ -381,7 +392,7 @@ impl Simulation {
     /// Get a mutable reference to the world.
     ///
     /// Exposed for advanced use cases (manual rider management, custom
-    /// component attachment). Prefer `spawn_rider` / `spawn_rider_by_stop_id`
+    /// component attachment). Prefer `spawn_rider` / `build_rider`
     /// for standard operations.
     #[allow(clippy::missing_const_for_fn)]
     pub fn world_mut(&mut self) -> &mut World {
@@ -1366,67 +1377,35 @@ impl Simulation {
 
     /// Create a rider builder for fluent rider spawning.
     ///
-    /// ```
-    /// use elevator_core::prelude::*;
-    ///
-    /// let mut sim = SimulationBuilder::demo().build().unwrap();
-    /// let s0 = sim.stop_entity(StopId(0)).unwrap();
-    /// let s1 = sim.stop_entity(StopId(1)).unwrap();
-    /// let rider = sim.build_rider(s0, s1)
-    ///     .weight(80.0)
-    ///     .spawn()
-    ///     .unwrap();
-    /// ```
-    #[allow(clippy::missing_const_for_fn)]
-    pub fn build_rider(&mut self, origin: EntityId, destination: EntityId) -> RiderBuilder<'_> {
-        RiderBuilder {
-            sim: self,
-            origin,
-            destination,
-            weight: 75.0,
-            group: None,
-            route: None,
-            patience: None,
-            preferences: None,
-            access_control: None,
-        }
-    }
-
-    /// Create a rider builder using config `StopId`s.
+    /// Accepts [`EntityId`] or [`StopId`] for origin and destination
+    /// (anything that implements `Into<StopRef>`).
     ///
     /// # Errors
     ///
-    /// Returns [`SimError::StopNotFound`] if either stop ID is unknown.
+    /// Returns [`SimError::StopNotFound`] if a [`StopId`] does not exist
+    /// in the building configuration.
     ///
     /// ```
     /// use elevator_core::prelude::*;
     ///
     /// let mut sim = SimulationBuilder::demo().build().unwrap();
-    /// let rider = sim.build_rider_by_stop_id(StopId(0), StopId(1))
+    /// let rider = sim.build_rider(StopId(0), StopId(1))
     ///     .unwrap()
     ///     .weight(80.0)
     ///     .spawn()
     ///     .unwrap();
     /// ```
-    pub fn build_rider_by_stop_id(
+    pub fn build_rider(
         &mut self,
-        origin: StopId,
-        destination: StopId,
+        origin: impl Into<StopRef>,
+        destination: impl Into<StopRef>,
     ) -> Result<RiderBuilder<'_>, SimError> {
-        let origin_eid = self
-            .stop_lookup
-            .get(&origin)
-            .copied()
-            .ok_or(SimError::StopNotFound(origin))?;
-        let dest_eid = self
-            .stop_lookup
-            .get(&destination)
-            .copied()
-            .ok_or(SimError::StopNotFound(destination))?;
+        let origin = self.resolve_stop(origin.into())?;
+        let destination = self.resolve_stop(destination.into())?;
         Ok(RiderBuilder {
             sim: self,
-            origin: origin_eid,
-            destination: dest_eid,
+            origin,
+            destination,
             weight: 75.0,
             group: None,
             route: None,
@@ -1497,39 +1476,6 @@ impl Simulation {
         Ok(self.spawn_rider_inner(origin, destination, weight, route))
     }
 
-    /// Spawn a rider with an explicit route.
-    ///
-    /// Same as [`spawn_rider`](Self::spawn_rider) but uses the provided route
-    /// instead of auto-detecting the group.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SimError::EntityNotFound`] if origin does not exist.
-    /// Returns [`SimError::RouteOriginMismatch`] if origin doesn't match the
-    /// route's first leg `from`.
-    pub fn spawn_rider_with_route(
-        &mut self,
-        origin: impl Into<StopRef>,
-        destination: impl Into<StopRef>,
-        weight: f64,
-        route: Route,
-    ) -> Result<EntityId, SimError> {
-        let origin = self.resolve_stop(origin.into())?;
-        let destination = self.resolve_stop(destination.into())?;
-        if self.world.stop(origin).is_none() {
-            return Err(SimError::EntityNotFound(origin));
-        }
-        if let Some(leg) = route.current()
-            && leg.from != origin
-        {
-            return Err(SimError::RouteOriginMismatch {
-                expected_origin: origin,
-                route_origin: leg.from,
-            });
-        }
-        Ok(self.spawn_rider_inner(origin, destination, weight, route))
-    }
-
     /// Internal helper: spawn a rider entity with the given route.
     fn spawn_rider_inner(
         &mut self,
@@ -1593,95 +1539,6 @@ impl Simulation {
         eid
     }
 
-    /// Convenience: spawn a rider by config `StopId`.
-    ///
-    /// Returns `Err` if either stop ID is not found.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SimError::StopNotFound`] if the origin or destination stop ID
-    /// is not in the building configuration.
-    ///
-    /// ```
-    /// use elevator_core::prelude::*;
-    ///
-    /// // Default builder has StopId(0) and StopId(1).
-    /// let mut sim = SimulationBuilder::demo().build().unwrap();
-    ///
-    /// let rider = sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 80.0).unwrap();
-    /// sim.step(); // metrics are updated during the tick
-    /// assert_eq!(sim.metrics().total_spawned(), 1);
-    /// ```
-    pub fn spawn_rider_by_stop_id(
-        &mut self,
-        origin: StopId,
-        destination: StopId,
-        weight: f64,
-    ) -> Result<EntityId, SimError> {
-        let origin_eid = self
-            .stop_lookup
-            .get(&origin)
-            .copied()
-            .ok_or(SimError::StopNotFound(origin))?;
-        let dest_eid = self
-            .stop_lookup
-            .get(&destination)
-            .copied()
-            .ok_or(SimError::StopNotFound(destination))?;
-        self.spawn_rider(origin_eid, dest_eid, weight)
-    }
-
-    /// Spawn a rider using a specific group for routing.
-    ///
-    /// Like [`spawn_rider`](Self::spawn_rider) but skips auto-detection —
-    /// uses the given group directly. Useful when the caller already knows
-    /// the group, or to resolve an [`AmbiguousRoute`](crate::error::SimError::AmbiguousRoute).
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SimError::GroupNotFound`] if the group does not exist.
-    pub fn spawn_rider_in_group(
-        &mut self,
-        origin: impl Into<StopRef>,
-        destination: impl Into<StopRef>,
-        weight: f64,
-        group: GroupId,
-    ) -> Result<EntityId, SimError> {
-        let origin = self.resolve_stop(origin.into())?;
-        let destination = self.resolve_stop(destination.into())?;
-        if !self.groups.iter().any(|g| g.id() == group) {
-            return Err(SimError::GroupNotFound(group));
-        }
-        let route = Route::direct(origin, destination, group);
-        Ok(self.spawn_rider_inner(origin, destination, weight, route))
-    }
-
-    /// Convenience: spawn a rider by config `StopId` in a specific group.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SimError::StopNotFound`] if a stop ID is unknown, or
-    /// [`SimError::GroupNotFound`] if the group does not exist.
-    pub fn spawn_rider_in_group_by_stop_id(
-        &mut self,
-        origin: StopId,
-        destination: StopId,
-        weight: f64,
-        group: GroupId,
-    ) -> Result<EntityId, SimError> {
-        let origin_eid = self
-            .stop_lookup
-            .get(&origin)
-            .copied()
-            .ok_or(SimError::StopNotFound(origin))?;
-        let dest_eid = self
-            .stop_lookup
-            .get(&destination)
-            .copied()
-            .ok_or(SimError::StopNotFound(destination))?;
-        self.spawn_rider_in_group(origin_eid, dest_eid, weight, group)
-    }
-
     /// Drain all pending events from completed ticks.
     ///
     /// Events emitted during `step()` (or per-phase methods) are buffered
@@ -1694,7 +1551,7 @@ impl Simulation {
     ///
     /// let mut sim = SimulationBuilder::demo().build().unwrap();
     ///
-    /// sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0).unwrap();
+    /// sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
     /// sim.step();
     ///
     /// let events = sim.drain_events();
@@ -1716,7 +1573,7 @@ impl Simulation {
     /// use elevator_core::prelude::*;
     ///
     /// let mut sim = SimulationBuilder::demo().build().unwrap();
-    /// sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0).unwrap();
+    /// sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
     /// sim.step();
     ///
     /// let spawns: Vec<Event> = sim.drain_events_where(|e| {

--- a/crates/elevator-core/src/tests/access_tests.rs
+++ b/crates/elevator-core/src/tests/access_tests.rs
@@ -18,7 +18,7 @@ fn rider_rejected_by_elevator_restriction() {
         crate::sim::Simulation::new(&config, helpers::scan()).expect("config should be valid");
 
     // Rider wants to go from Ground to Floor 3 (restricted).
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+    sim.spawn_rider(StopId(0), StopId(2), 70.0)
         .expect("spawn should succeed");
 
     let mut all_events = Vec::new();
@@ -54,7 +54,7 @@ fn rider_rejected_by_rider_access_control() {
 
     // Spawn rider to Floor 3.
     let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .spawn_rider(StopId(0), StopId(2), 70.0)
         .expect("spawn should succeed");
 
     // Set rider access to only allow Ground and Floor 2 — NOT Floor 3.
@@ -91,7 +91,7 @@ fn rider_boards_without_restrictions() {
     let mut sim =
         crate::sim::Simulation::new(&config, helpers::scan()).expect("config should be valid");
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+    sim.spawn_rider(StopId(0), StopId(2), 70.0)
         .expect("spawn should succeed");
 
     for _ in 0..2000 {
@@ -115,7 +115,7 @@ fn rider_boards_when_destination_in_allowed_stops() {
         crate::sim::Simulation::new(&config, helpers::scan()).expect("config should be valid");
 
     let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .spawn_rider(StopId(0), StopId(2), 70.0)
         .expect("spawn should succeed");
 
     // Allow all three stops.
@@ -149,7 +149,7 @@ fn restriction_does_not_affect_unrestricted_destinations() {
         crate::sim::Simulation::new(&config, helpers::scan()).expect("config should be valid");
 
     // Rider going to Floor 2 (not restricted).
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
+    sim.spawn_rider(StopId(0), StopId(1), 70.0)
         .expect("spawn should succeed");
 
     for _ in 0..2000 {
@@ -180,7 +180,7 @@ fn both_restriction_types_work_in_same_sim() {
 
     // Rider 1: going to Floor 2 (elevator-restricted). Test alone first.
     let rider1 = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
+        .spawn_rider(StopId(0), StopId(1), 70.0)
         .expect("spawn should succeed");
 
     let mut events_phase1 = Vec::new();
@@ -209,7 +209,7 @@ fn both_restriction_types_work_in_same_sim() {
 
     // Rider 2: going to Floor 3 with access control that doesn't include Floor 3.
     let rider2 = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .spawn_rider(StopId(0), StopId(2), 70.0)
         .expect("spawn should succeed");
     let stop0 = sim.stop_entity(StopId(0)).expect("stop 0 exists");
     let stop1 = sim.stop_entity(StopId(1)).expect("stop 1 exists");
@@ -248,7 +248,7 @@ fn rejection_event_has_access_denied_reason() {
         crate::sim::Simulation::new(&config, helpers::scan()).expect("config should be valid");
 
     let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .spawn_rider(StopId(0), StopId(2), 70.0)
         .expect("spawn should succeed");
 
     let mut all_events = Vec::new();

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -53,9 +53,7 @@ fn remove_elevator_ejects_riders_aboard() {
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
     // Spawn a rider and let it board.
-    let rider_id = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider_id = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     // Run enough ticks for the rider to board.
     for _ in 0..300 {
@@ -93,9 +91,7 @@ fn remove_elevator_ejects_rider_emits_event() {
     let mut sim = Simulation::new(&config, scan()).unwrap();
     sim.drain_events();
 
-    let rider_id = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider_id = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     // Run until rider is riding.
     for _ in 0..300 {
@@ -196,9 +192,7 @@ fn remove_stop_with_waiting_rider_invalidates_route() {
     sim.drain_events();
 
     // Spawn a rider targeting stop 2.
-    let rider_id = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider_id = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     // Ensure the rider is in Waiting phase (before boarding).
     let phase = sim.world().rider(rider_id).unwrap().phase;
@@ -295,8 +289,7 @@ fn drain_events_where_returns_only_matching_events() {
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
     // Spawn a rider to generate events.
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     // Run a few ticks to generate events.
     for _ in 0..5 {
         sim.step();
@@ -319,8 +312,7 @@ fn drain_events_where_retains_non_matching_events() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     for _ in 0..5 {
         sim.step();
     }
@@ -336,8 +328,7 @@ fn drain_events_where_retains_non_matching_events() {
     // Re-run for fresh events.
     let config2 = default_config();
     let mut sim2 = Simulation::new(&config2, scan()).unwrap();
-    sim2.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim2.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     for _ in 0..5 {
         sim2.step();
     }
@@ -366,8 +357,7 @@ fn drain_events_where_with_no_match_returns_empty_and_retains_all() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     for _ in 0..5 {
         sim.step();
     }
@@ -378,8 +368,7 @@ fn drain_events_where_with_no_match_returns_empty_and_retains_all() {
     // Re-run for fresh events.
     let config2 = default_config();
     let mut sim2 = Simulation::new(&config2, scan()).unwrap();
-    sim2.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim2.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     for _ in 0..5 {
         sim2.step();
     }
@@ -414,9 +403,7 @@ fn riders_on_returns_rider_ids_after_boarding() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
-    let rider_id = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider_id = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     let elevator_id = sim.groups()[0].elevator_entities()[0];
 
     // Run until rider is riding.
@@ -464,9 +451,7 @@ fn occupancy_returns_correct_count_after_boarding() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
-    let rider_id = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider_id = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     let elevator_id = sim.groups()[0].elevator_entities()[0];
 
     // Run until rider is riding.
@@ -635,7 +620,7 @@ fn rider_builder_basic_spawn() {
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
     let rider_id = sim
-        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .build_rider(StopId(0), StopId(2))
         .unwrap()
         .spawn()
         .unwrap();
@@ -650,7 +635,7 @@ fn rider_builder_custom_weight() {
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
     let rider_id = sim
-        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .build_rider(StopId(0), StopId(2))
         .unwrap()
         .weight(90.0)
         .spawn()
@@ -671,7 +656,7 @@ fn rider_builder_with_explicit_group() {
 
     // The default config has one group: GroupId(0).
     let rider_id = sim
-        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .build_rider(StopId(0), StopId(2))
         .unwrap()
         .group(GroupId(0))
         .spawn()
@@ -687,7 +672,7 @@ fn rider_builder_with_patience() {
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
     let rider_id = sim
-        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .build_rider(StopId(0), StopId(2))
         .unwrap()
         .patience(100)
         .spawn()
@@ -715,7 +700,7 @@ fn rider_builder_with_preferences() {
     };
 
     let rider_id = sim
-        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .build_rider(StopId(0), StopId(2))
         .unwrap()
         .preferences(prefs)
         .spawn()
@@ -745,7 +730,7 @@ fn rider_builder_with_access_control() {
     let ac = AccessControl::new(allowed.clone());
 
     let rider_id = sim
-        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .build_rider(StopId(0), StopId(2))
         .unwrap()
         .access_control(ac)
         .spawn()
@@ -767,7 +752,7 @@ fn rider_builder_invalid_stop_id_returns_stop_not_found() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
-    let result = sim.build_rider_by_stop_id(StopId(0), StopId(99));
+    let result = sim.build_rider(StopId(0), StopId(99));
     assert!(
         matches!(result, Err(SimError::StopNotFound(StopId(99)))),
         "expected StopNotFound(99)"
@@ -816,7 +801,7 @@ fn rider_builder_no_route_when_stops_not_in_same_group() {
 
     // Now attempting to build a rider from stop 0 to the removed stop1
     // should fail because stop1 is no longer in the stop_lookup.
-    let result = sim.build_rider_by_stop_id(StopId(0), StopId(1));
+    let result = sim.build_rider(StopId(0), StopId(1));
     assert!(
         matches!(result, Err(SimError::StopNotFound(_))),
         "expected StopNotFound after stop removed"
@@ -832,7 +817,7 @@ fn rider_builder_spawn_returns_no_route_when_group_not_serving_both_stops() {
 
     // GroupId(99) does not exist.
     let result = sim
-        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .build_rider(StopId(0), StopId(2))
         .unwrap()
         .group(GroupId(99))
         .spawn();
@@ -895,8 +880,7 @@ fn drain_events_where_with_all_matching_empties_buffer() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     for _ in 0..5 {
         sim.step();
     }
@@ -919,7 +903,7 @@ fn rider_builder_default_weight_is_75() {
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
     let rider_id = sim
-        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .build_rider(StopId(0), StopId(2))
         .unwrap()
         .spawn()
         .unwrap();
@@ -938,7 +922,7 @@ fn rider_builder_no_patience_by_default() {
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
     let rider_id = sim
-        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .build_rider(StopId(0), StopId(2))
         .unwrap()
         .spawn()
         .unwrap();
@@ -956,7 +940,7 @@ fn rider_builder_no_preferences_by_default() {
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
     let rider_id = sim
-        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .build_rider(StopId(0), StopId(2))
         .unwrap()
         .spawn()
         .unwrap();
@@ -973,7 +957,7 @@ fn rider_builder_no_access_control_by_default() {
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
     let rider_id = sim
-        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .build_rider(StopId(0), StopId(2))
         .unwrap()
         .spawn()
         .unwrap();

--- a/crates/elevator-core/src/tests/boundary_tests.rs
+++ b/crates/elevator-core/src/tests/boundary_tests.rs
@@ -12,9 +12,7 @@ fn patience_zero_abandons_immediately() {
     let config = default_config();
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     sim.world_mut().set_patience(
         rider,
         Patience {
@@ -39,9 +37,7 @@ fn patience_one_abandons_after_one_tick() {
     let config = default_config();
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     sim.world_mut().set_patience(
         rider,
         Patience {
@@ -65,9 +61,7 @@ fn patience_max_never_overflows() {
     let config = default_config();
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     sim.world_mut().set_patience(
         rider,
         Patience {
@@ -91,14 +85,10 @@ fn preferences_zero_crowding_rejects_any_load() {
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
     // Spawn first rider to create some load.
-    let r1 = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let r1 = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     // Spawn second rider with max_crowding_factor=0.0.
-    let r2 = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let r2 = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     sim.world_mut().set_preferences(
         r2,
         Preferences {
@@ -152,9 +142,7 @@ fn weight_exactly_at_capacity_boards() {
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
     // The default config has weight_capacity=800. Spawn a rider weighing exactly 800.
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 800.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 800.0).unwrap();
 
     // Run until rider boards or times out.
     let mut boarded = false;

--- a/crates/elevator-core/src/tests/braking_tests.rs
+++ b/crates/elevator-core/src/tests/braking_tests.rs
@@ -43,8 +43,7 @@ fn sim_braking_distance_stationary_elevator_is_zero() {
 #[test]
 fn sim_braking_distance_nonzero_while_moving() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     // Step until the elevator has picked up speed.
     let elev = first_elevator(&sim);
@@ -75,8 +74,7 @@ fn sim_future_stop_position_stationary_equals_current() {
 #[test]
 fn sim_future_stop_position_ahead_while_moving_up() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     let elev = first_elevator(&sim);
     for _ in 0..500 {
@@ -98,9 +96,7 @@ fn sim_future_stop_position_ahead_while_moving_up() {
 #[test]
 fn sim_braking_distance_none_for_non_elevator() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
     assert_eq!(sim.braking_distance(rider), None);
     assert_eq!(sim.future_stop_position(rider), None);
 }

--- a/crates/elevator-core/src/tests/destination_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/destination_dispatch_tests.rs
@@ -167,9 +167,7 @@ fn sticky_assignment_persists_across_ticks() {
     sim.world_mut()
         .register_ext::<AssignedCar>(ASSIGNED_CAR_EXT_NAME);
 
-    let rid = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
-        .unwrap();
+    let rid = sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
 
     sim.step();
     let first = sim.world().get_ext::<AssignedCar>(rid);
@@ -225,9 +223,7 @@ fn loading_respects_assignment_other_car_skips() {
     let car_b = elevs.iter().copied().find(|e| *e != car_a).unwrap();
 
     // Rider wants to go from F2 (pos 4) to F3 (pos 8).
-    let rid = sim
-        .spawn_rider_by_stop_id(StopId(1), StopId(2), 75.0)
-        .unwrap();
+    let rid = sim.spawn_rider(StopId(1), StopId(2), 75.0).unwrap();
 
     // Force sticky assignment to car B (the one at pos 12, farther away)
     // and seed B's queue with the rider's pickup + drop-off so DCS's normal
@@ -271,7 +267,7 @@ fn loading_respects_assignment_other_car_skips() {
 fn unassigned_manual_board_riders_still_work() {
     // A rider without a Route has no destination known at hall-call time,
     // so DCS must not assign them. The existing manual-board behaviour
-    // (attach rider via `build_rider_by_stop_id` with no destination) must
+    // (attach rider via `build_rider` with no destination) must
     // be preserved.
     let mut sim = Simulation::new(&single_car_config(), DestinationDispatch::new()).unwrap();
     for g in sim.groups_mut() {
@@ -281,9 +277,7 @@ fn unassigned_manual_board_riders_still_work() {
         .register_ext::<AssignedCar>(ASSIGNED_CAR_EXT_NAME);
 
     // Standard spawn: has a Route → DCS should assign.
-    let routed = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
-        .unwrap();
+    let routed = sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
 
     // Manual rider: set up a rider at stop 0 without a Route. We do this by
     // spawning and then removing the Route component via world mutation
@@ -334,9 +328,7 @@ fn closer_car_is_preferred_when_matching_direction() {
         .unwrap();
 
     // Rider at F2 → F3: pickup distance to car A = 4, to car B = 8.
-    let rid = sim
-        .spawn_rider_by_stop_id(StopId(1), StopId(2), 75.0)
-        .unwrap();
+    let rid = sim.spawn_rider(StopId(1), StopId(2), 75.0).unwrap();
 
     sim.step();
     let assigned = sim
@@ -357,9 +349,7 @@ fn up_peak_scenario_delivers_all_riders() {
     let mut riders = Vec::new();
     for i in 0..20 {
         let dest = StopId(1 + (i % 3));
-        let rid = sim
-            .spawn_rider_by_stop_id(StopId(0), dest, 75.0)
-            .expect("spawn");
+        let rid = sim.spawn_rider(StopId(0), dest, 75.0).expect("spawn");
         riders.push(rid);
     }
 
@@ -404,9 +394,7 @@ fn dcs_gated_to_destination_mode() {
     sim.world_mut()
         .register_ext::<AssignedCar>(ASSIGNED_CAR_EXT_NAME);
 
-    let rid = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
-        .unwrap();
+    let rid = sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
 
     // Step enough ticks that DCS would have assigned by now in Destination
     // mode. In Classic it stays None because pre_dispatch early-returns.

--- a/crates/elevator-core/src/tests/destination_queue_tests.rs
+++ b/crates/elevator-core/src/tests/destination_queue_tests.rs
@@ -35,8 +35,7 @@ fn dispatch_populates_queue() {
     let mut sim = build_sim();
     // Spawn rider traveling from stop 1 (not elevator's start) to stop 2,
     // so dispatch has to send the car somewhere — triggering a queue push.
-    sim.spawn_rider_by_stop_id(StopId(1), StopId(2), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(1), StopId(2), 75.0).unwrap();
     sim.step();
     let elev = first_elevator(&sim);
     let queue = sim.destination_queue(elev).unwrap();
@@ -50,8 +49,7 @@ fn dispatch_populates_queue() {
 #[test]
 fn queue_pops_on_arrival() {
     let mut sim = build_sim();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
     // Run enough ticks for the elevator to reach stop 2.
     for _ in 0..2000 {
         sim.step();
@@ -208,8 +206,7 @@ fn destination_queued_event_fires_on_push() {
     // One push via sim helper (top stop — elevator is at stop 0).
     sim.push_destination(elev, s2).unwrap();
     // Second push via dispatch: rider at stop 1 triggers a GoToStop(s1) push.
-    sim.spawn_rider_by_stop_id(StopId(1), StopId(2), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(1), StopId(2), 75.0).unwrap();
     sim.step();
 
     let events = sim.drain_events();
@@ -269,9 +266,7 @@ fn push_destination_errors_on_non_elevator() {
     let mut sim = build_sim();
     let s1 = sim.stop_entity(StopId(1)).unwrap();
     // Spawn a rider entity — not an elevator.
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
     let result = sim.push_destination(rider, s1);
     assert!(matches!(result, Err(SimError::NotAnElevator(_))));
 }
@@ -297,8 +292,7 @@ fn redirect_via_push_front_updates_direction_indicators() {
     let elev = first_elevator(&sim);
 
     // Dispatch sends the elevator upward toward stop 2.
-    sim.spawn_rider_by_stop_id(StopId(1), StopId(2), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(1), StopId(2), 75.0).unwrap();
     // Let dispatch push to the queue and the elevator begin moving up.
     for _ in 0..20 {
         sim.step();

--- a/crates/elevator-core/src/tests/direction_indicator_tests.rs
+++ b/crates/elevator-core/src/tests/direction_indicator_tests.rs
@@ -26,8 +26,7 @@ fn default_indicators_both_true() {
 fn dispatch_upward_sets_going_up_only() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     // Step until the elevator is moving upward.
     let elev = first_elevator(&sim);
@@ -53,8 +52,7 @@ fn dispatch_downward_sets_going_down_only() {
     config.elevators[0].starting_stop = StopId(2);
 
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(2), StopId(0), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(2), StopId(0), 70.0).unwrap();
 
     let elev = first_elevator(&sim);
     let mut saw_moving = false;
@@ -76,8 +74,7 @@ fn dispatch_downward_sets_going_down_only() {
 fn becoming_idle_resets_both_true() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     for _ in 0..10_000 {
         sim.step();
@@ -101,8 +98,7 @@ fn becoming_idle_resets_both_true() {
 fn direction_indicator_changed_event_fires_on_change() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     let mut all_events = Vec::new();
     for _ in 0..10_000 {
@@ -137,8 +133,7 @@ fn direction_indicator_changed_event_fires_on_change() {
 fn direction_indicator_event_does_not_spam() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     let mut all_events = Vec::new();
     for _ in 0..10_000 {
@@ -175,12 +170,8 @@ fn rider_going_up_skips_down_only_car() {
     config.elevators[0].starting_stop = StopId(2);
 
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    let down_rider = sim
-        .spawn_rider_by_stop_id(StopId(2), StopId(0), 70.0)
-        .unwrap();
-    let up_rider = sim
-        .spawn_rider_by_stop_id(StopId(1), StopId(2), 70.0)
-        .unwrap();
+    let down_rider = sim.spawn_rider(StopId(2), StopId(0), 70.0).unwrap();
+    let up_rider = sim.spawn_rider(StopId(1), StopId(2), 70.0).unwrap();
 
     let mut all_events = Vec::new();
     // Run until the downward rider arrives at stop 0.
@@ -243,9 +234,7 @@ fn idle_car_boards_riders_either_direction() {
 
     // First rider: up-bound.
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    let up_rider = sim
-        .spawn_rider_by_stop_id(StopId(1), StopId(2), 70.0)
-        .unwrap();
+    let up_rider = sim.spawn_rider(StopId(1), StopId(2), 70.0).unwrap();
     for _ in 0..20_000 {
         sim.step();
         if sim.world().rider(up_rider).map(|r| r.phase) == Some(RiderPhase::Arrived) {
@@ -262,9 +251,7 @@ fn idle_car_boards_riders_either_direction() {
     for _ in 0..60 {
         sim.step();
     }
-    let down_rider = sim
-        .spawn_rider_by_stop_id(StopId(1), StopId(0), 70.0)
-        .unwrap();
+    let down_rider = sim.spawn_rider(StopId(1), StopId(0), 70.0).unwrap();
     for _ in 0..20_000 {
         sim.step();
         if sim.world().rider(down_rider).map(|r| r.phase) == Some(RiderPhase::Arrived) {
@@ -281,8 +268,7 @@ fn idle_car_boards_riders_either_direction() {
 fn snapshot_roundtrip_preserves_indicators() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     let elev = first_elevator(&sim);
 

--- a/crates/elevator-core/src/tests/dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/dispatch_tests.rs
@@ -527,8 +527,7 @@ fn custom_dispatch_strategy() {
         .unwrap();
 
     // Spawn a rider so there's demand.
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
 
     // Step several times — the elevator should never move since dispatch always returns Idle.
     for _ in 0..100 {

--- a/crates/elevator-core/src/tests/door_control_tests.rs
+++ b/crates/elevator-core/src/tests/door_control_tests.rs
@@ -133,9 +133,7 @@ fn open_reverses_closing_door() {
 fn close_waits_for_boarding_rider() {
     let (mut sim, elev) = make_sim();
     // Spawn a rider at the car's current stop.
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
     // Open doors and wait until the rider is mid-Boarding.
     sim.open_door(elev).unwrap();
     let mut saw_boarding = false;
@@ -344,9 +342,7 @@ fn command_queued_during_motion_fires_on_arrival() {
 #[test]
 fn unknown_elevator_errors() {
     let (mut sim, _elev) = make_sim();
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
     assert!(matches!(
         sim.open_door(rider),
         Err(SimError::NotAnElevator(_))

--- a/crates/elevator-core/src/tests/energy_tests.rs
+++ b/crates/elevator-core/src/tests/energy_tests.rs
@@ -51,8 +51,7 @@ fn moving_energy_includes_weight_factor() {
     let mut sim = crate::sim::Simulation::new(&cfg, helpers::scan()).unwrap();
 
     // Spawn a rider going up so the elevator moves.
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
 
     // Run enough ticks for the elevator to start moving.
     let mut found_moving_energy = false;
@@ -85,8 +84,7 @@ fn regen_on_descent() {
     let mut sim = crate::sim::Simulation::new(&cfg, helpers::scan()).unwrap();
 
     // Spawn rider going down.
-    sim.spawn_rider_by_stop_id(StopId(2), StopId(0), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(2), StopId(0), 75.0).unwrap();
 
     let mut total_regen = 0.0;
     for _ in 0..500 {
@@ -114,8 +112,7 @@ fn regen_factor_zero_no_regen() {
 
     let mut sim = crate::sim::Simulation::new(&cfg, helpers::scan()).unwrap();
 
-    sim.spawn_rider_by_stop_id(StopId(2), StopId(0), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(2), StopId(0), 75.0).unwrap();
 
     for _ in 0..500 {
         sim.step();
@@ -156,8 +153,7 @@ fn aggregate_metrics_match() {
     let cfg = config_with_energy(default_profile());
     let mut sim = crate::sim::Simulation::new(&cfg, helpers::scan()).unwrap();
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
 
     for _ in 0..300 {
         sim.step();

--- a/crates/elevator-core/src/tests/error_tests.rs
+++ b/crates/elevator-core/src/tests/error_tests.rs
@@ -161,18 +161,14 @@ fn valid_config_succeeds() {
 #[test]
 fn spawn_rider_unknown_stop_returns_error() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
-    let err = sim
-        .spawn_rider_by_stop_id(StopId(99), StopId(0), 70.0)
-        .unwrap_err();
+    let err = sim.spawn_rider(StopId(99), StopId(0), 70.0).unwrap_err();
     assert!(matches!(err, SimError::StopNotFound(StopId(99))));
 }
 
 #[test]
 fn spawn_rider_unknown_destination_returns_error() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
-    let err = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(99), 70.0)
-        .unwrap_err();
+    let err = sim.spawn_rider(StopId(0), StopId(99), 70.0).unwrap_err();
     assert!(matches!(err, SimError::StopNotFound(StopId(99))));
 }
 

--- a/crates/elevator-core/src/tests/event_payload_tests.rs
+++ b/crates/elevator-core/src/tests/event_payload_tests.rs
@@ -11,9 +11,7 @@ use crate::tests::helpers::default_config;
 fn rider_boarded_event_has_correct_elevator() {
     let config = default_config();
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     // Run until we get a RiderBoarded event.
     let mut boarded_event = None;
@@ -54,9 +52,7 @@ fn rider_boarded_event_has_correct_elevator() {
 fn rider_exited_event_has_correct_stop() {
     let config = default_config();
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
-    let _rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let _rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     // Run until we get a RiderExited event.
     let mut exited_event = None;
@@ -113,8 +109,7 @@ fn event_ticks_are_monotonically_increasing() {
 
     // Spawn riders to generate events.
     for _ in 0..3 {
-        sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-            .unwrap();
+        sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     }
 
     let mut last_tick = 0u64;

--- a/crates/elevator-core/src/tests/feature_tests.rs
+++ b/crates/elevator-core/src/tests/feature_tests.rs
@@ -19,9 +19,7 @@ fn patience_abandonment_sets_abandoned_phase() {
     let config = default_config();
     let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
 
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     // Attach a short patience: abandon after 5 ticks.
     sim.world_mut().set_patience(
@@ -63,9 +61,7 @@ fn patience_abandonment_does_not_fire_before_limit() {
     let config = default_config();
     let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
 
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     sim.world_mut().set_patience(
         rider,
@@ -98,9 +94,7 @@ fn waited_ticks_increments_each_step() {
     let config = default_config();
     let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
 
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     sim.world_mut().set_patience(
         rider,
@@ -139,9 +133,7 @@ fn preferences_skip_crowded_elevator_prevents_boarding() {
 
     // Spawn a "ballast" rider that will fill the elevator to > 50 % capacity.
     // 60 kg / 100 kg = 0.60 load ratio — above our crowding threshold.
-    let ballast = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 60.0)
-        .unwrap();
+    let ballast = sim.spawn_rider(StopId(0), StopId(2), 60.0).unwrap();
 
     // Run until the ballast has boarded (is Riding).
     let max_ticks = 5_000;
@@ -163,9 +155,7 @@ fn preferences_skip_crowded_elevator_prevents_boarding() {
     );
 
     // Now spawn the picky rider with skip_full_elevator = true and a strict factor.
-    let picky = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 30.0)
-        .unwrap();
+    let picky = sim.spawn_rider(StopId(0), StopId(2), 30.0).unwrap();
     sim.world_mut().set_preferences(
         picky,
         Preferences {
@@ -222,9 +212,7 @@ fn preferences_boards_when_elevator_not_too_crowded() {
 
     let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
 
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 30.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 30.0).unwrap();
 
     // max_crowding_factor 0.5: current_load 0.0 / 100.0 = 0.0 — well below.
     sim.world_mut().set_preferences(
@@ -428,9 +416,7 @@ fn disable_elevator_ejects_riding_passenger_to_waiting() {
     let config = default_config();
     let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
 
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     // Run until the rider is Riding.
     let max_ticks = 5_000;
@@ -495,8 +481,7 @@ fn disable_elevator_clears_its_rider_list() {
     let config = default_config();
     let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     let elev = sim.world().elevator_ids()[0];
 
@@ -784,9 +769,9 @@ fn weight_rejection_boundary() {
 
     // Spawn rider1 (weight 60) and rider2 (weight 60) at stop 0 → stop 1.
     // Combined = 120, exceeds capacity 100. Only one should board.
-    sim.spawn_rider_by_stop_id(crate::stop::StopId(0), crate::stop::StopId(1), 60.0)
+    sim.spawn_rider(crate::stop::StopId(0), crate::stop::StopId(1), 60.0)
         .unwrap();
-    sim.spawn_rider_by_stop_id(crate::stop::StopId(0), crate::stop::StopId(1), 60.0)
+    sim.spawn_rider(crate::stop::StopId(0), crate::stop::StopId(1), 60.0)
         .unwrap();
 
     // Run enough ticks for loading to happen.
@@ -875,7 +860,7 @@ fn passing_floor_events_emitted() {
         crate::sim::Simulation::new(&config, crate::dispatch::scan::ScanDispatch::new()).unwrap();
 
     // Spawn a rider from stop 0 to stop 4 to trigger dispatch.
-    sim.spawn_rider_by_stop_id(crate::stop::StopId(0), crate::stop::StopId(4), 70.0)
+    sim.spawn_rider(crate::stop::StopId(0), crate::stop::StopId(4), 70.0)
         .unwrap();
 
     // Run enough ticks for the elevator to reach the destination.

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -12,9 +12,7 @@ use super::helpers::{default_config, scan};
 #[test]
 fn spawn_rider_auto_presses_hall_button() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
-    let rid = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rid = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     let origin = sim.stop_entity(StopId(0)).unwrap();
     let call = sim.world().hall_call(origin, CallDirection::Up).unwrap();
     assert_eq!(call.direction, CallDirection::Up);
@@ -40,13 +38,9 @@ fn spawn_rider_auto_presses_hall_button() {
 #[test]
 fn multiple_riders_aggregate_into_one_hall_call() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
-    let r1 = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let r1 = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     sim.drain_events();
-    let r2 = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let r2 = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     let origin = sim.stop_entity(StopId(0)).unwrap();
     let call = sim.world().hall_call(origin, CallDirection::Up).unwrap();
     assert!(call.pending_riders.contains(&r1));
@@ -162,8 +156,7 @@ fn destination_mode_records_destination_on_call() {
     }
     let origin = sim.stop_entity(StopId(0)).unwrap();
     let dest = sim.stop_entity(StopId(2)).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     let call = sim.world().hall_call(origin, CallDirection::Up).unwrap();
     assert_eq!(
         call.destination,
@@ -177,8 +170,7 @@ fn destination_mode_records_destination_on_call() {
 #[test]
 fn public_call_queries_return_active_calls() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     // One hall call registered at the origin going up.
     let count = sim.hall_calls().count();
     assert_eq!(count, 1);
@@ -193,8 +185,7 @@ fn public_call_queries_return_active_calls() {
 #[test]
 fn car_call_removed_on_exit() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     let car = sim.world().elevator_ids()[0];
 
     // Run until the rider reaches Arrived.
@@ -245,8 +236,7 @@ fn pinned_pin_does_not_clobber_loading_car() {
     use crate::components::ElevatorPhase;
 
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     // Run until the car reaches Loading phase at some stop.
     let car = sim.world().elevator_ids()[0];
     let mut loading_stop: Option<EntityId> = None;
@@ -288,7 +278,7 @@ fn abandon_on_full_abandons_immediately() {
 
     // Rider with abandon_on_full who skips anything with load > 0.5.
     let picky = sim
-        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .build_rider(StopId(0), StopId(2))
         .unwrap()
         .weight(30.0)
         .preferences(Preferences::default().with_abandon_on_full(true))
@@ -347,7 +337,7 @@ fn abandon_on_full_fires_before_balk_threshold_elapses() {
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
     let picky = sim
-        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .build_rider(StopId(0), StopId(2))
         .unwrap()
         .weight(30.0)
         .preferences(Preferences::default())
@@ -509,8 +499,7 @@ fn shared_stop_attributes_call_to_first_group() {
     // here as the one-group variant is sufficient until a public API
     // for overlapping groups is added.
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(1), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(1), StopId(2), 70.0).unwrap();
     let origin = sim.stop_entity(StopId(1)).unwrap();
     let calls: Vec<_> = sim.hall_calls().collect();
     assert_eq!(calls.len(), 1, "one call per (stop, direction)");
@@ -524,8 +513,7 @@ fn shared_stop_attributes_call_to_first_group() {
 #[test]
 fn reassignment_does_not_spam_elevator_assigned() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     sim.drain_events();
     // Step enough ticks to let dispatch commit + keep the car moving
     // (it won't arrive instantly). Count ElevatorAssigned emissions.
@@ -549,8 +537,7 @@ fn reassignment_does_not_spam_elevator_assigned() {
 #[test]
 fn zero_latency_acknowledges_immediately() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     let origin = sim.stop_entity(StopId(0)).unwrap();
     let call = sim.world().hall_call(origin, CallDirection::Up).unwrap();
     assert_eq!(
@@ -575,8 +562,7 @@ fn pinned_call_forces_specific_car() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
     // Spawn a rider at StopId(1) going up to StopId(2) — auto-presses
     // the hall call at the origin.
-    sim.spawn_rider_by_stop_id(StopId(1), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(1), StopId(2), 70.0).unwrap();
     let origin = sim.stop_entity(StopId(1)).unwrap();
     // Pin the call to elevator 0 even though SCAN would pick whichever
     // car is closest.
@@ -607,8 +593,7 @@ fn pinned_call_forces_specific_car() {
 #[test]
 fn door_opening_clears_hall_call() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     let origin = sim.stop_entity(StopId(0)).unwrap();
     assert!(sim.world().hall_call(origin, CallDirection::Up).is_some());
 
@@ -756,8 +741,7 @@ fn custom_strategy_reads_hall_calls_from_manifest() {
     // Spawning a rider auto-presses the up-button at stop 0 AND
     // registers waiting demand there, so `dispatch::assign` will
     // consider stop 0 a candidate and call `rank` for it.
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     // One tick runs dispatch, building the manifest with the pressed
     // hall call at stop 0 and calling `rank(car, stop)` for every
@@ -810,8 +794,7 @@ fn custom_strategy_reads_car_calls_from_manifest() {
     // Spawn a rider — they press the hall call (creating dispatch demand)
     // and on boarding will press a car button, which the strategy sees
     // through `car_calls_for` as soon as dispatch runs next.
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     // Step until the rider boards and a car call exists; then one
     // further step triggers a dispatch pass with the car call visible.
     let car = sim.world().elevator_ids()[0];
@@ -878,8 +861,7 @@ fn unacknowledged_hall_calls_hidden_from_manifest() {
     // Spawn the rider at a stop the car isn't already parked at, so
     // the car must travel — giving ack-latency time to elapse before
     // the call is cleared on arrival.
-    sim.spawn_rider_by_stop_id(StopId(1), StopId(0), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(1), StopId(0), 70.0).unwrap();
     // One tick: call exists under ack-latency, not yet acknowledged.
     sim.step();
     assert!(

--- a/crates/elevator-core/src/tests/manual_mode_tests.rs
+++ b/crates/elevator-core/src/tests/manual_mode_tests.rs
@@ -17,8 +17,7 @@ fn make_manual() -> (Simulation, crate::entity::EntityId) {
 #[test]
 fn manual_skips_dispatch() {
     let (mut sim, _elev) = make_manual();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
     for _ in 0..500 {
         sim.step();
     }

--- a/crates/elevator-core/src/tests/metrics_tests.rs
+++ b/crates/elevator-core/src/tests/metrics_tests.rs
@@ -6,10 +6,8 @@ use super::helpers::{all_riders_arrived, default_config, scan};
 #[test]
 fn metrics_track_deliveries() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
-        .unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 60.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 60.0).unwrap();
 
     for _ in 0..20_000 {
         sim.step();
@@ -30,8 +28,7 @@ fn metrics_track_deliveries() {
 #[test]
 fn metrics_wait_time_increases_with_distance() {
     let mut sim1 = Simulation::new(&default_config(), scan()).unwrap();
-    sim1.spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
-        .unwrap();
+    sim1.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
     for _ in 0..10_000 {
         sim1.step();
         if all_riders_arrived(&sim1) {
@@ -48,8 +45,7 @@ fn metrics_wait_time_increases_with_distance() {
 #[test]
 fn metrics_throughput_window() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
 
     for _ in 0..10_000 {
         sim.step();

--- a/crates/elevator-core/src/tests/move_count_tests.rs
+++ b/crates/elevator-core/src/tests/move_count_tests.rs
@@ -104,8 +104,7 @@ fn move_count_increments_on_arrival() {
         .unwrap();
 
     // Rider 0 -> 1: elevator moves past zero stops, arrives at stop 1. 1 move.
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
 
     for _ in 0..2000 {
         sim.step();
@@ -139,8 +138,7 @@ fn move_count_counts_passing_floors() {
         .unwrap();
 
     // Rider 0 -> 2: elevator passes stop 1, arrives at stop 2. 2 moves.
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     for _ in 0..2000 {
         sim.step();
@@ -169,10 +167,8 @@ fn total_moves_aggregates_across_elevators() {
     // Elevator 0 starts at stop 0 (pos 0), elevator 1 starts at stop 2 (pos 10).
     // Spawn one rider 0 -> 2 (goes up, picked up by E1 — 2 moves)
     // and one rider 2 -> 0 (goes down, picked up by E2 — 2 moves).
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
-    sim.spawn_rider_by_stop_id(StopId(2), StopId(0), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.spawn_rider(StopId(2), StopId(0), 70.0).unwrap();
 
     for _ in 0..3000 {
         sim.step();
@@ -234,8 +230,7 @@ fn move_count_persists_across_snapshot() {
     let config = helpers::default_config();
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     for _ in 0..2000 {
         sim.step();

--- a/crates/elevator-core/src/tests/multi_elevator_tests.rs
+++ b/crates/elevator-core/src/tests/multi_elevator_tests.rs
@@ -81,8 +81,7 @@ fn two_elevators_both_serve_demand() {
 
     // Spawn riders going to different floors.
     for _ in 0..5 {
-        sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-            .unwrap();
+        sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     }
 
     // Run until all arrive.
@@ -110,9 +109,7 @@ fn disable_elevator_mid_route_ejects_riders() {
     let config = two_elevator_config();
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     // Run until rider boards.
     let mut boarded_elevator = None;

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -436,7 +436,11 @@ fn cross_group_rider_arrives_via_explicit_two_leg_route() {
     };
 
     let rider = sim
-        .spawn_rider_with_route(ground, top, 70.0, route)
+        .build_rider(ground, top)
+        .unwrap()
+        .weight(70.0)
+        .route(route)
+        .spawn()
         .unwrap();
 
     // Run until rider arrives or we time out.
@@ -635,7 +639,13 @@ fn line_pinned_rider_boards_only_specified_line_elevator() {
         }],
         current_leg: 0,
     };
-    let rider = sim.spawn_rider_with_route(lobby, sky, 70.0, route).unwrap();
+    let rider = sim
+        .build_rider(lobby, sky)
+        .unwrap()
+        .weight(70.0)
+        .route(route)
+        .spawn()
+        .unwrap();
 
     // Step until rider boards.
     let mut boarding_elevator = None;
@@ -1377,7 +1387,11 @@ fn walk_only_route_rider_arrives_directly() {
 
     // Spawn at ground, destination transfer, route is walk-only.
     let rider = sim
-        .spawn_rider_with_route(ground, transfer, 70.0, route)
+        .build_rider(ground, transfer)
+        .unwrap()
+        .weight(70.0)
+        .route(route)
+        .spawn()
         .unwrap();
 
     // The rider starts Waiting.
@@ -1451,7 +1465,11 @@ fn walk_leg_teleports_rider_to_destination() {
     };
 
     let rider = sim
-        .spawn_rider_with_route(ground, top, 70.0, route)
+        .build_rider(ground, top)
+        .unwrap()
+        .weight(70.0)
+        .route(route)
+        .spawn()
         .unwrap();
 
     for _ in 0..5000 {
@@ -1489,7 +1507,11 @@ fn walk_leg_rider_does_not_board_elevator() {
     };
 
     let rider = sim
-        .spawn_rider_with_route(ground, transfer, 70.0, route)
+        .build_rider(ground, transfer)
+        .unwrap()
+        .weight(70.0)
+        .route(route)
+        .spawn()
         .unwrap();
 
     // Step 50 ticks — enough for an elevator to come and open its doors.
@@ -2301,7 +2323,13 @@ fn three_group_rider_navigates_all_legs() {
         current_leg: 0,
     };
 
-    let rider = sim.spawn_rider_with_route(a, d, 70.0, route).unwrap();
+    let rider = sim
+        .build_rider(a, d)
+        .unwrap()
+        .weight(70.0)
+        .route(route)
+        .spawn()
+        .unwrap();
 
     for _ in 0..10_000 {
         sim.step();
@@ -2452,10 +2480,10 @@ fn despawn_nonexistent_entity_does_not_panic() {
     sim.world_mut().despawn(fake_id);
 }
 
-// ── 18. spawn_rider_in_group ──────────────────────────────────────────────────
+// ── 18. build_rider with explicit group ──────────────────────────────────────
 
 #[test]
-fn spawn_rider_in_group_succeeds_when_group_serves_stops() {
+fn build_rider_with_group_succeeds_when_group_serves_stops() {
     let config = overlapping_groups_config();
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
@@ -2463,10 +2491,15 @@ fn spawn_rider_in_group_succeeds_when_group_serves_stops() {
     let top = sim.stop_entity(StopId(1)).unwrap();
 
     // Both groups serve bottom and top — explicitly pick Group A (id=0).
-    let result = sim.spawn_rider_in_group(bottom, top, 70.0, GroupId(0));
+    let result = sim
+        .build_rider(bottom, top)
+        .unwrap()
+        .weight(70.0)
+        .group(GroupId(0))
+        .spawn();
     assert!(
         result.is_ok(),
-        "spawn_rider_in_group should succeed for a valid group"
+        "build_rider with explicit group should succeed for a valid group"
     );
 
     let rider = result.unwrap();
@@ -2475,14 +2508,19 @@ fn spawn_rider_in_group_succeeds_when_group_serves_stops() {
 }
 
 #[test]
-fn spawn_rider_in_nonexistent_group_returns_group_not_found() {
+fn build_rider_with_nonexistent_group_returns_group_not_found() {
     let config = two_group_config();
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
     let ground = sim.stop_entity(StopId(0)).unwrap();
     let transfer = sim.stop_entity(StopId(1)).unwrap();
 
-    let result = sim.spawn_rider_in_group(ground, transfer, 70.0, GroupId(99));
+    let result = sim
+        .build_rider(ground, transfer)
+        .unwrap()
+        .weight(70.0)
+        .group(GroupId(99))
+        .spawn();
     assert!(
         matches!(result, Err(SimError::GroupNotFound(GroupId(99)))),
         "expected GroupNotFound(99), got {result:?}"
@@ -2827,7 +2865,11 @@ fn dispatch_ignores_waiting_rider_targeting_another_group() {
         current_leg: 0,
     };
     let rider = sim
-        .spawn_rider_with_route(bottom, top, 70.0, route)
+        .build_rider(bottom, top)
+        .unwrap()
+        .weight(70.0)
+        .route(route)
+        .spawn()
         .unwrap();
     assert_eq!(sim.world().rider(rider).unwrap().phase, RiderPhase::Waiting);
 
@@ -2888,7 +2930,11 @@ fn car_with_opposite_indicator_eventually_boards_waiting_rider() {
         current_leg: 0,
     };
     let rider = sim
-        .spawn_rider_with_route(transfer, ground, 70.0, route)
+        .build_rider(transfer, ground)
+        .unwrap()
+        .weight(70.0)
+        .route(route)
+        .spawn()
         .unwrap();
 
     // Run until the rider boards (or times out), collecting events so we can
@@ -2977,7 +3023,11 @@ fn dispatch_arrive_in_place_sets_target_and_pops_queue() {
         current_leg: 0,
     };
     let _rider = sim
-        .spawn_rider_with_route(ground, transfer, 70.0, route)
+        .build_rider(ground, transfer)
+        .unwrap()
+        .weight(70.0)
+        .route(route)
+        .spawn()
         .unwrap();
 
     // One step runs dispatch; the Idle car will be assigned Ground and, since

--- a/crates/elevator-core/src/tests/mutation_kills_tests.rs
+++ b/crates/elevator-core/src/tests/mutation_kills_tests.rs
@@ -49,8 +49,7 @@ fn run_until_all_delivered(sim: &mut Simulation, count: u64, max_ticks: u64) -> 
 #[test]
 fn metrics_records_spawn_board_delivery_in_sequence() {
     let mut sim = three_stop_sim();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 72.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 72.0).unwrap();
 
     run_until_all_delivered(&mut sim, 1, 2000);
 
@@ -67,16 +66,12 @@ fn metrics_records_spawn_board_delivery_in_sequence() {
 #[test]
 fn metrics_accumulates_distance_proportional_to_run_length() {
     let mut sim_short = three_stop_sim();
-    sim_short
-        .spawn_rider_by_stop_id(StopId(0), StopId(1), 75.0)
-        .unwrap();
+    sim_short.spawn_rider(StopId(0), StopId(1), 75.0).unwrap();
     run_until_all_delivered(&mut sim_short, 1, 2000);
     let short_dist = sim_short.metrics().total_distance();
 
     let mut sim_long = three_stop_sim();
-    sim_long
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
-        .unwrap();
+    sim_long.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
     run_until_all_delivered(&mut sim_long, 1, 2000);
     let long_dist = sim_long.metrics().total_distance();
 
@@ -98,7 +93,7 @@ fn metrics_records_abandonment() {
     // Seed a rider with zero patience. A real sim normally spawns via the
     // builder, but for abandonment testing we set patience directly.
     let rid = sim
-        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .build_rider(StopId(0), StopId(2))
         .unwrap()
         .patience(1)
         .spawn()
@@ -275,8 +270,7 @@ fn etd_prefers_closer_elevator_to_call() {
     let _elev_a = sim.groups()[0].elevator_entities()[0];
 
     // Spawn rider at stop 2 going down to stop 0.
-    sim.spawn_rider_by_stop_id(StopId(2), StopId(0), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(2), StopId(0), 70.0).unwrap();
 
     // Step once so dispatch assigns.
     sim.step();
@@ -304,8 +298,7 @@ fn etd_infinity_cost_path_exists() {
     let mut sim = Simulation::new(&config, EtdDispatch::new()).unwrap();
     sim.drain_events();
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     sim.step();
     // Should not panic or emit NaN cost events — just a successful
     // ElevatorAssigned.
@@ -328,8 +321,7 @@ fn loading_accepts_rider_exactly_at_capacity() {
 
     // Elevator has 800 kg default capacity. Rider at exactly 800.0
     // should be accepted (<=) not rejected (<).
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 800.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 800.0).unwrap();
 
     for _ in 0..2000 {
         sim.step();
@@ -357,7 +349,7 @@ fn loading_preference_boundary_allows_exact_match() {
     // Elevator empty: load_ratio = 0.0. Rider with max_crowding_factor
     // = 0.0 should still board (not skip_full_elevator).
     let rider = sim
-        .build_rider_by_stop_id(StopId(0), StopId(2))
+        .build_rider(StopId(0), StopId(2))
         .unwrap()
         .preferences(Preferences {
             skip_full_elevator: true,

--- a/crates/elevator-core/src/tests/position_interpolation_tests.rs
+++ b/crates/elevator-core/src/tests/position_interpolation_tests.rs
@@ -25,8 +25,7 @@ fn position_at_interpolates_between_prev_and_current() {
     let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
     let elev = sim.world().iter_elevators().next().unwrap().0;
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
 
     // Run until the elevator is actually moving (non-zero velocity).
     for _ in 0..200 {
@@ -56,8 +55,7 @@ fn position_at_clamps_alpha_out_of_range() {
     let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
     let elev = sim.world().iter_elevators().next().unwrap().0;
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
     for _ in 0..200 {
         sim.step();
         if sim.velocity(elev).is_some_and(|v| v.abs() > 0.01) {
@@ -87,8 +85,7 @@ fn velocity_convenience_matches_world_velocity() {
     let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
     let elev = sim.world().iter_elevators().next().unwrap().0;
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
     for _ in 0..50 {
         sim.step();
     }

--- a/crates/elevator-core/src/tests/proptest_tests.rs
+++ b/crates/elevator-core/src/tests/proptest_tests.rs
@@ -276,7 +276,7 @@ proptest! {
         };
 
         for _ in 0..rider_count {
-            sim.spawn_rider_by_stop_id(StopId(0), StopId(1), next_weight()).unwrap();
+            sim.spawn_rider(StopId(0), StopId(1), next_weight()).unwrap();
         }
 
         // Run enough ticks for loading to happen.
@@ -325,7 +325,7 @@ proptest! {
             if dest == origin {
                 dest = StopId((origin.0 + 1) % stop_count);
             }
-            sim.spawn_rider_by_stop_id(origin, dest, 70.0).unwrap();
+            sim.spawn_rider(origin, dest, 70.0).unwrap();
         }
 
         for _ in 0..5000 {

--- a/crates/elevator-core/src/tests/query_event_tests.rs
+++ b/crates/elevator-core/src/tests/query_event_tests.rs
@@ -31,9 +31,7 @@ fn is_stop_returns_true_for_stops() {
 #[test]
 fn is_rider_returns_true_for_riders() {
     let mut sim = SimulationBuilder::demo().build().unwrap();
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(1), 75.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(1), 75.0).unwrap();
     assert!(sim.is_rider(rider));
     assert!(!sim.is_elevator(rider));
     assert!(!sim.is_stop(rider));
@@ -50,8 +48,7 @@ fn idle_elevator_count_starts_at_one() {
 #[test]
 fn idle_elevator_count_decreases_when_moving() {
     let mut sim = SimulationBuilder::demo().build().unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(1), 75.0).unwrap();
 
     // Run until the elevator starts moving.
     for _ in 0..500 {
@@ -117,9 +114,7 @@ fn disabled_elevators_excluded_from_counts() {
 #[test]
 fn capacity_changed_emitted_on_disable_with_load() {
     let mut sim = SimulationBuilder::demo().build().unwrap();
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(1), 75.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(1), 75.0).unwrap();
 
     // Run until the rider is aboard.
     for _ in 0..500 {
@@ -169,8 +164,7 @@ fn capacity_changed_emitted_on_disable_with_load() {
 #[test]
 fn capacity_changed_emitted_on_boarding() {
     let mut sim = SimulationBuilder::demo().build().unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(1), 75.0).unwrap();
 
     // Run until we see a CapacityChanged event.
     let mut found_capacity_event = false;
@@ -201,8 +195,7 @@ fn capacity_changed_emitted_on_boarding() {
 #[test]
 fn capacity_changed_emitted_on_exit() {
     let mut sim = SimulationBuilder::demo().build().unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(1), 75.0).unwrap();
 
     // Run until rider is delivered, collecting CapacityChanged events.
     let mut capacity_events = Vec::new();

--- a/crates/elevator-core/src/tests/reposition_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_tests.rs
@@ -597,8 +597,7 @@ fn dispatch_assigns_after_repositioning() {
     assert!(!car.repositioning());
 
     // Spawn a rider — dispatch should pick up the now-idle elevator.
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     sim.step();
 
     let events = sim.drain_events();

--- a/crates/elevator-core/src/tests/reroute_tests.rs
+++ b/crates/elevator-core/src/tests/reroute_tests.rs
@@ -64,9 +64,7 @@ fn reroute_changes_rider_destination() {
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
     // Spawn rider from 0 → 2.
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     // Reroute to stop 1 instead.
     let stop1 = sim.stop_entity(StopId(1)).unwrap();
@@ -82,9 +80,7 @@ fn disable_stop_reroutes_affected_riders() {
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
     // Spawn rider from 0 → 1.
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
 
     // Disable stop 1 — rider should be rerouted to nearest alternative (stop 2).
     let stop1 = sim.stop_entity(StopId(1)).unwrap();
@@ -103,8 +99,7 @@ fn disable_stop_emits_route_invalidated_event() {
     let config = three_stop_config();
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
 
     let stop1 = sim.stop_entity(StopId(1)).unwrap();
     sim.disable(stop1).unwrap();
@@ -168,9 +163,7 @@ fn disable_only_stop_causes_abandonment() {
     };
 
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
 
     // Disable the only other stop — no alternative available.
     let stop1 = sim.stop_entity(StopId(1)).unwrap();
@@ -205,9 +198,7 @@ fn set_rider_route_replaces_route() {
     let config = three_stop_config();
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     let stop0 = sim.stop_entity(StopId(0)).unwrap();
     let stop1 = sim.stop_entity(StopId(1)).unwrap();
@@ -241,9 +232,7 @@ fn reroute_rejects_non_waiting_rider() {
     let config = three_stop_config();
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     // Advance until rider is boarding or riding.
     for _ in 0..500 {

--- a/crates/elevator-core/src/tests/resident_tests.rs
+++ b/crates/elevator-core/src/tests/resident_tests.rs
@@ -37,9 +37,7 @@ fn run_until_abandoned(sim: &mut Simulation, rider_id: crate::entity::EntityId) 
 fn settle_from_arrived() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     run_until_arrived(&mut sim, rider);
 
@@ -67,9 +65,7 @@ fn settle_from_arrived() {
 fn settle_from_abandoned() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     // Give very short patience so rider abandons.
     sim.world_mut().set_patience(
@@ -97,9 +93,7 @@ fn settle_from_abandoned() {
 fn settle_wrong_phase_returns_error() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     // Rider is Waiting — should fail.
     let result = sim.settle_rider(rider);
@@ -110,9 +104,7 @@ fn settle_wrong_phase_returns_error() {
 fn reroute_resident_to_waiting() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     run_until_arrived(&mut sim, rider);
     sim.settle_rider(rider).unwrap();
@@ -145,9 +137,7 @@ fn reroute_resident_to_waiting() {
 fn reroute_wrong_phase_returns_error() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     let dest = sim.stop_entity(StopId(2)).unwrap();
     let origin = sim.stop_entity(StopId(0)).unwrap();
@@ -162,9 +152,7 @@ fn reroute_wrong_phase_returns_error() {
 fn despawn_rider_removes_from_world_and_index() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     run_until_arrived(&mut sim, rider);
     sim.settle_rider(rider).unwrap();
@@ -193,9 +181,7 @@ fn despawn_rider_removes_from_world_and_index() {
 fn despawn_riding_rider_cleans_elevator() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     // Run until rider is Riding.
     for _ in 0..10_000 {
@@ -239,9 +225,7 @@ fn full_lifecycle_spawn_ride_settle_reroute_ride_despawn() {
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
     // Trip 1: Ground → Floor 3.
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     let origin = sim.stop_entity(StopId(0)).unwrap();
     assert!(sim.waiting_at(origin).any(|id| id == rider));
@@ -277,9 +261,7 @@ fn resident_invisible_to_loading_system() {
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
     // Spawn rider Ground → Floor 3, run until arrived, settle.
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     run_until_arrived(&mut sim, rider);
     sim.settle_rider(rider).unwrap();
     sim.drain_events();
@@ -303,15 +285,11 @@ fn dispatch_manifest_includes_resident_counts() {
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
     // Spawn and deliver 2 riders to Floor 3.
-    let r1 = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let r1 = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     run_until_arrived(&mut sim, r1);
     sim.settle_rider(r1).unwrap();
 
-    let r2 = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let r2 = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     run_until_arrived(&mut sim, r2);
     sim.settle_rider(r2).unwrap();
 
@@ -324,9 +302,7 @@ fn patience_reset_on_reroute() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     sim.world_mut().set_patience(
         rider,
         crate::components::Patience {
@@ -353,9 +329,7 @@ fn snapshot_roundtrip_preserves_residents() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     run_until_arrived(&mut sim, rider);
     sim.settle_rider(rider).unwrap();
 

--- a/crates/elevator-core/src/tests/runtime_upgrades_tests.rs
+++ b/crates/elevator-core/src/tests/runtime_upgrades_tests.rs
@@ -199,9 +199,7 @@ fn set_door_open_ticks_rejects_zero() {
 fn set_on_non_elevator_returns_invalid_state() {
     let (mut sim, _elev) = make_sim();
     // Spawning a rider produces an EntityId that is not an elevator.
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
     let err = sim.set_max_speed(rider, 4.0).unwrap_err();
     assert!(matches!(err, SimError::NotAnElevator(_)));
 }
@@ -311,9 +309,7 @@ fn door_open_ticks_change_does_not_affect_in_progress_cycle() {
 fn weight_capacity_below_current_load_still_applies() {
     let (mut sim, elev) = make_sim();
     // Get a rider boarded.
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 200.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 200.0).unwrap();
     let mut boarded = false;
     for _ in 0..500 {
         sim.step();

--- a/crates/elevator-core/src/tests/scenario_tests.rs
+++ b/crates/elevator-core/src/tests/scenario_tests.rs
@@ -9,8 +9,7 @@ use super::helpers::{all_riders_arrived, default_config, scan};
 fn single_rider_delivery() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     let max_ticks = 10_000;
     for _ in 0..max_ticks {
@@ -31,10 +30,8 @@ fn single_rider_delivery() {
 fn two_riders_opposite_directions() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
-    sim.spawn_rider_by_stop_id(StopId(2), StopId(0), 80.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.spawn_rider(StopId(2), StopId(0), 80.0).unwrap();
 
     let max_ticks = 20_000;
     for _ in 0..max_ticks {
@@ -64,10 +61,8 @@ fn two_riders_exceeding_capacity_delivered_in_two_trips() {
     config.elevators[0].weight_capacity = 100.0;
 
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
-        .unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
+    sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
 
     let max_ticks = 20_000;
     for _ in 0..max_ticks {
@@ -90,11 +85,8 @@ fn overweight_rider_rejected() {
     config.elevators[0].weight_capacity = 50.0;
 
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    let light = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(1), 40.0)
-        .unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 60.0)
-        .unwrap();
+    let light = sim.spawn_rider(StopId(0), StopId(1), 40.0).unwrap();
+    sim.spawn_rider(StopId(0), StopId(1), 60.0).unwrap();
 
     let mut all_events = Vec::new();
     let max_ticks = 20_000;
@@ -124,8 +116,7 @@ fn overweight_rider_rejected() {
 fn events_are_emitted_in_order() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
 
     let mut all_events = Vec::new();
     let max_ticks = 10_000;
@@ -176,15 +167,9 @@ fn rider_boarded_precedes_rider_exited_per_rider() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
-    let r1 = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
-    let r2 = sim
-        .spawn_rider_by_stop_id(StopId(2), StopId(0), 60.0)
-        .unwrap();
-    let r3 = sim
-        .spawn_rider_by_stop_id(StopId(1), StopId(2), 65.0)
-        .unwrap();
+    let r1 = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    let r2 = sim.spawn_rider(StopId(2), StopId(0), 60.0).unwrap();
+    let r3 = sim.spawn_rider(StopId(1), StopId(2), 65.0).unwrap();
 
     let mut boarded_at: std::collections::HashMap<_, usize> = std::collections::HashMap::new();
     let mut exited_at: std::collections::HashMap<_, usize> = std::collections::HashMap::new();
@@ -230,10 +215,8 @@ fn rider_boarded_precedes_rider_exited_per_rider() {
 fn door_opened_precedes_door_closed() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
-    sim.spawn_rider_by_stop_id(StopId(2), StopId(0), 60.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.spawn_rider(StopId(2), StopId(0), 60.0).unwrap();
 
     // Per-elevator open/close sequence; pairs must alternate open→close.
     let mut per_elevator: std::collections::HashMap<_, Vec<&'static str>> =
@@ -275,10 +258,8 @@ fn deterministic_replay() {
     let config = default_config();
 
     let mut sim1 = Simulation::new(&config, scan()).unwrap();
-    sim1.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
-    sim1.spawn_rider_by_stop_id(StopId(1), StopId(0), 60.0)
-        .unwrap();
+    sim1.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim1.spawn_rider(StopId(1), StopId(0), 60.0).unwrap();
 
     let mut ticks1 = 0u64;
     for _ in 0..20_000 {
@@ -290,10 +271,8 @@ fn deterministic_replay() {
     }
 
     let mut sim2 = Simulation::new(&config, scan()).unwrap();
-    sim2.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
-    sim2.spawn_rider_by_stop_id(StopId(1), StopId(0), 60.0)
-        .unwrap();
+    sim2.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim2.spawn_rider(StopId(1), StopId(0), 60.0).unwrap();
 
     let mut ticks2 = 0u64;
     for _ in 0..20_000 {

--- a/crates/elevator-core/src/tests/service_mode_tests.rs
+++ b/crates/elevator-core/src/tests/service_mode_tests.rs
@@ -13,8 +13,7 @@ fn default_mode_is_normal() {
     let elev = sim.world().elevator_ids()[0];
     assert_eq!(sim.service_mode(elev), ServiceMode::Normal);
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
 
     for _ in 0..1000 {
         sim.step();
@@ -33,8 +32,7 @@ fn independent_skips_dispatch() {
     sim.set_service_mode(elev, ServiceMode::Independent)
         .unwrap();
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
 
     for _ in 0..500 {
         sim.step();
@@ -66,8 +64,7 @@ fn inspection_reduced_speed() {
         let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
         let elev = sim.world().elevator_ids()[0];
 
-        sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
-            .unwrap();
+        sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
 
         let mut mode_set = false;
         let mut depart_tick: Option<u64> = None;
@@ -117,8 +114,7 @@ fn inspection_doors_hold_open() {
     sim.set_service_mode(elev, ServiceMode::Inspection).unwrap();
 
     // Spawn a rider so the elevator gets dispatched and eventually opens doors.
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
 
     // The elevator starts at stop 0, so dispatch should open doors immediately.
     // Run until doors are open.
@@ -232,8 +228,7 @@ fn independent_excluded_from_reposition() {
     let elev = sim.world().elevator_ids()[0];
 
     // First, get the elevator to a non-lobby stop by sending a rider.
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
     for _ in 0..1000 {
         sim.step();
     }

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -26,12 +26,9 @@ fn snapshot_roundtrip_preserves_riders() {
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
 
     // Spawn 3 riders.
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 80.0)
-        .unwrap();
-    sim.spawn_rider_by_stop_id(StopId(1), StopId(0), 60.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 80.0).unwrap();
+    sim.spawn_rider(StopId(1), StopId(0), 60.0).unwrap();
 
     // Advance a few ticks.
     for _ in 0..10 {
@@ -66,8 +63,7 @@ fn snapshot_roundtrip_preserves_metrics() {
     let config = helpers::default_config();
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     for _ in 0..500 {
         sim.step();
     }
@@ -84,8 +80,7 @@ fn snapshot_serializes_to_ron() {
     let config = helpers::default_config();
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     for _ in 0..10 {
         sim.step();
     }
@@ -105,8 +100,7 @@ fn restored_sim_can_continue_stepping() {
     let config = helpers::default_config();
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     for _ in 0..50 {
         sim.step();
     }
@@ -128,10 +122,8 @@ fn snapshot_remaps_entity_ids_for_mid_route_riders() {
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
 
     // Spawn riders and advance just a few ticks so some are still Waiting.
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 80.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 80.0).unwrap();
     for _ in 0..5 {
         sim.step();
     }
@@ -170,8 +162,7 @@ fn snapshot_roundtrip_via_ron_preserves_cross_references() {
     let config = helpers::default_config();
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     for _ in 0..3 {
         sim.step();
     }
@@ -198,8 +189,7 @@ fn snapshot_preserves_metric_tags() {
     // Tag stop 0 and spawn a rider.
     let stop0 = sim.stop_entity(StopId(0)).unwrap();
     sim.tag_entity(stop0, "zone:lobby").unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     for _ in 0..500 {
         sim.step();
     }
@@ -229,9 +219,7 @@ fn snapshot_preserves_extension_components() {
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
 
     // Attach extension component to a rider.
-    let rider = sim
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     sim.world_mut()
         .insert_ext(rider, VipTag { level: 5 }, "vip_tag");
 
@@ -257,8 +245,7 @@ fn snapshot_preserves_extension_components() {
 fn snapshot_bytes_roundtrip() {
     let config = helpers::default_config();
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     for _ in 0..50 {
         sim.step();
     }
@@ -353,19 +340,15 @@ fn snapshot_bytes_midrun_determinism() {
     let config = helpers::default_config();
 
     let mut fresh = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
-    fresh
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
-    fresh
-        .spawn_rider_by_stop_id(StopId(1), StopId(0), 80.0)
-        .unwrap();
+    fresh.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    fresh.spawn_rider(StopId(1), StopId(0), 80.0).unwrap();
 
     let mut via_snapshot = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
     via_snapshot
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
+        .spawn_rider(StopId(0), StopId(2), 70.0)
         .unwrap();
     via_snapshot
-        .spawn_rider_by_stop_id(StopId(1), StopId(0), 80.0)
+        .spawn_rider(StopId(1), StopId(0), 80.0)
         .unwrap();
 
     for _ in 0..250 {

--- a/crates/elevator-core/src/tests/substep_tests.rs
+++ b/crates/elevator-core/src/tests/substep_tests.rs
@@ -9,18 +9,14 @@ fn per_phase_methods_equivalent_to_step() {
 
     // Sim A: use step()
     let mut sim_a = crate::sim::Simulation::new(&config, scan()).unwrap();
-    sim_a
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim_a.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     for _ in 0..100 {
         sim_a.step();
     }
 
     // Sim B: use individual phases
     let mut sim_b = crate::sim::Simulation::new(&config, scan()).unwrap();
-    sim_b
-        .spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim_b.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     for _ in 0..100 {
         sim_b.run_advance_transient();
         sim_b.run_dispatch();
@@ -70,8 +66,7 @@ fn elevator_assigned_event_emitted() {
     let config = default_config();
     let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     sim.drain_events(); // clear spawn event
 
     sim.run_advance_transient();

--- a/crates/elevator-core/src/tests/tagged_metrics_tests.rs
+++ b/crates/elevator-core/src/tests/tagged_metrics_tests.rs
@@ -11,10 +11,8 @@ fn tagged_stop_metrics_track_riders() {
     sim.tag_entity(stop0, "zone:lobby").unwrap();
 
     // Spawn riders from stop 0 → stop 2 (they inherit "zone:lobby" tag).
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     // Run simulation until riders are delivered.
     for _ in 0..2000 {
@@ -42,8 +40,7 @@ fn untagged_riders_dont_affect_tagged_metrics() {
     sim.tag_entity(stop0, "zone:ground").unwrap();
 
     // Spawn a rider from stop 1 (not tagged).
-    sim.spawn_rider_by_stop_id(StopId(1), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(1), StopId(2), 70.0).unwrap();
 
     for _ in 0..500 {
         sim.step();
@@ -67,8 +64,7 @@ fn multiple_tags_per_entity() {
     sim.tag_entity(stop0, "zone:lobby").unwrap();
     sim.tag_entity(stop0, "floor:ground").unwrap();
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     for _ in 0..500 {
         sim.step();

--- a/crates/elevator-core/src/tests/topology_tests.rs
+++ b/crates/elevator-core/src/tests/topology_tests.rs
@@ -155,8 +155,7 @@ fn disabled_elevator_not_dispatched() {
     sim.drain_events();
 
     // Spawn a rider — should trigger dispatch, but elevator is disabled.
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     sim.step();
 
     let events = sim.drain_events();

--- a/crates/elevator-core/src/tests/traffic_tests.rs
+++ b/crates/elevator-core/src/tests/traffic_tests.rs
@@ -394,7 +394,7 @@ fn poisson_source_integration_with_simulation() {
     for _ in 0..500 {
         let tick = sim.current_tick();
         for req in source.generate(tick) {
-            let _ = sim.spawn_rider_by_stop_id(req.origin, req.destination, req.weight);
+            let _ = sim.spawn_rider(req.origin, req.destination, req.weight);
         }
         sim.step();
     }

--- a/crates/elevator-core/src/traffic.rs
+++ b/crates/elevator-core/src/traffic.rs
@@ -18,7 +18,7 @@
 //! Traffic generation is **external to the simulation loop**. A
 //! [`TrafficSource`](crate::traffic::TrafficSource) produces
 //! [`SpawnRequest`](crate::traffic::SpawnRequest)s each tick; the consumer feeds them into
-//! [`Simulation::spawn_rider_by_stop_id`](crate::sim::Simulation::spawn_rider_by_stop_id)
+//! [`Simulation::spawn_rider`](crate::sim::Simulation::spawn_rider)
 //! (or the [`RiderBuilder`](crate::sim::RiderBuilder) for richer configuration).
 //!
 //! ```rust,ignore
@@ -32,7 +32,7 @@
 //! for _ in 0..10_000 {
 //!     let tick = sim.current_tick();
 //!     for req in source.generate(tick) {
-//!         let _ = sim.spawn_rider_by_stop_id(req.origin, req.destination, req.weight);
+//!         let _ = sim.spawn_rider(req.origin, req.destination, req.weight);
 //!     }
 //!     sim.step();
 //! }
@@ -291,7 +291,7 @@ impl TrafficSchedule {
 
 /// A request to spawn a single rider, produced by a [`TrafficSource`].
 ///
-/// Feed these into [`Simulation::spawn_rider_by_stop_id`](crate::sim::Simulation::spawn_rider_by_stop_id)
+/// Feed these into [`Simulation::spawn_rider`](crate::sim::Simulation::spawn_rider)
 /// or the [`RiderBuilder`](crate::sim::RiderBuilder) each tick.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SpawnRequest {
@@ -310,7 +310,7 @@ pub struct SpawnRequest {
 ///
 /// ```rust,ignore
 /// for req in source.generate(tick) {
-///     sim.spawn_rider_by_stop_id(req.origin, req.destination, req.weight)?;
+///     sim.spawn_rider(req.origin, req.destination, req.weight)?;
 /// }
 /// ```
 ///

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -848,7 +848,7 @@ impl World {
     /// use elevator_core::prelude::*;
     ///
     /// let mut sim = SimulationBuilder::demo().build().unwrap();
-    /// sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 75.0).unwrap();
+    /// sim.spawn_rider(StopId(0), StopId(1), 75.0).unwrap();
     ///
     /// let world = sim.world();
     /// for (id, rider, pos) in world.query::<(EntityId, &Rider, &Position)>().iter() {

--- a/crates/elevator-core/tests/deterministic_replay.rs
+++ b/crates/elevator-core/tests/deterministic_replay.rs
@@ -148,7 +148,7 @@ fn run(total_ticks: u64) -> (Vec<Event>, Metrics) {
     for tick in 0..total_ticks {
         // Spawn all riders whose scheduled tick is this tick.
         for spawn in schedule.iter().filter(|s| s.tick == tick) {
-            sim.spawn_rider_by_stop_id(spawn.origin, spawn.destination, spawn.weight)
+            sim.spawn_rider(spawn.origin, spawn.destination, spawn.weight)
                 .unwrap();
         }
 

--- a/crates/elevator-core/tests/integration.rs
+++ b/crates/elevator-core/tests/integration.rs
@@ -10,8 +10,7 @@ fn riders_arrive_at_destination() {
 
     // Spawn 5 riders going from ground to top.
     for _ in 0..5 {
-        sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
-            .unwrap();
+        sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
     }
 
     // Step until all riders arrive or timeout.

--- a/crates/elevator-core/tests/snapshot_roundtrip.rs
+++ b/crates/elevator-core/tests/snapshot_roundtrip.rs
@@ -13,8 +13,7 @@ fn snapshot_roundtrip_preserves_state() {
 
     // Spawn riders and run for a while.
     for _ in 0..3 {
-        sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
-            .unwrap();
+        sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
     }
     for _ in 0..100 {
         sim.step();
@@ -49,8 +48,7 @@ fn snapshot_roundtrip_remaps_repositioning_phase() {
         .unwrap();
 
     // Send the elevator to the top, then wait for it to reposition back.
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 70.0)
-        .unwrap();
+    sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
     // Run until the elevator is in Repositioning phase.
     let elev = sim.world().elevator_ids()[0];
     let mut saw_repositioning = false;

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -1346,7 +1346,7 @@ mod tests {
             .map(|(s, _)| *s)
             .unwrap();
         for _ in 0..20 {
-            ev.sim.spawn_rider_by_stop_id(first, last, 75.0).unwrap();
+            ev.sim.spawn_rider(first, last, 75.0).unwrap();
         }
 
         for _ in 0..3000 {
@@ -1422,7 +1422,7 @@ mod tests {
             .map(|(s, _)| *s)
             .unwrap();
         // Spawning a rider in DCS mode populates `HallCall::destination`.
-        ev.sim.spawn_rider_by_stop_id(first, last, 75.0).unwrap();
+        ev.sim.spawn_rider(first, last, 75.0).unwrap();
 
         let dest_entity = ev.sim.stop_entity(last).expect("dest stop exists");
         let expected_dest_id = entity_to_u64(dest_entity);
@@ -1485,7 +1485,7 @@ mod tests {
             .max_by_key(|(s, _)| s.0)
             .map(|(s, _)| *s)
             .unwrap();
-        ev.sim.spawn_rider_by_stop_id(first, last, 75.0).unwrap();
+        ev.sim.spawn_rider(first, last, 75.0).unwrap();
 
         // Step a few ticks so all phases complete and events settle.
         for _ in 0..3 {
@@ -1554,15 +1554,9 @@ mod tests {
         // HallButtonPressed + HallCallAcknowledged events.
         let stops: Vec<_> = ev.sim.stop_lookup_iter().map(|(s, _)| *s).collect();
         assert!(stops.len() >= 3);
-        ev.sim
-            .spawn_rider_by_stop_id(stops[0], stops[2], 75.0)
-            .unwrap();
-        ev.sim
-            .spawn_rider_by_stop_id(stops[1], stops[0], 75.0)
-            .unwrap();
-        ev.sim
-            .spawn_rider_by_stop_id(stops[2], stops[0], 75.0)
-            .unwrap();
+        ev.sim.spawn_rider(stops[0], stops[2], 75.0).unwrap();
+        ev.sim.spawn_rider(stops[1], stops[0], 75.0).unwrap();
+        ev.sim.spawn_rider(stops[2], stops[0], 75.0).unwrap();
         assert_eq!(unsafe { ev_sim_step(handle) }, EvStatus::Ok);
 
         // Deliberately small buffer so we force overflow.

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -82,11 +82,8 @@ The core simulation state. Advance it by calling `step()`, or run individual pha
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `spawn_rider` | `(&mut self, EntityId, EntityId, f64) -> Result<EntityId, SimError>` | Spawn a rider at origin heading to destination; auto-detects group (returns `AmbiguousRoute` if multiple groups serve both stops) |
-| `spawn_rider_with_route` | `(&mut self, EntityId, EntityId, f64, Route) -> Result<EntityId, SimError>` | Spawn a rider with an explicit route |
-| `spawn_rider_by_stop_id` | `(&mut self, StopId, StopId, f64) -> Result<EntityId, SimError>` | Spawn a rider using config `StopId`s |
-| `spawn_rider_in_group` | `(&mut self, EntityId, EntityId, f64, GroupId) -> Result<EntityId, SimError>` | Spawn a rider in a specific group |
-| `spawn_rider_in_group_by_stop_id` | `(&mut self, StopId, StopId, f64, GroupId) -> Result<EntityId, SimError>` | Spawn a rider in a specific group using config `StopId`s |
+| `spawn_rider` | `(&mut self, impl Into<StopRef>, impl Into<StopRef>, f64) -> Result<EntityId, SimError>` | Spawn a rider at origin heading to destination; auto-detects group (accepts `EntityId` or `StopId`) |
+| `build_rider` | `(&mut self, impl Into<StopRef>, impl Into<StopRef>) -> Result<RiderBuilder, SimError>` | Fluent builder for riders with route, group, patience, preferences, or access control |
 | `reroute` | `(&mut self, EntityId, EntityId) -> Result<(), SimError>` | Change a waiting rider's destination |
 | `set_rider_route` | `(&mut self, EntityId, Route) -> Result<(), SimError>` | Replace a rider's entire remaining route |
 

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -14,7 +14,7 @@ World
   +-- Entity 3 (Rider)    -> Rider { phase: Waiting, weight: 75.0, ... }, Route { ... }
 ```
 
-You access the world through `sim.world()` (shared) and `sim.world_mut()` (mutable). The simulation also provides convenience methods like `sim.spawn_rider_by_stop_id()` that handle world operations for you.
+You access the world through `sim.world()` (shared) and `sim.world_mut()` (mutable). The simulation also provides convenience methods like `sim.spawn_rider()` that handle world operations for you.
 
 ## Identity types
 
@@ -23,7 +23,7 @@ The library uses several identity types, and it is important to understand which
 | Type | What it identifies | When you use it |
 |---|---|---|
 | `EntityId` | Any entity at runtime (stop, elevator, rider) | Event payloads, world lookups, dispatch decisions |
-| `StopId` | A stop in the *config* (e.g., `StopId(0)`) | Builder API, config files, `spawn_rider_by_stop_id` |
+| `StopId` | A stop in the *config* (e.g., `StopId(0)`) | Builder API, config files, `spawn_rider` |
 | `GroupId` | An elevator group (e.g., `GroupId(0)`) | Multi-group dispatch, group-specific hooks |
 
 `StopId` is a config-level concept. When the simulation boots, each `StopId` is mapped to an `EntityId`. At runtime you work with `EntityId` everywhere -- events, world queries, dispatch. Use `sim.stop_entity(StopId(0))` if you need to convert.

--- a/docs/src/extensions-and-hooks.md
+++ b/docs/src/extensions-and-hooks.md
@@ -61,7 +61,7 @@ Use `world.insert_ext()` to attach your component to an entity:
 #     .elevator(ElevatorConfig::default())
 #     .with_ext::<VipTag>("vip_tag")
 #     .build()?;
-let rider_id = sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 75.0)?;
+let rider_id = sim.spawn_rider(StopId(0), StopId(1), 75.0)?;
 
 sim.world_mut().insert_ext(
     rider_id,
@@ -208,7 +208,7 @@ let sim = SimulationBuilder::new()
 Hooks receive `&mut World` — not `&mut Simulation`. This means:
 
 - **You can:** read/mutate any component, insert/remove extensions, add/remove resources, read tick state via a resource mirror (see example below).
-- **You cannot:** call `sim.step()`, `sim.spawn_rider_by_stop_id()`, `sim.snapshot()` or other `Simulation`-level methods while a tick is in flight — the simulation is borrowed.
+- **You cannot:** call `sim.step()`, `sim.spawn_rider()`, `sim.snapshot()` or other `Simulation`-level methods while a tick is in flight — the simulation is borrowed.
 - **Spawning during a hook:** use `world.spawn()` + direct component inserts, or queue `SpawnRequest`s into a resource and drain them after `sim.step()` returns. The `before(Phase::Dispatch, ...)` slot is a convenient place to inject riders because the next phase will see them.
 - **Events:** hooks do not emit events directly. Use an extension/resource to record side effects and translate to events in game code.
 
@@ -285,7 +285,7 @@ fn main() -> Result<(), SimError> {
     sim.world_mut().insert_resource(CurrentTick(0));
 
     // Spawn some riders and attach extensions.
-    let r1 = sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)?;
+    let r1 = sim.spawn_rider(StopId(0), StopId(2), 75.0)?;
     sim.world_mut().insert_ext(r1, WaitWarning { warned: false }, "wait_warning");
 
     for _ in 0..600 {

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -79,7 +79,7 @@ A rider is anything that rides an elevator. To spawn one, you provide an origin 
 #     .stop(StopId(2), "Floor 3", 8.0)
 #     .elevator(ElevatorConfig { starting_stop: StopId(0), ..Default::default() })
 #     .build()?;
-let rider_id = sim.spawn_rider_by_stop_id(
+let rider_id = sim.spawn_rider(
     StopId(0),  // origin: Lobby
     StopId(2),  // destination: Floor 3
     75.0,       // weight in kg
@@ -89,7 +89,7 @@ println!("Spawned rider: {:?}", rider_id);
 # }
 ```
 
-`spawn_rider_by_stop_id` maps config-level `StopId` values to runtime `EntityId` values internally. It returns `Result<EntityId, SimError>` -- it will fail if you pass a `StopId` that does not exist in your building.
+`spawn_rider` maps config-level `StopId` values to runtime `EntityId` values internally. It returns `Result<EntityId, SimError>` -- it will fail if you pass a `StopId` that does not exist in your building.
 
 ## Run the simulation loop
 
@@ -106,7 +106,7 @@ Each call to `sim.step()` advances the simulation by one tick, running all eight
 #     .stop(StopId(2), "Floor 3", 8.0)
 #     .elevator(ElevatorConfig { starting_stop: StopId(0), ..Default::default() })
 #     .build()?;
-# let rider_id = sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)?;
+# let rider_id = sim.spawn_rider(StopId(0), StopId(2), 75.0)?;
 let mut arrived = false;
 
 while !arrived {
@@ -158,7 +158,7 @@ fn main() -> Result<(), SimError> {
         .build()?;
 
     // 2. Spawn a rider going from the Lobby to Floor 3.
-    let rider_id = sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)?;
+    let rider_id = sim.spawn_rider(StopId(0), StopId(2), 75.0)?;
 
     // 3. Run until the rider arrives.
     let mut arrived = false;
@@ -205,7 +205,7 @@ Total ticks: 482
 ## What just happened?
 
 1. The **builder** created a `Simulation` containing a `World` with three stop entities and one elevator entity, plus a SCAN dispatch strategy.
-2. `spawn_rider_by_stop_id` created a rider entity at the Lobby with a route to Floor 3.
+2. `spawn_rider` created a rider entity at the Lobby with a route to Floor 3.
 3. Each `step()` ran the seven-phase tick loop. The **dispatch** phase noticed a waiting rider and sent the elevator to the Lobby. The **reposition** phase was a no-op (no reposition strategy configured). The **movement** phase moved the elevator using a trapezoidal velocity profile. The **doors** phase opened and closed doors. The **loading** phase boarded and exited the rider. The **metrics** phase updated aggregate stats.
 4. Events fired at each significant moment, and we pattern-matched on them to detect arrival.
 

--- a/docs/src/metrics-and-events.md
+++ b/docs/src/metrics-and-events.md
@@ -109,8 +109,8 @@ fn main() -> Result<(), SimError> {
         .elevator(ElevatorConfig { starting_stop: StopId(0), ..Default::default() })
         .build()?;
 
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(2), 75.0)?;
-    sim.spawn_rider_by_stop_id(StopId(2), StopId(0), 80.0)?;
+    sim.spawn_rider(StopId(0), StopId(2), 75.0)?;
+    sim.spawn_rider(StopId(2), StopId(0), 80.0)?;
 
     let mut event_log: Vec<Event> = Vec::new();
 
@@ -268,7 +268,7 @@ let lobby = sim.stop_entity(StopId(0)).unwrap();
 sim.tag_entity(lobby, "zone:lobby")?;
 
 // Tag a rider (riders auto-inherit tags from their origin stop when spawned).
-let rider = sim.spawn_rider_by_stop_id(StopId(0), StopId(1), 75.0)?;
+let rider = sim.spawn_rider(StopId(0), StopId(1), 75.0)?;
 // rider automatically has "zone:lobby" because it was spawned at StopId(0).
 
 // You can also tag manually.
@@ -317,8 +317,8 @@ fn main() -> Result<(), SimError> {
     }
 
     // Spawn riders from different zones.
-    sim.spawn_rider_by_stop_id(StopId(0), StopId(3), 75.0)?;
-    sim.spawn_rider_by_stop_id(StopId(3), StopId(0), 80.0)?;
+    sim.spawn_rider(StopId(0), StopId(3), 75.0)?;
+    sim.spawn_rider(StopId(3), StopId(0), 80.0)?;
 
     // Run the simulation.
     for _ in 0..2000 {

--- a/docs/src/non-bevy-integration.md
+++ b/docs/src/non-bevy-integration.md
@@ -14,7 +14,7 @@ Integrating `elevator-core` into any host comes down to three things:
 
 3. **Read state out, inject input in.**
    - **Read state:** `sim.world()` returns a `World` you can query via `query::<(EntityId, &Rider, &Position)>()` for rendering, or via typed accessors (`world.elevator(id)`, `world.stop_position(id)`).
-   - **Inject input:** `sim.spawn_rider_by_stop_id(origin, dest, weight)`, `sim.push_destination(elev, stop)`, `sim.reroute(rider, new_dest)`, `sim.set_service_mode(elev, mode)`.
+   - **Inject input:** `sim.spawn_rider(origin, dest, weight)`, `sim.push_destination(elev, stop)`, `sim.reroute(rider, new_dest)`, `sim.set_service_mode(elev, mode)`.
    - **Change-event hook:** `sim.drain_events()` returns every event emitted during the last tick. Route them into toasts, particles, SFX, analytics.
 
 That's it. The entire public surface of the library is [`prelude`](api-reference.md) + a handful of typed submodules; no engine extension points, no traits your app must implement.
@@ -160,7 +160,7 @@ impl eframe::App for ElevatorApp {
 
             // 3b. Input via egui buttons.
             if ui.button("spawn rider 0→3").clicked() {
-                let _ = self.sim.spawn_rider_by_stop_id(StopId(0), StopId(3), 72.0);
+                let _ = self.sim.spawn_rider(StopId(0), StopId(3), 72.0);
             }
         });
     }

--- a/docs/src/traffic-generation.md
+++ b/docs/src/traffic-generation.md
@@ -30,7 +30,7 @@ let mut source = PoissonSource::new(
 for _ in 0..10_000 {
     let tick = sim.current_tick();
     for req in source.generate(tick) {
-        let _ = sim.spawn_rider_by_stop_id(req.origin, req.destination, req.weight);
+        let _ = sim.spawn_rider(req.origin, req.destination, req.weight);
     }
     sim.step();
 }
@@ -227,13 +227,13 @@ pub struct SpawnRequest {
 }
 ```
 
-For riders that need patience, preferences, or access control, spawn through the simulation's `build_rider_by_stop_id` fluent API instead of using `spawn_rider_by_stop_id` directly:
+For riders that need patience, preferences, or access control, spawn through the simulation's `build_rider` fluent API instead of using `spawn_rider` directly:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
 # use elevator_core::traffic::SpawnRequest;
 # fn run(sim: &mut Simulation, req: SpawnRequest) -> Result<(), SimError> {
-sim.build_rider_by_stop_id(req.origin, req.destination)?
+sim.build_rider(req.origin, req.destination)?
     .weight(req.weight)
     .patience(600)  // abandon after 10 seconds at 60 tps
     .spawn()?;


### PR DESCRIPTION
## Summary

BREAKING CHANGE: removes 5 redundant methods, consolidating to `spawn_rider` + `build_rider`/`RiderBuilder`:

- `spawn_rider_by_stop_id` → `spawn_rider(StopId(x), StopId(y), weight)` (StopRef accepts StopId via Into)
- `spawn_rider_with_route` → `build_rider(o, d)?.route(r).spawn()`
- `spawn_rider_in_group` → `build_rider(o, d)?.group(g).spawn()`
- `spawn_rider_in_group_by_stop_id` → same with StopId
- `build_rider_by_stop_id` → `build_rider(StopId(x), StopId(y))`

`build_rider` widened to `impl Into<StopRef>`, now returns `Result<RiderBuilder, SimError>`.

70 files changed, 380 insertions, 755 deletions. Net reduction of 375 lines.

Part 5b/9 (final stack PR) of the API ergonomics overhaul.

## Test plan

- [x] `cargo test -p elevator-core --all-features` all 567 tests green
- [x] `cargo clippy -p elevator-core --all-features -- -D warnings` clean
- [x] Zero references to deleted methods (`grep -rn` = 0)
- [x] All 13 examples compile and match updated API
- [ ] CI green
- [ ] Greptile review clean