### PR TITLE
fix: critical bug fixes (#163, #164, #165)

### DIFF
--- a/crates/elevator-core/src/movement.rs
+++ b/crates/elevator-core/src/movement.rs
@@ -61,7 +61,7 @@ pub fn tick_movement(
     let sign = displacement.signum();
     let distance_remaining = displacement.abs();
     let speed = velocity.abs();
-    let safe_decel = deceleration.max(1e-9);
+    let safe_decel = deceleration.max(EPSILON);
     let stopping_distance = speed * speed / (2.0 * safe_decel);
 
     let new_velocity = if stopping_distance >= distance_remaining - EPSILON {

--- a/crates/elevator-core/src/movement.rs
+++ b/crates/elevator-core/src/movement.rs
@@ -61,11 +61,12 @@ pub fn tick_movement(
     let sign = displacement.signum();
     let distance_remaining = displacement.abs();
     let speed = velocity.abs();
-    let stopping_distance = speed * speed / (2.0 * deceleration);
+    let safe_decel = deceleration.max(1e-9);
+    let stopping_distance = speed * speed / (2.0 * safe_decel);
 
     let new_velocity = if stopping_distance >= distance_remaining - EPSILON {
         // Decelerate
-        let v = (-deceleration * dt).mul_add(velocity.signum(), velocity);
+        let v = (-safe_decel * dt).mul_add(velocity.signum(), velocity);
         // Clamp to zero if sign would flip.
         if velocity > 0.0 && v < 0.0 || velocity < 0.0 && v > 0.0 {
             0.0

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -485,13 +485,19 @@ impl Simulation {
             });
         }
 
-        // Check for duplicate stop IDs.
+        // Check for duplicate stop IDs and validate positions.
         let mut seen_ids = HashSet::new();
         for stop in &config.building.stops {
             if !seen_ids.insert(stop.id) {
                 return Err(SimError::InvalidConfig {
                     field: "building.stops",
                     reason: format!("duplicate {}", stop.id),
+                });
+            }
+            if !stop.position.is_finite() {
+                return Err(SimError::InvalidConfig {
+                    field: "building.stops.position",
+                    reason: format!("{} has non-finite position {}", stop.id, stop.position),
                 });
             }
         }

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -161,6 +161,14 @@ fn commit_go_to_stop(
     eid: EntityId,
     stop_eid: EntityId,
 ) {
+    // Guard: never dispatch an elevator to a stop it is restricted from.
+    if world
+        .elevator(eid)
+        .is_some_and(|car| car.restricted_stops().contains(&stop_eid))
+    {
+        return;
+    }
+
     // Short-circuit the common reassignment case: the same car
     // already committed to the same stop on a prior tick. Re-emitting
     // `ElevatorAssigned` each tick would drown observability consumers

--- a/crates/elevator-core/src/tests/access_tests.rs
+++ b/crates/elevator-core/src/tests/access_tests.rs
@@ -281,6 +281,36 @@ fn rejection_event_has_access_denied_reason() {
     }
 }
 
+/// Elevator is never dispatched (no `ElevatorAssigned` event) to a restricted stop,
+/// even when it's the only stop with demand. Verifies the global guard in
+/// `systems::dispatch::commit_go_to_stop`.
+#[test]
+fn elevator_not_dispatched_to_restricted_stop() {
+    let mut config = helpers::default_config();
+    config.elevators[0].restricted_stops = vec![StopId(2)];
+
+    let mut sim =
+        crate::sim::Simulation::new(&config, helpers::scan()).expect("config should be valid");
+
+    sim.spawn_rider(StopId(0), StopId(2), 70.0)
+        .expect("spawn should succeed");
+
+    let mut all_events = Vec::new();
+    for _ in 0..500 {
+        sim.step();
+        all_events.extend(sim.drain_events());
+    }
+
+    let stop2 = sim.stop_entity(StopId(2)).expect("stop 2 exists");
+    let dispatched_to_restricted = all_events
+        .iter()
+        .any(|e| matches!(e, Event::ElevatorAssigned { stop, .. } if *stop == stop2));
+    assert!(
+        !dispatched_to_restricted,
+        "elevator should never be assigned to a restricted stop"
+    );
+}
+
 /// `AccessControl` component round-trips through serde.
 #[test]
 fn access_control_serde_roundtrip() {

--- a/crates/elevator-core/src/tests/config_tests.rs
+++ b/crates/elevator-core/src/tests/config_tests.rs
@@ -1,4 +1,5 @@
 use crate::config::SimConfig;
+use crate::error::SimError;
 
 #[test]
 fn deserialize_default_ron() {
@@ -24,4 +25,58 @@ fn roundtrip_ron() {
     let config2: SimConfig = ron::from_str(&serialized).unwrap();
     assert_eq!(config.building.stops.len(), config2.building.stops.len());
     assert_eq!(config.elevators.len(), config2.elevators.len());
+}
+
+#[test]
+fn rejects_nan_stop_position() {
+    use super::helpers;
+    let mut config = helpers::default_config();
+    config.building.stops[1].position = f64::NAN;
+    let result = crate::sim::Simulation::new(&config, helpers::scan());
+    assert!(
+        matches!(
+            result,
+            Err(SimError::InvalidConfig {
+                field: "building.stops.position",
+                ..
+            })
+        ),
+        "NaN position should be rejected, got {result:?}"
+    );
+}
+
+#[test]
+fn rejects_infinite_stop_position() {
+    use super::helpers;
+    let mut config = helpers::default_config();
+    config.building.stops[0].position = f64::INFINITY;
+    let result = crate::sim::Simulation::new(&config, helpers::scan());
+    assert!(
+        matches!(
+            result,
+            Err(SimError::InvalidConfig {
+                field: "building.stops.position",
+                ..
+            })
+        ),
+        "infinite position should be rejected, got {result:?}"
+    );
+}
+
+#[test]
+fn rejects_neg_infinite_stop_position() {
+    use super::helpers;
+    let mut config = helpers::default_config();
+    config.building.stops[2].position = f64::NEG_INFINITY;
+    let result = crate::sim::Simulation::new(&config, helpers::scan());
+    assert!(
+        matches!(
+            result,
+            Err(SimError::InvalidConfig {
+                field: "building.stops.position",
+                ..
+            })
+        ),
+        "negative infinity position should be rejected, got {result:?}"
+    );
 }

--- a/crates/elevator-core/src/tests/movement_tests.rs
+++ b/crates/elevator-core/src/tests/movement_tests.rs
@@ -283,6 +283,29 @@ fn moving_downward() {
     panic!("did not arrive within 2000 ticks");
 }
 
+// ── Zero deceleration guard (#165) ─────────────────────────────────
+
+#[test]
+fn tick_movement_zero_deceleration_produces_finite_result() {
+    let r = tick_movement(0.0, 1.0, 10.0, MAX_SPEED, ACCELERATION, 0.0, DT);
+    assert!(
+        !r.position.is_nan(),
+        "position must not be NaN with zero deceleration"
+    );
+    assert!(
+        !r.velocity.is_nan(),
+        "velocity must not be NaN with zero deceleration"
+    );
+    assert!(
+        r.position.is_finite(),
+        "position must be finite with zero deceleration"
+    );
+    assert!(
+        r.velocity.is_finite(),
+        "velocity must be finite with zero deceleration"
+    );
+}
+
 // ── Edge-case dt tests (#183) ──────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- **#163**: Guard dispatch from assigning elevators to restricted stops. Added a global guard in `commit_go_to_stop()` that checks `restricted_stops` before committing any assignment — protects all strategies (Scan, Look, NearestCar, ETD) and custom user-provided ones.
- **#164**: Validate stop positions for finiteness at config time. NaN, infinity, and negative infinity positions are now rejected in `validate_config()`.
- **#165**: Clamp deceleration to epsilon (`1e-9`) in `tick_movement()`. Prevents division-by-zero producing infinity when deceleration is zero/negative in release builds.

## Test plan

- [x] `elevator_not_dispatched_to_restricted_stop` — verifies no `ElevatorAssigned` event for restricted stops
- [x] `rejects_nan_stop_position` / `rejects_infinite_stop_position` / `rejects_neg_infinite_stop_position` — config validation rejects non-finite positions
- [x] `tick_movement_zero_deceleration_produces_finite_result` — zero deceleration produces finite position and velocity

Closes #163, closes #164, closes #165