### PR TITLE
chore: gitignore .worktrees/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ mutants.out.old/
 .claude/agent-memory-local/
 .claude/*.lock
 .claude/worktrees/
+.worktrees/
 .idea/
 .vscode/
 *.code-workspace


### PR DESCRIPTION
## Summary

- Adds `.worktrees/` to `.gitignore` so worktree directories placed at the repo root don't leak into `git add -A` as embedded-repo gitlinks.
- The existing `.claude/worktrees/` entry only covers the legacy Claude-managed location; current worktree workflows use the top-level `.worktrees/` path.

## Background

First PR in a broader correctness-audit effort on `elevator-core` (lifecycle/events → cross-feature → dispatch → motion/doors). Landing the trivial hygiene changes first keeps subsequent audit work on clean worktrees.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy -p elevator-core --all-features -- -D warnings`, `cargo test -p elevator-core --all-features` all green via pre-commit hook.
- [x] Verified: `git check-ignore .worktrees/` returns the path after the change.
- [x] No tracked files currently live under `.worktrees/`; this is purely preventative.