### PR TITLE
fix: medium bug fixes (#166, #167, #168, #169, #172, #173)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "12.0.0"
+version = "12.0.2"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -24,6 +24,8 @@
 //! monotone sequence so the car visits stops in sweep order rather than
 //! in the order assignments arrived.
 
+use std::collections::HashSet;
+
 use serde::{Deserialize, Serialize};
 
 use crate::components::{DestinationQueue, Direction, ElevatorPhase, TransportMode};
@@ -489,7 +491,8 @@ fn rebuild_car_queue(world: &mut crate::world::World, car_eid: EntityId) {
     out.extend(run1.into_iter().map(|(e, _)| e));
     out.extend(run2.into_iter().map(|(e, _)| e));
     out.extend(run3.into_iter().map(|(e, _)| e));
-    out.dedup();
+    let mut seen = HashSet::with_capacity(out.len());
+    out.retain(|e| seen.insert(*e));
 
     if let Some(q) = world.destination_queue_mut(car_eid) {
         q.replace(out);

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -553,6 +553,8 @@ pub enum Event {
     SnapshotDanglingReference {
         /// The entity ID from the snapshot that had no mapping.
         stale_id: EntityId,
+        /// Tick from the snapshot at restore time.
+        tick: u64,
     },
 }
 

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -547,6 +547,13 @@ pub enum Event {
         /// Tick of the balk.
         tick: u64,
     },
+    /// A snapshot restore encountered an entity reference that could not
+    /// be remapped. The original (now-invalid) ID was kept. This signals
+    /// a corrupted or hand-edited snapshot.
+    SnapshotDanglingReference {
+        /// The entity ID from the snapshot that had no mapping.
+        stale_id: EntityId,
+    },
 }
 
 /// Identifies which elevator parameter was changed in an
@@ -707,6 +714,7 @@ impl Event {
             | Self::HallCallCleared { .. }
             | Self::CarButtonPressed { .. } => EventCategory::Dispatch,
             Self::RiderBalked { .. } => EventCategory::Rider,
+            Self::SnapshotDanglingReference { .. } => EventCategory::Observability,
         }
     }
 }

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -1600,6 +1600,11 @@ impl Simulation {
         std::mem::take(&mut self.pending_output)
     }
 
+    /// Push an event into the pending output buffer (crate-internal).
+    pub(crate) fn push_event(&mut self, event: Event) {
+        self.pending_output.push(event);
+    }
+
     /// Drain only events matching a predicate.
     ///
     /// Events that don't match the predicate remain in the buffer
@@ -2203,6 +2208,10 @@ impl Simulation {
         let press_tick = self.tick;
         let ack_latency = self.ack_latency_for_car(car);
         let Some(queue) = self.world.car_calls_mut(car) else {
+            debug_assert!(
+                false,
+                "ensure_car_call: car {car:?} has no car_calls component"
+            );
             return;
         };
         let existing_idx = queue.iter().position(|c| c.floor == floor);

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -579,6 +579,18 @@ impl Simulation {
                 reason: format!("must be positive, got {}", elev.inspection_speed_factor),
             });
         }
+        if elev.door_transition_ticks == 0 {
+            return Err(SimError::InvalidConfig {
+                field: "elevators.door_transition_ticks",
+                reason: "must be > 0".into(),
+            });
+        }
+        if elev.door_open_ticks == 0 {
+            return Err(SimError::InvalidConfig {
+                field: "elevators.door_open_ticks",
+                reason: "must be > 0".into(),
+            });
+        }
         if !building.stops.iter().any(|s| s.id == elev.starting_stop) {
             return Err(SimError::InvalidConfig {
                 field: "elevators.starting_stop",
@@ -605,8 +617,14 @@ impl Simulation {
             }
         }
 
-        // Every line's serves must reference existing stops.
+        // Every line's serves must reference existing stops and be non-empty.
         for lc in line_configs {
+            if lc.serves.is_empty() {
+                return Err(SimError::InvalidConfig {
+                    field: "building.lines.serves",
+                    reason: format!("line {} has no stops", lc.id),
+                });
+            }
             for sid in &lc.serves {
                 if !stop_ids.contains(sid) {
                     return Err(SimError::InvalidConfig {

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -266,15 +266,30 @@ impl WorldSnapshot {
 
         // Emit warnings for any entity IDs referenced in the snapshot
         // that were not present in the id_remap (dangling references).
+        let snap_tick = self.tick;
         let mut dangling_seen = HashSet::new();
+        let mut check_dangling = |old: EntityId| {
+            if !id_remap.contains_key(&old) && dangling_seen.insert(old) {
+                sim.push_event(crate::events::Event::SnapshotDanglingReference {
+                    stale_id: old,
+                    tick: snap_tick,
+                });
+            }
+        };
         for snap in &self.entities {
-            Self::collect_referenced_ids(snap, |old| {
-                if !id_remap.contains_key(&old) && dangling_seen.insert(old) {
-                    sim.push_event(crate::events::Event::SnapshotDanglingReference {
-                        stale_id: old,
-                    });
-                }
-            });
+            Self::collect_referenced_ids(snap, &mut check_dangling);
+        }
+        for hc in &self.hall_calls {
+            check_dangling(hc.stop);
+            if let Some(car) = hc.assigned_car {
+                check_dangling(car);
+            }
+            if let Some(dest) = hc.destination {
+                check_dangling(dest);
+            }
+            for &rider in &hc.pending_riders {
+                check_dangling(rider);
+            }
         }
 
         Ok(sim)

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -18,7 +18,7 @@ use crate::metrics::Metrics;
 use crate::stop::StopId;
 use crate::tagged_metrics::MetricTags;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Serializable snapshot of a single entity's components.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -262,6 +262,19 @@ impl WorldSnapshot {
             {
                 sim.set_reposition(gs.id, strategy, repo_id.clone());
             }
+        }
+
+        // Emit warnings for any entity IDs referenced in the snapshot
+        // that were not present in the id_remap (dangling references).
+        let mut dangling_seen = HashSet::new();
+        for snap in &self.entities {
+            Self::collect_referenced_ids(snap, |old| {
+                if !id_remap.contains_key(&old) && dangling_seen.insert(old) {
+                    sim.push_event(crate::events::Event::SnapshotDanglingReference {
+                        stale_id: old,
+                    });
+                }
+            });
         }
 
         Ok(sim)
@@ -541,6 +554,63 @@ impl WorldSnapshot {
                 (name.clone(), remapped)
             })
             .collect()
+    }
+
+    /// Visit all cross-referenced `EntityId`s inside an entity snapshot.
+    fn collect_referenced_ids(snap: &EntitySnapshot, mut visit: impl FnMut(EntityId)) {
+        if let Some(ref elev) = snap.elevator {
+            for &r in &elev.riders {
+                visit(r);
+            }
+            if let Some(t) = elev.target_stop {
+                visit(t);
+            }
+            visit(elev.line);
+            match elev.phase {
+                crate::components::ElevatorPhase::MovingToStop(s)
+                | crate::components::ElevatorPhase::Repositioning(s) => visit(s),
+                _ => {}
+            }
+            for &s in &elev.restricted_stops {
+                visit(s);
+            }
+        }
+        if let Some(ref rider) = snap.rider {
+            if let Some(s) = rider.current_stop {
+                visit(s);
+            }
+            match rider.phase {
+                crate::components::RiderPhase::Boarding(e)
+                | crate::components::RiderPhase::Riding(e)
+                | crate::components::RiderPhase::Exiting(e) => visit(e),
+                _ => {}
+            }
+        }
+        if let Some(ref route) = snap.route {
+            for leg in &route.legs {
+                visit(leg.from);
+                visit(leg.to);
+                if let crate::components::TransportMode::Line(l) = leg.via {
+                    visit(l);
+                }
+            }
+        }
+        if let Some(ref ac) = snap.access_control {
+            for &s in ac.allowed_stops() {
+                visit(s);
+            }
+        }
+        if let Some(ref dq) = snap.destination_queue {
+            for &e in dq.queue() {
+                visit(e);
+            }
+        }
+        for cc in &snap.car_calls {
+            visit(cc.floor);
+            for &r in &cc.pending_riders {
+                visit(r);
+            }
+        }
     }
 }
 

--- a/crates/elevator-core/src/tests/config_tests.rs
+++ b/crates/elevator-core/src/tests/config_tests.rs
@@ -80,3 +80,68 @@ fn rejects_neg_infinite_stop_position() {
         "negative infinity position should be rejected, got {result:?}"
     );
 }
+
+#[test]
+fn rejects_zero_door_transition_ticks() {
+    use super::helpers;
+    let mut config = helpers::default_config();
+    config.elevators[0].door_transition_ticks = 0;
+    let result = crate::sim::Simulation::new(&config, helpers::scan());
+    assert!(
+        matches!(
+            result,
+            Err(SimError::InvalidConfig {
+                field: "elevators.door_transition_ticks",
+                ..
+            })
+        ),
+        "zero door_transition_ticks should be rejected, got {result:?}"
+    );
+}
+
+#[test]
+fn rejects_zero_door_open_ticks() {
+    use super::helpers;
+    let mut config = helpers::default_config();
+    config.elevators[0].door_open_ticks = 0;
+    let result = crate::sim::Simulation::new(&config, helpers::scan());
+    assert!(
+        matches!(
+            result,
+            Err(SimError::InvalidConfig {
+                field: "elevators.door_open_ticks",
+                ..
+            })
+        ),
+        "zero door_open_ticks should be rejected, got {result:?}"
+    );
+}
+
+#[test]
+fn rejects_empty_line_serves() {
+    use super::helpers;
+    use crate::config::LineConfig;
+    let mut config = helpers::default_config();
+    config.building.lines = Some(vec![LineConfig {
+        id: 0,
+        name: "Empty".into(),
+        serves: vec![],
+        elevators: config.elevators.clone(),
+        orientation: Default::default(),
+        position: None,
+        min_position: None,
+        max_position: None,
+        max_cars: None,
+    }]);
+    let result = crate::sim::Simulation::new(&config, helpers::scan());
+    assert!(
+        matches!(
+            result,
+            Err(SimError::InvalidConfig {
+                field: "building.lines.serves",
+                ..
+            })
+        ),
+        "empty line.serves should be rejected, got {result:?}"
+    );
+}

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -557,3 +557,28 @@ fn snapshot_preserves_hall_call_ack_state_under_latency() {
     );
     assert_eq!(call.ack_latency_ticks, 10);
 }
+
+/// Normal snapshot roundtrip should produce no `SnapshotDanglingReference` events.
+#[test]
+fn snapshot_roundtrip_emits_no_dangling_warnings() {
+    let config = helpers::default_config();
+    let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    for _ in 0..50 {
+        sim.step();
+    }
+    sim.drain_events();
+
+    let snap = sim.snapshot();
+    let mut restored = snap.restore(None).unwrap();
+    let events = restored.drain_events();
+    let dangling = events
+        .iter()
+        .filter(|e| matches!(e, crate::events::Event::SnapshotDanglingReference { .. }))
+        .count();
+    assert_eq!(
+        dangling, 0,
+        "normal snapshot should have no dangling references"
+    );
+}

--- a/crates/elevator-core/src/tests/world_tests.rs
+++ b/crates/elevator-core/src/tests/world_tests.rs
@@ -187,3 +187,56 @@ fn extension_components() {
     world.despawn(e);
     assert!(world.ext::<VipTag>(e).is_none());
 }
+
+/// Verify that despawn cleans up hall_calls and car_calls.
+#[test]
+fn despawn_cleans_up_hall_and_car_calls() {
+    let mut world = World::new();
+    let stop_eid = world.spawn();
+    world.set_stop(
+        stop_eid,
+        Stop {
+            name: "S".into(),
+            position: 0.0,
+        },
+    );
+
+    let car_eid = world.spawn();
+    world.set_elevator(
+        car_eid,
+        Elevator {
+            phase: ElevatorPhase::Idle,
+            door: DoorState::Closed,
+            max_speed: Speed::from(2.0),
+            acceleration: Accel::from(1.5),
+            deceleration: Accel::from(2.0),
+            weight_capacity: Weight::from(800.0),
+            current_load: Weight::from(0.0),
+            riders: vec![],
+            target_stop: None,
+            door_transition_ticks: 15,
+            door_open_ticks: 60,
+            line: crate::entity::EntityId::default(),
+            repositioning: false,
+            restricted_stops: HashSet::new(),
+            inspection_speed_factor: 0.25,
+            going_up: true,
+            going_down: true,
+            move_count: 0,
+            door_command_queue: Vec::new(),
+            manual_target_velocity: None,
+        },
+    );
+
+    // Populate car_calls for the elevator.
+    if let Some(cc) = world.car_calls_mut(car_eid) {
+        cc.push(crate::components::CarCall::new(car_eid, stop_eid, 0));
+    }
+    assert!(!world.car_calls(car_eid).is_empty());
+
+    world.despawn(car_eid);
+    assert!(
+        world.car_calls(car_eid).is_empty(),
+        "car_calls should be cleaned up after despawn"
+    );
+}

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -226,6 +226,8 @@ impl World {
         self.service_modes.remove(id);
         self.destination_queues.remove(id);
         self.disabled.remove(id);
+        self.hall_calls.remove(id);
+        self.car_calls.remove(id);
 
         for ext in self.extensions.values_mut() {
             ext.remove(id);


### PR DESCRIPTION
## Summary

- **#166**: Clean up `hall_calls` and `car_calls` in `World::despawn()` — prevents unbounded memory growth
- **#167**: Replace `Vec::dedup()` with `HashSet`-based retain in destination queue rebuild — catches non-consecutive cross-run duplicates
- **#168**: Reject empty `line.serves` in config validation — prevents degenerate elevator groups
- **#169**: Validate `door_transition_ticks` and `door_open_ticks` at config time — parity with runtime setter validation
- **#172**: Add `debug_assert!` on missing `car_calls` in `ensure_car_call` — surfaces silent failures in debug builds
- **#173**: Add `SnapshotDanglingReference` event for unmapped entity IDs during snapshot restore — surfaces corrupted snapshot data

## Test plan

- [x] `despawn_cleans_up_hall_and_car_calls` — verifies car_calls are removed on despawn
- [x] `rejects_zero_door_transition_ticks` / `rejects_zero_door_open_ticks` — config validation
- [x] `rejects_empty_line_serves` — config validation for empty serves
- [x] `snapshot_roundtrip_emits_no_dangling_warnings` — normal snapshots produce no warnings
- [x] All 594 existing tests continue to pass

Closes #166, closes #167, closes #168, closes #169, closes #172, closes #173