### PR TITLE
docs: update all documentation for API ergonomics overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ let mut sim = SimulationBuilder::new()
         starting_stop: StopId(0),
         ..Default::default()
     })
-    .with_ext::<VipTag>("vip_tag")
+    .with_ext::<VipTag>()
     .after(Phase::Loading, |world| {
         // Custom logic runs after the loading phase every tick.
         // Access world state, extension data, etc.
@@ -163,7 +163,7 @@ let mut sim = SimulationBuilder::new()
 
 // Spawn a rider and tag them as VIP.
 let rider_id = sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
-sim.world_mut().insert_ext(rider_id, VipTag { level: 3 }, "vip_tag");
+sim.world_mut().insert_ext(rider_id, VipTag { level: 3 }, ExtKey::from_type_name());
 
 // Later, read back the extension data.
 if let Some(tag) = sim.world().get_ext::<VipTag>(rider_id) {

--- a/crates/elevator-core/ARCHITECTURE.md
+++ b/crates/elevator-core/ARCHITECTURE.md
@@ -432,7 +432,7 @@ Extension types must be registered before restoring a snapshot:
 
 ```rust
 world.register_ext::<VipTag>(ExtKey::from_type_name());
-sim.load_extensions(&snapshot.extensions);
+sim.load_extensions();
 ```
 
 Unregistered types are stored in a `PendingExtensions` resource until
@@ -512,7 +512,7 @@ cross-references (elevator riders, rider phases, route legs, group caches).
 Extension components are serialized as `HashMap<String, HashMap<EntityId, String>>`
 (name to entity-RON-string mapping). On restore, this data is stored in a
 `PendingExtensions` resource. After the game registers its extension types
-via `world.register_ext::<T>(name)`, calling `sim.load_extensions()` deserializes
+via `world.register_ext::<T>(ExtKey::from_type_name())`, calling `sim.load_extensions()` deserializes
 and attaches the data.
 
 ### Custom dispatch strategies

--- a/crates/elevator-core/ARCHITECTURE.md
+++ b/crates/elevator-core/ARCHITECTURE.md
@@ -65,7 +65,7 @@ concrete struct definition.
 | `Preferences`      | Rider             | Boarding preferences (`skip_full_elevator`, `max_crowding_factor`). |
 | `AccessControl`    | Rider             | Per-rider allowlist of reachable stops.                          |
 | `DestinationQueue` | Elevator          | FIFO of pushed target stops; imperative-dispatch escape hatch.   |
-| `ServiceMode`      | Elevator          | `Normal` / `Independent` / `Inspection`.                         |
+| `ServiceMode`      | Elevator          | `Normal` / `Independent` / `Inspection` / `Manual`.              |
 | `Orientation`      | Line              | Vertical vs horizontal axis (for visualization).                 |
 
 All components above are re-exported from `elevator_core::prelude` so
@@ -404,13 +404,15 @@ without modifying the core library.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct VipTag { level: u32 }
 
-world.insert_ext(entity, VipTag { level: 3 }, "vip_tag");
+world.insert_ext(entity, VipTag { level: 3 }, ExtKey::from_type_name());
 world.get_ext::<VipTag>(entity);        // Option<VipTag> (cloned)
+world.get_ext_ref::<VipTag>(entity);    // Option<&VipTag> (zero-copy)
 world.get_ext_mut::<VipTag>(entity);    // Option<&mut VipTag>
 ```
 
-The `name` string is required for serialization roundtrips in snapshots.
-Extension components must implement `Serialize + DeserializeOwned`.
+The `ExtKey<T>` handle is required for serialization roundtrips in snapshots.
+Use `ExtKey::from_type_name()` for the common case or `ExtKey::new("name")` for
+explicit naming. Extension components must implement `Serialize + DeserializeOwned`.
 
 ### Querying extensions
 
@@ -429,7 +431,7 @@ world.query_ext_mut::<VipTag>().for_each_mut(|id, tag| { tag.level += 1; });
 Extension types must be registered before restoring a snapshot:
 
 ```rust
-world.register_ext::<VipTag>("vip_tag");
+world.register_ext::<VipTag>(ExtKey::from_type_name());
 sim.load_extensions(&snapshot.extensions);
 ```
 

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -311,8 +311,8 @@
 //! destinations, current kinematic state, and configured door dwell:
 //!
 //! - [`Simulation::eta`](sim::Simulation::eta) — seconds until a specific
-//!   elevator reaches a specific stop, or `None` if the stop isn't on its
-//!   route or the car is in a dispatch-excluded service mode.
+//!   elevator reaches a specific stop, or an [`EtaError`](error::EtaError) if the
+//!   stop isn't queued, the car is disabled, or the service mode excludes it.
 //! - [`Simulation::best_eta`](sim::Simulation::best_eta) — winner across all
 //!   eligible elevators, optionally filtered by indicator-lamp direction
 //!   ("which up-going car arrives first?").
@@ -449,6 +449,7 @@ macro_rules! register_extensions {
 ///   [`RiderBuilder`](crate::sim::RiderBuilder)
 /// - **Components:** [`Rider`](crate::components::Rider),
 ///   [`RiderPhase`](crate::components::RiderPhase),
+///   [`RiderPhaseKind`](crate::components::RiderPhaseKind),
 ///   [`Elevator`](crate::components::Elevator),
 ///   [`ElevatorPhase`](crate::components::ElevatorPhase),
 ///   [`Stop`](crate::components::Stop), [`Line`](crate::components::Line),
@@ -459,34 +460,42 @@ macro_rules! register_extensions {
 ///   [`Patience`](crate::components::Patience),
 ///   [`Preferences`](crate::components::Preferences),
 ///   [`AccessControl`](crate::components::AccessControl),
+///   [`DestinationQueue`](crate::components::DestinationQueue),
+///   [`Direction`](crate::components::Direction),
 ///   [`Orientation`](crate::components::Orientation),
 ///   [`ServiceMode`](crate::components::ServiceMode)
 /// - **Config:** [`SimConfig`](crate::config::SimConfig),
 ///   [`GroupConfig`](crate::config::GroupConfig),
 ///   [`LineConfig`](crate::config::LineConfig)
 /// - **Dispatch:** [`DispatchStrategy`](crate::dispatch::DispatchStrategy),
-///   [`RepositionStrategy`](crate::dispatch::RepositionStrategy), plus the
-///   built-in reposition strategies
+///   [`RepositionStrategy`](crate::dispatch::RepositionStrategy),
+///   [`AssignedCar`](crate::dispatch::AssignedCar),
+///   [`DestinationDispatch`](crate::dispatch::DestinationDispatch),
+///   plus the built-in reposition strategies
 ///   [`NearestIdle`](crate::dispatch::reposition::NearestIdle),
 ///   [`ReturnToLobby`](crate::dispatch::reposition::ReturnToLobby),
 ///   [`SpreadEvenly`](crate::dispatch::reposition::SpreadEvenly),
 ///   [`DemandWeighted`](crate::dispatch::reposition::DemandWeighted)
 /// - **Identity:** [`EntityId`](crate::entity::EntityId),
-///   [`StopId`](crate::stop::StopId), [`GroupId`](crate::ids::GroupId)
+///   [`StopId`](crate::stop::StopId), [`StopRef`](crate::stop::StopRef),
+///   [`GroupId`](crate::ids::GroupId)
 /// - **Errors & events:** [`SimError`](crate::error::SimError),
+///   [`EtaError`](crate::error::EtaError),
 ///   [`RejectionReason`](crate::error::RejectionReason),
 ///   [`RejectionContext`](crate::error::RejectionContext),
 ///   [`Event`](crate::events::Event),
-///   [`EventBus`](crate::events::EventBus)
+///   [`EventBus`](crate::events::EventBus),
+///   [`EventCategory`](crate::events::EventCategory)
 /// - **Misc:** [`Metrics`](crate::metrics::Metrics),
-///   [`TimeAdapter`](crate::time::TimeAdapter)
+///   [`TimeAdapter`](crate::time::TimeAdapter),
+///   [`ExtKey`](crate::world::ExtKey)
 ///
 /// # Not included (import explicitly)
 ///
 /// - Concrete dispatch implementations: `dispatch::scan::ScanDispatch`,
 ///   `dispatch::look::LookDispatch`, `dispatch::nearest_car::NearestCarDispatch`,
 ///   `dispatch::etd::EtdDispatch`
-/// - `ElevatorConfig` and `StopConfig` from [`crate::config`]
+/// - `ElevatorConfig` from [`crate::config`] and `StopConfig` from [`crate::stop`]
 /// - Traffic generation types from [`crate::traffic`] (feature-gated)
 /// - Snapshot types from [`crate::snapshot`]
 /// - The [`World`](crate::world::World) type (accessed via `sim.world()`,

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -53,7 +53,7 @@ Fluent builder for constructing a `Simulation`. Starts with a minimal valid conf
 | `lines` | `(Vec<LineConfig>) -> Self` | Replace all lines |
 | `group` | `(GroupConfig) -> Self` | Add a single group configuration |
 | `groups` | `(Vec<GroupConfig>) -> Self` | Replace all groups |
-| `with_ext::<T>` | `(&str) -> Self` | Pre-register an extension type for snapshot deserialization |
+| `with_ext::<T>` | `() -> Self` | Pre-register an extension type for snapshot deserialization |
 | `build` | `() -> Result<Simulation, SimError>` | Validate config and build the simulation |
 
 ---
@@ -281,11 +281,12 @@ Extensions let games attach custom typed data to simulation entities. Extension 
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `insert_ext` | `<T>(&mut self, EntityId, T, &str)` | Insert a custom component for an entity |
+| `insert_ext` | `<T>(&mut self, EntityId, T, ExtKey<T>)` | Insert a custom component for an entity |
 | `get_ext` | `<T: Clone>(&self, EntityId) -> Option<T>` | Get a clone of a custom component |
+| `get_ext_ref` | `<T>(&self, EntityId) -> Option<&T>` | Get a shared reference (zero-copy) to a custom component |
 | `get_ext_mut` | `<T>(&mut self, EntityId) -> Option<&mut T>` | Get a mutable reference to a custom component |
 | `remove_ext` | `<T>(&mut self, EntityId) -> Option<T>` | Remove a custom component |
-| `register_ext` | `<T>(&mut self, &str)` | Register an extension type for snapshot deserialization |
+| `register_ext` | `<T>(&mut self, ExtKey<T>) -> ExtKey<T>` | Register an extension type for snapshot deserialization |
 | `query_ext_mut` | `<T>(&mut self) -> ExtQueryMut<T>` | Create a mutable extension query builder |
 
 ### Global Resources

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -11,12 +11,13 @@ This chapter is a quick-reference for the public API of the `elevator-core` crat
 | Category | Items |
 |---|---|
 | Builder & sim | `SimulationBuilder`, `Simulation`, `RiderBuilder` |
-| Components | `Rider`, `RiderPhase`, `Elevator`, `ElevatorPhase`, `Stop`, `Line`, `Position`, `Velocity`, `SpatialPosition`, `Route`, `Patience`, `Preferences`, `AccessControl`, `Orientation`, `ServiceMode` |
+| Components | `Rider`, `RiderPhase`, `RiderPhaseKind`, `Elevator`, `ElevatorPhase`, `Stop`, `Line`, `Position`, `Velocity`, `SpatialPosition`, `Route`, `Patience`, `Preferences`, `AccessControl`, `Orientation`, `ServiceMode`, `DestinationQueue`, `Direction` |
 | Config | `SimConfig`, `GroupConfig`, `LineConfig` |
-| Dispatch traits | `DispatchStrategy`, `RepositionStrategy` |
+| Dispatch | `DispatchStrategy`, `RepositionStrategy`, `AssignedCar`, `DestinationDispatch` |
 | Reposition strategies | `NearestIdle`, `ReturnToLobby`, `SpreadEvenly`, `DemandWeighted` |
-| Identity | `EntityId`, `StopId`, `GroupId` |
-| Errors & events | `SimError`, `RejectionReason`, `RejectionContext`, `Event`, `EventBus` |
+| Identity | `EntityId`, `StopId`, `StopRef`, `GroupId` |
+| Errors & events | `SimError`, `EtaError`, `RejectionReason`, `RejectionContext`, `Event`, `EventBus`, `EventCategory` |
+| Extension | `ExtKey` |
 | Misc | `Metrics`, `TimeAdapter` |
 
 Not in the prelude (import explicitly):

--- a/docs/src/extensions-and-hooks.md
+++ b/docs/src/extensions-and-hooks.md
@@ -22,7 +22,7 @@ struct VipTag {
 
 ### Step 2: Register with the builder
 
-Call `.with_ext::<T>("name")` on the builder to register the extension type. The name string is used for snapshot serialization:
+Call `.with_ext::<T>()` on the builder to register the extension type (the type name is used automatically for snapshot serialization):
 
 ```rust,no_run
 # use serde::{Serialize, Deserialize};
@@ -37,7 +37,7 @@ fn main() -> Result<(), SimError> {
         .stop(StopId(0), "Ground", 0.0)
         .stop(StopId(1), "Top", 10.0)
         .elevator(ElevatorConfig::default())
-        .with_ext::<VipTag>("vip_tag")
+        .with_ext::<VipTag>()
         .build()?;
     Ok(())
 }
@@ -59,14 +59,14 @@ Use `world.insert_ext()` to attach your component to an entity:
 #     .stop(StopId(0), "Ground", 0.0)
 #     .stop(StopId(1), "Top", 10.0)
 #     .elevator(ElevatorConfig::default())
-#     .with_ext::<VipTag>("vip_tag")
+#     .with_ext::<VipTag>()
 #     .build()?;
 let rider_id = sim.spawn_rider(StopId(0), StopId(1), 75.0)?;
 
 sim.world_mut().insert_ext(
     rider_id,
     VipTag { level: 3, lounge_access: true },
-    "vip_tag",
+    ExtKey::from_type_name(),
 );
 # Ok(())
 # }
@@ -74,7 +74,7 @@ sim.world_mut().insert_ext(
 
 ### Step 4: Read it back
 
-Use `world.get_ext()` for a cloned value, or `world.get_ext_mut()` for a mutable reference:
+Use `world.get_ext()` for a cloned value, `world.get_ext_ref()` for a zero-copy borrow, or `world.get_ext_mut()` for a mutable reference:
 
 ```rust,no_run
 # use serde::{Serialize, Deserialize};
@@ -257,7 +257,7 @@ fn main() -> Result<(), SimError> {
         .stop(StopId(1), "Floor 2", 4.0)
         .stop(StopId(2), "Floor 3", 8.0)
         .elevator(ElevatorConfig { starting_stop: StopId(0), ..Default::default() })
-        .with_ext::<WaitWarning>("wait_warning")
+        .with_ext::<WaitWarning>()
         .after(Phase::Metrics, |world| {
             // Check all waiting riders for long waits.
             let rider_ids: Vec<EntityId> = world.rider_ids();
@@ -286,7 +286,7 @@ fn main() -> Result<(), SimError> {
 
     // Spawn some riders and attach extensions.
     let r1 = sim.spawn_rider(StopId(0), StopId(2), 75.0)?;
-    sim.world_mut().insert_ext(r1, WaitWarning { warned: false }, "wait_warning");
+    sim.world_mut().insert_ext(r1, WaitWarning { warned: false }, ExtKey::from_type_name());
 
     for _ in 0..600 {
         // Update the current tick resource before stepping.

--- a/docs/src/snapshots-and-determinism.md
+++ b/docs/src/snapshots-and-determinism.md
@@ -94,7 +94,7 @@ Extensions are serialized by their registered name. To restore them, re-register
 # #[derive(Clone, Serialize, Deserialize)] struct VipTag;
 # fn run(snapshot: WorldSnapshot) {
 let mut sim = snapshot.restore(None);
-sim.world_mut().register_ext::<VipTag>("vip_tag");
+sim.world_mut().register_ext::<VipTag>(ExtKey::from_type_name());
 sim.load_extensions();
 # }
 ```


### PR DESCRIPTION
## Summary

Comprehensive docs sweep after the 9-PR API ergonomics overhaul. Updates README, crate-level docs, ARCHITECTURE.md, and mdBook pages for:

- Extension API: string names → `ExtKey<T>` throughout
- ETA queries: `None` → `Err(EtaError)` prose
- Prelude listing: adds `StopRef`, `ExtKey`, `RiderPhaseKind`, `EtaError`
- API reference table: updated signatures for `insert_ext`, `register_ext`, `with_ext`, added `get_ext_ref`
- Snapshot docs: updated `register_ext` to use `ExtKey`

## Test plan

- [x] `cargo test -p elevator-core --all-features --doc` all doc tests pass
- [x] `cargo clippy -p elevator-core --all-features -- -D warnings` clean
- [ ] CI green
- [ ] Greptile review clean