### PR TITLE
fix: medium-severity bug fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "11.0.0"
+version = "12.0.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "cbindgen",
  "elevator-core",

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Each call to `sim.step()` executes eight phases:
 
 | Phase | Description |
 |-------|-------------|
-| **Advance Transient** | Promotes one-tick states forward (Boarding to Riding, Exiting to Resident/Arrived). |
+| **Advance Transient** | Promotes one-tick states forward (Boarding to Riding, Exiting to Arrived or back to Waiting for multi-leg routes). |
 | **Dispatch** | Assigns idle elevators to stops via the pluggable `DispatchStrategy`. |
 | **Reposition** | Moves idle elevators toward strategic positions to reduce future wait times. |
 | **Advance Queue** | Reconciles each elevator's phase/target with its `DestinationQueue` front (honors imperative `push_destination` / `push_destination_front` / `clear_destinations` calls). |

--- a/crates/elevator-core/ARCHITECTURE.md
+++ b/crates/elevator-core/ARCHITECTURE.md
@@ -293,16 +293,7 @@ Key relationship invariants:
 
 ```rust
 pub trait DispatchStrategy: Send + Sync {
-    fn rank(
-        &mut self,
-        car: EntityId,
-        car_position: f64,
-        stop: EntityId,
-        stop_position: f64,
-        group: &ElevatorGroup,
-        manifest: &DispatchManifest,
-        world: &World,
-    ) -> Option<f64>;
+    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64>;
 
     fn pre_dispatch(&mut self, _group: &ElevatorGroup, _manifest: &DispatchManifest, _world: &mut World) {}
     fn prepare_car(&mut self, _car: EntityId, _pos: f64, _group: &ElevatorGroup, _manifest: &DispatchManifest, _world: &World) {}

--- a/crates/elevator-core/Cargo.toml
+++ b/crates/elevator-core/Cargo.toml
@@ -56,3 +56,7 @@ harness = false
 [[bench]]
 name = "query_bench"
 harness = false
+
+[[example]]
+name = "dispatch_comparison"
+required-features = ["traffic"]

--- a/crates/elevator-core/src/scenario.rs
+++ b/crates/elevator-core/src/scenario.rs
@@ -92,6 +92,8 @@ pub struct ScenarioRunner {
     max_ticks: u64,
     /// Scenario name.
     name: String,
+    /// Number of spawn attempts that failed (e.g. disabled/removed stops).
+    skipped_spawns: u64,
 }
 
 impl ScenarioRunner {
@@ -114,6 +116,7 @@ impl ScenarioRunner {
             conditions: scenario.conditions,
             max_ticks: scenario.max_ticks,
             name: scenario.name,
+            skipped_spawns: 0,
         })
     }
 
@@ -123,6 +126,13 @@ impl ScenarioRunner {
         &self.sim
     }
 
+    /// Number of rider spawn attempts that were skipped due to errors
+    /// (e.g. referencing disabled or removed stops).
+    #[must_use]
+    pub const fn skipped_spawns(&self) -> u64 {
+        self.skipped_spawns
+    }
+
     /// Run one tick: spawn scheduled riders, then tick simulation.
     pub fn tick(&mut self) {
         // Spawn any riders scheduled for this tick.
@@ -130,12 +140,16 @@ impl ScenarioRunner {
             && self.spawns[self.spawn_cursor].tick <= self.sim.current_tick()
         {
             let spawn = &self.spawns[self.spawn_cursor];
-            // Deliberately ignore spawn errors: scenario files may reference stops
-            // that were removed or disabled during the scenario run. Silently
-            // skipping invalid spawns is the correct replay behavior.
-            let _ = self
+            // Spawn errors are expected: scenario files may reference stops
+            // that were removed or disabled during the run. We skip the
+            // spawn but track the count so callers can detect divergence.
+            if self
                 .sim
-                .spawn_rider(spawn.origin, spawn.destination, spawn.weight);
+                .spawn_rider(spawn.origin, spawn.destination, spawn.weight)
+                .is_err()
+            {
+                self.skipped_spawns += 1;
+            }
             self.spawn_cursor += 1;
         }
 
@@ -211,7 +225,7 @@ fn evaluate_condition(
         Condition::AllDeliveredByTick(deadline) => ConditionResult {
             condition: condition.clone(),
             passed: current_tick <= *deadline
-                && metrics.total_delivered() == metrics.total_spawned(),
+                && metrics.total_delivered() + metrics.total_abandoned() == metrics.total_spawned(),
             actual_value: current_tick as f64,
         },
         Condition::AbandonmentRateBelow(threshold) => ConditionResult {

--- a/crates/elevator-core/src/scenario.rs
+++ b/crates/elevator-core/src/scenario.rs
@@ -31,7 +31,10 @@ pub enum Condition {
     MaxWaitBelow(u64),
     /// Throughput must be above this value (riders per window).
     ThroughputAbove(u64),
-    /// All riders must be delivered by this tick.
+    /// All spawned riders must reach a terminal state (delivered or abandoned)
+    /// by this tick. Riders that failed to spawn (see
+    /// [`ScenarioRunner::skipped_spawns`]) are not counted — check that
+    /// value separately when replay fidelity matters.
     AllDeliveredByTick(u64),
     /// Abandonment rate must be below this value (0.0 - 1.0).
     AbandonmentRateBelow(f64),

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -419,10 +419,8 @@ impl Simulation {
     /// If the entity is an elevator in motion, it is reset to `Idle` with
     /// zero velocity to prevent stale target references on re-enable.
     ///
-    /// **Note on residents:** disabling a stop does not automatically handle
-    /// `Resident` riders parked there. Callers should listen for
-    /// [`Event::EntityDisabled`] and manually reroute or despawn any
-    /// residents at the affected stop.
+    /// If the entity is a stop, any `Resident` riders parked there are
+    /// transitioned to `Abandoned` and appropriate events are emitted.
     ///
     /// Emits `EntityDisabled`. Returns `Err` if the entity does not exist.
     ///
@@ -481,8 +479,22 @@ impl Simulation {
             vel.value = 0.0;
         }
 
-        // If this is a stop, invalidate routes that reference it.
+        // If this is a stop, abandon resident riders and invalidate routes.
         if self.world.stop(id).is_some() {
+            let resident_ids: Vec<EntityId> =
+                self.rider_index.residents_at(id).iter().copied().collect();
+            for rid in resident_ids {
+                self.rider_index.remove_resident(id, rid);
+                self.rider_index.insert_abandoned(id, rid);
+                if let Some(r) = self.world.rider_mut(rid) {
+                    r.phase = RiderPhase::Abandoned;
+                }
+                self.events.emit(Event::RiderAbandoned {
+                    rider: rid,
+                    stop: id,
+                    tick: self.tick,
+                });
+            }
             self.invalidate_routes_for_stop(id);
         }
 


### PR DESCRIPTION
## Summary
- Fix README Exiting→Resident transition docs — actual behavior is Exiting→Arrived or Exiting→Waiting for multi-leg routes (#184)
- Update ARCHITECTURE.md stale `DispatchStrategy::rank` signature to use `RankContext<'_>` (#185)
- Fix `AllDeliveredByTick` to account for abandoned riders: `delivered + abandoned == spawned` (#188)
- Track skipped spawns in scenario replay via `skipped_spawns()` accessor instead of silently swallowing errors (#189)
- Handle Resident riders when disabling stops — transition to Abandoned with events (#190)
- Gate `dispatch_comparison` example behind `traffic` feature in Cargo.toml (#192)

Closes #184, closes #185, closes #188, closes #189, closes #190, closes #192