### PR TITLE
feat!: prelude expansion and RepositionStrategy buffer pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "8.3.0"
+version = "9.0.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "cbindgen",
  "elevator-core",

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -11,7 +11,6 @@
 //!
 //! ```rust
 //! use elevator_core::prelude::*;
-//! use elevator_core::dispatch::RankContext;
 //!
 //! struct AlwaysFirstStop;
 //!
@@ -769,15 +768,17 @@ pub(crate) fn assign(
 pub trait RepositionStrategy: Send + Sync {
     /// Decide where to reposition idle elevators.
     ///
-    /// Returns a vec of `(elevator_entity, target_stop_entity)` pairs.
-    /// Elevators not in the returned vec remain idle.
+    /// Push `(elevator_entity, target_stop_entity)` pairs into `out`.
+    /// The buffer is cleared before each call — implementations should
+    /// only push, never read prior contents. Elevators not pushed remain idle.
     fn reposition(
         &mut self,
         idle_elevators: &[(EntityId, f64)],
         stop_positions: &[(EntityId, f64)],
         group: &ElevatorGroup,
         world: &World,
-    ) -> Vec<(EntityId, EntityId)>;
+        out: &mut Vec<(EntityId, EntityId)>,
+    );
 }
 
 /// Serializable identifier for built-in repositioning strategies.

--- a/crates/elevator-core/src/dispatch/reposition.rs
+++ b/crates/elevator-core/src/dispatch/reposition.rs
@@ -32,9 +32,10 @@ impl RepositionStrategy for SpreadEvenly {
         stop_positions: &[(EntityId, f64)],
         group: &ElevatorGroup,
         world: &World,
-    ) -> Vec<(EntityId, EntityId)> {
+        out: &mut Vec<(EntityId, EntityId)>,
+    ) {
         if idle_elevators.is_empty() || stop_positions.is_empty() {
-            return Vec::new();
+            return;
         }
 
         // Collect positions of all non-idle elevators in this group.
@@ -42,7 +43,6 @@ impl RepositionStrategy for SpreadEvenly {
             .elevator_entities()
             .iter()
             .filter_map(|&eid| {
-                // Skip idle elevators — they're the ones we're repositioning.
                 if idle_elevators.iter().any(|(ie, _)| *ie == eid) {
                     return None;
                 }
@@ -50,10 +50,7 @@ impl RepositionStrategy for SpreadEvenly {
             })
             .collect();
 
-        let mut results = Vec::new();
-
         for &(elev_eid, elev_pos) in idle_elevators {
-            // Find the stop that maximizes min distance from all occupied positions.
             let best = stop_positions.iter().max_by(|a, b| {
                 let min_a = min_distance_to(a.1, &occupied);
                 let min_b = min_distance_to(b.1, &occupied);
@@ -62,13 +59,11 @@ impl RepositionStrategy for SpreadEvenly {
 
             if let Some(&(stop_eid, stop_pos)) = best {
                 if (stop_pos - elev_pos).abs() > 1e-6 {
-                    results.push((elev_eid, stop_eid));
+                    out.push((elev_eid, stop_eid));
                 }
                 occupied.push(stop_pos);
             }
         }
-
-        results
     }
 }
 
@@ -111,16 +106,18 @@ impl RepositionStrategy for ReturnToLobby {
         stop_positions: &[(EntityId, f64)],
         _group: &ElevatorGroup,
         _world: &World,
-    ) -> Vec<(EntityId, EntityId)> {
+        out: &mut Vec<(EntityId, EntityId)>,
+    ) {
         let Some(&(home_eid, home_pos)) = stop_positions.get(self.home_stop_index) else {
-            return Vec::new();
+            return;
         };
 
-        idle_elevators
-            .iter()
-            .filter(|(_, pos)| (*pos - home_pos).abs() > 1e-6)
-            .map(|&(eid, _)| (eid, home_eid))
-            .collect()
+        out.extend(
+            idle_elevators
+                .iter()
+                .filter(|(_, pos)| (*pos - home_pos).abs() > 1e-6)
+                .map(|&(eid, _)| (eid, home_eid)),
+        );
     }
 }
 
@@ -138,12 +135,12 @@ impl RepositionStrategy for DemandWeighted {
         stop_positions: &[(EntityId, f64)],
         group: &ElevatorGroup,
         world: &World,
-    ) -> Vec<(EntityId, EntityId)> {
+        out: &mut Vec<(EntityId, EntityId)>,
+    ) {
         if idle_elevators.is_empty() || stop_positions.is_empty() {
-            return Vec::new();
+            return;
         }
 
-        // Build demand weights from tagged metrics.
         let tags = world.resource::<MetricTags>();
         let mut scored_stops: Vec<(EntityId, f64, f64)> = stop_positions
             .iter()
@@ -156,14 +153,12 @@ impl RepositionStrategy for DemandWeighted {
                             .max()
                     })
                     .unwrap_or(0) as f64;
-                (stop_eid, stop_pos, demand + 1.0) // +1 to avoid zero weights
+                (stop_eid, stop_pos, demand + 1.0)
             })
             .collect();
 
-        // Sort by demand descending — highest demand stops get elevators first.
         scored_stops.sort_by(|a, b| b.2.total_cmp(&a.2));
 
-        // Collect non-idle elevator positions.
         let mut occupied: Vec<f64> = group
             .elevator_entities()
             .iter()
@@ -175,16 +170,13 @@ impl RepositionStrategy for DemandWeighted {
             })
             .collect();
 
-        let mut results = Vec::new();
         let mut assigned_elevators: Vec<EntityId> = Vec::new();
 
         for (stop_eid, stop_pos, _demand) in &scored_stops {
-            // Skip if there's already an elevator near this stop.
             if min_distance_to(*stop_pos, &occupied) < 1e-6 {
                 continue;
             }
 
-            // Find the closest unassigned idle elevator.
             let closest = idle_elevators
                 .iter()
                 .filter(|(eid, _)| !assigned_elevators.contains(eid))
@@ -197,7 +189,7 @@ impl RepositionStrategy for DemandWeighted {
             if let Some(&(elev_eid, elev_pos)) = closest
                 && (elev_pos - stop_pos).abs() > 1e-6
             {
-                results.push((elev_eid, *stop_eid));
+                out.push((elev_eid, *stop_eid));
                 assigned_elevators.push(elev_eid);
                 occupied.push(*stop_pos);
             }
@@ -206,8 +198,6 @@ impl RepositionStrategy for DemandWeighted {
                 break;
             }
         }
-
-        results
     }
 }
 
@@ -224,8 +214,8 @@ impl RepositionStrategy for NearestIdle {
         _stop_positions: &[(EntityId, f64)],
         _group: &ElevatorGroup,
         _world: &World,
-    ) -> Vec<(EntityId, EntityId)> {
-        Vec::new()
+        _out: &mut Vec<(EntityId, EntityId)>,
+    ) {
     }
 }
 

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -465,12 +465,22 @@ macro_rules! register_extensions {
 ///   [`Orientation`](crate::components::Orientation),
 ///   [`ServiceMode`](crate::components::ServiceMode)
 /// - **Config:** [`SimConfig`](crate::config::SimConfig),
+///   [`ElevatorConfig`](crate::config::ElevatorConfig),
 ///   [`GroupConfig`](crate::config::GroupConfig),
-///   [`LineConfig`](crate::config::LineConfig)
+///   [`LineConfig`](crate::config::LineConfig),
+///   [`StopConfig`](crate::stop::StopConfig)
 /// - **Dispatch:** [`DispatchStrategy`](crate::dispatch::DispatchStrategy),
 ///   [`RepositionStrategy`](crate::dispatch::RepositionStrategy),
+///   [`DispatchDecision`](crate::dispatch::DispatchDecision),
+///   [`DispatchManifest`](crate::dispatch::DispatchManifest),
+///   [`ElevatorGroup`](crate::dispatch::ElevatorGroup),
 ///   [`AssignedCar`](crate::dispatch::AssignedCar),
+///   [`RankContext`](crate::dispatch::RankContext),
 ///   [`DestinationDispatch`](crate::dispatch::DestinationDispatch),
+///   [`ScanDispatch`](crate::dispatch::ScanDispatch),
+///   [`LookDispatch`](crate::dispatch::LookDispatch),
+///   [`NearestCarDispatch`](crate::dispatch::NearestCarDispatch),
+///   [`EtdDispatch`](crate::dispatch::EtdDispatch),
 ///   plus the built-in reposition strategies
 ///   [`NearestIdle`](crate::dispatch::reposition::NearestIdle),
 ///   [`ReturnToLobby`](crate::dispatch::reposition::ReturnToLobby),
@@ -486,20 +496,15 @@ macro_rules! register_extensions {
 ///   [`Event`](crate::events::Event),
 ///   [`EventBus`](crate::events::EventBus),
 ///   [`EventCategory`](crate::events::EventCategory)
-/// - **Misc:** [`Metrics`](crate::metrics::Metrics),
+/// - **World & misc:** [`World`](crate::world::World),
+///   [`Metrics`](crate::metrics::Metrics),
 ///   [`TimeAdapter`](crate::time::TimeAdapter),
 ///   [`ExtKey`](crate::world::ExtKey)
 ///
 /// # Not included (import explicitly)
 ///
-/// - Concrete dispatch implementations: `dispatch::scan::ScanDispatch`,
-///   `dispatch::look::LookDispatch`, `dispatch::nearest_car::NearestCarDispatch`,
-///   `dispatch::etd::EtdDispatch`
-/// - `ElevatorConfig` from [`crate::config`] and `StopConfig` from [`crate::stop`]
 /// - Traffic generation types from [`crate::traffic`] (feature-gated)
 /// - Snapshot types from [`crate::snapshot`]
-/// - The [`World`](crate::world::World) type (accessed via `sim.world()`,
-///   but required as a parameter when implementing custom dispatch)
 pub mod prelude {
     pub use crate::builder::SimulationBuilder;
     pub use crate::components::{
@@ -507,12 +512,14 @@ pub mod prelude {
         Orientation, Patience, Position, Preferences, Rider, RiderPhase, RiderPhaseKind, Route,
         ServiceMode, SpatialPosition, Speed, Stop, Velocity, Weight,
     };
-    pub use crate::config::{GroupConfig, LineConfig, SimConfig};
+    pub use crate::config::{ElevatorConfig, GroupConfig, LineConfig, SimConfig};
     pub use crate::dispatch::reposition::{
         DemandWeighted, NearestIdle, ReturnToLobby, SpreadEvenly,
     };
     pub use crate::dispatch::{
-        AssignedCar, DestinationDispatch, DispatchStrategy, RankContext, RepositionStrategy,
+        AssignedCar, DestinationDispatch, DispatchDecision, DispatchManifest, DispatchStrategy,
+        ElevatorGroup, EtdDispatch, LookDispatch, NearestCarDispatch, RankContext,
+        RepositionStrategy, ScanDispatch,
     };
     pub use crate::entity::EntityId;
     pub use crate::error::{EtaError, RejectionContext, RejectionReason, SimError};
@@ -520,9 +527,9 @@ pub mod prelude {
     pub use crate::ids::GroupId;
     pub use crate::metrics::Metrics;
     pub use crate::sim::{RiderBuilder, Simulation};
-    pub use crate::stop::{StopId, StopRef};
+    pub use crate::stop::{StopConfig, StopId, StopRef};
     pub use crate::time::TimeAdapter;
-    pub use crate::world::ExtKey;
+    pub use crate::world::{ExtKey, World};
 }
 
 #[cfg(test)]

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -368,6 +368,8 @@ pub struct Simulation {
     hooks: PhaseHooks,
     /// Reusable buffer for elevator IDs (avoids per-tick allocation).
     elevator_ids_buf: Vec<EntityId>,
+    /// Reusable buffer for reposition decisions (avoids per-tick allocation).
+    reposition_buf: Vec<(EntityId, EntityId)>,
     /// Lazy-rebuilt connectivity graph for cross-line topology queries.
     topo_graph: Mutex<TopologyGraph>,
     /// Phase-partitioned reverse index for O(1) population queries.
@@ -1802,6 +1804,7 @@ impl Simulation {
             &ctx,
             &self.groups,
             &mut self.repositioners,
+            &mut self.reposition_buf,
         );
         for group in &self.groups {
             if self.repositioners.contains_key(&group.id()) {

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -169,6 +169,7 @@ impl Simulation {
             time: TimeAdapter::new(config.simulation.ticks_per_second),
             hooks,
             elevator_ids_buf: Vec::new(),
+            reposition_buf: Vec::new(),
             topo_graph: Mutex::new(TopologyGraph::new()),
             rider_index: RiderIndex::default(),
         })
@@ -469,6 +470,7 @@ impl Simulation {
             time: TimeAdapter::new(ticks_per_second),
             hooks: PhaseHooks::default(),
             elevator_ids_buf: Vec::new(),
+            reposition_buf: Vec::new(),
             topo_graph: Mutex::new(TopologyGraph::new()),
             rider_index,
         }

--- a/crates/elevator-core/src/systems/reposition.rs
+++ b/crates/elevator-core/src/systems/reposition.rs
@@ -22,12 +22,13 @@ pub fn run(
     groups: &[ElevatorGroup],
     repositioners: &mut BTreeMap<GroupId, Box<dyn RepositionStrategy>>,
 ) {
+    let mut decisions: Vec<(EntityId, EntityId)> = Vec::new();
+
     for group in groups {
         let Some(strategy) = repositioners.get_mut(&group.id()) else {
             continue;
         };
 
-        // Collect idle elevators in this group.
         let idle_elevators: Vec<(EntityId, f64)> = group
             .elevator_entities()
             .iter()
@@ -35,7 +36,6 @@ pub fn run(
                 if world.is_disabled(eid) {
                     return None;
                 }
-                // Skip elevators that opt out of automatic dispatch.
                 if world
                     .service_mode(eid)
                     .is_some_and(|m| m.is_dispatch_excluded())
@@ -56,7 +56,6 @@ pub fn run(
             continue;
         }
 
-        // Stop positions in this group.
         let stop_positions: Vec<(EntityId, f64)> = group
             .stop_entities()
             .iter()
@@ -67,9 +66,18 @@ pub fn run(
             continue;
         }
 
-        let decisions = strategy.reposition(&idle_elevators, &stop_positions, group, world);
+        decisions.clear();
+        strategy.reposition(
+            &idle_elevators,
+            &stop_positions,
+            group,
+            world,
+            &mut decisions,
+        );
 
-        for (elev_eid, target_stop) in decisions {
+        for (elev_eid, target_stop) in &decisions {
+            let elev_eid = *elev_eid;
+            let target_stop = *target_stop;
             if let Some(car) = world.elevator_mut(elev_eid) {
                 car.phase = ElevatorPhase::Repositioning(target_stop);
                 car.target_stop = Some(target_stop);

--- a/crates/elevator-core/src/systems/reposition.rs
+++ b/crates/elevator-core/src/systems/reposition.rs
@@ -21,9 +21,8 @@ pub fn run(
     ctx: &PhaseContext,
     groups: &[ElevatorGroup],
     repositioners: &mut BTreeMap<GroupId, Box<dyn RepositionStrategy>>,
+    decisions: &mut Vec<(EntityId, EntityId)>,
 ) {
-    let mut decisions: Vec<(EntityId, EntityId)> = Vec::new();
-
     for group in groups {
         let Some(strategy) = repositioners.get_mut(&group.id()) else {
             continue;
@@ -67,17 +66,9 @@ pub fn run(
         }
 
         decisions.clear();
-        strategy.reposition(
-            &idle_elevators,
-            &stop_positions,
-            group,
-            world,
-            &mut decisions,
-        );
+        strategy.reposition(&idle_elevators, &stop_positions, group, world, decisions);
 
-        for (elev_eid, target_stop) in &decisions {
-            let elev_eid = *elev_eid;
-            let target_stop = *target_stop;
+        for &(elev_eid, target_stop) in decisions.iter() {
             if let Some(car) = world.elevator_mut(elev_eid) {
                 car.phase = ElevatorPhase::Repositioning(target_stop);
                 car.target_stop = Some(target_stop);

--- a/crates/elevator-core/src/tests/reposition_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_tests.rs
@@ -118,7 +118,8 @@ fn spread_evenly_distributes_elevators() {
         .collect();
 
     let mut strategy = SpreadEvenly;
-    let result = strategy.reposition(&idle, &stop_pos, &group, &world);
+    let mut result = Vec::new();
+    strategy.reposition(&idle, &stop_pos, &group, &world, &mut result);
 
     // Both should move to new positions (they shouldn't stay where they are).
     assert!(
@@ -150,7 +151,8 @@ fn spread_evenly_single_stop_no_movement() {
     let stop_pos = vec![(stops[0], 0.0)];
 
     let mut strategy = SpreadEvenly;
-    let result = strategy.reposition(&idle, &stop_pos, &group, &world);
+    let mut result = Vec::new();
+    strategy.reposition(&idle, &stop_pos, &group, &world, &mut result);
     assert!(
         result.is_empty(),
         "no movement when already at the only stop"
@@ -172,7 +174,8 @@ fn spread_evenly_all_at_same_position() {
         .collect();
 
     let mut strategy = SpreadEvenly;
-    let result = strategy.reposition(&idle, &stop_pos, &group, &world);
+    let mut result = Vec::new();
+    strategy.reposition(&idle, &stop_pos, &group, &world, &mut result);
 
     // At least one should move away from the shared position.
     assert!(!result.is_empty());
@@ -196,7 +199,8 @@ fn return_to_lobby_sends_to_home() {
         .collect();
 
     let mut strategy = ReturnToLobby::new();
-    let result = strategy.reposition(&idle, &stop_pos, &group, &world);
+    let mut result = Vec::new();
+    strategy.reposition(&idle, &stop_pos, &group, &world, &mut result);
 
     assert_eq!(result.len(), 1);
     assert_eq!(result[0], (elev, stops[0]));
@@ -216,7 +220,8 @@ fn return_to_lobby_custom_home() {
         .collect();
 
     let mut strategy = ReturnToLobby::with_home(2);
-    let result = strategy.reposition(&idle, &stop_pos, &group, &world);
+    let mut result = Vec::new();
+    strategy.reposition(&idle, &stop_pos, &group, &world, &mut result);
 
     assert_eq!(result.len(), 1);
     assert_eq!(result[0], (elev, stops[2]));
@@ -236,7 +241,8 @@ fn return_to_lobby_already_at_home() {
         .collect();
 
     let mut strategy = ReturnToLobby::new();
-    let result = strategy.reposition(&idle, &stop_pos, &group, &world);
+    let mut result = Vec::new();
+    strategy.reposition(&idle, &stop_pos, &group, &world, &mut result);
 
     assert!(result.is_empty(), "no movement when already at home");
 }
@@ -272,7 +278,8 @@ fn demand_weighted_prefers_high_demand() {
         .collect();
 
     let mut strategy = DemandWeighted;
-    let result = strategy.reposition(&idle, &stop_pos, &group, &world);
+    let mut result = Vec::new();
+    strategy.reposition(&idle, &stop_pos, &group, &world, &mut result);
 
     assert_eq!(result.len(), 1);
     // Should move toward the highest-demand stop (stop 2).
@@ -293,7 +300,8 @@ fn nearest_idle_returns_empty() {
         .collect();
 
     let mut strategy = NearestIdle;
-    let result = strategy.reposition(&idle, &stop_pos, &group, &world);
+    let mut result = Vec::new();
+    strategy.reposition(&idle, &stop_pos, &group, &world, &mut result);
 
     assert!(result.is_empty(), "NearestIdle should never generate moves");
 }
@@ -322,7 +330,8 @@ fn spread_evenly_sends_idle_car_to_specific_stop() {
         .collect();
 
     let mut strategy = SpreadEvenly;
-    let result = strategy.reposition(&idle, &stop_pos, &group, &world);
+    let mut result = Vec::new();
+    strategy.reposition(&idle, &stop_pos, &group, &world, &mut result);
 
     assert_eq!(result.len(), 1, "one assignment expected");
     let (elev, target) = result[0];
@@ -346,18 +355,12 @@ fn spread_evenly_empty_inputs_return_empty() {
         .collect();
 
     let mut strategy = SpreadEvenly;
-    assert!(
-        strategy
-            .reposition(&[], &stop_pos, &group, &world)
-            .is_empty(),
-        "no idle elevators → empty result"
-    );
-    assert!(
-        strategy
-            .reposition(&[(EntityId::default(), 0.0)], &[], &group, &world)
-            .is_empty(),
-        "no stop positions → empty result"
-    );
+    let mut out = Vec::new();
+    strategy.reposition(&[], &stop_pos, &group, &world, &mut out);
+    assert!(out.is_empty(), "no idle elevators → empty result");
+    out.clear();
+    strategy.reposition(&[(EntityId::default(), 0.0)], &[], &group, &world, &mut out);
+    assert!(out.is_empty(), "no stop positions → empty result");
 }
 
 #[test]
@@ -375,15 +378,15 @@ fn return_to_lobby_targets_the_home_stop_specifically() {
         .map(|&sid| (sid, world.stop_position(sid).unwrap()))
         .collect();
 
-    // Default home is index 0, which is stops[0] at position 0.
+    let mut r = Vec::new();
     let mut rtl = ReturnToLobby::new();
-    let r = rtl.reposition(&idle, &stop_pos, &group, &world);
+    rtl.reposition(&idle, &stop_pos, &group, &world, &mut r);
     assert_eq!(r, vec![(elev, stops[0])]);
 
-    // with_home(2) picks stops[2] at position 20.0.
+    r.clear();
     let mut rtl2 = ReturnToLobby::with_home(2);
-    let r2 = rtl2.reposition(&idle, &stop_pos, &group, &world);
-    assert_eq!(r2, vec![(elev, stops[2])]);
+    rtl2.reposition(&idle, &stop_pos, &group, &world, &mut r);
+    assert_eq!(r, vec![(elev, stops[2])]);
 }
 
 #[test]
@@ -402,7 +405,8 @@ fn return_to_lobby_skips_cars_already_at_home() {
         .collect();
 
     let mut rtl = ReturnToLobby::new();
-    let r = rtl.reposition(&idle, &stop_pos, &group, &world);
+    let mut r = Vec::new();
+    rtl.reposition(&idle, &stop_pos, &group, &world, &mut r);
     assert_eq!(
         r,
         vec![(away, stops[0])],
@@ -421,16 +425,12 @@ fn demand_weighted_empty_inputs_return_empty() {
         .collect();
 
     let mut strategy = DemandWeighted;
-    assert!(
-        strategy
-            .reposition(&[], &stop_pos, &group, &world)
-            .is_empty()
-    );
-    assert!(
-        strategy
-            .reposition(&[(EntityId::default(), 0.0)], &[], &group, &world)
-            .is_empty()
-    );
+    let mut out = Vec::new();
+    strategy.reposition(&[], &stop_pos, &group, &world, &mut out);
+    assert!(out.is_empty());
+    out.clear();
+    strategy.reposition(&[(EntityId::default(), 0.0)], &[], &group, &world, &mut out);
+    assert!(out.is_empty());
 }
 
 // ===== Repositioning Integration Tests =====


### PR DESCRIPTION
## Summary
- **#140 Prelude expansion:** Added `World`, `StopConfig`, `ElevatorConfig`, `DispatchManifest`, `DispatchDecision`, `ElevatorGroup`, `ScanDispatch`, `LookDispatch`, `NearestCarDispatch`, `EtdDispatch` to the prelude. Removes the "5 extra imports" friction for game developers implementing custom dispatch.
- **#148 RepositionStrategy buffer pattern:** Changed `RepositionStrategy::reposition()` from returning `Vec<(EntityId, EntityId)>` to accepting `&mut Vec<(EntityId, EntityId)>` out-parameter. Eliminates per-tick heap allocation on the hot path.

**Breaking:** `RepositionStrategy::reposition()` signature changed — implementors must add `out: &mut Vec<(EntityId, EntityId)>` parameter and push into it instead of returning.

Closes #140, closes #148.

## Test plan
- [x] All 567 unit tests pass
- [x] All 43 doc tests pass
- [x] Zero clippy warnings (`--all-features`)
- [x] Pre-commit hook passes (fmt + clippy + tests + doctests)