### PR TITLE
feat: add Simulation::abort_movement for mid-flight trip cancellation

### DIFF
--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -59,6 +59,21 @@ pub enum Event {
         /// The tick when the pass occurred.
         tick: u64,
     },
+    /// An in-flight movement was aborted by
+    /// [`Simulation::abort_movement`](crate::sim::Simulation::abort_movement).
+    ///
+    /// The car brakes along its normal deceleration profile, re-targets to
+    /// the nearest reachable stop, and arrives there without opening doors
+    /// (onboard riders stay aboard). The pending destination queue is also
+    /// cleared as part of the abort.
+    MovementAborted {
+        /// The elevator whose trip was aborted.
+        elevator: EntityId,
+        /// The stop the car will brake to and park at.
+        stopped_at: EntityId,
+        /// The tick when the abort was requested.
+        tick: u64,
+    },
 
     // -- Rider events (unified: passengers, cargo, any rideable entity) --
     /// A new rider appeared at a stop and wants to travel.
@@ -694,6 +709,7 @@ impl Event {
             | Self::DoorCommandQueued { .. }
             | Self::DoorCommandApplied { .. }
             | Self::PassingFloor { .. }
+            | Self::MovementAborted { .. }
             | Self::ElevatorIdle { .. } => EventCategory::Elevator,
             Self::RiderSpawned { .. }
             | Self::RiderBoarded { .. }

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -66,11 +66,15 @@ pub enum Event {
     /// the nearest reachable stop, and arrives there without opening doors
     /// (onboard riders stay aboard). The pending destination queue is also
     /// cleared as part of the abort.
+    ///
+    /// Emitted at abort time — the car is still in flight, decelerating
+    /// toward `brake_target`. A normal [`Event::ElevatorArrived`] fires
+    /// once the car actually reaches the stop.
     MovementAborted {
         /// The elevator whose trip was aborted.
         elevator: EntityId,
         /// The stop the car will brake to and park at.
-        stopped_at: EntityId,
+        brake_target: EntityId,
         /// The tick when the abort was requested.
         tick: u64,
     },

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -68,8 +68,8 @@ mod lifecycle;
 mod topology;
 
 use crate::components::{
-    Accel, AccessControl, Orientation, Patience, Preferences, Rider, RiderPhase, Route,
-    SpatialPosition, Speed, Velocity, Weight,
+    Accel, AccessControl, ElevatorPhase, Orientation, Patience, Preferences, Rider, RiderPhase,
+    Route, SpatialPosition, Speed, Velocity, Weight,
 };
 use crate::dispatch::{BuiltinReposition, DispatchStrategy, ElevatorGroup, RepositionStrategy};
 use crate::entity::{ElevatorId, EntityId, RiderId};
@@ -589,10 +589,11 @@ impl Simulation {
 
     /// Clear an elevator's destination queue.
     ///
-    /// TODO: clearing does not currently abort an in-flight movement — the
-    /// elevator will finish its current leg and then go idle (since the
-    /// queue is empty). A future change can add a phase transition to
-    /// cancel mid-flight.
+    /// Does **not** affect an in-flight movement — the elevator will
+    /// finish its current leg and then go idle (since the queue is empty).
+    /// To stop a moving car immediately, use
+    /// [`abort_movement`](Self::abort_movement), which brakes the car to
+    /// the nearest reachable stop and also clears the queue.
     ///
     /// # Errors
     ///
@@ -605,6 +606,69 @@ impl Simulation {
         if let Some(q) = self.world.destination_queue_mut(elev) {
             q.clear();
         }
+        Ok(())
+    }
+
+    /// Abort the elevator's in-flight movement and park at the nearest
+    /// reachable stop.
+    ///
+    /// Computes the minimum stopping position under the car's normal
+    /// deceleration profile (see
+    /// [`future_stop_position`](Self::future_stop_position)), picks the
+    /// closest stop at or past that position in the current direction of
+    /// travel, re-targets there via
+    /// [`ElevatorPhase::Repositioning`](crate::components::ElevatorPhase::Repositioning)
+    /// so the car arrives **without opening doors**, and clears any queued
+    /// destinations. Onboard riders stay aboard.
+    ///
+    /// Emits [`Event::MovementAborted`](crate::events::Event::MovementAborted)
+    /// when an abort occurs.
+    ///
+    /// # No-op conditions
+    ///
+    /// Returns `Ok(())` without changes if the car is not currently moving
+    /// (any phase other than
+    /// [`MovingToStop`](crate::components::ElevatorPhase::MovingToStop) or
+    /// [`Repositioning`](crate::components::ElevatorPhase::Repositioning)),
+    /// or if the simulation has no stops.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SimError::NotAnElevator`] if `elev` is not an elevator.
+    pub fn abort_movement(&mut self, elev: ElevatorId) -> Result<(), SimError> {
+        let eid = elev.entity();
+        let Some(car) = self.world.elevator(eid) else {
+            return Err(SimError::NotAnElevator(eid));
+        };
+        if !car.phase().is_moving() {
+            return Ok(());
+        }
+
+        let pos = self.world.position(eid).map_or(0.0, |p| p.value);
+        let vel = self.world.velocity(eid).map_or(0.0, |v| v.value);
+        let Some(brake_pos) = self.future_stop_position(eid) else {
+            return Ok(());
+        };
+
+        let Some(brake_stop) = brake_target_stop(&self.world, pos, vel, brake_pos) else {
+            return Ok(());
+        };
+
+        if let Some(car) = self.world.elevator_mut(eid) {
+            car.phase = ElevatorPhase::Repositioning(brake_stop);
+            car.target_stop = Some(brake_stop);
+            car.repositioning = true;
+        }
+        if let Some(q) = self.world.destination_queue_mut(eid) {
+            q.clear();
+        }
+
+        self.events.emit(Event::MovementAborted {
+            elevator: eid,
+            stopped_at: brake_stop,
+            tick: self.tick,
+        });
+
         Ok(())
     }
 
@@ -2271,4 +2335,31 @@ impl fmt::Debug for Simulation {
             .field("entities", &self.world.entity_count())
             .finish_non_exhaustive()
     }
+}
+
+/// Pick the stop to park at when aborting an in-flight movement.
+///
+/// Prefers the closest stop at or past `brake_pos` in the car's current
+/// direction of travel — the car can decelerate into it naturally without
+/// overshoot. If no such stop exists (e.g., the car is near the end of
+/// the line with no stop beyond the brake-rest point), falls back to the
+/// stop nearest `brake_pos` regardless of direction. Returns `None` only
+/// if the world has no stops at all.
+fn brake_target_stop(world: &World, pos: f64, vel: f64, brake_pos: f64) -> Option<EntityId> {
+    let dir = vel.signum();
+    if dir != 0.0 {
+        let candidate = world
+            .iter_stops()
+            .filter(|(_, stop)| (stop.position() - brake_pos) * dir >= 0.0)
+            .min_by(|(_, a), (_, b)| {
+                (a.position() - pos)
+                    .abs()
+                    .total_cmp(&(b.position() - pos).abs())
+            })
+            .map(|(id, _)| id);
+        if candidate.is_some() {
+            return candidate;
+        }
+    }
+    world.find_nearest_stop(brake_pos)
 }

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -51,6 +51,9 @@
 //!   [`Simulation::clear_destinations()`](crate::sim::Simulation::clear_destinations)
 //!   — override dispatch by pushing/clearing stops on an elevator's
 //!   [`DestinationQueue`](crate::components::DestinationQueue).
+//! - [`Simulation::abort_movement()`](crate::sim::Simulation::abort_movement)
+//!   — hard-abort an in-flight trip, braking the car to the nearest
+//!   reachable stop without opening doors (riders stay aboard).
 //!
 //! ### Persistence
 //!

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -668,7 +668,7 @@ impl Simulation {
 
         self.events.emit(Event::MovementAborted {
             elevator: eid,
-            stopped_at: brake_stop,
+            brake_target: brake_stop,
             tick: self.tick,
         });
 
@@ -2342,16 +2342,23 @@ impl fmt::Debug for Simulation {
 
 /// Pick the stop to park at when aborting an in-flight movement.
 ///
-/// Prefers the closest stop at or past `brake_pos` in the car's current
-/// direction of travel — the car can decelerate into it naturally without
-/// overshoot. If no such stop exists (e.g., the car is near the end of
-/// the line with no stop beyond the brake-rest point), falls back to the
-/// stop nearest `brake_pos` regardless of direction. Returns `None` only
-/// if the world has no stops at all.
+/// Tries three strategies in order:
+///
+/// 1. **Closest stop at or past `brake_pos` in the direction of travel.**
+///    The car can decelerate into it naturally without overshoot.
+/// 2. **Farthest stop still in the direction of travel (end-of-line).**
+///    If the car is too close to the end of the line to fit a full
+///    deceleration, pick the terminal stop ahead of it; the movement
+///    system's overshoot-snap will absorb the small residual distance.
+/// 3. **Nearest stop overall.** Only reachable when the car has no
+///    stops ahead of it at all (e.g., single-stop worlds or the car is
+///    already past the final stop); also handles the `vel == 0` case.
+///
+/// Returns `None` only if the world has no stops at all.
 fn brake_target_stop(world: &World, pos: f64, vel: f64, brake_pos: f64) -> Option<EntityId> {
     let dir = vel.signum();
     if dir != 0.0 {
-        let candidate = world
+        let ahead_of_brake = world
             .iter_stops()
             .filter(|(_, stop)| (stop.position() - brake_pos) * dir >= 0.0)
             .min_by(|(_, a), (_, b)| {
@@ -2360,8 +2367,18 @@ fn brake_target_stop(world: &World, pos: f64, vel: f64, brake_pos: f64) -> Optio
                     .total_cmp(&(b.position() - pos).abs())
             })
             .map(|(id, _)| id);
-        if candidate.is_some() {
-            return candidate;
+        if ahead_of_brake.is_some() {
+            return ahead_of_brake;
+        }
+        let ahead_of_car = world
+            .iter_stops()
+            .filter(|(_, stop)| (stop.position() - pos) * dir >= 0.0)
+            .max_by(|(_, a), (_, b)| {
+                ((a.position() - pos) * dir).total_cmp(&((b.position() - pos) * dir))
+            })
+            .map(|(id, _)| id);
+        if ahead_of_car.is_some() {
+            return ahead_of_car;
         }
     }
     world.find_nearest_stop(brake_pos)

--- a/crates/elevator-core/src/systems/advance_queue.rs
+++ b/crates/elevator-core/src/systems/advance_queue.rs
@@ -131,9 +131,9 @@ pub fn run(
                         update_indicators(world, events, eid, new_up, new_down, ctx.tick);
                     }
                     None => {
-                        // Queue was cleared; leave current target in place for
-                        // this PR (clearing does not abort mid-flight — see
-                        // TODO on Simulation::clear_destinations).
+                        // Queue cleared while moving: finish the current leg
+                        // and go idle. Hard-aborting mid-flight is a separate
+                        // operation (see Simulation::abort_movement).
                         let _ = current_target;
                     }
                 }

--- a/crates/elevator-core/src/tests/abort_movement_tests.rs
+++ b/crates/elevator-core/src/tests/abort_movement_tests.rs
@@ -111,9 +111,9 @@ fn abort_mid_flight_emits_event() {
         .filter_map(|e| match e {
             Event::MovementAborted {
                 elevator,
-                stopped_at,
+                brake_target,
                 ..
-            } => Some((*elevator, *stopped_at)),
+            } => Some((*elevator, *brake_target)),
             _ => None,
         })
         .collect();

--- a/crates/elevator-core/src/tests/abort_movement_tests.rs
+++ b/crates/elevator-core/src/tests/abort_movement_tests.rs
@@ -1,0 +1,292 @@
+//! Tests for `Simulation::abort_movement` — mid-flight trip cancellation.
+
+use crate::builder::SimulationBuilder;
+use crate::components::{ElevatorPhase, RiderPhase};
+use crate::dispatch::scan::ScanDispatch;
+use crate::entity::ElevatorId;
+use crate::error::SimError;
+use crate::events::Event;
+use crate::stop::StopId;
+
+use super::helpers::default_config;
+
+fn build_sim() -> crate::sim::Simulation {
+    SimulationBuilder::from_config(default_config())
+        .dispatch(ScanDispatch::new())
+        .build()
+        .unwrap()
+}
+
+fn first_elevator(sim: &crate::sim::Simulation) -> ElevatorId {
+    ElevatorId::from(sim.world().elevator_ids()[0])
+}
+
+/// Drive the sim until the elevator is actively moving (phase is
+/// MovingToStop), then return the elevator's current phase. Panics if it
+/// does not start moving within the budget.
+fn step_until_moving(sim: &mut crate::sim::Simulation, elev: ElevatorId) {
+    for _ in 0..200 {
+        sim.step();
+        let car = sim.world().elevator(elev.entity()).unwrap();
+        if car.phase().is_moving() {
+            return;
+        }
+    }
+    panic!("elevator never started moving");
+}
+
+// ── No-op / error paths ─────────────────────────────────────────────
+
+#[test]
+fn abort_movement_on_non_elevator_errors() {
+    let mut sim = build_sim();
+    let s0 = sim.stop_entity(StopId(0)).unwrap();
+    let err = sim
+        .abort_movement(ElevatorId::from(s0))
+        .expect_err("should reject non-elevator");
+    assert!(matches!(err, SimError::NotAnElevator(_)));
+}
+
+#[test]
+fn abort_movement_no_op_when_idle() {
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+    // Fresh sim — elevator is Idle.
+    assert_eq!(
+        sim.world().elevator(elev.entity()).unwrap().phase(),
+        ElevatorPhase::Idle
+    );
+    sim.abort_movement(elev).unwrap();
+    let car = sim.world().elevator(elev.entity()).unwrap();
+    assert_eq!(car.phase(), ElevatorPhase::Idle);
+    let emitted = sim
+        .drain_events()
+        .into_iter()
+        .any(|e| matches!(e, Event::MovementAborted { .. }));
+    assert!(!emitted, "idle abort should not emit MovementAborted");
+}
+
+// ── Happy path ──────────────────────────────────────────────────────
+
+#[test]
+fn abort_mid_flight_retargets_to_reachable_stop() {
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+    let s2 = sim.stop_entity(StopId(2)).unwrap();
+    // Send the car from stop 0 to stop 2; once it's mid-flight, abort.
+    sim.push_destination(elev, s2).unwrap();
+    step_until_moving(&mut sim, elev);
+
+    sim.abort_movement(elev).unwrap();
+    let car = sim.world().elevator(elev.entity()).unwrap();
+    // Must be in Repositioning so arrival skips doors.
+    let target = match car.phase() {
+        ElevatorPhase::Repositioning(t) => t,
+        other => panic!("expected Repositioning, got {other:?}"),
+    };
+    // Re-target must be a real stop entity; position must match one of
+    // the configured stops.
+    let pos = sim.world().stop_position(target).unwrap();
+    assert!(
+        [0.0, 4.0, 8.0].contains(&pos),
+        "brake target must be a configured stop (got pos={pos})"
+    );
+    assert!(car.repositioning());
+}
+
+#[test]
+fn abort_mid_flight_emits_event() {
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+    let s2 = sim.stop_entity(StopId(2)).unwrap();
+    sim.push_destination(elev, s2).unwrap();
+    step_until_moving(&mut sim, elev);
+    let _ = sim.drain_events(); // discard pre-abort chatter
+
+    sim.abort_movement(elev).unwrap();
+
+    let events = sim.drain_events();
+    let aborted: Vec<_> = events
+        .iter()
+        .filter_map(|e| match e {
+            Event::MovementAborted {
+                elevator,
+                stopped_at,
+                ..
+            } => Some((*elevator, *stopped_at)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(aborted.len(), 1, "exactly one MovementAborted should fire");
+    assert_eq!(aborted[0].0, elev.entity());
+}
+
+#[test]
+fn abort_mid_flight_clears_queue() {
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+    let s1 = sim.stop_entity(StopId(1)).unwrap();
+    let s2 = sim.stop_entity(StopId(2)).unwrap();
+    sim.push_destination(elev, s1).unwrap();
+    sim.push_destination(elev, s2).unwrap();
+    step_until_moving(&mut sim, elev);
+
+    sim.abort_movement(elev).unwrap();
+    assert!(
+        sim.destination_queue(elev).unwrap().is_empty(),
+        "queue should be cleared by abort"
+    );
+}
+
+#[test]
+fn abort_mid_flight_brake_target_is_reachable_in_direction() {
+    // The brake target must be at or past the brake-rest position in the
+    // direction of travel so the movement system can decelerate into it
+    // without overshoot.
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+    let s2 = sim.stop_entity(StopId(2)).unwrap();
+    sim.push_destination(elev, s2).unwrap();
+    step_until_moving(&mut sim, elev);
+
+    let pos = sim.world().position(elev.entity()).unwrap().value;
+    let vel = sim.world().velocity(elev.entity()).unwrap().value;
+    let brake_pos = sim.future_stop_position(elev.entity()).unwrap();
+    sim.abort_movement(elev).unwrap();
+
+    let car = sim.world().elevator(elev.entity()).unwrap();
+    let target = car.phase().moving_target().unwrap();
+    let target_pos = sim.world().stop_position(target).unwrap();
+
+    let dir = vel.signum();
+    assert!(
+        (target_pos - pos) * dir >= 0.0,
+        "brake target must lie in direction of travel (pos={pos}, target={target_pos}, vel={vel})"
+    );
+    assert!(
+        (target_pos - brake_pos) * dir >= -1e-9,
+        "brake target must be at or past brake_pos (brake_pos={brake_pos}, target={target_pos}, dir={dir})"
+    );
+}
+
+#[test]
+fn abort_mid_flight_arrives_without_opening_doors() {
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+    let s2 = sim.stop_entity(StopId(2)).unwrap();
+    sim.push_destination(elev, s2).unwrap();
+    step_until_moving(&mut sim, elev);
+
+    sim.abort_movement(elev).unwrap();
+    let _ = sim.drain_events();
+
+    let mut saw_door_opened = false;
+    let mut became_idle = false;
+    for _ in 0..600 {
+        sim.step();
+        for ev in sim.drain_events() {
+            match ev {
+                Event::DoorOpened { elevator, .. } if elevator == elev.entity() => {
+                    saw_door_opened = true;
+                }
+                Event::ElevatorIdle { elevator, .. } if elevator == elev.entity() => {
+                    became_idle = true;
+                }
+                _ => {}
+            }
+        }
+        if became_idle {
+            break;
+        }
+    }
+    assert!(
+        became_idle,
+        "elevator should become Idle after brake arrival"
+    );
+    assert!(
+        !saw_door_opened,
+        "aborted arrival must not open doors (onboard riders stay put)"
+    );
+}
+
+#[test]
+fn abort_from_repositioning_phase_is_also_supported() {
+    // Drive a rider to a stop, then let the car reposition, then abort.
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+
+    // Spawn and wait for arrival and any subsequent reposition.
+    sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
+
+    let mut saw_reposition = false;
+    for _ in 0..4000 {
+        sim.step();
+        let car = sim.world().elevator(elev.entity()).unwrap();
+        if matches!(car.phase(), ElevatorPhase::Repositioning(_)) {
+            saw_reposition = true;
+            break;
+        }
+    }
+
+    if !saw_reposition {
+        // Repositioning is strategy-dependent; if the default config does
+        // not exercise it, skip this case rather than fail.
+        return;
+    }
+
+    sim.abort_movement(elev).unwrap();
+    let car = sim.world().elevator(elev.entity()).unwrap();
+    assert!(
+        matches!(car.phase(), ElevatorPhase::Repositioning(_)),
+        "abort from repositioning should remain in Repositioning(brake_stop)"
+    );
+}
+
+#[test]
+fn abort_keeps_riders_onboard() {
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+
+    // Spawn a rider, wait for them to board, then abort mid-flight.
+    sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
+
+    let mut boarded_rider = None;
+    for _ in 0..2000 {
+        sim.step();
+        for ev in sim.drain_events() {
+            if let Event::RiderBoarded {
+                rider, elevator, ..
+            } = ev
+                && elevator == elev.entity()
+            {
+                boarded_rider = Some(rider);
+            }
+        }
+        let car = sim.world().elevator(elev.entity()).unwrap();
+        if boarded_rider.is_some() && car.phase().is_moving() {
+            break;
+        }
+    }
+    let rider = boarded_rider.expect("rider never boarded");
+
+    sim.abort_movement(elev).unwrap();
+    // Run the sim through the brake arrival.
+    for _ in 0..600 {
+        sim.step();
+        let car = sim.world().elevator(elev.entity()).unwrap();
+        if matches!(car.phase(), ElevatorPhase::Idle) {
+            break;
+        }
+    }
+
+    let car = sim.world().elevator(elev.entity()).unwrap();
+    assert!(
+        car.riders().contains(&rider),
+        "rider should remain onboard after abort arrival"
+    );
+    let rider_phase = sim.world().rider(rider).unwrap().phase;
+    assert!(
+        matches!(rider_phase, RiderPhase::Riding(_)),
+        "rider phase should still be Riding after abort, got {rider_phase:?}"
+    );
+}

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -37,6 +37,7 @@ mod topology_tests;
 mod traffic_tests;
 mod world_tests;
 
+mod abort_movement_tests;
 mod api_surface_tests;
 mod boundary_tests;
 mod braking_tests;

--- a/docs/src/dispatch-strategies.md
+++ b/docs/src/dispatch-strategies.md
@@ -26,10 +26,13 @@ If you want to tell an elevator exactly where to go -- bypassing strategy logic 
 sim.push_destination(elev, stop_a).unwrap();        // enqueue at back
 sim.push_destination_front(elev, stop_b).unwrap();  // jump to front of queue
 sim.clear_destinations(elev).unwrap();              // cancel all pending stops
+sim.abort_movement(elev).unwrap();                  // stop the current leg too
 let queue: &[EntityId] = sim.destination_queue(elev).unwrap();
 ```
 
 Adjacent duplicates are suppressed: pushing the same stop twice in a row is a no-op and emits a single `DestinationQueued` event.
+
+`clear_destinations` is a soft clear -- it only drains the pending queue. An elevator that is already mid-flight will finish its current leg and then go idle. To stop a moving car immediately, use `abort_movement`: it brakes the car along its normal deceleration profile, parks it at the nearest reachable stop (doors stay closed; onboard riders stay aboard), clears the queue, and emits `MovementAborted` so UI/metrics can react.
 
 Between the Dispatch and Movement phases, the **AdvanceQueue** phase reconciles each elevator's phase/target with the front of its queue. Idle elevators with a non-empty queue begin moving; elevators mid-flight whose queue front changed (because you called `push_destination_front`) are redirected. Movement pops the front on arrival.
 

--- a/docs/src/events-metrics.md
+++ b/docs/src/events-metrics.md
@@ -19,7 +19,7 @@ Every significant moment in the simulation -- a rider boarding, an elevator arri
 | `DoorCommandQueued { elevator, command, tick }` | A manual door command was accepted |
 | `DoorCommandApplied { elevator, command, tick }` | A queued door command took effect |
 | `PassingFloor { elevator, stop, moving_up, tick }` | An elevator passes a stop without stopping |
-| `MovementAborted { elevator, stopped_at, tick }` | `abort_movement` was called mid-flight; the car will brake to `stopped_at` without opening doors |
+| `MovementAborted { elevator, brake_target, tick }` | `abort_movement` was called mid-flight; the car will brake to `brake_target` without opening doors |
 | `CapacityChanged { elevator, current_load, capacity, tick }` | An elevator's load changed |
 | `DirectionIndicatorChanged { elevator, going_up, going_down, tick }` | Direction lamps changed |
 | `DestinationQueued { elevator, stop, tick }` | A stop was pushed onto the destination queue |

--- a/docs/src/events-metrics.md
+++ b/docs/src/events-metrics.md
@@ -19,6 +19,7 @@ Every significant moment in the simulation -- a rider boarding, an elevator arri
 | `DoorCommandQueued { elevator, command, tick }` | A manual door command was accepted |
 | `DoorCommandApplied { elevator, command, tick }` | A queued door command took effect |
 | `PassingFloor { elevator, stop, moving_up, tick }` | An elevator passes a stop without stopping |
+| `MovementAborted { elevator, stopped_at, tick }` | `abort_movement` was called mid-flight; the car will brake to `stopped_at` without opening doors |
 | `CapacityChanged { elevator, current_load, capacity, tick }` | An elevator's load changed |
 | `DirectionIndicatorChanged { elevator, going_up, going_down, tick }` | Direction lamps changed |
 | `DestinationQueued { elevator, stop, tick }` | A stop was pushed onto the destination queue |

--- a/docs/src/hall-calls.md
+++ b/docs/src/hall-calls.md
@@ -51,9 +51,10 @@ sim.press_hall_button(lobby, CallDirection::Down)?;
 // Cutscene pins the villain's elevator to the penthouse.
 sim.pin_assignment(villain_car, penthouse, CallDirection::Up)?;
 
-// Player hijacks -- release the pin, clear the car's existing queue.
+// Player hijacks -- release the pin and hard-abort the car's trip so
+// it brakes immediately instead of finishing the current leg.
 sim.unpin_assignment(penthouse, CallDirection::Up);
-sim.clear_destinations(villain_car)?;
+sim.abort_movement(villain_car)?;
 ```
 
 A pinned car that is mid-door-cycle (`Loading` / `DoorOpening` / `DoorClosing`) finishes its current cycle first; the pin takes effect on the next dispatch tick. Pins that cross lines (the car's line cannot reach the stop) return `SimError::LineDoesNotServeStop` rather than silently orphaning the call.

--- a/docs/src/headless-non-bevy.md
+++ b/docs/src/headless-non-bevy.md
@@ -14,7 +14,7 @@ Integrating `elevator-core` into any host comes down to three things:
 
 3. **Read state out, inject input in.**
    - **Read state:** `sim.world()` returns a `World` you can query via `query::<(EntityId, &Rider, &Position)>()` for rendering, or via typed accessors (`world.elevator(id)`, `world.stop_position(id)`).
-   - **Inject input:** `sim.spawn_rider(origin, dest, weight)`, `sim.push_destination(elev, stop)`, `sim.reroute(rider, new_dest)`, `sim.set_service_mode(elev, mode)`.
+   - **Inject input:** `sim.spawn_rider(origin, dest, weight)`, `sim.push_destination(elev, stop)`, `sim.abort_movement(elev)`, `sim.reroute(rider, new_dest)`, `sim.set_service_mode(elev, mode)`.
    - **Change-event hook:** `sim.drain_events()` returns every event emitted during the last tick. Route them into toasts, particles, SFX, analytics.
 
 That's it. The entire public surface of the library is the `prelude` module (see [docs.rs](https://docs.rs/elevator-core)) plus a handful of typed submodules; no engine extension points, no traits your app must implement.

--- a/docs/src/manual-inspection-modes.md
+++ b/docs/src/manual-inspection-modes.md
@@ -129,6 +129,8 @@ This is useful for freight elevators, service lifts, or any elevator that should
 sim.set_service_mode(elev.entity(), ServiceMode::Independent)?;
 // Now manually send it somewhere.
 sim.push_destination(elev, StopId(2))?;
+// Changed your mind mid-trip? Brake the car to the nearest stop.
+sim.abort_movement(elev)?;
 # Ok(())
 # }
 ```


### PR DESCRIPTION
## Summary

Closes the TODO on `Simulation::clear_destinations`. Previously, clearing
the destination queue only drained queued stops; the elevator still
finished its current leg before going idle. The new `abort_movement()`
hard-aborts an in-flight trip:

- Brakes the car along its normal deceleration profile (via the existing
  `future_stop_position()` primitive).
- Picks the closest stop at or past the brake-rest position in the
  current direction of travel, falling back to the nearest stop overall.
- Re-targets via `ElevatorPhase::Repositioning(brake_stop)` — reuses the
  existing "arrive without opening doors → Idle" semantics, so onboard
  riders stay aboard with doors closed.
- Clears the destination queue as part of the abort.
- Emits `Event::MovementAborted { elevator, stopped_at, tick }` so
  consumers can distinguish an aborted arrival from an ordinary one.

No-op if the car is not in `MovingToStop` or `Repositioning`. Returns
`SimError::NotAnElevator` for non-elevator entities.

## Design notes

Key choices (all made explicit in code review questions with the user):

- **API shape:** new `abort_movement()` method rather than mutating
  `clear_destinations` semantics — non-breaking.
- **Abort target:** closest stop at/past brake-rest position in the
  direction of travel, so the movement system can decelerate into it
  without overshoot.
- **Rider handling:** onboard riders remain `Riding` with doors closed
  — matches the "consumer manages rider semantics" principle.
- **Phase reuse:** `ElevatorPhase::Repositioning(stop)` already had
  the exact "arrive without doors → Idle" behavior we needed, so no new
  phase was introduced. `MovementAborted` disambiguates abort-repositioning
  from opportunistic-repositioning for downstream consumers.

## Test plan

- [x] `cargo test -p elevator-core --all-features` — 604 tests (9 new)
- [x] `cargo clippy -p elevator-core --all-features` — clean
- [x] `cargo fmt --check` — clean
- [x] New test file `abort_movement_tests.rs` covers:
  - Error on non-elevator entity
  - No-op when idle (no event emitted)
  - Mid-flight `MovingToStop` abort re-targets to a configured stop
  - `MovementAborted` event emitted exactly once
  - Destination queue cleared by abort
  - Brake target lies at/past brake-rest position in direction of travel
  - Arrival transitions to `Idle` without emitting `DoorOpened`
  - Abort from `Repositioning` phase also works
  - Onboard riders stay `Riding` through the brake arrival