### PR TITLE
refactor!: replace archaic balk vocabulary

### DIFF
--- a/crates/elevator-bevy/src/sim_bridge.rs
+++ b/crates/elevator-bevy/src/sim_bridge.rs
@@ -38,7 +38,7 @@ pub fn tick_simulation(
     }
 }
 
-/// Running counters for the five hall-call / car-call / balk events.
+/// Running counters for the five hall-call / car-call / skip events.
 /// Rendered in the HUD so observers can confirm the events are firing
 /// and games can base UI cues on the same counts.
 #[derive(Resource, Default, Debug, Clone, Copy)]
@@ -51,11 +51,11 @@ pub struct HallCallEventCounters {
     pub cleared: u64,
     /// `CarButtonPressed` count.
     pub car_button_pressed: u64,
-    /// `RiderBalked` count.
-    pub balked: u64,
+    /// `RiderSkipped` count.
+    pub skipped: u64,
 }
 
-/// Tally the five hall-call / balk events into [`HallCallEventCounters`].
+/// Tally the five hall-call / skip events into [`HallCallEventCounters`].
 /// Runs every frame; reads every `EventWrapper` message this frame.
 #[allow(clippy::needless_pass_by_value)]
 pub fn tally_hall_call_events(
@@ -69,7 +69,7 @@ pub fn tally_hall_call_events(
             Event::HallCallAcknowledged { .. } => counters.acknowledged += 1,
             Event::HallCallCleared { .. } => counters.cleared += 1,
             Event::CarButtonPressed { .. } => counters.car_button_pressed += 1,
-            Event::RiderBalked { .. } => counters.balked += 1,
+            Event::RiderSkipped { .. } => counters.skipped += 1,
             _ => {}
         }
     }

--- a/crates/elevator-bevy/src/ui.rs
+++ b/crates/elevator-bevy/src/ui.rs
@@ -171,13 +171,13 @@ Waiting: {waiting}
 Delivered: {delivered}
 ---
 Hall press: {hp}  Ack: {ack}  Cleared: {cl}
-Car press: {cp}  Balked: {balk}",
+Car press: {cp}  Skipped: {skip}",
         sim.sim.current_tick(),
         hp = events.button_pressed,
         ack = events.acknowledged,
         cl = events.cleared,
         cp = events.car_button_pressed,
-        balk = events.balked,
+        skip = events.skipped,
     );
 
     for mut t in &mut query {

--- a/crates/elevator-core/src/components/patience.rs
+++ b/crates/elevator-core/src/components/patience.rs
@@ -51,6 +51,7 @@ pub struct Preferences {
     /// increments during `Waiting` and correctly excludes ride time for
     /// multi-leg routes. Without `Patience`, the budget degrades to
     /// lifetime ticks since spawn, which matches single-leg behavior.
+    #[serde(alias = "balk_threshold_ticks")]
     pub(crate) abandon_after_ticks: Option<u32>,
     /// Abandon on the first full-car skip, rather than silently
     /// passing and continuing to wait. Default `false`.

--- a/crates/elevator-core/src/components/patience.rs
+++ b/crates/elevator-core/src/components/patience.rs
@@ -41,7 +41,7 @@ pub struct Preferences {
     pub(crate) skip_full_elevator: bool,
     /// Maximum load factor (0.0-1.0) the rider will tolerate when boarding.
     pub(crate) max_crowding_factor: f64,
-    /// Wait budget before the rider abandons. `None` disables balking-
+    /// Wait budget before the rider abandons. `None` disables time-
     /// based abandonment; `Some(n)` causes the rider to enter
     /// [`RiderPhase::Abandoned`](crate::components::RiderPhase) after
     /// `n` ticks of being [`Waiting`](crate::components::RiderPhase::Waiting).
@@ -51,23 +51,23 @@ pub struct Preferences {
     /// increments during `Waiting` and correctly excludes ride time for
     /// multi-leg routes. Without `Patience`, the budget degrades to
     /// lifetime ticks since spawn, which matches single-leg behavior.
-    pub(crate) balk_threshold_ticks: Option<u32>,
+    pub(crate) abandon_after_ticks: Option<u32>,
     /// Abandon on the first full-car skip, rather than silently
     /// passing and continuing to wait. Default `false`.
     ///
     /// This is an **independent** abandonment axis from
-    /// [`balk_threshold_ticks`](Self::balk_threshold_ticks) — the two
+    /// [`abandon_after_ticks`](Self::abandon_after_ticks) — the two
     /// do not compose or gate each other:
     ///
     /// - `abandon_on_full` is *event-triggered* from the loading phase
-    ///   (`systems::loading`), firing on a full-car balk.
-    /// - `balk_threshold_ticks` is *time-triggered* from the transient
+    ///   (`systems::loading`), firing on a full-car skip.
+    /// - `abandon_after_ticks` is *time-triggered* from the transient
     ///   phase (`systems::advance_transient`), firing when the rider's
     ///   wait budget elapses.
     ///
     /// Both paths set [`RiderPhase::Abandoned`](crate::components::RiderPhase);
     /// whichever condition is reached first wins. Setting
-    /// `abandon_on_full = true` with `balk_threshold_ticks = None` is
+    /// `abandon_on_full = true` with `abandon_after_ticks = None` is
     /// valid and abandons on the first full-car skip regardless of
     /// wait time.
     pub(crate) abandon_on_full: bool,
@@ -86,14 +86,14 @@ impl Preferences {
         self.max_crowding_factor
     }
 
-    /// Wait budget before the rider abandons. `None` disables balking-
+    /// Wait budget before the rider abandons. `None` disables time-
     /// based abandonment.
     #[must_use]
-    pub const fn balk_threshold_ticks(&self) -> Option<u32> {
-        self.balk_threshold_ticks
+    pub const fn abandon_after_ticks(&self) -> Option<u32> {
+        self.abandon_after_ticks
     }
 
-    /// Should balking a full car convert directly to abandonment?
+    /// Should skipping a full car convert directly to abandonment?
     #[must_use]
     pub const fn abandon_on_full(&self) -> bool {
         self.abandon_on_full
@@ -113,10 +113,10 @@ impl Preferences {
         self
     }
 
-    /// Builder: set `balk_threshold_ticks`.
+    /// Builder: set `abandon_after_ticks`.
     #[must_use]
-    pub const fn with_balk_threshold_ticks(mut self, ticks: Option<u32>) -> Self {
-        self.balk_threshold_ticks = ticks;
+    pub const fn with_abandon_after_ticks(mut self, ticks: Option<u32>) -> Self {
+        self.abandon_after_ticks = ticks;
         self
     }
 
@@ -133,7 +133,7 @@ impl Default for Preferences {
         Self {
             skip_full_elevator: false,
             max_crowding_factor: 0.8,
-            balk_threshold_ticks: None,
+            abandon_after_ticks: None,
             abandon_on_full: false,
         }
     }

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -534,17 +534,17 @@ pub enum Event {
         /// Tick of the press.
         tick: u64,
     },
-    /// A rider balked at boarding a car they considered too crowded
+    /// A rider skipped boarding a car they considered too crowded
     /// (their preferences filtered the car out). The rider remains
     /// Waiting and may board a later car.
-    RiderBalked {
-        /// Rider who balked.
+    RiderSkipped {
+        /// Rider who skipped.
         rider: EntityId,
         /// Elevator they declined to board.
         elevator: EntityId,
-        /// Stop where the balking happened.
+        /// Stop where the skip happened.
         at_stop: EntityId,
-        /// Tick of the balk.
+        /// Tick of the skip.
         tick: u64,
     },
     /// A snapshot restore encountered an entity reference that could not
@@ -731,7 +731,7 @@ impl Event {
             | Self::HallCallAcknowledged { .. }
             | Self::HallCallCleared { .. }
             | Self::CarButtonPressed { .. } => EventCategory::Dispatch,
-            Self::RiderBalked { .. } => EventCategory::Rider,
+            Self::RiderSkipped { .. } => EventCategory::Rider,
             Self::SnapshotDanglingReference { .. } | Self::RepositionStrategyNotRestored { .. } => {
                 EventCategory::Observability
             }

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -537,6 +537,7 @@ pub enum Event {
     /// A rider skipped boarding a car they considered too crowded
     /// (their preferences filtered the car out). The rider remains
     /// Waiting and may board a later car.
+    #[serde(alias = "RiderBalked")]
     RiderSkipped {
         /// Rider who skipped.
         rider: EntityId,

--- a/crates/elevator-core/src/systems/advance_transient.rs
+++ b/crates/elevator-core/src/systems/advance_transient.rs
@@ -184,7 +184,7 @@ pub fn run(
         });
     }
 
-    // Balk-threshold abandonment: riders with `Preferences::balk_threshold_ticks`
+    // Time-triggered abandonment: riders with `Preferences::abandon_after_ticks`
     // give up once their *waiting* time exceeds their budget. Uses
     // `Patience::waited_ticks` when available — that counter only
     // increments while the rider is in `Waiting`, so it correctly
@@ -192,14 +192,14 @@ pub fn run(
     // `Patience` fall back to `tick - spawn_tick` (a lifetime budget)
     // which is accurate for single-leg trips, the common case. Runs
     // after the patience path so both limits can coexist.
-    let balk_abandon: Vec<(EntityId, EntityId)> = world
+    let time_abandon: Vec<(EntityId, EntityId)> = world
         .iter_riders()
         .filter_map(|(id, r)| {
             if world.is_disabled(id) || r.phase != RiderPhase::Waiting {
                 return None;
             }
             let prefs = world.preferences(id)?;
-            let threshold = prefs.balk_threshold_ticks()?;
+            let threshold = prefs.abandon_after_ticks()?;
             let stop = r.current_stop?;
             let waited = world.patience(id).map_or_else(
                 || ctx.tick.saturating_sub(r.spawn_tick),
@@ -212,7 +212,7 @@ pub fn run(
             }
         })
         .collect();
-    for (id, stop) in balk_abandon {
+    for (id, stop) in time_abandon {
         if let Some(r) = world.rider_mut(id) {
             r.phase = RiderPhase::Abandoned;
         }

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -52,14 +52,14 @@ enum LoadAction {
         /// Elevator whose lamps are being re-lit.
         elevator: EntityId,
     },
-    /// A rider balked at an otherwise-eligible car (skipped it because
-    /// their preferences flagged it too crowded).
-    Balk {
-        /// Rider who balked.
+    /// A rider skipped an otherwise-eligible car because their
+    /// preferences flagged it too crowded.
+    Skip {
+        /// Rider who skipped.
         rider: EntityId,
         /// Elevator they declined to board.
         elevator: EntityId,
-        /// Stop where the balking happened.
+        /// Stop where the skip happened.
         at_stop: EntityId,
     },
 }
@@ -261,14 +261,14 @@ fn collect_actions(world: &World, elevator_ids: &[EntityId]) -> Vec<LoadAction> 
                     capacity: car.weight_capacity.value().into(),
                 }),
             });
-            // A preference-filtered rider just balked at a crowded car.
+            // A preference-filtered rider just skipped a crowded car.
             // Emit an observable signal so games can animate it; the
             // rider remains Waiting unless `abandon_on_full` is set, in
-            // which case the Balk arm below escalates to Abandoned
+            // which case the Skip arm below escalates to Abandoned
             // immediately — event-triggered, this phase, independent
-            // of the balk_threshold time budget.
+            // of the abandon_after_ticks time budget.
             if let Some(stop) = world.rider(rid).and_then(|r| r.current_stop) {
-                actions.push(LoadAction::Balk {
+                actions.push(LoadAction::Skip {
                     rider: rid,
                     elevator: eid,
                     at_stop: stop,
@@ -421,12 +421,12 @@ fn apply_actions(
             LoadAction::ResetIndicators { elevator } => {
                 update_indicators(world, events, elevator, true, true, ctx.tick);
             }
-            LoadAction::Balk {
+            LoadAction::Skip {
                 rider,
                 elevator,
                 at_stop,
             } => {
-                events.emit(Event::RiderBalked {
+                events.emit(Event::RiderSkipped {
                     rider,
                     elevator,
                     at_stop,

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -695,7 +695,7 @@ fn rider_builder_with_preferences() {
     let prefs = Preferences {
         skip_full_elevator: true,
         max_crowding_factor: 0.5,
-        balk_threshold_ticks: None,
+        abandon_after_ticks: None,
         abandon_on_full: false,
     };
 

--- a/crates/elevator-core/src/tests/boundary_tests.rs
+++ b/crates/elevator-core/src/tests/boundary_tests.rs
@@ -163,7 +163,7 @@ fn preferences_zero_crowding_rejects_any_load() {
         Preferences {
             skip_full_elevator: true,
             max_crowding_factor: 0.0,
-            balk_threshold_ticks: None,
+            abandon_after_ticks: None,
             abandon_on_full: false,
         },
     );

--- a/crates/elevator-core/src/tests/feature_tests.rs
+++ b/crates/elevator-core/src/tests/feature_tests.rs
@@ -161,7 +161,7 @@ fn preferences_skip_crowded_elevator_prevents_boarding() {
         Preferences {
             skip_full_elevator: true,
             max_crowding_factor: 0.5, // will skip if load > 50 %
-            balk_threshold_ticks: None,
+            abandon_after_ticks: None,
             abandon_on_full: false,
         },
     );
@@ -220,7 +220,7 @@ fn preferences_boards_when_elevator_not_too_crowded() {
         Preferences {
             skip_full_elevator: true,
             max_crowding_factor: 0.5,
-            balk_threshold_ticks: None,
+            abandon_after_ticks: None,
             abandon_on_full: false,
         },
     );

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -267,7 +267,7 @@ fn pinned_pin_does_not_clobber_loading_car() {
     }
 }
 
-/// `abandon_on_full = true` escalates a balk into immediate abandonment.
+/// `abandon_on_full = true` escalates a skip into immediate abandonment.
 /// Regression guard — the flag was documented but previously inert.
 #[test]
 fn abandon_on_full_abandons_immediately() {
@@ -292,7 +292,7 @@ fn abandon_on_full_abandons_immediately() {
         Preferences {
             skip_full_elevator: true,
             max_crowding_factor: 0.5,
-            balk_threshold_ticks: None,
+            abandon_after_ticks: None,
             abandon_on_full: true,
         },
     );
@@ -322,16 +322,16 @@ fn abandon_on_full_abandons_immediately() {
     assert_eq!(
         phase,
         Some(crate::components::RiderPhase::Abandoned),
-        "abandon_on_full should escalate the balk into Abandoned"
+        "abandon_on_full should escalate the skip into Abandoned"
     );
 }
 
-/// `abandon_on_full` and `balk_threshold_ticks` are independent axes.
+/// `abandon_on_full` and `abandon_after_ticks` are independent axes.
 /// Setting both with `abandon_on_full = true` and a large threshold
 /// proves the event-triggered path fires before the time-triggered
 /// one — the two do not gate each other.
 #[test]
-fn abandon_on_full_fires_before_balk_threshold_elapses() {
+fn abandon_on_full_fires_before_abandon_after_ticks_elapses() {
     use crate::components::Preferences;
     let mut config = default_config();
     config.elevators[0].weight_capacity = Weight::from(100.0);
@@ -352,7 +352,7 @@ fn abandon_on_full_fires_before_balk_threshold_elapses() {
         Preferences {
             skip_full_elevator: true,
             max_crowding_factor: 0.5,
-            balk_threshold_ticks: Some(1_000_000),
+            abandon_after_ticks: Some(1_000_000),
             abandon_on_full: true,
         },
     );

--- a/crates/elevator-core/src/tests/mutation_kills_tests.rs
+++ b/crates/elevator-core/src/tests/mutation_kills_tests.rs
@@ -355,7 +355,7 @@ fn loading_preference_boundary_allows_exact_match() {
         .preferences(Preferences {
             skip_full_elevator: true,
             max_crowding_factor: 0.0,
-            balk_threshold_ticks: None,
+            abandon_after_ticks: None,
             abandon_on_full: false,
         })
         .spawn()

--- a/crates/elevator-ffi/include/elevator_ffi.h
+++ b/crates/elevator-ffi/include/elevator_ffi.h
@@ -40,9 +40,9 @@
 #define CAR_BUTTON_PRESSED 4
 
 /**
- * `Event::RiderBalked`.
+ * `Event::RiderSkipped`.
  */
-#define RIDER_BALKED 5
+#define RIDER_SKIPPED 5
 
 /**
  * Status code returned by every FFI entrypoint.
@@ -333,7 +333,7 @@ typedef struct EvHallCall {
 } EvHallCall;
 
 /**
- * C-ABI-flat projection of the five hall-call / car-call / balk
+ * C-ABI-flat projection of the five hall-call / car-call / skip
  * events emitted by the simulation.
  *
  * All entity-id fields use `0` to mean "not applicable for this
@@ -358,17 +358,17 @@ typedef struct EvEvent {
     uint64_t tick;
     /**
      * Stop entity id. Meaningful for all three hall-call kinds and
-     * for `RiderBalked` (as the balk site). `0` for `CarButtonPressed`.
+     * for `RiderSkipped` (as the skip site). `0` for `CarButtonPressed`.
      */
     uint64_t stop;
     /**
      * Car entity id. `HallCallCleared.car`, `CarButtonPressed.car`,
-     * `RiderBalked.elevator`. `0` for kinds that don't carry a car.
+     * `RiderSkipped.elevator`. `0` for kinds that don't carry a car.
      */
     uint64_t car;
     /**
      * Rider entity id. `CarButtonPressed.rider` (may be `0` for
-     * synthetic presses), `RiderBalked.rider`. `0` otherwise.
+     * synthetic presses), `RiderSkipped.rider`. `0` otherwise.
      */
     uint64_t rider;
     /**
@@ -583,7 +583,7 @@ enum EvStatus ev_sim_hall_calls_snapshot(struct EvSim *handle,
                                          uint32_t *out_written);
 
 /**
- * Drain pending hall-call / car-call / balk events into `out`.
+ * Drain pending hall-call / car-call / skip events into `out`.
  *
  * This is the FFI mirror of `Simulation::drain_events`, filtered to
  * the five events added by the hall-call work: every call produced
@@ -599,8 +599,8 @@ enum EvStatus ev_sim_hall_calls_snapshot(struct EvSim *handle,
  * - `HALL_CALL_CLEARED`: `stop`, `direction`, `car`, `tick`.
  * - `CAR_BUTTON_PRESSED`: `car`, `floor`, `rider` (or `0` for
  *   synthetic presses), `tick`.
- * - `RIDER_BALKED`: `rider`, `car` (the elevator declined), `stop`
- *   (the balk site), `tick`.
+ * - `RIDER_SKIPPED`: `rider`, `car` (the elevator declined), `stop`
+ *   (the skip site), `tick`.
  *
  * Unused fields for each kind are zeroed so the caller can inspect
  * a uniform struct layout. Other event kinds in the sim (door

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -1074,11 +1074,11 @@ pub mod ev_event_kind {
     pub const HALL_CALL_CLEARED: u8 = 3;
     /// `Event::CarButtonPressed`.
     pub const CAR_BUTTON_PRESSED: u8 = 4;
-    /// `Event::RiderBalked`.
-    pub const RIDER_BALKED: u8 = 5;
+    /// `Event::RiderSkipped`.
+    pub const RIDER_SKIPPED: u8 = 5;
 }
 
-/// C-ABI-flat projection of the five hall-call / car-call / balk
+/// C-ABI-flat projection of the five hall-call / car-call / skip
 /// events emitted by the simulation.
 ///
 /// All entity-id fields use `0` to mean "not applicable for this
@@ -1097,20 +1097,20 @@ pub struct EvEvent {
     /// Tick the event was emitted on.
     pub tick: u64,
     /// Stop entity id. Meaningful for all three hall-call kinds and
-    /// for `RiderBalked` (as the balk site). `0` for `CarButtonPressed`.
+    /// for `RiderSkipped` (as the skip site). `0` for `CarButtonPressed`.
     pub stop: u64,
     /// Car entity id. `HallCallCleared.car`, `CarButtonPressed.car`,
-    /// `RiderBalked.elevator`. `0` for kinds that don't carry a car.
+    /// `RiderSkipped.elevator`. `0` for kinds that don't carry a car.
     pub car: u64,
     /// Rider entity id. `CarButtonPressed.rider` (may be `0` for
-    /// synthetic presses), `RiderBalked.rider`. `0` otherwise.
+    /// synthetic presses), `RiderSkipped.rider`. `0` otherwise.
     pub rider: u64,
     /// Floor entity id for `CarButtonPressed` (the requested stop).
     /// `0` for every other kind.
     pub floor: u64,
 }
 
-/// Drain pending hall-call / car-call / balk events into `out`.
+/// Drain pending hall-call / car-call / skip events into `out`.
 ///
 /// This is the FFI mirror of `Simulation::drain_events`, filtered to
 /// the five events added by the hall-call work: every call produced
@@ -1126,8 +1126,8 @@ pub struct EvEvent {
 /// - `HALL_CALL_CLEARED`: `stop`, `direction`, `car`, `tick`.
 /// - `CAR_BUTTON_PRESSED`: `car`, `floor`, `rider` (or `0` for
 ///   synthetic presses), `tick`.
-/// - `RIDER_BALKED`: `rider`, `car` (the elevator declined), `stop`
-///   (the balk site), `tick`.
+/// - `RIDER_SKIPPED`: `rider`, `car` (the elevator declined), `stop`
+///   (the skip site), `tick`.
 ///
 /// Unused fields for each kind are zeroed so the caller can inspect
 /// a uniform struct layout. Other event kinds in the sim (door
@@ -1213,7 +1213,7 @@ pub unsafe extern "C" fn ev_sim_pending_event_count(handle: *mut EvSim) -> u32 {
 }
 
 /// Drain the sim's event queue into `ev.pending_events`, keeping
-/// only the five hall-call / balk events. The buffer is FIFO so
+/// only the five hall-call / skip events. The buffer is FIFO so
 /// order matches sim emission order across calls.
 fn refill_pending_events(ev: &mut EvSim) {
     use elevator_core::events::Event;
@@ -1273,13 +1273,13 @@ fn refill_pending_events(ev: &mut EvSim) {
                 rider: rider.map_or(0, entity_to_u64),
                 floor: entity_to_u64(floor),
             },
-            Event::RiderBalked {
+            Event::RiderSkipped {
                 rider,
                 elevator,
                 at_stop,
                 tick,
             } => EvEvent {
-                kind: ev_event_kind::RIDER_BALKED,
+                kind: ev_event_kind::RIDER_SKIPPED,
                 direction: 0,
                 tick,
                 stop: entity_to_u64(at_stop),

--- a/docs/src/events-metrics.md
+++ b/docs/src/events-metrics.md
@@ -35,7 +35,7 @@ Every significant moment in the simulation -- a rider boarding, an elevator arri
 | `RiderExited { rider, elevator, stop, tick }` | A rider exits at their destination |
 | `RiderRejected { rider, elevator, reason, context, tick }` | A rider was refused boarding |
 | `RiderAbandoned { rider, stop, tick }` | A rider gave up waiting |
-| `RiderBalked { rider, elevator, at_stop, tick }` | A rider skipped a crowded car (may still board the next) |
+| `RiderSkipped { rider, elevator, at_stop, tick }` | A rider skipped a crowded car (may still board the next) |
 | `RiderEjected { rider, elevator, stop, tick }` | A rider was ejected (elevator disabled) |
 | `RiderSettled { rider, stop, tick }` | A rider settled as a resident |
 | `RiderDespawned { rider, tick }` | A rider was removed from the simulation |

--- a/docs/src/hall-calls.md
+++ b/docs/src/hall-calls.md
@@ -62,10 +62,10 @@ A pinned car that is mid-door-cycle (`Loading` / `DoorOpening` / `DoorClosing`) 
 
 The `Preferences` component has two knobs for game-designer-tuned rider behavior:
 
-- **`balk_threshold_ticks: Option<u32>`** -- the rider abandons after this many ticks of waiting. Uses `Patience::waited_ticks` when present, so multi-leg routes don't over-count ride time.
+- **`abandon_after_ticks: Option<u32>`** -- the rider abandons after this many ticks of waiting. Uses `Patience::waited_ticks` when present, so multi-leg routes don't over-count ride time.
 - **`abandon_on_full: bool`** -- when set, a rider filtered out of a car via `skip_full_elevator` abandons immediately rather than waiting for the next one. Emits `RiderAbandoned` on the spot.
 
-Both knobs generate events (`RiderBalked`, `RiderAbandoned`) so game UI can react to individual behavioral beats. See [Rider Lifecycle -- Preferences](rider-lifecycle.md#preferences) for the full details on how these interact.
+Both knobs generate events (`RiderSkipped`, `RiderAbandoned`) so game UI can react to individual behavioral beats. See [Rider Lifecycle -- Preferences](rider-lifecycle.md#preferences) for the full details on how these interact.
 
 ## Public query API
 
@@ -84,7 +84,7 @@ Both knobs generate events (`RiderBalked`, `RiderAbandoned`) so game UI can reac
 | `HallCallAcknowledged` | Ack-latency window elapsed | UI confirmation signal |
 | `HallCallCleared` | Assigned car opens doors at stop | Clears the button light |
 | `CarButtonPressed` | First press per `(car, floor)` | `rider` field is `None` for synthetic presses |
-| `RiderBalked` | Preference filter rejects a candidate car | Rider may still board a later car unless `abandon_on_full` is set |
+| `RiderSkipped` | Preference filter rejects a candidate car | Rider may still board a later car unless `abandon_on_full` is set |
 
 ## FFI
 

--- a/docs/src/rider-lifecycle.md
+++ b/docs/src/rider-lifecycle.md
@@ -69,15 +69,15 @@ The `Preferences` component controls boarding behavior:
 |---|---|---|---|
 | `skip_full_elevator` | `bool` | `false` | Skip a crowded elevator and wait for the next one |
 | `max_crowding_factor` | `f64` | `0.8` | Maximum load factor (0.0-1.0) the rider will tolerate |
-| `balk_threshold_ticks` | `Option<u32>` | `None` | Abandon after N ticks of waiting (time-triggered) |
+| `abandon_after_ticks` | `Option<u32>` | `None` | Abandon after N ticks of waiting (time-triggered) |
 | `abandon_on_full` | `bool` | `false` | Abandon immediately on first full-car skip (event-triggered) |
 
 The two abandonment paths are independent axes:
 
-- `balk_threshold_ticks` is **time-triggered** -- the rider abandons after their wait budget elapses, checked during AdvanceTransient.
+- `abandon_after_ticks` is **time-triggered** -- the rider abandons after their wait budget elapses, checked during AdvanceTransient.
 - `abandon_on_full` is **event-triggered** -- the rider abandons the moment a full-car skip happens, checked during Loading.
 
-Whichever condition fires first wins. Setting `abandon_on_full = true` with `balk_threshold_ticks = None` is valid and abandons on the first full-car skip regardless of wait time.
+Whichever condition fires first wins. Setting `abandon_on_full = true` with `abandon_after_ticks = None` is valid and abandons on the first full-car skip regardless of wait time.
 
 ```rust,no_run
 # use elevator_core::prelude::*;
@@ -95,7 +95,7 @@ let rider = sim.build_rider(StopId(0), StopId(2))
     .unwrap();
 ```
 
-When `skip_full_elevator` is true and the load exceeds `max_crowding_factor`, the rider silently skips the car. A `RiderBalked` event fires so game UI can animate the reaction. The rider remains `Waiting` for the next car -- unless `abandon_on_full` escalates it to `Abandoned`.
+When `skip_full_elevator` is true and the load exceeds `max_crowding_factor`, the rider silently skips the car. A `RiderSkipped` event fires so game UI can animate the reaction. The rider remains `Waiting` for the next car -- unless `abandon_on_full` escalates it to `Abandoned`.
 
 ## Access control
 

--- a/docs/src/simulation-loop.md
+++ b/docs/src/simulation-loop.md
@@ -14,7 +14,8 @@ flowchart TD
     P5 --> P6["6. Doors"]
     P6 --> P7["7. Loading"]
     P7 --> P8["8. Metrics"]
-    P8 --> ADV["advance_tick()<br>flush events, tick += 1"]
+    P8 --> ADV["advance_tick()
+flush events, tick += 1"]
 ```
 
 Events emitted during a tick are buffered internally. After all eight phases complete, `advance_tick()` drains the buffer into the output queue, making events available to your code via `sim.drain_events()`.

--- a/docs/src/stops-lines-groups.md
+++ b/docs/src/stops-lines-groups.md
@@ -56,15 +56,24 @@ The full hierarchy looks like this:
 
 ```mermaid
 graph TD
-    G[Group<br><i>GroupId</i>] -->|owns| L1[Line A<br><i>EntityId</i>]
-    G -->|owns| L2[Line B<br><i>EntityId</i>]
-    L1 -->|contains| E1[Elevator 1<br><i>EntityId</i>]
-    L1 -->|contains| E2[Elevator 2<br><i>EntityId</i>]
-    L2 -->|contains| E3[Elevator 3<br><i>EntityId</i>]
-    L1 -->|serves| S0[Stop: Lobby<br><i>EntityId</i>]
-    L1 -->|serves| S1[Stop: Floor 10<br><i>EntityId</i>]
+    G["Group
+*GroupId*"] -->|owns| L1["Line A
+*EntityId*"]
+    G -->|owns| L2["Line B
+*EntityId*"]
+    L1 -->|contains| E1["Elevator 1
+*EntityId*"]
+    L1 -->|contains| E2["Elevator 2
+*EntityId*"]
+    L2 -->|contains| E3["Elevator 3
+*EntityId*"]
+    L1 -->|serves| S0["Stop: Lobby
+*EntityId*"]
+    L1 -->|serves| S1["Stop: Floor 10
+*EntityId*"]
     L2 -->|serves| S0
-    L2 -->|serves| S2[Stop: Floor 20<br><i>EntityId</i>]
+    L2 -->|serves| S2["Stop: Floor 20
+*EntityId*"]
 ```
 
 Key invariants:

--- a/examples/csharp-harness/Program.cs
+++ b/examples/csharp-harness/Program.cs
@@ -108,7 +108,7 @@ internal static class Native
     public const byte EV_HALL_CALL_ACKNOWLEDGED = 2;
     public const byte EV_HALL_CALL_CLEARED = 3;
     public const byte EV_CAR_BUTTON_PRESSED = 4;
-    public const byte EV_RIDER_BALKED = 5;
+    public const byte EV_RIDER_SKIPPED = 5;
 
     // Explicit layout so the 6 bytes of padding before `tick`
     // (natural u64 alignment on the Rust #[repr(C)] side) are


### PR DESCRIPTION
## Summary

- Renames `balk_threshold_ticks` → `abandon_after_ticks` to pair naturally with `abandon_on_full`
- Renames `Event::RiderBalked` → `Event::RiderSkipped` and `LoadAction::Balk` → `LoadAction::Skip`
- Updates FFI constants, C header, C# example, Bevy HUD, and all docs
- Fixes mermaid diagrams using HTML tags (`<br>`, `<i>`) that triggered "Unsupported markdown: list" warnings in mermaid v11

## Test plan

- [x] All 595 elevator-core tests pass
- [x] Clippy clean (all features)
- [x] Doc tests pass
- [x] Doc lint passes
- [x] Pre-commit hook passes
- [x] `grep -ri balk` returns only CHANGELOG historical entries
- [x] mdBook builds without warnings