### PR TITLE
fix: low-severity bug fixes

### DIFF
--- a/crates/elevator-core/src/components/hall_call.rs
+++ b/crates/elevator-core/src/components/hall_call.rs
@@ -62,8 +62,8 @@ impl CallDirection {
 /// A pressed hall button at `stop` requesting service in `direction`.
 ///
 /// Stored per `(stop, direction)` pair — at most two per stop. Built-in
-/// dispatch reads calls via [`DispatchManifest::hall_calls`](
-/// crate::dispatch::DispatchManifest::hall_calls).
+/// dispatch reads calls via [`DispatchManifest::iter_hall_calls`](
+/// crate::dispatch::DispatchManifest::iter_hall_calls).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct HallCall {

--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -13,7 +13,7 @@
 //! ```
 //!
 //! Assignments are recorded as an [`AssignedCar`] extension component on the
-//! rider; the loading filter in [`crate::systems::loading`] consults this to
+//! rider; the loading filter in `crate::systems::loading` consults this to
 //! enforce the stickiness invariant.
 //!
 //! This is a sim — not a faithful reproduction of any vendor's controller.

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -1,11 +1,12 @@
 //! Pluggable dispatch strategies for assigning elevators to stops.
 //!
 //! Strategies express preferences as scores on `(car, stop)` pairs via
-//! [`DispatchStrategy::rank`]. The dispatch system then runs an optimal
-//! bipartite assignment (Kuhn–Munkres / Hungarian algorithm) so coordination
-//! — one car per hall call — is a library invariant, not a per-strategy
-//! responsibility. Cars left unassigned are handed to
-//! [`DispatchStrategy::fallback`] for per-car policy (idle, park, etc.).
+//! [`DispatchStrategy::rank`](crate::dispatch::DispatchStrategy::rank). The
+//! dispatch system then runs an optimal bipartite assignment (Kuhn–Munkres /
+//! Hungarian algorithm) so coordination — one car per hall call — is a library
+//! invariant, not a per-strategy responsibility. Cars left unassigned are
+//! handed to [`DispatchStrategy::fallback`](crate::dispatch::DispatchStrategy::fallback)
+//! for per-car policy (idle, park, etc.).
 //!
 //! # Example: custom dispatch strategy
 //!
@@ -336,7 +337,7 @@ pub enum HallCallMode {
     ///
     /// Riders press an up or down button in the hall; the destination
     /// is revealed only *after* boarding, via a
-    /// [`CarCall`](crate::components::CarCall). Dispatch sees a direction
+    /// [`CarCall`]. Dispatch sees a direction
     /// per call but does not know individual rider destinations until
     /// they're aboard.
     #[default]
@@ -345,7 +346,7 @@ pub enum HallCallMode {
     /// Polaris, Schindler PORT).
     ///
     /// Riders enter their destination at a hall kiosk, so each
-    /// [`HallCall`](crate::components::HallCall) carries a destination
+    /// [`HallCall`] carries a destination
     /// stop from the moment it's pressed. Required by
     /// [`DestinationDispatch`].
     Destination,
@@ -632,8 +633,8 @@ pub trait DispatchStrategy: Send + Sync {
 
 /// Resolution of a single dispatch assignment pass for one group.
 ///
-/// Produced by [`assign`] and consumed by
-/// [`crate::systems::dispatch::run`] to apply decisions to the world.
+/// Produced by `assign` and consumed by
+/// `crate::systems::dispatch::run` to apply decisions to the world.
 #[derive(Debug, Clone)]
 pub struct AssignmentResult {
     /// `(car, decision)` pairs for every idle car in the group.

--- a/crates/elevator-core/src/energy.rs
+++ b/crates/elevator-core/src/energy.rs
@@ -1,9 +1,11 @@
 //! Simplified energy modeling for elevators.
 //!
-//! Provides an [`EnergyProfile`] that parameterizes per-tick energy costs
-//! and an [`EnergyMetrics`] accumulator for tracking consumption and
-//! regeneration over time. The pure function [`compute_tick_energy`]
-//! calculates consumed and regenerated energy for a single tick.
+//! Provides an [`EnergyProfile`](crate::energy::EnergyProfile) that
+//! parameterizes per-tick energy costs and an
+//! [`EnergyMetrics`](crate::energy::EnergyMetrics) accumulator for tracking
+//! consumption and regeneration over time. The pure function
+//! `compute_tick_energy` calculates consumed and regenerated energy for a
+//! single tick.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/elevator-core/src/eta.rs
+++ b/crates/elevator-core/src/eta.rs
@@ -2,7 +2,7 @@
 //!
 //! Given an elevator's kinematic parameters (max speed, acceleration,
 //! deceleration), an initial speed, and a remaining distance to a target,
-//! [`travel_time`] returns the seconds required to coast in, brake, and
+//! [`travel_time`](crate::eta::travel_time) returns the seconds required to coast in, brake, and
 //! arrive at rest. Used by [`Simulation::eta`](crate::sim::Simulation::eta)
 //! and [`Simulation::best_eta`](crate::sim::Simulation::best_eta) to walk a
 //! destination queue and sum per-leg travel plus per-stop door dwell.

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -268,7 +268,7 @@
 //! ```
 //!
 //! The previous-position snapshot is refreshed automatically at the start
-//! of every [`step`](sim::Simulation::step). [`Simulation::velocity`] is
+//! of every [`step`](sim::Simulation::step). [`Simulation::velocity`](sim::Simulation::velocity) is
 //! a convenience that returns the raw `f64` along the shaft axis (signed:
 //! +up, -down) for camera tilt, motion blur, or cabin-sway effects.
 //!

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -1808,9 +1808,10 @@ impl Simulation {
 
     /// Run only the reposition phase (with hooks).
     ///
-    /// Hooks always fire even when no [`RepositionStrategy`] is configured.
-    /// Idle elevators with no pending dispatch assignment are repositioned
-    /// according to their group's strategy.
+    /// Global before/after hooks always fire even when no [`RepositionStrategy`]
+    /// is configured. Per-group hooks only fire for groups that have a
+    /// repositioner — this differs from other phases where per-group hooks
+    /// fire unconditionally.
     pub fn run_reposition(&mut self) {
         self.hooks.run_before(Phase::Reposition, &mut self.world);
         if !self.repositioners.is_empty() {

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -1808,34 +1808,33 @@ impl Simulation {
 
     /// Run only the reposition phase (with hooks).
     ///
-    /// Only runs if at least one group has a [`RepositionStrategy`] configured.
+    /// Hooks always fire even when no [`RepositionStrategy`] is configured.
     /// Idle elevators with no pending dispatch assignment are repositioned
     /// according to their group's strategy.
     pub fn run_reposition(&mut self) {
-        if self.repositioners.is_empty() {
-            return;
-        }
         self.hooks.run_before(Phase::Reposition, &mut self.world);
-        // Only run per-group hooks for groups that have a repositioner.
-        for group in &self.groups {
-            if self.repositioners.contains_key(&group.id()) {
-                self.hooks
-                    .run_before_group(Phase::Reposition, group.id(), &mut self.world);
+        if !self.repositioners.is_empty() {
+            // Only run per-group hooks for groups that have a repositioner.
+            for group in &self.groups {
+                if self.repositioners.contains_key(&group.id()) {
+                    self.hooks
+                        .run_before_group(Phase::Reposition, group.id(), &mut self.world);
+                }
             }
-        }
-        let ctx = self.phase_context();
-        crate::systems::reposition::run(
-            &mut self.world,
-            &mut self.events,
-            &ctx,
-            &self.groups,
-            &mut self.repositioners,
-            &mut self.reposition_buf,
-        );
-        for group in &self.groups {
-            if self.repositioners.contains_key(&group.id()) {
-                self.hooks
-                    .run_after_group(Phase::Reposition, group.id(), &mut self.world);
+            let ctx = self.phase_context();
+            crate::systems::reposition::run(
+                &mut self.world,
+                &mut self.events,
+                &ctx,
+                &self.groups,
+                &mut self.repositioners,
+                &mut self.reposition_buf,
+            );
+            for group in &self.groups {
+                if self.repositioners.contains_key(&group.id()) {
+                    self.hooks
+                        .run_after_group(Phase::Reposition, group.id(), &mut self.world);
+                }
             }
         }
         self.hooks.run_after(Phase::Reposition, &mut self.world);

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -684,14 +684,15 @@ impl crate::sim::Simulation {
     /// Serialize the current state to a self-describing byte blob.
     ///
     /// The blob is postcard-encoded and carries a magic prefix plus the
-    /// `elevator-core` crate version. Use [`Simulation::restore_bytes`]
+    /// `elevator-core` crate version. Use [`Self::restore_bytes`]
     /// on the receiving end. Determinism is bit-exact across builds of
     /// the same crate version; cross-version restores return
     /// [`SimError::SnapshotVersion`](crate::error::SimError::SnapshotVersion).
     ///
     /// Extension component *data* is serialized (identical to
-    /// [`Simulation::snapshot`]); after restore, use
-    /// [`Simulation::load_extensions_with`] to register and load them.
+    /// [`Self::snapshot`]); after restore, use
+    /// [`Simulation::load_extensions_with`](crate::sim::Simulation::load_extensions_with)
+    /// to register and load them.
     /// Custom dispatch strategies and arbitrary `World` resources are
     /// not included.
     ///
@@ -710,7 +711,7 @@ impl crate::sim::Simulation {
             .map_err(|e| crate::error::SimError::SnapshotFormat(e.to_string()))
     }
 
-    /// Restore a simulation from bytes produced by [`Simulation::snapshot_bytes`].
+    /// Restore a simulation from bytes produced by [`Self::snapshot_bytes`].
     ///
     /// Built-in dispatch strategies are auto-restored. For groups using
     /// [`BuiltinStrategy::Custom`](crate::dispatch::BuiltinStrategy::Custom),

--- a/crates/elevator-core/src/tests/proptest_tests.rs
+++ b/crates/elevator-core/src/tests/proptest_tests.rs
@@ -272,7 +272,7 @@ proptest! {
         let mut rng_state = seed;
         let mut next_weight = || -> f64 {
             rng_state = rng_state.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
-            let frac = (rng_state >> 32) as f64 / u32::MAX as f64;
+            let frac = (rng_state >> 32) as f64 / (1u64 << 32) as f64;
             10.0 + frac * (capacity * 0.3) // individual weight always < capacity
         };
 

--- a/crates/elevator-core/src/topology.rs
+++ b/crates/elevator-core/src/topology.rs
@@ -113,7 +113,9 @@ impl TopologyGraph {
     /// Stops that appear in two or more groups (transfer points).
     ///
     /// This inspects group membership directly and does not require the
-    /// adjacency graph.
+    /// adjacency graph. Note: this checks group membership only, not whether
+    /// riders can actually transfer between groups at the shared stop. A stop
+    /// served by two disconnected groups would still appear here.
     #[must_use]
     pub fn transfer_points(groups: &[ElevatorGroup]) -> Vec<EntityId> {
         let mut stop_groups: HashMap<EntityId, usize> = HashMap::new();

--- a/crates/elevator-core/src/traffic.rs
+++ b/crates/elevator-core/src/traffic.rs
@@ -106,9 +106,9 @@ fn sample_indices(
             }
             let r: f64 = rng.random_range(0.0..1.0);
             let upper_start = n.div_ceil(2);
-            if r < 0.4 && upper_start < n {
+            if r < 0.4 && upper_start < n && upper_start != mid {
                 Some((rng.random_range(upper_start..n), mid))
-            } else if r < 0.8 && upper_start < n {
+            } else if r < 0.8 && upper_start < n && upper_start != mid {
                 Some((mid, rng.random_range(upper_start..n)))
             } else {
                 Some(uniform_pair_indices(n, rng))

--- a/crates/elevator-core/src/traffic.rs
+++ b/crates/elevator-core/src/traffic.rs
@@ -101,8 +101,11 @@ fn sample_indices(
 
         TrafficPattern::Lunchtime => {
             // 40% upper→mid, 40% mid→upper, 20% random.
+            if n < 2 {
+                return Some(uniform_pair_indices(n, rng));
+            }
             let r: f64 = rng.random_range(0.0..1.0);
-            let upper_start = n / 2 + 1;
+            let upper_start = n.div_ceil(2);
             if r < 0.4 && upper_start < n {
                 Some((rng.random_range(upper_start..n), mid))
             } else if r < 0.8 && upper_start < n {

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -959,7 +959,7 @@ pub(crate) struct SortedStops(pub(crate) Vec<(f64, EntityId)>);
 /// The up/down hall call pair at a single stop.
 ///
 /// At most two calls coexist at a stop (one per [`CallDirection`]);
-/// this struct owns the slots. Stored in [`World::hall_calls`] keyed by
+/// this struct owns the slots. Stored in `World::hall_calls` keyed by
 /// the stop's entity id.
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct StopCalls {


### PR DESCRIPTION
## Summary
- Fire reposition hooks even when no repositioner is configured — before/after hooks now always execute (#176)
- Document `transfer_points()` group connectivity limitation (#178)
- Fix all 18 broken intra-doc links and cargo doc warnings across 8 files (#186)
- Fix Lunchtime traffic pattern for 2-3 stop buildings using `n.div_ceil(2)` (#191)
- Fix proptest weight RNG divisor from `u32::MAX` to `1u64 << 32` for proper [0,1) distribution (#193)

Closes #176, closes #178, closes #186, closes #191, closes #193