### PR TITLE
chore: ignore .worktrees/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ mutants.out.old/
 .claude/agent-memory-local/
 .claude/*.lock
 .claude/worktrees/
+.worktrees/
 .idea/
 .vscode/
 *.code-workspace


### PR DESCRIPTION
## Summary
- Add `.worktrees/` to `.gitignore` so parallel git worktrees created under the repo root don't appear as untracked files.

## Test plan
- [x] `git status` on a repo with `.worktrees/` present shows a clean tree