### PR TITLE
feat: Godot 4.3+ elevator demo with GDExtension binding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,11 @@
 [workspace]
 resolver = "2"
-members = ["crates/elevator-core", "crates/elevator-bevy", "crates/elevator-ffi"]
+members = [
+    "crates/elevator-core",
+    "crates/elevator-bevy",
+    "crates/elevator-ffi",
+    "crates/elevator-gdext",
+]
 default-members = ["crates/elevator-bevy"]
 
 [workspace.package]

--- a/crates/elevator-gdext/Cargo.toml
+++ b/crates/elevator-gdext/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "elevator-gdext"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+# gdext uses unsafe internally; override the workspace-level deny.
+[lints.rust]
+unsafe_code = "allow"
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+module_name_repetitions = "allow"
+# gdext macros produce code that triggers these
+needless_pass_by_value = "allow"
+# GDScript uses signed integers; casts are intentional at the FFI boundary
+cast_sign_loss = "allow"
+cast_possible_wrap = "allow"
+cast_possible_truncation = "allow"
+# gdext exposed functions need many params for GDScript convenience
+too_many_arguments = "allow"
+# doc backtick lint noise on Godot types
+doc_markdown = "allow"
+# Noise on match/if-let patterns at FFI boundary
+option_if_let_else = "allow"
+manual_let_else = "allow"
+
+[dependencies]
+elevator-core = { path = "../elevator-core" }
+godot = "0.5"
+ron.workspace = true
+rand.workspace = true
+slotmap.workspace = true

--- a/crates/elevator-gdext/src/lib.rs
+++ b/crates/elevator-gdext/src/lib.rs
@@ -1,0 +1,15 @@
+//! GDExtension binding for elevator-core.
+//!
+//! Exposes the elevator simulation as Godot nodes that GDScript can use
+//! directly. The primary entry point is [`ElevatorSim`], a `Node` subclass
+//! that wraps [`elevator_core::sim::Simulation`].
+
+mod sim_node;
+
+use godot::prelude::*;
+
+/// GDExtension entry point.
+struct ElevatorExtension;
+
+#[gdextension]
+unsafe impl ExtensionLibrary for ElevatorExtension {}

--- a/crates/elevator-gdext/src/sim_node.rs
+++ b/crates/elevator-gdext/src/sim_node.rs
@@ -1,0 +1,511 @@
+//! The `ElevatorSim` Godot node — wraps the core simulation.
+
+use godot::prelude::*;
+use slotmap::Key;
+
+use elevator_core::config::SimConfig;
+use elevator_core::dispatch::BuiltinStrategy;
+use elevator_core::dispatch::scan::ScanDispatch;
+use elevator_core::sim::Simulation;
+
+/// Elevator simulation node.
+///
+/// Attach to your scene tree and configure via exported properties.
+/// On `_ready`, loads a RON config and creates the simulation.
+/// On `_process`, steps the sim and auto-spawns riders if enabled.
+#[derive(GodotClass)]
+#[class(base=Node)]
+pub struct ElevatorSim {
+    base: Base<Node>,
+
+    /// Simulation instance (created on `_ready`).
+    sim: Option<Simulation>,
+
+    /// Path to the RON config file (filesystem path, not res://).
+    #[export]
+    config_path: GString,
+
+    /// Simulation steps per frame. 0 = paused, 1 = normal, 2 = 2x, etc.
+    #[export]
+    speed_multiplier: i32,
+
+    /// Whether to auto-spawn riders at random stops.
+    #[export]
+    auto_spawn: bool,
+
+    /// Mean interval (in ticks) between auto-spawned riders.
+    #[export]
+    spawn_interval_ticks: i32,
+
+    /// Minimum rider weight for auto-spawn.
+    #[export]
+    weight_min: f64,
+
+    /// Maximum rider weight for auto-spawn.
+    #[export]
+    weight_max: f64,
+
+    /// Ticks remaining until next auto-spawn.
+    ticks_until_spawn: u32,
+}
+
+#[godot_api]
+impl INode for ElevatorSim {
+    fn init(base: Base<Node>) -> Self {
+        Self {
+            base,
+            sim: None,
+            config_path: GString::new(),
+            speed_multiplier: 1,
+            auto_spawn: true,
+            spawn_interval_ticks: 120,
+            weight_min: 50.0,
+            weight_max: 100.0,
+            ticks_until_spawn: 120,
+        }
+    }
+
+    fn ready(&mut self) {
+        let path = self.config_path.to_string();
+        if path.is_empty() {
+            godot_error!("ElevatorSim: config_path is empty");
+            return;
+        }
+        let ron_str = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) => {
+                godot_error!("ElevatorSim: failed to read {path}: {e}");
+                return;
+            }
+        };
+        let config: SimConfig = match ron::from_str(&ron_str) {
+            Ok(c) => c,
+            Err(e) => {
+                godot_error!("ElevatorSim: failed to parse {path}: {e}");
+                return;
+            }
+        };
+
+        // Extract spawn config before consuming config.
+        self.spawn_interval_ticks =
+            i32::try_from(config.passenger_spawning.mean_interval_ticks).unwrap_or(120);
+        self.weight_min = config.passenger_spawning.weight_range.0;
+        self.weight_max = config.passenger_spawning.weight_range.1;
+        self.ticks_until_spawn = config.passenger_spawning.mean_interval_ticks;
+
+        match Simulation::new(&config, ScanDispatch::new()) {
+            Ok(sim) => self.sim = Some(sim),
+            Err(e) => godot_error!("ElevatorSim: simulation build failed: {e}"),
+        }
+    }
+
+    fn process(&mut self, _delta: f64) {
+        let Some(sim) = self.sim.as_mut() else {
+            return;
+        };
+
+        let steps = self.speed_multiplier.max(0) as u32;
+
+        // Auto-spawn riders.
+        if self.auto_spawn && steps > 0 {
+            Self::maybe_spawn_rider(
+                sim,
+                &mut self.ticks_until_spawn,
+                self.spawn_interval_ticks.max(1) as u32,
+                self.weight_min,
+                self.weight_max,
+                steps,
+            );
+        }
+
+        // Step the simulation.
+        for _ in 0..steps {
+            sim.step();
+        }
+    }
+}
+
+#[godot_api]
+impl ElevatorSim {
+    // ── Rider management ────────────────────────────────────────────
+
+    /// Spawn a rider with default preferences. Returns the rider entity
+    /// ID (as i64 for GDScript compatibility), or -1 on failure.
+    #[func]
+    fn spawn_rider(&mut self, origin_stop_index: i32, dest_stop_index: i32, weight: f64) -> i64 {
+        let Some(sim) = self.sim.as_mut() else {
+            return -1;
+        };
+        let stops: Vec<_> = sim.world().stop_ids();
+        let Some(&origin) = stops.get(origin_stop_index as usize) else {
+            return -1;
+        };
+        let Some(&dest) = stops.get(dest_stop_index as usize) else {
+            return -1;
+        };
+        match sim.spawn_rider(origin, dest, weight) {
+            Ok(id) => id.entity().data().as_ffi() as i64,
+            Err(_) => -1,
+        }
+    }
+
+    /// Spawn a rider with full preferences and patience.
+    /// Returns the rider entity ID (i64), or -1 on failure.
+    #[func]
+    fn spawn_rider_ex(
+        &mut self,
+        origin_stop_index: i32,
+        dest_stop_index: i32,
+        weight: f64,
+        skip_full: bool,
+        max_crowding: f64,
+        abandon_after_ticks: i32,
+        abandon_on_full: bool,
+        max_wait_ticks: i64,
+    ) -> i64 {
+        let Some(sim) = self.sim.as_mut() else {
+            return -1;
+        };
+        let stops: Vec<_> = sim.world().stop_ids();
+        let Some(&origin) = stops.get(origin_stop_index as usize) else {
+            return -1;
+        };
+        let Some(&dest) = stops.get(dest_stop_index as usize) else {
+            return -1;
+        };
+
+        let prefs = elevator_core::components::Preferences::default()
+            .with_skip_full_elevator(skip_full)
+            .with_max_crowding_factor(max_crowding)
+            .with_abandon_after_ticks(u32::try_from(abandon_after_ticks).ok())
+            .with_abandon_on_full(abandon_on_full);
+
+        let mut builder = match sim.build_rider(origin, dest) {
+            Ok(b) => b,
+            Err(_) => return -1,
+        };
+        builder = builder.weight(weight).preferences(prefs);
+        if let Ok(ticks) = u64::try_from(max_wait_ticks) {
+            builder = builder.patience(ticks);
+        }
+        match builder.spawn() {
+            Ok(id) => id.entity().data().as_ffi() as i64,
+            Err(_) => -1,
+        }
+    }
+
+    /// Remove a rider from the simulation.
+    #[func]
+    fn despawn_rider(&mut self, rider_entity_id: i64) -> bool {
+        let Some(sim) = self.sim.as_mut() else {
+            return false;
+        };
+        let kd = slotmap::KeyData::from_ffi(rider_entity_id as u64);
+        let eid = elevator_core::entity::EntityId::from(kd);
+        let rid = elevator_core::entity::RiderId::from(eid);
+        sim.despawn_rider(rid).is_ok()
+    }
+
+    // ── Strategy ────────────────────────────────────────────────────
+
+    /// Set the dispatch strategy for a group.
+    /// strategy: 0=Scan, 1=Look, 2=NearestCar, 3=Etd.
+    #[func]
+    fn set_strategy(&mut self, group_id: i32, strategy: i32) {
+        let Some(sim) = self.sim.as_mut() else {
+            return;
+        };
+        let gid = elevator_core::ids::GroupId(group_id as u32);
+        let (strat, id): (
+            Box<dyn elevator_core::dispatch::DispatchStrategy>,
+            BuiltinStrategy,
+        ) = match strategy {
+            0 => (Box::new(ScanDispatch::new()), BuiltinStrategy::Scan),
+            1 => (
+                Box::new(elevator_core::dispatch::look::LookDispatch::new()),
+                BuiltinStrategy::Look,
+            ),
+            2 => (
+                Box::new(elevator_core::dispatch::nearest_car::NearestCarDispatch::new()),
+                BuiltinStrategy::NearestCar,
+            ),
+            3 => (
+                Box::new(elevator_core::dispatch::etd::EtdDispatch::new()),
+                BuiltinStrategy::Etd,
+            ),
+            _ => return,
+        };
+        sim.set_dispatch(gid, strat, id);
+    }
+
+    // ── Frame data ──────────────────────────────────────────────────
+
+    /// Get the current simulation tick.
+    #[func]
+    fn current_tick(&self) -> i64 {
+        self.sim.as_ref().map_or(0, |s| s.current_tick() as i64)
+    }
+
+    /// Get the number of stops.
+    #[func]
+    fn stop_count(&self) -> i32 {
+        self.sim
+            .as_ref()
+            .map_or(0, |s| s.world().stop_ids().len() as i32)
+    }
+
+    /// Get the number of elevators.
+    #[func]
+    fn elevator_count(&self) -> i32 {
+        self.sim
+            .as_ref()
+            .map_or(0, |s| s.world().elevator_ids().len() as i32)
+    }
+
+    /// Get stop data as a Dictionary.
+    #[func]
+    fn get_stop(&self, index: i32) -> Dictionary<Variant, Variant> {
+        let Some(sim) = self.sim.as_ref() else {
+            return Dictionary::new();
+        };
+        let stop_ids = sim.world().stop_ids();
+        let Some(&eid) = stop_ids.get(index as usize) else {
+            return Dictionary::new();
+        };
+        let Some(stop) = sim.world().stop(eid) else {
+            return Dictionary::new();
+        };
+        let waiting = sim.waiting_at(eid).count();
+        let residents = sim.residents_at(eid).count();
+        let abandoned = sim.abandoned_at(eid).count();
+
+        // Look up the config-time StopId for this entity.
+        let stop_id = sim
+            .stop_lookup_iter()
+            .find(|(_, e)| **e == eid)
+            .map_or(0i64, |(sid, _)| i64::from(sid.0));
+
+        dict! {
+            "entity_id" => eid.data().as_ffi() as i64,
+            "stop_id" => stop_id,
+            "position" => stop.position(),
+            "name" => stop.name(),
+            "waiting" => waiting as i64,
+            "residents" => residents as i64,
+            "abandoned" => abandoned as i64,
+        }
+    }
+
+    /// Get elevator data as a Dictionary.
+    #[func]
+    fn get_elevator(&self, index: i32) -> Dictionary<Variant, Variant> {
+        let Some(sim) = self.sim.as_ref() else {
+            return Dictionary::new();
+        };
+        let elev_ids = sim.world().elevator_ids();
+        let Some(&eid) = elev_ids.get(index as usize) else {
+            return Dictionary::new();
+        };
+        let w = sim.world();
+        let Some(elev) = w.elevator(eid) else {
+            return Dictionary::new();
+        };
+        let pos = w
+            .position(eid)
+            .map_or(0.0, elevator_core::components::Position::value);
+        let vel = w
+            .velocity(eid)
+            .map_or(0.0, elevator_core::components::Velocity::value);
+        let phase_str = format!("{:?}", elev.phase());
+
+        dict! {
+            "entity_id" => eid.data().as_ffi() as i64,
+            "phase" => phase_str.as_str(),
+            "position" => pos,
+            "velocity" => vel,
+            "occupancy" => elev.riders().len() as i64,
+            "capacity_kg" => elev.weight_capacity().value(),
+            "current_load_kg" => elev.current_load().value(),
+        }
+    }
+
+    /// Get rider data as a Dictionary.
+    #[func]
+    fn get_rider(&self, index: i32) -> Dictionary<Variant, Variant> {
+        let Some(sim) = self.sim.as_ref() else {
+            return Dictionary::new();
+        };
+        let rider_ids: Vec<_> = sim.world().rider_ids();
+        let Some(&eid) = rider_ids.get(index as usize) else {
+            return Dictionary::new();
+        };
+        let Some(rider) = sim.world().rider(eid) else {
+            return Dictionary::new();
+        };
+        let phase_tag: i32 = match rider.phase() {
+            elevator_core::components::RiderPhase::Waiting => 0,
+            elevator_core::components::RiderPhase::Boarding(_) => 1,
+            elevator_core::components::RiderPhase::Riding(_) => 2,
+            elevator_core::components::RiderPhase::Exiting(_) => 3,
+            elevator_core::components::RiderPhase::Walking => 4,
+            elevator_core::components::RiderPhase::Arrived => 5,
+            elevator_core::components::RiderPhase::Abandoned => 6,
+            elevator_core::components::RiderPhase::Resident => 7,
+            _ => -1,
+        };
+        let current_stop = rider
+            .current_stop()
+            .map_or(0i64, |s| s.data().as_ffi() as i64);
+
+        dict! {
+            "entity_id" => eid.data().as_ffi() as i64,
+            "phase" => phase_tag,
+            "current_stop" => current_stop,
+        }
+    }
+
+    /// Get the number of riders currently in the simulation.
+    #[func]
+    fn rider_count(&self) -> i32 {
+        self.sim
+            .as_ref()
+            .map_or(0, |s| s.world().rider_ids().len() as i32)
+    }
+
+    /// Get aggregate metrics as a Dictionary.
+    #[func]
+    fn get_metrics(&self) -> Dictionary<Variant, Variant> {
+        let Some(sim) = self.sim.as_ref() else {
+            return Dictionary::new();
+        };
+        let m = sim.metrics();
+        dict! {
+            "total_spawned" => m.total_spawned() as i64,
+            "total_delivered" => m.total_delivered() as i64,
+            "total_abandoned" => m.total_abandoned() as i64,
+            "avg_wait_seconds" => m.avg_wait_time(),
+            "avg_ride_seconds" => m.avg_ride_time(),
+        }
+    }
+
+    /// Drain all pending events as an Array of Dictionaries.
+    /// Each dict has: { kind, tick, rider, elevator, stop }.
+    #[func]
+    fn drain_events(&mut self) -> Array<Dictionary<Variant, Variant>> {
+        let Some(sim) = self.sim.as_mut() else {
+            return Array::new();
+        };
+        let events = sim.drain_events();
+        let mut arr = Array::new();
+        for event in events {
+            use elevator_core::events::Event;
+            let d = match event {
+                Event::RiderSpawned {
+                    rider,
+                    origin,
+                    destination,
+                    tick,
+                } => dict! {
+                    "kind" => "RiderSpawned",
+                    "tick" => tick as i64,
+                    "rider" => rider.data().as_ffi() as i64,
+                    "stop" => origin.data().as_ffi() as i64,
+                    "destination" => destination.data().as_ffi() as i64,
+                },
+                Event::RiderBoarded {
+                    rider,
+                    elevator,
+                    tick,
+                } => dict! {
+                    "kind" => "RiderBoarded",
+                    "tick" => tick as i64,
+                    "rider" => rider.data().as_ffi() as i64,
+                    "elevator" => elevator.data().as_ffi() as i64,
+                },
+                Event::RiderExited {
+                    rider,
+                    elevator,
+                    stop,
+                    tick,
+                } => dict! {
+                    "kind" => "RiderExited",
+                    "tick" => tick as i64,
+                    "rider" => rider.data().as_ffi() as i64,
+                    "elevator" => elevator.data().as_ffi() as i64,
+                    "stop" => stop.data().as_ffi() as i64,
+                },
+                Event::RiderAbandoned { rider, stop, tick } => dict! {
+                    "kind" => "RiderAbandoned",
+                    "tick" => tick as i64,
+                    "rider" => rider.data().as_ffi() as i64,
+                    "stop" => stop.data().as_ffi() as i64,
+                },
+                Event::RiderSkipped {
+                    rider,
+                    elevator,
+                    at_stop,
+                    tick,
+                } => dict! {
+                    "kind" => "RiderSkipped",
+                    "tick" => tick as i64,
+                    "rider" => rider.data().as_ffi() as i64,
+                    "elevator" => elevator.data().as_ffi() as i64,
+                    "stop" => at_stop.data().as_ffi() as i64,
+                },
+                Event::HallButtonPressed { stop, tick, .. } => dict! {
+                    "kind" => "HallButtonPressed",
+                    "tick" => tick as i64,
+                    "stop" => stop.data().as_ffi() as i64,
+                },
+                Event::ElevatorAssigned {
+                    elevator,
+                    stop,
+                    tick,
+                    ..
+                } => dict! {
+                    "kind" => "ElevatorAssigned",
+                    "tick" => tick as i64,
+                    "elevator" => elevator.data().as_ffi() as i64,
+                    "stop" => stop.data().as_ffi() as i64,
+                },
+                _ => continue,
+            };
+            arr.push(&d);
+        }
+        arr
+    }
+}
+
+impl ElevatorSim {
+    /// Poisson-style spawn timer matching the Bevy `passenger_ai.rs` logic.
+    fn maybe_spawn_rider(
+        sim: &mut Simulation,
+        ticks_until_spawn: &mut u32,
+        mean_interval: u32,
+        weight_min: f64,
+        weight_max: f64,
+        steps: u32,
+    ) {
+        use rand::RngExt;
+
+        if *ticks_until_spawn <= steps {
+            let stop_ids: Vec<_> = sim.world().stop_ids();
+            if stop_ids.len() < 2 {
+                return;
+            }
+            let mut rng = rand::rng();
+            let origin_idx = rng.random_range(0..stop_ids.len());
+            let mut dest_idx = rng.random_range(0..stop_ids.len());
+            while dest_idx == origin_idx {
+                dest_idx = rng.random_range(0..stop_ids.len());
+            }
+            let weight = rng.random_range(weight_min..weight_max);
+            let _ = sim.spawn_rider(stop_ids[origin_idx], stop_ids[dest_idx], weight);
+
+            let jitter = rng.random_range(0.5f64..1.5);
+            *ticks_until_spawn = (f64::from(mean_interval) * jitter) as u32;
+        } else {
+            *ticks_until_spawn -= steps;
+        }
+    }
+}

--- a/crates/elevator-gdext/src/sim_node.rs
+++ b/crates/elevator-gdext/src/sim_node.rs
@@ -151,6 +151,8 @@ impl ElevatorSim {
 
     /// Spawn a rider with full preferences and patience.
     /// Returns the rider entity ID (i64), or -1 on failure.
+    /// Pass `max_wait_ticks < 0` to skip attaching a Patience component
+    /// (the rider uses default patience behavior).
     #[func]
     fn spawn_rider_ex(
         &mut self,
@@ -195,8 +197,12 @@ impl ElevatorSim {
     }
 
     /// Remove a rider from the simulation.
+    /// Pass the entity ID returned by spawn_rider; negative IDs are rejected.
     #[func]
     fn despawn_rider(&mut self, rider_entity_id: i64) -> bool {
+        if rider_entity_id < 0 {
+            return false;
+        }
         let Some(sim) = self.sim.as_mut() else {
             return false;
         };
@@ -488,24 +494,31 @@ impl ElevatorSim {
     ) {
         use rand::RngExt;
 
-        if *ticks_until_spawn <= steps {
-            let stop_ids: Vec<_> = sim.world().stop_ids();
-            if stop_ids.len() < 2 {
-                return;
-            }
-            let mut rng = rand::rng();
-            let origin_idx = rng.random_range(0..stop_ids.len());
-            let mut dest_idx = rng.random_range(0..stop_ids.len());
-            while dest_idx == origin_idx {
-                dest_idx = rng.random_range(0..stop_ids.len());
-            }
-            let weight = rng.random_range(weight_min..weight_max);
-            let _ = sim.spawn_rider(stop_ids[origin_idx], stop_ids[dest_idx], weight);
+        let stop_ids: Vec<_> = sim.world().stop_ids();
+        if stop_ids.len() < 2 {
+            return;
+        }
+        let mut rng = rand::rng();
+        let mut remaining = steps;
 
-            let jitter = rng.random_range(0.5f64..1.5);
-            *ticks_until_spawn = (f64::from(mean_interval) * jitter) as u32;
-        } else {
-            *ticks_until_spawn -= steps;
+        loop {
+            if *ticks_until_spawn <= remaining {
+                remaining -= *ticks_until_spawn;
+
+                let origin_idx = rng.random_range(0..stop_ids.len());
+                let mut dest_idx = rng.random_range(0..stop_ids.len());
+                while dest_idx == origin_idx {
+                    dest_idx = rng.random_range(0..stop_ids.len());
+                }
+                let weight = rng.random_range(weight_min..weight_max);
+                let _ = sim.spawn_rider(stop_ids[origin_idx], stop_ids[dest_idx], weight);
+
+                let jitter = rng.random_range(0.5f64..1.5);
+                *ticks_until_spawn = (f64::from(mean_interval) * jitter) as u32;
+            } else {
+                *ticks_until_spawn -= remaining;
+                break;
+            }
         }
     }
 }

--- a/examples/godot-demo/.gitignore
+++ b/examples/godot-demo/.gitignore
@@ -1,0 +1,8 @@
+# Godot
+.godot/
+*.import
+
+# Native libraries (built by build.sh)
+bin/*.so
+bin/*.dll
+bin/*.dylib

--- a/examples/godot-demo/README.md
+++ b/examples/godot-demo/README.md
@@ -1,0 +1,53 @@
+# Godot Elevator Demo
+
+A 2D elevator simulation demo using the `elevator-core` library via a GDExtension binding (`elevator-gdext`).
+
+## Prerequisites
+
+- **Rust toolchain** (stable, 1.88+)
+- **Godot 4.3+** (standard build, not .NET)
+
+## Build
+
+```bash
+# From the repo root or this directory:
+bash examples/godot-demo/build.sh
+```
+
+This compiles `elevator-gdext` in release mode and copies the native library to `bin/`.
+
+## Run
+
+1. Open `examples/godot-demo/` as a Godot project
+2. Press **Play** (F5)
+
+## Controls
+
+| Key | Action |
+|-----|--------|
+| Space | Toggle pause |
+| 1 | 1x speed |
+| 2 | 2x speed |
+| 3 | 10x speed |
+| Spawn button | Add a random rider |
+
+## Project Structure
+
+```
+examples/godot-demo/
+  project.godot              Godot project file
+  elevator_gdext.gdextension GDExtension registration
+  bin/                       Native library (built by build.sh)
+  scenes/
+    main.tscn                Main scene
+  scripts/
+    main.gd                  Root script — creates ElevatorSim, wires controls
+    elevator_view.gd         2D rendering — shaft, stops, car, riders
+    hud.gd                   Stats overlay — tick, speed, metrics
+```
+
+## Architecture
+
+The `ElevatorSim` node (`crates/elevator-gdext/`) wraps `elevator-core::Simulation` directly as a Godot Node subclass via gdext. GDScript calls methods like `spawn_rider()`, `get_elevator()`, `get_metrics()`, and `drain_events()` — all data is marshaled as Godot Dictionaries and Arrays.
+
+Rider spawning uses a Poisson timer (matching the Bevy demo's `passenger_ai.rs`) with parameters read from the RON config's `passenger_spawning` section.

--- a/examples/godot-demo/build.sh
+++ b/examples/godot-demo/build.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Build the elevator-gdext GDExtension library and copy it to the Godot
+# project's bin/ directory. Run from anywhere — paths are resolved
+# relative to this script.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BIN_DIR="$SCRIPT_DIR/bin"
+
+echo "Building elevator-gdext (release)..."
+cargo build \
+    --manifest-path "$REPO_ROOT/crates/elevator-gdext/Cargo.toml" \
+    --release
+
+mkdir -p "$BIN_DIR"
+
+# Detect platform and copy the compiled library.
+case "$(uname -s)" in
+    Linux*)
+        cp "$REPO_ROOT/target/release/libelevator_gdext.so" "$BIN_DIR/"
+        echo "Copied libelevator_gdext.so to $BIN_DIR/"
+        ;;
+    Darwin*)
+        cp "$REPO_ROOT/target/release/libelevator_gdext.dylib" "$BIN_DIR/"
+        echo "Copied libelevator_gdext.dylib to $BIN_DIR/"
+        ;;
+    MINGW*|MSYS*|CYGWIN*)
+        cp "$REPO_ROOT/target/release/elevator_gdext.dll" "$BIN_DIR/"
+        echo "Copied elevator_gdext.dll to $BIN_DIR/"
+        ;;
+    *)
+        echo "Unknown platform: $(uname -s)" >&2
+        exit 1
+        ;;
+esac
+
+echo "Done. Open the project in Godot 4.3+ and press Play."

--- a/examples/godot-demo/elevator_gdext.gdextension
+++ b/examples/godot-demo/elevator_gdext.gdextension
@@ -1,0 +1,11 @@
+[configuration]
+entry_symbol = "gdext_rust_init"
+compatibility_minimum = 4.3
+
+[libraries]
+linux.debug.x86_64 = "res://bin/libelevator_gdext.so"
+linux.release.x86_64 = "res://bin/libelevator_gdext.so"
+windows.debug.x86_64 = "res://bin/elevator_gdext.dll"
+windows.release.x86_64 = "res://bin/elevator_gdext.dll"
+macos.debug = "res://bin/libelevator_gdext.dylib"
+macos.release = "res://bin/libelevator_gdext.dylib"

--- a/examples/godot-demo/project.godot
+++ b/examples/godot-demo/project.godot
@@ -1,0 +1,21 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] key=value
+
+[application]
+
+config/name="Elevator Demo"
+run/main_scene="res://scenes/main.tscn"
+config/features=PackedStringArray("4.3")
+
+[display]
+
+window/size/viewport_width=1024
+window/size/viewport_height=768
+
+[rendering]
+
+renderer/rendering_method="gl_compatibility"

--- a/examples/godot-demo/scenes/main.tscn
+++ b/examples/godot-demo/scenes/main.tscn
@@ -1,0 +1,54 @@
+[gd_scene load_steps=4 format=3 uid="uid://main_scene"]
+
+[ext_resource type="Script" path="res://scripts/main.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/hud.gd" id="2"]
+[ext_resource type="Script" path="res://scripts/elevator_view.gd" id="3"]
+
+[node name="Main" type="Node2D"]
+script = ExtResource("1")
+
+[node name="ElevatorView" type="Node2D" parent="."]
+script = ExtResource("3")
+
+[node name="HUD" type="CanvasLayer" parent="."]
+
+[node name="Panel" type="PanelContainer" parent="HUD"]
+offset_right = 320.0
+offset_bottom = 400.0
+
+[node name="VBox" type="VBoxContainer" parent="HUD/Panel"]
+layout_mode = 2
+
+[node name="StatsLabel" type="Label" parent="HUD/Panel/VBox"]
+layout_mode = 2
+text = "Initializing..."
+script = ExtResource("2")
+
+[node name="Controls" type="HBoxContainer" parent="HUD/Panel/VBox"]
+layout_mode = 2
+
+[node name="PauseBtn" type="Button" parent="HUD/Panel/VBox/Controls"]
+layout_mode = 2
+text = "Pause"
+
+[node name="Speed1" type="Button" parent="HUD/Panel/VBox/Controls"]
+layout_mode = 2
+text = "1x"
+
+[node name="Speed2" type="Button" parent="HUD/Panel/VBox/Controls"]
+layout_mode = 2
+text = "2x"
+
+[node name="Speed10" type="Button" parent="HUD/Panel/VBox/Controls"]
+layout_mode = 2
+text = "10x"
+
+[node name="SpawnBtn" type="Button" parent="HUD/Panel/VBox/Controls"]
+layout_mode = 2
+text = "Spawn"
+
+[node name="HelpLabel" type="Label" parent="HUD/Panel/VBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
+theme_override_font_sizes/font_size = 11
+text = "Space: pause | 1: 1x | 2: 2x | 3: 10x"

--- a/examples/godot-demo/scripts/elevator_view.gd
+++ b/examples/godot-demo/scripts/elevator_view.gd
@@ -1,0 +1,116 @@
+extends Node2D
+## Draws the elevator shaft, stops, car, and riders as procedural 2D shapes.
+
+const SHAFT_WIDTH := 60.0
+const CAR_WIDTH := 50.0
+const CAR_HEIGHT := 30.0
+const RIDER_SIZE := 8.0
+const PPU := 40.0  # pixels per sim unit
+const SHAFT_X := 512.0  # horizontal center of shaft
+
+const COLOR_SHAFT := Color(0.2, 0.2, 0.25, 1.0)
+const COLOR_CAR := Color(0.2, 0.5, 0.9, 1.0)
+const COLOR_STOP := Color(0.5, 0.5, 0.5, 0.6)
+const COLOR_WAITING := Color(0.2, 0.8, 0.3, 1.0)
+const COLOR_BOARDING := Color(0.3, 0.9, 0.9, 1.0)
+const COLOR_RIDING := Color(0.9, 0.8, 0.2, 1.0)
+const COLOR_EXITING := Color(0.9, 0.4, 0.2, 1.0)
+
+var shaft_top_y := 0.0
+var shaft_bottom_y := 0.0
+
+func _process(_delta: float) -> void:
+	queue_redraw()
+
+func _draw() -> void:
+	var sim: ElevatorSim = _get_sim()
+	if sim == null:
+		return
+
+	var stop_count := sim.stop_count()
+	if stop_count == 0:
+		return
+
+	# Gather stop positions to compute shaft bounds.
+	var stops: Array[Dictionary] = []
+	var min_pos := INF
+	var max_pos := -INF
+	for i in range(stop_count):
+		var s: Dictionary = sim.get_stop(i)
+		stops.append(s)
+		var p: float = s.get("position", 0.0)
+		min_pos = min(min_pos, p)
+		max_pos = max(max_pos, p)
+
+	var shaft_height: float = (max_pos - min_pos) * PPU
+	shaft_bottom_y = 650.0
+	shaft_top_y = shaft_bottom_y - shaft_height
+
+	# Draw shaft background.
+	draw_rect(
+		Rect2(SHAFT_X - SHAFT_WIDTH / 2, shaft_top_y, SHAFT_WIDTH, shaft_height),
+		COLOR_SHAFT
+	)
+
+	# Draw stops.
+	for s in stops:
+		var pos_y := _sim_to_screen_y(s.get("position", 0.0), min_pos)
+		# Horizontal line.
+		draw_line(
+			Vector2(SHAFT_X - SHAFT_WIDTH / 2 - 10, pos_y),
+			Vector2(SHAFT_X + SHAFT_WIDTH / 2 + 10, pos_y),
+			COLOR_STOP, 2.0
+		)
+		# Stop name label.
+		var stop_name: String = s.get("name", "")
+		var waiting: int = s.get("waiting", 0)
+		var label := "%s (%d)" % [stop_name, waiting]
+		draw_string(ThemeDB.fallback_font, Vector2(SHAFT_X + SHAFT_WIDTH / 2 + 15, pos_y + 4), label, HORIZONTAL_ALIGNMENT_LEFT, -1, 12, Color.WHITE)
+
+	# Draw elevators.
+	var elev_count := sim.elevator_count()
+	for i in range(elev_count):
+		var e: Dictionary = sim.get_elevator(i)
+		var pos_y := _sim_to_screen_y(e.get("position", 0.0), min_pos)
+		draw_rect(
+			Rect2(SHAFT_X - CAR_WIDTH / 2, pos_y - CAR_HEIGHT / 2, CAR_WIDTH, CAR_HEIGHT),
+			COLOR_CAR
+		)
+		# Occupancy label inside car.
+		var occ: int = e.get("occupancy", 0)
+		if occ > 0:
+			draw_string(ThemeDB.fallback_font, Vector2(SHAFT_X - 8, pos_y + 4), str(occ), HORIZONTAL_ALIGNMENT_CENTER, -1, 12, Color.WHITE)
+
+	# Draw riders.
+	var rider_count := sim.rider_count()
+	for i in range(rider_count):
+		var r: Dictionary = sim.get_rider(i)
+		var phase: int = r.get("phase", -1)
+		# Only draw waiting riders (phase 0) at their stop.
+		if phase == 0:  # Waiting
+			# Find the stop position for this rider.
+			var stop_eid: int = r.get("current_stop", 0)
+			if stop_eid == 0:
+				continue
+			for s in stops:
+				if s.get("entity_id", 0) == stop_eid:
+					var pos_y := _sim_to_screen_y(s.get("position", 0.0), min_pos)
+					# Offset riders to the left of the shaft, spread by index.
+					var offset_x := SHAFT_X - SHAFT_WIDTH / 2 - 20 - (i % 5) * (RIDER_SIZE + 2)
+					draw_rect(
+						Rect2(offset_x - RIDER_SIZE / 2, pos_y - RIDER_SIZE / 2, RIDER_SIZE, RIDER_SIZE),
+						COLOR_WAITING
+					)
+					break
+
+func _sim_to_screen_y(sim_pos: float, min_pos: float) -> float:
+	return shaft_bottom_y - (sim_pos - min_pos) * PPU
+
+func _get_sim() -> ElevatorSim:
+	var parent := get_parent()
+	if parent == null:
+		return null
+	for child in parent.get_children():
+		if child is ElevatorSim:
+			return child
+	return null

--- a/examples/godot-demo/scripts/elevator_view.gd
+++ b/examples/godot-demo/scripts/elevator_view.gd
@@ -83,22 +83,27 @@ func _draw() -> void:
 
 	# Draw riders.
 	var rider_count := sim.rider_count()
+	var stop_waiting_count: Dictionary = {}  # stop entity_id -> int
 	for i in range(rider_count):
 		var r: Dictionary = sim.get_rider(i)
 		var phase: int = r.get("phase", -1)
 		# Only draw waiting riders (phase 0) at their stop.
 		if phase == 0:  # Waiting
-			# Find the stop position for this rider.
 			var stop_eid: int = r.get("current_stop", 0)
 			if stop_eid == 0:
 				continue
 			for s in stops:
 				if s.get("entity_id", 0) == stop_eid:
 					var pos_y := _sim_to_screen_y(s.get("position", 0.0), min_pos)
-					# Offset riders to the left of the shaft, spread by index.
-					var offset_x := SHAFT_X - SHAFT_WIDTH / 2 - 20 - (i % 5) * (RIDER_SIZE + 2)
+					# Use per-stop counter to avoid overlapping riders.
+					var local_i: int = stop_waiting_count.get(stop_eid, 0)
+					stop_waiting_count[stop_eid] = local_i + 1
+					var row := local_i / 5
+					var col := local_i % 5
+					var offset_x := SHAFT_X - SHAFT_WIDTH / 2 - 20 - col * (RIDER_SIZE + 2)
+					var offset_y := row * (RIDER_SIZE + 2)
 					draw_rect(
-						Rect2(offset_x - RIDER_SIZE / 2, pos_y - RIDER_SIZE / 2, RIDER_SIZE, RIDER_SIZE),
+						Rect2(offset_x - RIDER_SIZE / 2, pos_y - RIDER_SIZE / 2 - offset_y, RIDER_SIZE, RIDER_SIZE),
 						COLOR_WAITING
 					)
 					break

--- a/examples/godot-demo/scripts/hud.gd
+++ b/examples/godot-demo/scripts/hud.gd
@@ -1,0 +1,70 @@
+extends Label
+## Updates the HUD stats label every frame.
+
+func _process(_delta: float) -> void:
+	var sim: ElevatorSim = _get_sim()
+	if sim == null:
+		text = "No simulation"
+		return
+
+	var tick := sim.current_tick()
+	var speed := sim.speed_multiplier
+
+	var speed_label := "PAUSED" if speed == 0 else "%dx" % speed
+
+	# Elevator info.
+	var elev_lines := ""
+	var elev_count := sim.elevator_count()
+	for i in range(elev_count):
+		var e: Dictionary = sim.get_elevator(i)
+		var phase: String = e.get("phase", "?")
+		var pos: float = e.get("position", 0.0)
+		var vel: float = e.get("velocity", 0.0)
+		var occ: int = e.get("occupancy", 0)
+		var cap: float = e.get("capacity_kg", 0.0)
+		var load_kg: float = e.get("current_load_kg", 0.0)
+		var load_pct := 0.0
+		if cap > 0:
+			load_pct = (load_kg / cap) * 100.0
+		elev_lines += "Car %d: %s  pos=%.1f  vel=%.2f\n" % [i, phase, pos, vel]
+		elev_lines += "  Load: %.0f/%.0f kg (%.0f%%)  Riders: %d\n" % [load_kg, cap, load_pct, occ]
+
+	# Rider counts.
+	var metrics: Dictionary = sim.get_metrics()
+	var spawned: int = metrics.get("total_spawned", 0)
+	var delivered: int = metrics.get("total_delivered", 0)
+	var abandoned: int = metrics.get("total_abandoned", 0)
+	var avg_wait: float = metrics.get("avg_wait_seconds", 0.0)
+	var avg_ride: float = metrics.get("avg_ride_seconds", 0.0)
+
+	# Count waiting riders across stops.
+	var total_waiting := 0
+	for i in range(sim.stop_count()):
+		var s: Dictionary = sim.get_stop(i)
+		total_waiting += s.get("waiting", 0) as int
+
+	text = "Tick: %d  Speed: %s\n" % [tick, speed_label]
+	text += "---\n"
+	text += elev_lines
+	text += "---\n"
+	text += "Waiting: %d  On board: %d\n" % [total_waiting, _count_riding(sim)]
+	text += "Delivered: %d  Abandoned: %d\n" % [delivered, abandoned]
+	text += "Spawned: %d\n" % spawned
+	text += "Avg wait: %.1fs  Avg ride: %.1fs\n" % [avg_wait, avg_ride]
+
+func _count_riding(sim: ElevatorSim) -> int:
+	var count := 0
+	for i in range(sim.elevator_count()):
+		var e: Dictionary = sim.get_elevator(i)
+		count += e.get("occupancy", 0) as int
+	return count
+
+func _get_sim() -> ElevatorSim:
+	# Walk up to Main and find the ElevatorSim child.
+	var main := get_tree().current_scene
+	if main == null:
+		return null
+	for child in main.get_children():
+		if child is ElevatorSim:
+			return child
+	return null

--- a/examples/godot-demo/scripts/main.gd
+++ b/examples/godot-demo/scripts/main.gd
@@ -1,0 +1,66 @@
+extends Node2D
+## Root script. Creates the ElevatorSim node and wires up controls.
+
+var sim: ElevatorSim
+
+func _ready() -> void:
+	# Create the simulation node programmatically.
+	sim = ElevatorSim.new()
+	# Resolve config path relative to the project root.
+	var project_dir := ProjectSettings.globalize_path("res://")
+	# Walk up to the repo root (examples/godot-demo/ -> repo root).
+	var repo_root := project_dir.get_base_dir().get_base_dir()
+	sim.config_path = repo_root.path_join("assets/config/default.ron")
+	sim.speed_multiplier = 1
+	sim.auto_spawn = true
+	add_child(sim)
+
+	# Wire up button signals.
+	var pause_btn: Button = $HUD/Panel/VBox/Controls/PauseBtn
+	var speed1_btn: Button = $HUD/Panel/VBox/Controls/Speed1
+	var speed2_btn: Button = $HUD/Panel/VBox/Controls/Speed2
+	var speed10_btn: Button = $HUD/Panel/VBox/Controls/Speed10
+	var spawn_btn: Button = $HUD/Panel/VBox/Controls/SpawnBtn
+
+	pause_btn.pressed.connect(_on_pause)
+	speed1_btn.pressed.connect(_on_speed_1)
+	speed2_btn.pressed.connect(_on_speed_2)
+	speed10_btn.pressed.connect(_on_speed_10)
+	spawn_btn.pressed.connect(_on_spawn)
+
+func _unhandled_key_input(event: InputEvent) -> void:
+	if event is InputEventKey and event.pressed:
+		match event.keycode:
+			KEY_SPACE:
+				_on_pause()
+			KEY_1:
+				_on_speed_1()
+			KEY_2:
+				_on_speed_2()
+			KEY_3:
+				_on_speed_10()
+
+func _on_pause() -> void:
+	if sim.speed_multiplier == 0:
+		sim.speed_multiplier = 1
+	else:
+		sim.speed_multiplier = 0
+
+func _on_speed_1() -> void:
+	sim.speed_multiplier = 1
+
+func _on_speed_2() -> void:
+	sim.speed_multiplier = 2
+
+func _on_speed_10() -> void:
+	sim.speed_multiplier = 10
+
+func _on_spawn() -> void:
+	var stop_count := sim.stop_count()
+	if stop_count < 2:
+		return
+	var origin := randi_range(0, stop_count - 1)
+	var dest := randi_range(0, stop_count - 2)
+	if dest >= origin:
+		dest += 1
+	sim.spawn_rider(origin, dest, randf_range(50.0, 100.0))


### PR DESCRIPTION
## Summary

- New `crates/elevator-gdext/` crate wrapping `elevator-core` as a Godot Node via gdext 0.5
- `ElevatorSim` GDExtension node exposes: `spawn_rider`, `spawn_rider_ex`, `despawn_rider`, `set_strategy`, `get_elevator`/`get_stop`/`get_rider`/`get_metrics`, `drain_events`
- All data marshaled as Godot Dictionaries/Arrays for GDScript consumption
- Poisson auto-spawn timer matching the Bevy demo's `passenger_ai.rs`
- 2D procedural rendering: gray shaft, stop lines with labels, blue car, color-coded waiting riders
- HUD overlay: tick, speed, elevator state/position/velocity, load %, rider counts, metrics
- Controls: Space=pause, 1/2/3=speed, Spawn button
- Build script (`build.sh`) compiles gdext and copies native lib to `bin/`
- Added `elevator-gdext` to workspace members

## Test plan

- [x] `cargo check -p elevator-gdext` compiles clean
- [x] `cargo clippy -p elevator-gdext` no warnings
- [x] `build.sh` produces `libelevator_gdext.so` in `bin/`
- [x] 595 elevator-core tests still pass
- [x] Pre-commit hook passes (fmt, clippy, tests, doc tests)
- [ ] Manual: open in Godot 4.3+, press Play, verify simulation runs