### PR TITLE
feat!: typed ElevatorId and RiderId for compile-time entity safety

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "9.0.0"
+version = "11.0.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.6.0"
+version = "0.8.0"
 dependencies = [
  "cbindgen",
  "elevator-core",

--- a/crates/elevator-core/examples/custom_dispatch.rs
+++ b/crates/elevator-core/examples/custom_dispatch.rs
@@ -153,7 +153,7 @@ fn main() {
     // does. That's the escape hatch games use to compose custom
     // dispatch with building scripts, cutscenes, or DCS overrides.
     let mezzanine = sim.stop_entity(StopId(1)).unwrap();
-    let lobby_car = sim.world().elevator_ids()[0];
+    let lobby_car = ElevatorId::from(sim.world().elevator_ids()[0]);
     sim.press_hall_button(mezzanine, CallDirection::Up).unwrap();
     sim.pin_assignment(lobby_car, mezzanine, CallDirection::Up)
         .unwrap();

--- a/crates/elevator-core/examples/door_commands.rs
+++ b/crates/elevator-core/examples/door_commands.rs
@@ -42,13 +42,13 @@ fn main() {
         .build()
         .unwrap();
 
-    let elev = sim.world().iter_elevators().next().unwrap().0;
+    let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
 
     // First rider heading up from the lobby.
     let first = sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
 
     let mut held = false;
-    let mut friend: Option<EntityId> = None;
+    let mut friend: Option<RiderId> = None;
     let mut forced_close = false;
 
     for tick in 0..400 {
@@ -57,7 +57,7 @@ fn main() {
         // The moment the first rider is aboard, hold the doors for a friend.
         if !held
             && matches!(
-                sim.world().rider(first).unwrap().phase(),
+                sim.world().rider(first.entity()).unwrap().phase(),
                 RiderPhase::Boarding(_) | RiderPhase::Riding(_)
             )
         {
@@ -73,7 +73,10 @@ fn main() {
         // Once friend is aboard too, force the doors shut.
         if !forced_close
             && let Some(f) = friend
-            && matches!(sim.world().rider(f).unwrap().phase(), RiderPhase::Riding(_))
+            && matches!(
+                sim.world().rider(f.entity()).unwrap().phase(),
+                RiderPhase::Riding(_)
+            )
         {
             println!("[t={tick:>3}] Both aboard — forcing doors closed");
             sim.close_door(elev).unwrap();
@@ -82,7 +85,7 @@ fn main() {
 
         if forced_close
             && matches!(
-                sim.world().elevator(elev).unwrap().phase(),
+                sim.world().elevator(elev.entity()).unwrap().phase(),
                 ElevatorPhase::MovingToStop(_)
             )
         {

--- a/crates/elevator-core/examples/extensions.rs
+++ b/crates/elevator-core/examples/extensions.rs
@@ -19,8 +19,11 @@ fn main() {
 
     // Spawn a rider and tag them as VIP.
     let rider = sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
-    sim.world_mut()
-        .insert_ext(rider, VipTag { level: 5 }, ExtKey::from_type_name());
+    sim.world_mut().insert_ext(
+        rider.entity(),
+        VipTag { level: 5 },
+        ExtKey::from_type_name(),
+    );
 
     // Query extension components.
     for (id, vip) in sim.world().query::<(EntityId, &Ext<VipTag>)>().iter() {

--- a/crates/elevator-core/examples/manual_driver.rs
+++ b/crates/elevator-core/examples/manual_driver.rs
@@ -17,9 +17,10 @@ use elevator_core::prelude::*;
 
 fn main() {
     let mut sim = SimulationBuilder::demo().build().unwrap();
-    let elev = sim.world().iter_elevators().next().unwrap().0;
+    let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
 
-    sim.set_service_mode(elev, ServiceMode::Manual).unwrap();
+    sim.set_service_mode(elev.entity(), ServiceMode::Manual)
+        .unwrap();
 
     // Phase 1: command full ascent.
     sim.set_target_velocity(elev, 2.0).unwrap();
@@ -34,8 +35,8 @@ fn main() {
         }
         sim.step();
 
-        let pos = sim.world().position(elev).unwrap().value();
-        let vel = sim.velocity(elev).unwrap();
+        let pos = sim.world().position(elev.entity()).unwrap().value();
+        let vel = sim.velocity(elev.entity()).unwrap();
         let phase = if t < 90 { "ascending " } else { "e-stopping" };
         println!("{t:>4}  {phase}  {pos:>5.2}m  {vel:>5.2}");
 

--- a/crates/elevator-core/examples/runtime_upgrades.rs
+++ b/crates/elevator-core/examples/runtime_upgrades.rs
@@ -71,8 +71,13 @@ fn run_baseline() -> (u64, f64) {
 
 fn run_upgraded() -> (u64, f64) {
     let mut sim = make_sim();
-    let elev = sim.world().iter_elevators().next().unwrap().0;
-    let baseline_speed = sim.world().elevator(elev).unwrap().max_speed().value();
+    let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
+    let baseline_speed = sim
+        .world()
+        .elevator(elev.entity())
+        .unwrap()
+        .max_speed()
+        .value();
 
     for tick in 0..TOTAL_TICKS {
         spawn_wave(&mut sim, tick);

--- a/crates/elevator-core/examples/showcase.rs
+++ b/crates/elevator-core/examples/showcase.rs
@@ -214,11 +214,14 @@ fn part3_extensions() {
 
     // Spawn a rider and attach the VIP extension.
     let rider = sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
-    sim.world_mut()
-        .insert_ext(rider, VipTag { level: 3 }, ExtKey::from_type_name());
+    sim.world_mut().insert_ext(
+        rider.entity(),
+        VipTag { level: 3 },
+        ExtKey::from_type_name(),
+    );
 
     // Read the extension back.
-    let vip: Option<VipTag> = sim.world().ext::<VipTag>(rider);
+    let vip: Option<VipTag> = sim.world().ext::<VipTag>(rider.entity());
     println!("Rider {rider:?} VIP tag: {vip:?}");
 
     // Extensions are arbitrary typed data — useful for game-specific components
@@ -321,7 +324,8 @@ fn part5_metrics_deep_dive() {
 
     // Tag a rider individually for a different dimension.
     let special = sim.spawn_rider(StopId(0), StopId(1), 60.0).unwrap();
-    sim.tag_entity(special, "priority:express").unwrap();
+    sim.tag_entity(special.entity(), "priority:express")
+        .unwrap();
 
     // Run enough ticks for deliveries.
     for _ in 0..600 {

--- a/crates/elevator-core/src/entity.rs
+++ b/crates/elevator-core/src/entity.rs
@@ -1,7 +1,61 @@
 //! Entity identity and allocation via generational keys.
 
+use serde::{Deserialize, Serialize};
+
 slotmap::new_key_type! {
     /// Universal entity identifier used across all component storages.
     /// Serialize/Deserialize provided by slotmap's `serde` feature.
     pub struct EntityId;
+}
+
+/// Generates a typed newtype wrapper around [`EntityId`].
+///
+/// Each wrapper is `#[repr(transparent)]` with a public inner field for
+/// convenient internal access via `.0`, and delegates `Display` to
+/// `EntityId`'s `Debug` (since slotmap keys do not implement `Display`).
+macro_rules! typed_entity_id {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[serde(transparent)]
+        #[repr(transparent)]
+        pub struct $name(pub EntityId);
+
+        impl $name {
+            /// Returns the inner [`EntityId`].
+            #[inline]
+            pub const fn entity(self) -> EntityId {
+                self.0
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}({:?})", stringify!($name), self.0)
+            }
+        }
+
+        impl From<EntityId> for $name {
+            #[inline]
+            fn from(id: EntityId) -> Self {
+                Self(id)
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self(EntityId::default())
+            }
+        }
+    };
+}
+
+typed_entity_id! {
+    /// Typed wrapper around [`EntityId`] for elevator entities.
+    ElevatorId
+}
+
+typed_entity_id! {
+    /// Typed wrapper around [`EntityId`] for rider entities.
+    RiderId
 }

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -521,7 +521,7 @@ pub mod prelude {
         ElevatorGroup, EtdDispatch, LookDispatch, NearestCarDispatch, RankContext,
         RepositionStrategy, ScanDispatch,
     };
-    pub use crate::entity::EntityId;
+    pub use crate::entity::{ElevatorId, EntityId, RiderId};
     pub use crate::error::{EtaError, RejectionContext, RejectionReason, SimError};
     pub use crate::events::{Event, EventBus, EventCategory};
     pub use crate::ids::GroupId;

--- a/crates/elevator-core/src/query/mod.rs
+++ b/crates/elevator-core/src/query/mod.rs
@@ -15,7 +15,7 @@
 //! let rider_eid = sim.spawn_rider(StopId(0), StopId(1), 75.0).unwrap();
 //!
 //! // Attach an extension component.
-//! sim.world_mut().insert_ext(rider_eid, VipTag { level: 5 }, ExtKey::from_type_name());
+//! sim.world_mut().insert_ext(rider_eid.entity(), VipTag { level: 5 }, ExtKey::from_type_name());
 //!
 //! let world = sim.world();
 //!

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -72,7 +72,7 @@ use crate::components::{
     SpatialPosition, Speed, Velocity, Weight,
 };
 use crate::dispatch::{BuiltinReposition, DispatchStrategy, ElevatorGroup, RepositionStrategy};
-use crate::entity::EntityId;
+use crate::entity::{ElevatorId, EntityId, RiderId};
 use crate::error::{EtaError, SimError};
 use crate::events::{Event, EventBus};
 use crate::hooks::{Phase, PhaseHooks};
@@ -247,7 +247,7 @@ impl RiderBuilder<'_> {
     /// Returns [`SimError::GroupNotFound`] if an explicit group does not exist.
     /// Returns [`SimError::RouteOriginMismatch`] if an explicit route's first leg
     /// does not start at `origin`.
-    pub fn spawn(self) -> Result<EntityId, SimError> {
+    pub fn spawn(self) -> Result<RiderId, SimError> {
         let route = if let Some(route) = self.route {
             // Validate route origin matches the spawn origin.
             if let Some(leg) = route.current()
@@ -332,7 +332,7 @@ impl RiderBuilder<'_> {
             self.sim.world.set_access_control(eid, ac);
         }
 
-        Ok(eid)
+        Ok(RiderId::from(eid))
     }
 }
 
@@ -512,7 +512,8 @@ impl Simulation {
     /// Returns `None` if `elev` is not an elevator entity. Returns
     /// `Some(&[])` for elevators with an empty queue.
     #[must_use]
-    pub fn destination_queue(&self, elev: EntityId) -> Option<&[EntityId]> {
+    pub fn destination_queue(&self, elev: ElevatorId) -> Option<&[EntityId]> {
+        let elev = elev.entity();
         self.world
             .destination_queue(elev)
             .map(crate::components::DestinationQueue::queue)
@@ -530,9 +531,10 @@ impl Simulation {
     /// - [`SimError::NotAStop`] if `stop` is not a stop.
     pub fn push_destination(
         &mut self,
-        elev: EntityId,
+        elev: ElevatorId,
         stop: impl Into<StopRef>,
     ) -> Result<(), SimError> {
+        let elev = elev.entity();
         let stop = self.resolve_stop(stop.into())?;
         self.validate_push_targets(elev, stop)?;
         let appended = self
@@ -565,9 +567,10 @@ impl Simulation {
     /// - [`SimError::NotAStop`] if `stop` is not a stop.
     pub fn push_destination_front(
         &mut self,
-        elev: EntityId,
+        elev: ElevatorId,
         stop: impl Into<StopRef>,
     ) -> Result<(), SimError> {
+        let elev = elev.entity();
         let stop = self.resolve_stop(stop.into())?;
         self.validate_push_targets(elev, stop)?;
         let inserted = self
@@ -594,7 +597,8 @@ impl Simulation {
     /// # Errors
     ///
     /// Returns [`SimError::NotAnElevator`] if `elev` is not an elevator.
-    pub fn clear_destinations(&mut self, elev: EntityId) -> Result<(), SimError> {
+    pub fn clear_destinations(&mut self, elev: ElevatorId) -> Result<(), SimError> {
+        let elev = elev.entity();
         if self.world.elevator(elev).is_none() {
             return Err(SimError::NotAnElevator(elev));
         }
@@ -642,7 +646,8 @@ impl Simulation {
     /// with no mid-trip insertions; dispatch decisions, manual door commands,
     /// and rider boarding/exiting beyond the configured dwell will perturb
     /// the actual arrival.
-    pub fn eta(&self, elev: EntityId, stop: EntityId) -> Result<Duration, EtaError> {
+    pub fn eta(&self, elev: ElevatorId, stop: EntityId) -> Result<Duration, EtaError> {
+        let elev = elev.entity();
         let elevator = self
             .world
             .elevator(elev)
@@ -770,7 +775,7 @@ impl Simulation {
                 if !direction_ok {
                     return None;
                 }
-                self.eta(eid, stop).ok().map(|d| (eid, d))
+                self.eta(ElevatorId::from(eid), stop).ok().map(|d| (eid, d))
             })
             .min_by_key(|(_, d)| *d)
     }
@@ -818,11 +823,12 @@ impl Simulation {
     /// use elevator_core::prelude::*;
     ///
     /// let mut sim = SimulationBuilder::demo().build().unwrap();
-    /// let elev = sim.world().iter_elevators().next().unwrap().0;
+    /// let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     /// sim.set_max_speed(elev, 4.0).unwrap();
-    /// assert_eq!(sim.world().elevator(elev).unwrap().max_speed().value(), 4.0);
+    /// assert_eq!(sim.world().elevator(elev.entity()).unwrap().max_speed().value(), 4.0);
     /// ```
-    pub fn set_max_speed(&mut self, elevator: EntityId, speed: f64) -> Result<(), SimError> {
+    pub fn set_max_speed(&mut self, elevator: ElevatorId, speed: f64) -> Result<(), SimError> {
+        let elevator = elevator.entity();
         Self::validate_positive_finite_f64(speed, "elevators.max_speed")?;
         let old = self.require_elevator(elevator)?.max_speed.value();
         let speed = Speed::from(speed);
@@ -854,11 +860,12 @@ impl Simulation {
     /// use elevator_core::prelude::*;
     ///
     /// let mut sim = SimulationBuilder::demo().build().unwrap();
-    /// let elev = sim.world().iter_elevators().next().unwrap().0;
+    /// let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     /// sim.set_acceleration(elev, 3.0).unwrap();
-    /// assert_eq!(sim.world().elevator(elev).unwrap().acceleration().value(), 3.0);
+    /// assert_eq!(sim.world().elevator(elev.entity()).unwrap().acceleration().value(), 3.0);
     /// ```
-    pub fn set_acceleration(&mut self, elevator: EntityId, accel: f64) -> Result<(), SimError> {
+    pub fn set_acceleration(&mut self, elevator: ElevatorId, accel: f64) -> Result<(), SimError> {
+        let elevator = elevator.entity();
         Self::validate_positive_finite_f64(accel, "elevators.acceleration")?;
         let old = self.require_elevator(elevator)?.acceleration.value();
         let accel = Accel::from(accel);
@@ -890,11 +897,12 @@ impl Simulation {
     /// use elevator_core::prelude::*;
     ///
     /// let mut sim = SimulationBuilder::demo().build().unwrap();
-    /// let elev = sim.world().iter_elevators().next().unwrap().0;
+    /// let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     /// sim.set_deceleration(elev, 3.5).unwrap();
-    /// assert_eq!(sim.world().elevator(elev).unwrap().deceleration().value(), 3.5);
+    /// assert_eq!(sim.world().elevator(elev.entity()).unwrap().deceleration().value(), 3.5);
     /// ```
-    pub fn set_deceleration(&mut self, elevator: EntityId, decel: f64) -> Result<(), SimError> {
+    pub fn set_deceleration(&mut self, elevator: ElevatorId, decel: f64) -> Result<(), SimError> {
+        let elevator = elevator.entity();
         Self::validate_positive_finite_f64(decel, "elevators.deceleration")?;
         let old = self.require_elevator(elevator)?.deceleration.value();
         let decel = Accel::from(decel);
@@ -929,15 +937,16 @@ impl Simulation {
     /// use elevator_core::prelude::*;
     ///
     /// let mut sim = SimulationBuilder::demo().build().unwrap();
-    /// let elev = sim.world().iter_elevators().next().unwrap().0;
+    /// let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     /// sim.set_weight_capacity(elev, 1200.0).unwrap();
-    /// assert_eq!(sim.world().elevator(elev).unwrap().weight_capacity().value(), 1200.0);
+    /// assert_eq!(sim.world().elevator(elev.entity()).unwrap().weight_capacity().value(), 1200.0);
     /// ```
     pub fn set_weight_capacity(
         &mut self,
-        elevator: EntityId,
+        elevator: ElevatorId,
         capacity: f64,
     ) -> Result<(), SimError> {
+        let elevator = elevator.entity();
         Self::validate_positive_finite_f64(capacity, "elevators.weight_capacity")?;
         let old = self.require_elevator(elevator)?.weight_capacity.value();
         let capacity = Weight::from(capacity);
@@ -969,15 +978,16 @@ impl Simulation {
     /// use elevator_core::prelude::*;
     ///
     /// let mut sim = SimulationBuilder::demo().build().unwrap();
-    /// let elev = sim.world().iter_elevators().next().unwrap().0;
+    /// let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     /// sim.set_door_transition_ticks(elev, 3).unwrap();
-    /// assert_eq!(sim.world().elevator(elev).unwrap().door_transition_ticks(), 3);
+    /// assert_eq!(sim.world().elevator(elev.entity()).unwrap().door_transition_ticks(), 3);
     /// ```
     pub fn set_door_transition_ticks(
         &mut self,
-        elevator: EntityId,
+        elevator: ElevatorId,
         ticks: u32,
     ) -> Result<(), SimError> {
+        let elevator = elevator.entity();
         Self::validate_nonzero_u32(ticks, "elevators.door_transition_ticks")?;
         let old = self.require_elevator(elevator)?.door_transition_ticks;
         if let Some(car) = self.world.elevator_mut(elevator) {
@@ -1009,11 +1019,16 @@ impl Simulation {
     /// use elevator_core::prelude::*;
     ///
     /// let mut sim = SimulationBuilder::demo().build().unwrap();
-    /// let elev = sim.world().iter_elevators().next().unwrap().0;
+    /// let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     /// sim.set_door_open_ticks(elev, 20).unwrap();
-    /// assert_eq!(sim.world().elevator(elev).unwrap().door_open_ticks(), 20);
+    /// assert_eq!(sim.world().elevator(elev.entity()).unwrap().door_open_ticks(), 20);
     /// ```
-    pub fn set_door_open_ticks(&mut self, elevator: EntityId, ticks: u32) -> Result<(), SimError> {
+    pub fn set_door_open_ticks(
+        &mut self,
+        elevator: ElevatorId,
+        ticks: u32,
+    ) -> Result<(), SimError> {
+        let elevator = elevator.entity();
         Self::validate_nonzero_u32(ticks, "elevators.door_open_ticks")?;
         let old = self.require_elevator(elevator)?.door_open_ticks;
         if let Some(car) = self.world.elevator_mut(elevator) {
@@ -1057,10 +1072,11 @@ impl Simulation {
     /// use elevator_core::prelude::*;
     ///
     /// let mut sim = SimulationBuilder::demo().build().unwrap();
-    /// let elev = sim.world().iter_elevators().next().unwrap().0;
+    /// let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     /// sim.open_door(elev).unwrap();
     /// ```
-    pub fn open_door(&mut self, elevator: EntityId) -> Result<(), SimError> {
+    pub fn open_door(&mut self, elevator: ElevatorId) -> Result<(), SimError> {
+        let elevator = elevator.entity();
         self.require_enabled_elevator(elevator)?;
         self.enqueue_door_command(elevator, crate::door::DoorCommand::Open);
         Ok(())
@@ -1084,10 +1100,11 @@ impl Simulation {
     /// use elevator_core::prelude::*;
     ///
     /// let mut sim = SimulationBuilder::demo().build().unwrap();
-    /// let elev = sim.world().iter_elevators().next().unwrap().0;
+    /// let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     /// sim.close_door(elev).unwrap();
     /// ```
-    pub fn close_door(&mut self, elevator: EntityId) -> Result<(), SimError> {
+    pub fn close_door(&mut self, elevator: ElevatorId) -> Result<(), SimError> {
+        let elevator = elevator.entity();
         self.require_enabled_elevator(elevator)?;
         self.enqueue_door_command(elevator, crate::door::DoorCommand::Close);
         Ok(())
@@ -1111,10 +1128,11 @@ impl Simulation {
     /// use elevator_core::prelude::*;
     ///
     /// let mut sim = SimulationBuilder::demo().build().unwrap();
-    /// let elev = sim.world().iter_elevators().next().unwrap().0;
+    /// let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     /// sim.hold_door(elev, 30).unwrap();
     /// ```
-    pub fn hold_door(&mut self, elevator: EntityId, ticks: u32) -> Result<(), SimError> {
+    pub fn hold_door(&mut self, elevator: ElevatorId, ticks: u32) -> Result<(), SimError> {
+        let elevator = elevator.entity();
         Self::validate_nonzero_u32(ticks, "hold_door.ticks")?;
         self.require_enabled_elevator(elevator)?;
         self.enqueue_door_command(elevator, crate::door::DoorCommand::HoldOpen { ticks });
@@ -1137,11 +1155,12 @@ impl Simulation {
     /// use elevator_core::prelude::*;
     ///
     /// let mut sim = SimulationBuilder::demo().build().unwrap();
-    /// let elev = sim.world().iter_elevators().next().unwrap().0;
+    /// let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     /// sim.hold_door(elev, 100).unwrap();
     /// sim.cancel_door_hold(elev).unwrap();
     /// ```
-    pub fn cancel_door_hold(&mut self, elevator: EntityId) -> Result<(), SimError> {
+    pub fn cancel_door_hold(&mut self, elevator: ElevatorId) -> Result<(), SimError> {
+        let elevator = elevator.entity();
         self.require_enabled_elevator(elevator)?;
         self.enqueue_door_command(elevator, crate::door::DoorCommand::CancelHold);
         Ok(())
@@ -1164,9 +1183,10 @@ impl Simulation {
     /// [`ServiceMode::Manual`]: crate::components::ServiceMode::Manual
     pub fn set_target_velocity(
         &mut self,
-        elevator: EntityId,
+        elevator: ElevatorId,
         velocity: f64,
     ) -> Result<(), SimError> {
+        let elevator = elevator.entity();
         self.require_enabled_elevator(elevator)?;
         self.require_manual_mode(elevator)?;
         if !velocity.is_finite() {
@@ -1202,7 +1222,8 @@ impl Simulation {
     /// # Errors
     /// Same as [`set_target_velocity`](Self::set_target_velocity), minus
     /// the finite-velocity check.
-    pub fn emergency_stop(&mut self, elevator: EntityId) -> Result<(), SimError> {
+    pub fn emergency_stop(&mut self, elevator: ElevatorId) -> Result<(), SimError> {
+        let elevator = elevator.entity();
         self.require_enabled_elevator(elevator)?;
         self.require_manual_mode(elevator)?;
         if let Some(car) = self.world.elevator_mut(elevator) {
@@ -1439,7 +1460,7 @@ impl Simulation {
         origin: impl Into<StopRef>,
         destination: impl Into<StopRef>,
         weight: impl Into<Weight>,
-    ) -> Result<EntityId, SimError> {
+    ) -> Result<RiderId, SimError> {
         let origin = self.resolve_stop(origin.into())?;
         let destination = self.resolve_stop(destination.into())?;
         let weight: Weight = weight.into();
@@ -1484,7 +1505,12 @@ impl Simulation {
         };
 
         let route = Route::direct(origin, destination, group);
-        Ok(self.spawn_rider_inner(origin, destination, weight, route))
+        Ok(RiderId::from(self.spawn_rider_inner(
+            origin,
+            destination,
+            weight,
+            route,
+        )))
     }
 
     /// Internal helper: spawn a rider entity with the given route.
@@ -1921,9 +1947,10 @@ impl Simulation {
     /// Returns [`SimError::EntityNotFound`] if `car` or `floor` is invalid.
     pub fn press_car_button(
         &mut self,
-        car: EntityId,
+        car: ElevatorId,
         floor: impl Into<StopRef>,
     ) -> Result<(), SimError> {
+        let car = car.entity();
         let floor = self.resolve_stop(floor.into())?;
         if self.world.elevator(car).is_none() {
             return Err(SimError::EntityNotFound(car));
@@ -1950,10 +1977,11 @@ impl Simulation {
     ///   blocking every other car.
     pub fn pin_assignment(
         &mut self,
-        car: EntityId,
+        car: ElevatorId,
         stop: EntityId,
         direction: crate::components::CallDirection,
     ) -> Result<(), SimError> {
+        let car = car.entity();
         let Some(elev) = self.world.elevator(car) else {
             return Err(SimError::EntityNotFound(car));
         };
@@ -2006,7 +2034,8 @@ impl Simulation {
     /// Floor buttons currently pressed inside `car`. Returns an empty
     /// slice when the car has no aboard riders or hasn't been used.
     #[must_use]
-    pub fn car_calls(&self, car: EntityId) -> &[crate::components::CarCall] {
+    pub fn car_calls(&self, car: ElevatorId) -> &[crate::components::CarCall] {
+        let car = car.entity();
         self.world.car_calls(car)
     }
 

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -7,7 +7,7 @@
 use std::collections::HashSet;
 
 use crate::components::{Elevator, ElevatorPhase, RiderPhase, RiderPhaseKind, Route};
-use crate::entity::EntityId;
+use crate::entity::{ElevatorId, EntityId, RiderId};
 use crate::error::SimError;
 use crate::events::Event;
 use crate::ids::GroupId;
@@ -113,7 +113,8 @@ impl Simulation {
     /// Returns [`SimError::WrongRiderPhase`] if the rider is not in
     /// [`RiderPhase::Waiting`], or [`SimError::RiderHasNoStop`] if the
     /// rider has no current stop.
-    pub fn reroute(&mut self, rider: EntityId, new_destination: EntityId) -> Result<(), SimError> {
+    pub fn reroute(&mut self, rider: RiderId, new_destination: EntityId) -> Result<(), SimError> {
+        let rider = rider.entity();
         let r = self
             .world
             .rider(rider)
@@ -170,7 +171,8 @@ impl Simulation {
     /// Returns [`SimError::WrongRiderPhase`] if the rider is not in
     /// `Arrived` or `Abandoned` phase, or [`SimError::RiderHasNoStop`]
     /// if the rider has no current stop.
-    pub fn settle_rider(&mut self, id: EntityId) -> Result<(), SimError> {
+    pub fn settle_rider(&mut self, id: RiderId) -> Result<(), SimError> {
+        let id = id.entity();
         let rider = self.world.rider(id).ok_or(SimError::EntityNotFound(id))?;
 
         let old_phase = rider.phase;
@@ -279,7 +281,8 @@ impl Simulation {
     ///
     /// Returns [`SimError::EntityNotFound`] if `id` does not exist or is
     /// not a rider.
-    pub fn despawn_rider(&mut self, id: EntityId) -> Result<(), SimError> {
+    pub fn despawn_rider(&mut self, id: RiderId) -> Result<(), SimError> {
+        let id = id.entity();
         let rider = self.world.rider(id).ok_or(SimError::EntityNotFound(id))?;
 
         // Targeted index removal based on current phase (O(1) vs O(n) scan).
@@ -665,10 +668,11 @@ impl Simulation {
     ///
     /// let sim = SimulationBuilder::demo().build().unwrap();
     /// let stop = sim.stop_entity(StopId(0)).unwrap();
-    /// assert_eq!(sim.elevator_load(stop), None); // not an elevator
+    /// assert_eq!(sim.elevator_load(ElevatorId::from(stop)), None); // not an elevator
     /// ```
     #[must_use]
-    pub fn elevator_load(&self, id: EntityId) -> Option<f64> {
+    pub fn elevator_load(&self, id: ElevatorId) -> Option<f64> {
+        let id = id.entity();
         self.world.elevator(id).map(|e| e.current_load.value())
     }
 

--- a/crates/elevator-core/src/tests/access_tests.rs
+++ b/crates/elevator-core/src/tests/access_tests.rs
@@ -60,7 +60,7 @@ fn rider_rejected_by_rider_access_control() {
     // Set rider access to only allow Ground and Floor 2 — NOT Floor 3.
     let stop0 = sim.stop_entity(StopId(0)).expect("stop 0 exists");
     let stop1 = sim.stop_entity(StopId(1)).expect("stop 1 exists");
-    sim.set_rider_access(rider, HashSet::from([stop0, stop1]))
+    sim.set_rider_access(rider.entity(), HashSet::from([stop0, stop1]))
         .expect("set_rider_access should succeed");
 
     let mut all_events = Vec::new();
@@ -122,7 +122,7 @@ fn rider_boards_when_destination_in_allowed_stops() {
     let stop0 = sim.stop_entity(StopId(0)).expect("stop 0 exists");
     let stop1 = sim.stop_entity(StopId(1)).expect("stop 1 exists");
     let stop2 = sim.stop_entity(StopId(2)).expect("stop 2 exists");
-    sim.set_rider_access(rider, HashSet::from([stop0, stop1, stop2]))
+    sim.set_rider_access(rider.entity(), HashSet::from([stop0, stop1, stop2]))
         .expect("set_rider_access should succeed");
 
     for _ in 0..2000 {
@@ -196,7 +196,7 @@ fn both_restriction_types_work_in_same_sim() {
                 rider,
                 reason: RejectionReason::AccessDenied,
                 ..
-            } if *rider == rider1
+            } if *rider == rider1.entity()
         )
     });
     assert!(
@@ -213,7 +213,7 @@ fn both_restriction_types_work_in_same_sim() {
         .expect("spawn should succeed");
     let stop0 = sim.stop_entity(StopId(0)).expect("stop 0 exists");
     let stop1 = sim.stop_entity(StopId(1)).expect("stop 1 exists");
-    sim.set_rider_access(rider2, HashSet::from([stop0, stop1]))
+    sim.set_rider_access(rider2.entity(), HashSet::from([stop0, stop1]))
         .expect("set_rider_access should succeed");
 
     let mut events_phase2 = Vec::new();
@@ -229,7 +229,7 @@ fn both_restriction_types_work_in_same_sim() {
                 rider,
                 reason: RejectionReason::AccessDenied,
                 ..
-            } if *rider == rider2
+            } if *rider == rider2.entity()
         )
     });
     assert!(
@@ -275,7 +275,7 @@ fn rejection_event_has_access_denied_reason() {
         ..
     }) = rejection
     {
-        assert_eq!(*rid, rider);
+        assert_eq!(*rid, rider.entity());
         assert_eq!(*reason, RejectionReason::AccessDenied);
         assert!(context.is_none(), "AccessDenied should have no context");
     }

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -8,7 +8,7 @@ use crate::components::{Accel, AccessControl, Preferences, RiderPhase, Speed, We
 use crate::dispatch::BuiltinReposition;
 use crate::dispatch::reposition::ReturnToLobby;
 use crate::dispatch::{EtdDispatch, LookDispatch, NearestCarDispatch, ScanDispatch};
-use crate::entity::{ElevatorId, EntityId, RiderId};
+use crate::entity::{ElevatorId, EntityId};
 use crate::error::SimError;
 use crate::events::Event;
 use crate::ids::GroupId;

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -8,7 +8,7 @@ use crate::components::{Accel, AccessControl, Preferences, RiderPhase, Speed, We
 use crate::dispatch::BuiltinReposition;
 use crate::dispatch::reposition::ReturnToLobby;
 use crate::dispatch::{EtdDispatch, LookDispatch, NearestCarDispatch, ScanDispatch};
-use crate::entity::EntityId;
+use crate::entity::{ElevatorId, EntityId, RiderId};
 use crate::error::SimError;
 use crate::events::Event;
 use crate::ids::GroupId;
@@ -58,7 +58,7 @@ fn remove_elevator_ejects_riders_aboard() {
     // Run enough ticks for the rider to board.
     for _ in 0..300 {
         sim.step();
-        let phase = sim.world().rider(rider_id).unwrap().phase;
+        let phase = sim.world().rider(rider_id.entity()).unwrap().phase;
         if matches!(phase, RiderPhase::Riding(_)) {
             break;
         }
@@ -67,7 +67,7 @@ fn remove_elevator_ejects_riders_aboard() {
     let elevator_id = sim.groups()[0].elevator_entities()[0];
     assert!(
         matches!(
-            sim.world().rider(rider_id).unwrap().phase,
+            sim.world().rider(rider_id.entity()).unwrap().phase,
             RiderPhase::Riding(_)
         ),
         "rider should have boarded within 300 ticks"
@@ -77,7 +77,7 @@ fn remove_elevator_ejects_riders_aboard() {
     sim.remove_elevator(elevator_id).unwrap();
     sim.drain_events(); // consume events
 
-    let phase = sim.world().rider(rider_id).unwrap().phase;
+    let phase = sim.world().rider(rider_id.entity()).unwrap().phase;
     // After ejection, rider is put back to Waiting.
     assert!(
         matches!(phase, RiderPhase::Waiting),
@@ -97,7 +97,7 @@ fn remove_elevator_ejects_rider_emits_event() {
     for _ in 0..300 {
         sim.step();
         if matches!(
-            sim.world().rider(rider_id).unwrap().phase,
+            sim.world().rider(rider_id.entity()).unwrap().phase,
             RiderPhase::Riding(_)
         ) {
             break;
@@ -108,7 +108,7 @@ fn remove_elevator_ejects_rider_emits_event() {
 
     assert!(
         matches!(
-            sim.world().rider(rider_id).unwrap().phase,
+            sim.world().rider(rider_id.entity()).unwrap().phase,
             RiderPhase::Riding(_)
         ),
         "rider should have boarded within 300 ticks"
@@ -119,7 +119,7 @@ fn remove_elevator_ejects_rider_emits_event() {
 
     let ejected = events
         .iter()
-        .any(|e| matches!(e, Event::RiderEjected { rider, .. } if *rider == rider_id));
+        .any(|e| matches!(e, Event::RiderEjected { rider, .. } if *rider == rider_id.entity()));
     assert!(
         ejected,
         "should emit RiderEjected when removing elevator with rider aboard"
@@ -195,7 +195,7 @@ fn remove_stop_with_waiting_rider_invalidates_route() {
     let rider_id = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     // Ensure the rider is in Waiting phase (before boarding).
-    let phase = sim.world().rider(rider_id).unwrap().phase;
+    let phase = sim.world().rider(rider_id.entity()).unwrap().phase;
     assert_eq!(phase, RiderPhase::Waiting);
 
     // Remove the destination stop.
@@ -206,7 +206,7 @@ fn remove_stop_with_waiting_rider_invalidates_route() {
     // Removing a stop should emit RouteInvalidated for any rider whose route references it.
     let invalidated = events
         .iter()
-        .any(|e| matches!(e, Event::RouteInvalidated { rider, .. } if *rider == rider_id));
+        .any(|e| matches!(e, Event::RouteInvalidated { rider, .. } if *rider == rider_id.entity()));
     assert!(
         invalidated,
         "should emit RouteInvalidated for rider targeting the removed stop"
@@ -228,7 +228,7 @@ fn remove_stop_clears_dangling_references_on_elevator() {
 
     // Queue stop 2 as a destination, then dispatch so the elevator picks
     // it as its target.
-    sim.push_destination(elev, stop2).unwrap();
+    sim.push_destination(ElevatorId::from(elev), stop2).unwrap();
     sim.step();
 
     // Seed the restricted_stops set directly (normally populated via
@@ -242,7 +242,7 @@ fn remove_stop_clears_dangling_references_on_elevator() {
     assert!(
         car.target_stop == Some(stop2)
             || sim
-                .destination_queue(elev)
+                .destination_queue(ElevatorId::from(elev))
                 .is_some_and(|q| q.contains(&stop2)),
         "test precondition: elevator should reference stop2 somehow"
     );
@@ -256,7 +256,7 @@ fn remove_stop_clears_dangling_references_on_elevator() {
         Some(stop2),
         "target_stop must be cleared when the referenced stop is removed"
     );
-    if let Some(q) = sim.destination_queue(elev) {
+    if let Some(q) = sim.destination_queue(ElevatorId::from(elev)) {
         assert!(
             !q.contains(&stop2),
             "DestinationQueue must not contain the removed stop"
@@ -410,7 +410,7 @@ fn riders_on_returns_rider_ids_after_boarding() {
     for _ in 0..300 {
         sim.step();
         if matches!(
-            sim.world().rider(rider_id).unwrap().phase,
+            sim.world().rider(rider_id.entity()).unwrap().phase,
             RiderPhase::Riding(_)
         ) {
             break;
@@ -418,11 +418,11 @@ fn riders_on_returns_rider_ids_after_boarding() {
     }
 
     if matches!(
-        sim.world().rider(rider_id).unwrap().phase,
+        sim.world().rider(rider_id.entity()).unwrap().phase,
         RiderPhase::Riding(_)
     ) {
         assert!(
-            sim.riders_on(elevator_id).contains(&rider_id),
+            sim.riders_on(elevator_id).contains(&rider_id.entity()),
             "rider should appear in riders_on after boarding"
         );
     }
@@ -458,7 +458,7 @@ fn occupancy_returns_correct_count_after_boarding() {
     for _ in 0..300 {
         sim.step();
         if matches!(
-            sim.world().rider(rider_id).unwrap().phase,
+            sim.world().rider(rider_id.entity()).unwrap().phase,
             RiderPhase::Riding(_)
         ) {
             break;
@@ -466,7 +466,7 @@ fn occupancy_returns_correct_count_after_boarding() {
     }
 
     if matches!(
-        sim.world().rider(rider_id).unwrap().phase,
+        sim.world().rider(rider_id.entity()).unwrap().phase,
         RiderPhase::Riding(_)
     ) {
         assert_eq!(
@@ -625,7 +625,7 @@ fn rider_builder_basic_spawn() {
         .spawn()
         .unwrap();
 
-    let rider = sim.world().rider(rider_id).unwrap();
+    let rider = sim.world().rider(rider_id.entity()).unwrap();
     assert_eq!(rider.phase, RiderPhase::Waiting);
 }
 
@@ -641,7 +641,7 @@ fn rider_builder_custom_weight() {
         .spawn()
         .unwrap();
 
-    let rider = sim.world().rider(rider_id).unwrap();
+    let rider = sim.world().rider(rider_id.entity()).unwrap();
     assert!(
         (rider.weight.value() - 90.0).abs() < f64::EPSILON,
         "rider weight should be 90.0, got {}",
@@ -662,7 +662,7 @@ fn rider_builder_with_explicit_group() {
         .spawn()
         .unwrap();
 
-    let rider = sim.world().rider(rider_id).unwrap();
+    let rider = sim.world().rider(rider_id.entity()).unwrap();
     assert_eq!(rider.phase, RiderPhase::Waiting);
 }
 
@@ -678,7 +678,7 @@ fn rider_builder_with_patience() {
         .spawn()
         .unwrap();
 
-    let patience = sim.world().patience(rider_id).unwrap();
+    let patience = sim.world().patience(rider_id.entity()).unwrap();
     assert_eq!(
         patience.max_wait_ticks(),
         100,
@@ -706,7 +706,7 @@ fn rider_builder_with_preferences() {
         .spawn()
         .unwrap();
 
-    let stored = sim.world().preferences(rider_id).unwrap();
+    let stored = sim.world().preferences(rider_id.entity()).unwrap();
     assert!(
         stored.skip_full_elevator(),
         "skip_full_elevator should be true"
@@ -736,7 +736,7 @@ fn rider_builder_with_access_control() {
         .spawn()
         .unwrap();
 
-    let stored = sim.world().access_control(rider_id).unwrap();
+    let stored = sim.world().access_control(rider_id.entity()).unwrap();
     assert!(
         stored.can_access(stop0),
         "rider should have access to stop 0"
@@ -908,7 +908,7 @@ fn rider_builder_default_weight_is_75() {
         .spawn()
         .unwrap();
 
-    let rider = sim.world().rider(rider_id).unwrap();
+    let rider = sim.world().rider(rider_id.entity()).unwrap();
     assert!(
         (rider.weight.value() - 75.0).abs() < f64::EPSILON,
         "default weight should be 75.0, got {}",
@@ -929,7 +929,7 @@ fn rider_builder_no_patience_by_default() {
 
     // Without calling .patience(), no Patience component is set.
     assert!(
-        sim.world().patience(rider_id).is_none(),
+        sim.world().patience(rider_id.entity()).is_none(),
         "rider should have no Patience component by default"
     );
 }
@@ -946,7 +946,7 @@ fn rider_builder_no_preferences_by_default() {
         .unwrap();
 
     assert!(
-        sim.world().preferences(rider_id).is_none(),
+        sim.world().preferences(rider_id.entity()).is_none(),
         "rider should have no Preferences component by default"
     );
 }
@@ -963,7 +963,7 @@ fn rider_builder_no_access_control_by_default() {
         .unwrap();
 
     assert!(
-        sim.world().access_control(rider_id).is_none(),
+        sim.world().access_control(rider_id.entity()).is_none(),
         "rider should have no AccessControl component by default"
     );
 }

--- a/crates/elevator-core/src/tests/boundary_tests.rs
+++ b/crates/elevator-core/src/tests/boundary_tests.rs
@@ -2,6 +2,7 @@
 
 use crate::components::{Patience, Preferences, RiderPhase};
 use crate::dispatch::scan::ScanDispatch;
+use crate::entity::RiderId;
 use crate::events::Event;
 use crate::sim::Simulation;
 use crate::stop::StopId;
@@ -14,7 +15,7 @@ fn patience_zero_abandons_immediately() {
 
     let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     sim.world_mut().set_patience(
-        rider,
+        rider.entity(),
         Patience {
             max_wait_ticks: 0,
             waited_ticks: 0,
@@ -24,7 +25,7 @@ fn patience_zero_abandons_immediately() {
     // After 1 step, rider should abandon (max_wait_ticks=0 means abandon on first patience check).
     sim.step();
 
-    let phase = sim.world().rider(rider).map(|r| r.phase);
+    let phase = sim.world().rider(rider.entity()).map(|r| r.phase);
     assert_eq!(
         phase,
         Some(RiderPhase::Abandoned),
@@ -39,7 +40,7 @@ fn patience_one_abandons_after_one_tick() {
 
     let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     sim.world_mut().set_patience(
-        rider,
+        rider.entity(),
         Patience {
             max_wait_ticks: 1,
             waited_ticks: 0,
@@ -48,7 +49,7 @@ fn patience_one_abandons_after_one_tick() {
 
     sim.step();
 
-    let phase = sim.world().rider(rider).map(|r| r.phase);
+    let phase = sim.world().rider(rider.entity()).map(|r| r.phase);
     assert_eq!(
         phase,
         Some(RiderPhase::Abandoned),
@@ -63,7 +64,7 @@ fn patience_max_never_overflows() {
 
     let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     sim.world_mut().set_patience(
-        rider,
+        rider.entity(),
         Patience {
             max_wait_ticks: u64::MAX,
             waited_ticks: u64::MAX - 1,
@@ -73,7 +74,7 @@ fn patience_max_never_overflows() {
     // Should not panic or overflow.
     sim.step();
 
-    let phase = sim.world().rider(rider).map(|r| r.phase);
+    let phase = sim.world().rider(rider.entity()).map(|r| r.phase);
     // With waited=MAX-1 and max=MAX, after increment waited becomes MAX,
     // which triggers abandon (waited >= max.saturating_sub(1) = MAX-1).
     assert_eq!(phase, Some(RiderPhase::Abandoned));
@@ -90,7 +91,7 @@ fn preferences_zero_crowding_rejects_any_load() {
     // Spawn second rider with max_crowding_factor=0.0.
     let r2 = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     sim.world_mut().set_preferences(
-        r2,
+        r2.entity(),
         Preferences {
             skip_full_elevator: true,
             max_crowding_factor: 0.0,
@@ -102,7 +103,7 @@ fn preferences_zero_crowding_rejects_any_load() {
     // Run until first rider boards.
     for _ in 0..500 {
         sim.step();
-        if let Some(r) = sim.world().rider(r1)
+        if let Some(r) = sim.world().rider(r1.entity())
             && matches!(r.phase, RiderPhase::Riding(_) | RiderPhase::Arrived)
         {
             break;
@@ -118,7 +119,7 @@ fn preferences_zero_crowding_rejects_any_load() {
                 rider,
                 reason,
                 ..
-            } if *rider == r2 && *reason == crate::error::RejectionReason::PreferenceBased
+            } if *rider == r2.entity() && *reason == crate::error::RejectionReason::PreferenceBased
         )
     });
 
@@ -126,7 +127,7 @@ fn preferences_zero_crowding_rejects_any_load() {
     // (Any non-zero load triggers rejection.)
     if sim
         .world()
-        .rider(r1)
+        .rider(r1.entity())
         .is_some_and(|r| matches!(r.phase, RiderPhase::Riding(_) | RiderPhase::Arrived))
     {
         assert!(
@@ -148,7 +149,7 @@ fn weight_exactly_at_capacity_boards() {
     let mut boarded = false;
     for _ in 0..500 {
         sim.step();
-        if let Some(r) = sim.world().rider(rider)
+        if let Some(r) = sim.world().rider(rider.entity())
             && matches!(
                 r.phase,
                 RiderPhase::Boarding(_) | RiderPhase::Riding(_) | RiderPhase::Arrived

--- a/crates/elevator-core/src/tests/boundary_tests.rs
+++ b/crates/elevator-core/src/tests/boundary_tests.rs
@@ -2,7 +2,6 @@
 
 use crate::components::{Patience, Preferences, RiderPhase};
 use crate::dispatch::scan::ScanDispatch;
-use crate::entity::RiderId;
 use crate::events::Event;
 use crate::sim::Simulation;
 use crate::stop::StopId;

--- a/crates/elevator-core/src/tests/braking_tests.rs
+++ b/crates/elevator-core/src/tests/braking_tests.rs
@@ -1,7 +1,6 @@
 //! Tests for the public braking-distance helpers.
 
 use crate::components::ElevatorPhase;
-use crate::entity::ElevatorId;
 use crate::movement::braking_distance;
 use crate::sim::Simulation;
 use crate::stop::StopId;

--- a/crates/elevator-core/src/tests/braking_tests.rs
+++ b/crates/elevator-core/src/tests/braking_tests.rs
@@ -1,7 +1,7 @@
 //! Tests for the public braking-distance helpers.
 
 use crate::components::ElevatorPhase;
-use crate::entity::{ElevatorId, RiderId};
+use crate::entity::ElevatorId;
 use crate::movement::braking_distance;
 use crate::sim::Simulation;
 use crate::stop::StopId;

--- a/crates/elevator-core/src/tests/braking_tests.rs
+++ b/crates/elevator-core/src/tests/braking_tests.rs
@@ -1,6 +1,7 @@
 //! Tests for the public braking-distance helpers.
 
 use crate::components::ElevatorPhase;
+use crate::entity::{ElevatorId, RiderId};
 use crate::movement::braking_distance;
 use crate::sim::Simulation;
 use crate::stop::StopId;
@@ -8,8 +9,8 @@ use crate::stop::StopId;
 use super::helpers::{default_config, scan};
 
 /// Grab the first elevator in a sim.
-fn first_elevator(sim: &Simulation) -> crate::entity::EntityId {
-    sim.world().elevator_ids()[0]
+fn first_elevator(sim: &Simulation) -> crate::entity::ElevatorId {
+    crate::entity::ElevatorId::from(sim.world().elevator_ids()[0])
 }
 
 #[test]
@@ -37,7 +38,7 @@ fn braking_distance_rejects_nonpositive_deceleration() {
 fn sim_braking_distance_stationary_elevator_is_zero() {
     let sim = Simulation::new(&default_config(), scan()).unwrap();
     let elev = first_elevator(&sim);
-    assert_eq!(sim.braking_distance(elev), Some(0.0));
+    assert_eq!(sim.braking_distance(elev.entity()), Some(0.0));
 }
 
 #[test]
@@ -51,15 +52,15 @@ fn sim_braking_distance_nonzero_while_moving() {
         sim.step();
         let is_moving = sim
             .world()
-            .elevator(elev)
+            .elevator(elev.entity())
             .is_some_and(|c| matches!(c.phase(), ElevatorPhase::MovingToStop(_)));
-        let vel = sim.world().velocity(elev).map_or(0.0, |v| v.value);
+        let vel = sim.world().velocity(elev.entity()).map_or(0.0, |v| v.value);
         if is_moving && vel.abs() > 0.5 {
             break;
         }
     }
 
-    let d = sim.braking_distance(elev).expect("is an elevator");
+    let d = sim.braking_distance(elev.entity()).expect("is an elevator");
     assert!(d > 0.0, "expected nonzero braking distance while moving");
 }
 
@@ -67,8 +68,8 @@ fn sim_braking_distance_nonzero_while_moving() {
 fn sim_future_stop_position_stationary_equals_current() {
     let sim = Simulation::new(&default_config(), scan()).unwrap();
     let elev = first_elevator(&sim);
-    let pos = sim.world().position(elev).unwrap().value;
-    assert_eq!(sim.future_stop_position(elev), Some(pos));
+    let pos = sim.world().position(elev.entity()).unwrap().value;
+    assert_eq!(sim.future_stop_position(elev.entity()), Some(pos));
 }
 
 #[test]
@@ -79,14 +80,14 @@ fn sim_future_stop_position_ahead_while_moving_up() {
     let elev = first_elevator(&sim);
     for _ in 0..500 {
         sim.step();
-        let vel = sim.world().velocity(elev).map_or(0.0, |v| v.value);
+        let vel = sim.world().velocity(elev.entity()).map_or(0.0, |v| v.value);
         if vel > 0.5 {
             break;
         }
     }
 
-    let pos = sim.world().position(elev).unwrap().value;
-    let future = sim.future_stop_position(elev).unwrap();
+    let pos = sim.world().position(elev.entity()).unwrap().value;
+    let future = sim.future_stop_position(elev.entity()).unwrap();
     assert!(
         future > pos,
         "future stop position {future} should be above current {pos} while moving up",
@@ -97,6 +98,6 @@ fn sim_future_stop_position_ahead_while_moving_up() {
 fn sim_braking_distance_none_for_non_elevator() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
     let rider = sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
-    assert_eq!(sim.braking_distance(rider), None);
-    assert_eq!(sim.future_stop_position(rider), None);
+    assert_eq!(sim.braking_distance(rider.entity()), None);
+    assert_eq!(sim.future_stop_position(rider.entity()), None);
 }

--- a/crates/elevator-core/src/tests/destination_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/destination_dispatch_tests.rs
@@ -6,6 +6,7 @@ use crate::config::{
     SimulationParams,
 };
 use crate::dispatch::destination::{ASSIGNED_CAR_KEY, AssignedCar, DestinationDispatch};
+use crate::entity::{ElevatorId, RiderId};
 use crate::sim::Simulation;
 use crate::stop::{StopConfig, StopId};
 
@@ -170,7 +171,7 @@ fn sticky_assignment_persists_across_ticks() {
     let rid = sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
 
     sim.step();
-    let first = sim.world().ext::<AssignedCar>(rid);
+    let first = sim.world().ext::<AssignedCar>(rid.entity());
     assert!(first.is_some(), "rider should be assigned after first tick");
 
     // Step the sim many times; assignment must never change.
@@ -178,12 +179,12 @@ fn sticky_assignment_persists_across_ticks() {
         sim.step();
         if sim
             .world()
-            .rider(rid)
+            .rider(rid.entity())
             .is_some_and(|r| r.phase() == RiderPhase::Arrived)
         {
             break;
         }
-        let cur = sim.world().ext::<AssignedCar>(rid);
+        let cur = sim.world().ext::<AssignedCar>(rid.entity());
         assert_eq!(cur, first, "assignment must be sticky");
     }
 }
@@ -229,24 +230,24 @@ fn loading_respects_assignment_other_car_skips() {
     // and seed B's queue with the rider's pickup + drop-off so DCS's normal
     // queue-driven movement applies to the forced assignment too.
     sim.world_mut()
-        .insert_ext(rid, AssignedCar(car_b), ASSIGNED_CAR_KEY);
+        .insert_ext(rid.entity(), AssignedCar(car_b), ASSIGNED_CAR_KEY);
     let f2 = sim.stop_entity(StopId(1)).unwrap();
     let f3 = sim.stop_entity(StopId(2)).unwrap();
-    sim.push_destination(car_b, f2).unwrap();
-    sim.push_destination(car_b, f3).unwrap();
+    sim.push_destination(ElevatorId::from(car_b), f2).unwrap();
+    sim.push_destination(ElevatorId::from(car_b), f3).unwrap();
 
     // Run many ticks. The rider must never board car A.
     for _ in 0..2000 {
         sim.step();
         if sim
             .world()
-            .rider(rid)
+            .rider(rid.entity())
             .is_some_and(|r| r.phase() == RiderPhase::Arrived)
         {
             break;
         }
         // If the rider is aboard an elevator, it must be car B.
-        if let Some(rider) = sim.world().rider(rid) {
+        if let Some(rider) = sim.world().rider(rid.entity()) {
             match rider.phase() {
                 RiderPhase::Boarding(e) | RiderPhase::Riding(e) | RiderPhase::Exiting(e) => {
                     assert_eq!(e, car_b, "rider must only board its assigned car");
@@ -257,7 +258,7 @@ fn loading_respects_assignment_other_car_skips() {
     }
     assert!(
         sim.world()
-            .rider(rid)
+            .rider(rid.entity())
             .is_some_and(|r| r.phase() == RiderPhase::Arrived),
         "rider should eventually arrive via assigned car"
     );
@@ -285,7 +286,7 @@ fn unassigned_manual_board_riders_still_work() {
     // assignment while we reuse the sim.
     sim.step();
     assert!(
-        sim.world().ext::<AssignedCar>(routed).is_some(),
+        sim.world().ext::<AssignedCar>(routed.entity()).is_some(),
         "routed rider should be assigned"
     );
 
@@ -294,7 +295,7 @@ fn unassigned_manual_board_riders_still_work() {
         sim.step();
         if sim
             .world()
-            .rider(routed)
+            .rider(routed.entity())
             .is_some_and(|r| r.phase() == RiderPhase::Arrived)
         {
             break;
@@ -302,7 +303,7 @@ fn unassigned_manual_board_riders_still_work() {
     }
     assert!(
         sim.world()
-            .rider(routed)
+            .rider(routed.entity())
             .is_some_and(|r| r.phase() == RiderPhase::Arrived)
     );
 }
@@ -333,7 +334,7 @@ fn closer_car_is_preferred_when_matching_direction() {
     sim.step();
     let assigned = sim
         .world()
-        .ext::<AssignedCar>(rid)
+        .ext::<AssignedCar>(rid.entity())
         .expect("rider should be assigned");
     assert_eq!(assigned.0, car_a, "closer car should be preferred");
 }
@@ -358,7 +359,7 @@ fn up_peak_scenario_delivers_all_riders() {
         sim.step();
         let done = riders.iter().all(|&rid| {
             sim.world()
-                .rider(rid)
+                .rider(rid.entity())
                 .is_some_and(|r| r.phase() == RiderPhase::Arrived)
         });
         if done {
@@ -367,7 +368,7 @@ fn up_peak_scenario_delivers_all_riders() {
     }
 
     for &rid in &riders {
-        let phase = sim.world().rider(rid).map(Rider::phase);
+        let phase = sim.world().rider(rid.entity()).map(Rider::phase);
         assert_eq!(
             phase,
             Some(RiderPhase::Arrived),
@@ -402,7 +403,7 @@ fn dcs_gated_to_destination_mode() {
         sim.step();
     }
     assert!(
-        sim.world().ext::<AssignedCar>(rid).is_none(),
+        sim.world().ext::<AssignedCar>(rid.entity()).is_none(),
         "DCS must not assign when group is in Classic mode",
     );
 }

--- a/crates/elevator-core/src/tests/destination_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/destination_dispatch_tests.rs
@@ -6,7 +6,7 @@ use crate::config::{
     SimulationParams,
 };
 use crate::dispatch::destination::{ASSIGNED_CAR_KEY, AssignedCar, DestinationDispatch};
-use crate::entity::{ElevatorId, RiderId};
+use crate::entity::ElevatorId;
 use crate::sim::Simulation;
 use crate::stop::{StopConfig, StopId};
 

--- a/crates/elevator-core/src/tests/destination_queue_tests.rs
+++ b/crates/elevator-core/src/tests/destination_queue_tests.rs
@@ -4,6 +4,7 @@
 use crate::builder::SimulationBuilder;
 use crate::components::ElevatorPhase;
 use crate::dispatch::scan::ScanDispatch;
+use crate::entity::{ElevatorId, RiderId};
 use crate::error::SimError;
 use crate::events::Event;
 use crate::stop::StopId;
@@ -17,8 +18,8 @@ fn build_sim() -> crate::sim::Simulation {
         .unwrap()
 }
 
-fn first_elevator(sim: &crate::sim::Simulation) -> crate::entity::EntityId {
-    sim.world().elevator_ids()[0]
+fn first_elevator(sim: &crate::sim::Simulation) -> crate::entity::ElevatorId {
+    crate::entity::ElevatorId::from(sim.world().elevator_ids()[0])
 }
 
 // 1
@@ -54,7 +55,7 @@ fn queue_pops_on_arrival() {
     for _ in 0..2000 {
         sim.step();
         let elev = first_elevator(&sim);
-        let car = sim.world().elevator(elev).unwrap();
+        let car = sim.world().elevator(elev.entity()).unwrap();
         if !matches!(car.phase(), ElevatorPhase::MovingToStop(_))
             && sim.destination_queue(elev).is_some_and(<[_]>::is_empty)
         {
@@ -140,7 +141,7 @@ fn imperative_push_drives_elevator() {
             if let Event::ElevatorArrived {
                 elevator, at_stop, ..
             } = ev
-                && elevator == elev
+                && elevator == elev.entity()
                 && at_stop == s2
             {
                 arrived = true;
@@ -179,7 +180,7 @@ fn push_front_overrides_current_target() {
             if let Event::ElevatorArrived {
                 elevator, at_stop, ..
             } = ev
-                && elevator == elev
+                && elevator == elev.entity()
             {
                 arrived_at = Some(at_stop);
                 break;
@@ -254,7 +255,7 @@ fn snapshot_roundtrip_preserves_queue() {
 
     let snapshot = sim.snapshot();
     let restored = snapshot.restore(None).unwrap();
-    let new_elev = restored.world().elevator_ids()[0];
+    let new_elev = ElevatorId::from(restored.world().elevator_ids()[0]);
 
     let restored_queue = restored.destination_queue(new_elev).unwrap();
     assert_eq!(restored_queue.len(), 3);
@@ -267,7 +268,7 @@ fn push_destination_errors_on_non_elevator() {
     let s1 = sim.stop_entity(StopId(1)).unwrap();
     // Spawn a rider entity — not an elevator.
     let rider = sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
-    let result = sim.push_destination(rider, s1);
+    let result = sim.push_destination(ElevatorId::from(rider.entity()), s1);
     assert!(matches!(result, Err(SimError::NotAnElevator(_))));
 }
 
@@ -277,7 +278,7 @@ fn push_destination_errors_on_non_stop() {
     let mut sim = build_sim();
     let elev = first_elevator(&sim);
     // Use the elevator entity as the target — not a stop.
-    let result = sim.push_destination(elev, elev);
+    let result = sim.push_destination(elev, elev.entity());
     assert!(matches!(result, Err(SimError::NotAStop(_))));
 }
 
@@ -298,15 +299,15 @@ fn redirect_via_push_front_updates_direction_indicators() {
         sim.step();
         if matches!(
             sim.world()
-                .elevator(elev)
+                .elevator(elev.entity())
                 .map(crate::components::Elevator::phase),
             Some(ElevatorPhase::MovingToStop(_))
         ) {
             break;
         }
     }
-    assert_eq!(sim.elevator_going_up(elev), Some(true));
-    assert_eq!(sim.elevator_going_down(elev), Some(false));
+    assert_eq!(sim.elevator_going_up(elev.entity()), Some(true));
+    assert_eq!(sim.elevator_going_down(elev.entity()), Some(false));
 
     // Game imperatively redirects to a stop below the current position.
     let stop_0 = sim.stop_entity(StopId(0)).unwrap();
@@ -315,9 +316,9 @@ fn redirect_via_push_front_updates_direction_indicators() {
     sim.step();
 
     assert_eq!(
-        sim.elevator_going_up(elev),
+        sim.elevator_going_up(elev.entity()),
         Some(false),
         "push_destination_front to a lower stop must clear going_up",
     );
-    assert_eq!(sim.elevator_going_down(elev), Some(true));
+    assert_eq!(sim.elevator_going_down(elev.entity()), Some(true));
 }

--- a/crates/elevator-core/src/tests/destination_queue_tests.rs
+++ b/crates/elevator-core/src/tests/destination_queue_tests.rs
@@ -4,7 +4,7 @@
 use crate::builder::SimulationBuilder;
 use crate::components::ElevatorPhase;
 use crate::dispatch::scan::ScanDispatch;
-use crate::entity::{ElevatorId, RiderId};
+use crate::entity::ElevatorId;
 use crate::error::SimError;
 use crate::events::Event;
 use crate::stop::StopId;

--- a/crates/elevator-core/src/tests/direction_indicator_tests.rs
+++ b/crates/elevator-core/src/tests/direction_indicator_tests.rs
@@ -1,7 +1,7 @@
 //! Tests for the elevator direction indicator lamps (`going_up`/`going_down`).
 
 use crate::components::{ElevatorPhase, RiderPhase};
-use crate::entity::{ElevatorId, RiderId};
+use crate::entity::ElevatorId;
 use crate::events::Event;
 use crate::sim::Simulation;
 use crate::stop::StopId;

--- a/crates/elevator-core/src/tests/direction_indicator_tests.rs
+++ b/crates/elevator-core/src/tests/direction_indicator_tests.rs
@@ -1,6 +1,7 @@
 //! Tests for the elevator direction indicator lamps (`going_up`/`going_down`).
 
 use crate::components::{ElevatorPhase, RiderPhase};
+use crate::entity::{ElevatorId, RiderId};
 use crate::events::Event;
 use crate::sim::Simulation;
 use crate::stop::StopId;
@@ -8,8 +9,8 @@ use crate::stop::StopId;
 use super::helpers::{all_riders_arrived, default_config, scan};
 
 /// Grab the first (and usually only) elevator in a sim.
-fn first_elevator(sim: &Simulation) -> crate::entity::EntityId {
-    sim.world().elevator_ids()[0]
+fn first_elevator(sim: &Simulation) -> crate::entity::ElevatorId {
+    crate::entity::ElevatorId::from(sim.world().elevator_ids()[0])
 }
 
 #[test]
@@ -18,8 +19,8 @@ fn default_indicators_both_true() {
     let sim = Simulation::new(&config, scan()).unwrap();
     let elev = first_elevator(&sim);
 
-    assert_eq!(sim.elevator_going_up(elev), Some(true));
-    assert_eq!(sim.elevator_going_down(elev), Some(true));
+    assert_eq!(sim.elevator_going_up(elev.entity()), Some(true));
+    assert_eq!(sim.elevator_going_down(elev.entity()), Some(true));
 }
 
 #[test]
@@ -33,7 +34,7 @@ fn dispatch_upward_sets_going_up_only() {
     let mut saw_moving = false;
     for _ in 0..1_000 {
         sim.step();
-        if let Some(car) = sim.world().elevator(elev)
+        if let Some(car) = sim.world().elevator(elev.entity())
             && matches!(car.phase(), ElevatorPhase::MovingToStop(_))
         {
             saw_moving = true;
@@ -41,8 +42,8 @@ fn dispatch_upward_sets_going_up_only() {
         }
     }
     assert!(saw_moving, "elevator should start moving within 1000 ticks");
-    assert_eq!(sim.elevator_going_up(elev), Some(true));
-    assert_eq!(sim.elevator_going_down(elev), Some(false));
+    assert_eq!(sim.elevator_going_up(elev.entity()), Some(true));
+    assert_eq!(sim.elevator_going_down(elev.entity()), Some(false));
 }
 
 #[test]
@@ -58,7 +59,7 @@ fn dispatch_downward_sets_going_down_only() {
     let mut saw_moving = false;
     for _ in 0..1_000 {
         sim.step();
-        if let Some(car) = sim.world().elevator(elev)
+        if let Some(car) = sim.world().elevator(elev.entity())
             && matches!(car.phase(), ElevatorPhase::MovingToStop(_))
         {
             saw_moving = true;
@@ -66,8 +67,8 @@ fn dispatch_downward_sets_going_down_only() {
         }
     }
     assert!(saw_moving, "elevator should start moving within 1000 ticks");
-    assert_eq!(sim.elevator_going_up(elev), Some(false));
-    assert_eq!(sim.elevator_going_down(elev), Some(true));
+    assert_eq!(sim.elevator_going_up(elev.entity()), Some(false));
+    assert_eq!(sim.elevator_going_down(elev.entity()), Some(true));
 }
 
 #[test]
@@ -90,8 +91,8 @@ fn becoming_idle_resets_both_true() {
     }
 
     let elev = first_elevator(&sim);
-    assert_eq!(sim.elevator_going_up(elev), Some(true));
-    assert_eq!(sim.elevator_going_down(elev), Some(true));
+    assert_eq!(sim.elevator_going_up(elev.entity()), Some(true));
+    assert_eq!(sim.elevator_going_down(elev.entity()), Some(true));
 }
 
 #[test]
@@ -178,12 +179,12 @@ fn rider_going_up_skips_down_only_car() {
     for _ in 0..20_000 {
         sim.step();
         all_events.extend(sim.drain_events());
-        if sim.world().rider(down_rider).map(|r| r.phase) == Some(RiderPhase::Arrived) {
+        if sim.world().rider(down_rider.entity()).map(|r| r.phase) == Some(RiderPhase::Arrived) {
             break;
         }
     }
     assert_eq!(
-        sim.world().rider(down_rider).map(|r| r.phase),
+        sim.world().rider(down_rider.entity()).map(|r| r.phase),
         Some(RiderPhase::Arrived)
     );
 
@@ -191,7 +192,7 @@ fn rider_going_up_skips_down_only_car() {
     let up_rider_boarded_during_down = all_events.iter().any(|e| {
         matches!(
             e,
-            Event::RiderBoarded { rider, .. } if *rider == up_rider
+            Event::RiderBoarded { rider, .. } if *rider == up_rider.entity()
         )
     });
     assert!(
@@ -202,7 +203,7 @@ fn rider_going_up_skips_down_only_car() {
     let up_rider_rejected = all_events.iter().any(|e| {
         matches!(
             e,
-            Event::RiderRejected { rider, .. } if *rider == up_rider
+            Event::RiderRejected { rider, .. } if *rider == up_rider.entity()
         )
     });
     assert!(
@@ -213,12 +214,12 @@ fn rider_going_up_skips_down_only_car() {
     // Now run until the up-rider arrives — the car should turn around and pick them up.
     for _ in 0..20_000 {
         sim.step();
-        if sim.world().rider(up_rider).map(|r| r.phase) == Some(RiderPhase::Arrived) {
+        if sim.world().rider(up_rider.entity()).map(|r| r.phase) == Some(RiderPhase::Arrived) {
             break;
         }
     }
     assert_eq!(
-        sim.world().rider(up_rider).map(|r| r.phase),
+        sim.world().rider(up_rider.entity()).map(|r| r.phase),
         Some(RiderPhase::Arrived),
         "up-rider should eventually be picked up on the return trip"
     );
@@ -237,12 +238,12 @@ fn idle_car_boards_riders_either_direction() {
     let up_rider = sim.spawn_rider(StopId(1), StopId(2), 70.0).unwrap();
     for _ in 0..20_000 {
         sim.step();
-        if sim.world().rider(up_rider).map(|r| r.phase) == Some(RiderPhase::Arrived) {
+        if sim.world().rider(up_rider.entity()).map(|r| r.phase) == Some(RiderPhase::Arrived) {
             break;
         }
     }
     assert_eq!(
-        sim.world().rider(up_rider).map(|r| r.phase),
+        sim.world().rider(up_rider.entity()).map(|r| r.phase),
         Some(RiderPhase::Arrived)
     );
 
@@ -254,12 +255,12 @@ fn idle_car_boards_riders_either_direction() {
     let down_rider = sim.spawn_rider(StopId(1), StopId(0), 70.0).unwrap();
     for _ in 0..20_000 {
         sim.step();
-        if sim.world().rider(down_rider).map(|r| r.phase) == Some(RiderPhase::Arrived) {
+        if sim.world().rider(down_rider.entity()).map(|r| r.phase) == Some(RiderPhase::Arrived) {
             break;
         }
     }
     assert_eq!(
-        sim.world().rider(down_rider).map(|r| r.phase),
+        sim.world().rider(down_rider.entity()).map(|r| r.phase),
         Some(RiderPhase::Arrived)
     );
 }
@@ -275,18 +276,25 @@ fn snapshot_roundtrip_preserves_indicators() {
     // Step until indicators are (true, false) — upward-only.
     for _ in 0..1_000 {
         sim.step();
-        if sim.elevator_going_up(elev) == Some(true) && sim.elevator_going_down(elev) == Some(false)
+        if sim.elevator_going_up(elev.entity()) == Some(true)
+            && sim.elevator_going_down(elev.entity()) == Some(false)
         {
             break;
         }
     }
-    assert_eq!(sim.elevator_going_up(elev), Some(true));
-    assert_eq!(sim.elevator_going_down(elev), Some(false));
+    assert_eq!(sim.elevator_going_up(elev.entity()), Some(true));
+    assert_eq!(sim.elevator_going_down(elev.entity()), Some(false));
 
     let snap = sim.snapshot();
     let restored = snap.restore(None).unwrap();
-    let restored_elev = restored.world().elevator_ids()[0];
+    let restored_elev = ElevatorId::from(restored.world().elevator_ids()[0]);
 
-    assert_eq!(restored.elevator_going_up(restored_elev), Some(true));
-    assert_eq!(restored.elevator_going_down(restored_elev), Some(false));
+    assert_eq!(
+        restored.elevator_going_up(restored_elev.entity()),
+        Some(true)
+    );
+    assert_eq!(
+        restored.elevator_going_down(restored_elev.entity()),
+        Some(false)
+    );
 }

--- a/crates/elevator-core/src/tests/door_control_tests.rs
+++ b/crates/elevator-core/src/tests/door_control_tests.rs
@@ -5,7 +5,7 @@
 use crate::components::{ElevatorPhase, RiderPhase};
 use crate::dispatch::scan::ScanDispatch;
 use crate::door::{DoorCommand, DoorState};
-use crate::entity::{ElevatorId, EntityId, RiderId};
+use crate::entity::ElevatorId;
 use crate::error::SimError;
 use crate::events::Event;
 use crate::sim::Simulation;

--- a/crates/elevator-core/src/tests/door_control_tests.rs
+++ b/crates/elevator-core/src/tests/door_control_tests.rs
@@ -5,17 +5,17 @@
 use crate::components::{ElevatorPhase, RiderPhase};
 use crate::dispatch::scan::ScanDispatch;
 use crate::door::{DoorCommand, DoorState};
-use crate::entity::EntityId;
+use crate::entity::{ElevatorId, EntityId, RiderId};
 use crate::error::SimError;
 use crate::events::Event;
 use crate::sim::Simulation;
 use crate::stop::StopId;
 use crate::tests::helpers::default_config;
 
-fn make_sim() -> (Simulation, EntityId) {
+fn make_sim() -> (Simulation, ElevatorId) {
     let config = default_config();
     let sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
-    let elev = sim.world().iter_elevators().next().unwrap().0;
+    let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     (sim, elev)
 }
 
@@ -48,14 +48,14 @@ fn open_while_stopped_opens_doors() {
     let (mut sim, elev) = make_sim();
     // Car starts Idle at Ground with doors Closed.
     assert!(matches!(
-        sim.world().elevator(elev).unwrap().door(),
+        sim.world().elevator(elev.entity()).unwrap().door(),
         DoorState::Closed
     ));
 
     sim.open_door(elev).unwrap();
     sim.step();
 
-    let phase = sim.world().elevator(elev).unwrap().phase();
+    let phase = sim.world().elevator(elev.entity()).unwrap().phase();
     assert!(
         matches!(phase, ElevatorPhase::DoorOpening | ElevatorPhase::Loading),
         "expected DoorOpening or Loading, got {phase}"
@@ -73,19 +73,19 @@ fn close_during_open_forces_close() {
     // Step until Loading (doors fully open).
     for _ in 0..20 {
         sim.step();
-        if sim.world().elevator(elev).unwrap().phase() == ElevatorPhase::Loading {
+        if sim.world().elevator(elev.entity()).unwrap().phase() == ElevatorPhase::Loading {
             break;
         }
     }
     assert_eq!(
-        sim.world().elevator(elev).unwrap().phase(),
+        sim.world().elevator(elev.entity()).unwrap().phase(),
         ElevatorPhase::Loading
     );
     let _ = drain_events(&mut sim);
 
     sim.close_door(elev).unwrap();
     sim.step();
-    let phase = sim.world().elevator(elev).unwrap().phase();
+    let phase = sim.world().elevator(elev.entity()).unwrap().phase();
     assert!(
         matches!(phase, ElevatorPhase::DoorClosing | ElevatorPhase::Stopped),
         "expected DoorClosing or Stopped after forced close, got {phase}"
@@ -103,14 +103,14 @@ fn open_reverses_closing_door() {
     // Drive the doors open then force them into DoorClosing.
     for _ in 0..20 {
         sim.step();
-        if sim.world().elevator(elev).unwrap().phase() == ElevatorPhase::Loading {
+        if sim.world().elevator(elev.entity()).unwrap().phase() == ElevatorPhase::Loading {
             break;
         }
     }
     sim.close_door(elev).unwrap();
     sim.step();
     // Now at DoorClosing (or already Closed if transition was instant).
-    let phase = sim.world().elevator(elev).unwrap().phase();
+    let phase = sim.world().elevator(elev.entity()).unwrap().phase();
     if phase != ElevatorPhase::DoorClosing {
         // Race — skip the test body; closing was too fast. Ensure basic
         // invariants still hold in that edge case.
@@ -120,7 +120,7 @@ fn open_reverses_closing_door() {
 
     sim.open_door(elev).unwrap();
     sim.step();
-    let phase = sim.world().elevator(elev).unwrap().phase();
+    let phase = sim.world().elevator(elev.entity()).unwrap().phase();
     assert!(
         matches!(phase, ElevatorPhase::DoorOpening | ElevatorPhase::Loading),
         "expected reversal to DoorOpening, got {phase}"
@@ -140,8 +140,8 @@ fn close_waits_for_boarding_rider() {
     for _ in 0..30 {
         sim.step();
         if matches!(
-            sim.world().rider(rider).unwrap().phase,
-            RiderPhase::Boarding(e) if e == elev
+            sim.world().rider(rider.entity()).unwrap().phase,
+            RiderPhase::Boarding(e) if e == elev.entity()
         ) {
             saw_boarding = true;
             break;
@@ -171,7 +171,7 @@ fn close_waits_for_boarding_rider() {
     // queue state right after the setter: command should be present.
     let pending = sim
         .world()
-        .elevator(elev)
+        .elevator(elev.entity())
         .unwrap()
         .door_command_queue()
         .to_vec();
@@ -182,8 +182,8 @@ fn close_waits_for_boarding_rider() {
     sim.step();
     // Rider should now be Riding, and the close should have applied.
     assert!(matches!(
-        sim.world().rider(rider).unwrap().phase,
-        RiderPhase::Riding(e) if e == elev
+        sim.world().rider(rider.entity()).unwrap().phase,
+        RiderPhase::Riding(e) if e == elev.entity()
     ));
     let events = drain_events(&mut sim);
     assert!(has_applied(&events, DoorCommand::Close));
@@ -198,12 +198,12 @@ fn hold_extends_open_timer() {
     // Reach Loading.
     for _ in 0..20 {
         sim.step();
-        if sim.world().elevator(elev).unwrap().phase() == ElevatorPhase::Loading {
+        if sim.world().elevator(elev.entity()).unwrap().phase() == ElevatorPhase::Loading {
             break;
         }
     }
     assert_eq!(
-        sim.world().elevator(elev).unwrap().phase(),
+        sim.world().elevator(elev.entity()).unwrap().phase(),
         ElevatorPhase::Loading
     );
     let _ = drain_events(&mut sim);
@@ -219,7 +219,7 @@ fn hold_extends_open_timer() {
         sim.step();
     }
     assert_eq!(
-        sim.world().elevator(elev).unwrap().phase(),
+        sim.world().elevator(elev.entity()).unwrap().phase(),
         ElevatorPhase::Loading,
         "hold should keep doors open"
     );
@@ -232,12 +232,12 @@ fn hold_is_cumulative() {
     sim.open_door(elev).unwrap();
     for _ in 0..20 {
         sim.step();
-        if sim.world().elevator(elev).unwrap().phase() == ElevatorPhase::Loading {
+        if sim.world().elevator(elev.entity()).unwrap().phase() == ElevatorPhase::Loading {
             break;
         }
     }
     // Capture remaining ticks immediately after reaching Loading.
-    let remaining_before = match sim.world().elevator(elev).unwrap().door() {
+    let remaining_before = match sim.world().elevator(elev.entity()).unwrap().door() {
         DoorState::Open {
             ticks_remaining, ..
         } => *ticks_remaining,
@@ -246,7 +246,7 @@ fn hold_is_cumulative() {
     sim.hold_door(elev, 10).unwrap();
     sim.hold_door(elev, 10).unwrap();
     sim.step(); // apply both
-    let remaining_after = match sim.world().elevator(elev).unwrap().door() {
+    let remaining_after = match sim.world().elevator(elev.entity()).unwrap().door() {
         DoorState::Open {
             ticks_remaining, ..
         } => *ticks_remaining,
@@ -265,15 +265,19 @@ fn cancel_hold_clamps_to_base() {
     sim.open_door(elev).unwrap();
     for _ in 0..20 {
         sim.step();
-        if sim.world().elevator(elev).unwrap().phase() == ElevatorPhase::Loading {
+        if sim.world().elevator(elev.entity()).unwrap().phase() == ElevatorPhase::Loading {
             break;
         }
     }
-    let base = sim.world().elevator(elev).unwrap().door_open_ticks();
+    let base = sim
+        .world()
+        .elevator(elev.entity())
+        .unwrap()
+        .door_open_ticks();
     sim.hold_door(elev, 100).unwrap();
     sim.step();
     // Remaining should be well over `base`.
-    let held = match sim.world().elevator(elev).unwrap().door() {
+    let held = match sim.world().elevator(elev.entity()).unwrap().door() {
         DoorState::Open {
             ticks_remaining, ..
         } => *ticks_remaining,
@@ -283,7 +287,7 @@ fn cancel_hold_clamps_to_base() {
 
     sim.cancel_door_hold(elev).unwrap();
     sim.step();
-    let after = match sim.world().elevator(elev).unwrap().door() {
+    let after = match sim.world().elevator(elev.entity()).unwrap().door() {
         DoorState::Open {
             ticks_remaining, ..
         } => *ticks_remaining,
@@ -306,11 +310,23 @@ fn command_queued_during_motion_fires_on_arrival() {
     // Step until moving.
     for _ in 0..100 {
         sim.step();
-        if sim.world().elevator(elev).unwrap().phase().is_moving() {
+        if sim
+            .world()
+            .elevator(elev.entity())
+            .unwrap()
+            .phase()
+            .is_moving()
+        {
             break;
         }
     }
-    assert!(sim.world().elevator(elev).unwrap().phase().is_moving());
+    assert!(
+        sim.world()
+            .elevator(elev.entity())
+            .unwrap()
+            .phase()
+            .is_moving()
+    );
     let _ = drain_events(&mut sim);
 
     sim.open_door(elev).unwrap();
@@ -343,20 +359,22 @@ fn command_queued_during_motion_fires_on_arrival() {
 fn unknown_elevator_errors() {
     let (mut sim, _elev) = make_sim();
     let rider = sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
+    // Wrap a rider's EntityId in ElevatorId to test the runtime check.
+    let fake_elev = ElevatorId::from(rider.entity());
     assert!(matches!(
-        sim.open_door(rider),
+        sim.open_door(fake_elev),
         Err(SimError::NotAnElevator(_))
     ));
     assert!(matches!(
-        sim.close_door(rider),
+        sim.close_door(fake_elev),
         Err(SimError::NotAnElevator(_))
     ));
     assert!(matches!(
-        sim.hold_door(rider, 10),
+        sim.hold_door(fake_elev, 10),
         Err(SimError::NotAnElevator(_))
     ));
     assert!(matches!(
-        sim.cancel_door_hold(rider),
+        sim.cancel_door_hold(fake_elev),
         Err(SimError::NotAnElevator(_))
     ));
 }
@@ -382,7 +400,13 @@ fn queue_is_capped() {
     for _ in 0..5 {
         sim.step();
     }
-    assert!(sim.world().elevator(elev).unwrap().phase().is_moving());
+    assert!(
+        sim.world()
+            .elevator(elev.entity())
+            .unwrap()
+            .phase()
+            .is_moving()
+    );
 
     // Alternate commands so adjacent-dedup doesn't collapse them.
     for i in 0..100 {
@@ -394,7 +418,7 @@ fn queue_is_capped() {
     }
     let q_len = sim
         .world()
-        .elevator(elev)
+        .elevator(elev.entity())
         .unwrap()
         .door_command_queue()
         .len();

--- a/crates/elevator-core/src/tests/eta_tests.rs
+++ b/crates/elevator-core/src/tests/eta_tests.rs
@@ -1,4 +1,5 @@
 use crate::components::{Accel, Direction, ServiceMode, Speed, Weight};
+use crate::entity::ElevatorId;
 use crate::error::EtaError;
 use crate::eta::travel_time;
 use crate::stop::StopId;
@@ -51,7 +52,7 @@ fn travel_time_brake_only_when_overspeed_close() {
 fn eta_returns_none_for_unqueued_stop() {
     let config = helpers::default_config();
     let sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
-    let elev = sim.world().iter_elevators().next().unwrap().0;
+    let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     let stop1 = sim.stop_entity(StopId(1)).unwrap();
     // Empty queue, no movement target → Err.
     assert!(sim.eta(elev, stop1).is_err());
@@ -63,7 +64,7 @@ fn eta_returns_some_for_queued_stop() {
     // Pump down ticks_per_second so wall-clock arithmetic is easy to read.
     config.simulation.ticks_per_second = 60.0;
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
-    let elev = sim.world().iter_elevators().next().unwrap().0;
+    let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     let stop1 = sim.stop_entity(StopId(1)).unwrap();
 
     sim.push_destination(elev, stop1).unwrap();
@@ -86,7 +87,7 @@ fn eta_actual_arrival_within_estimate_tolerance() {
     // out of sync between movement.rs and eta.rs.
     let config = helpers::default_config();
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
-    let elev = sim.world().iter_elevators().next().unwrap().0;
+    let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     let stop2 = sim.stop_entity(StopId(2)).unwrap();
     sim.push_destination(elev, stop2).unwrap();
 
@@ -100,7 +101,7 @@ fn eta_actual_arrival_within_estimate_tolerance() {
     for _ in 0..2000 {
         sim.step();
         actual_ticks += 1;
-        let phase = sim.world().elevator(elev).unwrap().phase();
+        let phase = sim.world().elevator(elev.entity()).unwrap().phase();
         if !phase.is_moving() && !matches!(phase, crate::components::ElevatorPhase::Idle) {
             arrived = true;
             break;
@@ -118,7 +119,7 @@ fn eta_actual_arrival_within_estimate_tolerance() {
 fn eta_sums_door_cycles_for_intermediate_stops() {
     let config = helpers::default_config();
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
-    let elev = sim.world().iter_elevators().next().unwrap().0;
+    let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     let stop1 = sim.stop_entity(StopId(1)).unwrap();
     let stop2 = sim.stop_entity(StopId(2)).unwrap();
 
@@ -144,8 +145,8 @@ fn eta_queue_order_matters() {
     let config = helpers::default_config();
     let mut sim_a = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
     let mut sim_b = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
-    let elev_a = sim_a.world().iter_elevators().next().unwrap().0;
-    let elev_b = sim_b.world().iter_elevators().next().unwrap().0;
+    let elev_a = ElevatorId::from(sim_a.world().iter_elevators().next().unwrap().0);
+    let elev_b = ElevatorId::from(sim_b.world().iter_elevators().next().unwrap().0);
     let s1_a = sim_a.stop_entity(StopId(1)).unwrap();
     let s2_a = sim_a.stop_entity(StopId(2)).unwrap();
     let s1_b = sim_b.stop_entity(StopId(1)).unwrap();
@@ -164,11 +165,12 @@ fn eta_queue_order_matters() {
 fn eta_returns_none_for_manual_mode() {
     let config = helpers::default_config();
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
-    let elev = sim.world().iter_elevators().next().unwrap().0;
+    let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     let stop1 = sim.stop_entity(StopId(1)).unwrap();
     sim.push_destination(elev, stop1).unwrap();
 
-    sim.set_service_mode(elev, ServiceMode::Manual).unwrap();
+    sim.set_service_mode(elev.entity(), ServiceMode::Manual)
+        .unwrap();
     assert!(matches!(
         sim.eta(elev, stop1),
         Err(EtaError::ServiceModeExcluded(_))
@@ -179,11 +181,11 @@ fn eta_returns_none_for_manual_mode() {
 fn eta_returns_none_for_independent_mode() {
     let config = helpers::default_config();
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
-    let elev = sim.world().iter_elevators().next().unwrap().0;
+    let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     let stop1 = sim.stop_entity(StopId(1)).unwrap();
     sim.push_destination(elev, stop1).unwrap();
 
-    sim.set_service_mode(elev, ServiceMode::Independent)
+    sim.set_service_mode(elev.entity(), ServiceMode::Independent)
         .unwrap();
     assert!(matches!(
         sim.eta(elev, stop1),
@@ -195,14 +197,17 @@ fn eta_returns_none_for_independent_mode() {
 fn eta_rejects_non_elevator_and_non_stop() {
     let config = helpers::default_config();
     let sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
-    let elev = sim.world().iter_elevators().next().unwrap().0;
+    let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     let stop1 = sim.stop_entity(StopId(1)).unwrap();
     // Swap arguments: stop is not an elevator, elevator is not a stop.
     assert!(matches!(
-        sim.eta(stop1, stop1),
+        sim.eta(ElevatorId::from(stop1), stop1),
         Err(EtaError::NotAnElevator(_))
     ));
-    assert!(matches!(sim.eta(elev, elev), Err(EtaError::NotAStop(_))));
+    assert!(matches!(
+        sim.eta(elev, elev.entity()),
+        Err(EtaError::NotAStop(_))
+    ));
 }
 
 #[test]
@@ -231,7 +236,7 @@ fn best_eta_picks_min_across_elevators() {
     let elevs: Vec<_> = sim.world().iter_elevators().map(|(e, _, _)| e).collect();
     let stop1 = sim.stop_entity(StopId(1)).unwrap();
     for &e in &elevs {
-        sim.push_destination(e, stop1).unwrap();
+        sim.push_destination(ElevatorId::from(e), stop1).unwrap();
     }
     let (winner, _) = sim.best_eta(stop1, Direction::Either).unwrap();
     let winner_pos = sim.world().position(winner).unwrap().value;
@@ -253,7 +258,7 @@ fn best_eta_returns_none_when_nobody_queued() {
 fn best_eta_filters_by_direction() {
     let config = helpers::default_config();
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
-    let elev = sim.world().iter_elevators().next().unwrap().0;
+    let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     let stop2 = sim.stop_entity(StopId(2)).unwrap();
     sim.push_destination(elev, stop2).unwrap();
 

--- a/crates/elevator-core/src/tests/event_payload_tests.rs
+++ b/crates/elevator-core/src/tests/event_payload_tests.rs
@@ -2,6 +2,7 @@
 
 use crate::components::RiderPhase;
 use crate::dispatch::scan::ScanDispatch;
+use crate::entity::RiderId;
 use crate::events::Event;
 use crate::sim::Simulation;
 use crate::stop::StopId;
@@ -22,7 +23,7 @@ fn rider_boarded_event_has_correct_elevator() {
             if let Event::RiderBoarded {
                 rider: r, elevator, ..
             } = e
-                && *r == rider
+                && *r == rider.entity()
             {
                 boarded_event = Some(*elevator);
             }
@@ -36,7 +37,10 @@ fn rider_boarded_event_has_correct_elevator() {
 
     // Verify the rider is riding (or has already ridden) this elevator.
     // By the time we drain the event the rider may have progressed past Riding.
-    let rider_data = sim.world().rider(rider).expect("rider should exist");
+    let rider_data = sim
+        .world()
+        .rider(rider.entity())
+        .expect("rider should exist");
     let phase_ok = matches!(
         rider_data.phase,
         RiderPhase::Boarding(e) | RiderPhase::Riding(e) | RiderPhase::Exiting(e) if e == elevator_id

--- a/crates/elevator-core/src/tests/event_payload_tests.rs
+++ b/crates/elevator-core/src/tests/event_payload_tests.rs
@@ -2,7 +2,6 @@
 
 use crate::components::RiderPhase;
 use crate::dispatch::scan::ScanDispatch;
-use crate::entity::RiderId;
 use crate::events::Event;
 use crate::sim::Simulation;
 use crate::stop::StopId;

--- a/crates/elevator-core/src/tests/feature_tests.rs
+++ b/crates/elevator-core/src/tests/feature_tests.rs
@@ -3,7 +3,7 @@ use crate::components::{
     Speed, Stop, Velocity, Weight,
 };
 use crate::door::DoorState;
-use crate::entity::EntityId;
+use crate::entity::{ElevatorId, EntityId, RiderId};
 use crate::events::Event;
 use crate::ids::GroupId;
 use crate::stop::StopId;
@@ -23,7 +23,7 @@ fn patience_abandonment_sets_abandoned_phase() {
 
     // Attach a short patience: abandon after 5 ticks.
     sim.world_mut().set_patience(
-        rider,
+        rider.entity(),
         Patience {
             max_wait_ticks: 5,
             waited_ticks: 0,
@@ -31,8 +31,8 @@ fn patience_abandonment_sets_abandoned_phase() {
     );
 
     // Disable the elevator so the rider is never served.
-    let elev = sim.world().elevator_ids()[0];
-    sim.disable(elev).unwrap();
+    let elev = ElevatorId::from(sim.world().elevator_ids()[0]);
+    sim.disable(elev.entity()).unwrap();
     sim.drain_events();
 
     // Step enough ticks that the patience limit is exceeded.
@@ -43,7 +43,7 @@ fn patience_abandonment_sets_abandoned_phase() {
     }
 
     assert_eq!(
-        sim.world().rider(rider).map(|r| r.phase),
+        sim.world().rider(rider.entity()).map(|r| r.phase),
         Some(RiderPhase::Abandoned),
         "rider should reach Abandoned phase after patience expires"
     );
@@ -51,7 +51,7 @@ fn patience_abandonment_sets_abandoned_phase() {
     assert!(
         all_events
             .iter()
-            .any(|e| matches!(e, Event::RiderAbandoned { rider: r, .. } if *r == rider)),
+            .any(|e| matches!(e, Event::RiderAbandoned { rider: r, .. } if *r == rider.entity())),
         "RiderAbandoned event should be emitted for the patience-expired rider"
     );
 }
@@ -64,7 +64,7 @@ fn patience_abandonment_does_not_fire_before_limit() {
     let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     sim.world_mut().set_patience(
-        rider,
+        rider.entity(),
         Patience {
             max_wait_ticks: 100,
             waited_ticks: 0,
@@ -72,8 +72,8 @@ fn patience_abandonment_does_not_fire_before_limit() {
     );
 
     // Disable elevator so dispatch never picks the rider up.
-    let elev = sim.world().elevator_ids()[0];
-    sim.disable(elev).unwrap();
+    let elev = ElevatorId::from(sim.world().elevator_ids()[0]);
+    sim.disable(elev.entity()).unwrap();
     sim.drain_events();
 
     // Step only a handful of ticks — well under the patience limit.
@@ -83,7 +83,7 @@ fn patience_abandonment_does_not_fire_before_limit() {
     }
 
     assert_eq!(
-        sim.world().rider(rider).map(|r| r.phase),
+        sim.world().rider(rider.entity()).map(|r| r.phase),
         Some(RiderPhase::Waiting),
         "rider should still be Waiting when patience has not expired"
     );
@@ -97,15 +97,15 @@ fn waited_ticks_increments_each_step() {
     let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     sim.world_mut().set_patience(
-        rider,
+        rider.entity(),
         Patience {
             max_wait_ticks: 1000,
             waited_ticks: 0,
         },
     );
 
-    let elev = sim.world().elevator_ids()[0];
-    sim.disable(elev).unwrap();
+    let elev = ElevatorId::from(sim.world().elevator_ids()[0]);
+    sim.disable(elev.entity()).unwrap();
     sim.drain_events();
 
     for _ in 0..3 {
@@ -113,7 +113,7 @@ fn waited_ticks_increments_each_step() {
         sim.drain_events();
     }
 
-    let waited = sim.world().patience(rider).map(|p| p.waited_ticks);
+    let waited = sim.world().patience(rider.entity()).map(|p| p.waited_ticks);
     assert_eq!(
         waited,
         Some(3),
@@ -140,7 +140,7 @@ fn preferences_skip_crowded_elevator_prevents_boarding() {
     for _ in 0..max_ticks {
         sim.step();
         sim.drain_events();
-        if sim.world().rider(ballast).map(|r| r.phase)
+        if sim.world().rider(ballast.entity()).map(|r| r.phase)
             == Some(RiderPhase::Riding(sim.world().elevator_ids()[0]))
         {
             break;
@@ -148,7 +148,7 @@ fn preferences_skip_crowded_elevator_prevents_boarding() {
     }
     assert!(
         matches!(
-            sim.world().rider(ballast).map(|r| r.phase),
+            sim.world().rider(ballast.entity()).map(|r| r.phase),
             Some(RiderPhase::Riding(_))
         ),
         "ballast rider should be riding before the test begins"
@@ -157,7 +157,7 @@ fn preferences_skip_crowded_elevator_prevents_boarding() {
     // Now spawn the picky rider with skip_full_elevator = true and a strict factor.
     let picky = sim.spawn_rider(StopId(0), StopId(2), 30.0).unwrap();
     sim.world_mut().set_preferences(
-        picky,
+        picky.entity(),
         Preferences {
             skip_full_elevator: true,
             max_crowding_factor: 0.5, // will skip if load > 50 %
@@ -172,20 +172,20 @@ fn preferences_skip_crowded_elevator_prevents_boarding() {
     // then run only the loading phase once to observe the skip.
     //
     // Find the elevator entity and the stop-0 entity.
-    let elev = sim.world().elevator_ids()[0];
+    let elev = ElevatorId::from(sim.world().elevator_ids()[0]);
     let stop0 = sim.stop_entity(StopId(0)).unwrap();
     let stop0_pos = sim.world().stop(stop0).unwrap().position;
 
     // Force elevator to stop 0, Loading phase, with ballast load.
     {
         let w = sim.world_mut();
-        if let Some(pos) = w.position_mut(elev) {
+        if let Some(pos) = w.position_mut(elev.entity()) {
             pos.value = stop0_pos;
         }
-        if let Some(vel) = w.velocity_mut(elev) {
+        if let Some(vel) = w.velocity_mut(elev.entity()) {
             vel.value = 0.0;
         }
-        if let Some(car) = w.elevator_mut(elev) {
+        if let Some(car) = w.elevator_mut(elev.entity()) {
             car.phase = ElevatorPhase::Loading;
             car.current_load = Weight::from(60.0); // ballast weight
             car.target_stop = None;
@@ -199,7 +199,7 @@ fn preferences_skip_crowded_elevator_prevents_boarding() {
 
     // The picky rider should still be Waiting — not Boarding or Riding.
     assert_eq!(
-        sim.world().rider(picky).map(|r| r.phase),
+        sim.world().rider(picky.entity()).map(|r| r.phase),
         Some(RiderPhase::Waiting),
         "picky rider should remain Waiting when elevator exceeds max_crowding_factor"
     );
@@ -216,7 +216,7 @@ fn preferences_boards_when_elevator_not_too_crowded() {
 
     // max_crowding_factor 0.5: current_load 0.0 / 100.0 = 0.0 — well below.
     sim.world_mut().set_preferences(
-        rider,
+        rider.entity(),
         Preferences {
             skip_full_elevator: true,
             max_crowding_factor: 0.5,
@@ -225,19 +225,19 @@ fn preferences_boards_when_elevator_not_too_crowded() {
         },
     );
 
-    let elev = sim.world().elevator_ids()[0];
+    let elev = ElevatorId::from(sim.world().elevator_ids()[0]);
     let stop0 = sim.stop_entity(StopId(0)).unwrap();
     let stop0_pos = sim.world().stop(stop0).unwrap().position;
 
     {
         let w = sim.world_mut();
-        if let Some(pos) = w.position_mut(elev) {
+        if let Some(pos) = w.position_mut(elev.entity()) {
             pos.value = stop0_pos;
         }
-        if let Some(vel) = w.velocity_mut(elev) {
+        if let Some(vel) = w.velocity_mut(elev.entity()) {
             vel.value = 0.0;
         }
-        if let Some(car) = w.elevator_mut(elev) {
+        if let Some(car) = w.elevator_mut(elev.entity()) {
             car.phase = ElevatorPhase::Loading;
             car.current_load = Weight::from(0.0);
             car.target_stop = None;
@@ -250,7 +250,7 @@ fn preferences_boards_when_elevator_not_too_crowded() {
 
     assert!(
         matches!(
-            sim.world().rider(rider).map(|r| r.phase),
+            sim.world().rider(rider.entity()).map(|r| r.phase),
             Some(RiderPhase::Boarding(_))
         ),
         "rider should board when elevator is below max_crowding_factor"
@@ -356,10 +356,10 @@ fn double_board_guard_rider_appears_in_exactly_one_elevator() {
         inspection_speed_factor: 0.25,
     };
     let line = sim.lines_in_group(GroupId(0))[0];
-    let elev2 = sim.add_elevator(&params, line, 0.0).unwrap();
+    let elev2 = ElevatorId::from(sim.add_elevator(&params, line, 0.0).unwrap());
     sim.drain_events();
 
-    let elev1 = sim.world().elevator_ids()[0];
+    let elev1 = ElevatorId::from(sim.world().elevator_ids()[0]);
     let stop0 = sim.stop_entity(StopId(0)).unwrap();
     let stop0_pos = sim.world().stop(stop0).unwrap().position;
     let stop2 = sim.stop_entity(StopId(2)).unwrap();
@@ -372,13 +372,13 @@ fn double_board_guard_rider_appears_in_exactly_one_elevator() {
     {
         let w = sim.world_mut();
         for &eid in &[elev1, elev2] {
-            if let Some(pos) = w.position_mut(eid) {
+            if let Some(pos) = w.position_mut(eid.entity()) {
                 pos.value = stop0_pos;
             }
-            if let Some(vel) = w.velocity_mut(eid) {
+            if let Some(vel) = w.velocity_mut(eid.entity()) {
                 vel.value = 0.0;
             }
-            if let Some(car) = w.elevator_mut(eid) {
+            if let Some(car) = w.elevator_mut(eid.entity()) {
                 car.phase = ElevatorPhase::Loading;
                 car.riders.clear();
                 car.current_load = Weight::from(0.0);
@@ -399,7 +399,7 @@ fn double_board_guard_rider_appears_in_exactly_one_elevator() {
         .filter(|&&eid| {
             sim.world()
                 .elevator(eid)
-                .is_some_and(|car| car.riders.contains(&rider))
+                .is_some_and(|car| car.riders.contains(&rider.entity()))
         })
         .count();
 
@@ -424,7 +424,7 @@ fn disable_elevator_ejects_riding_passenger_to_waiting() {
         sim.step();
         sim.drain_events();
         if matches!(
-            sim.world().rider(rider).map(|r| r.phase),
+            sim.world().rider(rider.entity()).map(|r| r.phase),
             Some(RiderPhase::Riding(_))
         ) {
             break;
@@ -433,26 +433,29 @@ fn disable_elevator_ejects_riding_passenger_to_waiting() {
 
     assert!(
         matches!(
-            sim.world().rider(rider).map(|r| r.phase),
+            sim.world().rider(rider.entity()).map(|r| r.phase),
             Some(RiderPhase::Riding(_))
         ),
         "rider should be Riding before we disable the elevator"
     );
 
     // Disable the elevator.
-    let elev = sim.world().elevator_ids()[0];
-    sim.disable(elev).unwrap();
+    let elev = ElevatorId::from(sim.world().elevator_ids()[0]);
+    sim.disable(elev.entity()).unwrap();
     let events = sim.drain_events();
 
     // Rider should now be Waiting.
     assert_eq!(
-        sim.world().rider(rider).map(|r| r.phase),
+        sim.world().rider(rider.entity()).map(|r| r.phase),
         Some(RiderPhase::Waiting),
         "ejected rider should be in Waiting phase"
     );
 
     // Rider should be at a valid stop.
-    let current_stop = sim.world().rider(rider).and_then(|r| r.current_stop);
+    let current_stop = sim
+        .world()
+        .rider(rider.entity())
+        .and_then(|r| r.current_stop);
     assert!(
         current_stop.is_some(),
         "ejected rider should have a current_stop"
@@ -470,7 +473,7 @@ fn disable_elevator_ejects_riding_passenger_to_waiting() {
     assert!(
         events.iter().any(
             |e| matches!(e, Event::RiderEjected { rider: r, elevator: e, .. }
-                if *r == rider && *e == elev)
+                if *r == rider.entity() && *e == elev.entity())
         ),
         "RiderEjected event should be emitted when elevator is disabled"
     );
@@ -483,7 +486,7 @@ fn disable_elevator_clears_its_rider_list() {
 
     sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
-    let elev = sim.world().elevator_ids()[0];
+    let elev = ElevatorId::from(sim.world().elevator_ids()[0]);
 
     // Wait until the elevator has boarded the rider.
     for _ in 0..5_000 {
@@ -491,17 +494,17 @@ fn disable_elevator_clears_its_rider_list() {
         sim.drain_events();
         if sim
             .world()
-            .elevator(elev)
+            .elevator(elev.entity())
             .is_some_and(|c| !c.riders.is_empty())
         {
             break;
         }
     }
 
-    sim.disable(elev).unwrap();
+    sim.disable(elev.entity()).unwrap();
     sim.drain_events();
 
-    let car = sim.world().elevator(elev).unwrap();
+    let car = sim.world().elevator(elev.entity()).unwrap();
     assert!(
         car.riders.is_empty(),
         "elevator riders list should be empty after disable"

--- a/crates/elevator-core/src/tests/feature_tests.rs
+++ b/crates/elevator-core/src/tests/feature_tests.rs
@@ -3,7 +3,7 @@ use crate::components::{
     Speed, Stop, Velocity, Weight,
 };
 use crate::door::DoorState;
-use crate::entity::{ElevatorId, EntityId, RiderId};
+use crate::entity::{ElevatorId, EntityId};
 use crate::events::Event;
 use crate::ids::GroupId;
 use crate::stop::StopId;

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -2,7 +2,7 @@
 
 use crate::components::CallDirection;
 use crate::components::Weight;
-use crate::entity::{ElevatorId, EntityId, RiderId};
+use crate::entity::{ElevatorId, EntityId};
 use crate::events::Event;
 use crate::sim::Simulation;
 use crate::stop::StopId;

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -2,7 +2,7 @@
 
 use crate::components::CallDirection;
 use crate::components::Weight;
-use crate::entity::EntityId;
+use crate::entity::{ElevatorId, EntityId, RiderId};
 use crate::events::Event;
 use crate::sim::Simulation;
 use crate::stop::StopId;
@@ -18,7 +18,7 @@ fn spawn_rider_auto_presses_hall_button() {
     let call = sim.world().hall_call(origin, CallDirection::Up).unwrap();
     assert_eq!(call.direction, CallDirection::Up);
     assert!(
-        call.pending_riders.contains(&rid),
+        call.pending_riders.contains(&rid.entity()),
         "rider should be aggregated into the hall call's pending list"
     );
     let events = sim.drain_events();
@@ -44,8 +44,8 @@ fn multiple_riders_aggregate_into_one_hall_call() {
     let r2 = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     let origin = sim.stop_entity(StopId(0)).unwrap();
     let call = sim.world().hall_call(origin, CallDirection::Up).unwrap();
-    assert!(call.pending_riders.contains(&r1));
-    assert!(call.pending_riders.contains(&r2));
+    assert!(call.pending_riders.contains(&r1.entity()));
+    assert!(call.pending_riders.contains(&r2.entity()));
     let extra_events = sim.drain_events();
     let press_count = extra_events
         .iter()
@@ -73,11 +73,11 @@ fn explicit_press_hall_button_without_rider() {
 fn pin_assignment_pins_and_assigns() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
     let stop = sim.stop_entity(StopId(1)).unwrap();
-    let car = sim.world().elevator_ids()[0];
+    let car = ElevatorId::from(sim.world().elevator_ids()[0]);
     sim.press_hall_button(stop, CallDirection::Up).unwrap();
     sim.pin_assignment(car, stop, CallDirection::Up).unwrap();
     let call = sim.world().hall_call(stop, CallDirection::Up).unwrap();
-    assert_eq!(call.assigned_car, Some(car));
+    assert_eq!(call.assigned_car, Some(car.entity()));
     assert!(call.pinned);
     sim.unpin_assignment(stop, CallDirection::Up);
     let call = sim.world().hall_call(stop, CallDirection::Up).unwrap();
@@ -176,7 +176,7 @@ fn public_call_queries_return_active_calls() {
     let count = sim.hall_calls().count();
     assert_eq!(count, 1);
     // No car calls yet (rider hasn't boarded).
-    let car = sim.world().elevator_ids()[0];
+    let car = ElevatorId::from(sim.world().elevator_ids()[0]);
     assert!(sim.car_calls(car).is_empty());
 }
 
@@ -187,7 +187,7 @@ fn public_call_queries_return_active_calls() {
 fn car_call_removed_on_exit() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
     sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
-    let car = sim.world().elevator_ids()[0];
+    let car = ElevatorId::from(sim.world().elevator_ids()[0]);
 
     // Run until the rider reaches Arrived.
     let mut boarded = false;
@@ -212,7 +212,7 @@ fn car_call_removed_on_exit() {
 #[test]
 fn press_car_button_without_rider_emits_none_rider() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
-    let car = sim.world().elevator_ids()[0];
+    let car = ElevatorId::from(sim.world().elevator_ids()[0]);
     let floor = sim.stop_entity(StopId(2)).unwrap();
     sim.press_car_button(car, floor).unwrap();
     let events = sim.drain_events();
@@ -239,11 +239,11 @@ fn pinned_pin_does_not_clobber_loading_car() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
     sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     // Run until the car reaches Loading phase at some stop.
-    let car = sim.world().elevator_ids()[0];
+    let car = ElevatorId::from(sim.world().elevator_ids()[0]);
     let mut loading_stop: Option<EntityId> = None;
     for _ in 0..2000 {
         sim.step();
-        if let Some(c) = sim.world().elevator(car)
+        if let Some(c) = sim.world().elevator(car.entity())
             && c.phase == ElevatorPhase::Loading
         {
             loading_stop = c.target_stop;
@@ -259,7 +259,7 @@ fn pinned_pin_does_not_clobber_loading_car() {
         sim.drain_events();
         // One tick of dispatch must not yank the car out of Loading.
         sim.step();
-        let phase_after = sim.world().elevator(car).map(|c| c.phase);
+        let phase_after = sim.world().elevator(car.entity()).map(|c| c.phase);
         assert!(
             !matches!(phase_after, Some(ElevatorPhase::MovingToStop(s)) if s == other),
             "pin should not override a Loading car mid-door-cycle"
@@ -288,7 +288,7 @@ fn abandon_on_full_abandons_immediately() {
     // Note: Preferences::default has skip_full_elevator = false, but
     // max_crowding_factor 0.8 means a 60-weight preload still exceeds.
     sim.world_mut().set_preferences(
-        picky,
+        picky.entity(),
         Preferences {
             skip_full_elevator: true,
             max_crowding_factor: 0.5,
@@ -299,18 +299,18 @@ fn abandon_on_full_abandons_immediately() {
 
     // Force the elevator to Loading phase at the picky rider's stop
     // with a ballast preload that trips the preference filter.
-    let elev = sim.world().elevator_ids()[0];
+    let elev = ElevatorId::from(sim.world().elevator_ids()[0]);
     let stop0 = sim.stop_entity(StopId(0)).unwrap();
     let stop0_pos = sim.world().stop(stop0).unwrap().position;
     {
         let w = sim.world_mut();
-        if let Some(pos) = w.position_mut(elev) {
+        if let Some(pos) = w.position_mut(elev.entity()) {
             pos.value = stop0_pos;
         }
-        if let Some(vel) = w.velocity_mut(elev) {
+        if let Some(vel) = w.velocity_mut(elev.entity()) {
             vel.value = 0.0;
         }
-        if let Some(car) = w.elevator_mut(elev) {
+        if let Some(car) = w.elevator_mut(elev.entity()) {
             car.phase = crate::components::ElevatorPhase::Loading;
             car.current_load = Weight::from(60.0);
             car.target_stop = None;
@@ -318,7 +318,7 @@ fn abandon_on_full_abandons_immediately() {
     }
     sim.run_loading();
     sim.advance_tick();
-    let phase = sim.world().rider(picky).map(|r| r.phase);
+    let phase = sim.world().rider(picky.entity()).map(|r| r.phase);
     assert_eq!(
         phase,
         Some(crate::components::RiderPhase::Abandoned),
@@ -348,7 +348,7 @@ fn abandon_on_full_fires_before_balk_threshold_elapses() {
     // this test, plus abandon_on_full = true. The rider should abandon
     // on the first full-car skip — not wait the threshold out.
     sim.world_mut().set_preferences(
-        picky,
+        picky.entity(),
         Preferences {
             skip_full_elevator: true,
             max_crowding_factor: 0.5,
@@ -357,18 +357,18 @@ fn abandon_on_full_fires_before_balk_threshold_elapses() {
         },
     );
 
-    let elev = sim.world().elevator_ids()[0];
+    let elev = ElevatorId::from(sim.world().elevator_ids()[0]);
     let stop0 = sim.stop_entity(StopId(0)).unwrap();
     let stop0_pos = sim.world().stop(stop0).unwrap().position;
     {
         let w = sim.world_mut();
-        if let Some(pos) = w.position_mut(elev) {
+        if let Some(pos) = w.position_mut(elev.entity()) {
             pos.value = stop0_pos;
         }
-        if let Some(vel) = w.velocity_mut(elev) {
+        if let Some(vel) = w.velocity_mut(elev.entity()) {
             vel.value = 0.0;
         }
-        if let Some(car) = w.elevator_mut(elev) {
+        if let Some(car) = w.elevator_mut(elev.entity()) {
             car.phase = crate::components::ElevatorPhase::Loading;
             car.current_load = Weight::from(60.0);
             car.target_stop = None;
@@ -377,7 +377,7 @@ fn abandon_on_full_fires_before_balk_threshold_elapses() {
     sim.run_loading();
     sim.advance_tick();
     assert_eq!(
-        sim.world().rider(picky).map(|r| r.phase),
+        sim.world().rider(picky.entity()).map(|r| r.phase),
         Some(crate::components::RiderPhase::Abandoned),
         "abandon_on_full should fire on first full-car contact regardless of threshold",
     );
@@ -475,7 +475,7 @@ fn pin_across_lines_is_rejected() {
         })
         .expect("Low elevator should exist and not serve Top");
 
-    let err = sim.pin_assignment(low_car, top, CallDirection::Down);
+    let err = sim.pin_assignment(ElevatorId::from(low_car), top, CallDirection::Down);
     assert!(
         matches!(
             err,
@@ -570,7 +570,7 @@ fn pinned_call_forces_specific_car() {
     let cars = sim.world().elevator_ids();
     assert!(!cars.is_empty());
     let pinned_car = cars[0];
-    sim.pin_assignment(pinned_car, origin, CallDirection::Up)
+    sim.pin_assignment(ElevatorId::from(pinned_car), origin, CallDirection::Up)
         .unwrap();
     // Step a few ticks; dispatch should commit the pinned car.
     for _ in 0..10 {
@@ -783,7 +783,7 @@ fn custom_strategy_reads_car_calls_from_manifest() {
     sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     // Step until the rider boards and a car call exists; then one
     // further step triggers a dispatch pass with the car call visible.
-    let car = sim.world().elevator_ids()[0];
+    let car = ElevatorId::from(sim.world().elevator_ids()[0]);
     for _ in 0..200 {
         sim.step();
         if !sim.car_calls(car).is_empty() && saw.load(Ordering::Relaxed) > 0 {

--- a/crates/elevator-core/src/tests/manual_mode_tests.rs
+++ b/crates/elevator-core/src/tests/manual_mode_tests.rs
@@ -2,15 +2,17 @@
 
 use crate::components::{RiderPhase, ServiceMode};
 use crate::dispatch::scan::ScanDispatch;
+use crate::entity::ElevatorId;
 use crate::events::Event;
 use crate::sim::Simulation;
 use crate::stop::StopId;
 use crate::tests::helpers::default_config;
 
-fn make_manual() -> (Simulation, crate::entity::EntityId) {
+fn make_manual() -> (Simulation, ElevatorId) {
     let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
-    let elev = sim.world().iter_elevators().next().unwrap().0;
-    sim.set_service_mode(elev, ServiceMode::Manual).unwrap();
+    let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
+    sim.set_service_mode(elev.entity(), ServiceMode::Manual)
+        .unwrap();
     (sim, elev)
 }
 
@@ -35,12 +37,12 @@ fn set_target_velocity_moves_elevator_up() {
     let (mut sim, elev) = make_manual();
     sim.set_target_velocity(elev, 1.0).unwrap();
 
-    let p0 = sim.world().position(elev).unwrap().value();
+    let p0 = sim.world().position(elev.entity()).unwrap().value();
     for _ in 0..60 {
         sim.step();
     }
-    let p1 = sim.world().position(elev).unwrap().value();
-    let v = sim.velocity(elev).unwrap();
+    let p1 = sim.world().position(elev.entity()).unwrap().value();
+    let v = sim.velocity(elev.entity()).unwrap();
     assert!(p1 > p0, "elevator should move upward: {p0} -> {p1}");
     assert!(v > 0.0, "velocity should be positive, got {v}");
 }
@@ -52,7 +54,7 @@ fn set_target_velocity_ramps_using_acceleration() {
     // velocity should be acceleration*dt ≈ 0.025.
     sim.set_target_velocity(elev, 2.0).unwrap();
     sim.step();
-    let v = sim.velocity(elev).unwrap();
+    let v = sim.velocity(elev.entity()).unwrap();
     assert!(
         (v - (1.5 / 60.0)).abs() < 1e-6,
         "expected ~{}, got {v}",
@@ -68,7 +70,7 @@ fn set_target_velocity_clamped_to_max_speed() {
     for _ in 0..1000 {
         sim.step();
     }
-    let v = sim.velocity(elev).unwrap();
+    let v = sim.velocity(elev.entity()).unwrap();
     assert!(v <= 2.0 + 1e-9, "velocity should cap at max_speed, got {v}");
     assert!((v - 2.0).abs() < 1e-6, "should reach max_speed, got {v}");
 }
@@ -80,16 +82,19 @@ fn emergency_stop_decelerates_to_zero() {
     for _ in 0..1000 {
         sim.step();
     }
-    assert!(sim.velocity(elev).unwrap() > 1.0, "needs to be moving");
+    assert!(
+        sim.velocity(elev.entity()).unwrap() > 1.0,
+        "needs to be moving"
+    );
 
     sim.emergency_stop(elev).unwrap();
     for _ in 0..1000 {
         sim.step();
-        if sim.velocity(elev).unwrap().abs() < 1e-6 {
+        if sim.velocity(elev.entity()).unwrap().abs() < 1e-6 {
             break;
         }
     }
-    let v = sim.velocity(elev).unwrap();
+    let v = sim.velocity(elev.entity()).unwrap();
     assert!(v.abs() < 1e-6, "velocity should reach zero, got {v}");
 }
 
@@ -103,11 +108,11 @@ fn manual_elevator_can_stop_at_any_position() {
     sim.emergency_stop(elev).unwrap();
     for _ in 0..1000 {
         sim.step();
-        if sim.velocity(elev).unwrap().abs() < 1e-6 {
+        if sim.velocity(elev.entity()).unwrap().abs() < 1e-6 {
             break;
         }
     }
-    let pos = sim.world().position(elev).unwrap().value();
+    let pos = sim.world().position(elev.entity()).unwrap().value();
     // Should be somewhere between stops 0 (0.0) and 1 (4.0) — not snapped.
     assert!(
         pos > 0.1 && pos < 3.9,
@@ -118,7 +123,7 @@ fn manual_elevator_can_stop_at_any_position() {
 #[test]
 fn set_target_velocity_on_non_manual_errors() {
     let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
-    let elev = sim.world().iter_elevators().next().unwrap().0;
+    let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     // Mode is default Normal.
     let err = sim.set_target_velocity(elev, 1.0).unwrap_err();
     assert!(
@@ -166,12 +171,19 @@ fn leaving_manual_clears_target_velocity() {
     let (mut sim, elev) = make_manual();
     sim.set_target_velocity(elev, 1.0).unwrap();
     assert_eq!(
-        sim.world().elevator(elev).unwrap().manual_target_velocity(),
+        sim.world()
+            .elevator(elev.entity())
+            .unwrap()
+            .manual_target_velocity(),
         Some(1.0)
     );
-    sim.set_service_mode(elev, ServiceMode::Normal).unwrap();
+    sim.set_service_mode(elev.entity(), ServiceMode::Normal)
+        .unwrap();
     assert_eq!(
-        sim.world().elevator(elev).unwrap().manual_target_velocity(),
+        sim.world()
+            .elevator(elev.entity())
+            .unwrap()
+            .manual_target_velocity(),
         None
     );
 }
@@ -185,11 +197,11 @@ fn manual_mode_updates_total_moves_metric() {
     sim.set_target_velocity(elev, 2.0).unwrap();
     for _ in 0..300 {
         sim.step();
-        if sim.world().position(elev).unwrap().value() > 8.5 {
+        if sim.world().position(elev.entity()).unwrap().value() > 8.5 {
             break;
         }
     }
-    let car_count = sim.world().elevator(elev).unwrap().move_count();
+    let car_count = sim.world().elevator(elev.entity()).unwrap().move_count();
     assert!(car_count > 0, "expected per-elevator move_count > 0");
     assert_eq!(
         sim.metrics().total_moves(),
@@ -208,13 +220,14 @@ fn leaving_manual_zeroes_velocity() {
         sim.step();
     }
     assert!(
-        sim.velocity(elev).unwrap().abs() > 0.1,
+        sim.velocity(elev.entity()).unwrap().abs() > 0.1,
         "needs to be moving"
     );
 
-    sim.set_service_mode(elev, ServiceMode::Normal).unwrap();
+    sim.set_service_mode(elev.entity(), ServiceMode::Normal)
+        .unwrap();
     assert_eq!(
-        sim.velocity(elev).unwrap(),
+        sim.velocity(elev.entity()).unwrap(),
         0.0,
         "velocity should be zeroed on Manual exit"
     );
@@ -228,7 +241,7 @@ fn manual_mode_emits_passing_floor_events() {
     // Run long enough to cross stop 1 (position 4.0).
     for _ in 0..300 {
         sim.step();
-        if sim.world().position(elev).unwrap().value() > 5.0 {
+        if sim.world().position(elev.entity()).unwrap().value() > 5.0 {
             break;
         }
     }

--- a/crates/elevator-core/src/tests/multi_elevator_tests.rs
+++ b/crates/elevator-core/src/tests/multi_elevator_tests.rs
@@ -4,6 +4,7 @@ use crate::components::RiderPhase;
 use crate::components::{Accel, Speed, Weight};
 use crate::config::*;
 use crate::dispatch::scan::ScanDispatch;
+use crate::entity::RiderId;
 use crate::sim::Simulation;
 use crate::stop::{StopConfig, StopId};
 
@@ -116,7 +117,7 @@ fn disable_elevator_mid_route_ejects_riders() {
     let mut boarded_elevator = None;
     for _ in 0..500 {
         sim.step();
-        if let Some(r) = sim.world().rider(rider)
+        if let Some(r) = sim.world().rider(rider.entity())
             && let RiderPhase::Riding(eid) = r.phase
         {
             boarded_elevator = Some(eid);
@@ -137,7 +138,7 @@ fn disable_elevator_mid_route_ejects_riders() {
             crate::events::Event::RiderEjected {
                 rider: r,
                 ..
-            } if *r == rider
+            } if *r == rider.entity()
         )
     });
     assert!(

--- a/crates/elevator-core/src/tests/multi_elevator_tests.rs
+++ b/crates/elevator-core/src/tests/multi_elevator_tests.rs
@@ -4,7 +4,6 @@ use crate::components::RiderPhase;
 use crate::components::{Accel, Speed, Weight};
 use crate::config::*;
 use crate::dispatch::scan::ScanDispatch;
-use crate::entity::RiderId;
 use crate::sim::Simulation;
 use crate::stop::{StopConfig, StopId};
 

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -1638,7 +1638,7 @@ fn remove_line_marks_topology_graph_dirty() {
 #[test]
 fn reassign_elevator_to_line_notifies_old_group_dispatcher_on_cross_group() {
     use crate::dispatch::DispatchStrategy;
-    use crate::entity::{ElevatorId, EntityId, RiderId};
+    use crate::entity::EntityId;
     use std::sync::{Arc, Mutex};
 
     /// Dispatcher that records every `notify_removed` call it receives.

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -8,6 +8,7 @@ use crate::config::{
     SimulationParams,
 };
 use crate::dispatch::scan::ScanDispatch;
+use crate::entity::ElevatorId;
 use crate::error::SimError;
 use crate::events::Event as SimEvent;
 use crate::ids::GroupId;
@@ -448,14 +449,14 @@ fn cross_group_rider_arrives_via_explicit_two_leg_route() {
     // Run until rider arrives or we time out.
     for _ in 0..5000 {
         sim.step();
-        if let Some(r) = sim.world().rider(rider)
+        if let Some(r) = sim.world().rider(rider.entity())
             && r.phase == RiderPhase::Arrived
         {
             break;
         }
     }
 
-    let rider_data = sim.world().rider(rider).unwrap();
+    let rider_data = sim.world().rider(rider.entity()).unwrap();
     assert_eq!(
         rider_data.phase,
         RiderPhase::Arrived,
@@ -495,7 +496,7 @@ fn rider_only_boards_elevator_from_matching_group() {
     let mut boarding_elevator = None;
     for _ in 0..3000 {
         sim.step();
-        if let Some(r) = sim.world().rider(rider)
+        if let Some(r) = sim.world().rider(rider.entity())
             && let RiderPhase::Boarding(eid) | RiderPhase::Riding(eid) = r.phase
         {
             boarding_elevator = Some(eid);
@@ -653,7 +654,7 @@ fn line_pinned_rider_boards_only_specified_line_elevator() {
     let mut boarding_elevator = None;
     for _ in 0..3000 {
         sim.step();
-        if let Some(r) = sim.world().rider(rider)
+        if let Some(r) = sim.world().rider(rider.entity())
             && let RiderPhase::Boarding(eid) | RiderPhase::Riding(eid) = r.phase
         {
             boarding_elevator = Some(eid);
@@ -1397,7 +1398,10 @@ fn walk_only_route_rider_arrives_directly() {
         .unwrap();
 
     // The rider starts Waiting.
-    assert_eq!(sim.world().rider(rider).unwrap().phase, RiderPhase::Waiting);
+    assert_eq!(
+        sim.world().rider(rider.entity()).unwrap().phase,
+        RiderPhase::Waiting
+    );
 
     // Walk is processed during advance_transient when in Exiting phase, but a
     // Walk leg rider begins Waiting — a single elevator step is not needed.
@@ -1410,12 +1414,12 @@ fn walk_only_route_rider_arrives_directly() {
     // executed in handle_exit, which fires when a rider transitions from Exiting.
     // For a walk-only route with no elevator, we exercise the path by placing the
     // rider in Exiting phase manually and stepping once.
-    sim.world_mut().rider_mut(rider).unwrap().phase =
+    sim.world_mut().rider_mut(rider.entity()).unwrap().phase =
         RiderPhase::Exiting(crate::entity::EntityId::default());
 
     sim.step();
 
-    let rider_data = sim.world().rider(rider).unwrap();
+    let rider_data = sim.world().rider(rider.entity()).unwrap();
     assert_eq!(
         rider_data.phase,
         RiderPhase::Arrived,
@@ -1476,7 +1480,7 @@ fn walk_leg_teleports_rider_to_destination() {
 
     for _ in 0..5000 {
         sim.step();
-        if let Some(r) = sim.world().rider(rider)
+        if let Some(r) = sim.world().rider(rider.entity())
             && r.phase == RiderPhase::Arrived
         {
             break;
@@ -1484,7 +1488,7 @@ fn walk_leg_teleports_rider_to_destination() {
     }
 
     assert_eq!(
-        sim.world().rider(rider).unwrap().phase,
+        sim.world().rider(rider.entity()).unwrap().phase,
         RiderPhase::Arrived,
         "rider with walk leg in multi-leg route should eventually arrive"
     );
@@ -1523,7 +1527,7 @@ fn walk_leg_rider_does_not_board_elevator() {
 
     // Rider should still be Waiting (or already Waiting to board nothing) —
     // never Boarding or Riding.
-    let phase = sim.world().rider(rider).unwrap().phase;
+    let phase = sim.world().rider(rider.entity()).unwrap().phase;
     assert!(
         matches!(phase, RiderPhase::Waiting | RiderPhase::Arrived),
         "walk-leg rider should never board an elevator, got {phase:?}"
@@ -1547,7 +1551,7 @@ fn remove_line_with_riders_aboard_ejects_riders() {
     let mut is_riding = false;
     for _ in 0..3000 {
         sim.step();
-        if let Some(r) = sim.world().rider(rider)
+        if let Some(r) = sim.world().rider(rider.entity())
             && matches!(r.phase, RiderPhase::Riding(_))
         {
             is_riding = true;
@@ -1564,7 +1568,7 @@ fn remove_line_with_riders_aboard_ejects_riders() {
     sim.step();
 
     // Rider must NOT be in a Riding phase anymore.
-    let phase = sim.world().rider(rider).unwrap().phase;
+    let phase = sim.world().rider(rider.entity()).unwrap().phase;
     assert!(
         matches!(phase, RiderPhase::Waiting | RiderPhase::Arrived),
         "rider should be ejected when line is removed; got {phase:?}"
@@ -1634,7 +1638,7 @@ fn remove_line_marks_topology_graph_dirty() {
 #[test]
 fn reassign_elevator_to_line_notifies_old_group_dispatcher_on_cross_group() {
     use crate::dispatch::DispatchStrategy;
-    use crate::entity::EntityId;
+    use crate::entity::{ElevatorId, EntityId, RiderId};
     use std::sync::{Arc, Mutex};
 
     /// Dispatcher that records every `notify_removed` call it receives.
@@ -2319,7 +2323,7 @@ fn three_group_rider_navigates_all_legs() {
         sim.step();
         if sim
             .world()
-            .rider(rider)
+            .rider(rider.entity())
             .is_some_and(|r| r.phase == RiderPhase::Arrived)
         {
             break;
@@ -2327,7 +2331,7 @@ fn three_group_rider_navigates_all_legs() {
     }
 
     assert_eq!(
-        sim.world().rider(rider).unwrap().phase,
+        sim.world().rider(rider.entity()).unwrap().phase,
         RiderPhase::Arrived,
         "rider should arrive at D via all three groups"
     );
@@ -2389,11 +2393,11 @@ fn despawn_waiting_rider_removes_from_world() {
     sim.despawn_rider(rider).unwrap();
 
     assert!(
-        !sim.world().is_alive(rider),
+        !sim.world().is_alive(rider.entity()),
         "despawned waiting rider should no longer be alive"
     );
     assert!(
-        sim.world().rider(rider).is_none(),
+        sim.world().rider(rider.entity()).is_none(),
         "despawned waiting rider should have no rider component"
     );
 }
@@ -2412,7 +2416,7 @@ fn despawn_riding_rider_removes_from_elevator_riders_list() {
     let mut elevator_id = None;
     for _ in 0..3000 {
         sim.step();
-        if let Some(r) = sim.world().rider(rider)
+        if let Some(r) = sim.world().rider(rider.entity())
             && let RiderPhase::Riding(e) = r.phase
         {
             elevator_id = Some(e);
@@ -2432,14 +2436,14 @@ fn despawn_riding_rider_removes_from_elevator_riders_list() {
     sim.despawn_rider(rider).unwrap();
 
     assert!(
-        !sim.world().is_alive(rider),
+        !sim.world().is_alive(rider.entity()),
         "despawned riding rider should not be alive"
     );
 
     // The elevator's riders list should no longer contain this rider.
     let car = sim.world().elevator(elev).unwrap();
     assert!(
-        !car.riders.contains(&rider),
+        !car.riders.contains(&rider.entity()),
         "elevator riders list should not contain despawned rider"
     );
 
@@ -2487,7 +2491,7 @@ fn build_rider_with_group_succeeds_when_group_serves_stops() {
     );
 
     let rider = result.unwrap();
-    let r = sim.world().rider(rider).unwrap();
+    let r = sim.world().rider(rider.entity()).unwrap();
     assert_eq!(r.phase, RiderPhase::Waiting);
 }
 
@@ -2855,7 +2859,10 @@ fn dispatch_ignores_waiting_rider_targeting_another_group() {
         .route(route)
         .spawn()
         .unwrap();
-    assert_eq!(sim.world().rider(rider).unwrap().phase, RiderPhase::Waiting);
+    assert_eq!(
+        sim.world().rider(rider.entity()).unwrap().phase,
+        RiderPhase::Waiting
+    );
 
     // Tick for a while. Group A's elevator should never open its doors
     // because no Group-A rider is waiting.
@@ -2934,7 +2941,7 @@ fn car_with_opposite_indicator_eventually_boards_waiting_rider() {
     for _ in 0..3000 {
         sim.step();
         events.extend(sim.drain_events());
-        if let Some(r) = sim.world().rider(rider)
+        if let Some(r) = sim.world().rider(rider.entity())
             && matches!(
                 r.phase,
                 RiderPhase::Boarding(_) | RiderPhase::Riding(_) | RiderPhase::Arrived
@@ -2960,7 +2967,7 @@ fn car_with_opposite_indicator_eventually_boards_waiting_rider() {
             SimEvent::DoorClosed { elevator, .. } if *elevator == g0_elev => {
                 door_closes_before_board += 1;
             }
-            SimEvent::RiderBoarded { rider: r, .. } if *r == rider => break,
+            SimEvent::RiderBoarded { rider: r, .. } if *r == rider.entity() => break,
             _ => {}
         }
     }
@@ -2993,8 +3000,12 @@ fn dispatch_arrive_in_place_sets_target_and_pops_queue() {
         .elevator_entities()[0];
 
     // Seed the queue with the current stop so we can observe the pop.
-    sim.push_destination(elev, ground).unwrap();
-    assert_eq!(sim.destination_queue(elev).unwrap().len(), 1);
+    sim.push_destination(ElevatorId::from(elev), ground)
+        .unwrap();
+    assert_eq!(
+        sim.destination_queue(ElevatorId::from(elev)).unwrap().len(),
+        1
+    );
 
     // Spawn a rider at Ground so dispatch has demand at this stop.
     let transfer = sim.stop_entity(StopId(1)).unwrap();
@@ -3025,7 +3036,9 @@ fn dispatch_arrive_in_place_sets_target_and_pops_queue() {
         "arrive-in-place dispatch must set target_stop to the assigned stop"
     );
     assert!(
-        !sim.destination_queue(elev).unwrap().contains(&ground),
+        !sim.destination_queue(ElevatorId::from(elev))
+            .unwrap()
+            .contains(&ground),
         "arrive-in-place dispatch must pop the matching queue front"
     );
 }
@@ -3065,7 +3078,8 @@ fn advance_queue_arrive_in_place_resets_direction_indicators() {
     }
 
     // Queue the car to its own stop via the imperative front-push API.
-    sim.push_destination_front(elev, ground).unwrap();
+    sim.push_destination_front(ElevatorId::from(elev), ground)
+        .unwrap();
 
     // One step: advance_queue runs, sees at_stop == front, pops and opens
     // doors — and must reset lamps to (true, true) along the way.

--- a/crates/elevator-core/src/tests/query_event_tests.rs
+++ b/crates/elevator-core/src/tests/query_event_tests.rs
@@ -1,5 +1,6 @@
 use crate::builder::SimulationBuilder;
 use crate::components::ElevatorPhase;
+use crate::entity::{ElevatorId, RiderId};
 use crate::events::Event;
 use crate::stop::StopId;
 
@@ -32,9 +33,9 @@ fn is_stop_returns_true_for_stops() {
 fn is_rider_returns_true_for_riders() {
     let mut sim = SimulationBuilder::demo().build().unwrap();
     let rider = sim.spawn_rider(StopId(0), StopId(1), 75.0).unwrap();
-    assert!(sim.is_rider(rider));
-    assert!(!sim.is_elevator(rider));
-    assert!(!sim.is_stop(rider));
+    assert!(sim.is_rider(rider.entity()));
+    assert!(!sim.is_elevator(rider.entity()));
+    assert!(!sim.is_stop(rider.entity()));
 }
 
 // ── Aggregate queries ────────────────────────────────────────────────
@@ -72,14 +73,14 @@ fn elevator_load_starts_at_zero() {
         .next()
         .map(|(id, _, _)| id)
         .unwrap();
-    assert_eq!(sim.elevator_load(elevator_id), Some(0.0));
+    assert_eq!(sim.elevator_load(ElevatorId::from(elevator_id)), Some(0.0));
 }
 
 #[test]
 fn elevator_load_returns_none_for_non_elevator() {
     let sim = SimulationBuilder::demo().build().unwrap();
     let stop_id = sim.stop_entity(StopId(0)).unwrap();
-    assert_eq!(sim.elevator_load(stop_id), None);
+    assert_eq!(sim.elevator_load(ElevatorId::from(stop_id)), None);
 }
 
 #[test]
@@ -119,7 +120,7 @@ fn capacity_changed_emitted_on_disable_with_load() {
     // Run until the rider is aboard.
     for _ in 0..500 {
         sim.step();
-        if sim.world().rider(rider).is_some_and(|r| {
+        if sim.world().rider(rider.entity()).is_some_and(|r| {
             matches!(
                 r.phase,
                 crate::components::RiderPhase::Riding(_)
@@ -138,7 +139,11 @@ fn capacity_changed_emitted_on_disable_with_load() {
         .unwrap();
 
     // Only proceed if we actually have load — otherwise test is inconclusive.
-    if sim.elevator_load(elevator_id).unwrap_or(0.0) > 0.0 {
+    if sim
+        .elevator_load(ElevatorId::from(elevator_id))
+        .unwrap_or(0.0)
+        > 0.0
+    {
         sim.drain_events(); // clear prior events
         sim.disable(elevator_id).unwrap();
 

--- a/crates/elevator-core/src/tests/query_event_tests.rs
+++ b/crates/elevator-core/src/tests/query_event_tests.rs
@@ -1,6 +1,6 @@
 use crate::builder::SimulationBuilder;
 use crate::components::ElevatorPhase;
-use crate::entity::{ElevatorId, RiderId};
+use crate::entity::ElevatorId;
 use crate::events::Event;
 use crate::stop::StopId;
 

--- a/crates/elevator-core/src/tests/reroute_tests.rs
+++ b/crates/elevator-core/src/tests/reroute_tests.rs
@@ -4,6 +4,7 @@ use crate::config::{
     BuildingConfig, ElevatorConfig, PassengerSpawnConfig, SimConfig, SimulationParams,
 };
 use crate::dispatch::scan::ScanDispatch;
+use crate::entity::RiderId;
 use crate::error::SimError;
 use crate::events::{Event, RouteInvalidReason};
 use crate::sim::Simulation;
@@ -71,7 +72,7 @@ fn reroute_changes_rider_destination() {
     let stop1 = sim.stop_entity(StopId(1)).unwrap();
     sim.reroute(rider, stop1).unwrap();
 
-    let route = sim.world().route(rider).unwrap();
+    let route = sim.world().route(rider.entity()).unwrap();
     assert_eq!(route.current_destination(), Some(stop1));
 }
 
@@ -88,7 +89,7 @@ fn disable_stop_reroutes_affected_riders() {
     sim.disable(stop1).unwrap();
     sim.drain_events(); // flush
 
-    let route = sim.world().route(rider).unwrap();
+    let route = sim.world().route(rider.entity()).unwrap();
     let dest = route.current_destination().unwrap();
     // Should have been rerouted to stop 2 (nearest enabled alternative).
     let stop2 = sim.stop_entity(StopId(2)).unwrap();
@@ -171,7 +172,7 @@ fn disable_only_stop_causes_abandonment() {
     sim.disable(stop1).unwrap();
 
     // Rider should have been abandoned.
-    let r = sim.world().rider(rider).unwrap();
+    let r = sim.world().rider(rider.entity()).unwrap();
     assert_eq!(r.phase, RiderPhase::Abandoned);
 
     // Should emit NoAlternative event.
@@ -221,9 +222,9 @@ fn set_rider_route_replaces_route() {
         ],
         current_leg: 0,
     };
-    sim.set_rider_route(rider, route).unwrap();
+    sim.set_rider_route(rider.entity(), route).unwrap();
 
-    let r = sim.world().route(rider).unwrap();
+    let r = sim.world().route(rider.entity()).unwrap();
     assert_eq!(r.legs.len(), 2);
     assert_eq!(r.current_destination(), Some(stop1));
 }
@@ -238,7 +239,7 @@ fn reroute_rejects_non_waiting_rider() {
     // Advance until rider is boarding or riding.
     for _ in 0..500 {
         sim.step();
-        let phase = sim.world().rider(rider).unwrap().phase;
+        let phase = sim.world().rider(rider.entity()).unwrap().phase;
         if matches!(phase, RiderPhase::Riding(_) | RiderPhase::Arrived) {
             break;
         }
@@ -248,7 +249,7 @@ fn reroute_rejects_non_waiting_rider() {
     let result = sim.reroute(rider, stop1);
 
     // Should fail if rider is not Waiting.
-    let phase = sim.world().rider(rider).unwrap().phase;
+    let phase = sim.world().rider(rider.entity()).unwrap().phase;
     if phase != RiderPhase::Waiting {
         assert!(result.is_err());
         assert!(matches!(
@@ -265,6 +266,6 @@ fn reroute_nonexistent_rider_returns_error() {
 
     let stop1 = sim.stop_entity(StopId(1)).unwrap();
     // Use a stop entity as a fake rider — it's a valid EntityId but not a rider.
-    let result = sim.reroute(stop1, stop1);
+    let result = sim.reroute(RiderId::from(stop1), stop1);
     assert!(result.is_err());
 }

--- a/crates/elevator-core/src/tests/resident_tests.rs
+++ b/crates/elevator-core/src/tests/resident_tests.rs
@@ -1,4 +1,5 @@
 use crate::components::{RiderPhase, Route};
+use crate::entity::RiderId;
 use crate::error::SimError;
 use crate::events::Event;
 use crate::ids::GroupId;
@@ -8,10 +9,10 @@ use crate::stop::StopId;
 use super::helpers::{default_config, scan};
 
 /// Run until the given rider reaches Arrived, or panic after max ticks.
-fn run_until_arrived(sim: &mut Simulation, rider_id: crate::entity::EntityId) {
+fn run_until_arrived(sim: &mut Simulation, rider_id: RiderId) {
     for _ in 0..10_000 {
         sim.step();
-        if let Some(r) = sim.world().rider(rider_id)
+        if let Some(r) = sim.world().rider(rider_id.entity())
             && r.phase() == RiderPhase::Arrived
         {
             return;
@@ -21,10 +22,10 @@ fn run_until_arrived(sim: &mut Simulation, rider_id: crate::entity::EntityId) {
 }
 
 /// Run until the given rider reaches Abandoned, or panic after max ticks.
-fn run_until_abandoned(sim: &mut Simulation, rider_id: crate::entity::EntityId) {
+fn run_until_abandoned(sim: &mut Simulation, rider_id: RiderId) {
     for _ in 0..10_000 {
         sim.step();
-        if let Some(r) = sim.world().rider(rider_id)
+        if let Some(r) = sim.world().rider(rider_id.entity())
             && r.phase() == RiderPhase::Abandoned
         {
             return;
@@ -44,12 +45,12 @@ fn settle_from_arrived() {
     // Settle the rider.
     sim.settle_rider(rider).unwrap();
 
-    let r = sim.world().rider(rider).unwrap();
+    let r = sim.world().rider(rider.entity()).unwrap();
     assert_eq!(r.phase(), RiderPhase::Resident);
     assert!(r.current_stop().is_some());
 
     let stop = r.current_stop().unwrap();
-    assert!(sim.residents_at(stop).any(|id| id == rider));
+    assert!(sim.residents_at(stop).any(|id| id == rider.entity()));
     assert_eq!(sim.resident_count_at(stop), 1);
 
     // Check event was emitted.
@@ -57,7 +58,7 @@ fn settle_from_arrived() {
     assert!(
         events
             .iter()
-            .any(|e| matches!(e, Event::RiderSettled { rider: r, .. } if *r == rider))
+            .any(|e| matches!(e, Event::RiderSettled { rider: r, .. } if *r == rider.entity()))
     );
 }
 
@@ -69,7 +70,7 @@ fn settle_from_abandoned() {
 
     // Give very short patience so rider abandons.
     sim.world_mut().set_patience(
-        rider,
+        rider.entity(),
         crate::components::Patience {
             max_wait_ticks: 1,
             waited_ticks: 0,
@@ -80,13 +81,13 @@ fn settle_from_abandoned() {
 
     sim.settle_rider(rider).unwrap();
 
-    let r = sim.world().rider(rider).unwrap();
+    let r = sim.world().rider(rider.entity()).unwrap();
     assert_eq!(r.phase(), RiderPhase::Resident);
 
     let stop = r.current_stop().unwrap();
-    assert!(sim.residents_at(stop).any(|id| id == rider));
+    assert!(sim.residents_at(stop).any(|id| id == rider.entity()));
     // Should no longer be in abandoned index.
-    assert!(!sim.abandoned_at(stop).any(|id| id == rider));
+    assert!(!sim.abandoned_at(stop).any(|id| id == rider.entity()));
 }
 
 #[test]
@@ -110,26 +111,31 @@ fn reroute_resident_to_waiting() {
     sim.settle_rider(rider).unwrap();
     sim.drain_events(); // Clear events from settlement.
 
-    let stop = sim.world().rider(rider).unwrap().current_stop().unwrap();
+    let stop = sim
+        .world()
+        .rider(rider.entity())
+        .unwrap()
+        .current_stop()
+        .unwrap();
 
     // Resolve StopId(0) to EntityId for the route.
     let dest = sim.stop_entity(StopId(0)).unwrap();
     let route = Route::direct(stop, dest, GroupId(0));
-    sim.reroute_rider(rider, route).unwrap();
+    sim.reroute_rider(rider.entity(), route).unwrap();
 
-    let r = sim.world().rider(rider).unwrap();
+    let r = sim.world().rider(rider.entity()).unwrap();
     assert_eq!(r.phase(), RiderPhase::Waiting);
 
     // Rider should be in waiting index, not resident index.
-    assert!(sim.waiting_at(stop).any(|id| id == rider));
-    assert!(!sim.residents_at(stop).any(|id| id == rider));
+    assert!(sim.waiting_at(stop).any(|id| id == rider.entity()));
+    assert!(!sim.residents_at(stop).any(|id| id == rider.entity()));
 
     // Check event was emitted.
     let events = sim.drain_events();
     assert!(
         events
             .iter()
-            .any(|e| matches!(e, Event::RiderRerouted { rider: r, .. } if *r == rider))
+            .any(|e| matches!(e, Event::RiderRerouted { rider: r, .. } if *r == rider.entity()))
     );
 }
 
@@ -144,7 +150,7 @@ fn reroute_wrong_phase_returns_error() {
     let route = Route::direct(origin, dest, GroupId(0));
 
     // Rider is Waiting — should fail.
-    let result = sim.reroute_rider(rider, route);
+    let result = sim.reroute_rider(rider.entity(), route);
     assert!(matches!(result, Err(SimError::WrongRiderPhase { .. })));
 }
 
@@ -157,14 +163,19 @@ fn despawn_rider_removes_from_world_and_index() {
     run_until_arrived(&mut sim, rider);
     sim.settle_rider(rider).unwrap();
 
-    let stop = sim.world().rider(rider).unwrap().current_stop().unwrap();
+    let stop = sim
+        .world()
+        .rider(rider.entity())
+        .unwrap()
+        .current_stop()
+        .unwrap();
     assert_eq!(sim.resident_count_at(stop), 1);
 
     sim.drain_events();
     sim.despawn_rider(rider).unwrap();
 
     // Entity gone.
-    assert!(!sim.world().is_alive(rider));
+    assert!(!sim.world().is_alive(rider.entity()));
     // Index clean.
     assert_eq!(sim.resident_count_at(stop), 0);
 
@@ -173,7 +184,7 @@ fn despawn_rider_removes_from_world_and_index() {
     assert!(
         events
             .iter()
-            .any(|e| matches!(e, Event::RiderDespawned { rider: r, .. } if *r == rider))
+            .any(|e| matches!(e, Event::RiderDespawned { rider: r, .. } if *r == rider.entity()))
     );
 }
 
@@ -186,14 +197,14 @@ fn despawn_riding_rider_cleans_elevator() {
     // Run until rider is Riding.
     for _ in 0..10_000 {
         sim.step();
-        if let Some(r) = sim.world().rider(rider)
+        if let Some(r) = sim.world().rider(rider.entity())
             && matches!(r.phase(), RiderPhase::Riding(_))
         {
             break;
         }
     }
 
-    let riding_eid = match sim.world().rider(rider).unwrap().phase() {
+    let riding_eid = match sim.world().rider(rider.entity()).unwrap().phase() {
         RiderPhase::Riding(eid) => eid,
         other => panic!("expected Riding, got {other}"),
     };
@@ -204,7 +215,7 @@ fn despawn_riding_rider_cleans_elevator() {
             .elevator(riding_eid)
             .unwrap()
             .riders()
-            .contains(&rider)
+            .contains(&rider.entity())
     );
 
     sim.despawn_rider(rider).unwrap();
@@ -215,7 +226,7 @@ fn despawn_riding_rider_cleans_elevator() {
             .elevator(riding_eid)
             .unwrap()
             .riders()
-            .contains(&rider)
+            .contains(&rider.entity())
     );
 }
 
@@ -228,31 +239,36 @@ fn full_lifecycle_spawn_ride_settle_reroute_ride_despawn() {
     let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     let origin = sim.stop_entity(StopId(0)).unwrap();
-    assert!(sim.waiting_at(origin).any(|id| id == rider));
+    assert!(sim.waiting_at(origin).any(|id| id == rider.entity()));
 
     run_until_arrived(&mut sim, rider);
 
     // Settle at Floor 3.
     sim.settle_rider(rider).unwrap();
-    let floor3 = sim.world().rider(rider).unwrap().current_stop().unwrap();
-    assert!(sim.residents_at(floor3).any(|id| id == rider));
+    let floor3 = sim
+        .world()
+        .rider(rider.entity())
+        .unwrap()
+        .current_stop()
+        .unwrap();
+    assert!(sim.residents_at(floor3).any(|id| id == rider.entity()));
     assert_eq!(sim.metrics().total_settled(), 1);
 
     // Reroute back to Ground.
     let ground = sim.stop_entity(StopId(0)).unwrap();
     let route = Route::direct(floor3, ground, GroupId(0));
-    sim.reroute_rider(rider, route).unwrap();
+    sim.reroute_rider(rider.entity(), route).unwrap();
     assert_eq!(sim.metrics().total_rerouted(), 1);
 
-    assert!(sim.waiting_at(floor3).any(|id| id == rider));
-    assert!(!sim.residents_at(floor3).any(|id| id == rider));
+    assert!(sim.waiting_at(floor3).any(|id| id == rider.entity()));
+    assert!(!sim.residents_at(floor3).any(|id| id == rider.entity()));
 
     // Trip 2: ride back to Ground.
     run_until_arrived(&mut sim, rider);
 
     // Despawn.
     sim.despawn_rider(rider).unwrap();
-    assert!(!sim.world().is_alive(rider));
+    assert!(!sim.world().is_alive(rider.entity()));
 }
 
 #[test]
@@ -271,7 +287,7 @@ fn resident_invisible_to_loading_system() {
         sim.step();
     }
 
-    let r = sim.world().rider(rider).unwrap();
+    let r = sim.world().rider(rider.entity()).unwrap();
     assert_eq!(
         r.phase(),
         RiderPhase::Resident,
@@ -293,7 +309,12 @@ fn dispatch_manifest_includes_resident_counts() {
     run_until_arrived(&mut sim, r2);
     sim.settle_rider(r2).unwrap();
 
-    let floor3 = sim.world().rider(r1).unwrap().current_stop().unwrap();
+    let floor3 = sim
+        .world()
+        .rider(r1.entity())
+        .unwrap()
+        .current_stop()
+        .unwrap();
     assert_eq!(sim.resident_count_at(floor3), 2);
 }
 
@@ -304,7 +325,7 @@ fn patience_reset_on_reroute() {
 
     let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     sim.world_mut().set_patience(
-        rider,
+        rider.entity(),
         crate::components::Patience {
             max_wait_ticks: 1000,
             waited_ticks: 500,
@@ -314,13 +335,18 @@ fn patience_reset_on_reroute() {
     run_until_arrived(&mut sim, rider);
     sim.settle_rider(rider).unwrap();
 
-    let stop = sim.world().rider(rider).unwrap().current_stop().unwrap();
+    let stop = sim
+        .world()
+        .rider(rider.entity())
+        .unwrap()
+        .current_stop()
+        .unwrap();
     let dest = sim.stop_entity(StopId(0)).unwrap();
     let route = Route::direct(stop, dest, GroupId(0));
-    sim.reroute_rider(rider, route).unwrap();
+    sim.reroute_rider(rider.entity(), route).unwrap();
 
     // Patience should be reset.
-    let patience = sim.world().patience(rider).unwrap();
+    let patience = sim.world().patience(rider.entity()).unwrap();
     assert_eq!(patience.waited_ticks, 0);
 }
 
@@ -333,7 +359,12 @@ fn snapshot_roundtrip_preserves_residents() {
     run_until_arrived(&mut sim, rider);
     sim.settle_rider(rider).unwrap();
 
-    let stop = sim.world().rider(rider).unwrap().current_stop().unwrap();
+    let stop = sim
+        .world()
+        .rider(rider.entity())
+        .unwrap()
+        .current_stop()
+        .unwrap();
     assert_eq!(sim.resident_count_at(stop), 1);
 
     // Snapshot and restore.

--- a/crates/elevator-core/src/tests/runtime_upgrades_tests.rs
+++ b/crates/elevator-core/src/tests/runtime_upgrades_tests.rs
@@ -7,17 +7,17 @@
 
 use crate::components::ElevatorPhase;
 use crate::dispatch::scan::ScanDispatch;
-use crate::entity::EntityId;
+use crate::entity::{ElevatorId, EntityId, RiderId};
 use crate::error::SimError;
 use crate::events::{Event, UpgradeField, UpgradeValue};
 use crate::sim::Simulation;
 use crate::stop::StopId;
 use crate::tests::helpers::default_config;
 
-fn make_sim() -> (Simulation, EntityId) {
+fn make_sim() -> (Simulation, ElevatorId) {
     let config = default_config();
     let sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
-    let elev = sim.world().iter_elevators().next().unwrap().0;
+    let elev = ElevatorId::from(sim.world().iter_elevators().next().unwrap().0);
     (sim, elev)
 }
 
@@ -42,11 +42,18 @@ fn find_upgrade(events: &[Event], field: UpgradeField) -> Option<(UpgradeValue, 
 #[test]
 fn set_max_speed_applies_and_emits_event() {
     let (mut sim, elev) = make_sim();
-    let old = sim.world().elevator(elev).unwrap().max_speed();
+    let old = sim.world().elevator(elev.entity()).unwrap().max_speed();
 
     sim.set_max_speed(elev, 4.0).unwrap();
 
-    assert_eq!(sim.world().elevator(elev).unwrap().max_speed().value(), 4.0);
+    assert_eq!(
+        sim.world()
+            .elevator(elev.entity())
+            .unwrap()
+            .max_speed()
+            .value(),
+        4.0
+    );
     let events = sim.drain_events();
     assert_eq!(count_upgrades(&events, UpgradeField::MaxSpeed), 1);
     let (old_v, new_v) = find_upgrade(&events, UpgradeField::MaxSpeed).unwrap();
@@ -57,10 +64,14 @@ fn set_max_speed_applies_and_emits_event() {
 #[test]
 fn set_acceleration_applies_and_emits_event() {
     let (mut sim, elev) = make_sim();
-    let old = sim.world().elevator(elev).unwrap().acceleration();
+    let old = sim.world().elevator(elev.entity()).unwrap().acceleration();
     sim.set_acceleration(elev, 3.0).unwrap();
     assert_eq!(
-        sim.world().elevator(elev).unwrap().acceleration().value(),
+        sim.world()
+            .elevator(elev.entity())
+            .unwrap()
+            .acceleration()
+            .value(),
         3.0
     );
     let events = sim.drain_events();
@@ -73,10 +84,14 @@ fn set_acceleration_applies_and_emits_event() {
 #[test]
 fn set_deceleration_applies_and_emits_event() {
     let (mut sim, elev) = make_sim();
-    let old = sim.world().elevator(elev).unwrap().deceleration();
+    let old = sim.world().elevator(elev.entity()).unwrap().deceleration();
     sim.set_deceleration(elev, 3.5).unwrap();
     assert_eq!(
-        sim.world().elevator(elev).unwrap().deceleration().value(),
+        sim.world()
+            .elevator(elev.entity())
+            .unwrap()
+            .deceleration()
+            .value(),
         3.5
     );
     let events = sim.drain_events();
@@ -89,11 +104,15 @@ fn set_deceleration_applies_and_emits_event() {
 #[test]
 fn set_weight_capacity_applies_and_emits_event() {
     let (mut sim, elev) = make_sim();
-    let old = sim.world().elevator(elev).unwrap().weight_capacity();
+    let old = sim
+        .world()
+        .elevator(elev.entity())
+        .unwrap()
+        .weight_capacity();
     sim.set_weight_capacity(elev, 1200.0).unwrap();
     assert_eq!(
         sim.world()
-            .elevator(elev)
+            .elevator(elev.entity())
             .unwrap()
             .weight_capacity()
             .value(),
@@ -109,10 +128,17 @@ fn set_weight_capacity_applies_and_emits_event() {
 #[test]
 fn set_door_transition_ticks_applies_and_emits_event() {
     let (mut sim, elev) = make_sim();
-    let old = sim.world().elevator(elev).unwrap().door_transition_ticks();
+    let old = sim
+        .world()
+        .elevator(elev.entity())
+        .unwrap()
+        .door_transition_ticks();
     sim.set_door_transition_ticks(elev, 3).unwrap();
     assert_eq!(
-        sim.world().elevator(elev).unwrap().door_transition_ticks(),
+        sim.world()
+            .elevator(elev.entity())
+            .unwrap()
+            .door_transition_ticks(),
         3
     );
     let events = sim.drain_events();
@@ -128,9 +154,19 @@ fn set_door_transition_ticks_applies_and_emits_event() {
 #[test]
 fn set_door_open_ticks_applies_and_emits_event() {
     let (mut sim, elev) = make_sim();
-    let old = sim.world().elevator(elev).unwrap().door_open_ticks();
+    let old = sim
+        .world()
+        .elevator(elev.entity())
+        .unwrap()
+        .door_open_ticks();
     sim.set_door_open_ticks(elev, 20).unwrap();
-    assert_eq!(sim.world().elevator(elev).unwrap().door_open_ticks(), 20);
+    assert_eq!(
+        sim.world()
+            .elevator(elev.entity())
+            .unwrap()
+            .door_open_ticks(),
+        20
+    );
     let events = sim.drain_events();
     assert_eq!(count_upgrades(&events, UpgradeField::DoorOpenTicks), 1);
     let (old_v, new_v) = find_upgrade(&events, UpgradeField::DoorOpenTicks).unwrap();
@@ -143,29 +179,42 @@ fn set_door_open_ticks_applies_and_emits_event() {
 #[test]
 fn set_max_speed_rejects_non_positive() {
     let (mut sim, elev) = make_sim();
-    let before = sim.world().elevator(elev).unwrap().max_speed();
+    let before = sim.world().elevator(elev.entity()).unwrap().max_speed();
     let err = sim.set_max_speed(elev, -1.0).unwrap_err();
     assert!(matches!(err, SimError::InvalidConfig { .. }));
-    assert_eq!(sim.world().elevator(elev).unwrap().max_speed(), before);
+    assert_eq!(
+        sim.world().elevator(elev.entity()).unwrap().max_speed(),
+        before
+    );
 }
 
 #[test]
 fn set_acceleration_rejects_zero() {
     let (mut sim, elev) = make_sim();
-    let before = sim.world().elevator(elev).unwrap().acceleration();
+    let before = sim.world().elevator(elev.entity()).unwrap().acceleration();
     let err = sim.set_acceleration(elev, 0.0).unwrap_err();
     assert!(matches!(err, SimError::InvalidConfig { .. }));
-    assert_eq!(sim.world().elevator(elev).unwrap().acceleration(), before);
+    assert_eq!(
+        sim.world().elevator(elev.entity()).unwrap().acceleration(),
+        before
+    );
 }
 
 #[test]
 fn set_weight_capacity_rejects_nan() {
     let (mut sim, elev) = make_sim();
-    let before = sim.world().elevator(elev).unwrap().weight_capacity();
+    let before = sim
+        .world()
+        .elevator(elev.entity())
+        .unwrap()
+        .weight_capacity();
     let err = sim.set_weight_capacity(elev, f64::NAN).unwrap_err();
     assert!(matches!(err, SimError::InvalidConfig { .. }));
     assert_eq!(
-        sim.world().elevator(elev).unwrap().weight_capacity(),
+        sim.world()
+            .elevator(elev.entity())
+            .unwrap()
+            .weight_capacity(),
         before
     );
 }
@@ -173,20 +222,30 @@ fn set_weight_capacity_rejects_nan() {
 #[test]
 fn set_deceleration_rejects_infinite() {
     let (mut sim, elev) = make_sim();
-    let before = sim.world().elevator(elev).unwrap().deceleration();
+    let before = sim.world().elevator(elev.entity()).unwrap().deceleration();
     let err = sim.set_deceleration(elev, f64::INFINITY).unwrap_err();
     assert!(matches!(err, SimError::InvalidConfig { .. }));
-    assert_eq!(sim.world().elevator(elev).unwrap().deceleration(), before);
+    assert_eq!(
+        sim.world().elevator(elev.entity()).unwrap().deceleration(),
+        before
+    );
 }
 
 #[test]
 fn set_door_transition_ticks_rejects_zero() {
     let (mut sim, elev) = make_sim();
-    let before = sim.world().elevator(elev).unwrap().door_transition_ticks();
+    let before = sim
+        .world()
+        .elevator(elev.entity())
+        .unwrap()
+        .door_transition_ticks();
     let err = sim.set_door_transition_ticks(elev, 0).unwrap_err();
     assert!(matches!(err, SimError::InvalidConfig { .. }));
     assert_eq!(
-        sim.world().elevator(elev).unwrap().door_transition_ticks(),
+        sim.world()
+            .elevator(elev.entity())
+            .unwrap()
+            .door_transition_ticks(),
         before
     );
 }
@@ -194,11 +253,18 @@ fn set_door_transition_ticks_rejects_zero() {
 #[test]
 fn set_door_open_ticks_rejects_zero() {
     let (mut sim, elev) = make_sim();
-    let before = sim.world().elevator(elev).unwrap().door_open_ticks();
+    let before = sim
+        .world()
+        .elevator(elev.entity())
+        .unwrap()
+        .door_open_ticks();
     let err = sim.set_door_open_ticks(elev, 0).unwrap_err();
     assert!(matches!(err, SimError::InvalidConfig { .. }));
     assert_eq!(
-        sim.world().elevator(elev).unwrap().door_open_ticks(),
+        sim.world()
+            .elevator(elev.entity())
+            .unwrap()
+            .door_open_ticks(),
         before
     );
 }
@@ -210,7 +276,9 @@ fn set_on_non_elevator_returns_invalid_state() {
     let (mut sim, _elev) = make_sim();
     // Spawning a rider produces an EntityId that is not an elevator.
     let rider = sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
-    let err = sim.set_max_speed(rider, 4.0).unwrap_err();
+    let err = sim
+        .set_max_speed(ElevatorId::from(rider.entity()), 4.0)
+        .unwrap_err();
     assert!(matches!(err, SimError::NotAnElevator(_)));
 }
 
@@ -228,7 +296,7 @@ fn raising_max_speed_preserves_current_velocity() {
     for _ in 0..30 {
         sim.step();
     }
-    let vel_before = sim.world().velocity(elev).unwrap().value;
+    let vel_before = sim.world().velocity(elev.entity()).unwrap().value;
     assert!(
         vel_before > 0.0,
         "car should be moving; got velocity {vel_before}"
@@ -236,7 +304,7 @@ fn raising_max_speed_preserves_current_velocity() {
 
     sim.set_max_speed(elev, 10.0).unwrap();
     sim.step();
-    let vel_after = sim.world().velocity(elev).unwrap().value;
+    let vel_after = sim.world().velocity(elev.entity()).unwrap().value;
     // Velocity should be >= prior velocity (either unchanged or accelerated).
     assert!(
         vel_after >= vel_before - 1e-6,
@@ -258,7 +326,7 @@ fn lowering_max_speed_clamps_velocity_on_next_tick() {
     for _ in 0..30 {
         sim.step();
     }
-    let vel_before = sim.world().velocity(elev).unwrap().value;
+    let vel_before = sim.world().velocity(elev.entity()).unwrap().value;
     assert!(vel_before > 0.5, "car should be cruising: v={vel_before}");
 
     // Pick a cap well below current cruising velocity.
@@ -266,7 +334,7 @@ fn lowering_max_speed_clamps_velocity_on_next_tick() {
     sim.set_max_speed(elev, new_cap).unwrap();
     sim.step();
 
-    let vel_after = sim.world().velocity(elev).unwrap().value;
+    let vel_after = sim.world().velocity(elev.entity()).unwrap().value;
     assert!(
         vel_after <= new_cap + 1e-6,
         "expected velocity to be clamped at or below new cap {new_cap}, got {vel_after}"
@@ -288,7 +356,7 @@ fn door_open_ticks_change_does_not_affect_in_progress_cycle() {
     let mut reached_loading = false;
     for _ in 0..500 {
         sim.step();
-        if sim.world().elevator(elev).unwrap().phase() == ElevatorPhase::Loading {
+        if sim.world().elevator(elev.entity()).unwrap().phase() == ElevatorPhase::Loading {
             reached_loading = true;
             break;
         }
@@ -296,18 +364,24 @@ fn door_open_ticks_change_does_not_affect_in_progress_cycle() {
     assert!(reached_loading, "elevator should reach Loading phase");
 
     // Snapshot the current in-progress door state.
-    let door_before = *sim.world().elevator(elev).unwrap().door();
+    let door_before = *sim.world().elevator(elev.entity()).unwrap().door();
 
     // Change the open-ticks config. This must NOT mutate the current
     // in-progress DoorState — only the next cycle picks it up.
     sim.set_door_open_ticks(elev, 99).unwrap();
 
-    let door_after = *sim.world().elevator(elev).unwrap().door();
+    let door_after = *sim.world().elevator(elev.entity()).unwrap().door();
     assert_eq!(
         door_before, door_after,
         "in-progress door FSM must not change when door_open_ticks setter is called"
     );
-    assert_eq!(sim.world().elevator(elev).unwrap().door_open_ticks(), 99);
+    assert_eq!(
+        sim.world()
+            .elevator(elev.entity())
+            .unwrap()
+            .door_open_ticks(),
+        99
+    );
 }
 
 // ── Capacity below current_load ──────────────────────────────────────
@@ -324,7 +398,7 @@ fn weight_capacity_below_current_load_still_applies() {
     for _ in 0..500 {
         sim.step();
         if matches!(
-            sim.world().rider(rider).unwrap().phase,
+            sim.world().rider(rider.entity()).unwrap().phase,
             crate::components::RiderPhase::Riding(_)
                 | crate::components::RiderPhase::Exiting(_)
                 | crate::components::RiderPhase::Arrived
@@ -334,7 +408,12 @@ fn weight_capacity_below_current_load_still_applies() {
         }
     }
     assert!(boarded, "rider should board within 500 ticks");
-    let load = sim.world().elevator(elev).unwrap().current_load().value();
+    let load = sim
+        .world()
+        .elevator(elev.entity())
+        .unwrap()
+        .current_load()
+        .value();
     assert!(load > 0.0, "current_load should be non-zero after boarding");
 
     // Force capacity below current load.
@@ -342,7 +421,7 @@ fn weight_capacity_below_current_load_still_applies() {
     sim.set_weight_capacity(elev, new_cap).unwrap();
     assert_eq!(
         sim.world()
-            .elevator(elev)
+            .elevator(elev.entity())
             .unwrap()
             .weight_capacity()
             .value(),
@@ -350,7 +429,14 @@ fn weight_capacity_below_current_load_still_applies() {
     );
     // current_load is unchanged — no riders ejected.
     assert!(
-        (sim.world().elevator(elev).unwrap().current_load().value() - load).abs() < 1e-9,
+        (sim.world()
+            .elevator(elev.entity())
+            .unwrap()
+            .current_load()
+            .value()
+            - load)
+            .abs()
+            < 1e-9,
         "current_load must not change when capacity is lowered"
     );
 }

--- a/crates/elevator-core/src/tests/runtime_upgrades_tests.rs
+++ b/crates/elevator-core/src/tests/runtime_upgrades_tests.rs
@@ -7,7 +7,7 @@
 
 use crate::components::ElevatorPhase;
 use crate::dispatch::scan::ScanDispatch;
-use crate::entity::{ElevatorId, EntityId, RiderId};
+use crate::entity::ElevatorId;
 use crate::error::SimError;
 use crate::events::{Event, UpgradeField, UpgradeValue};
 use crate::sim::Simulation;

--- a/crates/elevator-core/src/tests/scenario_tests.rs
+++ b/crates/elevator-core/src/tests/scenario_tests.rs
@@ -1,6 +1,5 @@
 use crate::components::RiderPhase;
 use crate::components::Weight;
-use crate::entity::RiderId;
 use crate::events::Event;
 use crate::sim::Simulation;
 use crate::stop::StopId;

--- a/crates/elevator-core/src/tests/scenario_tests.rs
+++ b/crates/elevator-core/src/tests/scenario_tests.rs
@@ -1,5 +1,6 @@
 use crate::components::RiderPhase;
 use crate::components::Weight;
+use crate::entity::RiderId;
 use crate::events::Event;
 use crate::sim::Simulation;
 use crate::stop::StopId;
@@ -94,13 +95,13 @@ fn overweight_rider_rejected() {
     for _ in 0..max_ticks {
         sim.step();
         all_events.extend(sim.drain_events());
-        if sim.world().rider(light).map(|r| r.phase) == Some(RiderPhase::Arrived) {
+        if sim.world().rider(light.entity()).map(|r| r.phase) == Some(RiderPhase::Arrived) {
             break;
         }
     }
 
     assert_eq!(
-        sim.world().rider(light).map(|r| r.phase),
+        sim.world().rider(light.entity()).map(|r| r.phase),
         Some(RiderPhase::Arrived)
     );
 
@@ -197,10 +198,10 @@ fn rider_boarded_precedes_rider_exited_per_rider() {
 
     for rid in [r1, r2, r3] {
         let b = boarded_at
-            .get(&rid)
+            .get(&rid.entity())
             .unwrap_or_else(|| panic!("rider {rid:?} never boarded"));
         let e = exited_at
-            .get(&rid)
+            .get(&rid.entity())
             .unwrap_or_else(|| panic!("rider {rid:?} never exited"));
         assert!(
             b < e,

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -259,8 +259,11 @@ fn load_extensions_with_convenience() {
     let config = helpers::default_config();
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
     let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
-    sim.world_mut()
-        .insert_ext(rider, VipTag { level: 3 }, ExtKey::from_type_name());
+    sim.world_mut().insert_ext(
+        rider.entity(),
+        VipTag { level: 3 },
+        ExtKey::from_type_name(),
+    );
 
     let snap = sim.snapshot();
     let mut restored = snap.restore(None).unwrap();
@@ -296,8 +299,11 @@ fn load_extensions_reports_unregistered_types() {
     let config = helpers::default_config();
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
     let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
-    sim.world_mut()
-        .insert_ext(rider, VipTag { level: 1 }, ExtKey::from_type_name());
+    sim.world_mut().insert_ext(
+        rider.entity(),
+        VipTag { level: 1 },
+        ExtKey::from_type_name(),
+    );
 
     let snap = sim.snapshot();
     let mut restored = snap.restore(None).unwrap();

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -1,4 +1,5 @@
 use crate::components::RiderPhase;
+use crate::entity::{ElevatorId, RiderId};
 use crate::stop::StopId;
 use crate::tests::helpers;
 use crate::world::ExtKey;
@@ -221,8 +222,11 @@ fn snapshot_preserves_extension_components() {
 
     // Attach extension component to a rider.
     let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
-    sim.world_mut()
-        .insert_ext(rider, VipTag { level: 5 }, ExtKey::from_type_name());
+    sim.world_mut().insert_ext(
+        rider.entity(),
+        VipTag { level: 5 },
+        ExtKey::from_type_name(),
+    );
 
     let snap = sim.snapshot();
     let mut restored = snap.restore(None).unwrap();
@@ -445,7 +449,7 @@ fn snapshot_preserves_hall_calls_and_pinning() {
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
 
     let stop = sim.stop_entity(StopId(1)).unwrap();
-    let car = sim.world().elevator_ids()[0];
+    let car = ElevatorId::from(sim.world().elevator_ids()[0]);
     sim.press_hall_button(stop, CallDirection::Up).unwrap();
     sim.pin_assignment(car, stop, CallDirection::Up).unwrap();
 
@@ -475,7 +479,7 @@ fn snapshot_preserves_car_calls() {
     let config = helpers::default_config();
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
 
-    let car = sim.world().elevator_ids()[0];
+    let car = ElevatorId::from(sim.world().elevator_ids()[0]);
     let floor = sim.stop_entity(StopId(2)).unwrap();
     sim.press_car_button(car, floor).unwrap();
     assert_eq!(sim.car_calls(car).len(), 1);
@@ -483,7 +487,7 @@ fn snapshot_preserves_car_calls() {
     let snap = sim.snapshot();
     let restored = snap.restore(None).unwrap();
 
-    let restored_car = restored.world().elevator_ids()[0];
+    let restored_car = ElevatorId::from(restored.world().elevator_ids()[0]);
     let calls = restored.car_calls(restored_car);
     assert_eq!(calls.len(), 1, "car call must round-trip");
     // Floor reference must have been remapped to a valid stop entity.

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -1,5 +1,5 @@
 use crate::components::RiderPhase;
-use crate::entity::{ElevatorId, RiderId};
+use crate::entity::ElevatorId;
 use crate::stop::StopId;
 use crate::tests::helpers;
 use crate::world::ExtKey;

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -39,7 +39,7 @@ use elevator_core::components::{Direction, ElevatorPhase, RiderPhase, Velocity};
 use elevator_core::config::SimConfig;
 use elevator_core::dispatch::BuiltinStrategy;
 use elevator_core::door::DoorState;
-use elevator_core::entity::EntityId;
+use elevator_core::entity::{ElevatorId, EntityId};
 use elevator_core::ids::GroupId;
 use elevator_core::sim::Simulation;
 use slotmap::{Key, KeyData};
@@ -810,7 +810,7 @@ pub unsafe extern "C" fn ev_sim_press_car_button(
             return EvStatus::InvalidArg;
         };
         let ev = unsafe { &mut *handle };
-        match ev.sim.press_car_button(car, floor) {
+        match ev.sim.press_car_button(ElevatorId::from(car), floor) {
             Ok(()) => EvStatus::Ok,
             Err(e) => {
                 set_last_error(e.to_string());
@@ -851,7 +851,7 @@ pub unsafe extern "C" fn ev_sim_pin_assignment(
             return EvStatus::InvalidArg;
         };
         let ev = unsafe { &mut *handle };
-        match ev.sim.pin_assignment(car, stop, dir) {
+        match ev.sim.pin_assignment(ElevatorId::from(car), stop, dir) {
             Ok(()) => EvStatus::Ok,
             Err(e) => {
                 set_last_error(e.to_string());


### PR DESCRIPTION
## Summary
Introduces `ElevatorId` and `RiderId` newtype wrappers around `EntityId` at the Simulation public API boundary, preventing entity-type transposition bugs at compile time.

- **New types:** `ElevatorId(EntityId)` and `RiderId(EntityId)` in `entity.rs`, generated via `typed_entity_id!` macro with full derive/serde/Display/From support
- **Simulation API:** 20+ elevator methods now take `ElevatorId`, `spawn_rider`/`build_rider` return `RiderId`, rider lifecycle methods take `RiderId`
- **Internal scope:** World storage, Events, dispatch traits, and system internals remain `EntityId`-based. Typed IDs convert via `.entity()` or `.0`
- **Prelude:** Both types exported from prelude

**Breaking:** Simulation methods that previously took `EntityId` for elevators now require `ElevatorId`; rider spawn/lifecycle methods use `RiderId`. Wrap with `ElevatorId::from(eid)` or `RiderId::from(eid)` at call sites.

Closes #135.

## Test plan
- [x] All 567 unit tests pass
- [x] All 43 doc tests pass
- [x] Zero clippy warnings (`--all-features`)
- [x] Pre-commit hook passes
- [x] All examples compile