### PR TITLE
chore: compile every doc example via cargo test --doc

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -27,6 +27,9 @@ cargo test -p elevator-core --all-features --quiet
 
 echo "pre-commit: running doc tests..."
 cargo test -p elevator-core --all-features --doc --quiet
+# elevator-bevy has its own doc tests (bevy-integration chapter). They are
+# fast once bevy is cached; catch drift here instead of waiting for CI.
+cargo test -p elevator-bevy --doc --quiet
 
 echo "pre-commit: checking workspace..."
 cargo check --workspace --all-features --quiet

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -34,8 +34,10 @@ cargo test -p elevator-bevy --doc --quiet
 echo "pre-commit: checking workspace..."
 cargo check --workspace --all-features --quiet
 
-# Lint docs if any docs/ files are staged.
-if grep -q '^docs/' <<<"$staged"; then
+# Lint docs if any docs/ files or the README are staged. README.md is
+# pulled into the doctest harness, so it is under the same ignore-fence
+# policy as the mdBook chapters.
+if grep -qE '^(docs/|README\.md$)' <<<"$staged"; then
     echo "pre-commit: linting docs..."
     scripts/lint-docs.sh --quick
 fi

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Plug it into Bevy, Unity, your own renderer, or run headless.
 
 You define stops at arbitrary positions on a 1-D axis, spawn riders, and call `step()`. The engine handles dispatch, trapezoidal motion, doors, boarding, and metrics — your code just reacts to events.
 
-```rust
+```rust,no_run
 use elevator_core::prelude::*;
 use elevator_core::config::ElevatorConfig;
 

--- a/crates/elevator-bevy/src/doctests.rs
+++ b/crates/elevator-bevy/src/doctests.rs
@@ -1,0 +1,9 @@
+//! Compiles the `bevy-integration.md` chapter so its code fences cannot
+//! drift from the real `elevator-bevy` bridge types and the current Bevy
+//! version the crate pins.
+
+#![cfg(doctest)]
+#![allow(missing_docs)]
+
+#[doc = include_str!("../../../docs/src/bevy-integration.md")]
+pub struct BevyIntegration;

--- a/crates/elevator-bevy/src/lib.rs
+++ b/crates/elevator-bevy/src/lib.rs
@@ -1,0 +1,15 @@
+//! Library surface for `elevator-bevy`.
+//!
+//! The crate ships primarily as a binary (`src/main.rs`). This library target
+//! is intentionally minimal: it re-exports only `sim_bridge`, which is the one
+//! module whose types (`SimulationRes`, `SimSpeed`, `EventWrapper`) the
+//! `bevy-integration.md` chapter imports directly. The chapter's other
+//! snippets (the `ElevatorSimPlugin` declaration, per-system examples) define
+//! their own shadow types inline so they stay self-contained doctests. If a
+//! future chapter needs `plugin` or any other sibling module, expose it here
+//! rather than widening the hidden scaffolding.
+
+pub mod sim_bridge;
+
+#[cfg(doctest)]
+mod doctests;

--- a/crates/elevator-core/src/doctests.rs
+++ b/crates/elevator-core/src/doctests.rs
@@ -1,0 +1,83 @@
+//! Compiles the crate README and every `docs/src/` chapter as doc tests so
+//! the code fences inside them cannot drift from the real API.
+//!
+//! Each `include_str!` pulls a markdown file into rustdoc's view. `cargo
+//! test --doc` then extracts every fenced Rust block and compiles it. Bare
+//! ```rust fences are compiled and run; ```rust,no_run fences are compiled
+//! only (safe for infinite loops or long simulations); ```rust,ignore is
+//! disallowed by `scripts/lint-docs.sh`.
+//!
+//! Chapters that require the `elevator-bevy` crate (e.g. `bevy-integration.md`)
+//! are hosted in that crate's doctest module instead.
+
+#![cfg(doctest)]
+#![allow(missing_docs)]
+
+#[doc = include_str!("../../../README.md")]
+pub struct Readme;
+
+#[doc = include_str!("../../../docs/src/quick-start.md")]
+pub struct QuickStart;
+
+#[doc = include_str!("../../../docs/src/configuration.md")]
+pub struct Configuration;
+
+#[doc = include_str!("../../../docs/src/stops-lines-groups.md")]
+pub struct StopsLinesGroups;
+
+#[doc = include_str!("../../../docs/src/elevators.md")]
+pub struct Elevators;
+
+#[doc = include_str!("../../../docs/src/riders.md")]
+pub struct Riders;
+
+#[doc = include_str!("../../../docs/src/rider-lifecycle.md")]
+pub struct RiderLifecycle;
+
+#[doc = include_str!("../../../docs/src/simulation-loop.md")]
+pub struct SimulationLoop;
+
+#[doc = include_str!("../../../docs/src/dispatch-strategies.md")]
+pub struct DispatchStrategies;
+
+#[doc = include_str!("../../../docs/src/custom-dispatch.md")]
+pub struct CustomDispatch;
+
+#[doc = include_str!("../../../docs/src/hall-calls.md")]
+pub struct HallCalls;
+
+#[doc = include_str!("../../../docs/src/door-control.md")]
+pub struct DoorControl;
+
+#[doc = include_str!("../../../docs/src/movement-physics.md")]
+pub struct MovementPhysics;
+
+#[doc = include_str!("../../../docs/src/manual-inspection-modes.md")]
+pub struct ManualInspectionModes;
+
+#[doc = include_str!("../../../docs/src/events-metrics.md")]
+pub struct EventsMetrics;
+
+#[doc = include_str!("../../../docs/src/lifecycle-hooks.md")]
+pub struct LifecycleHooks;
+
+#[doc = include_str!("../../../docs/src/extensions.md")]
+pub struct Extensions;
+
+#[doc = include_str!("../../../docs/src/snapshots-determinism.md")]
+pub struct SnapshotsDeterminism;
+
+#[doc = include_str!("../../../docs/src/traffic-generation.md")]
+pub struct TrafficGeneration;
+
+#[doc = include_str!("../../../docs/src/error-handling.md")]
+pub struct ErrorHandling;
+
+#[doc = include_str!("../../../docs/src/headless-non-bevy.md")]
+pub struct HeadlessNonBevy;
+
+#[doc = include_str!("../../../docs/src/testing.md")]
+pub struct Testing;
+
+#[doc = include_str!("../../../docs/src/performance.md")]
+pub struct Performance;

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -345,13 +345,14 @@ pub enum Event {
     /// Load values use [`OrderedFloat`] for
     /// `Eq` compatibility. Dereference to get the inner `f64`:
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
     /// use elevator_core::events::Event;
-    ///
+    /// # fn handle(event: Event) {
     /// if let Event::CapacityChanged { current_load, capacity, .. } = event {
     ///     let pct = *current_load / *capacity * 100.0;
     ///     println!("Elevator at {pct:.0}% capacity");
     /// }
+    /// # }
     /// ```
     CapacityChanged {
         /// The elevator whose load changed.

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -146,7 +146,13 @@
 //!
 //! Games attach custom data to any entity without modifying the library:
 //!
-//! ```rust,ignore
+//! ```rust,no_run
+//! # use elevator_core::prelude::*;
+//! # use elevator_core::query::Ext;
+//! # use serde::{Serialize, Deserialize};
+//! # #[derive(Debug, Clone, Serialize, Deserialize)]
+//! # struct VipTag { priority: u32 }
+//! # fn run(world: &mut World, rider_id: EntityId) {
 //! // Attach a VIP flag to a rider.
 //! world.insert_ext(rider_id, VipTag { priority: 1 }, ExtKey::from_type_name());
 //!
@@ -154,6 +160,7 @@
 //! for (id, rider, vip) in world.query::<(EntityId, &Rider, &Ext<VipTag>)>().iter() {
 //!     // ...
 //! }
+//! # }
 //! ```
 //!
 //! Extensions participate in snapshots via `serialize_extensions()` /
@@ -326,6 +333,9 @@
 
 #![forbid(unsafe_code)]
 #![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+#[cfg(doctest)]
+mod doctests;
 
 /// Entity-component data types for the simulation.
 pub mod components;

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -47,12 +47,21 @@ impl Simulation {
     /// This is the recommended way to restore extensions. It replaces the
     /// manual 3-step ceremony of `register_ext` → `load_extensions`:
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use elevator_core::prelude::*;
+    /// # use elevator_core::register_extensions;
+    /// # use elevator_core::snapshot::WorldSnapshot;
+    /// # use serde::{Serialize, Deserialize};
+    /// # #[derive(Clone, Serialize, Deserialize)] struct VipTag;
+    /// # #[derive(Clone, Serialize, Deserialize)] struct TeamId;
+    /// # fn before(snapshot: WorldSnapshot) -> Result<(), SimError> {
     /// // Before (3-step ceremony):
     /// let mut sim = snapshot.restore(None)?;
     /// sim.world_mut().register_ext::<VipTag>(ExtKey::from_type_name());
     /// sim.world_mut().register_ext::<TeamId>(ExtKey::from_type_name());
     /// sim.load_extensions();
+    /// # Ok(()) }
+    /// # fn after(snapshot: WorldSnapshot) -> Result<(), SimError> {
     ///
     /// // After:
     /// let mut sim = snapshot.restore(None)?;
@@ -60,6 +69,7 @@ impl Simulation {
     ///     register_extensions!(world, VipTag, TeamId);
     /// });
     /// assert!(unregistered.is_empty(), "missing: {unregistered:?}");
+    /// # Ok(()) }
     /// ```
     ///
     /// Returns the names of any extension types in the snapshot that were

--- a/crates/elevator-core/src/traffic.rs
+++ b/crates/elevator-core/src/traffic.rs
@@ -21,13 +21,13 @@
 //! [`Simulation::spawn_rider`](crate::sim::Simulation::spawn_rider)
 //! (or the [`RiderBuilder`](crate::sim::RiderBuilder) for richer configuration).
 //!
-//! ```rust,ignore
+//! ```rust,no_run
 //! use elevator_core::prelude::*;
-//! use elevator_core::traffic::{PoissonSource, SpawnRequest};
-//!
-//! let config: SimConfig = /* load from RON */;
-//! let mut sim = SimulationBuilder::from_config(&config).build().unwrap();
-//! let mut source = PoissonSource::from_config(&config);
+//! use elevator_core::config::SimConfig;
+//! use elevator_core::traffic::{PoissonSource, TrafficSource};
+//! # fn run(config: &SimConfig) -> Result<(), SimError> {
+//! let mut sim = SimulationBuilder::from_config(config.clone()).build()?;
+//! let mut source = PoissonSource::from_config(config);
 //!
 //! for _ in 0..10_000 {
 //!     let tick = sim.current_tick();
@@ -36,6 +36,8 @@
 //!     }
 //!     sim.step();
 //! }
+//! # Ok(())
+//! # }
 //! ```
 
 use crate::config::SimConfig;
@@ -178,8 +180,10 @@ impl TrafficPattern {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust,no_run
+/// use elevator_core::prelude::*;
 /// use elevator_core::traffic::{TrafficPattern, TrafficSchedule};
+/// use rand::{SeedableRng, rngs::StdRng};
 ///
 /// let schedule = TrafficSchedule::new(vec![
 ///     (0..3600, TrafficPattern::UpPeak),      // First hour: morning rush
@@ -189,8 +193,11 @@ impl TrafficPattern {
 /// ]);
 ///
 /// // Sampling uses the pattern active at the given tick
-/// let stops = vec![/* ... */];
-/// let (origin, dest) = schedule.sample(tick, &stops, &mut rng).unwrap();
+/// let stops = vec![StopId(0), StopId(1)];
+/// let mut rng = StdRng::seed_from_u64(0);
+/// let tick: u64 = 0;
+/// let (origin, dest) = schedule.sample_stop_ids(tick, &stops, &mut rng).unwrap();
+/// # let _ = (origin, dest);
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TrafficSchedule {
@@ -311,10 +318,15 @@ pub struct SpawnRequest {
 /// Implementors produce zero or more [`SpawnRequest`]s per tick. The consumer
 /// is responsible for feeding them into the simulation:
 ///
-/// ```rust,ignore
+/// ```rust,no_run
+/// # use elevator_core::prelude::*;
+/// # use elevator_core::traffic::TrafficSource;
+/// # fn run(sim: &mut Simulation, source: &mut impl TrafficSource, tick: u64) -> Result<(), SimError> {
 /// for req in source.generate(tick) {
 ///     sim.spawn_rider(req.origin, req.destination, req.weight)?;
 /// }
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// This design keeps traffic generation external to the simulation loop,
@@ -341,19 +353,25 @@ pub trait TrafficSource {
 ///
 /// # Example
 ///
-/// ```rust,ignore
-/// use elevator_core::traffic::PoissonSource;
+/// ```rust,no_run
+/// use elevator_core::prelude::*;
+/// use elevator_core::config::SimConfig;
+/// use elevator_core::traffic::{PoissonSource, TrafficSchedule};
 ///
+/// # fn run(config: &SimConfig) {
 /// // From a SimConfig (reads stops and spawn parameters).
-/// let mut source = PoissonSource::from_config(&config);
+/// let mut source = PoissonSource::from_config(config);
 ///
 /// // Or build manually.
+/// let stops = vec![StopId(0), StopId(1)];
 /// let mut source = PoissonSource::new(
 ///     stops,
 ///     TrafficSchedule::office_day(3600),
 ///     120,           // mean_interval_ticks
 ///     (60.0, 90.0),  // weight_range
 /// );
+/// # let _ = source;
+/// # }
 /// ```
 pub struct PoissonSource {
     /// Sorted stop IDs (lowest position first).

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -942,10 +942,15 @@ impl World {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use elevator_core::prelude::*;
+    /// # use serde::{Serialize, Deserialize};
+    /// # #[derive(Clone, Serialize, Deserialize)] struct VipTag { level: u32 }
+    /// # fn run(world: &mut World) {
     /// world.query_ext_mut::<VipTag>().for_each_mut(|id, tag| {
     ///     tag.level += 1;
     /// });
+    /// # }
     /// ```
     pub fn query_ext_mut<T: 'static + Send + Sync>(&mut self) -> crate::query::ExtQueryMut<'_, T> {
         crate::query::ExtQueryMut::new(self)

--- a/docs/src/bevy-integration.md
+++ b/docs/src/bevy-integration.md
@@ -22,8 +22,13 @@ The app reads a RON config file, creates a `Simulation`, and renders the buildin
 
 The integration is built around a single Bevy plugin:
 
-```rust,ignore
+```rust,no_run
+# use bevy::prelude::*;
 pub struct ElevatorSimPlugin;
+
+impl Plugin for ElevatorSimPlugin {
+    fn build(&self, _app: &mut App) { /* wire resources, systems, messages */ }
+}
 ```
 
 When you add this plugin to a Bevy app, it:
@@ -40,7 +45,9 @@ When you add this plugin to a Bevy app, it:
 
 The core simulation is wrapped in a Bevy resource:
 
-```rust,ignore
+```rust,no_run
+# use bevy::prelude::*;
+# use elevator_core::prelude::*;
 #[derive(Resource)]
 pub struct SimulationRes {
     pub sim: Simulation,
@@ -53,7 +60,8 @@ Any Bevy system can access the simulation through `Res<SimulationRes>` (read) or
 
 Controls how many simulation ticks run per Bevy frame:
 
-```rust,ignore
+```rust,no_run
+# use bevy::prelude::*;
 #[derive(Resource)]
 pub struct SimSpeed {
     pub multiplier: u32,
@@ -70,14 +78,20 @@ The built-in input system maps keyboard keys to speed changes.
 
 Core simulation events are bridged into Bevy's message system:
 
-```rust,ignore
+```rust,no_run
+# use bevy::prelude::*;
+# use elevator_core::events::Event;
 #[derive(Message)]
 pub struct EventWrapper(pub Event);
 ```
 
 Bevy systems can read simulation events using `MessageReader<EventWrapper>`:
 
-```rust,ignore
+```rust,no_run
+# use bevy::prelude::*;
+# use elevator_core::events::Event;
+# #[derive(Message, Clone)]
+# pub struct EventWrapper(pub Event);
 fn my_system(mut events: MessageReader<EventWrapper>) {
     for EventWrapper(event) in events.read() {
         match event {
@@ -94,7 +108,16 @@ fn my_system(mut events: MessageReader<EventWrapper>) {
 
 The bridge between elevator-core and Bevy is a single system that runs each frame:
 
-```rust,ignore
+```rust,no_run
+# use bevy::prelude::*;
+# use elevator_core::events::Event;
+# use elevator_core::sim::Simulation;
+# #[derive(Resource)]
+# pub struct SimulationRes { pub sim: Simulation }
+# #[derive(Resource)]
+# pub struct SimSpeed { pub multiplier: u32 }
+# #[derive(Message, Clone)]
+# pub struct EventWrapper(pub Event);
 pub fn tick_simulation(
     mut sim: ResMut<SimulationRes>,
     speed: Res<SimSpeed>,
@@ -115,7 +138,7 @@ It steps the simulation `multiplier` times, then drains all events and re-emits 
 
 To add your own gameplay systems that interact with the simulation, access `SimulationRes`:
 
-```rust,ignore
+```rust,no_run
 use bevy::prelude::*;
 use elevator_bevy::sim_bridge::SimulationRes;
 use elevator_core::prelude::*;
@@ -135,7 +158,13 @@ fn print_metrics(sim: Res<SimulationRes>) {
 
 Register your system in the Bevy app after the plugin:
 
-```rust,ignore
+```rust,no_run
+# use bevy::prelude::*;
+# use elevator_bevy::sim_bridge::SimulationRes;
+# pub struct ElevatorSimPlugin;
+# impl Plugin for ElevatorSimPlugin { fn build(&self, _: &mut App) {} }
+# fn print_metrics(_sim: Res<SimulationRes>) {}
+# let mut app = App::new();
 app.add_plugins(ElevatorSimPlugin)
     .add_systems(Update, print_metrics);
 ```

--- a/docs/src/custom-dispatch.md
+++ b/docs/src/custom-dispatch.md
@@ -19,7 +19,7 @@ flowchart LR
 
 ## The trait surface
 
-```rust,ignore
+```text
 pub trait DispatchStrategy: Send + Sync {
     /// Pre-pass hook with mutable world access. Used by sticky strategies
     /// (e.g. destination dispatch) to commit rider -> car assignments.
@@ -67,7 +67,7 @@ pub trait DispatchStrategy: Send + Sync {
 
 `RankContext` bundles the per-call arguments into a single struct:
 
-```rust,ignore
+```text
 pub struct RankContext<'a> {
     pub car: EntityId,
     pub car_position: f64,
@@ -85,7 +85,7 @@ Only `rank` is required. The default `fallback` returns `Idle`; the other hooks 
 
 "Nearest-car by distance, favoring stops with more waiting riders."
 
-```rust,ignore
+```rust,no_run
 use elevator_core::dispatch::{DispatchStrategy, RankContext};
 
 struct BusyStopNearest;
@@ -116,7 +116,7 @@ Strategies whose ranking depends on per-car state (a sweep direction, a queue po
 
 The built-in `ScanDispatch` uses this hook to decide whether the car's sweep direction should flip for the current pass. That decision depends on whole-group demand, so doing it inside `rank` would give different answers depending on which stop was scored first.
 
-```rust,ignore
+```rust,no_run
 use std::collections::HashMap;
 use elevator_core::dispatch::{
     DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext,
@@ -184,7 +184,7 @@ The framework calls `notify_removed(elevator)` on the group's dispatcher wheneve
 
 Forgetting to implement this is the most common correctness bug in custom strategies. `ScanDispatch` and `LookDispatch` both use it to evict direction entries.
 
-```rust,ignore
+```text
 use std::collections::HashMap;
 
 #[derive(Default)]
@@ -213,37 +213,49 @@ On restore, `WorldSnapshot::restore()` takes an optional factory function that m
 
 The canonical pattern:
 
-```rust,ignore
-use elevator_core::dispatch::{BuiltinStrategy, DispatchStrategy};
+```rust,no_run
+use elevator_core::prelude::*;
+use elevator_core::config::ElevatorConfig;
+use elevator_core::dispatch::{BuiltinStrategy, DispatchStrategy, RankContext};
 use elevator_core::ids::GroupId;
 use elevator_core::snapshot::WorldSnapshot;
 
+#[derive(Default)]
+struct PriorityDispatch;
+impl DispatchStrategy for PriorityDispatch {
+    // Real implementations score against `ctx`; see `BusyStopNearest` above.
+    fn rank(&mut self, _ctx: &RankContext<'_>) -> Option<f64> { Some(0.0) }
+}
+
 const PRIORITY_NAME: &str = "priority";
 
-// When building the sim, install the strategy via `Simulation::set_dispatch`,
-// which takes both the strategy and the `BuiltinStrategy` id used for
-// snapshot serialization.
-let mut sim = SimulationBuilder::new()
-    .stop(StopId(0), "Ground", 0.0)
-    .stop(StopId(1), "Top", 10.0)
-    .elevator(ElevatorConfig::default())
-    .build()?;
-sim.set_dispatch(
-    GroupId(0),
-    Box::new(PriorityDispatch::default()),
-    BuiltinStrategy::Custom(PRIORITY_NAME.into()),
-);
+fn run(snapshot: WorldSnapshot) -> Result<(), SimError> {
+    // When building the sim, install the strategy via `Simulation::set_dispatch`,
+    // which takes both the strategy and the `BuiltinStrategy` id used for
+    // snapshot serialization.
+    let mut sim = SimulationBuilder::new()
+        .stop(StopId(0), "Ground", 0.0)
+        .stop(StopId(1), "Top", 10.0)
+        .elevator(ElevatorConfig::default())
+        .build()?;
+    sim.set_dispatch(
+        GroupId(0),
+        Box::new(PriorityDispatch),
+        BuiltinStrategy::Custom(PRIORITY_NAME.into()),
+    );
 
-// When restoring:
-let snapshot: WorldSnapshot = /* deserialized from RON/JSON/bincode */;
-let sim = snapshot.restore(Some(&|name: &str| -> Option<Box<dyn DispatchStrategy>> {
-    match name {
-        PRIORITY_NAME => Some(Box::new(PriorityDispatch::default())),
-        // Return `None` for unknown names -- the restore falls back to
-        // `ScanDispatch` rather than panicking.
-        _ => None,
-    }
-}));
+    // When restoring, the factory maps names back to strategy instances.
+    let sim = snapshot.restore(Some(&|name: &str| -> Option<Box<dyn DispatchStrategy>> {
+        match name {
+            PRIORITY_NAME => Some(Box::new(PriorityDispatch)),
+            // Return `None` for unknown names -- the restore falls back to
+            // `ScanDispatch` rather than panicking.
+            _ => None,
+        }
+    }))?;
+    let _ = sim;
+    Ok(())
+}
 ```
 
 The name is opaque to the library. Keep it stable across releases -- changing the name breaks old saved snapshots.
@@ -256,7 +268,12 @@ Two levels of test coverage work well:
 
 **Integration-test via a full `Simulation`.** Spawn riders, step the loop, assert on events (`ElevatorAssigned`, `RiderBoarded`, etc.). This catches bugs that only surface through the 8-phase interaction -- e.g., a strategy that excludes every `(car, stop)` pair it shouldn't, or one whose `prepare_car` mutation leaves stale state between passes.
 
-```rust,ignore
+```rust,no_run
+# use elevator_core::prelude::*;
+# struct BusyStopNearest;
+# impl DispatchStrategy for BusyStopNearest {
+#     fn rank(&mut self, _ctx: &RankContext<'_>) -> Option<f64> { Some(0.0) }
+# }
 #[test]
 fn custom_strategy_assigns_nearest_car() {
     let mut sim = SimulationBuilder::new()

--- a/docs/src/dispatch-strategies.md
+++ b/docs/src/dispatch-strategies.md
@@ -138,14 +138,21 @@ fn main() -> Result<(), SimError> {
 
 After dispatch, idle elevators with no pending demand can be repositioned for better coverage. Configure a `RepositionStrategy` on the builder:
 
-```rust,ignore
+```rust,no_run
 use elevator_core::prelude::*;
+use elevator_core::config::ElevatorConfig;
 use elevator_core::dispatch::BuiltinReposition;
+use elevator_core::dispatch::reposition::SpreadEvenly;
 
-let sim = SimulationBuilder::new()
-    // ... stops and elevators ...
-    .reposition(SpreadEvenly, BuiltinReposition::SpreadEvenly)
-    .build()?;
+fn main() -> Result<(), SimError> {
+    let sim = SimulationBuilder::new()
+        .stop(StopId(0), "Ground", 0.0)
+        .stop(StopId(1), "Top", 10.0)
+        .elevator(ElevatorConfig::default())
+        .reposition(SpreadEvenly, BuiltinReposition::SpreadEvenly)
+        .build()?;
+    Ok(())
+}
 ```
 
 The second argument is a `BuiltinReposition` identifier used for snapshot serialization. Pass the variant that matches your strategy so snapshots can restore it correctly.

--- a/docs/src/elevators.md
+++ b/docs/src/elevators.md
@@ -28,7 +28,9 @@ From `Stopped`, dispatch can assign a new target (back to `MovingToStop`) or lea
 
 Access elevator data through the simulation or the world directly:
 
-```rust,ignore
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(sim: &Simulation, elevator_id: EntityId) {
 // World accessors return Option -- unwrap when you know the entity exists.
 let pos: f64 = sim.world().position(elevator_id).unwrap().value();
 let vel: f64 = sim.world().velocity(elevator_id).unwrap().value();
@@ -38,6 +40,8 @@ let elev = sim.world().elevator(elevator_id).unwrap();
 let phase = elev.phase();
 let load = elev.current_load();
 let capacity = elev.weight_capacity();
+# let _ = (pos, vel, phase, load, capacity);
+# }
 ```
 
 ## Direction indicators
@@ -59,17 +63,25 @@ The loading phase uses these lamps as a boarding filter. A rider heading up will
 
 Read the lamps through the simulation API:
 
-```rust,ignore
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(sim: &Simulation, elevator_id: EntityId) {
 let going_up = sim.elevator_going_up(elevator_id);
 let going_down = sim.elevator_going_down(elevator_id);
+# let _ = (going_up, going_down);
+# }
 ```
 
 Or directly from the component:
 
-```rust,ignore
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(sim: &Simulation, elevator_id: EntityId) {
 let elev = sim.world().elevator(elevator_id).unwrap();
 let going_up = elev.going_up();
 let going_down = elev.going_down();
+# let _ = (going_up, going_down);
+# }
 ```
 
 ## Physics
@@ -104,8 +116,6 @@ When constructing elevators, use `ElevatorConfig` to set initial parameters:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
-# use elevator_core::config::ElevatorConfig;
-# use elevator_core::stop::StopId;
 # fn main() -> Result<(), SimError> {
 # let sim = SimulationBuilder::new()
 #     .stop(StopId(0), "Ground", 0.0)
@@ -133,13 +143,17 @@ All physics parameters must be positive. Invalid values are rejected at build ti
 
 Physics parameters, capacity, and door timing can be changed on a running elevator. This is useful for tycoon-style games where players upgrade elevators:
 
-```rust,ignore
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(sim: &mut Simulation, elev: ElevatorId) -> Result<(), SimError> {
 sim.set_max_speed(elev, 4.0)?;
 sim.set_acceleration(elev, 2.5)?;
 sim.set_deceleration(elev, 3.0)?;
 sim.set_weight_capacity(elev, 1500.0)?;
 sim.set_door_open_ticks(elev, 30)?;
 sim.set_door_transition_ticks(elev, 8)?;
+# Ok(())
+# }
 ```
 
 Each setter emits an `ElevatorUpgraded` event with the field name, old value, and new value. Changes take effect on the next tick.

--- a/docs/src/error-handling.md
+++ b/docs/src/error-handling.md
@@ -78,17 +78,28 @@ When a rider cannot board an elevator, a `RiderRejected` event fires with a type
 
 Every `RiderRejected` event includes a `RejectionContext` with the numeric details behind the decision:
 
-```rust,ignore
-RejectionContext {
-    attempted_weight: OrderedFloat<f64>,  // weight the rider tried to add
-    current_load: OrderedFloat<f64>,      // elevator's load at rejection time
-    capacity: OrderedFloat<f64>,          // elevator's maximum weight capacity
-}
+```rust,no_run
+# use elevator_core::prelude::*;
+use ordered_float::OrderedFloat;
+
+let context = RejectionContext {
+    attempted_weight: OrderedFloat(80.0), // weight the rider tried to add
+    current_load: OrderedFloat(750.0),    // elevator's load at rejection time
+    capacity: OrderedFloat(800.0),        // elevator's maximum weight capacity
+};
+# let _ = context;
 ```
 
 `RejectionContext` implements `Display` for game-friendly feedback:
 
-```rust,ignore
+```rust,no_run
+# use elevator_core::prelude::*;
+# use ordered_float::OrderedFloat;
+# let context = RejectionContext {
+#     attempted_weight: OrderedFloat(80.0),
+#     current_load: OrderedFloat(750.0),
+#     capacity: OrderedFloat(800.0),
+# };
 // "over capacity by 30.0kg (750.0/800.0 + 80.0)"
 println!("{}", context);
 ```

--- a/docs/src/events-metrics.md
+++ b/docs/src/events-metrics.md
@@ -185,8 +185,6 @@ For per-zone or per-label breakdowns, tag entities with string labels and query 
 
 ```rust,no_run
 # use elevator_core::prelude::*;
-# use elevator_core::config::ElevatorConfig;
-# use elevator_core::stop::StopId;
 # fn main() -> Result<(), SimError> {
 # let mut sim = SimulationBuilder::new()
 #     .stop(StopId(0), "Ground", 0.0)

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -52,8 +52,6 @@ Use `world.insert_ext()` to attach your component to an entity:
 # #[derive(Debug, Clone, Serialize, Deserialize)]
 # struct VipTag { level: u32, lounge_access: bool }
 # use elevator_core::prelude::*;
-# use elevator_core::config::ElevatorConfig;
-# use elevator_core::stop::StopId;
 # fn main() -> Result<(), SimError> {
 # let mut sim = SimulationBuilder::new()
 #     .stop(StopId(0), "Ground", 0.0)
@@ -98,7 +96,13 @@ if let Some(vip) = sim.world_mut().ext_mut::<VipTag>(rider_id) {
 
 Extensions integrate with the query builder for ECS-style iteration:
 
-```rust,ignore
+```rust,no_run
+# use serde::{Serialize, Deserialize};
+# #[derive(Debug, Clone, Serialize, Deserialize)]
+# struct VipTag { level: u32, lounge_access: bool }
+# use elevator_core::prelude::*;
+# use elevator_core::query::Ext;
+# fn run(world: &mut World) {
 // Read-only iteration (cloned via Ext<T>)
 for (id, vip) in world.query::<(EntityId, &Ext<VipTag>)>().iter() {
     println!("{:?} is VIP level {}", id, vip.level);
@@ -108,6 +112,7 @@ for (id, vip) in world.query::<(EntityId, &Ext<VipTag>)>().iter() {
 world.query_ext_mut::<VipTag>().for_each_mut(|id, tag| {
     tag.level += 1;
 });
+# }
 ```
 
 The mutable query collects entity IDs first, then iterates with mutable borrows, so it is safe to use without aliasing issues.

--- a/docs/src/hall-calls.md
+++ b/docs/src/hall-calls.md
@@ -18,14 +18,17 @@ Two modes are available, chosen per group via `HallCallMode`:
 - **`HallCallMode::Classic`** (default) -- traditional collective control. Hall calls carry direction only; the `CarCall` reveals the destination after boarding.
 - **`HallCallMode::Destination`** -- DCS mode. Hall calls carry a destination from the moment they are pressed (kiosk entry). Required by `DestinationDispatch`.
 
-```rust,ignore
+```rust,no_run
 use elevator_core::prelude::*;
 use elevator_core::dispatch::HallCallMode;
 
-let mut sim = SimulationBuilder::demo().build()?;
-for g in sim.groups_mut() {
-    g.set_hall_call_mode(HallCallMode::Destination);
-    g.set_ack_latency_ticks(5);  // 5-tick controller latency
+fn main() -> Result<(), SimError> {
+    let mut sim = SimulationBuilder::demo().build()?;
+    for g in sim.groups_mut() {
+        g.set_hall_call_mode(HallCallMode::Destination);
+        g.set_ack_latency_ticks(5);  // 5-tick controller latency
+    }
+    Ok(())
 }
 ```
 
@@ -44,7 +47,15 @@ Car calls follow the same pattern: `CarButtonPressed` fires on the first press p
 
 Games can drive the call system outside the normal rider flow:
 
-```rust,ignore
+```rust,no_run
+# use elevator_core::prelude::*;
+# use elevator_core::components::hall_call::CallDirection;
+# fn run(
+#     sim: &mut Simulation,
+#     lobby: StopId,
+#     penthouse: EntityId,
+#     villain_car: ElevatorId,
+# ) -> Result<(), SimError> {
 // An NPC walks up and presses the down button.
 sim.press_hall_button(lobby, CallDirection::Down)?;
 
@@ -55,6 +66,8 @@ sim.pin_assignment(villain_car, penthouse, CallDirection::Up)?;
 // it brakes immediately instead of finishing the current leg.
 sim.unpin_assignment(penthouse, CallDirection::Up);
 sim.abort_movement(villain_car)?;
+# Ok(())
+# }
 ```
 
 A pinned car that is mid-door-cycle (`Loading` / `DoorOpening` / `DoorClosing`) finishes its current cycle first; the pin takes effect on the next dispatch tick. Pins that cross lines (the car's line cannot reach the stop) return `SimError::LineDoesNotServeStop` rather than silently orphaning the call.

--- a/docs/src/headless-non-bevy.md
+++ b/docs/src/headless-non-bevy.md
@@ -34,14 +34,19 @@ cargo run --example headless_trace -- \
 
 The body of the main loop is small enough to inline here:
 
-```rust,ignore
-for _ in 0..args.ticks {
+```rust,no_run
+# use elevator_core::prelude::*;
+# use std::io::Write;
+# fn run(sim: &mut Simulation, out: &mut impl Write, ticks: u64) -> Result<(), Box<dyn std::error::Error>> {
+for _ in 0..ticks {
     sim.step();
     for event in sim.drain_events() {
         let line = serde_json::to_string(&event)?;
         writeln!(out, "{line}")?;
     }
 }
+# Ok(())
+# }
 ```
 
 `Event` implements `Serialize` / `Deserialize`, so consumers in any language can read the NDJSON stream. This is the integration shape a web backend would use: stream events over SSE / WebSocket, have a JS frontend render them.
@@ -59,7 +64,7 @@ for _ in 0..args.ticks {
 
 The relevant integration pattern:
 
-```rust,ignore
+```text
 use elevator_core::components::{Elevator, RiderPhase, Stop};
 use elevator_core::prelude::*;
 use macroquad::prelude::*;
@@ -106,7 +111,7 @@ The rendering functions pull component state via `sim.world().query::<...>()` --
 
 The example above steps the sim once per rendered frame. If you want the sim to run at a fixed 60 tick/sec regardless of display refresh rate:
 
-```rust,ignore
+```text
 let mut tick_accumulator = 0.0_f64;
 let tick_interval = 1.0 / sim.time().ticks_per_second();
 
@@ -126,7 +131,7 @@ loop {
 
 [eframe](https://github.com/emilk/egui) is the immediate-mode UI framework behind egui. It's suited for inspector-style tools -- a dashboard on the sim rather than a game. We don't ship a runnable eframe example (eframe transitively pulls in wgpu, which is a heavy dep for an example), but the pattern is:
 
-```rust,ignore
+```text
 // Your app holds the sim as state.
 struct ElevatorApp {
     sim: Simulation,

--- a/docs/src/lifecycle-hooks.md
+++ b/docs/src/lifecycle-hooks.md
@@ -7,6 +7,7 @@ Hooks let you inject custom logic before or after any of the simulation's tick p
 ```rust,no_run
 use elevator_core::prelude::*;
 use elevator_core::config::ElevatorConfig;
+use elevator_core::hooks::Phase;
 use elevator_core::stop::StopId;
 
 fn main() -> Result<(), SimError> {
@@ -33,8 +34,7 @@ You can add hooks to a running simulation. This is useful when hook logic depend
 
 ```rust,no_run
 # use elevator_core::prelude::*;
-# use elevator_core::config::ElevatorConfig;
-# use elevator_core::stop::StopId;
+# use elevator_core::hooks::Phase;
 # fn main() -> Result<(), SimError> {
 # let mut sim = SimulationBuilder::new()
 #     .stop(StopId(0), "Ground", 0.0)
@@ -54,8 +54,7 @@ For multi-group buildings, you can register hooks that only fire for a specific 
 
 ```rust,no_run
 # use elevator_core::prelude::*;
-# use elevator_core::config::ElevatorConfig;
-# use elevator_core::stop::StopId;
+# use elevator_core::hooks::Phase;
 # fn main() -> Result<(), SimError> {
 let sim = SimulationBuilder::new()
     .stop(StopId(0), "Ground", 0.0)
@@ -130,6 +129,7 @@ The hook closure cannot call `sim.current_tick()` directly (the simulation is bo
 ```rust,no_run
 use elevator_core::prelude::*;
 use elevator_core::config::ElevatorConfig;
+use elevator_core::hooks::Phase;
 use elevator_core::stop::StopId;
 use serde::{Serialize, Deserialize};
 
@@ -177,8 +177,9 @@ fn main() -> Result<(), SimError> {
 
     for _ in 0..600 {
         // Update the current tick resource before stepping.
+        let now = sim.current_tick();
         if let Some(t) = sim.world_mut().resource_mut::<CurrentTick>() {
-            t.0 = sim.current_tick();
+            t.0 = now;
         }
         sim.step();
     }

--- a/docs/src/manual-inspection-modes.md
+++ b/docs/src/manual-inspection-modes.md
@@ -161,13 +161,13 @@ sim.enable(elev)?;
 
 The `Event::ServiceModeChanged` event fires whenever `set_service_mode` changes an elevator's mode. It carries the `from` and `to` modes along with the elevator entity and tick:
 
-```rust,ignore
-Event::ServiceModeChanged {
-    elevator: EntityId,
-    from: ServiceMode,
-    to: ServiceMode,
-    tick: u64,
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn handle(event: Event) {
+if let Event::ServiceModeChanged { elevator, from, to, tick } = event {
+    let _ = (elevator, from, to, tick); // use the fields in your game
 }
+# }
 ```
 
 If you set the mode to its current value, no event is emitted and the call returns `Ok(())`.

--- a/docs/src/movement-physics.md
+++ b/docs/src/movement-physics.md
@@ -86,7 +86,6 @@ Two methods estimate arrival times for UI countdown displays and dispatch logic:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
-# use elevator_core::components::Direction;
 # let sim: Simulation = todo!();
 # let elev: ElevatorId = todo!();
 # let lobby: EntityId = todo!();
@@ -108,8 +107,13 @@ ETA queries can fail with `EtaError` -- the elevator might not be headed to that
 
 When an elevator passes a stop without stopping, a `PassingFloor` event fires:
 
-```rust,ignore
-Event::PassingFloor { elevator, stop, moving_up, tick }
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn handle(event: Event) {
+if let Event::PassingFloor { elevator, stop, moving_up, tick } = event {
+    let _ = (elevator, stop, moving_up, tick);
+}
+# }
 ```
 
 This is useful for:

--- a/docs/src/quick-start.md
+++ b/docs/src/quick-start.md
@@ -12,7 +12,7 @@ cargo add elevator-core
 
 The prelude re-exports everything you need for typical usage:
 
-```rust,ignore
+```rust
 use elevator_core::prelude::*;
 ```
 
@@ -55,8 +55,6 @@ A rider is anything that rides an elevator. Provide an origin stop, a destinatio
 
 ```rust,no_run
 # use elevator_core::prelude::*;
-# use elevator_core::config::ElevatorConfig;
-# use elevator_core::stop::StopId;
 # fn main() -> Result<(), SimError> {
 # let mut sim = SimulationBuilder::new()
 #     .stop(StopId(0), "Lobby", 0.0)
@@ -81,8 +79,6 @@ Each call to `sim.step()` advances the simulation by one tick, running all [eigh
 
 ```rust,no_run
 # use elevator_core::prelude::*;
-# use elevator_core::config::ElevatorConfig;
-# use elevator_core::stop::StopId;
 # fn main() -> Result<(), SimError> {
 # let mut sim = SimulationBuilder::new()
 #     .stop(StopId(0), "Lobby", 0.0)
@@ -106,7 +102,7 @@ while !arrived {
             }
             Event::RiderExited { rider, stop, tick, .. } => {
                 println!("Tick {tick}: rider {rider:?} exited at {stop:?}");
-                if rider == rider_id {
+                if rider == rider_id.entity() {
                     arrived = true;
                 }
             }
@@ -156,7 +152,7 @@ fn main() -> Result<(), SimError> {
                 }
                 Event::RiderExited { rider, stop, tick, .. } => {
                     println!("Tick {tick}: rider {rider:?} exited at {stop:?}");
-                    if rider == rider_id {
+                    if rider == rider_id.entity() {
                         arrived = true;
                     }
                 }

--- a/docs/src/riders.md
+++ b/docs/src/riders.md
@@ -6,15 +6,22 @@ A rider is anything that rides an elevator. The core library is deliberately gen
 
 The simplest way to create a rider is `spawn_rider`, which takes an origin stop, a destination stop, and a weight:
 
-```rust,ignore
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(sim: &mut Simulation) -> Result<(), SimError> {
 let rider_id = sim.spawn_rider(StopId(0), StopId(3), 75.0)?;
+# let _ = rider_id;
+# Ok(())
+# }
 ```
 
 This creates a rider at stop 0, heading to stop 3, weighing 75 units. The rider starts in the `Waiting` phase and a `RiderSpawned` event is emitted.
 
 For more control, use the `RiderBuilder` fluent API:
 
-```rust,ignore
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(sim: &mut Simulation) -> Result<(), SimError> {
 let rider_id = sim.build_rider(StopId(0), StopId(3))?
     .weight(80.0)
     .patience(600)                 // abandon after 10 seconds at 60 tps
@@ -23,6 +30,9 @@ let rider_id = sim.build_rider(StopId(0), StopId(3))?
             .with_skip_full_elevator(true)
     )
     .spawn()?;
+# let _ = rider_id;
+# Ok(())
+# }
 ```
 
 The builder lets you set patience, boarding preferences, access control, and other per-rider options in a single chain.
@@ -58,7 +68,9 @@ Key accessors on the `Rider` component (all are getter methods):
 
 The simulation maintains a reverse index (`RiderIndex`) that tracks riders at each stop, enabling O(1) population queries without scanning every entity:
 
-```rust,ignore
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(sim: &Simulation, lobby_entity: EntityId, floor_10: EntityId, stop_entity: EntityId) {
 // Who is waiting at the lobby?
 let waiting: Vec<EntityId> = sim.waiting_at(lobby_entity).collect();
 
@@ -67,6 +79,8 @@ let count = sim.residents_at(floor_10).count();
 
 // Did anyone abandon at this stop?
 let abandoned: Vec<EntityId> = sim.abandoned_at(stop_entity).collect();
+# let _ = (waiting, count, abandoned);
+# }
 ```
 
 These three methods cover the main population categories:
@@ -81,7 +95,9 @@ These three methods cover the main population categories:
 
 When you have an `EntityId` and need to know what it refers to, use the type-check helpers:
 
-```rust,ignore
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(sim: &Simulation, id: EntityId) {
 if sim.is_rider(id) {
     // handle rider
 } else if sim.is_elevator(id) {
@@ -89,6 +105,7 @@ if sim.is_rider(id) {
 } else if sim.is_stop(id) {
     // handle stop
 }
+# }
 ```
 
 These are more readable than querying `sim.world().elevator(id).is_some()` and are the preferred pattern in game code.
@@ -105,15 +122,20 @@ Three methods manage rider state transitions after arrival or abandonment:
 
 Always use `sim.despawn_rider(id)` instead of calling `world.despawn()` directly -- it keeps the population index consistent and emits a `RiderDespawned` event.
 
-```rust,ignore
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(sim: &mut Simulation, rider_id: RiderId, new_route: Route) -> Result<(), SimError> {
 // A rider arrives at their destination. Settle them as a resident.
 sim.settle_rider(rider_id)?;
 
 // Later, they want to go back down. Reroute them.
-sim.reroute_rider(rider_id, new_route)?;
+// (`reroute_rider` takes an `EntityId`; the sibling calls take `RiderId`.)
+sim.reroute_rider(rider_id.entity(), new_route)?;
 
 // Or remove them entirely.
 sim.despawn_rider(rider_id)?;
+# Ok(())
+# }
 ```
 
 ## Next steps

--- a/docs/src/simulation-loop.md
+++ b/docs/src/simulation-loop.md
@@ -138,10 +138,14 @@ This phase is a read-only consumer -- it does not emit events.
 
 Each phase supports before/after lifecycle hooks, letting you inject custom logic without sub-stepping:
 
-```rust,ignore
+```rust,no_run
+# use elevator_core::prelude::*;
+# use elevator_core::hooks::Phase;
+# fn run(sim: &mut Simulation) {
 sim.add_before_hook(Phase::Loading, |world| {
     // Custom logic before loading runs
 });
+# }
 ```
 
 See [Lifecycle Hooks](lifecycle-hooks.md) for the full hook API.
@@ -152,8 +156,6 @@ For advanced use cases, you can run individual phases instead of calling `step()
 
 ```rust,no_run
 # use elevator_core::prelude::*;
-# use elevator_core::config::ElevatorConfig;
-# use elevator_core::stop::StopId;
 # fn main() -> Result<(), SimError> {
 # let mut sim = SimulationBuilder::new()
 #     .stop(StopId(0), "Ground", 0.0)

--- a/docs/src/snapshots-determinism.md
+++ b/docs/src/snapshots-determinism.md
@@ -26,8 +26,6 @@ A `WorldSnapshot` captures the full simulation state -- all entities, components
 
 ```rust,no_run
 # use elevator_core::prelude::*;
-# use elevator_core::config::ElevatorConfig;
-# use elevator_core::stop::StopId;
 # fn main() -> Result<(), SimError> {
 # let mut sim = SimulationBuilder::new()
 #     .stop(StopId(0), "Ground", 0.0)
@@ -72,7 +70,6 @@ Built-in strategies (`Scan`, `Look`, `NearestCar`, `Etd`) are auto-restored by n
 ```rust,no_run
 # use elevator_core::prelude::*;
 # use elevator_core::snapshot::WorldSnapshot;
-# use elevator_core::dispatch::RankContext;
 # struct HighestFirstDispatch;
 # impl DispatchStrategy for HighestFirstDispatch {
 #   fn rank(&mut self, _ctx: &RankContext<'_>) -> Option<f64> { Some(0.0) }
@@ -119,11 +116,15 @@ Snapshots are a stronger alternative -- you can start replay from any tick by re
 
 Run a seeded scenario for N ticks, snapshot, and diff against a golden snapshot:
 
-```rust,ignore
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(sim: &mut Simulation, expected: &str) {
 let snap = sim.snapshot();
 let actual = ron::to_string(&snap).unwrap();
-let expected = include_str!("../golden/scenario_a.ron");
+// Compare against a golden file checked into the repo:
+// let expected = include_str!("../golden/scenario_a.ron");
 assert_eq!(actual, expected);
+# }
 ```
 
 This catches unintended behavior changes anywhere in the tick pipeline. See [Testing Your Simulation](testing.md) for more patterns.
@@ -134,10 +135,6 @@ To compare dispatch strategies fairly, use identical seeded traffic across runs:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
-# use elevator_core::config::ElevatorConfig;
-# use elevator_core::stop::StopId;
-# use elevator_core::dispatch::scan::ScanDispatch;
-# use elevator_core::dispatch::etd::EtdDispatch;
 # fn build_sim(dispatch: impl DispatchStrategy + 'static) -> Simulation {
 #   SimulationBuilder::new()
 #       .stop(StopId(0), "Ground", 0.0)

--- a/docs/src/stops-lines-groups.md
+++ b/docs/src/stops-lines-groups.md
@@ -8,8 +8,6 @@ A **stop** is a named position along a 1D shaft axis. Unlike traditional elevato
 
 ```rust,no_run
 # use elevator_core::prelude::*;
-# use elevator_core::stop::StopId;
-# use elevator_core::config::ElevatorConfig;
 # fn main() -> Result<(), SimError> {
 let sim = SimulationBuilder::new()
     .stop(StopId(0), "Basement", -3.0)
@@ -30,7 +28,9 @@ A **line** represents a physical path: a shaft, a tether, a track. Every elevato
 
 For simple single-shaft buildings, you never need to think about lines. The builder auto-creates a default line that includes all stops and all elevators:
 
-```rust,ignore
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn main() -> Result<(), SimError> {
 // This implicitly creates one line containing both elevators and all stops.
 SimulationBuilder::new()
     .stop(StopId(0), "Ground", 0.0)
@@ -38,6 +38,8 @@ SimulationBuilder::new()
     .elevator(ElevatorConfig { id: 0, ..Default::default() })
     .elevator(ElevatorConfig { id: 1, ..Default::default() })
     .build()?;
+# Ok(())
+# }
 ```
 
 Lines matter when you have separate shafts serving different sets of stops -- a low-rise bank that only reaches floors 1-20 and a high-rise bank that serves 20-40, for example.
@@ -94,8 +96,12 @@ The library uses three identity types. Knowing which to reach for saves confusio
 
 `StopId` is a config-level concept. When the simulation boots, each `StopId` is mapped to an `EntityId`. At runtime you work with `EntityId` everywhere. Convert when needed:
 
-```rust,ignore
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(sim: &Simulation) {
 let lobby_entity: Option<EntityId> = sim.stop_entity(StopId(0));
+# let _ = lobby_entity;
+# }
 ```
 
 ## Coordinate system
@@ -110,8 +116,12 @@ The fundamental unit of time is the **tick**. Each call to `sim.step()` advances
 
 Convert between ticks and seconds using the time API:
 
-```rust,ignore
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(sim: &Simulation) {
 let seconds = sim.time().ticks_to_seconds(120);  // 120 ticks -> seconds
+# let _ = seconds;
+# }
 ```
 
 The conversion uses `ticks_per_second` from your config (default: 60). At 60 ticks/second, 120 ticks = 2.0 seconds.

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -13,13 +13,26 @@ The key ingredients for a replay test:
 3. Step for a fixed number of ticks and collect events.
 4. Run the same scenario again and compare.
 
-```rust,ignore
+```rust,no_run
+use elevator_core::prelude::*;
+use elevator_core::config::ElevatorConfig;
+use elevator_core::dispatch::etd::EtdDispatch;
+
 /// A rider spawn scheduled at a specific tick.
 struct ScheduledSpawn {
     tick: u64,
     origin: StopId,
     destination: StopId,
     weight: f64,
+}
+
+fn car_config(id: u32, name: &str) -> ElevatorConfig {
+    ElevatorConfig {
+        id,
+        name: name.into(),
+        starting_stop: StopId(0),
+        ..Default::default()
+    }
 }
 
 fn run_scenario(spawns: &[ScheduledSpawn], total_ticks: u64) -> (Vec<Event>, Metrics) {
@@ -45,7 +58,7 @@ fn run_scenario(spawns: &[ScheduledSpawn], total_ticks: u64) -> (Vec<Event>, Met
 
 #[test]
 fn replay_is_deterministic() {
-    let spawns = vec![/* fixed schedule */];
+    let spawns: Vec<ScheduledSpawn> = vec![/* fixed schedule */];
     let (events_a, metrics_a) = run_scenario(&spawns, 5_000);
     let (events_b, metrics_b) = run_scenario(&spawns, 5_000);
 
@@ -63,7 +76,9 @@ A regression that introduces `HashMap` iteration into a code path, or any other 
 
 Save a snapshot, serialize it, deserialize it, restore, and verify the state matches:
 
-```rust,ignore
+```rust,no_run
+# use elevator_core::prelude::*;
+# use elevator_core::snapshot::WorldSnapshot;
 #[test]
 fn snapshot_roundtrip_preserves_state() {
     let mut sim = SimulationBuilder::demo().build().unwrap();
@@ -97,7 +112,9 @@ This catches serialization bugs, entity ID remapping errors, and missing compone
 
 For elevators in non-trivial phases (e.g., `Repositioning`), verify that the phase variant and its inner entity reference survived the remap:
 
-```rust,ignore
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(restored: &Simulation, elev_id: EntityId) {
 let restored_phase = restored.world().elevator(elev_id).unwrap().phase();
 match restored_phase {
     ElevatorPhase::Repositioning(target) => {
@@ -105,36 +122,41 @@ match restored_phase {
     }
     other => panic!("expected Repositioning, got {other:?}"),
 }
+# }
 ```
 
 ## Scenario scripting
 
 The `scenario` module provides a structured way to define timed rider spawns with pass/fail conditions. A `Scenario` bundles a `SimConfig`, a list of `TimedSpawn` events, evaluation conditions, and a tick limit:
 
-```rust,ignore
+```rust,no_run
+use elevator_core::prelude::*;
+use elevator_core::dispatch::scan::ScanDispatch;
 use elevator_core::scenario::{Scenario, TimedSpawn, Condition, ScenarioRunner};
 
-let scenario = Scenario {
-    name: "Morning rush".into(),
-    config: my_sim_config(),
-    spawns: vec![
-        TimedSpawn { tick: 0, origin: StopId(0), destination: StopId(2), weight: 72.0 },
-        TimedSpawn { tick: 15, origin: StopId(0), destination: StopId(1), weight: 85.0 },
-        TimedSpawn { tick: 60, origin: StopId(2), destination: StopId(0), weight: 68.0 },
-    ],
-    conditions: vec![
-        Condition::AvgWaitBelow(100.0),
-        Condition::MaxWaitBelow(300),
-        Condition::AbandonmentRateBelow(0.05),
-        Condition::AllDeliveredByTick(5000),
-    ],
-    max_ticks: 10_000,
-};
+fn run(my_sim_config: SimConfig) {
+    let scenario = Scenario {
+        name: "Morning rush".into(),
+        config: my_sim_config,
+        spawns: vec![
+            TimedSpawn { tick: 0, origin: StopId(0), destination: StopId(2), weight: 72.0 },
+            TimedSpawn { tick: 15, origin: StopId(0), destination: StopId(1), weight: 85.0 },
+            TimedSpawn { tick: 60, origin: StopId(2), destination: StopId(0), weight: 68.0 },
+        ],
+        conditions: vec![
+            Condition::AvgWaitBelow(100.0),
+            Condition::MaxWaitBelow(300),
+            Condition::AbandonmentRateBelow(0.05),
+            Condition::AllDeliveredByTick(5000),
+        ],
+        max_ticks: 10_000,
+    };
 
-let mut runner = ScenarioRunner::new(scenario, ScanDispatch::new()).unwrap();
-let result = runner.run_to_completion();
+    let mut runner = ScenarioRunner::new(scenario, ScanDispatch::new()).unwrap();
+    let result = runner.run_to_completion();
 
-assert!(result.passed, "scenario failed: {:?}", result.conditions);
+    assert!(result.passed, "scenario failed: {:?}", result.conditions);
+}
 ```
 
 Available conditions:
@@ -155,7 +177,8 @@ Scenarios are `Serialize + Deserialize`, so you can store them as RON files and 
 
 The `proptest` crate (a dev dependency of elevator-core) is used for fuzz-testing simulation invariants. The library's own tests use it to verify physics and convergence properties:
 
-```rust,ignore
+```rust,no_run
+use elevator_core::movement::tick_movement;
 use proptest::prelude::*;
 
 proptest! {
@@ -226,9 +249,12 @@ Criterion generates HTML reports in `target/criterion/` with statistical analysi
 
 **Assert that your fixture actually exercises the sim.** A deterministic replay test is vacuously correct if no riders ever board. Add sanity checks:
 
-```rust,ignore
+```rust,no_run
+# use elevator_core::prelude::*;
+# fn run(events: Vec<Event>, metrics: &Metrics, expected_minimum: u64) {
 assert!(events.iter().any(|e| matches!(e, Event::RiderBoarded { .. })));
 assert!(metrics.total_delivered() >= expected_minimum);
+# }
 ```
 
 **Use `SimulationBuilder::demo()` for quick integration tests.** It creates a minimal two-stop, one-elevator setup that is enough to test most game logic without a full config.

--- a/docs/src/traffic-generation.md
+++ b/docs/src/traffic-generation.md
@@ -9,7 +9,7 @@ Traffic generation is **external to the simulation loop**. A `TrafficSource` pro
 ```rust,no_run
 use elevator_core::prelude::*;
 use elevator_core::config::ElevatorConfig;
-use elevator_core::traffic::{PoissonSource, TrafficPattern, TrafficSchedule};
+use elevator_core::traffic::{PoissonSource, TrafficPattern, TrafficSchedule, TrafficSource};
 
 # fn main() -> Result<(), SimError> {
 let mut sim = SimulationBuilder::new()
@@ -146,7 +146,7 @@ For reproducible traffic, write a custom [`TrafficSource`](#custom-traffic-sourc
 ```rust,no_run
 use elevator_core::traffic::{TrafficSource, SpawnRequest, TrafficPattern};
 use elevator_core::stop::StopId;
-use rand::{Rng, SeedableRng, rngs::StdRng};
+use rand::{RngExt, SeedableRng, rngs::StdRng};
 
 struct SeededPoisson {
     stops: Vec<StopId>,
@@ -219,12 +219,16 @@ You can layer multiple sources, wrap them in a composite, or mix Poisson arrival
 
 A `SpawnRequest` is the minimal description of a rider to spawn:
 
-```rust,ignore
-pub struct SpawnRequest {
-    pub origin: StopId,
-    pub destination: StopId,
-    pub weight: f64,
-}
+```rust,no_run
+# use elevator_core::prelude::*;
+# use elevator_core::traffic::SpawnRequest;
+// Constructing a SpawnRequest to feed into the simulation:
+let req = SpawnRequest {
+    origin: StopId(0),
+    destination: StopId(1),
+    weight: 75.0,
+};
+# let _ = req;
 ```
 
 For riders that need patience, preferences, or access control, spawn through the simulation's `build_rider` fluent API instead of using `spawn_rider` directly:

--- a/scripts/lint-docs.sh
+++ b/scripts/lint-docs.sh
@@ -57,10 +57,12 @@ echo "checking code fence annotations..."
 ignore_err() {
     err "$1: \`\`\`ignore is not allowed (use rust or rust,no_run so the fence is type-checked)"
 }
-# Chapters: fence opens a line like ```rust,ignore or ```ignore.
+# Chapters and README: fence opens a line like ```rust,ignore or ```ignore.
+# README.md is included in the doctest pipeline via `include_str!`, so it
+# belongs under the same policy as the mdBook chapters.
 while IFS=: read -r file line _; do
-    ignore_err "$(basename "$file"):$line"
-done < <(grep -HnE '^```.*\bignore\b' "$DOCS_SRC"/*.md 2>/dev/null || true)
+    ignore_err "${file#"$REPO_ROOT/"}:$line"
+done < <(grep -HnE '^```.*\bignore\b' "$DOCS_SRC"/*.md "$REPO_ROOT"/README.md 2>/dev/null || true)
 # Rustdoc: fence inside /// or //! comments — same rule applies.
 while IFS=: read -r file line _; do
     ignore_err "${file#"$REPO_ROOT/"}:$line"

--- a/scripts/lint-docs.sh
+++ b/scripts/lint-docs.sh
@@ -4,7 +4,7 @@
 # Checks:
 #   1. mdBook builds without errors
 #   2. Every internal [text](file.md) link resolves to an existing file
-#   3. No bare ```rust code fences (must be rust,no_run or rust,ignore)
+#   3. No `ignore` fences in docs/ or rustdoc; they hide drift from `cargo test --doc`
 #   4. Every chapter starts with a level-1 heading
 #   5. No heading-level skips (e.g., ## then ####)
 #   6. No references to deleted files (old chapter names)
@@ -47,11 +47,24 @@ for f in "$DOCS_SRC"/*.md; do
     done < <(grep -oP '\]\(\K[a-z][-a-z0-9]*\.md(?=[)#])' "$f" 2>/dev/null)
 done
 
-# ── 3. Bare ```rust fences ───────────────────────────────────────
+# ── 3. Forbid `ignore` fences ─────────────────────────────────────
+# Every Rust fence must compile via `cargo test --doc`. Use bare ```rust
+# (compiled and run) or ```rust,no_run (compiled only). Any fence tagged
+# `ignore` (bare `ignore`, `rust,ignore`, or combinations) lets drift slip
+# in silently, so it is not allowed — in the mdBook chapters OR in rustdoc
+# comments inside the workspace's Rust sources.
 echo "checking code fence annotations..."
+ignore_err() {
+    err "$1: \`\`\`ignore is not allowed (use rust or rust,no_run so the fence is type-checked)"
+}
+# Chapters: fence opens a line like ```rust,ignore or ```ignore.
 while IFS=: read -r file line _; do
-    err "$(basename "$file"):$line: bare \`\`\`rust (use rust,no_run or rust,ignore)"
-done < <(grep -Hn '^```rust$' "$DOCS_SRC"/*.md 2>/dev/null || true)
+    ignore_err "$(basename "$file"):$line"
+done < <(grep -HnE '^```.*\bignore\b' "$DOCS_SRC"/*.md 2>/dev/null || true)
+# Rustdoc: fence inside /// or //! comments — same rule applies.
+while IFS=: read -r file line _; do
+    ignore_err "${file#"$REPO_ROOT/"}:$line"
+done < <(grep -rHnE '^\s*(///|//!)\s*```.*\bignore\b' "$REPO_ROOT"/crates/*/src 2>/dev/null || true)
 
 # ── 4, 5, 7. Per-file structure checks ──────────────────────────
 # Single pass per file: first-line heading, heading-level skips, "Next steps" section


### PR DESCRIPTION
## Summary

- Wires the README and all 22 mdBook chapters into `cargo test --doc` via `include_str!`, so every Rust fence is type-checked on every pre-commit. No more silent drift when the crate's API evolves.
- Converts every `rust,ignore` fence in `docs/src/` (49 of them) to compilable `rust` / `rust,no_run`. Pseudocode and external-crate sketches (macroquad, eframe, trait body quotes) become `text` fences.
- Fixes the drift the compiler surfaced: missing `Phase` import, `rider == rider_id.entity()` conversion, `rand::RngExt` rename, `bevy::prelude::Event` shadowing the core enum, `TrafficSchedule::new` arity, `SimulationBuilder::from_config` arg-by-value, and a `reroute_rider` mutable-borrow order bug.
- Adds a tiny lib target to `elevator-bevy` so the Bevy chapter's doctests can reference real `sim_bridge` types.
- Tightens `scripts/lint-docs.sh` to forbid `ignore` fence variants (bare, `rust,ignore`, combos) in both `docs/src/` and rustdoc under `crates/*/src/`.
- Extends the pre-commit hook to also run `elevator-bevy` doc tests.

Result: **156 elevator-core + 8 elevator-bevy doc tests compile on every pre-commit, 0 ignored.**

## Test plan

- [x] `cargo test -p elevator-core --all-features --doc` — 156 passed, 0 ignored
- [x] `cargo test -p elevator-bevy --doc` — 8 passed, 0 ignored
- [x] `scripts/lint-docs.sh` — all checks pass
- [x] `bash .githooks/pre-commit` — exits 0 end-to-end (fmt, clippy, 604 unit tests, doc tests, workspace check, doc lint)
- [ ] Verify CI runs and passes on the PR
- [ ] Verify greptile review has no blocking feedback