### PR TITLE
feat!: API ergonomics — trait impls, naming, and quick wins

### DIFF
--- a/crates/elevator-core/ARCHITECTURE.md
+++ b/crates/elevator-core/ARCHITECTURE.md
@@ -405,9 +405,9 @@ without modifying the core library.
 struct VipTag { level: u32 }
 
 world.insert_ext(entity, VipTag { level: 3 }, ExtKey::from_type_name());
-world.get_ext::<VipTag>(entity);        // Option<VipTag> (cloned)
-world.get_ext_ref::<VipTag>(entity);    // Option<&VipTag> (zero-copy)
-world.get_ext_mut::<VipTag>(entity);    // Option<&mut VipTag>
+world.ext::<VipTag>(entity);        // Option<VipTag> (cloned)
+world.ext_ref::<VipTag>(entity);    // Option<&VipTag> (zero-copy)
+world.ext_mut::<VipTag>(entity);    // Option<&mut VipTag>
 ```
 
 The `ExtKey<T>` handle is required for serialization roundtrips in snapshots.

--- a/crates/elevator-core/examples/showcase.rs
+++ b/crates/elevator-core/examples/showcase.rs
@@ -218,7 +218,7 @@ fn part3_extensions() {
         .insert_ext(rider, VipTag { level: 3 }, ExtKey::from_type_name());
 
     // Read the extension back.
-    let vip: Option<VipTag> = sim.world().get_ext::<VipTag>(rider);
+    let vip: Option<VipTag> = sim.world().ext::<VipTag>(rider);
     println!("Rider {rider:?} VIP tag: {vip:?}");
 
     // Extensions are arbitrary typed data — useful for game-specific components

--- a/crates/elevator-core/src/components/destination_queue.rs
+++ b/crates/elevator-core/src/components/destination_queue.rs
@@ -129,11 +129,3 @@ impl<'a> IntoIterator for &'a DestinationQueue {
         self.queue.iter()
     }
 }
-
-impl std::ops::Deref for DestinationQueue {
-    type Target = [EntityId];
-
-    fn deref(&self) -> &[EntityId] {
-        &self.queue
-    }
-}

--- a/crates/elevator-core/src/components/destination_queue.rs
+++ b/crates/elevator-core/src/components/destination_queue.rs
@@ -110,8 +110,30 @@ impl DestinationQueue {
         self.queue.contains(stop)
     }
 
+    /// Iterate over stop entities in FIFO order.
+    pub fn iter(&self) -> std::slice::Iter<'_, EntityId> {
+        self.queue.iter()
+    }
+
     /// Remove and return the front entry.
     pub(crate) fn pop_front(&mut self) -> Option<EntityId> {
         (!self.queue.is_empty()).then(|| self.queue.remove(0))
+    }
+}
+
+impl<'a> IntoIterator for &'a DestinationQueue {
+    type Item = &'a EntityId;
+    type IntoIter = std::slice::Iter<'a, EntityId>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.queue.iter()
+    }
+}
+
+impl std::ops::Deref for DestinationQueue {
+    type Target = [EntityId];
+
+    fn deref(&self) -> &[EntityId] {
+        &self.queue
     }
 }

--- a/crates/elevator-core/src/components/elevator.rs
+++ b/crates/elevator-core/src/components/elevator.rs
@@ -107,7 +107,7 @@ impl std::fmt::Display for ElevatorPhase {
 }
 
 /// Component for an elevator entity.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Elevator {
     /// Current operational phase.
     pub(crate) phase: ElevatorPhase,

--- a/crates/elevator-core/src/components/patience.rs
+++ b/crates/elevator-core/src/components/patience.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Tracks how long a rider will wait before abandoning.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Patience {
     /// Maximum ticks the rider will wait before abandoning.
     pub(crate) max_wait_ticks: u64,
@@ -35,7 +35,7 @@ impl Default for Patience {
 }
 
 /// Boarding preferences for a rider.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct Preferences {
     /// If true, the rider will skip a crowded elevator and wait for the next.
     pub(crate) skip_full_elevator: bool,
@@ -97,6 +97,20 @@ impl Preferences {
     #[must_use]
     pub const fn abandon_on_full(&self) -> bool {
         self.abandon_on_full
+    }
+
+    /// Builder: set `skip_full_elevator`.
+    #[must_use]
+    pub const fn with_skip_full_elevator(mut self, skip: bool) -> Self {
+        self.skip_full_elevator = skip;
+        self
+    }
+
+    /// Builder: set `max_crowding_factor`.
+    #[must_use]
+    pub const fn with_max_crowding_factor(mut self, factor: f64) -> Self {
+        self.max_crowding_factor = factor;
+        self
     }
 
     /// Builder: set `balk_threshold_ticks`.

--- a/crates/elevator-core/src/components/position.rs
+++ b/crates/elevator-core/src/components/position.rs
@@ -14,17 +14,26 @@ use std::fmt;
 /// let pos = Position::from(4.5);
 /// assert_eq!(format!("{pos}"), "4.50m");
 /// ```
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct Position {
     /// Absolute position value.
     pub(crate) value: f64,
 }
 
 impl Position {
+    /// Zero position (shaft origin).
+    pub const ZERO: Self = Self { value: 0.0 };
+
     /// Absolute position value.
     #[must_use]
     pub const fn value(&self) -> f64 {
         self.value
+    }
+
+    /// Absolute distance between two positions.
+    #[must_use]
+    pub fn distance_to(self, other: Self) -> f64 {
+        (self.value - other.value).abs()
     }
 }
 
@@ -57,17 +66,26 @@ impl From<f64> for Position {
 /// let stopped = Velocity::from(0.0);
 /// assert_eq!(format!("{stopped}"), "0.00m/s");
 /// ```
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct Velocity {
     /// Signed velocity value.
     pub(crate) value: f64,
 }
 
 impl Velocity {
+    /// Zero velocity (stationary).
+    pub const ZERO: Self = Self { value: 0.0 };
+
     /// Signed velocity value.
     #[must_use]
     pub const fn value(&self) -> f64 {
         self.value
+    }
+
+    /// Absolute speed (magnitude of velocity).
+    #[must_use]
+    pub const fn speed(self) -> f64 {
+        self.value.abs()
     }
 }
 

--- a/crates/elevator-core/src/components/rider.rs
+++ b/crates/elevator-core/src/components/rider.rs
@@ -117,7 +117,7 @@ impl std::fmt::Display for RiderPhase {
 /// additional components (`VipTag`, `FreightData`, `PersonData`, etc.)
 /// for game-specific behavior. An entity with `Rider` but no
 /// Route component can be boarded/exited manually by game code.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Rider {
     /// Weight contributed to elevator load.
     pub(crate) weight: f64,

--- a/crates/elevator-core/src/components/stop.rs
+++ b/crates/elevator-core/src/components/stop.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Component for a stop (floor/station) entity.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Stop {
     /// Human-readable stop name.
     pub(crate) name: String,

--- a/crates/elevator-core/src/config.rs
+++ b/crates/elevator-core/src/config.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Validated at construction time by [`Simulation::new()`](crate::sim::Simulation::new)
 /// or [`SimulationBuilder::build()`](crate::builder::SimulationBuilder::build).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SimConfig {
     /// Building layout describing the stops (floors/stations) along the shaft.
     pub building: BuildingConfig,
@@ -178,6 +178,17 @@ impl Default for ElevatorConfig {
     }
 }
 
+impl Default for BuildingConfig {
+    fn default() -> Self {
+        Self {
+            name: "Building".into(),
+            stops: Vec::new(),
+            lines: None,
+            groups: None,
+        }
+    }
+}
+
 /// Global simulation timing parameters.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SimulationParams {
@@ -189,6 +200,14 @@ pub struct SimulationParams {
     ///
     /// Default (from `SimulationBuilder`): `60.0`.
     pub ticks_per_second: f64,
+}
+
+impl Default for SimulationParams {
+    fn default() -> Self {
+        Self {
+            ticks_per_second: 60.0,
+        }
+    }
 }
 
 /// Passenger spawning parameters (used by the game layer).
@@ -214,6 +233,15 @@ pub struct PassengerSpawnConfig {
     /// Units: same as elevator `weight_capacity` (typically kilograms).
     /// Default (from `SimulationBuilder`): `(50.0, 100.0)`.
     pub weight_range: (f64, f64),
+}
+
+impl Default for PassengerSpawnConfig {
+    fn default() -> Self {
+        Self {
+            mean_interval_ticks: 120,
+            weight_range: (50.0, 100.0),
+        }
+    }
 }
 
 /// Configuration for a single line (physical path).

--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -125,7 +125,7 @@ impl DispatchStrategy for DestinationDispatch {
         let mut pending: Vec<(EntityId, EntityId, EntityId, f64)> = Vec::new();
         for riders in manifest.waiting_at_stop.values() {
             for info in riders {
-                if world.get_ext::<AssignedCar>(info.id).is_some() {
+                if world.ext::<AssignedCar>(info.id).is_some() {
                     continue; // sticky
                 }
                 let Some(dest) = info.destination else {
@@ -165,7 +165,7 @@ impl DispatchStrategy for DestinationDispatch {
             // inflate the former car's committed load over long runs.
             let car = match rider.phase() {
                 RiderPhase::Riding(c) | RiderPhase::Boarding(c) => Some(c),
-                RiderPhase::Waiting => world.get_ext::<AssignedCar>(rid).map(|AssignedCar(c)| c),
+                RiderPhase::Waiting => world.ext::<AssignedCar>(rid).map(|AssignedCar(c)| c),
                 _ => None,
             };
             if let Some(c) = car {
@@ -368,7 +368,7 @@ fn rebuild_car_queue(world: &mut crate::world::World, car_eid: EntityId) {
     // Gather (origin?, dest) pairs from all sticky-assigned riders for this car.
     let mut trips: Vec<Trip> = Vec::new();
     for (rid, rider) in world.iter_riders() {
-        let Some(AssignedCar(assigned)) = world.get_ext::<AssignedCar>(rid) else {
+        let Some(AssignedCar(assigned)) = world.ext::<AssignedCar>(rid) else {
             continue;
         };
         if assigned != car_eid {

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -609,6 +609,10 @@ const ASSIGNMENT_SCALE: f64 = 1_000_000.0;
 /// to the unavailable sentinel.
 fn scale_cost(cost: f64) -> i64 {
     if !cost.is_finite() || cost < 0.0 {
+        debug_assert!(
+            cost.is_finite() && cost >= 0.0,
+            "DispatchStrategy::rank() returned invalid cost {cost}; must be finite and non-negative"
+        );
         return ASSIGNMENT_SENTINEL;
     }
     // Cap at just below sentinel so any real rank always beats unavailable.

--- a/crates/elevator-core/src/query/iter.rs
+++ b/crates/elevator-core/src/query/iter.rs
@@ -55,7 +55,7 @@ impl<'w, T: 'static + Send + Sync, F: QueryFilter> ExtQueryMut<'w, T, F> {
     /// Apply a closure to each matching entity's extension data mutably.
     pub fn for_each_mut(&mut self, mut f: impl FnMut(EntityId, &mut T)) {
         for &id in &self.ids {
-            if let Some(val) = self.world.get_ext_mut::<T>(id) {
+            if let Some(val) = self.world.ext_mut::<T>(id) {
                 f(id, val);
             }
         }

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -141,7 +141,7 @@ fn collect_actions(world: &World, elevator_ids: &[EntityId]) -> Vec<LoadAction> 
             // assigned to another car, the current car must skip them so the
             // assigned car can pick them up.
             if let Some(crate::dispatch::AssignedCar(assigned)) =
-                world.get_ext::<crate::dispatch::AssignedCar>(rid)
+                world.ext::<crate::dispatch::AssignedCar>(rid)
                 && assigned != eid
             {
                 return None;

--- a/crates/elevator-core/src/tests/destination_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/destination_dispatch_tests.rs
@@ -170,7 +170,7 @@ fn sticky_assignment_persists_across_ticks() {
     let rid = sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
 
     sim.step();
-    let first = sim.world().get_ext::<AssignedCar>(rid);
+    let first = sim.world().ext::<AssignedCar>(rid);
     assert!(first.is_some(), "rider should be assigned after first tick");
 
     // Step the sim many times; assignment must never change.
@@ -183,7 +183,7 @@ fn sticky_assignment_persists_across_ticks() {
         {
             break;
         }
-        let cur = sim.world().get_ext::<AssignedCar>(rid);
+        let cur = sim.world().ext::<AssignedCar>(rid);
         assert_eq!(cur, first, "assignment must be sticky");
     }
 }
@@ -285,7 +285,7 @@ fn unassigned_manual_board_riders_still_work() {
     // assignment while we reuse the sim.
     sim.step();
     assert!(
-        sim.world().get_ext::<AssignedCar>(routed).is_some(),
+        sim.world().ext::<AssignedCar>(routed).is_some(),
         "routed rider should be assigned"
     );
 
@@ -333,7 +333,7 @@ fn closer_car_is_preferred_when_matching_direction() {
     sim.step();
     let assigned = sim
         .world()
-        .get_ext::<AssignedCar>(rid)
+        .ext::<AssignedCar>(rid)
         .expect("rider should be assigned");
     assert_eq!(assigned.0, car_a, "closer car should be preferred");
 }
@@ -402,7 +402,7 @@ fn dcs_gated_to_destination_mode() {
         sim.step();
     }
     assert!(
-        sim.world().get_ext::<AssignedCar>(rid).is_none(),
+        sim.world().ext::<AssignedCar>(rid).is_none(),
         "DCS must not assign when group is in Classic mode",
     );
 }

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -236,7 +236,7 @@ fn snapshot_preserves_extension_components() {
     // Find the rider in the restored world and check the extension.
     let mut found = false;
     for (rid, _) in restored.world().iter_riders() {
-        if let Some(tag) = restored.world().get_ext::<VipTag>(rid) {
+        if let Some(tag) = restored.world().ext::<VipTag>(rid) {
             assert_eq!(tag.level, 5);
             found = true;
         }

--- a/crates/elevator-core/src/tests/world_tests.rs
+++ b/crates/elevator-core/src/tests/world_tests.rs
@@ -177,12 +177,12 @@ fn extension_components() {
 
     // Insert, get, mutate.
     world.insert_ext(e, VipTag { level: 3 }, ExtKey::from_type_name());
-    assert_eq!(world.get_ext::<VipTag>(e), Some(VipTag { level: 3 }));
+    assert_eq!(world.ext::<VipTag>(e), Some(VipTag { level: 3 }));
 
-    world.get_ext_mut::<VipTag>(e).unwrap().level = 5;
-    assert_eq!(world.get_ext::<VipTag>(e).unwrap().level, 5);
+    world.ext_mut::<VipTag>(e).unwrap().level = 5;
+    assert_eq!(world.ext::<VipTag>(e).unwrap().level, 5);
 
     // Despawn cleans up extensions.
     world.despawn(e);
-    assert!(world.get_ext::<VipTag>(e).is_none());
+    assert!(world.ext::<VipTag>(e).is_none());
 }

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -73,7 +73,7 @@ impl<T> Default for ExtKey<T> {
 /// within the same system function.
 ///
 /// Built-in components are accessed via typed methods. Games can attach
-/// custom data via the extension storage (`insert_ext` / `get_ext`).
+/// custom data via the extension storage (`insert_ext` / `ext`).
 /// The query builder (`world.query::<...>()`) provides ECS-style iteration.
 pub struct World {
     /// Primary key storage. An entity exists iff its key is here.
@@ -749,22 +749,22 @@ impl World {
 
     /// Get a clone of a custom component for an entity.
     #[must_use]
-    pub fn get_ext<T: 'static + Send + Sync + Clone>(&self, id: EntityId) -> Option<T> {
+    pub fn ext<T: 'static + Send + Sync + Clone>(&self, id: EntityId) -> Option<T> {
         self.ext_map::<T>()?.get(id).cloned()
     }
 
-    /// Get a shared reference to a custom component for an entity.
+    /// Shared reference to a custom component for an entity.
     ///
-    /// Zero-copy alternative to [`get_ext`](Self::get_ext): prefer this when
+    /// Zero-copy alternative to [`ext`](Self::ext): prefer this when
     /// `T` is large or expensive to clone, or when the caller only needs a
-    /// borrow. Unlike `get_ext`, `T` does not need to implement `Clone`.
+    /// borrow. Unlike `ext`, `T` does not need to implement `Clone`.
     #[must_use]
-    pub fn get_ext_ref<T: 'static + Send + Sync>(&self, id: EntityId) -> Option<&T> {
+    pub fn ext_ref<T: 'static + Send + Sync>(&self, id: EntityId) -> Option<&T> {
         self.ext_map::<T>()?.get(id)
     }
 
-    /// Get a mutable reference to a custom component for an entity.
-    pub fn get_ext_mut<T: 'static + Send + Sync>(&mut self, id: EntityId) -> Option<&mut T> {
+    /// Mutable reference to a custom component for an entity.
+    pub fn ext_mut<T: 'static + Send + Sync>(&mut self, id: EntityId) -> Option<&mut T> {
         self.ext_map_mut::<T>()?.get_mut(id)
     }
 


### PR DESCRIPTION
## Summary

First batch of API ergonomics improvements from the audit (#135–#150). Non-architectural changes that improve day-to-day usability for game developers.

**Breaking:** `get_ext`/`get_ext_ref`/`get_ext_mut` → `ext`/`ext_ref`/`ext_mut` (#139)

### Changes

- **#143 Position/Velocity comparison:** Add `PartialEq`, `PartialOrd`, `ZERO` constants, `distance_to()`, `speed()`
- **#150 Component PartialEq:** Add `PartialEq` to `Rider`, `Elevator`, `Stop`, `Patience`, `Preferences`
- **#139 Extension naming:** Rename `get_ext`→`ext`, `get_ext_ref`→`ext_ref`, `get_ext_mut`→`ext_mut`
- **#147 DestinationQueue iteration:** Add `IntoIterator`, `Deref<Target=[EntityId]>`, `iter()`
- **#146 Preferences builders:** Add `with_skip_full_elevator()`, `with_max_crowding_factor()`
- **#144 Config defaults:** Add `Default` for `SimConfig`, `BuildingConfig`, `SimulationParams`, `PassengerSpawnConfig`
- **#149 scale_cost debug assertion:** `debug_assert!` on invalid rank scores (NaN, negative, infinite)

## Test plan

- [x] All 567 unit tests pass
- [x] All 40 doc tests pass
- [x] Zero clippy warnings (`--all-features`)
- [x] Pre-commit hook passes (fmt + clippy + tests + doctests)