### PR TITLE
ci: run FFI smoke tests only on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,8 @@ jobs:
 
   ffi-harness:
     name: FFI smoke test (${{ matrix.os }})
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.user.login != 'release-kun[bot]' ||
-      !startsWith(github.event.pull_request.title, 'chore(main): release')
+    # Cross-platform FFI builds are slow — only run after merge to main.
+    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

FFI smoke tests (Linux, macOS, Windows + .NET) are slow and rarely catch issues beyond what the core test suite covers. Restrict to post-merge runs only.

## Test plan

- [x] PR CI will no longer run FFI jobs (verified by `if: github.event_name == 'push'`)
- [x] FFI jobs still run on merge to main