### PR TITLE
fix!: runtime validation for Weight, Speed, and Accel constructors

### DIFF
--- a/crates/elevator-core/src/components/mod.rs
+++ b/crates/elevator-core/src/components/mod.rs
@@ -39,4 +39,4 @@ pub use rider::{Rider, RiderPhase, RiderPhaseKind};
 pub use route::{Route, RouteLeg, TransportMode};
 pub use service_mode::ServiceMode;
 pub use stop::Stop;
-pub use units::{Accel, Speed, Weight};
+pub use units::{Accel, Speed, UnitError, Weight};

--- a/crates/elevator-core/src/components/units.rs
+++ b/crates/elevator-core/src/components/units.rs
@@ -3,6 +3,38 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+/// Error returned when constructing a unit type from an invalid `f64`.
+///
+/// The value was not finite or was negative.
+///
+/// ```
+/// # use elevator_core::components::units::UnitError;
+/// let err = UnitError { unit: "Weight", value: f64::NAN };
+/// assert_eq!(
+///     format!("{err}"),
+///     "invalid Weight value: NaN (must be finite and non-negative)"
+/// );
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct UnitError {
+    /// Name of the unit type that failed validation.
+    pub unit: &'static str,
+    /// The rejected value.
+    pub value: f64,
+}
+
+impl fmt::Display for UnitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid {} value: {} (must be finite and non-negative)",
+            self.unit, self.value
+        )
+    }
+}
+
+impl std::error::Error for UnitError {}
+
 /// Weight / mass (always non-negative).
 ///
 /// Used for rider weight, elevator load, and weight capacity.
@@ -24,6 +56,29 @@ impl Weight {
     /// Zero weight.
     pub const ZERO: Self = Self { value: 0.0 };
 
+    /// Fallible constructor — returns `Err` for NaN, infinity, or negative values.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UnitError`] if `value` is not finite or is negative.
+    ///
+    /// ```
+    /// # use elevator_core::components::Weight;
+    /// assert!(Weight::try_new(75.0).is_ok());
+    /// assert!(Weight::try_new(f64::NAN).is_err());
+    /// assert!(Weight::try_new(-1.0).is_err());
+    /// ```
+    pub fn try_new(value: f64) -> Result<Self, UnitError> {
+        if value.is_finite() && value >= 0.0 {
+            Ok(Self { value })
+        } else {
+            Err(UnitError {
+                unit: "Weight",
+                value,
+            })
+        }
+    }
+
     /// The inner value.
     #[must_use]
     pub const fn value(self) -> f64 {
@@ -37,9 +92,10 @@ impl fmt::Display for Weight {
     }
 }
 
+#[allow(clippy::panic)]
 impl From<f64> for Weight {
     fn from(value: f64) -> Self {
-        debug_assert!(
+        assert!(
             value.is_finite() && value >= 0.0,
             "Weight must be finite and non-negative, got {value}"
         );
@@ -92,6 +148,28 @@ pub struct Speed {
 }
 
 impl Speed {
+    /// Fallible constructor — returns `Err` for NaN, infinity, or negative values.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UnitError`] if `value` is not finite or is negative.
+    ///
+    /// ```
+    /// # use elevator_core::components::Speed;
+    /// assert!(Speed::try_new(2.0).is_ok());
+    /// assert!(Speed::try_new(f64::INFINITY).is_err());
+    /// ```
+    pub fn try_new(value: f64) -> Result<Self, UnitError> {
+        if value.is_finite() && value >= 0.0 {
+            Ok(Self { value })
+        } else {
+            Err(UnitError {
+                unit: "Speed",
+                value,
+            })
+        }
+    }
+
     /// The inner value.
     #[must_use]
     pub const fn value(self) -> f64 {
@@ -105,9 +183,10 @@ impl fmt::Display for Speed {
     }
 }
 
+#[allow(clippy::panic)]
 impl From<f64> for Speed {
     fn from(value: f64) -> Self {
-        debug_assert!(
+        assert!(
             value.is_finite() && value >= 0.0,
             "Speed must be finite and non-negative, got {value}"
         );
@@ -130,6 +209,28 @@ pub struct Accel {
 }
 
 impl Accel {
+    /// Fallible constructor — returns `Err` for NaN, infinity, or negative values.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UnitError`] if `value` is not finite or is negative.
+    ///
+    /// ```
+    /// # use elevator_core::components::Accel;
+    /// assert!(Accel::try_new(1.5).is_ok());
+    /// assert!(Accel::try_new(-0.5).is_err());
+    /// ```
+    pub fn try_new(value: f64) -> Result<Self, UnitError> {
+        if value.is_finite() && value >= 0.0 {
+            Ok(Self { value })
+        } else {
+            Err(UnitError {
+                unit: "Accel",
+                value,
+            })
+        }
+    }
+
     /// The inner value.
     #[must_use]
     pub const fn value(self) -> f64 {
@@ -143,9 +244,10 @@ impl fmt::Display for Accel {
     }
 }
 
+#[allow(clippy::panic)]
 impl From<f64> for Accel {
     fn from(value: f64) -> Self {
-        debug_assert!(
+        assert!(
             value.is_finite() && value >= 0.0,
             "Accel must be finite and non-negative, got {value}"
         );

--- a/crates/elevator-core/src/components/units.rs
+++ b/crates/elevator-core/src/components/units.rs
@@ -95,11 +95,7 @@ impl fmt::Display for Weight {
 #[allow(clippy::panic)]
 impl From<f64> for Weight {
     fn from(value: f64) -> Self {
-        assert!(
-            value.is_finite() && value >= 0.0,
-            "Weight must be finite and non-negative, got {value}"
-        );
-        Self { value }
+        Self::try_new(value).unwrap_or_else(|e| panic!("{e}"))
     }
 }
 
@@ -186,11 +182,7 @@ impl fmt::Display for Speed {
 #[allow(clippy::panic)]
 impl From<f64> for Speed {
     fn from(value: f64) -> Self {
-        assert!(
-            value.is_finite() && value >= 0.0,
-            "Speed must be finite and non-negative, got {value}"
-        );
-        Self { value }
+        Self::try_new(value).unwrap_or_else(|e| panic!("{e}"))
     }
 }
 
@@ -247,10 +239,6 @@ impl fmt::Display for Accel {
 #[allow(clippy::panic)]
 impl From<f64> for Accel {
     fn from(value: f64) -> Self {
-        assert!(
-            value.is_finite() && value >= 0.0,
-            "Accel must be finite and non-negative, got {value}"
-        );
-        Self { value }
+        Self::try_new(value).unwrap_or_else(|e| panic!("{e}"))
     }
 }

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -510,7 +510,7 @@ pub mod prelude {
     pub use crate::components::{
         Accel, AccessControl, DestinationQueue, Direction, Elevator, ElevatorPhase, Line,
         Orientation, Patience, Position, Preferences, Rider, RiderPhase, RiderPhaseKind, Route,
-        ServiceMode, SpatialPosition, Speed, Stop, Velocity, Weight,
+        ServiceMode, SpatialPosition, Speed, Stop, UnitError, Velocity, Weight,
     };
     pub use crate::config::{ElevatorConfig, GroupConfig, LineConfig, SimConfig};
     pub use crate::dispatch::reposition::{


### PR DESCRIPTION
## Summary
- Replace `debug_assert!` with `assert!` in `From<f64>` impls for `Weight`, `Speed`, and `Accel` so invalid values (NaN, infinity, negative) are caught in release builds
- Add fallible `try_new()` constructors returning `Result<Self, UnitError>` for paths that need graceful error handling (traffic generators, snapshot restore)
- Export `UnitError` from `components` module

## Breaking change
`From<f64>` now panics in release builds on invalid input (previously only panicked in debug builds).

Closes #187