### PR TITLE
test: fill missing test coverage gaps

### DIFF
--- a/crates/elevator-core/src/tests/boundary_tests.rs
+++ b/crates/elevator-core/src/tests/boundary_tests.rs
@@ -56,6 +56,75 @@ fn patience_one_abandons_after_one_tick() {
     );
 }
 
+/// Document: max_wait_ticks = 0 and max_wait_ticks = 1 both abandon on the first tick.
+///
+/// The abandon condition is `waited_ticks >= max_wait_ticks.saturating_sub(1)`.
+/// - max_wait_ticks=0: saturating_sub(1) → 0, so 0 >= 0 is true → abandons before increment.
+/// - max_wait_ticks=1: saturating_sub(1) → 0, so 0 >= 0 is true → same behavior.
+/// This equivalence is intentional: there is no meaningful difference between
+/// "zero patience" and "one-tick patience" since the check runs before the
+/// waited_ticks counter increments.
+#[test]
+fn patience_zero_and_one_are_equivalent() {
+    for max_wait in [0, 1] {
+        let config = default_config();
+        let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+        let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+        sim.world_mut().set_patience(
+            rider.entity(),
+            Patience {
+                max_wait_ticks: max_wait,
+                waited_ticks: 0,
+            },
+        );
+
+        sim.step();
+
+        let phase = sim.world().rider(rider.entity()).map(|r| r.phase);
+        assert_eq!(
+            phase,
+            Some(RiderPhase::Abandoned),
+            "rider with max_wait_ticks={max_wait} should abandon after 1 step"
+        );
+    }
+}
+
+#[test]
+fn patience_two_survives_first_tick() {
+    // max_wait_ticks=2: saturating_sub(1) → 1, so 0 >= 1 is false on the first tick.
+    // After the first tick, waited_ticks increments to 1, and 1 >= 1 is true → abandons.
+    let config = default_config();
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.world_mut().set_patience(
+        rider.entity(),
+        Patience {
+            max_wait_ticks: 2,
+            waited_ticks: 0,
+        },
+    );
+
+    // First tick: should NOT abandon.
+    sim.step();
+    let phase = sim.world().rider(rider.entity()).map(|r| r.phase);
+    assert_eq!(
+        phase,
+        Some(RiderPhase::Waiting),
+        "rider with max_wait_ticks=2 should survive the first tick"
+    );
+
+    // Second tick: should abandon.
+    sim.step();
+    let phase = sim.world().rider(rider.entity()).map(|r| r.phase);
+    assert_eq!(
+        phase,
+        Some(RiderPhase::Abandoned),
+        "rider with max_wait_ticks=2 should abandon after the second tick"
+    );
+}
+
 #[test]
 fn patience_max_never_overflows() {
     let config = default_config();
@@ -132,6 +201,86 @@ fn preferences_zero_crowding_rejects_any_load() {
         assert!(
             preference_rejections,
             "rider with max_crowding_factor=0.0 should be rejected when elevator has any load"
+        );
+    }
+}
+
+#[test]
+fn weight_exactly_at_capacity_after_partial_load_boards() {
+    // Load the elevator partway, then try a rider whose weight exactly fills the
+    // remaining capacity. Verifies the `<=` check at the boundary.
+    let config = default_config(); // capacity = 800
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+    // First rider: 500 kg. Leaves 300 kg remaining.
+    let r1 = sim.spawn_rider(StopId(0), StopId(2), 500.0).unwrap();
+    // Second rider: exactly 300 kg (fills remaining capacity to the byte).
+    let r2 = sim.spawn_rider(StopId(0), StopId(2), 300.0).unwrap();
+
+    let mut both_boarded = false;
+    for _ in 0..1000 {
+        sim.step();
+        let r1_riding = sim.world().rider(r1.entity()).is_some_and(|r| {
+            matches!(
+                r.phase,
+                RiderPhase::Boarding(_) | RiderPhase::Riding(_) | RiderPhase::Arrived
+            )
+        });
+        let r2_riding = sim.world().rider(r2.entity()).is_some_and(|r| {
+            matches!(
+                r.phase,
+                RiderPhase::Boarding(_) | RiderPhase::Riding(_) | RiderPhase::Arrived
+            )
+        });
+        if r1_riding && r2_riding {
+            both_boarded = true;
+            break;
+        }
+    }
+    assert!(
+        both_boarded,
+        "rider weighing exactly the remaining capacity (500+300=800) should board"
+    );
+}
+
+#[test]
+fn weight_exceeds_capacity_by_epsilon_rejects() {
+    // A rider that exceeds remaining capacity by the smallest practical amount
+    // should be rejected (not boarded).
+    let config = default_config(); // capacity = 800
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+    // First rider: 799.5 kg. Leaves 0.5 remaining.
+    let r1 = sim.spawn_rider(StopId(0), StopId(2), 799.5).unwrap();
+    // Second rider: 0.5 + a small overshoot.
+    let r2 = sim.spawn_rider(StopId(0), StopId(2), 0.500001).unwrap();
+
+    // Run until r1 boards.
+    for _ in 0..500 {
+        sim.step();
+        if sim
+            .world()
+            .rider(r1.entity())
+            .is_some_and(|r| matches!(r.phase, RiderPhase::Riding(_) | RiderPhase::Arrived))
+        {
+            break;
+        }
+    }
+
+    // Continue stepping — r2 should never board because 0.500001 > 0.5 remaining.
+    for _ in 0..500 {
+        sim.step();
+    }
+
+    // Verify the elevator never exceeded capacity during the run.
+    // (The proptest already covers this, but we check the specific rider.)
+    let r2_phase = sim.world().rider(r2.entity()).map(|r| r.phase);
+    // r2 should still be Waiting (never boarded) or potentially Rejected.
+    // It should NOT be Riding or Arrived.
+    if let Some(phase) = r2_phase {
+        assert!(
+            !matches!(phase, RiderPhase::Riding(_) | RiderPhase::Arrived),
+            "rider exceeding capacity by epsilon should not board, but phase is {phase:?}"
         );
     }
 }

--- a/crates/elevator-core/src/tests/boundary_tests.rs
+++ b/crates/elevator-core/src/tests/boundary_tests.rs
@@ -245,44 +245,39 @@ fn weight_exactly_at_capacity_after_partial_load_boards() {
 
 #[test]
 fn weight_exceeds_capacity_by_epsilon_rejects() {
-    // A rider that exceeds remaining capacity by the smallest practical amount
-    // should be rejected (not boarded).
     let config = default_config(); // capacity = 800
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
-    // First rider: 799.5 kg. Leaves 0.5 remaining.
     let r1 = sim.spawn_rider(StopId(0), StopId(2), 799.5).unwrap();
-    // Second rider: 0.5 + a small overshoot.
     let r2 = sim.spawn_rider(StopId(0), StopId(2), 0.500001).unwrap();
 
-    // Run until r1 boards.
-    for _ in 0..500 {
+    // Run until r1 is aboard.
+    for _ in 0..100 {
         sim.step();
         if sim
             .world()
             .rider(r1.entity())
-            .is_some_and(|r| matches!(r.phase, RiderPhase::Riding(_) | RiderPhase::Arrived))
+            .is_some_and(|r| matches!(r.phase, RiderPhase::Riding(_)))
         {
             break;
         }
     }
 
-    // Continue stepping — r2 should never board because 0.500001 > 0.5 remaining.
-    for _ in 0..500 {
-        sim.step();
-    }
+    assert!(
+        sim.world()
+            .rider(r1.entity())
+            .is_some_and(|r| matches!(r.phase, RiderPhase::Riding(_))),
+        "r1 should be riding by now"
+    );
 
-    // Verify the elevator never exceeded capacity during the run.
-    // (The proptest already covers this, but we check the specific rider.)
-    let r2_phase = sim.world().rider(r2.entity()).map(|r| r.phase);
-    // r2 should still be Waiting (never boarded) or potentially Rejected.
-    // It should NOT be Riding or Arrived.
-    if let Some(phase) = r2_phase {
-        assert!(
-            !matches!(phase, RiderPhase::Riding(_) | RiderPhase::Arrived),
-            "rider exceeding capacity by epsilon should not board, but phase is {phase:?}"
-        );
-    }
+    let rejected = sim
+        .drain_events()
+        .into_iter()
+        .any(|e| matches!(e, Event::RiderRejected { rider, .. } if rider == r2.entity()));
+    assert!(
+        rejected,
+        "r2 (0.500001 kg) should be rejected while remaining capacity is 0.5 kg"
+    );
 }
 
 #[test]

--- a/crates/elevator-core/src/tests/dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/dispatch_tests.rs
@@ -531,7 +531,7 @@ fn custom_dispatch_strategy() {
     let elevators: Vec<_> = sim.world().iter_elevators().collect();
     assert!(!elevators.is_empty());
     assert!(
-        (elevators[0].1.value - 0.0).abs() < f64::EPSILON,
+        (elevators[0].1.value - 0.0).abs() < 1e-9,
         "elevator should not have moved with AlwaysIdle dispatch"
     );
 }
@@ -601,6 +601,100 @@ fn assign_handles_large_group_without_overflow() {
         })
         .collect();
     assert_eq!(assigned_stops.len(), car_count);
+}
+
+// ===== Single-elevator, single-stop edge case tests (#179) =====
+
+/// Build a `World` with 1 stop and return (world, stop_entities).
+fn single_stop_world() -> (World, Vec<crate::entity::EntityId>) {
+    let mut world = World::new();
+    let eid = world.spawn();
+    world.set_stop(
+        eid,
+        Stop {
+            name: "Only".into(),
+            position: 0.0,
+        },
+    );
+    (world, vec![eid])
+}
+
+#[test]
+fn scan_single_stop_no_panic() {
+    let (mut world, stops) = single_stop_world();
+    let elev = spawn_elevator(&mut world, 0.0);
+    let group = test_group(&stops, vec![elev]);
+    let manifest = DispatchManifest::default();
+    let mut scan = ScanDispatch::new();
+    let decision = decide_one(&mut scan, elev, 0.0, &group, &manifest, &mut world);
+    assert_eq!(decision, DispatchDecision::Idle);
+}
+
+#[test]
+fn look_single_stop_no_panic() {
+    let (mut world, stops) = single_stop_world();
+    let elev = spawn_elevator(&mut world, 0.0);
+    let group = test_group(&stops, vec![elev]);
+    let manifest = DispatchManifest::default();
+    let mut look = LookDispatch::new();
+    let decision = decide_one(&mut look, elev, 0.0, &group, &manifest, &mut world);
+    assert_eq!(decision, DispatchDecision::Idle);
+}
+
+#[test]
+fn nearest_car_single_stop_no_panic() {
+    let (mut world, stops) = single_stop_world();
+    let elev = spawn_elevator(&mut world, 0.0);
+    let group = test_group(&stops, vec![elev]);
+    let manifest = DispatchManifest::default();
+    let mut nc = NearestCarDispatch::new();
+    let decision = decide_one(&mut nc, elev, 0.0, &group, &manifest, &mut world);
+    assert_eq!(decision, DispatchDecision::Idle);
+}
+
+#[test]
+fn etd_single_stop_no_panic() {
+    let (mut world, stops) = single_stop_world();
+    let elev = spawn_elevator(&mut world, 0.0);
+    let group = test_group(&stops, vec![elev]);
+    let manifest = DispatchManifest::default();
+    let mut etd = EtdDispatch::new();
+    let decision = decide_one(&mut etd, elev, 0.0, &group, &manifest, &mut world);
+    assert_eq!(decision, DispatchDecision::Idle);
+}
+
+#[test]
+fn scan_single_stop_with_demand_no_panic() {
+    let (mut world, stops) = single_stop_world();
+    let elev = spawn_elevator(&mut world, 0.0);
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    add_demand(&mut manifest, &mut world, stops[0], 70.0);
+    let mut scan = ScanDispatch::new();
+    // With demand at the only stop (where the elevator already is), dispatch
+    // should not enter a direction-reversal loop. It may return Idle or GoToStop.
+    let decision = decide_one(&mut scan, elev, 0.0, &group, &manifest, &mut world);
+    // Either Idle (nothing to do — already there) or GoToStop(only stop) are acceptable.
+    match decision {
+        DispatchDecision::Idle | DispatchDecision::GoToStop(_) => {}
+    }
+}
+
+#[test]
+fn scan_single_stop_no_reversal_loop() {
+    let (mut world, stops) = single_stop_world();
+    let elev = spawn_elevator(&mut world, 0.0);
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    add_demand(&mut manifest, &mut world, stops[0], 70.0);
+    let mut scan = ScanDispatch::new();
+    // Call dispatch multiple times to ensure no infinite direction flipping.
+    for _ in 0..10 {
+        let decision = decide_one(&mut scan, elev, 0.0, &group, &manifest, &mut world);
+        match decision {
+            DispatchDecision::Idle | DispatchDecision::GoToStop(_) => {}
+        }
+    }
 }
 
 /// `EtdDispatch::pre_dispatch` must cache the group's demanded-stop

--- a/crates/elevator-core/src/tests/movement_tests.rs
+++ b/crates/elevator-core/src/tests/movement_tests.rs
@@ -210,8 +210,16 @@ fn tick_movement_snaps_to_target_on_overshoot() {
     // on the overshoot guard.
     let r = tick_movement(9.999, 2.0, 10.0, MAX_SPEED, ACCELERATION, DECELERATION, DT);
     assert!(r.arrived);
-    assert_eq!(r.position, 10.0, "snap to exact target");
-    assert_eq!(r.velocity, 0.0, "velocity zeroed on snap");
+    assert!(
+        (r.position - 10.0).abs() < 1e-9,
+        "snap to exact target, got {}",
+        r.position
+    );
+    assert!(
+        r.velocity.abs() < 1e-9,
+        "velocity zeroed on snap, got {}",
+        r.velocity
+    );
 }
 
 #[test]
@@ -236,8 +244,16 @@ fn tick_movement_zero_sign_when_already_at_target() {
     // Kills `velocity > 0.0 ... v < 0.0` sign-flip check when position == target.
     let r = tick_movement(5.0, 0.0, 5.0, MAX_SPEED, ACCELERATION, DECELERATION, DT);
     assert!(r.arrived);
-    assert_eq!(r.position, 5.0);
-    assert_eq!(r.velocity, 0.0);
+    assert!(
+        (r.position - 5.0).abs() < 1e-9,
+        "position should be target, got {}",
+        r.position
+    );
+    assert!(
+        r.velocity.abs() < 1e-9,
+        "velocity should be zero, got {}",
+        r.velocity
+    );
 }
 
 #[test]
@@ -265,4 +281,88 @@ fn moving_downward() {
         }
     }
     panic!("did not arrive within 2000 ticks");
+}
+
+// ── Edge-case dt tests (#183) ──────────────────────────────────────
+
+#[test]
+fn dt_zero_does_not_change_state() {
+    // With dt=0, no time passes — position and velocity should remain unchanged.
+    let r = tick_movement(5.0, 1.0, 10.0, MAX_SPEED, ACCELERATION, DECELERATION, 0.0);
+    // The function may snap to arrived if displacement is within EPSILON,
+    // but at 5.0 → 10.0 it should not. Either way, position must not
+    // change meaningfully.
+    assert!(
+        !r.arrived,
+        "should not arrive with dt=0 when far from target"
+    );
+    assert!(
+        (r.position - 5.0).abs() < 1e-9,
+        "position should not change with dt=0, got {}",
+        r.position
+    );
+    // velocity.abs() should not exceed max_speed.
+    assert!(
+        r.velocity.abs() <= MAX_SPEED + 1e-9,
+        "velocity must not exceed max_speed with dt=0"
+    );
+    // No NaN.
+    assert!(!r.position.is_nan(), "position must not be NaN");
+    assert!(!r.velocity.is_nan(), "velocity must not be NaN");
+}
+
+#[test]
+fn very_large_dt_arrives_without_overshoot() {
+    // A huge dt should still arrive at the target without going past it.
+    let r = tick_movement(0.0, 0.0, 10.0, MAX_SPEED, ACCELERATION, DECELERATION, 1e6);
+    assert!(r.arrived, "should arrive with very large dt");
+    assert!(
+        (r.position - 10.0).abs() < 1e-9,
+        "position should be exactly at target after large dt, got {}",
+        r.position
+    );
+    assert!(
+        r.velocity.abs() < 1e-9,
+        "velocity should be zero on arrival, got {}",
+        r.velocity
+    );
+}
+
+#[test]
+fn very_large_dt_downward() {
+    // Same test but moving downward.
+    let r = tick_movement(100.0, 0.0, 3.0, MAX_SPEED, ACCELERATION, DECELERATION, 1e6);
+    assert!(r.arrived, "should arrive with very large dt (downward)");
+    assert!(
+        (r.position - 3.0).abs() < 1e-9,
+        "position should be at target, got {}",
+        r.position
+    );
+}
+
+#[test]
+fn very_small_dt_makes_minimal_progress() {
+    // Extremely small dt should make tiny but non-NaN progress.
+    let r = tick_movement(
+        0.0,
+        0.0,
+        100.0,
+        MAX_SPEED,
+        ACCELERATION,
+        DECELERATION,
+        1e-15,
+    );
+    assert!(!r.arrived, "should not arrive with tiny dt");
+    assert!(!r.position.is_nan(), "position must not be NaN");
+    assert!(!r.velocity.is_nan(), "velocity must not be NaN");
+    assert!(
+        r.position >= 0.0,
+        "position should not go backward, got {}",
+        r.position
+    );
+    assert!(
+        r.velocity >= 0.0,
+        "velocity should not be negative when heading up, got {}",
+        r.velocity
+    );
 }

--- a/crates/elevator-core/src/tests/proptest_tests.rs
+++ b/crates/elevator-core/src/tests/proptest_tests.rs
@@ -20,11 +20,15 @@ proptest! {
         acceleration in 0.01..50.0_f64,
         deceleration in 0.01..50.0_f64,
         dt in 0.001..1.0_f64,
+        initial_velocity in 0.0..100.0_f64,
     ) {
         // Filter out cases where position ~= target.
         prop_assume!((target - position).abs() > 1e-6);
 
-        let result = tick_movement(position, 0.0, target, max_speed, acceleration, deceleration, dt);
+        // Use initial velocity in the direction of the target, clamped to max_speed.
+        let sign = (target - position).signum();
+        let vel = (initial_velocity.min(max_speed)) * sign;
+        let result = tick_movement(position, vel, target, max_speed, acceleration, deceleration, dt);
 
         // 1. If arrived, position must equal target (within epsilon).
         if result.arrived {

--- a/crates/elevator-core/src/tests/rider_index_tests.rs
+++ b/crates/elevator-core/src/tests/rider_index_tests.rs
@@ -203,3 +203,68 @@ fn rider_index_phases_are_independent() {
     assert!(!idx.residents_at(stop).contains(&a));
     assert!(!idx.abandoned_at(stop).contains(&w));
 }
+
+/// Integration test: run a full simulation with riders going through various
+/// lifecycle phases (boarding, exiting, abandonment, settlement) and verify
+/// the live rider index matches a from-scratch rebuild after every tick.
+#[test]
+fn rider_index_consistent_through_tick_cycles() {
+    use crate::components::Patience;
+    use crate::dispatch::scan::ScanDispatch;
+    use crate::sim::Simulation;
+    use crate::stop::StopId;
+    use crate::tests::helpers::default_config;
+
+    let config = default_config(); // 3 stops, 1 elevator
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+    // Spawn several riders: some will board, ride, exit (arrive), and one
+    // will abandon due to low patience.
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.spawn_rider(StopId(0), StopId(1), 60.0).unwrap();
+    sim.spawn_rider(StopId(2), StopId(0), 80.0).unwrap();
+
+    // A rider with very low patience that will abandon.
+    let impatient = sim.spawn_rider(StopId(2), StopId(0), 50.0).unwrap();
+    sim.world_mut().set_patience(
+        impatient.entity(),
+        Patience {
+            max_wait_ticks: 5,
+            waited_ticks: 0,
+        },
+    );
+
+    // Collect all stop entity IDs for querying.
+    let stop_entities: Vec<EntityId> = sim.world().iter_stops().map(|(eid, _)| eid).collect();
+
+    for tick in 0..500 {
+        sim.step();
+
+        // Build a fresh index from world state and compare against the live index.
+        let mut fresh = RiderIndex::default();
+        fresh.rebuild(sim.world());
+
+        for &stop in &stop_entities {
+            let live_waiting = sim.waiting_count_at(stop);
+            let fresh_waiting = fresh.waiting_count_at(stop);
+            assert_eq!(
+                live_waiting, fresh_waiting,
+                "tick {tick}: waiting count mismatch at {stop:?}: live={live_waiting}, rebuilt={fresh_waiting}"
+            );
+
+            let live_residents = sim.resident_count_at(stop);
+            let fresh_residents = fresh.resident_count_at(stop);
+            assert_eq!(
+                live_residents, fresh_residents,
+                "tick {tick}: resident count mismatch at {stop:?}: live={live_residents}, rebuilt={fresh_residents}"
+            );
+
+            let live_abandoned = sim.abandoned_count_at(stop);
+            let fresh_abandoned = fresh.abandoned_count_at(stop);
+            assert_eq!(
+                live_abandoned, fresh_abandoned,
+                "tick {tick}: abandoned count mismatch at {stop:?}: live={live_abandoned}, rebuilt={fresh_abandoned}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add dispatch tests for single elevator/single stop degenerate case across Scan, Look, NearestCar, Etd (#179)
- Add capacity boundary tests for exact weight match and epsilon-over rejection (#180)
- Add RiderIndex consistency integration test — rebuilds index from scratch every tick for 500 ticks and compares against live index (#181)
- Add patience boundary tests documenting `max_wait_ticks` 0 and 1 equivalence via `saturating_sub(1)` (#182)
- Add movement tests for `dt=0`, very large `dt`, and very small `dt` edge cases (#183)
- Replace exact `f64` equality with `1e-9` epsilon comparison in movement and dispatch tests (#194)
- Add non-zero initial velocity to proptest `tick_movement` strategy (#195)

Closes #179, closes #180, closes #181, closes #182, closes #183, closes #194, closes #195