### PR TITLE
feat!: design hardening (#170, #171, #174, #175, #177)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "12.0.2"
+version = "13.0.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -556,6 +556,22 @@ pub enum Event {
         /// Tick from the snapshot at restore time.
         tick: u64,
     },
+    /// A snapshot restore could not re-instantiate the reposition strategy
+    /// for a group (e.g. custom strategy not registered). Idle elevator
+    /// positioning will not work for this group until the game calls
+    /// [`Simulation::set_reposition`](crate::sim::Simulation::set_reposition).
+    RepositionStrategyNotRestored {
+        /// The group whose strategy was lost.
+        group: GroupId,
+    },
+    /// A stop was removed while resident riders were present.
+    /// The game must relocate or despawn these riders.
+    ResidentsAtRemovedStop {
+        /// The removed stop.
+        stop: EntityId,
+        /// Riders that were resident at the stop.
+        residents: Vec<EntityId>,
+    },
 }
 
 /// Identifies which elevator parameter was changed in an
@@ -716,7 +732,10 @@ impl Event {
             | Self::HallCallCleared { .. }
             | Self::CarButtonPressed { .. } => EventCategory::Dispatch,
             Self::RiderBalked { .. } => EventCategory::Rider,
-            Self::SnapshotDanglingReference { .. } => EventCategory::Observability,
+            Self::SnapshotDanglingReference { .. } | Self::RepositionStrategyNotRestored { .. } => {
+                EventCategory::Observability
+            }
+            Self::ResidentsAtRemovedStop { .. } => EventCategory::Topology,
         }
     }
 }

--- a/crates/elevator-core/src/hooks.rs
+++ b/crates/elevator-core/src/hooks.rs
@@ -70,6 +70,7 @@ impl PhaseHooks {
             for hook in hooks {
                 hook(world);
             }
+            Self::debug_check_invariants(phase, world);
         }
     }
 
@@ -79,8 +80,25 @@ impl PhaseHooks {
             for hook in hooks {
                 hook(world);
             }
+            Self::debug_check_invariants(phase, world);
         }
     }
+
+    /// In debug builds, verify that hooks did not break core invariants.
+    #[cfg(debug_assertions)]
+    fn debug_check_invariants(phase: Phase, world: &World) {
+        for (eid, _, elev) in world.iter_elevators() {
+            for &rider_id in &elev.riders {
+                debug_assert!(
+                    world.is_alive(rider_id),
+                    "hook after {phase:?}: elevator {eid:?} references dead rider {rider_id:?}"
+                );
+            }
+        }
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn debug_check_invariants(_phase: Phase, _world: &World) {}
 
     /// Register a hook to run before a phase.
     pub(crate) fn add_before(&mut self, phase: Phase, hook: PhaseHook) {

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -1672,6 +1672,24 @@ impl Simulation {
     }
 
     /// Run only the `advance_transient` phase (with hooks).
+    ///
+    /// # Phase ordering
+    ///
+    /// When calling individual phase methods instead of [`step()`](Self::step),
+    /// phases **must** be called in this order each tick:
+    ///
+    /// 1. `run_advance_transient`
+    /// 2. `run_dispatch`
+    /// 3. `run_reposition`
+    /// 4. `run_advance_queue`
+    /// 5. `run_movement`
+    /// 6. `run_doors`
+    /// 7. `run_loading`
+    /// 8. `run_metrics`
+    ///
+    /// Out-of-order execution may cause riders to board with closed doors,
+    /// elevators to move before dispatch, or transient states to persist
+    /// across tick boundaries.
     pub fn run_advance_transient(&mut self) {
         self.hooks
             .run_before(Phase::AdvanceTransient, &mut self.world);

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -346,6 +346,19 @@ impl Simulation {
             return Err(SimError::EntityNotFound(stop));
         }
 
+        // Warn if resident riders exist at the stop before we disable it
+        // (disabling will abandon them, clearing the residents index).
+        let residents: Vec<EntityId> = self
+            .rider_index
+            .residents_at(stop)
+            .iter()
+            .copied()
+            .collect();
+        if !residents.is_empty() {
+            self.events
+                .emit(Event::ResidentsAtRemovedStop { stop, residents });
+        }
+
         // Disable first to invalidate routes referencing this stop.
         let _ = self.disable(stop);
 

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -257,10 +257,14 @@ impl WorldSnapshot {
 
         // Restore reposition strategies from group snapshots.
         for gs in &self.groups {
-            if let Some(ref repo_id) = gs.reposition
-                && let Some(strategy) = repo_id.instantiate()
-            {
-                sim.set_reposition(gs.id, strategy, repo_id.clone());
+            if let Some(ref repo_id) = gs.reposition {
+                if let Some(strategy) = repo_id.instantiate() {
+                    sim.set_reposition(gs.id, strategy, repo_id.clone());
+                } else {
+                    sim.push_event(crate::events::Event::RepositionStrategyNotRestored {
+                        group: gs.id,
+                    });
+                }
             }
         }
 

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -268,33 +268,13 @@ impl WorldSnapshot {
             }
         }
 
-        // Emit warnings for any entity IDs referenced in the snapshot
-        // that were not present in the id_remap (dangling references).
-        let snap_tick = self.tick;
-        let mut dangling_seen = HashSet::new();
-        let mut check_dangling = |old: EntityId| {
-            if !id_remap.contains_key(&old) && dangling_seen.insert(old) {
-                sim.push_event(crate::events::Event::SnapshotDanglingReference {
-                    stale_id: old,
-                    tick: snap_tick,
-                });
-            }
-        };
-        for snap in &self.entities {
-            Self::collect_referenced_ids(snap, &mut check_dangling);
-        }
-        for hc in &self.hall_calls {
-            check_dangling(hc.stop);
-            if let Some(car) = hc.assigned_car {
-                check_dangling(car);
-            }
-            if let Some(dest) = hc.destination {
-                check_dangling(dest);
-            }
-            for &rider in &hc.pending_riders {
-                check_dangling(rider);
-            }
-        }
+        Self::emit_dangling_warnings(
+            &self.entities,
+            &self.hall_calls,
+            &id_remap,
+            self.tick,
+            &mut sim,
+        );
 
         Ok(sim)
     }
@@ -573,6 +553,40 @@ impl WorldSnapshot {
                 (name.clone(), remapped)
             })
             .collect()
+    }
+
+    /// Emit `SnapshotDanglingReference` events for entity IDs not in `id_remap`.
+    fn emit_dangling_warnings(
+        entities: &[EntitySnapshot],
+        hall_calls: &[HallCall],
+        id_remap: &HashMap<EntityId, EntityId>,
+        tick: u64,
+        sim: &mut crate::sim::Simulation,
+    ) {
+        let mut seen = HashSet::new();
+        let mut check = |old: EntityId| {
+            if !id_remap.contains_key(&old) && seen.insert(old) {
+                sim.push_event(crate::events::Event::SnapshotDanglingReference {
+                    stale_id: old,
+                    tick,
+                });
+            }
+        };
+        for snap in entities {
+            Self::collect_referenced_ids(snap, &mut check);
+        }
+        for hc in hall_calls {
+            check(hc.stop);
+            if let Some(car) = hc.assigned_car {
+                check(car);
+            }
+            if let Some(dest) = hc.destination {
+                check(dest);
+            }
+            for &rider in &hc.pending_riders {
+                check(rider);
+            }
+        }
     }
 
     /// Visit all cross-referenced `EntityId`s inside an entity snapshot.

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -1001,3 +1001,54 @@ fn remove_stop_emits_stop_removed_event() {
         .any(|e| matches!(e, Event::StopRemoved { stop, .. } if *stop == stop_eid));
     assert!(removed, "should emit StopRemoved event");
 }
+
+/// Removing a stop that has resident riders emits `ResidentsAtRemovedStop`.
+#[test]
+fn remove_stop_emits_warning_for_residents() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    // Spawn a rider and run until they arrive.
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    for _ in 0..2000 {
+        sim.step();
+    }
+    sim.drain_events();
+
+    // Find an arrived rider and settle them at their stop.
+    let arrived: Vec<_> = sim
+        .world()
+        .iter_riders()
+        .filter(|(_, r)| r.phase == RiderPhase::Arrived)
+        .map(|(eid, _)| eid)
+        .collect();
+    assert!(!arrived.is_empty(), "should have an arrived rider");
+
+    let rider_eid = arrived[0];
+    let rider = sim.world().rider(rider_eid).unwrap();
+    let stop = rider.current_stop.unwrap();
+    sim.settle_rider(crate::entity::RiderId::from(rider_eid))
+        .unwrap();
+
+    // Verify the rider is now Resident.
+    let phase = sim.world().rider(rider_eid).unwrap().phase;
+    assert_eq!(phase, RiderPhase::Resident, "rider should be Resident");
+
+    // Now remove the stop where the resident is.
+    sim.remove_stop(stop).unwrap();
+    let events = sim.drain_events();
+    let warning = events.iter().find(|e| {
+        matches!(
+            e,
+            Event::ResidentsAtRemovedStop {
+                stop: s,
+                residents,
+                ..
+            } if *s == stop && residents.contains(&rider_eid)
+        )
+    });
+    assert!(
+        warning.is_some(),
+        "should emit ResidentsAtRemovedStop for resident riders"
+    );
+}

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -340,7 +340,13 @@ impl World {
     }
 
     /// Set an entity's rider component.
-    pub fn set_rider(&mut self, id: EntityId, rider: Rider) {
+    ///
+    /// # Warning
+    ///
+    /// This does **not** update the [`RiderIndex`](crate::rider_index::RiderIndex).
+    /// Call [`RiderIndex::rebuild`](crate::rider_index::RiderIndex::rebuild) afterward
+    /// if the phase or `current_stop` changed.
+    pub(crate) fn set_rider(&mut self, id: EntityId, rider: Rider) {
         self.riders.insert(id, rider);
     }
 


### PR DESCRIPTION
## Summary

**BREAKING**: `World::set_rider()` is now `pub(crate)`. External consumers must use `Simulation::spawn_rider()`, `settle_rider()`, or `despawn_rider()` instead.

- **#170**: Emit `RepositionStrategyNotRestored` event when a group's reposition strategy cannot be re-instantiated during snapshot restore (custom strategies)
- **#171**: Document phase ordering requirements on `run_advance_transient()` — lists the required execution order for sub-stepping consumers
- **#174**: Emit `ResidentsAtRemovedStop` event when `remove_stop()` is called on a stop that has resident riders — games must handle this to avoid orphaned entities
- **#175**: Restrict `World::set_rider()` to `pub(crate)` — prevents external code from bypassing `RiderIndex` updates
- **#177**: Add `debug_assert!` invariant checks after hook execution — in debug builds, hooks that leave dead rider references on elevators trigger an assertion

## New event variants

- `Event::RepositionStrategyNotRestored { group }` — Observability category
- `Event::ResidentsAtRemovedStop { stop, residents }` — Topology category

## Test plan

- [x] `remove_stop_emits_warning_for_residents` — verifies event is emitted when removing a stop with residents
- [x] `pub(crate)` on `set_rider` — enforced at compile time
- [x] Hook invariant checks validated by all existing hook tests (debug_assert active in test builds)
- [x] All 595 tests pass

Closes #170, closes #171, closes #174, closes #175, closes #177