### PR TITLE
feat!: dispatch ergonomics — RankContext, manifest encapsulation

### DIFF
--- a/crates/elevator-core/examples/custom_dispatch.rs
+++ b/crates/elevator-core/examples/custom_dispatch.rs
@@ -32,7 +32,9 @@
 use std::collections::HashMap;
 
 use elevator_core::components::CallDirection;
-use elevator_core::dispatch::{BuiltinStrategy, DispatchManifest, DispatchStrategy, ElevatorGroup};
+use elevator_core::dispatch::{
+    BuiltinStrategy, DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext,
+};
 use elevator_core::entity::EntityId;
 use elevator_core::ids::GroupId;
 use elevator_core::prelude::*;
@@ -88,18 +90,9 @@ impl DispatchStrategy for IdlePenaltyDispatch {
     /// Cost is distance minus a small bonus for cars that haven't been
     /// used recently. Returning `None` would exclude a `(car, stop)`
     /// pair entirely — useful for capacity limits or restricted stops.
-    fn rank(
-        &mut self,
-        car: EntityId,
-        car_position: f64,
-        _stop: EntityId,
-        stop_position: f64,
-        _group: &ElevatorGroup,
-        _manifest: &DispatchManifest,
-        _world: &World,
-    ) -> Option<f64> {
-        let distance = (car_position - stop_position).abs();
-        let idle_for = self.idle_for.get(&car).copied().unwrap_or(0.0);
+    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+        let distance = (ctx.car_position - ctx.stop_position).abs();
+        let idle_for = self.idle_for.get(&ctx.car).copied().unwrap_or(0.0);
         // Bias toward long-idle cars; clamp so cost stays non-negative.
         Some(0.01f64.mul_add(-idle_for, distance).max(0.0))
     }

--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -30,7 +30,7 @@ use crate::components::{DestinationQueue, Direction, ElevatorPhase, TransportMod
 use crate::entity::EntityId;
 use crate::world::{ExtKey, World};
 
-use super::{DispatchManifest, DispatchStrategy, ElevatorGroup};
+use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext};
 
 /// Sticky rider → car assignment produced by [`DestinationDispatch`].
 ///
@@ -123,7 +123,7 @@ impl DispatchStrategy for DestinationDispatch {
 
         // Collect unassigned waiting riders in this group.
         let mut pending: Vec<(EntityId, EntityId, EntityId, f64)> = Vec::new();
-        for riders in manifest.waiting_at_stop.values() {
+        for (_, riders) in manifest.iter_waiting_stops() {
             for info in riders {
                 if world.get_ext::<AssignedCar>(info.id).is_some() {
                     continue; // sticky
@@ -213,24 +213,16 @@ impl DispatchStrategy for DestinationDispatch {
         }
     }
 
-    fn rank(
-        &mut self,
-        car: EntityId,
-        _car_position: f64,
-        stop: EntityId,
-        _stop_position: f64,
-        _group: &ElevatorGroup,
-        _manifest: &DispatchManifest,
-        world: &World,
-    ) -> Option<f64> {
+    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
         // The queue is the source of truth — route each car strictly to
         // its own queue front. Every other stop is unavailable for this
         // car, so the Hungarian assignment reduces to the identity match
         // between each car and the stop it has already committed to.
-        let front = world
-            .destination_queue(car)
+        let front = ctx
+            .world
+            .destination_queue(ctx.car)
             .and_then(DestinationQueue::front)?;
-        if front == stop { Some(0.0) } else { None }
+        if front == ctx.stop { Some(0.0) } else { None }
     }
 }
 

--- a/crates/elevator-core/src/dispatch/etd.rs
+++ b/crates/elevator-core/src/dispatch/etd.rs
@@ -12,7 +12,7 @@ use crate::components::{ElevatorPhase, Route};
 use crate::entity::EntityId;
 use crate::world::World;
 
-use super::{DispatchManifest, DispatchStrategy, ElevatorGroup};
+use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext};
 
 /// Estimated Time to Destination (ETD) dispatch algorithm.
 ///
@@ -94,17 +94,8 @@ impl DispatchStrategy for EtdDispatch {
         }
     }
 
-    fn rank(
-        &mut self,
-        car: EntityId,
-        car_position: f64,
-        _stop: EntityId,
-        stop_position: f64,
-        _group: &ElevatorGroup,
-        _manifest: &DispatchManifest,
-        world: &World,
-    ) -> Option<f64> {
-        let cost = self.compute_cost(car, car_position, stop_position, world);
+    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+        let cost = self.compute_cost(ctx.car, ctx.car_position, ctx.stop_position, ctx.world);
         if cost.is_finite() { Some(cost) } else { None }
     }
 }

--- a/crates/elevator-core/src/dispatch/look.rs
+++ b/crates/elevator-core/src/dispatch/look.rs
@@ -16,7 +16,7 @@ use crate::entity::EntityId;
 use crate::world::World;
 
 use super::sweep::{self, SweepDirection, SweepMode};
-use super::{DispatchManifest, DispatchStrategy, ElevatorGroup};
+use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext};
 
 /// Elevator dispatch using the LOOK algorithm. See module docs.
 pub struct LookDispatch {
@@ -74,21 +74,12 @@ impl DispatchStrategy for LookDispatch {
         }
     }
 
-    fn rank(
-        &mut self,
-        car: EntityId,
-        car_position: f64,
-        _stop: EntityId,
-        stop_position: f64,
-        _group: &ElevatorGroup,
-        _manifest: &DispatchManifest,
-        _world: &World,
-    ) -> Option<f64> {
+    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
         sweep::rank(
-            self.mode_for(car),
-            self.direction_for(car),
-            car_position,
-            stop_position,
+            self.mode_for(ctx.car),
+            self.direction_for(ctx.car),
+            ctx.car_position,
+            ctx.stop_position,
         )
     }
 

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -11,26 +11,15 @@
 //!
 //! ```rust
 //! use elevator_core::prelude::*;
-//! use elevator_core::dispatch::{
-//!     DispatchDecision, DispatchManifest, ElevatorGroup,
-//! };
+//! use elevator_core::dispatch::RankContext;
 //!
 //! struct AlwaysFirstStop;
 //!
 //! impl DispatchStrategy for AlwaysFirstStop {
-//!     fn rank(
-//!         &mut self,
-//!         _car: EntityId,
-//!         car_position: f64,
-//!         stop: EntityId,
-//!         stop_position: f64,
-//!         group: &ElevatorGroup,
-//!         _manifest: &DispatchManifest,
-//!         _world: &elevator_core::world::World,
-//!     ) -> Option<f64> {
+//!     fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
 //!         // Prefer the group's first stop; everything else is unavailable.
-//!         if Some(&stop) == group.stop_entities().first() {
-//!             Some((car_position - stop_position).abs())
+//!         if Some(&ctx.stop) == ctx.group.stop_entities().first() {
+//!             Some((ctx.car_position - ctx.stop_position).abs())
 //!         } else {
 //!             None
 //!         }
@@ -95,20 +84,20 @@ pub struct RiderInfo {
 #[derive(Debug, Clone, Default)]
 pub struct DispatchManifest {
     /// Riders waiting at each stop, with full per-rider metadata.
-    pub waiting_at_stop: BTreeMap<EntityId, Vec<RiderInfo>>,
+    pub(crate) waiting_at_stop: BTreeMap<EntityId, Vec<RiderInfo>>,
     /// Riders currently aboard elevators, grouped by their destination stop.
-    pub riding_to_stop: BTreeMap<EntityId, Vec<RiderInfo>>,
+    pub(crate) riding_to_stop: BTreeMap<EntityId, Vec<RiderInfo>>,
     /// Number of residents at each stop (read-only hint for dispatch strategies).
-    pub resident_count_at_stop: BTreeMap<EntityId, usize>,
+    pub(crate) resident_count_at_stop: BTreeMap<EntityId, usize>,
     /// Pending hall calls at each stop — at most two entries per stop
     /// (one per [`CallDirection`]). Populated only for stops served by
     /// the group being dispatched. Strategies read this to rank based on
     /// call age, pending-rider count, pin flags, or DCS destinations.
-    pub hall_calls_at_stop: BTreeMap<EntityId, Vec<HallCall>>,
+    pub(crate) hall_calls_at_stop: BTreeMap<EntityId, Vec<HallCall>>,
     /// Floor buttons pressed inside each car in the group. Keyed by car
     /// entity. Strategies read this to plan intermediate stops without
     /// poking into `World` directly.
-    pub car_calls_by_car: BTreeMap<EntityId, Vec<CarCall>>,
+    pub(crate) car_calls_by_car: BTreeMap<EntityId, Vec<CarCall>>,
 }
 
 impl DispatchManifest {
@@ -167,6 +156,32 @@ impl DispatchManifest {
     #[must_use]
     pub fn car_calls_for(&self, car: EntityId) -> &[CarCall] {
         self.car_calls_by_car.get(&car).map_or(&[], Vec::as_slice)
+    }
+
+    /// Riders waiting at a specific stop.
+    #[must_use]
+    pub fn waiting_riders_at(&self, stop: EntityId) -> &[RiderInfo] {
+        self.waiting_at_stop.get(&stop).map_or(&[], Vec::as_slice)
+    }
+
+    /// Iterate over all `(stop, riders)` pairs with waiting demand.
+    pub fn iter_waiting_stops(&self) -> impl Iterator<Item = (&EntityId, &[RiderInfo])> {
+        self.waiting_at_stop
+            .iter()
+            .map(|(stop, riders)| (stop, riders.as_slice()))
+    }
+
+    /// Riders currently riding toward a specific stop.
+    #[must_use]
+    pub fn riding_riders_to(&self, stop: EntityId) -> &[RiderInfo] {
+        self.riding_to_stop.get(&stop).map_or(&[], Vec::as_slice)
+    }
+
+    /// Iterate over all `(stop, riders)` pairs with in-transit demand.
+    pub fn iter_riding_stops(&self) -> impl Iterator<Item = (&EntityId, &[RiderInfo])> {
+        self.riding_to_stop
+            .iter()
+            .map(|(stop, riders)| (stop, riders.as_slice()))
     }
 }
 
@@ -486,6 +501,43 @@ impl ElevatorGroup {
     }
 }
 
+/// Context passed to [`DispatchStrategy::rank`] and
+/// [`DispatchStrategy::prepare_car`].
+///
+/// Bundles the per-call arguments into a single struct so future context
+/// fields can be added without breaking existing trait implementations.
+#[non_exhaustive]
+pub struct RankContext<'a> {
+    /// The elevator being evaluated.
+    pub car: EntityId,
+    /// Current position of the car along the shaft axis.
+    pub car_position: f64,
+    /// The stop being evaluated as a candidate destination.
+    pub stop: EntityId,
+    /// Position of the candidate stop along the shaft axis.
+    pub stop_position: f64,
+    /// The dispatch group this assignment belongs to.
+    pub group: &'a ElevatorGroup,
+    /// Demand snapshot for the current dispatch pass.
+    pub manifest: &'a DispatchManifest,
+    /// Read-only world state.
+    pub world: &'a World,
+}
+
+impl std::fmt::Debug for RankContext<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RankContext")
+            .field("car", &self.car)
+            .field("car_position", &self.car_position)
+            .field("stop", &self.stop)
+            .field("stop_position", &self.stop_position)
+            .field("group", &self.group)
+            .field("manifest", &self.manifest)
+            .field("world", &"World { .. }")
+            .finish()
+    }
+}
+
 /// Pluggable dispatch algorithm.
 ///
 /// Strategies implement [`rank`](Self::rank) to score each `(car, stop)`
@@ -548,17 +600,7 @@ pub trait DispatchStrategy: Send + Sync {
     /// whose results depend on iteration order. Use
     /// [`prepare_car`](Self::prepare_car) to compute and store any
     /// per-car state before `rank` is called.
-    #[allow(clippy::too_many_arguments)]
-    fn rank(
-        &mut self,
-        car: EntityId,
-        car_position: f64,
-        stop: EntityId,
-        stop_position: f64,
-        group: &ElevatorGroup,
-        manifest: &DispatchManifest,
-        world: &World,
-    ) -> Option<f64>;
+    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64>;
 
     /// Decide what an idle car should do when no stop was assigned to it.
     ///
@@ -662,9 +704,16 @@ pub(crate) fn assign(
     for (i, &(car_eid, car_pos)) in idle_cars.iter().enumerate() {
         strategy.prepare_car(car_eid, car_pos, group, manifest, world);
         for (j, &(stop_eid, stop_pos)) in pending_stops.iter().enumerate() {
-            let scaled = strategy
-                .rank(car_eid, car_pos, stop_eid, stop_pos, group, manifest, world)
-                .map_or(ASSIGNMENT_SENTINEL, scale_cost);
+            let ctx = RankContext {
+                car: car_eid,
+                car_position: car_pos,
+                stop: stop_eid,
+                stop_position: stop_pos,
+                group,
+                manifest,
+                world,
+            };
+            let scaled = strategy.rank(&ctx).map_or(ASSIGNMENT_SENTINEL, scale_cost);
             data[i * cols + j] = scaled;
         }
     }

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -183,6 +183,13 @@ impl DispatchManifest {
             .iter()
             .map(|(stop, riders)| (stop, riders.as_slice()))
     }
+
+    /// Iterate over all `(stop, hall_calls)` pairs with active calls.
+    pub fn iter_hall_call_stops(&self) -> impl Iterator<Item = (&EntityId, &[HallCall])> {
+        self.hall_calls_at_stop
+            .iter()
+            .map(|(stop, calls)| (stop, calls.as_slice()))
+    }
 }
 
 /// Serializable identifier for built-in dispatch strategies.
@@ -501,8 +508,7 @@ impl ElevatorGroup {
     }
 }
 
-/// Context passed to [`DispatchStrategy::rank`] and
-/// [`DispatchStrategy::prepare_car`].
+/// Context passed to [`DispatchStrategy::rank`].
 ///
 /// Bundles the per-call arguments into a single struct so future context
 /// fields can be added without breaking existing trait implementations.

--- a/crates/elevator-core/src/dispatch/nearest_car.rs
+++ b/crates/elevator-core/src/dispatch/nearest_car.rs
@@ -1,9 +1,6 @@
 //! Nearest-car dispatch — assigns each call to the closest idle elevator.
 
-use crate::entity::EntityId;
-use crate::world::World;
-
-use super::{DispatchManifest, DispatchStrategy, ElevatorGroup};
+use super::{DispatchStrategy, RankContext};
 
 /// Scores `(car, stop)` by absolute distance between the car and the stop.
 ///
@@ -27,16 +24,7 @@ impl Default for NearestCarDispatch {
 }
 
 impl DispatchStrategy for NearestCarDispatch {
-    fn rank(
-        &mut self,
-        _car: EntityId,
-        car_position: f64,
-        _stop: EntityId,
-        stop_position: f64,
-        _group: &ElevatorGroup,
-        _manifest: &DispatchManifest,
-        _world: &World,
-    ) -> Option<f64> {
-        Some((car_position - stop_position).abs())
+    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+        Some((ctx.car_position - ctx.stop_position).abs())
     }
 }

--- a/crates/elevator-core/src/dispatch/scan.rs
+++ b/crates/elevator-core/src/dispatch/scan.rs
@@ -11,7 +11,7 @@ use crate::entity::EntityId;
 use crate::world::World;
 
 use super::sweep::{self, SweepDirection, SweepMode};
-use super::{DispatchManifest, DispatchStrategy, ElevatorGroup};
+use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext};
 
 /// Elevator dispatch using the SCAN (elevator) algorithm.
 ///
@@ -76,21 +76,12 @@ impl DispatchStrategy for ScanDispatch {
         }
     }
 
-    fn rank(
-        &mut self,
-        car: EntityId,
-        car_position: f64,
-        _stop: EntityId,
-        stop_position: f64,
-        _group: &ElevatorGroup,
-        _manifest: &DispatchManifest,
-        _world: &World,
-    ) -> Option<f64> {
+    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
         sweep::rank(
-            self.mode_for(car),
-            self.direction_for(car),
-            car_position,
-            stop_position,
+            self.mode_for(ctx.car),
+            self.direction_for(ctx.car),
+            ctx.car_position,
+            ctx.stop_position,
         )
     }
 

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -512,7 +512,7 @@ pub mod prelude {
         DemandWeighted, NearestIdle, ReturnToLobby, SpreadEvenly,
     };
     pub use crate::dispatch::{
-        AssignedCar, DestinationDispatch, DispatchStrategy, RepositionStrategy,
+        AssignedCar, DestinationDispatch, DispatchStrategy, RankContext, RepositionStrategy,
     };
     pub use crate::entity::EntityId;
     pub use crate::error::{EtaError, RejectionContext, RejectionReason, SimError};

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -1415,7 +1415,11 @@ impl Simulation {
         })
     }
 
-    /// Spawn a rider at the given origin stop entity, headed to destination stop entity.
+    /// Spawn a rider with default preferences (convenience shorthand).
+    ///
+    /// Equivalent to `build_rider(origin, destination)?.weight(weight).spawn()`.
+    /// Use [`build_rider`](Self::build_rider) instead when you need to set
+    /// patience, preferences, access control, or an explicit route.
     ///
     /// Auto-detects the elevator group by finding groups that serve both origin
     /// and destination stops.

--- a/crates/elevator-core/src/tests/dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/dispatch_tests.rs
@@ -6,7 +6,8 @@ use crate::dispatch::look::LookDispatch;
 use crate::dispatch::nearest_car::NearestCarDispatch;
 use crate::dispatch::scan::ScanDispatch;
 use crate::dispatch::{
-    self, DispatchDecision, DispatchManifest, DispatchStrategy, ElevatorGroup, RiderInfo,
+    self, DispatchDecision, DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext,
+    RiderInfo,
 };
 use crate::door::DoorState;
 use crate::ids::GroupId;
@@ -502,16 +503,7 @@ fn nearest_car_distance_calculation() {
 struct AlwaysIdleDispatch;
 
 impl DispatchStrategy for AlwaysIdleDispatch {
-    fn rank(
-        &mut self,
-        _car: crate::entity::EntityId,
-        _car_position: f64,
-        _stop: crate::entity::EntityId,
-        _stop_position: f64,
-        _group: &ElevatorGroup,
-        _manifest: &DispatchManifest,
-        _world: &World,
-    ) -> Option<f64> {
+    fn rank(&mut self, _ctx: &RankContext<'_>) -> Option<f64> {
         None
     }
 }
@@ -673,20 +665,11 @@ fn strategy_rank_is_order_independent_when_state_lives_in_prepare_car() {
             // Snapshot once; `rank` reads only.
             self.idle.insert(car, self.tick as f64);
         }
-        fn rank(
-            &mut self,
-            car: crate::entity::EntityId,
-            car_pos: f64,
-            _s: crate::entity::EntityId,
-            stop_pos: f64,
-            _g: &ElevatorGroup,
-            _m: &DispatchManifest,
-            _w: &World,
-        ) -> Option<f64> {
-            let boost = self.idle.get(&car).copied().unwrap_or(0.0);
+        fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+            let boost = self.idle.get(&ctx.car).copied().unwrap_or(0.0);
             Some(
                 0.001f64
-                    .mul_add(-boost, (car_pos - stop_pos).abs())
+                    .mul_add(-boost, (ctx.car_position - ctx.stop_position).abs())
                     .max(0.0),
             )
         }

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -698,8 +698,7 @@ fn group_config_ron_defaults_to_classic_zero_latency() {
 /// directly. This exercises the #102 contract end-to-end.
 #[test]
 fn custom_strategy_reads_hall_calls_from_manifest() {
-    use crate::dispatch::{DispatchManifest, DispatchStrategy, ElevatorGroup};
-    use crate::world::World;
+    use crate::dispatch::DispatchStrategy;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -711,21 +710,17 @@ fn custom_strategy_reads_hall_calls_from_manifest() {
     }
 
     impl DispatchStrategy for Observer {
-        fn rank(
-            &mut self,
-            _car: EntityId,
-            car_pos: f64,
-            stop: EntityId,
-            stop_pos: f64,
-            _group: &ElevatorGroup,
-            manifest: &DispatchManifest,
-            _world: &World,
-        ) -> Option<f64> {
+        fn rank(&mut self, ctx: &crate::dispatch::RankContext<'_>) -> Option<f64> {
             let target = *self.target_stop.lock().unwrap();
-            if Some(stop) == target && manifest.hall_call_at(stop, CallDirection::Up).is_some() {
+            if Some(ctx.stop) == target
+                && ctx
+                    .manifest
+                    .hall_call_at(ctx.stop, CallDirection::Up)
+                    .is_some()
+            {
                 self.saw_call.fetch_add(1, Ordering::Relaxed);
             }
-            Some((car_pos - stop_pos).abs())
+            Some((ctx.car_position - ctx.stop_position).abs())
         }
     }
 
@@ -760,8 +755,7 @@ fn custom_strategy_reads_hall_calls_from_manifest() {
 /// `World`.
 #[test]
 fn custom_strategy_reads_car_calls_from_manifest() {
-    use crate::dispatch::{DispatchManifest, DispatchStrategy, ElevatorGroup};
-    use crate::world::World;
+    use crate::dispatch::DispatchStrategy;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -769,20 +763,11 @@ fn custom_strategy_reads_car_calls_from_manifest() {
         saw_car_call: Arc<AtomicUsize>,
     }
     impl DispatchStrategy for Observer {
-        fn rank(
-            &mut self,
-            car: EntityId,
-            car_pos: f64,
-            _stop: EntityId,
-            stop_pos: f64,
-            _group: &ElevatorGroup,
-            manifest: &DispatchManifest,
-            _world: &World,
-        ) -> Option<f64> {
-            if !manifest.car_calls_for(car).is_empty() {
+        fn rank(&mut self, ctx: &crate::dispatch::RankContext<'_>) -> Option<f64> {
+            if !ctx.manifest.car_calls_for(ctx.car).is_empty() {
                 self.saw_car_call.fetch_add(1, Ordering::Relaxed);
             }
-            Some((car_pos - stop_pos).abs())
+            Some((ctx.car_position - ctx.stop_position).abs())
         }
     }
 
@@ -817,9 +802,8 @@ fn custom_strategy_reads_car_calls_from_manifest() {
 /// `HallCall::is_acknowledged`'s documented contract.
 #[test]
 fn unacknowledged_hall_calls_hidden_from_manifest() {
-    use crate::dispatch::{DispatchManifest, DispatchStrategy, ElevatorGroup, HallCallMode};
+    use crate::dispatch::{DispatchStrategy, HallCallMode};
     use crate::ids::GroupId;
-    use crate::world::World;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -827,22 +811,13 @@ fn unacknowledged_hall_calls_hidden_from_manifest() {
         visible_call_count: Arc<AtomicUsize>,
     }
     impl DispatchStrategy for Observer {
-        fn rank(
-            &mut self,
-            _car: EntityId,
-            car_pos: f64,
-            _stop: EntityId,
-            stop_pos: f64,
-            _group: &ElevatorGroup,
-            manifest: &DispatchManifest,
-            _world: &World,
-        ) -> Option<f64> {
+        fn rank(&mut self, ctx: &crate::dispatch::RankContext<'_>) -> Option<f64> {
             // Track running max so a later `rank` call observing zero
             // calls (e.g. after the car arrived and cleared the call)
             // doesn't overwrite a previous nonzero observation.
-            let count = manifest.iter_hall_calls().count();
+            let count = ctx.manifest.iter_hall_calls().count();
             self.visible_call_count.fetch_max(count, Ordering::Relaxed);
-            Some((car_pos - stop_pos).abs())
+            Some((ctx.car_position - ctx.stop_position).abs())
         }
     }
 

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -1631,9 +1631,8 @@ fn remove_line_marks_topology_graph_dirty() {
 /// dispatching the next call.
 #[test]
 fn reassign_elevator_to_line_notifies_old_group_dispatcher_on_cross_group() {
-    use crate::dispatch::{DispatchManifest, DispatchStrategy, ElevatorGroup};
+    use crate::dispatch::DispatchStrategy;
     use crate::entity::EntityId;
-    use crate::world::World;
     use std::sync::{Arc, Mutex};
 
     /// Dispatcher that records every `notify_removed` call it receives.
@@ -1642,25 +1641,8 @@ fn reassign_elevator_to_line_notifies_old_group_dispatcher_on_cross_group() {
         inner: ScanDispatch,
     }
     impl DispatchStrategy for TrackingDispatch {
-        fn rank(
-            &mut self,
-            car: EntityId,
-            car_position: f64,
-            stop: EntityId,
-            stop_position: f64,
-            group: &ElevatorGroup,
-            manifest: &DispatchManifest,
-            world: &World,
-        ) -> Option<f64> {
-            self.inner.rank(
-                car,
-                car_position,
-                stop,
-                stop_position,
-                group,
-                manifest,
-                world,
-            )
+        fn rank(&mut self, ctx: &crate::dispatch::RankContext<'_>) -> Option<f64> {
+            self.inner.rank(ctx)
         }
         fn notify_removed(&mut self, elevator: EntityId) {
             self.removed.lock().unwrap().push(elevator);


### PR DESCRIPTION
## Summary

Second batch of API ergonomics improvements — focused on the dispatch extension point.

### Changes

- **#141 RankContext struct:** `DispatchStrategy::rank()` now takes `&RankContext<'_>` instead of 7 parameters. The struct is `#[non_exhaustive]` so future context (e.g. `current_tick`, `hall_call_mode`) can be added without breaking implementors. Net -59 lines.
- **#138 DispatchManifest encapsulation:** Fields are now `pub(crate)`. Added `waiting_riders_at()`, `iter_waiting_stops()`, `riding_riders_to()`, `iter_riding_stops()` accessors.
- **#145 spawn_rider docs:** Clarified that `spawn_rider` is a convenience shorthand; use `build_rider` for patience/preferences/route control.
- **Prelude:** Added `RankContext` to prelude.

## Test plan

- [x] All 567 unit tests pass
- [x] All 40 doc tests pass (including updated dispatch module example)
- [x] Zero clippy warnings
- [x] Pre-commit hook passes