### PR TITLE
polish: demo readability, camera framing, and full rider rendering

### DIFF
--- a/crates/elevator-ffi/include/elevator_ffi.h
+++ b/crates/elevator-ffi/include/elevator_ffi.h
@@ -17,7 +17,7 @@
 /**
  * Current ABI version. Bumped for any breaking change to the C layout.
  */
-#define EV_ABI_VERSION 1
+#define EV_ABI_VERSION 2
 
 /**
  * `Event::HallButtonPressed`.
@@ -184,6 +184,14 @@ typedef struct EvElevatorView {
      * [`DoorState`] tag: 0 `Closed`, 1 `Opening`, 2 `Open`, 3 `Closing`.
      */
     uint8_t door_state;
+    /**
+     * Direction indicator: 1 if the "going up" lamp is lit, 0 otherwise.
+     */
+    uint8_t going_up;
+    /**
+     * Direction indicator: 1 if the "going down" lamp is lit, 0 otherwise.
+     */
+    uint8_t going_down;
 } EvElevatorView;
 
 /**

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -45,7 +45,7 @@ use elevator_core::sim::Simulation;
 use slotmap::{Key, KeyData};
 
 /// Current ABI version. Bumped for any breaking change to the C layout.
-pub const EV_ABI_VERSION: u32 = 1;
+pub const EV_ABI_VERSION: u32 = 2;
 
 /// Return the ABI version compiled into this shared library.
 #[unsafe(no_mangle)]
@@ -185,6 +185,10 @@ pub struct EvElevatorView {
     pub capacity_kg: f64,
     /// [`DoorState`] tag: 0 `Closed`, 1 `Opening`, 2 `Open`, 3 `Closing`.
     pub door_state: u8,
+    /// Direction indicator: 1 if the "going up" lamp is lit, 0 otherwise.
+    pub going_up: u8,
+    /// Direction indicator: 1 if the "going down" lamp is lit, 0 otherwise.
+    pub going_down: u8,
 }
 
 /// View of a single stop at the current tick.
@@ -578,6 +582,8 @@ fn populate_frame(ev: &mut EvSim) {
             occupancy: u32::try_from(elev.riders().len()).unwrap_or(u32::MAX),
             capacity_kg: elev.weight_capacity().value(),
             door_state: door_state_tag(elev.door()),
+            going_up: u8::from(elev.going_up()),
+            going_down: u8::from(elev.going_down()),
         });
     }
 
@@ -1543,8 +1549,8 @@ mod tests {
     use std::ffi::CString;
 
     #[test]
-    fn abi_version_is_one() {
-        assert_eq!(ev_abi_version(), 1);
+    fn abi_version_is_two() {
+        assert_eq!(ev_abi_version(), 2);
     }
 
     #[test]

--- a/crates/elevator-gdext/src/sim_node.rs
+++ b/crates/elevator-gdext/src/sim_node.rs
@@ -1,4 +1,26 @@
-//! The `ElevatorSim` Godot node — wraps the core simulation.
+//! The `ElevatorSim` Godot node — public API for GDScript.
+//!
+//! # Exported properties
+//!
+//! | Property              | Type     | Description                         |
+//! |-----------------------|----------|-------------------------------------|
+//! | `config_path`         | `String` | Filesystem path to a RON config     |
+//! | `speed_multiplier`    | `i32`    | Sim steps per frame (0 = paused)    |
+//! | `auto_spawn`          | `bool`   | Enable random rider spawning        |
+//! | `spawn_interval_ticks`| `i32`    | Mean ticks between auto-spawns      |
+//! | `weight_min`          | `f64`    | Minimum auto-spawn rider weight     |
+//! | `weight_max`          | `f64`    | Maximum auto-spawn rider weight     |
+//!
+//! # GDScript methods
+//!
+//! **Rider management:** `spawn_rider`, `spawn_rider_ex`, `despawn_rider`
+//!
+//! **Strategy:** `set_strategy`
+//!
+//! **Frame data (read each frame):**
+//! `current_tick`, `stop_count`, `elevator_count`, `rider_count`,
+//! `get_stop`, `get_elevator`, `get_rider`, `get_metrics`,
+//! `eta_to_stop`, `drain_events`
 
 use godot::prelude::*;
 use slotmap::Key;
@@ -129,8 +151,10 @@ impl INode for ElevatorSim {
 impl ElevatorSim {
     // ── Rider management ────────────────────────────────────────────
 
-    /// Spawn a rider with default preferences. Returns the rider entity
-    /// ID (as i64 for GDScript compatibility), or -1 on failure.
+    /// Spawn a rider with default preferences.
+    ///
+    /// Returns the rider entity ID (as i64 for GDScript compatibility),
+    /// or -1 on failure.
     #[func]
     fn spawn_rider(&mut self, origin_stop_index: i32, dest_stop_index: i32, weight: f64) -> i64 {
         let Some(sim) = self.sim.as_mut() else {
@@ -150,6 +174,7 @@ impl ElevatorSim {
     }
 
     /// Spawn a rider with full preferences and patience.
+    ///
     /// Returns the rider entity ID (i64), or -1 on failure.
     /// Pass `max_wait_ticks < 0` to skip attaching a Patience component
     /// (the rider uses default patience behavior).
@@ -197,7 +222,9 @@ impl ElevatorSim {
     }
 
     /// Remove a rider from the simulation.
-    /// Pass the entity ID returned by spawn_rider; negative IDs are rejected.
+    ///
+    /// Pass the entity ID returned by `spawn_rider`; negative IDs are
+    /// rejected.
     #[func]
     fn despawn_rider(&mut self, rider_entity_id: i64) -> bool {
         if rider_entity_id < 0 {
@@ -215,7 +242,8 @@ impl ElevatorSim {
     // ── Strategy ────────────────────────────────────────────────────
 
     /// Set the dispatch strategy for a group.
-    /// strategy: 0=Scan, 1=Look, 2=NearestCar, 3=Etd.
+    ///
+    /// Strategy codes: 0 = Scan, 1 = Look, 2 = NearestCar, 3 = Etd.
     #[func]
     fn set_strategy(&mut self, group_id: i32, strategy: i32) {
         let Some(sim) = self.sim.as_mut() else {
@@ -252,7 +280,7 @@ impl ElevatorSim {
         self.sim.as_ref().map_or(0, |s| s.current_tick() as i64)
     }
 
-    /// Get the number of stops.
+    /// Get the number of stops in the simulation.
     #[func]
     fn stop_count(&self) -> i32 {
         self.sim
@@ -260,7 +288,7 @@ impl ElevatorSim {
             .map_or(0, |s| s.world().stop_ids().len() as i32)
     }
 
-    /// Get the number of elevators.
+    /// Get the number of elevators in the simulation.
     #[func]
     fn elevator_count(&self) -> i32 {
         self.sim
@@ -269,6 +297,9 @@ impl ElevatorSim {
     }
 
     /// Get stop data as a Dictionary.
+    ///
+    /// Keys: `entity_id`, `stop_id`, `position`, `name`, `waiting`,
+    /// `residents`, `abandoned`.
     #[func]
     fn get_stop(&self, index: i32) -> Dictionary<Variant, Variant> {
         let Some(sim) = self.sim.as_ref() else {
@@ -303,6 +334,9 @@ impl ElevatorSim {
     }
 
     /// Get elevator data as a Dictionary.
+    ///
+    /// Keys: `entity_id`, `phase`, `position`, `velocity`, `occupancy`,
+    /// `capacity_kg`, `current_load_kg`, `going_up`, `going_down`.
     #[func]
     fn get_elevator(&self, index: i32) -> Dictionary<Variant, Variant> {
         let Some(sim) = self.sim.as_ref() else {
@@ -332,10 +366,19 @@ impl ElevatorSim {
             "occupancy" => elev.riders().len() as i64,
             "capacity_kg" => elev.weight_capacity().value(),
             "current_load_kg" => elev.current_load().value(),
+            "going_up" => elev.going_up(),
+            "going_down" => elev.going_down(),
         }
     }
 
     /// Get rider data as a Dictionary.
+    ///
+    /// Keys: `entity_id`, `phase` (int tag), `current_stop`,
+    /// `elevator_entity` (entity ID of the elevator if boarding/riding/
+    /// exiting, otherwise 0).
+    ///
+    /// Phase tags: 0 = Waiting, 1 = Boarding, 2 = Riding, 3 = Exiting,
+    /// 4 = Walking, 5 = Arrived, 6 = Abandoned, 7 = Resident.
     #[func]
     fn get_rider(&self, index: i32) -> Dictionary<Variant, Variant> {
         let Some(sim) = self.sim.as_ref() else {
@@ -348,17 +391,19 @@ impl ElevatorSim {
         let Some(rider) = sim.world().rider(eid) else {
             return Dictionary::new();
         };
-        let phase_tag: i32 = match rider.phase() {
-            elevator_core::components::RiderPhase::Waiting => 0,
-            elevator_core::components::RiderPhase::Boarding(_) => 1,
-            elevator_core::components::RiderPhase::Riding(_) => 2,
-            elevator_core::components::RiderPhase::Exiting(_) => 3,
-            elevator_core::components::RiderPhase::Walking => 4,
-            elevator_core::components::RiderPhase::Arrived => 5,
-            elevator_core::components::RiderPhase::Abandoned => 6,
-            elevator_core::components::RiderPhase::Resident => 7,
-            _ => -1,
+
+        let (phase_tag, elevator_entity): (i32, i64) = match rider.phase() {
+            elevator_core::components::RiderPhase::Waiting => (0, 0),
+            elevator_core::components::RiderPhase::Boarding(e) => (1, e.data().as_ffi() as i64),
+            elevator_core::components::RiderPhase::Riding(e) => (2, e.data().as_ffi() as i64),
+            elevator_core::components::RiderPhase::Exiting(e) => (3, e.data().as_ffi() as i64),
+            elevator_core::components::RiderPhase::Walking => (4, 0),
+            elevator_core::components::RiderPhase::Arrived => (5, 0),
+            elevator_core::components::RiderPhase::Abandoned => (6, 0),
+            elevator_core::components::RiderPhase::Resident => (7, 0),
+            _ => (-1, 0),
         };
+
         let current_stop = rider
             .current_stop()
             .map_or(0i64, |s| s.data().as_ffi() as i64);
@@ -367,6 +412,7 @@ impl ElevatorSim {
             "entity_id" => eid.data().as_ffi() as i64,
             "phase" => phase_tag,
             "current_stop" => current_stop,
+            "elevator_entity" => elevator_entity,
         }
     }
 
@@ -379,6 +425,9 @@ impl ElevatorSim {
     }
 
     /// Get aggregate metrics as a Dictionary.
+    ///
+    /// Keys: `total_spawned`, `total_delivered`, `total_abandoned`,
+    /// `avg_wait_seconds`, `avg_ride_seconds`.
     #[func]
     fn get_metrics(&self) -> Dictionary<Variant, Variant> {
         let Some(sim) = self.sim.as_ref() else {
@@ -394,8 +443,36 @@ impl ElevatorSim {
         }
     }
 
+    /// Estimate time of arrival for an elevator at a stop.
+    ///
+    /// Returns estimated seconds as f64, or -1.0 if unavailable (e.g.
+    /// the stop is not in the elevator's queue, the elevator is in
+    /// manual/independent mode, or the indices are out of range).
+    #[func]
+    fn eta_to_stop(&self, elevator_index: i32, stop_index: i32) -> f64 {
+        let Some(sim) = self.sim.as_ref() else {
+            return -1.0;
+        };
+        let elev_ids = sim.world().elevator_ids();
+        let stop_ids = sim.world().stop_ids();
+        let Some(&elevator) = elev_ids.get(elevator_index as usize) else {
+            return -1.0;
+        };
+        let Some(&stop) = stop_ids.get(stop_index as usize) else {
+            return -1.0;
+        };
+        let typed_elev = elevator_core::entity::ElevatorId::from(elevator);
+        match sim.eta(typed_elev, stop) {
+            Ok(dur) => dur.as_secs_f64(),
+            Err(_) => -1.0,
+        }
+    }
+
     /// Drain all pending events as an Array of Dictionaries.
-    /// Each dict has: { kind, tick, rider, elevator, stop }.
+    ///
+    /// Each dict has at least: `kind` (String), `tick` (i64).
+    /// Additional keys depend on the event kind: `rider`, `elevator`,
+    /// `stop`, `destination`.
     #[func]
     fn drain_events(&mut self) -> Array<Dictionary<Variant, Variant>> {
         let Some(sim) = self.sim.as_mut() else {

--- a/examples/csharp-harness/Program.cs
+++ b/examples/csharp-harness/Program.cs
@@ -73,6 +73,8 @@ internal static class Native
         public uint occupancy;
         public double capacity_kg;
         public byte door_state;
+        public byte going_up;
+        public byte going_down;
     }
 
     // Matches crates/elevator-ffi/src/lib.rs::EvStopView.
@@ -170,7 +172,7 @@ internal static class Native
 internal static class Program
 {
     private const int TICKS = 600;
-    private const uint EXPECTED_ABI = 1;
+    private const uint EXPECTED_ABI = 2;
 
     private static int Main(string[] args)
     {

--- a/examples/godot-demo/scripts/elevator_view.gd
+++ b/examples/godot-demo/scripts/elevator_view.gd
@@ -1,13 +1,19 @@
 extends Node2D
-## Draws the elevator shaft, stops, car, and riders as procedural 2D shapes.
+## Draws the elevator shaft, stops, cars, and riders as procedural 2D shapes.
+## PPU is computed dynamically so any config (15-unit building or 1000-unit
+## space elevator) fits the viewport.
 
 const SHAFT_WIDTH := 60.0
 const CAR_WIDTH := 50.0
 const CAR_HEIGHT := 30.0
 const RIDER_SIZE := 8.0
-const PPU := 40.0  # pixels per sim unit
-const SHAFT_X := 512.0  # horizontal center of shaft
 
+## Vertical margin above/below the shaft, in pixels.
+const SHAFT_MARGIN_V := 40.0
+## Width reserved for the HUD panel on the left side.
+const HUD_PANEL_WIDTH := 320.0
+
+## Phase colors matching the Bevy demo.
 const COLOR_SHAFT := Color(0.2, 0.2, 0.25, 1.0)
 const COLOR_CAR := Color(0.2, 0.5, 0.9, 1.0)
 const COLOR_STOP := Color(0.5, 0.5, 0.5, 0.6)
@@ -16,11 +22,16 @@ const COLOR_BOARDING := Color(0.3, 0.9, 0.9, 1.0)
 const COLOR_RIDING := Color(0.9, 0.8, 0.2, 1.0)
 const COLOR_EXITING := Color(0.9, 0.4, 0.2, 1.0)
 
+## Computed each frame from viewport size and sim range.
+var shaft_x := 512.0
 var shaft_top_y := 0.0
 var shaft_bottom_y := 0.0
+var ppu := 40.0  # pixels per sim unit
+
 
 func _process(_delta: float) -> void:
 	queue_redraw()
+
 
 func _draw() -> void:
 	var sim: ElevatorSim = _get_sim()
@@ -42,13 +53,26 @@ func _draw() -> void:
 		min_pos = min(min_pos, p)
 		max_pos = max(max_pos, p)
 
-	var shaft_height: float = (max_pos - min_pos) * PPU
-	shaft_bottom_y = 650.0
-	shaft_top_y = shaft_bottom_y - shaft_height
+	# Dynamic PPU: fit the full stop range into the available vertical space.
+	var viewport_size := get_viewport_rect().size
+	var available_height: float = viewport_size.y - 2.0 * SHAFT_MARGIN_V
+	var sim_range: float = max_pos - min_pos
+	if sim_range > 0.0:
+		ppu = available_height / sim_range
+	else:
+		ppu = 40.0
+
+	# Center the shaft in the drawable area (viewport minus HUD panel).
+	var drawable_width: float = viewport_size.x - HUD_PANEL_WIDTH
+	shaft_x = HUD_PANEL_WIDTH + drawable_width / 2.0
+
+	shaft_bottom_y = viewport_size.y - SHAFT_MARGIN_V
+	shaft_top_y = shaft_bottom_y - sim_range * ppu
 
 	# Draw shaft background.
+	var shaft_height: float = sim_range * ppu
 	draw_rect(
-		Rect2(SHAFT_X - SHAFT_WIDTH / 2, shaft_top_y, SHAFT_WIDTH, shaft_height),
+		Rect2(shaft_x - SHAFT_WIDTH / 2, shaft_top_y, SHAFT_WIDTH, shaft_height),
 		COLOR_SHAFT
 	)
 
@@ -57,59 +81,117 @@ func _draw() -> void:
 		var pos_y := _sim_to_screen_y(s.get("position", 0.0), min_pos)
 		# Horizontal line.
 		draw_line(
-			Vector2(SHAFT_X - SHAFT_WIDTH / 2 - 10, pos_y),
-			Vector2(SHAFT_X + SHAFT_WIDTH / 2 + 10, pos_y),
+			Vector2(shaft_x - SHAFT_WIDTH / 2 - 10, pos_y),
+			Vector2(shaft_x + SHAFT_WIDTH / 2 + 10, pos_y),
 			COLOR_STOP, 2.0
 		)
 		# Stop name label.
 		var stop_name: String = s.get("name", "")
 		var waiting: int = s.get("waiting", 0)
 		var label := "%s (%d)" % [stop_name, waiting]
-		draw_string(ThemeDB.fallback_font, Vector2(SHAFT_X + SHAFT_WIDTH / 2 + 15, pos_y + 4), label, HORIZONTAL_ALIGNMENT_LEFT, -1, 12, Color.WHITE)
+		draw_string(
+			ThemeDB.fallback_font,
+			Vector2(shaft_x + SHAFT_WIDTH / 2 + 15, pos_y + 4),
+			label, HORIZONTAL_ALIGNMENT_LEFT, -1, 12, Color.WHITE
+		)
 
-	# Draw elevators.
+	# Build lookup: elevator entity_id -> screen Y position.
 	var elev_count := sim.elevator_count()
+	var elev_screen_y: Dictionary = {}
 	for i in range(elev_count):
 		var e: Dictionary = sim.get_elevator(i)
+		var eid: int = e.get("entity_id", 0)
 		var pos_y := _sim_to_screen_y(e.get("position", 0.0), min_pos)
+		elev_screen_y[eid] = pos_y
+		# Draw car.
 		draw_rect(
-			Rect2(SHAFT_X - CAR_WIDTH / 2, pos_y - CAR_HEIGHT / 2, CAR_WIDTH, CAR_HEIGHT),
+			Rect2(shaft_x - CAR_WIDTH / 2, pos_y - CAR_HEIGHT / 2, CAR_WIDTH, CAR_HEIGHT),
 			COLOR_CAR
 		)
 		# Occupancy label inside car.
 		var occ: int = e.get("occupancy", 0)
 		if occ > 0:
-			draw_string(ThemeDB.fallback_font, Vector2(SHAFT_X - 8, pos_y + 4), str(occ), HORIZONTAL_ALIGNMENT_CENTER, -1, 12, Color.WHITE)
+			draw_string(
+				ThemeDB.fallback_font,
+				Vector2(shaft_x - 8, pos_y + 4),
+				str(occ), HORIZONTAL_ALIGNMENT_CENTER, -1, 12, Color.WHITE
+			)
 
-	# Draw riders.
+	# Draw riders — all phases.
 	var rider_count := sim.rider_count()
-	var stop_waiting_count: Dictionary = {}  # stop entity_id -> int
+	var stop_waiting_offset: Dictionary = {}  # stop entity_id -> int
+	var elev_riding_offset: Dictionary = {}   # elevator entity_id -> int
 	for i in range(rider_count):
 		var r: Dictionary = sim.get_rider(i)
 		var phase: int = r.get("phase", -1)
-		# Only draw waiting riders (phase 0) at their stop.
-		if phase == 0:  # Waiting
-			var stop_eid: int = r.get("current_stop", 0)
+		var stop_eid: int = r.get("current_stop", 0)
+		var elev_eid: int = r.get("elevator_entity", 0)
+
+		if phase == 0:  # Waiting — positioned at stop, offset left
 			if stop_eid == 0:
 				continue
-			for s in stops:
-				if s.get("entity_id", 0) == stop_eid:
-					var pos_y := _sim_to_screen_y(s.get("position", 0.0), min_pos)
-					# Use per-stop counter to avoid overlapping riders.
-					var local_i: int = stop_waiting_count.get(stop_eid, 0)
-					stop_waiting_count[stop_eid] = local_i + 1
-					var row := local_i / 5
-					var col := local_i % 5
-					var offset_x := SHAFT_X - SHAFT_WIDTH / 2 - 20 - col * (RIDER_SIZE + 2)
-					var offset_y := row * (RIDER_SIZE + 2)
-					draw_rect(
-						Rect2(offset_x - RIDER_SIZE / 2, pos_y - RIDER_SIZE / 2 - offset_y, RIDER_SIZE, RIDER_SIZE),
-						COLOR_WAITING
-					)
-					break
+			var stop_y := _stop_screen_y(stops, stop_eid, min_pos)
+			if stop_y < 0.0:
+				continue
+			var local_i: int = stop_waiting_offset.get(stop_eid, 0)
+			stop_waiting_offset[stop_eid] = local_i + 1
+			var row := local_i / 5
+			var col := local_i % 5
+			var rx := shaft_x - SHAFT_WIDTH / 2 - 20 - col * (RIDER_SIZE + 2)
+			var ry := stop_y - RIDER_SIZE / 2 - row * (RIDER_SIZE + 2)
+			draw_rect(Rect2(rx - RIDER_SIZE / 2, ry, RIDER_SIZE, RIDER_SIZE), COLOR_WAITING)
+
+		elif phase == 1:  # Boarding — partially toward car
+			if elev_eid == 0:
+				continue
+			var car_y: float = elev_screen_y.get(elev_eid, -1.0)
+			if car_y < 0.0:
+				continue
+			# Position at the left edge of the car, offset outward.
+			var local_i: int = elev_riding_offset.get(elev_eid, 0)
+			elev_riding_offset[elev_eid] = local_i + 1
+			var rx := shaft_x - CAR_WIDTH / 2 - 6 - local_i * (RIDER_SIZE + 2)
+			var ry := car_y - RIDER_SIZE / 2
+			draw_rect(Rect2(rx - RIDER_SIZE / 2, ry, RIDER_SIZE, RIDER_SIZE), COLOR_BOARDING)
+
+		elif phase == 2:  # Riding — inside the car
+			if elev_eid == 0:
+				continue
+			var car_y: float = elev_screen_y.get(elev_eid, -1.0)
+			if car_y < 0.0:
+				continue
+			var local_i: int = elev_riding_offset.get(elev_eid, 0)
+			elev_riding_offset[elev_eid] = local_i + 1
+			var row := local_i / 4
+			var col := local_i % 4
+			var rx := shaft_x - CAR_WIDTH / 2 + 6 + col * (RIDER_SIZE + 2)
+			var ry := car_y - CAR_HEIGHT / 2 + 4 + row * (RIDER_SIZE + 2)
+			draw_rect(Rect2(rx, ry, RIDER_SIZE, RIDER_SIZE), COLOR_RIDING)
+
+		elif phase == 3:  # Exiting — partially away from car
+			if elev_eid == 0:
+				continue
+			var car_y: float = elev_screen_y.get(elev_eid, -1.0)
+			if car_y < 0.0:
+				continue
+			var local_i: int = elev_riding_offset.get(elev_eid, 0)
+			elev_riding_offset[elev_eid] = local_i + 1
+			var rx := shaft_x + CAR_WIDTH / 2 + 6 + local_i * (RIDER_SIZE + 2)
+			var ry := car_y - RIDER_SIZE / 2
+			draw_rect(Rect2(rx - RIDER_SIZE / 2, ry, RIDER_SIZE, RIDER_SIZE), COLOR_EXITING)
+
 
 func _sim_to_screen_y(sim_pos: float, min_pos: float) -> float:
-	return shaft_bottom_y - (sim_pos - min_pos) * PPU
+	return shaft_bottom_y - (sim_pos - min_pos) * ppu
+
+
+## Look up the screen Y for a stop by its entity_id. Returns -1.0 if not found.
+func _stop_screen_y(stops: Array[Dictionary], stop_eid: int, min_pos: float) -> float:
+	for s in stops:
+		if s.get("entity_id", 0) == stop_eid:
+			return _sim_to_screen_y(s.get("position", 0.0), min_pos)
+	return -1.0
+
 
 func _get_sim() -> ElevatorSim:
 	var parent := get_parent()

--- a/examples/godot-demo/scripts/hud.gd
+++ b/examples/godot-demo/scripts/hud.gd
@@ -1,5 +1,7 @@
 extends Label
 ## Updates the HUD stats label every frame.
+## Display order: tick/speed, per-elevator details, rider counts, averages.
+
 
 func _process(_delta: float) -> void:
 	var sim: ElevatorSim = _get_sim()
@@ -9,55 +11,81 @@ func _process(_delta: float) -> void:
 
 	var tick := sim.current_tick()
 	var speed := sim.speed_multiplier
-
 	var speed_label := "PAUSED" if speed == 0 else "%dx" % speed
 
-	# Elevator info.
-	var elev_lines := ""
+	# ── Tick and speed ──
+	var lines := "Tick: %d  Speed: %s\n" % [tick, speed_label]
+	lines += "---\n"
+
+	# ── Per-elevator info ──
 	var elev_count := sim.elevator_count()
+	var stop_count := sim.stop_count()
+	var total_on_board := 0
+
 	for i in range(elev_count):
 		var e: Dictionary = sim.get_elevator(i)
 		var phase: String = e.get("phase", "?")
 		var pos: float = e.get("position", 0.0)
 		var vel: float = e.get("velocity", 0.0)
 		var occ: int = e.get("occupancy", 0)
-		var cap: float = e.get("capacity_kg", 0.0)
+		var cap_kg: float = e.get("capacity_kg", 0.0)
 		var load_kg: float = e.get("current_load_kg", 0.0)
-		var load_pct := 0.0
-		if cap > 0:
-			load_pct = (load_kg / cap) * 100.0
-		elev_lines += "Car %d: %s  pos=%.1f  vel=%.2f\n" % [i, phase, pos, vel]
-		elev_lines += "  Load: %.0f/%.0f kg (%.0f%%)  Riders: %d\n" % [load_kg, cap, load_pct, occ]
+		var going_up: bool = e.get("going_up", false)
+		var going_down: bool = e.get("going_down", false)
 
-	# Rider counts.
+		total_on_board += occ
+
+		var load_pct := 0.0
+		if cap_kg > 0:
+			load_pct = (load_kg / cap_kg) * 100.0
+
+		# Direction indicators.
+		var dir_str := ""
+		if going_up:
+			dir_str += "↑"
+		if going_down:
+			dir_str += "↓"
+		if dir_str.is_empty():
+			dir_str = "-"
+
+		lines += "Car %d: %s %s  pos=%.1f  vel=%.2f\n" % [i, phase, dir_str, pos, vel]
+		lines += "  Load: %.0f/%.0f kg (%.0f%%)  Riders: %d\n" % [load_kg, cap_kg, load_pct, occ]
+
+		# ETA to each stop.
+		var eta_parts: PackedStringArray = []
+		for s_i in range(stop_count):
+			var eta_sec: float = sim.eta_to_stop(i, s_i)
+			if eta_sec >= 0.0:
+				var s: Dictionary = sim.get_stop(s_i)
+				var stop_name: String = s.get("name", "S%d" % s_i)
+				eta_parts.append("%s:%.0fs" % [stop_name, eta_sec])
+		if not eta_parts.is_empty():
+			lines += "  ETA: %s\n" % ", ".join(eta_parts)
+
+	lines += "---\n"
+
+	# ── Rider counts ──
 	var metrics: Dictionary = sim.get_metrics()
 	var spawned: int = metrics.get("total_spawned", 0)
 	var delivered: int = metrics.get("total_delivered", 0)
 	var abandoned: int = metrics.get("total_abandoned", 0)
-	var avg_wait: float = metrics.get("avg_wait_seconds", 0.0)
-	var avg_ride: float = metrics.get("avg_ride_seconds", 0.0)
 
-	# Count waiting riders across stops.
 	var total_waiting := 0
-	for i in range(sim.stop_count()):
+	for i in range(stop_count):
 		var s: Dictionary = sim.get_stop(i)
 		total_waiting += s.get("waiting", 0) as int
 
-	text = "Tick: %d  Speed: %s\n" % [tick, speed_label]
-	text += "---\n"
-	text += elev_lines
-	text += "---\n"
-	text += "Waiting: %d  On board: %d\n" % [total_waiting, _count_riding(sim)]
-	text += "Delivered: %d  Abandoned: %d\n" % [delivered, abandoned]
-	text += "Spawned: %d\n" % spawned
-	text += "Avg wait: %.1fs  Avg ride: %.1fs\n" % [avg_wait, avg_ride]
+	lines += "On board: %d  Waiting: %d\n" % [total_on_board, total_waiting]
+	lines += "Delivered: %d  Abandoned: %d\n" % [delivered, abandoned]
+	lines += "Spawned: %d\n" % spawned
 
-func _count_riding(sim: ElevatorSim) -> int:
-	var count := 0
-	for i in range(sim.elevator_count()):
-		var e: Dictionary = sim.get_elevator(i)
-		count += e.get("occupancy", 0) as int
-	return count
+	# ── Average wait/ride times ──
+	var avg_wait: float = metrics.get("avg_wait_seconds", 0.0)
+	var avg_ride: float = metrics.get("avg_ride_seconds", 0.0)
+	lines += "Avg wait: %.1fs  Avg ride: %.1fs\n" % [avg_wait, avg_ride]
+
+	text = lines
+
 
 func _get_sim() -> ElevatorSim:
 	# Walk up to Main and find the ElevatorSim child.

--- a/examples/unity-demo/Assets/Scripts/BuildingVisualizer.cs
+++ b/examples/unity-demo/Assets/Scripts/BuildingVisualizer.cs
@@ -1,22 +1,52 @@
-// Procedural 3D visualization of the elevator simulation.
-// Orthographic side-view with cubes for shaft, car, stops, and riders.
+/// <summary>
+/// Procedural 3D visualization of the elevator simulation.
+/// Orthographic side-view with cubes for shaft, car, stops, and riders.
+/// </summary>
 
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace ElevatorDemo
 {
+    /// <summary>
+    /// Renders the building shaft, stops, elevator cars, and riders as an
+    /// orthographic side-view using primitive cubes.
+    /// </summary>
     public class BuildingVisualizer : MonoBehaviour
     {
         public ElevatorSimManager simManager;
 
-        private const float PPU = 2f; // world-units per sim-unit
+        // --- Layout constants ---
+        private const float PPU = 2f;
         private const float ShaftWidth = 1f;
         private const float CarWidth = 0.8f;
         private const float CarHeight = 0.5f;
         private const float RiderSize = 0.15f;
+        private const float RiderSpacing = 0.05f;
+        private const int RidersPerColumn = 5;
+        private const float StopMarkerHeight = 0.05f;
+        private const float StopMarkerOverhang = 0.4f;
+        private const float LabelCharSize = 0.08f;
+        private const int LabelFontSize = 32;
+        private const float CameraMarginY = 2.5f;
+        private const float CameraHudOffsetX = 1.0f;
+        private const float BoardingLerp = 0.4f;
+        private const float ExitingLerp = 0.6f;
+        private const int InitialRiderPoolSize = 64;
+        private const int RiderPoolGrowth = 32;
+
+        // --- Colors (matching the Bevy demo) ---
+        private static readonly Color CarColor = new(0.2f, 0.5f, 0.9f);
+        private static readonly Color ShaftColor = new(0.2f, 0.2f, 0.25f);
+        private static readonly Color StopColor = new(0.5f, 0.5f, 0.5f, 0.6f);
+        private static readonly Color WaitingColor = new(0.2f, 0.8f, 0.3f);
+        private static readonly Color BoardingColor = new(0.3f, 0.9f, 0.9f);
+        private static readonly Color RidingColor = new(0.9f, 0.8f, 0.2f);
+        private static readonly Color ExitingColor = new(0.9f, 0.4f, 0.2f);
+        private static readonly Color BackgroundColor = new(0.1f, 0.1f, 0.12f);
 
         private GameObject _shaft;
-        private GameObject _car;
+        private GameObject[] _cars;
         private GameObject[] _stopMarkers;
         private TextMesh[] _stopLabels;
         private GameObject[] _riderPool;
@@ -25,10 +55,13 @@ namespace ElevatorDemo
         private float _maxPos;
         private bool _initialized;
 
-        private static readonly Color CarColor = new(0.2f, 0.5f, 0.9f);
-        private static readonly Color ShaftColor = new(0.2f, 0.2f, 0.25f);
-        private static readonly Color StopColor = new(0.5f, 0.5f, 0.5f, 0.6f);
-        private static readonly Color WaitingColor = new(0.2f, 0.8f, 0.3f);
+        // Lookup tables rebuilt each frame for fast stop/elevator position queries.
+        private readonly Dictionary<ulong, float> _stopPositions = new();
+        private readonly Dictionary<ulong, float> _elevatorPositions = new();
+        private readonly Dictionary<ulong, int> _waitingCounts = new();
+        private readonly Dictionary<ulong, int> _boardingCounts = new();
+        private readonly Dictionary<ulong, int> _ridingCounts = new();
+        private readonly Dictionary<ulong, int> _exitingCounts = new();
 
         private void LateUpdate()
         {
@@ -41,15 +74,15 @@ namespace ElevatorDemo
             if (!_initialized)
                 Initialize(sim);
 
-            UpdateCar(sim);
+            UpdateCars(sim);
             UpdateRiders(sim);
         }
 
+        /// <summary>Creates all static geometry (shaft, stops, labels) and configures the camera.</summary>
         private void Initialize(ElevatorSimulation sim)
         {
             _initialized = true;
 
-            // Compute shaft bounds.
             _minPos = float.MaxValue;
             _maxPos = float.MinValue;
             foreach (var s in sim.Stops)
@@ -62,13 +95,10 @@ namespace ElevatorDemo
             float shaftCenterY = shaftHeight / 2f;
 
             // Shaft background.
-            _shaft = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            _shaft.name = "Shaft";
-            _shaft.transform.SetParent(transform);
-            _shaft.transform.localScale = new Vector3(ShaftWidth, shaftHeight, 0.1f);
-            _shaft.transform.localPosition = new Vector3(0, shaftCenterY, 0);
-            _shaft.GetComponent<Renderer>().material.color = ShaftColor;
-            Destroy(_shaft.GetComponent<Collider>());
+            _shaft = CreateCube("Shaft",
+                new Vector3(ShaftWidth, shaftHeight, 0.1f),
+                new Vector3(0, shaftCenterY, 0),
+                ShaftColor);
 
             // Stops.
             _stopMarkers = new GameObject[sim.Stops.Length];
@@ -77,134 +107,136 @@ namespace ElevatorDemo
             {
                 float y = SimToWorldY(sim.Stops[i].position);
 
-                var marker = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                marker.name = $"Stop_{i}";
-                marker.transform.SetParent(transform);
-                marker.transform.localScale = new Vector3(ShaftWidth + 0.4f, 0.05f, 0.1f);
-                marker.transform.localPosition = new Vector3(0, y, 0);
-                marker.GetComponent<Renderer>().material.color = StopColor;
-                Destroy(marker.GetComponent<Collider>());
-                _stopMarkers[i] = marker;
+                _stopMarkers[i] = CreateCube($"Stop_{i}",
+                    new Vector3(ShaftWidth + StopMarkerOverhang, StopMarkerHeight, 0.1f),
+                    new Vector3(0, y, 0),
+                    StopColor);
 
-                // Stop name label.
                 var labelObj = new GameObject($"StopLabel_{i}");
                 labelObj.transform.SetParent(transform);
                 labelObj.transform.localPosition = new Vector3(ShaftWidth / 2 + 0.5f, y, 0);
                 var tm = labelObj.AddComponent<TextMesh>();
-                string stopName = GetStopName(sim.Stops[i]);
-                tm.text = stopName;
-                tm.fontSize = 32;
-                tm.characterSize = 0.08f;
+                tm.text = GetStopName(sim.Stops[i]);
+                tm.fontSize = LabelFontSize;
+                tm.characterSize = LabelCharSize;
                 tm.color = Color.white;
                 tm.anchor = TextAnchor.MiddleLeft;
                 _stopLabels[i] = tm;
             }
 
-            // Car.
-            _car = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            _car.name = "Car";
-            _car.transform.SetParent(transform);
-            _car.transform.localScale = new Vector3(CarWidth, CarHeight, 0.15f);
-            _car.GetComponent<Renderer>().material.color = CarColor;
-            Destroy(_car.GetComponent<Collider>());
+            // Cars (one per elevator).
+            int carCount = Mathf.Max(1, sim.Elevators.Length);
+            _cars = new GameObject[carCount];
+            for (int i = 0; i < carCount; i++)
+            {
+                _cars[i] = CreateCube($"Car_{i}",
+                    new Vector3(CarWidth, CarHeight, 0.15f),
+                    Vector3.zero,
+                    CarColor);
+            }
 
             // Rider pool.
-            _riderPoolSize = 64;
+            _riderPoolSize = InitialRiderPoolSize;
             _riderPool = new GameObject[_riderPoolSize];
             for (int i = 0; i < _riderPoolSize; i++)
             {
-                var rider = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                rider.name = $"Rider_{i}";
-                rider.transform.SetParent(transform);
-                rider.transform.localScale = new Vector3(RiderSize, RiderSize, RiderSize);
-                rider.GetComponent<Renderer>().material.color = WaitingColor;
-                Destroy(rider.GetComponent<Collider>());
-                rider.SetActive(false);
-                _riderPool[i] = rider;
+                _riderPool[i] = CreateRiderCube(i);
             }
 
-            // Set up orthographic camera.
+            // Orthographic camera — account for labels, HUD, and margin.
             var cam = Camera.main;
             if (cam != null)
             {
                 cam.orthographic = true;
-                cam.orthographicSize = shaftHeight / 2f + 1f;
-                cam.transform.position = new Vector3(0, shaftCenterY, -10);
-                cam.transform.LookAt(new Vector3(0, shaftCenterY, 0));
-                cam.backgroundColor = new Color(0.1f, 0.1f, 0.12f);
+                cam.orthographicSize = shaftHeight / 2f + CameraMarginY;
+                cam.transform.position = new Vector3(CameraHudOffsetX, shaftCenterY, -10);
+                cam.transform.LookAt(new Vector3(CameraHudOffsetX, shaftCenterY, 0));
+                cam.backgroundColor = BackgroundColor;
             }
         }
 
-        private void UpdateCar(ElevatorSimulation sim)
+        /// <summary>Updates car positions from the current elevator views.</summary>
+        private void UpdateCars(ElevatorSimulation sim)
         {
-            if (sim.Elevators.Length == 0 || _car == null) return;
-
-            float y = SimToWorldY(sim.Elevators[0].position);
-            _car.transform.localPosition = new Vector3(0, y, -0.05f);
+            for (int i = 0; i < sim.Elevators.Length && i < _cars.Length; i++)
+            {
+                float y = SimToWorldY(sim.Elevators[i].position);
+                _cars[i].transform.localPosition = new Vector3(0, y, -0.05f);
+            }
         }
 
+        /// <summary>
+        /// Renders all active riders (Waiting, Boarding, Riding, Exiting) with
+        /// phase-specific colors and positions.
+        /// </summary>
         private void UpdateRiders(ElevatorSimulation sim)
         {
-            // Ensure pool is large enough.
-            if (sim.Riders.Length > _riderPoolSize)
-            {
-                int newSize = sim.Riders.Length + 32;
-                var newPool = new GameObject[newSize];
-                System.Array.Copy(_riderPool, newPool, _riderPoolSize);
-                for (int i = _riderPoolSize; i < newSize; i++)
-                {
-                    var rider = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                    rider.name = $"Rider_{i}";
-                    rider.transform.SetParent(transform);
-                    rider.transform.localScale = new Vector3(RiderSize, RiderSize, RiderSize);
-                    rider.GetComponent<Renderer>().material.color = WaitingColor;
-                    Destroy(rider.GetComponent<Collider>());
-                    rider.SetActive(false);
-                    newPool[i] = rider;
-                }
-                _riderPool = newPool;
-                _riderPoolSize = newSize;
-            }
+            EnsurePoolCapacity(sim.Riders.Length);
+            RebuildLookupTables(sim);
 
-            // Per-stop counter for offset.
-            var stopCounts = new System.Collections.Generic.Dictionary<ulong, int>();
+            // Reset per-stop/elevator counters for layout offsets.
+            _waitingCounts.Clear();
+            _boardingCounts.Clear();
+            _ridingCounts.Clear();
+            _exitingCounts.Clear();
+
             int activeCount = 0;
 
             for (int i = 0; i < sim.Riders.Length; i++)
             {
                 var r = sim.Riders[i];
-                // Only show waiting riders (phase 0).
-                if (r.phase != 0)
-                    continue;
+
+                Vector3 pos;
+                Color color;
+
+                switch (r.phase)
+                {
+                    case RiderPhase.Waiting:
+                    {
+                        float stopY = LookupStopY(r.origin_stop_id);
+                        int idx = IncrementCount(_waitingCounts, r.origin_stop_id);
+                        pos = WaitingPosition(stopY, idx);
+                        color = WaitingColor;
+                        break;
+                    }
+                    case RiderPhase.Boarding:
+                    {
+                        float stopY = LookupStopY(r.origin_stop_id);
+                        float carY = LookupElevatorY(r.elevator_id);
+                        int idx = IncrementCount(_boardingCounts, r.elevator_id);
+                        float lerpY = Mathf.Lerp(stopY, carY, BoardingLerp);
+                        pos = RidingPosition(lerpY, idx);
+                        color = BoardingColor;
+                        break;
+                    }
+                    case RiderPhase.Riding:
+                    {
+                        float carY = LookupElevatorY(r.elevator_id);
+                        int idx = IncrementCount(_ridingCounts, r.elevator_id);
+                        pos = RidingPosition(carY, idx);
+                        color = RidingColor;
+                        break;
+                    }
+                    case RiderPhase.Exiting:
+                    {
+                        float destY = LookupStopY(r.destination_stop_id);
+                        float carY = LookupElevatorY(r.elevator_id);
+                        int idx = IncrementCount(_exitingCounts, r.elevator_id);
+                        float lerpY = Mathf.Lerp(carY, destY, ExitingLerp);
+                        pos = ExitingPosition(lerpY, idx);
+                        color = ExitingColor;
+                        break;
+                    }
+                    default:
+                        continue; // Skip Arrived, Abandoned, Resident, Walking
+                }
 
                 if (activeCount >= _riderPoolSize) break;
 
                 var go = _riderPool[activeCount];
                 go.SetActive(true);
-
-                // Find stop position.
-                float stopY = 0;
-                foreach (var s in sim.Stops)
-                {
-                    if (s.entity_id == r.origin_stop_id)
-                    {
-                        stopY = SimToWorldY(s.position);
-                        break;
-                    }
-                }
-
-                // Per-stop offset.
-                if (!stopCounts.TryGetValue(r.origin_stop_id, out int localIdx))
-                    localIdx = 0;
-                stopCounts[r.origin_stop_id] = localIdx + 1;
-
-                int col = localIdx % 5;
-                int row = localIdx / 5;
-                float xOffset = -(ShaftWidth / 2 + 0.3f) - col * (RiderSize + 0.05f);
-                float yOffset = row * (RiderSize + 0.05f);
-                go.transform.localPosition = new Vector3(xOffset, stopY + yOffset, -0.05f);
-                go.GetComponent<Renderer>().material.color = WaitingColor;
-
+                go.transform.localPosition = pos;
+                go.GetComponent<Renderer>().material.color = color;
                 activeCount++;
             }
 
@@ -214,6 +246,114 @@ namespace ElevatorDemo
                 if (_riderPool[i].activeSelf)
                     _riderPool[i].SetActive(false);
             }
+        }
+
+        // --- Position helpers ---
+
+        /// <summary>Positions a waiting rider to the left of the shaft at the given stop.</summary>
+        private static Vector3 WaitingPosition(float stopY, int index)
+        {
+            int col = index % RidersPerColumn;
+            int row = index / RidersPerColumn;
+            float xOffset = -(ShaftWidth / 2 + 0.3f) - col * (RiderSize + RiderSpacing);
+            float yOffset = row * (RiderSize + RiderSpacing);
+            return new Vector3(xOffset, stopY + yOffset, -0.05f);
+        }
+
+        /// <summary>Positions a riding/boarding rider inside the car in columns.</summary>
+        private static Vector3 RidingPosition(float carY, int index)
+        {
+            int col = index % 3;
+            int row = index / 3;
+            float xOffset = -0.2f + col * (RiderSize + RiderSpacing);
+            float yOffset = -CarHeight / 2 + RiderSize / 2 + row * (RiderSize + RiderSpacing);
+            return new Vector3(xOffset, carY + yOffset, -0.1f);
+        }
+
+        /// <summary>Positions an exiting rider to the right of the shaft.</summary>
+        private static Vector3 ExitingPosition(float y, int index)
+        {
+            int col = index % RidersPerColumn;
+            int row = index / RidersPerColumn;
+            float xOffset = ShaftWidth / 2 + 0.3f + col * (RiderSize + RiderSpacing);
+            float yOffset = row * (RiderSize + RiderSpacing);
+            return new Vector3(xOffset, y + yOffset, -0.05f);
+        }
+
+        // --- Lookup table helpers ---
+
+        /// <summary>Rebuilds stop and elevator position lookup tables from the current frame.</summary>
+        private void RebuildLookupTables(ElevatorSimulation sim)
+        {
+            _stopPositions.Clear();
+            foreach (var s in sim.Stops)
+                _stopPositions[s.entity_id] = SimToWorldY(s.position);
+
+            _elevatorPositions.Clear();
+            foreach (var e in sim.Elevators)
+                _elevatorPositions[e.entity_id] = SimToWorldY(e.position);
+        }
+
+        private float LookupStopY(ulong stopId)
+        {
+            return _stopPositions.TryGetValue(stopId, out float y) ? y : 0f;
+        }
+
+        private float LookupElevatorY(ulong elevatorId)
+        {
+            return _elevatorPositions.TryGetValue(elevatorId, out float y) ? y : 0f;
+        }
+
+        private static int IncrementCount(Dictionary<ulong, int> counts, ulong key)
+        {
+            if (!counts.TryGetValue(key, out int idx))
+                idx = 0;
+            counts[key] = idx + 1;
+            return idx;
+        }
+
+        // --- Pool management ---
+
+        /// <summary>Grows the rider object pool if needed.</summary>
+        private void EnsurePoolCapacity(int needed)
+        {
+            if (needed <= _riderPoolSize) return;
+
+            int newSize = needed + RiderPoolGrowth;
+            var newPool = new GameObject[newSize];
+            System.Array.Copy(_riderPool, newPool, _riderPoolSize);
+            for (int i = _riderPoolSize; i < newSize; i++)
+            {
+                newPool[i] = CreateRiderCube(i);
+            }
+            _riderPool = newPool;
+            _riderPoolSize = newSize;
+        }
+
+        // --- Factory helpers ---
+
+        private GameObject CreateCube(string name, Vector3 scale, Vector3 position, Color color)
+        {
+            var obj = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            obj.name = name;
+            obj.transform.SetParent(transform);
+            obj.transform.localScale = scale;
+            obj.transform.localPosition = position;
+            obj.GetComponent<Renderer>().material.color = color;
+            Destroy(obj.GetComponent<Collider>());
+            return obj;
+        }
+
+        private GameObject CreateRiderCube(int index)
+        {
+            var rider = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            rider.name = $"Rider_{index}";
+            rider.transform.SetParent(transform);
+            rider.transform.localScale = new Vector3(RiderSize, RiderSize, RiderSize);
+            rider.GetComponent<Renderer>().material.color = WaitingColor;
+            Destroy(rider.GetComponent<Collider>());
+            rider.SetActive(false);
+            return rider;
         }
 
         private float SimToWorldY(double simPos)

--- a/examples/unity-demo/Assets/Scripts/ElevatorHUD.cs
+++ b/examples/unity-demo/Assets/Scripts/ElevatorHUD.cs
@@ -1,74 +1,106 @@
-// OnGUI-based HUD for the elevator demo.
-// Shows stats, metrics, and speed controls.
+/// <summary>
+/// OnGUI-based HUD for the elevator demo.
+/// Shows elevator stats, rider metrics, direction indicators, and speed controls.
+/// </summary>
 
 using UnityEngine;
 
 namespace ElevatorDemo
 {
+    /// <summary>
+    /// Renders an IMGUI overlay with simulation status, per-elevator details,
+    /// aggregate rider metrics, event counters, and playback controls.
+    /// </summary>
     public class ElevatorHUD : MonoBehaviour
     {
         public ElevatorSimManager simManager;
 
+        // --- Layout constants ---
+        private const float PanelX = 10f;
+        private const float PanelWidth = 320f;
+        private const float LineHeight = 20f;
+        private const float ButtonWidth = 55f;
+        private const float ButtonHeight = 25f;
+        private const float ButtonGap = 5f;
+        private const int LabelFontSize = 14;
+        private const int ButtonFontSize = 13;
+        private const int HelpFontSize = 11;
+        private const float AssumedRiderWeightKg = 75f;
+
+        private static readonly Color HelpTextColor = new(0.6f, 0.6f, 0.6f);
+
         private GUIStyle _labelStyle;
         private GUIStyle _buttonStyle;
+        private GUIStyle _helpStyle;
 
         private void OnGUI()
         {
             if (simManager == null || simManager.Sim == null || !simManager.Sim.IsValid)
             {
-                GUI.Label(new Rect(10, 10, 300, 30), "No simulation loaded");
+                GUI.Label(new Rect(PanelX, PanelX, PanelWidth, LineHeight), "No simulation loaded");
                 return;
             }
 
-            if (_labelStyle == null)
-            {
-                _labelStyle = new GUIStyle(GUI.skin.label)
-                {
-                    fontSize = 14,
-                    normal = { textColor = Color.white }
-                };
-                _buttonStyle = new GUIStyle(GUI.skin.button) { fontSize = 13 };
-            }
+            EnsureStyles();
 
             var sim = simManager.Sim;
             var m = sim.Metrics;
 
-            float y = 10;
-            float x = 10;
-            float w = 320;
-            float lineH = 20;
+            float y = PanelX;
 
-            // Background panel.
-            GUI.Box(new Rect(x - 5, y - 5, w + 10, 340), "");
+            // Count lines needed for dynamic panel height.
+            int elevatorLines = sim.Elevators.Length * 3; // 3 lines per elevator
+            float panelHeight = LineHeight * (9 + elevatorLines) + ButtonHeight + LineHeight + 30f;
+            GUI.Box(new Rect(PanelX - 5, y - 5, PanelWidth + 10, panelHeight), "");
 
+            // --- Tick and speed ---
             string speedLabel = simManager.speedMultiplier == 0 ? "PAUSED" : $"{simManager.speedMultiplier}x";
-            GUI.Label(new Rect(x, y, w, lineH), $"Tick: {m.current_tick}  Speed: {speedLabel}", _labelStyle);
-            y += lineH;
+            GUI.Label(new Rect(PanelX, y, PanelWidth, LineHeight),
+                $"Tick: {m.current_tick}  Speed: {speedLabel}", _labelStyle);
+            y += LineHeight;
 
-            GUI.Label(new Rect(x, y, w, lineH), "---", _labelStyle);
-            y += lineH;
+            DrawSeparator(ref y);
 
-            // Elevator info.
+            // --- Per-elevator info ---
             for (int i = 0; i < sim.Elevators.Length; i++)
             {
                 var e = sim.Elevators[i];
                 string phase = ElevatorPhaseName(e.phase);
-                GUI.Label(new Rect(x, y, w, lineH),
-                    $"Car {i}: {phase}  pos={e.position:F1}  vel={e.velocity:F2}", _labelStyle);
-                y += lineH;
+                string direction = FormatDirection(e.going_up, e.going_down);
+
+                GUI.Label(new Rect(PanelX, y, PanelWidth, LineHeight),
+                    $"Car {i}: {phase} {direction}  pos={e.position:F1}  vel={e.velocity:F2}",
+                    _labelStyle);
+                y += LineHeight;
 
                 float loadPct = e.capacity_kg > 0
-                    ? Mathf.Clamp01((float)(e.occupancy * 75.0 / e.capacity_kg)) * 100f
+                    ? Mathf.Clamp01((float)(e.occupancy * AssumedRiderWeightKg / e.capacity_kg)) * 100f
                     : 0f;
-                GUI.Label(new Rect(x, y, w, lineH),
-                    $"  Capacity: {e.capacity_kg:F0} kg  Riders: {e.occupancy}  Load: {loadPct:F0}%", _labelStyle);
-                y += lineH;
+                GUI.Label(new Rect(PanelX, y, PanelWidth, LineHeight),
+                    $"  Load: {loadPct:F0}%  Riders: {e.occupancy}  Cap: {e.capacity_kg:F0} kg",
+                    _labelStyle);
+                y += LineHeight;
+
+                // ETA for the target stop (if moving).
+                if (e.target_stop_id != 0)
+                {
+                    sbyte dir = e.going_up != 0 ? (sbyte)1 : (e.going_down != 0 ? (sbyte)-1 : (sbyte)0);
+                    double eta = sim.BestEta(e.target_stop_id, dir);
+                    string etaStr = eta >= 0 ? $"{eta:F1}s" : "--";
+                    GUI.Label(new Rect(PanelX, y, PanelWidth, LineHeight),
+                        $"  Target ETA: {etaStr}", _labelStyle);
+                }
+                else
+                {
+                    GUI.Label(new Rect(PanelX, y, PanelWidth, LineHeight),
+                        "  No target", _labelStyle);
+                }
+                y += LineHeight;
             }
 
-            GUI.Label(new Rect(x, y, w, lineH), "---", _labelStyle);
-            y += lineH;
+            DrawSeparator(ref y);
 
-            // Rider counts.
+            // --- Rider counts ---
             int totalWaiting = 0;
             foreach (var s in sim.Stops)
                 totalWaiting += (int)s.waiting;
@@ -77,52 +109,93 @@ namespace ElevatorDemo
             foreach (var e in sim.Elevators)
                 totalOnBoard += (int)e.occupancy;
 
-            GUI.Label(new Rect(x, y, w, lineH),
+            GUI.Label(new Rect(PanelX, y, PanelWidth, LineHeight),
                 $"Waiting: {totalWaiting}  On board: {totalOnBoard}", _labelStyle);
-            y += lineH;
+            y += LineHeight;
 
-            GUI.Label(new Rect(x, y, w, lineH),
+            GUI.Label(new Rect(PanelX, y, PanelWidth, LineHeight),
                 $"Delivered: {m.total_delivered}  Abandoned: {m.total_abandoned}", _labelStyle);
-            y += lineH;
+            y += LineHeight;
 
-            GUI.Label(new Rect(x, y, w, lineH),
-                $"Avg wait: {m.avg_wait_seconds:F1}s  Avg ride: {m.avg_ride_seconds:F1}s", _labelStyle);
-            y += lineH;
+            // --- Average times ---
+            GUI.Label(new Rect(PanelX, y, PanelWidth, LineHeight),
+                $"Avg wait: {m.avg_wait_seconds:F1}s  Avg ride: {m.avg_ride_seconds:F1}s",
+                _labelStyle);
+            y += LineHeight;
 
-            GUI.Label(new Rect(x, y, w, lineH),
-                $"Events — Spawned: {simManager.EventsSpawned}  Boarded: {simManager.EventsBoarded}", _labelStyle);
-            y += lineH;
+            // --- Event counters ---
+            GUI.Label(new Rect(PanelX, y, PanelWidth, LineHeight),
+                $"Events \u2014 Spawned: {simManager.EventsSpawned}  Boarded: {simManager.EventsBoarded}",
+                _labelStyle);
+            y += LineHeight;
 
-            GUI.Label(new Rect(x, y, w, lineH),
-                $"  Exited: {simManager.EventsExited}  Abandoned: {simManager.EventsAbandoned}", _labelStyle);
-            y += lineH * 1.5f;
+            GUI.Label(new Rect(PanelX, y, PanelWidth, LineHeight),
+                $"  Exited: {simManager.EventsExited}  Abandoned: {simManager.EventsAbandoned}",
+                _labelStyle);
+            y += LineHeight * 1.5f;
 
-            // Controls.
-            float btnW = 55;
-            float btnH = 25;
-            if (GUI.Button(new Rect(x, y, btnW, btnH), "Pause", _buttonStyle))
-                simManager.speedMultiplier = simManager.speedMultiplier == 0 ? 1 : 0;
-            if (GUI.Button(new Rect(x + btnW + 5, y, btnW, btnH), "1x", _buttonStyle))
-                simManager.speedMultiplier = 1;
-            if (GUI.Button(new Rect(x + (btnW + 5) * 2, y, btnW, btnH), "2x", _buttonStyle))
-                simManager.speedMultiplier = 2;
-            if (GUI.Button(new Rect(x + (btnW + 5) * 3, y, btnW, btnH), "10x", _buttonStyle))
-                simManager.speedMultiplier = 10;
-            if (GUI.Button(new Rect(x + (btnW + 5) * 4, y, btnW, btnH), "Spawn", _buttonStyle))
-                simManager.SpawnRandomRider();
+            // --- Controls ---
+            DrawControls(ref y);
 
-            y += btnH + 10;
-
-            // Help text.
-            var helpStyle = new GUIStyle(_labelStyle)
-            {
-                fontSize = 11,
-                normal = { textColor = new Color(0.6f, 0.6f, 0.6f) }
-            };
-            GUI.Label(new Rect(x, y, w, lineH),
-                "Space: pause | 1: 1x | 2: 2x | 3: 10x", helpStyle);
+            // --- Help ---
+            y += ButtonHeight + 10;
+            GUI.Label(new Rect(PanelX, y, PanelWidth, LineHeight),
+                "Space: pause | 1: 1x | 2: 2x | 3: 10x", _helpStyle);
         }
 
+        /// <summary>Formats the direction indicator lamps as arrow characters.</summary>
+        private static string FormatDirection(byte goingUp, byte goingDown)
+        {
+            if (goingUp != 0 && goingDown != 0) return "\u2195"; // ↕
+            if (goingUp != 0) return "\u2191"; // ↑
+            if (goingDown != 0) return "\u2193"; // ↓
+            return "\u2022"; // bullet (idle)
+        }
+
+        /// <summary>Draws speed control and spawn buttons.</summary>
+        private void DrawControls(ref float y)
+        {
+            if (GUI.Button(new Rect(PanelX, y, ButtonWidth, ButtonHeight), "Pause", _buttonStyle))
+                simManager.speedMultiplier = simManager.speedMultiplier == 0 ? 1 : 0;
+            if (GUI.Button(new Rect(PanelX + (ButtonWidth + ButtonGap), y, ButtonWidth, ButtonHeight),
+                "1x", _buttonStyle))
+                simManager.speedMultiplier = 1;
+            if (GUI.Button(new Rect(PanelX + (ButtonWidth + ButtonGap) * 2, y, ButtonWidth, ButtonHeight),
+                "2x", _buttonStyle))
+                simManager.speedMultiplier = 2;
+            if (GUI.Button(new Rect(PanelX + (ButtonWidth + ButtonGap) * 3, y, ButtonWidth, ButtonHeight),
+                "10x", _buttonStyle))
+                simManager.speedMultiplier = 10;
+            if (GUI.Button(new Rect(PanelX + (ButtonWidth + ButtonGap) * 4, y, ButtonWidth, ButtonHeight),
+                "Spawn", _buttonStyle))
+                simManager.SpawnRandomRider();
+        }
+
+        private void DrawSeparator(ref float y)
+        {
+            GUI.Label(new Rect(PanelX, y, PanelWidth, LineHeight), "---", _labelStyle);
+            y += LineHeight;
+        }
+
+        /// <summary>Lazily initializes GUI styles on first use.</summary>
+        private void EnsureStyles()
+        {
+            if (_labelStyle != null) return;
+
+            _labelStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = LabelFontSize,
+                normal = { textColor = Color.white }
+            };
+            _buttonStyle = new GUIStyle(GUI.skin.button) { fontSize = ButtonFontSize };
+            _helpStyle = new GUIStyle(_labelStyle)
+            {
+                fontSize = HelpFontSize,
+                normal = { textColor = HelpTextColor }
+            };
+        }
+
+        /// <summary>Returns a human-readable name for the elevator phase byte.</summary>
         private static string ElevatorPhaseName(byte phase) => phase switch
         {
             0 => "Idle",

--- a/examples/unity-demo/Assets/Scripts/ElevatorNative.cs
+++ b/examples/unity-demo/Assets/Scripts/ElevatorNative.cs
@@ -1,11 +1,14 @@
-// P/Invoke bindings for the elevator-ffi native library.
-// Struct layouts match crates/elevator-ffi/src/lib.rs exactly.
+/// <summary>
+/// P/Invoke bindings for the elevator-ffi native library.
+/// Struct layouts match crates/elevator-ffi/src/lib.rs exactly.
+/// </summary>
 
 using System;
 using System.Runtime.InteropServices;
 
 namespace ElevatorDemo
 {
+    /// <summary>Status code returned by every FFI entrypoint.</summary>
     public enum EvStatus : int
     {
         Ok = 0,
@@ -19,6 +22,7 @@ namespace ElevatorDemo
         Panic = 99,
     }
 
+    /// <summary>Built-in dispatch strategy identifier.</summary>
     public enum EvStrategy : int
     {
         Scan = 0,
@@ -27,6 +31,7 @@ namespace ElevatorDemo
         Etd = 3,
     }
 
+    /// <summary>Aggregate metrics at the current tick.</summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct EvMetricsView
     {
@@ -37,6 +42,7 @@ namespace ElevatorDemo
         public ulong current_tick;
     }
 
+    /// <summary>Borrowed per-tick snapshot with slice pointers valid until the next frame call.</summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct EvFrame
     {
@@ -49,6 +55,7 @@ namespace ElevatorDemo
         public EvMetricsView metrics;
     }
 
+    /// <summary>View of a single elevator at the current tick.</summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct EvElevatorView
     {
@@ -63,8 +70,11 @@ namespace ElevatorDemo
         public uint occupancy;
         public double capacity_kg;
         public byte door_state;
+        public byte going_up;
+        public byte going_down;
     }
 
+    /// <summary>View of a single stop at the current tick.</summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct EvStopView
     {
@@ -78,6 +88,7 @@ namespace ElevatorDemo
         public UIntPtr name_len;
     }
 
+    /// <summary>View of a single rider at the current tick.</summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct EvRiderView
     {
@@ -88,7 +99,7 @@ namespace ElevatorDemo
         public ulong elevator_id;
     }
 
-    // Explicit layout for correct padding (bytes 2..8 are padding).
+    /// <summary>C-ABI-flat projection of simulation events.</summary>
     [StructLayout(LayoutKind.Explicit, Size = 48)]
     public struct EvEvent
     {
@@ -101,6 +112,7 @@ namespace ElevatorDemo
         [FieldOffset(40)] public ulong floor;
     }
 
+    /// <summary>Event kind discriminator constants.</summary>
     public static class EvEventKind
     {
         public const byte HallButtonPressed = 1;
@@ -114,6 +126,20 @@ namespace ElevatorDemo
         public const byte RiderAbandoned = 9;
     }
 
+    /// <summary>Rider phase constants matching the FFI EvRiderView.phase field.</summary>
+    public static class RiderPhase
+    {
+        public const byte Waiting = 0;
+        public const byte Boarding = 1;
+        public const byte Riding = 2;
+        public const byte Exiting = 3;
+        public const byte Walking = 4;
+        public const byte Arrived = 5;
+        public const byte Abandoned = 6;
+        public const byte Resident = 7;
+    }
+
+    /// <summary>Static P/Invoke declarations for the elevator_ffi native library.</summary>
     public static class ElevatorNative
     {
         private const string Lib = "elevator_ffi";
@@ -127,6 +153,10 @@ namespace ElevatorDemo
         [DllImport(Lib)] public static extern EvStatus ev_sim_step(IntPtr handle);
         [DllImport(Lib)]
         public static extern EvStatus ev_sim_frame(IntPtr handle, out EvFrame outFrame);
+        [DllImport(Lib)]
+        public static extern EvStatus ev_sim_best_eta(
+            IntPtr handle, ulong stopEntityId, sbyte direction,
+            out ulong outElevator, out double outSeconds);
         [DllImport(Lib)]
         public static extern EvStatus ev_sim_set_strategy(
             IntPtr handle, uint groupId, EvStrategy strategy);
@@ -142,6 +172,7 @@ namespace ElevatorDemo
         [DllImport(Lib)]
         public static extern uint ev_sim_pending_event_count(IntPtr handle);
 
+        /// <summary>Returns the last FFI error as a managed string.</summary>
         public static string LastError()
         {
             var ptr = ev_last_error();

--- a/examples/unity-demo/Assets/Scripts/ElevatorSimManager.cs
+++ b/examples/unity-demo/Assets/Scripts/ElevatorSimManager.cs
@@ -1,10 +1,16 @@
-// Main simulation manager MonoBehaviour.
-// Steps the sim, auto-spawns riders, and exposes frame data to other scripts.
+/// <summary>
+/// Main simulation manager MonoBehaviour.
+/// Steps the sim, auto-spawns riders, and exposes frame data to other scripts.
+/// </summary>
 
 using UnityEngine;
 
 namespace ElevatorDemo
 {
+    /// <summary>
+    /// Drives the simulation loop: steps the sim each frame, auto-spawns riders
+    /// on a random interval, drains events, and handles keyboard shortcuts.
+    /// </summary>
     public class ElevatorSimManager : MonoBehaviour
     {
         [Header("Configuration")]
@@ -21,12 +27,19 @@ namespace ElevatorDemo
         public float weightMin = 50f;
         public float weightMax = 100f;
 
+        /// <summary>The managed simulation handle. Null until Awake completes.</summary>
         public ElevatorSimulation Sim { get; private set; }
 
-        // Event counters for the HUD.
+        /// <summary>Cumulative count of RiderSpawned events.</summary>
         public int EventsSpawned { get; private set; }
+
+        /// <summary>Cumulative count of RiderBoarded events.</summary>
         public int EventsBoarded { get; private set; }
+
+        /// <summary>Cumulative count of RiderExited events.</summary>
         public int EventsExited { get; private set; }
+
+        /// <summary>Cumulative count of RiderAbandoned events.</summary>
         public int EventsAbandoned { get; private set; }
 
         private int _ticksUntilSpawn;
@@ -45,18 +58,14 @@ namespace ElevatorDemo
 
             int steps = Mathf.Max(0, speedMultiplier);
 
-            // Auto-spawn riders.
             if (autoSpawn && steps > 0)
                 MaybeSpawnRider(steps);
 
-            // Step the simulation.
             for (int i = 0; i < steps; i++)
                 Sim.Step();
 
-            // Update frame snapshot.
             Sim.GetFrame();
 
-            // Drain and count events.
             var events = Sim.DrainEvents();
             foreach (var ev in events)
             {
@@ -69,12 +78,7 @@ namespace ElevatorDemo
                 }
             }
 
-            // Handle keyboard shortcuts.
-            if (Input.GetKeyDown(KeyCode.Space))
-                speedMultiplier = speedMultiplier == 0 ? 1 : 0;
-            if (Input.GetKeyDown(KeyCode.Alpha1)) speedMultiplier = 1;
-            if (Input.GetKeyDown(KeyCode.Alpha2)) speedMultiplier = 2;
-            if (Input.GetKeyDown(KeyCode.Alpha3)) speedMultiplier = 10;
+            HandleKeyboardInput();
         }
 
         private void OnDestroy()
@@ -82,6 +86,7 @@ namespace ElevatorDemo
             Sim?.Dispose();
         }
 
+        /// <summary>Spawns a rider between two random stops with a random weight.</summary>
         public void SpawnRandomRider()
         {
             if (Sim == null || !Sim.IsValid || Sim.Stops.Length < 2) return;
@@ -95,6 +100,15 @@ namespace ElevatorDemo
                 Sim.Stops[originIdx].entity_id,
                 Sim.Stops[destIdx].entity_id,
                 weight);
+        }
+
+        private void HandleKeyboardInput()
+        {
+            if (Input.GetKeyDown(KeyCode.Space))
+                speedMultiplier = speedMultiplier == 0 ? 1 : 0;
+            if (Input.GetKeyDown(KeyCode.Alpha1)) speedMultiplier = 1;
+            if (Input.GetKeyDown(KeyCode.Alpha2)) speedMultiplier = 2;
+            if (Input.GetKeyDown(KeyCode.Alpha3)) speedMultiplier = 10;
         }
 
         private void MaybeSpawnRider(int steps)

--- a/examples/unity-demo/Assets/Scripts/ElevatorSimulation.cs
+++ b/examples/unity-demo/Assets/Scripts/ElevatorSimulation.cs
@@ -1,5 +1,7 @@
-// Managed wrapper around the elevator-ffi native handle.
-// Owns the simulation lifetime and provides safe C# methods.
+/// <summary>
+/// Managed wrapper around the elevator-ffi native handle.
+/// Owns the simulation lifetime and provides safe C# methods.
+/// </summary>
 
 using System;
 using System.Runtime.InteropServices;
@@ -7,29 +9,44 @@ using UnityEngine;
 
 namespace ElevatorDemo
 {
+    /// <summary>
+    /// Wraps an <c>EvSim</c> handle with safe, managed accessors for stepping,
+    /// querying frame data, spawning riders, and querying ETAs.
+    /// </summary>
     public class ElevatorSimulation : IDisposable
     {
         private IntPtr _handle;
         private bool _disposed;
 
-        // Cached frame data — valid until next GetFrame() call.
+        /// <summary>Elevator views from the most recent frame snapshot.</summary>
         public EvElevatorView[] Elevators { get; private set; } = Array.Empty<EvElevatorView>();
+
+        /// <summary>Stop views from the most recent frame snapshot.</summary>
         public EvStopView[] Stops { get; private set; } = Array.Empty<EvStopView>();
+
+        /// <summary>Rider views from the most recent frame snapshot.</summary>
         public EvRiderView[] Riders { get; private set; } = Array.Empty<EvRiderView>();
+
+        /// <summary>Aggregate metrics from the most recent frame snapshot.</summary>
         public EvMetricsView Metrics { get; private set; }
 
+        /// <summary>Whether the native handle is valid and usable.</summary>
         public bool IsValid => _handle != IntPtr.Zero;
 
+        /// <summary>
+        /// Creates a new simulation from a RON config file on disk.
+        /// Returns a simulation instance; check <see cref="IsValid"/> before use.
+        /// </summary>
         public static ElevatorSimulation Create(string configPath)
         {
-            const uint ExpectedAbi = 1;
+            const uint ExpectedAbi = 2;
             uint abiVersion = ElevatorNative.ev_abi_version();
             if (abiVersion != ExpectedAbi)
             {
                 Debug.LogError(
                     $"elevator_ffi ABI version mismatch: expected {ExpectedAbi}, got {abiVersion}. " +
                     "Run build.sh to recompile the native library.");
-                return new ElevatorSimulation(); // IsValid == false
+                return new ElevatorSimulation();
             }
 
             var sim = new ElevatorSimulation();
@@ -41,12 +58,17 @@ namespace ElevatorDemo
             return sim;
         }
 
+        /// <summary>Advances the simulation by one tick.</summary>
         public EvStatus Step()
         {
             if (!IsValid) return EvStatus.NullArg;
             return ElevatorNative.ev_sim_step(_handle);
         }
 
+        /// <summary>
+        /// Snapshots the current frame into <see cref="Elevators"/>, <see cref="Stops"/>,
+        /// <see cref="Riders"/>, and <see cref="Metrics"/>.
+        /// </summary>
         public void GetFrame()
         {
             if (!IsValid) return;
@@ -56,7 +78,6 @@ namespace ElevatorDemo
 
             Metrics = frame.metrics;
 
-            // Copy elevator views.
             int elevCount = (int)frame.elevator_count;
             if (Elevators.Length != elevCount)
                 Elevators = new EvElevatorView[elevCount];
@@ -66,7 +87,6 @@ namespace ElevatorDemo
                     frame.elevators + i * Marshal.SizeOf<EvElevatorView>());
             }
 
-            // Copy stop views.
             int stopCount = (int)frame.stop_count;
             if (Stops.Length != stopCount)
                 Stops = new EvStopView[stopCount];
@@ -76,7 +96,6 @@ namespace ElevatorDemo
                     frame.stops + i * Marshal.SizeOf<EvStopView>());
             }
 
-            // Copy rider views.
             int riderCount = (int)frame.rider_count;
             if (Riders.Length != riderCount)
                 Riders = new EvRiderView[riderCount];
@@ -87,6 +106,27 @@ namespace ElevatorDemo
             }
         }
 
+        /// <summary>
+        /// Queries the best ETA to a stop across eligible elevators.
+        /// Returns the estimated seconds, or -1.0 if no elevator is heading there.
+        /// </summary>
+        /// <param name="stopEntityId">Stop entity id to query.</param>
+        /// <param name="direction">-1 = Down, 0 = Either, 1 = Up.</param>
+        public double BestEta(ulong stopEntityId, int direction)
+        {
+            if (!IsValid) return -1.0;
+
+            var status = ElevatorNative.ev_sim_best_eta(
+                _handle, stopEntityId, (sbyte)direction,
+                out ulong _, out double seconds);
+
+            if (status != EvStatus.Ok || double.IsNaN(seconds))
+                return -1.0;
+
+            return seconds;
+        }
+
+        /// <summary>Spawns a rider with default preferences. Returns the rider entity id, or 0 on failure.</summary>
         public ulong SpawnRider(ulong origin, ulong dest, double weight)
         {
             if (!IsValid) return 0;
@@ -100,12 +140,14 @@ namespace ElevatorDemo
             return riderId;
         }
 
+        /// <summary>Removes a rider from the simulation. Returns true on success.</summary>
         public bool DespawnRider(ulong riderId)
         {
             if (!IsValid) return false;
             return ElevatorNative.ev_sim_despawn_rider(_handle, riderId) == EvStatus.Ok;
         }
 
+        /// <summary>Drains pending events into a managed array.</summary>
         public EvEvent[] DrainEvents(int bufferSize = 128)
         {
             if (!IsValid) return Array.Empty<EvEvent>();
@@ -121,12 +163,14 @@ namespace ElevatorDemo
             return result;
         }
 
+        /// <summary>Replaces the dispatch strategy for a group.</summary>
         public void SetStrategy(uint groupId, EvStrategy strategy)
         {
             if (!IsValid) return;
             ElevatorNative.ev_sim_set_strategy(_handle, groupId, strategy);
         }
 
+        /// <summary>Destroys the native simulation handle.</summary>
         public void Dispose()
         {
             if (_disposed) return;


### PR DESCRIPTION
## Summary

Polish pass across both engine demos and the FFI layer for consistency, readability, and visual completeness.

**FFI (ABI v2):**
- Added `going_up`/`going_down` direction indicator fields to `EvElevatorView`
- Bumped `EV_ABI_VERSION` from 1 to 2
- Updated C header, C# harness, and Unity demo bindings

**Godot demo:**
- Dynamic PPU scaling — fits any config (default.ron 15 units, space_elevator.ron 1000 units)
- Viewport centered with HUD panel offset
- All rider phases rendered: waiting (green), boarding (cyan), riding (yellow inside car), exiting (orange)
- HUD shows direction indicators and ETA
- Added `eta_to_stop()` method to gdext node
- Doc comments on all exported methods

**Unity demo:**
- Camera margin and HUD offset improved
- All rider phases rendered with correct colors and positioning (boarding lerped 40%, riding in columns, exiting lerped 60%)
- HUD shows direction arrows and ETA via `ev_sim_best_eta`
- Added `BestEta()` to managed wrapper + `ev_sim_best_eta` DllImport
- Extracted all magic numbers into named constants
- XML doc comments on all public types
- Multi-car support in BuildingVisualizer

## Test plan

- [x] 595 elevator-core tests pass
- [x] 9 elevator-ffi tests pass (ABI version test updated to 2)
- [x] Clippy clean on elevator-gdext and elevator-ffi
- [x] Pre-commit hook passes
- [ ] Manual: verify Godot demo renders all rider phases with dynamic scaling
- [ ] Manual: verify Unity demo renders all rider phases with direction + ETA in HUD