### PR TITLE
chore: remove elevator-ffi from release-please

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,3 @@
 {
-  "crates/elevator-core": "12.0.0",
-  "crates/elevator-ffi": "0.9.0"
+  "crates/elevator-core": "12.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,13 +6,6 @@
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "include-component-in-tag": true
-    },
-    "crates/elevator-ffi": {
-      "release-type": "rust",
-      "component": "elevator-ffi",
-      "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": true,
-      "include-component-in-tag": true
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
## Summary
- Remove `elevator-ffi` from release-please config and manifest
- Supersedes #162 (rebased on current main to resolve merge conflict)

## Test plan
- [x] Both JSON files remain valid after removal
- [x] Pre-commit hook passes (fmt, clippy, tests, doctests)