### PR TITLE
feat!: snapshot restore errors and extension convenience

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "8.3.0"
+version = "9.0.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "cbindgen",
  "elevator-core",

--- a/crates/elevator-core/src/error.rs
+++ b/crates/elevator-core/src/error.rs
@@ -104,6 +104,13 @@ pub enum SimError {
     },
     /// Snapshot bytes are malformed or not a snapshot at all.
     SnapshotFormat(String),
+    /// A custom dispatch strategy in a snapshot could not be resolved.
+    UnresolvedCustomStrategy {
+        /// The strategy name stored in the snapshot.
+        name: String,
+        /// The group that references the strategy.
+        group: GroupId,
+    },
 }
 
 impl fmt::Display for SimError {
@@ -187,6 +194,13 @@ impl fmt::Display for SimError {
                 )
             }
             Self::SnapshotFormat(reason) => write!(f, "malformed snapshot: {reason}"),
+            Self::UnresolvedCustomStrategy { name, group } => {
+                write!(
+                    f,
+                    "custom dispatch strategy {name:?} for group {group} could not be resolved — \
+                     provide a factory that handles this name",
+                )
+            }
         }
     }
 }

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -22,18 +22,51 @@ impl Simulation {
     /// Call this after restoring from a snapshot and registering all
     /// extension types via `world.register_ext::<T>(key)`.
     ///
-    /// ```ignore
-    /// let mut sim = snapshot.restore(None);
-    /// sim.world_mut().register_ext::<VipTag>(ExtKey::from_type_name());
-    /// sim.load_extensions();
-    /// ```
-    pub fn load_extensions(&mut self) {
-        if let Some(pending) = self
+    /// Returns the names of any extension types present in the snapshot
+    /// that were not registered. An empty vec means all extensions were
+    /// deserialized successfully.
+    ///
+    /// Prefer [`load_extensions_with`](Self::load_extensions_with) which
+    /// combines registration and loading in one call.
+    pub fn load_extensions(&mut self) -> Vec<String> {
+        let Some(pending) = self
             .world
             .remove_resource::<crate::snapshot::PendingExtensions>()
-        {
-            self.world.deserialize_extensions(&pending.0);
-        }
+        else {
+            return Vec::new();
+        };
+        let unregistered = self.world.unregistered_ext_names(pending.0.keys());
+        self.world.deserialize_extensions(&pending.0);
+        unregistered
+    }
+
+    /// Register extension types and load their data from a snapshot
+    /// in one step.
+    ///
+    /// This is the recommended way to restore extensions. It replaces the
+    /// manual 3-step ceremony of `register_ext` → `load_extensions`:
+    ///
+    /// ```ignore
+    /// // Before:
+    /// let mut sim = snapshot.restore(None)?;
+    /// sim.world_mut().register_ext::<VipTag>(ExtKey::from_type_name());
+    /// sim.world_mut().register_ext::<TeamId>(ExtKey::from_type_name());
+    /// sim.load_extensions();
+    ///
+    /// // After:
+    /// let mut sim = snapshot.restore(None)?;
+    /// register_extensions!(sim.world_mut(), VipTag, TeamId);
+    /// sim.load_extensions();
+    /// ```
+    ///
+    /// Returns the names of any extension types in the snapshot that were
+    /// not registered. This catches "forgot to register" bugs at load time.
+    pub fn load_extensions_with<F>(&mut self, register: F) -> Vec<String>
+    where
+        F: FnOnce(&mut crate::world::World),
+    {
+        register(&mut self.world);
+        self.load_extensions()
     }
 
     // ── Helpers ──────────────────────────────────────────────────────

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -28,6 +28,7 @@ impl Simulation {
     ///
     /// Prefer [`load_extensions_with`](Self::load_extensions_with) which
     /// combines registration and loading in one call.
+    #[must_use]
     pub fn load_extensions(&mut self) -> Vec<String> {
         let Some(pending) = self
             .world
@@ -47,7 +48,7 @@ impl Simulation {
     /// manual 3-step ceremony of `register_ext` → `load_extensions`:
     ///
     /// ```ignore
-    /// // Before:
+    /// // Before (3-step ceremony):
     /// let mut sim = snapshot.restore(None)?;
     /// sim.world_mut().register_ext::<VipTag>(ExtKey::from_type_name());
     /// sim.world_mut().register_ext::<TeamId>(ExtKey::from_type_name());
@@ -55,12 +56,15 @@ impl Simulation {
     ///
     /// // After:
     /// let mut sim = snapshot.restore(None)?;
-    /// register_extensions!(sim.world_mut(), VipTag, TeamId);
-    /// sim.load_extensions();
+    /// let unregistered = sim.load_extensions_with(|world| {
+    ///     register_extensions!(world, VipTag, TeamId);
+    /// });
+    /// assert!(unregistered.is_empty(), "missing: {unregistered:?}");
     /// ```
     ///
     /// Returns the names of any extension types in the snapshot that were
     /// not registered. This catches "forgot to register" bugs at load time.
+    #[must_use]
     pub fn load_extensions_with<F>(&mut self, register: F) -> Vec<String>
     where
         F: FnOnce(&mut crate::world::World),

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -4,8 +4,9 @@
 //! (all entities, components, groups, metrics, tick counter) in a
 //! serializable form. Games choose the serialization format via serde.
 //!
-//! Extension components are NOT included — games must serialize their
-//! own extensions separately and re-attach them after restoring.
+//! Extension component *data* is included in the snapshot. After restoring,
+//! call [`Simulation::load_extensions_with`](crate::sim::Simulation::load_extensions_with)
+//! to register types and materialize the data.
 
 use crate::components::{
     AccessControl, CarCall, DestinationQueue, Elevator, HallCall, Line, Patience, Position,
@@ -157,15 +158,17 @@ impl WorldSnapshot {
     /// For `Custom` strategies, provide a factory function that maps strategy
     /// names to instances. Pass `None` if only using built-in strategies.
     ///
-    /// To restore extension components, call `world.register_ext::<T>(key)`
-    /// on the returned simulation's world for each extension type, then call
-    /// [`Simulation::load_extensions()`](crate::sim::Simulation::load_extensions)
-    /// with this snapshot's `extensions` data.
-    #[must_use]
+    /// # Errors
+    /// Returns [`SimError::UnresolvedCustomStrategy`](crate::error::SimError::UnresolvedCustomStrategy)
+    /// if a snapshot group uses a `Custom` strategy and the factory returns `None`.
+    ///
+    /// To restore extension components, call
+    /// [`Simulation::load_extensions_with`](crate::sim::Simulation::load_extensions_with)
+    /// on the returned simulation.
     pub fn restore(
         self,
         custom_strategy_factory: CustomStrategyFactory<'_>,
-    ) -> crate::sim::Simulation {
+    ) -> Result<crate::sim::Simulation, crate::error::SimError> {
         use crate::world::{SortedStops, World};
 
         let mut world = World::new();
@@ -189,7 +192,7 @@ impl WorldSnapshot {
 
         // Rebuild groups, stop lookup, dispatchers, and extensions (borrows self).
         let (mut groups, stop_lookup, dispatchers, strategy_ids) =
-            self.rebuild_groups_and_dispatchers(&index_to_id, custom_strategy_factory);
+            self.rebuild_groups_and_dispatchers(&index_to_id, custom_strategy_factory)?;
 
         // Fix legacy snapshots: synthetic LineInfo entries with EntityId::default()
         // need real line entities spawned in the world.
@@ -261,7 +264,7 @@ impl WorldSnapshot {
             }
         }
 
-        sim
+        Ok(sim)
     }
 
     /// Spawn entities in the world and build the old→new `EntityId` mapping.
@@ -431,12 +434,15 @@ impl WorldSnapshot {
         &self,
         index_to_id: &[EntityId],
         custom_strategy_factory: CustomStrategyFactory<'_>,
-    ) -> (
-        Vec<crate::dispatch::ElevatorGroup>,
-        HashMap<StopId, EntityId>,
-        std::collections::BTreeMap<GroupId, Box<dyn crate::dispatch::DispatchStrategy>>,
-        std::collections::BTreeMap<GroupId, crate::dispatch::BuiltinStrategy>,
-    ) {
+    ) -> Result<
+        (
+            Vec<crate::dispatch::ElevatorGroup>,
+            HashMap<StopId, EntityId>,
+            std::collections::BTreeMap<GroupId, Box<dyn crate::dispatch::DispatchStrategy>>,
+            std::collections::BTreeMap<GroupId, crate::dispatch::BuiltinStrategy>,
+        ),
+        crate::error::SimError,
+    > {
         use crate::dispatch::ElevatorGroup;
 
         let groups: Vec<ElevatorGroup> = self
@@ -497,22 +503,24 @@ impl WorldSnapshot {
         let mut dispatchers = std::collections::BTreeMap::new();
         let mut strategy_ids = std::collections::BTreeMap::new();
         for (gs, group) in self.groups.iter().zip(groups.iter()) {
-            let strategy: Box<dyn crate::dispatch::DispatchStrategy> = gs
-                .strategy
-                .instantiate()
-                .or_else(|| {
-                    if let crate::dispatch::BuiltinStrategy::Custom(ref name) = gs.strategy {
-                        custom_strategy_factory.and_then(|f| f(name))
-                    } else {
-                        None
-                    }
-                })
-                .unwrap_or_else(|| Box::new(crate::dispatch::scan::ScanDispatch::new()));
+            let strategy: Box<dyn crate::dispatch::DispatchStrategy> =
+                if let Some(builtin) = gs.strategy.instantiate() {
+                    builtin
+                } else if let crate::dispatch::BuiltinStrategy::Custom(ref name) = gs.strategy {
+                    custom_strategy_factory
+                        .and_then(|f| f(name))
+                        .ok_or_else(|| crate::error::SimError::UnresolvedCustomStrategy {
+                            name: name.clone(),
+                            group: group.id(),
+                        })?
+                } else {
+                    Box::new(crate::dispatch::scan::ScanDispatch::new())
+                };
             dispatchers.insert(group.id(), strategy);
             strategy_ids.insert(group.id(), gs.strategy.clone());
         }
 
-        (groups, stop_lookup, dispatchers, strategy_ids)
+        Ok((groups, stop_lookup, dispatchers, strategy_ids))
     }
 
     /// Remap `EntityId`s in extension data using the old→new mapping.
@@ -682,11 +690,10 @@ impl crate::sim::Simulation {
     /// [`SimError::SnapshotVersion`](crate::error::SimError::SnapshotVersion).
     ///
     /// Extension component *data* is serialized (identical to
-    /// [`Simulation::snapshot`]); after restore you must still call
-    /// `world.register_ext::<T>(key)` for each extension type and then
-    /// [`Simulation::load_extensions`] to materialize them. Custom
-    /// dispatch strategies and arbitrary `World` resources are not
-    /// included.
+    /// [`Simulation::snapshot`]); after restore, use
+    /// [`Simulation::load_extensions_with`] to register and load them.
+    /// Custom dispatch strategies and arbitrary `World` resources are
+    /// not included.
     ///
     /// # Errors
     /// Returns [`SimError::SnapshotFormat`](crate::error::SimError::SnapshotFormat)
@@ -715,6 +722,8 @@ impl crate::sim::Simulation {
     ///   not match.
     /// - [`SimError::SnapshotVersion`](crate::error::SimError::SnapshotVersion)
     ///   if the blob was produced by a different crate version.
+    /// - [`SimError::UnresolvedCustomStrategy`](crate::error::SimError::UnresolvedCustomStrategy)
+    ///   if a group uses a custom strategy that the factory cannot resolve.
     pub fn restore_bytes(
         bytes: &[u8],
         custom_strategy_factory: CustomStrategyFactory<'_>,
@@ -740,6 +749,6 @@ impl crate::sim::Simulation {
                 current: current.to_owned(),
             });
         }
-        Ok(envelope.payload.restore(custom_strategy_factory))
+        envelope.payload.restore(custom_strategy_factory)
     }
 }

--- a/crates/elevator-core/src/tests/destination_queue_tests.rs
+++ b/crates/elevator-core/src/tests/destination_queue_tests.rs
@@ -253,7 +253,7 @@ fn snapshot_roundtrip_preserves_queue() {
     sim.push_destination(elev, s0).unwrap();
 
     let snapshot = sim.snapshot();
-    let restored = snapshot.restore(None);
+    let restored = snapshot.restore(None).unwrap();
     let new_elev = restored.world().elevator_ids()[0];
 
     let restored_queue = restored.destination_queue(new_elev).unwrap();

--- a/crates/elevator-core/src/tests/direction_indicator_tests.rs
+++ b/crates/elevator-core/src/tests/direction_indicator_tests.rs
@@ -284,7 +284,7 @@ fn snapshot_roundtrip_preserves_indicators() {
     assert_eq!(sim.elevator_going_down(elev), Some(false));
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None);
+    let restored = snap.restore(None).unwrap();
     let restored_elev = restored.world().elevator_ids()[0];
 
     assert_eq!(restored.elevator_going_up(restored_elev), Some(true));

--- a/crates/elevator-core/src/tests/move_count_tests.rs
+++ b/crates/elevator-core/src/tests/move_count_tests.rs
@@ -256,7 +256,7 @@ fn move_count_persists_across_snapshot() {
     let per_elev_before = sim.elevator_move_count(elev).unwrap();
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None);
+    let restored = snap.restore(None).unwrap();
 
     assert_eq!(restored.metrics().total_moves(), moves_before);
     let restored_elev = restored

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -2519,7 +2519,7 @@ fn snapshot_roundtrip_preserves_multi_group_topology() {
     let sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None);
+    let restored = snap.restore(None).unwrap();
 
     // Both groups must survive.
     assert_eq!(
@@ -2560,7 +2560,7 @@ fn snapshot_roundtrip_elevator_line_reference_is_valid() {
     let orig_g1_line = sim.world().elevator(orig_g1_elev).unwrap().line();
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None);
+    let restored = snap.restore(None).unwrap();
 
     // In the restored sim, each elevator's line reference must still point to a
     // valid line entity (even though EntityIds are remapped).

--- a/crates/elevator-core/src/tests/resident_tests.rs
+++ b/crates/elevator-core/src/tests/resident_tests.rs
@@ -338,7 +338,7 @@ fn snapshot_roundtrip_preserves_residents() {
 
     // Snapshot and restore.
     let snapshot = sim.snapshot();
-    let restored = snapshot.restore(None);
+    let restored = snapshot.restore(None).unwrap();
 
     // Verify residents are in the index after restore.
     // Entity IDs may be remapped, so find the resident rider.

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -17,7 +17,7 @@ fn snapshot_roundtrip_preserves_tick() {
     let snap = sim.snapshot();
     assert_eq!(snap.tick, 100);
 
-    let restored = snap.restore(None);
+    let restored = snap.restore(None).unwrap();
     assert_eq!(restored.current_tick(), 100);
 }
 
@@ -37,7 +37,7 @@ fn snapshot_roundtrip_preserves_riders() {
     }
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None);
+    let restored = snap.restore(None).unwrap();
 
     // Rider count should match.
     let original_count = sim.world().iter_riders().count();
@@ -51,7 +51,7 @@ fn snapshot_roundtrip_preserves_stop_lookup() {
     let sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None);
+    let restored = snap.restore(None).unwrap();
 
     // All stop IDs should resolve.
     assert!(restored.stop_entity(StopId(0)).is_some());
@@ -71,7 +71,7 @@ fn snapshot_roundtrip_preserves_metrics() {
 
     let original_delivered = sim.metrics().total_delivered();
     let snap = sim.snapshot();
-    let restored = snap.restore(None);
+    let restored = snap.restore(None).unwrap();
 
     assert_eq!(restored.metrics().total_delivered(), original_delivered);
 }
@@ -107,7 +107,7 @@ fn restored_sim_can_continue_stepping() {
     }
 
     let snap = sim.snapshot();
-    let mut restored = snap.restore(None);
+    let mut restored = snap.restore(None).unwrap();
 
     // Should be able to keep stepping without panics.
     for _ in 0..200 {
@@ -130,7 +130,7 @@ fn snapshot_remaps_entity_ids_for_mid_route_riders() {
     }
 
     let snap = sim.snapshot();
-    let mut restored = snap.restore(None);
+    let mut restored = snap.restore(None).unwrap();
 
     // Riders should still have valid routes pointing to real stops.
     for (_, rider) in restored.world().iter_riders() {
@@ -172,7 +172,7 @@ fn snapshot_roundtrip_via_ron_preserves_cross_references() {
     let snap = sim.snapshot();
     let ron_str = ron::to_string(&snap).unwrap();
     let deserialized: crate::snapshot::WorldSnapshot = ron::from_str(&ron_str).unwrap();
-    let mut restored = deserialized.restore(None);
+    let mut restored = deserialized.restore(None).unwrap();
 
     // Should complete without panics and deliver riders.
     for _ in 0..2000 {
@@ -201,7 +201,7 @@ fn snapshot_preserves_metric_tags() {
     assert!(original_spawned > 0);
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None);
+    let restored = snap.restore(None).unwrap();
 
     let restored_spawned = restored
         .metrics_for_tag("zone:lobby")
@@ -225,7 +225,7 @@ fn snapshot_preserves_extension_components() {
         .insert_ext(rider, VipTag { level: 5 }, ExtKey::from_type_name());
 
     let snap = sim.snapshot();
-    let mut restored = snap.restore(None);
+    let mut restored = snap.restore(None).unwrap();
 
     // Register the extension type on the restored world, then load.
     restored
@@ -242,6 +242,65 @@ fn snapshot_preserves_extension_components() {
         }
     }
     assert!(found, "VipTag extension should survive snapshot roundtrip");
+}
+
+#[test]
+fn load_extensions_with_convenience() {
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct VipTag {
+        level: u32,
+    }
+
+    let config = helpers::default_config();
+    let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.world_mut()
+        .insert_ext(rider, VipTag { level: 3 }, ExtKey::from_type_name());
+
+    let snap = sim.snapshot();
+    let mut restored = snap.restore(None).unwrap();
+
+    let unregistered = restored.load_extensions_with(|world| {
+        world.register_ext::<VipTag>(ExtKey::from_type_name());
+    });
+    assert!(
+        unregistered.is_empty(),
+        "all extensions should be registered: {unregistered:?}"
+    );
+
+    let mut found = false;
+    for (rid, _) in restored.world().iter_riders() {
+        if let Some(tag) = restored.world().ext::<VipTag>(rid) {
+            assert_eq!(tag.level, 3);
+            found = true;
+        }
+    }
+    assert!(
+        found,
+        "VipTag should survive load_extensions_with roundtrip"
+    );
+}
+
+#[test]
+fn load_extensions_reports_unregistered_types() {
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct VipTag {
+        level: u32,
+    }
+
+    let config = helpers::default_config();
+    let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.world_mut()
+        .insert_ext(rider, VipTag { level: 1 }, ExtKey::from_type_name());
+
+    let snap = sim.snapshot();
+    let mut restored = snap.restore(None).unwrap();
+
+    // Load without registering VipTag — should report it as unregistered.
+    let unregistered = restored.load_extensions();
+    assert_eq!(unregistered.len(), 1);
+    assert!(unregistered[0].contains("VipTag"));
 }
 
 #[test]
@@ -390,7 +449,7 @@ fn snapshot_preserves_hall_calls_and_pinning() {
     sim.pin_assignment(car, stop, CallDirection::Up).unwrap();
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None);
+    let restored = snap.restore(None).unwrap();
 
     let restored_stop = restored.stop_entity(StopId(1)).unwrap();
     let call = restored
@@ -421,7 +480,7 @@ fn snapshot_preserves_car_calls() {
     assert_eq!(sim.car_calls(car).len(), 1);
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None);
+    let restored = snap.restore(None).unwrap();
 
     let restored_car = restored.world().elevator_ids()[0];
     let calls = restored.car_calls(restored_car);
@@ -440,7 +499,7 @@ fn snapshot_preserves_group_hall_mode_and_ack_latency() {
     sim.groups_mut()[0].set_ack_latency_ticks(12);
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None);
+    let restored = snap.restore(None).unwrap();
 
     assert_eq!(
         restored.groups()[0].hall_call_mode(),
@@ -473,7 +532,7 @@ fn snapshot_preserves_hall_call_ack_state_under_latency() {
         .press_tick;
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None);
+    let restored = snap.restore(None).unwrap();
 
     let restored_stop = restored.stop_entity(StopId(1)).unwrap();
     let call = restored

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -231,7 +231,8 @@ fn snapshot_preserves_extension_components() {
     restored
         .world_mut()
         .register_ext::<VipTag>(ExtKey::from_type_name());
-    restored.load_extensions();
+    let unregistered = restored.load_extensions();
+    assert!(unregistered.is_empty());
 
     // Find the rider in the restored world and check the extension.
     let mut found = false;

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -817,6 +817,19 @@ impl World {
         }
     }
 
+    /// Return names from `snapshot_names` that have no registered extension type.
+    pub(crate) fn unregistered_ext_names<'a>(
+        &self,
+        snapshot_names: impl Iterator<Item = &'a String>,
+    ) -> Vec<String> {
+        let registered: std::collections::HashSet<&str> =
+            self.ext_names.values().map(String::as_str).collect();
+        snapshot_names
+            .filter(|name| !registered.contains(name.as_str()))
+            .cloned()
+            .collect()
+    }
+
     /// Register an extension type for deserialization (creates empty storage).
     ///
     /// Must be called before `restore()` for each extension type that was

--- a/crates/elevator-core/tests/snapshot_roundtrip.rs
+++ b/crates/elevator-core/tests/snapshot_roundtrip.rs
@@ -26,7 +26,7 @@ fn snapshot_roundtrip_preserves_state() {
     let snap = sim.snapshot();
     let ron_str = ron::to_string(&snap).unwrap();
     let snap2: WorldSnapshot = ron::from_str(&ron_str).unwrap();
-    let restored = snap2.restore(None);
+    let restored = snap2.restore(None).unwrap();
 
     assert_eq!(restored.current_tick(), original_tick);
     assert_eq!(restored.metrics().total_delivered(), original_delivered);
@@ -70,7 +70,7 @@ fn snapshot_roundtrip_remaps_repositioning_phase() {
     let snap = sim.snapshot();
     let ron_str = ron::to_string(&snap).unwrap();
     let snap2: WorldSnapshot = ron::from_str(&ron_str).unwrap();
-    let restored = snap2.restore(None);
+    let restored = snap2.restore(None).unwrap();
 
     // The elevator must still be in Repositioning, and its target stop
     // entity must resolve to a real stop in the restored world.


### PR DESCRIPTION
## Summary
- **#142 Custom strategy errors:** `WorldSnapshot::restore()` now returns `Result<Simulation, SimError>`. If a snapshot group uses `Custom("name")` and the factory can't resolve it, restore returns `SimError::UnresolvedCustomStrategy` instead of silently falling back to ScanDispatch. This catches typos and strategy renames at load time.
- **#137 Extension restore convenience:** Added `Simulation::load_extensions_with(|world| { ... })` which combines type registration and loading in one call. `load_extensions()` now returns `Vec<String>` of unregistered extension type names, catching the "forgot to register" bug at load time.

**Breaking:** `WorldSnapshot::restore()` returns `Result` instead of `Simulation` directly. All callers must add `.unwrap()` or `?`.

Closes #137, closes #142.

## Test plan
- [x] All 569 unit tests pass (2 new)
- [x] All 43 doc tests pass
- [x] Zero clippy warnings (`--all-features`)
- [x] Pre-commit hook passes