### PR TITLE
chore: improve pre-commit hook and commit to repo

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Pre-commit: fmt check, clippy (all features), core tests, doc tests
+set -e
+
+echo "pre-commit: checking formatting..."
+cargo fmt --check
+
+echo "pre-commit: running clippy..."
+cargo clippy -p elevator-core --all-features -- -D warnings
+
+echo "pre-commit: running core tests..."
+cargo test -p elevator-core --all-features --quiet
+
+echo "pre-commit: running doc tests..."
+cargo test -p elevator-core --all-features --doc --quiet

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,14 +9,22 @@ Cargo workspace with two crates:
 ## Build
 
 ```bash
-cargo test -p elevator-core
-cargo clippy -p elevator-core
+cargo test -p elevator-core --all-features
+cargo clippy -p elevator-core --all-features
 cargo build            # full workspace (PKG_CONFIG_PATH set by .cargo/config.toml)
 cargo run              # default config
 cargo run -- assets/config/space_elevator.ron
 ```
 
 System deps (Ubuntu): `libudev-dev libasound2-dev`
+
+## Pre-commit Hook
+
+Shared hook at `.githooks/pre-commit` — runs fmt, clippy (all features), tests, and doc tests. After cloning:
+
+```bash
+git config core.hooksPath .githooks
+```
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- Move pre-commit hook from `.git/hooks/` to `.githooks/` (committed, shared across clones)
- Switch clippy and tests to `--all-features` (prevents dead code behind feature gates — the energy.rs unused import was caught only by --all-features)
- Add doc test compilation (`cargo test --doc`) to catch stale doc examples referencing removed API
- Document `git config core.hooksPath .githooks` setup in CLAUDE.md

## Test plan

- [x] `.githooks/pre-commit` runs manually and passes
- [x] Covers fmt, clippy --all-features, tests --all-features, doc tests
- [ ] CI green
- [ ] Greptile review clean