### PR TITLE
test: smoke-test every asset config parses and builds

### DIFF
--- a/crates/elevator-core/tests/parse_asset_configs.rs
+++ b/crates/elevator-core/tests/parse_asset_configs.rs
@@ -1,0 +1,48 @@
+//! Smoke test: every RON config under `assets/config/` parses into a
+//! `SimConfig`, builds a `Simulation`, and survives a handful of ticks.
+//!
+//! These files are referenced by the README (`cargo run -- assets/config/...`)
+//! and the FFI harness, so schema drift that breaks them is a user-visible
+//! regression. CI catches it here before publish.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::fs;
+use std::path::Path;
+
+use elevator_core::config::SimConfig;
+use elevator_core::prelude::*;
+
+#[test]
+fn every_asset_config_parses_and_builds() {
+    let config_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../assets/config");
+    let mut seen = 0;
+
+    for entry in
+        fs::read_dir(&config_dir).unwrap_or_else(|e| panic!("read {}: {e}", config_dir.display()))
+    {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("ron") {
+            continue;
+        }
+        seen += 1;
+
+        let ron_str =
+            fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        let config: SimConfig =
+            ron::from_str(&ron_str).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
+
+        let mut sim = SimulationBuilder::from_config(config)
+            .build()
+            .unwrap_or_else(|e| panic!("build {}: {e}", path.display()));
+
+        // Step past construction to surface any runtime invariant
+        // violations latent in the config (e.g., an elevator starting
+        // at an unserviceable stop).
+        for _ in 0..10 {
+            sim.step();
+        }
+    }
+
+    assert!(seen > 0, "no .ron files found in {}", config_dir.display());
+}


### PR DESCRIPTION
## Summary

Adds an integration test that iterates every RON file under `assets/config/`, parses it into a `SimConfig`, builds a `Simulation` via `SimulationBuilder::from_config()`, and steps 10 ticks. Catches schema-drift or runtime-validation regressions before users notice on `cargo run -- assets/config/...`.

Currently covers `annotated.ron`, `default.ron`, `space_elevator.ron` — any new config file added to that directory is automatically picked up.

## Why now

Part of the broader correctness-audit prep. These asset configs are:
- Referenced by the README (\`cargo run -- assets/config/space_elevator.ron\`)
- Used by the C# FFI harness (\`just harness-smoke\` reads \`default.ron\`)
- Parsed in the \`config_file.rs\` example

Before this PR nothing in CI loaded them — any breakage surfaced only when a user tried to run a demo.

## Test plan

- [x] \`cargo test -p elevator-core --test parse_asset_configs --all-features\` passes locally.
- [x] Pre-commit hook green (fmt / clippy / all-features tests / doc tests).
- [x] Deliberately checked: \`Path::new(env!(\"CARGO_MANIFEST_DIR\"))\` resolves correctly under \`cargo test -p elevator-core\` (CWD is the crate dir).