### PR TITLE
ci: restore release-please auto-merge after API overhaul

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,36 +36,30 @@ jobs:
           manifest-file: .release-please-manifest.json
           token: ${{ steps.app-token.outputs.token }}
 
-      # Auto-approve and auto-merge are TEMPORARILY DISABLED during the
-      # API ergonomics overhaul stack. During the overhaul, every merge
-      # to main would otherwise produce a separate release (and a
-      # `SnapshotVersion` break for downstream consumers). With these
-      # steps disabled, release-please still opens/updates the release
-      # PR on every push — but the PR accumulates all stack commits
-      # into a single release. Manually approve and merge the release
-      # PR once the overhaul lands.
-      #
-      # TO RESTORE (final step of the overhaul): uncomment both steps
-      # below.
-      #
-      # - name: Auto-approve release PR
-      #   if: steps.release.outputs.pr
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     gh pr review ${{ fromJSON(steps.release.outputs.pr).number }} \
-      #       --approve \
-      #       --body "Auto-approved by release pipeline." \
-      #       --repo ${{ github.repository }}
-      #
-      # - name: Auto-merge release PR
-      #   if: steps.release.outputs.pr
-      #   env:
-      #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
-      #   run: |
-      #     gh pr merge ${{ fromJSON(steps.release.outputs.pr).number }} \
-      #       --auto --squash \
-      #       --repo ${{ github.repository }}
+      # Inline approve + auto-merge in the same workflow run that
+      # opened the PR. Approval uses the default GITHUB_TOKEN
+      # (`github-actions[bot]` actor), which is distinct from the App
+      # that authored the PR — GitHub forbids self-review, so the two
+      # actors must differ. The merge call uses the App token so
+      # branch-protection rules requiring a PR approval are satisfied.
+      - name: Auto-approve release PR
+        if: steps.release.outputs.pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review ${{ fromJSON(steps.release.outputs.pr).number }} \
+            --approve \
+            --body "Auto-approved by release pipeline." \
+            --repo ${{ github.repository }}
+
+      - name: Auto-merge release PR
+        if: steps.release.outputs.pr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh pr merge ${{ fromJSON(steps.release.outputs.pr).number }} \
+            --auto --squash \
+            --repo ${{ github.repository }}
 
   publish:
     needs: release-please


### PR DESCRIPTION
## Summary

Restores the `Auto-approve release PR` and `Auto-merge release PR` steps in `.github/workflows/release-please.yml` that were disabled during the API ergonomics overhaul (PR #120).

Once this merges, release-please will auto-approve and auto-merge the accumulated release PR #124, cutting **elevator-core v9.0.0**.

## Context

The 9-PR overhaul stack is complete:
- PR #121: additive ergonomics (get_ext_ref, is_aboard, Stops::linear, drop const)
- PR #122: door method rename
- PR #123: FloorPosition → SpatialPosition
- PR #125: StopRef unification
- PR #126: SimError elevator variants
- PR #127: eta/tag_entity → Result
- PR #128: SimError rider variants + delete InvalidState
- PR #129: typed ExtKey<T>
- PR #130: spawn_rider consolidation (-375 lines)
- PR #131: flaky FFI test fix
- PR #132: comprehensive docs sweep

## Test plan

- [x] Pre-commit hook passes
- [ ] CI green
- [ ] Greptile review clean