### PR TITLE
chore: tighten pre-commit hook and CLAUDE.md

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
-# Pre-commit: fmt check, clippy (all features), core tests, doc tests, doc lint
-set -e
+# Pre-commit: fmt check, clippy (core), core tests, doc tests, doc lint,
+# workspace check, Cargo.lock drift guard.
+set -euo pipefail
+
+staged=$(git diff --cached --name-only --diff-filter=ACMR)
+
+# Cargo.lock drift guard: staging Cargo.toml without Cargo.lock is almost
+# always a mistake — the lockfile will be out of sync with deps.
+if grep -qE '(^|/)Cargo\.toml$' <<<"$staged" \
+    && ! grep -qE '(^|/)Cargo\.lock$' <<<"$staged"; then
+    if ! git diff --quiet Cargo.lock 2>/dev/null; then
+        echo "pre-commit: Cargo.toml is staged but Cargo.lock has unstaged changes." >&2
+        echo "  Stage Cargo.lock too, or revert the Cargo.toml change." >&2
+        exit 1
+    fi
+fi
 
 echo "pre-commit: checking formatting..."
 cargo fmt --check
@@ -14,8 +28,11 @@ cargo test -p elevator-core --all-features --quiet
 echo "pre-commit: running doc tests..."
 cargo test -p elevator-core --all-features --doc --quiet
 
+echo "pre-commit: checking workspace..."
+cargo check --workspace --all-features --quiet
+
 # Lint docs if any docs/ files are staged.
-if git diff --cached --name-only | grep -q '^docs/'; then
+if grep -q '^docs/' <<<"$staged"; then
     echo "pre-commit: linting docs..."
     scripts/lint-docs.sh --quick
 fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ System deps (Ubuntu): `libudev-dev libasound2-dev`
 
 ## Pre-commit Hook
 
-Shared hook at `.githooks/pre-commit` — runs fmt, clippy (all features), tests, doc tests, and doc lint (when `docs/` files are staged). After cloning:
+Shared hook at `.githooks/pre-commit` — runs fmt, clippy (all features on core), core tests, doc tests, `cargo check --workspace` (catches FFI/bevy drift), a Cargo.lock drift guard, and doc lint (when `docs/` files are staged). After cloning:
 
 ```bash
 git config core.hooksPath .githooks
@@ -45,12 +45,18 @@ Key design decisions:
 
 ## Conventions
 
-Commits: conventional commits enforced by hook (`feat:`, `fix:`, `refactor:`, `chore:`, etc.)
+Commits: conventional commits (`feat:`, `fix:`, `refactor:`, `chore:`, etc.). `#[non_exhaustive]` enum additions are NOT breaking — use `feat:` not `feat!:`.
+
+PR workflow: every change lands via PR. Wait for the greptile review bot before merging; no auto-merge. After a PR merges, `git checkout main && git pull` before starting new work.
+
+Parallel work: use git worktrees under `.worktrees/<branch>` (gitignored). Sibling-directory worktrees and `.claude/worktrees/` are not the convention.
 
 Type naming — domain-first, no redundant suffixes:
 - `Rider`, `Elevator`, `Stop`, `Line` (not `RiderData`, `ElevatorCar`)
 - `RiderPhase`, `ElevatorPhase` (not `*State`); fields use `.phase`
 - `Event`, `RejectionReason` (not `SimEvent`, `String`)
+
+ID types: `ElevatorId`, `RiderId`, `StopId` are phantom-typed newtypes over `EntityId`. Prefer them on public API surfaces for type safety; `EntityId` is the untyped form used internally by `World`.
 
 ## Bevy API Notes (0.18)
 


### PR DESCRIPTION
## Summary

Tightens the two most-touched tooling surfaces in the repo.

### `.githooks/pre-commit`

- `set -euo pipefail` (was `set -e`) — consistent with `scripts/lint-docs.sh`, catches unset-variable bugs.
- Adds `cargo check --workspace --all-features` at the end, so breakage in `elevator-bevy` or `elevator-ffi` is caught at commit rather than in CI.
- Adds a **Cargo.lock drift guard**: if `Cargo.toml` is staged but `Cargo.lock` has unstaged changes, the commit is refused with a message pointing out the fix. This is the class of mistake that ships out-of-sync lockfiles.

### `CLAUDE.md`

- Documents the `ElevatorId`/`RiderId`/`StopId` vs `EntityId` distinction — previously invisible to anyone writing new API methods.
- Codifies the PR workflow (every change via PR, wait for greptile, no auto-merge, checkout+pull `main` after merging) that was previously only in tacit convention.
- Documents the `.worktrees/` convention for parallel work.
- Clarifies that `#[non_exhaustive]` enum additions are `feat:`, not `feat!:`.

## Test plan

- [x] `bash .githooks/pre-commit` exits 0 on a clean tree
- [x] The new `cargo check --workspace` phase runs and passes
- [x] Commit on this branch exercised the new hook end-to-end