### PR TITLE
feat: add premium in-browser playground UI

### DIFF
--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.vite/

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,0 +1,48 @@
+# elevator-core playground
+
+In-browser demo of the `elevator-core` Rust simulation library. Swap dispatch
+strategies, stream live metrics, share your seed.
+
+## Local development
+
+The playground consumes the `elevator-wasm` crate's `wasm-pack` output from
+`public/pkg/`. Build it once, then start Vite:
+
+```sh
+wasm-pack build ../crates/elevator-wasm --target web --out-dir ../../playground/public/pkg
+pnpm install
+pnpm dev
+```
+
+`pnpm dev` starts Vite on `http://localhost:5173/`. Type changes re-typecheck
+and hot-reload; Rust changes require a fresh `wasm-pack build`.
+
+## Scripts
+
+| Script | What it does |
+|---|---|
+| `pnpm dev` | Vite dev server with HMR |
+| `pnpm build` | `tsc --noEmit && vite build` — output in `dist/` |
+| `pnpm preview` | Preview the production build locally |
+| `pnpm typecheck` | `tsc --noEmit` only |
+
+## Deploy
+
+`pnpm build` emits a fully static `dist/` that drops into any static host.
+In CI, the mdBook docs workflow runs `wasm-pack build` + `pnpm build` and
+copies `dist/` into the GitHub Pages site under `/playground/`.
+
+## Architecture
+
+| File | Purpose |
+|---|---|
+| `src/main.ts` | Entry point, requestAnimationFrame loop |
+| `src/sim.ts` | Typed TS wrapper around `WasmSim` |
+| `src/traffic.ts` | Seeded LCG rider spawning (determinism guarantee) |
+| `src/canvas.ts` | Shaft + cars + stops renderer |
+| `src/charts.ts` | Sparkline / bar chart / heatmap primitives |
+| `src/eventLog.ts` | Scrolling event view |
+| `src/export.ts` | CSV + GIF export (gif.js dynamic import) |
+| `src/permalink.ts` | URL query-string state encoding |
+| `src/scenarios.ts` | Embedded RON scenarios |
+| `src/types.ts` | DTO mirrors of the wasm-bindgen surface |

--- a/playground/index.html
+++ b/playground/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>elevator-core playground</title>
+    <meta
+      name="description"
+      content="Live in-browser demo of the elevator-core Rust simulation library. Swap dispatch strategies, stream metrics, share your seed."
+    />
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='4' y='2' width='16' height='20' rx='2' fill='%2310b981'/%3E%3Crect x='8' y='6' width='8' height='4' fill='%230f172a'/%3E%3Crect x='8' y='14' width='8' height='4' fill='%230f172a'/%3E%3C/svg%3E" />
+    <link rel="stylesheet" href="./src/style.css" />
+  </head>
+  <body>
+    <header class="top">
+      <h1>elevator-core playground</h1>
+      <nav>
+        <a href="https://github.com/andymai/elevator-core">repo</a>
+        <a href="https://docs.rs/elevator-core">docs.rs</a>
+        <a href="../">guide</a>
+      </nav>
+    </header>
+
+    <section class="controls">
+      <label>
+        Scenario
+        <select id="scenario"></select>
+      </label>
+      <label>
+        Dispatch
+        <select id="strategy"></select>
+      </label>
+      <label>
+        Seed
+        <input id="seed" type="number" value="42" min="0" />
+      </label>
+      <label>
+        Speed <span id="speed-label" class="value">4×</span>
+        <input id="speed" type="range" min="1" max="16" step="1" value="4" />
+      </label>
+      <label>
+        Traffic <span id="traffic-label" class="value">8 / min</span>
+        <input id="traffic" type="range" min="0" max="120" step="1" value="8" />
+      </label>
+      <div class="actions">
+        <button id="play">Pause</button>
+        <button id="reset">Reset</button>
+        <button id="share">Share seed</button>
+        <button id="csv-events">Export events.csv</button>
+        <button id="csv-metrics">Export metrics.csv</button>
+        <button id="gif">Record</button>
+      </div>
+    </section>
+
+    <main class="layout">
+      <section class="shaft-wrap">
+        <canvas id="shaft"></canvas>
+      </section>
+      <aside class="right">
+        <section class="panel">
+          <h2>Metrics</h2>
+          <div id="metrics" class="metrics"></div>
+        </section>
+        <section class="panel">
+          <canvas id="wait-chart" class="chart-small"></canvas>
+        </section>
+        <section class="panel">
+          <canvas id="queue-chart" class="chart-small"></canvas>
+        </section>
+        <section class="panel">
+          <canvas id="heatmap" class="chart-heatmap"></canvas>
+        </section>
+      </aside>
+      <section class="panel event-log-panel">
+        <h2>Event log</h2>
+        <ul id="event-log" class="event-log"></ul>
+      </section>
+    </main>
+
+    <div id="toast" class="toast" role="status"></div>
+
+    <script type="module" src="./src/main.ts"></script>
+  </body>
+</html>

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "elevator-playground",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "gif.js.optimized": "^1.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vite": "^5.4.0"
+  }
+}

--- a/playground/pnpm-lock.yaml
+++ b/playground/pnpm-lock.yaml
@@ -1,0 +1,619 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      gif.js.optimized:
+        specifier: ^1.0.1
+        version: 1.0.1
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vite:
+        specifier: ^5.4.0
+        version: 5.4.21(@types/node@22.19.17)
+
+packages:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.1':
+    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.1':
+    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gif.js.optimized@1.0.1:
+    resolution: {integrity: sha512-IS0F42Xken6lp/iR4irgG4r52tvxRkEKsXGZmlUHUOb00SWNMezJOJwkVaJk2MLW53rqzMbPnnBtEhs9hcMJ9w==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.60.1:
+    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  fsevents@2.3.3:
+    optional: true
+
+  gif.js.optimized@1.0.1: {}
+
+  nanoid@3.3.11: {}
+
+  picocolors@1.1.1: {}
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.60.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.1
+      '@rollup/rollup-android-arm64': 4.60.1
+      '@rollup/rollup-darwin-arm64': 4.60.1
+      '@rollup/rollup-darwin-x64': 4.60.1
+      '@rollup/rollup-freebsd-arm64': 4.60.1
+      '@rollup/rollup-freebsd-x64': 4.60.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
+      '@rollup/rollup-linux-arm64-gnu': 4.60.1
+      '@rollup/rollup-linux-arm64-musl': 4.60.1
+      '@rollup/rollup-linux-loong64-gnu': 4.60.1
+      '@rollup/rollup-linux-loong64-musl': 4.60.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
+      '@rollup/rollup-linux-ppc64-musl': 4.60.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
+      '@rollup/rollup-linux-riscv64-musl': 4.60.1
+      '@rollup/rollup-linux-s390x-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-musl': 4.60.1
+      '@rollup/rollup-openbsd-x64': 4.60.1
+      '@rollup/rollup-openharmony-arm64': 4.60.1
+      '@rollup/rollup-win32-arm64-msvc': 4.60.1
+      '@rollup/rollup-win32-ia32-msvc': 4.60.1
+      '@rollup/rollup-win32-x64-gnu': 4.60.1
+      '@rollup/rollup-win32-x64-msvc': 4.60.1
+      fsevents: 2.3.3
+
+  source-map-js@1.2.1: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  vite@5.4.21(@types/node@22.19.17):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.10
+      rollup: 4.60.1
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3

--- a/playground/src/ambient.d.ts
+++ b/playground/src/ambient.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+// gif.js.optimized ships without types; our usage is narrow (default export
+// constructor with addFrame / on / render), so a permissive declaration is
+// fine — the strict types live at the call site in export.ts.
+declare module "gif.js.optimized" {
+  const GifCtor: unknown;
+  export default GifCtor;
+}

--- a/playground/src/canvas.ts
+++ b/playground/src/canvas.ts
@@ -25,6 +25,7 @@ export class CanvasRenderer {
   #canvas: HTMLCanvasElement;
   #ctx: CanvasRenderingContext2D;
   #dpr: number;
+  #onResize: () => void;
 
   constructor(canvas: HTMLCanvasElement) {
     this.#canvas = canvas;
@@ -33,7 +34,16 @@ export class CanvasRenderer {
     this.#ctx = ctx;
     this.#dpr = window.devicePixelRatio || 1;
     this.#resize();
-    window.addEventListener("resize", () => this.#resize());
+    // Store the bound handler so `dispose()` can detach it. Without this
+    // indirection, a later replacement of the renderer would leak the old
+    // listener — it would keep firing against a detached canvas.
+    this.#onResize = (): void => this.#resize();
+    window.addEventListener("resize", this.#onResize);
+  }
+
+  /** Detach the resize listener. Call when replacing the renderer. */
+  dispose(): void {
+    window.removeEventListener("resize", this.#onResize);
   }
 
   #resize(): void {

--- a/playground/src/canvas.ts
+++ b/playground/src/canvas.ts
@@ -1,0 +1,156 @@
+import type { Car, Snapshot } from "./types";
+
+// Simple 2-D renderer. Cars are drawn as rectangles that travel vertically
+// along a shaft; stops are horizontal rungs with a waiting-count chip. One
+// shaft per "line" (elevator group) — lines are inferred by unique `car.line`
+// ids in the snapshot so the renderer stays scenario-agnostic.
+
+const PADDING = 32;
+const CAR_WIDTH = 28;
+const CAR_HEIGHT = 20;
+const STOP_LINE_WIDTH = 2;
+
+const PHASE_COLORS: Record<Car["phase"], string> = {
+  idle: "#4b5563",
+  moving: "#10b981",
+  repositioning: "#8b5cf6",
+  "door-opening": "#f59e0b",
+  loading: "#3b82f6",
+  "door-closing": "#f59e0b",
+  stopped: "#64748b",
+  unknown: "#9ca3af",
+};
+
+export class CanvasRenderer {
+  #canvas: HTMLCanvasElement;
+  #ctx: CanvasRenderingContext2D;
+  #dpr: number;
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.#canvas = canvas;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("2D context unavailable");
+    this.#ctx = ctx;
+    this.#dpr = window.devicePixelRatio || 1;
+    this.#resize();
+    window.addEventListener("resize", () => this.#resize());
+  }
+
+  #resize(): void {
+    const { clientWidth, clientHeight } = this.#canvas;
+    this.#canvas.width = clientWidth * this.#dpr;
+    this.#canvas.height = clientHeight * this.#dpr;
+    this.#ctx.setTransform(this.#dpr, 0, 0, this.#dpr, 0, 0);
+  }
+
+  draw(snap: Snapshot): void {
+    const { clientWidth: w, clientHeight: h } = this.#canvas;
+    this.#ctx.clearRect(0, 0, w, h);
+
+    if (snap.stops.length === 0) return;
+
+    // Compute Y scale from stops (the sim's vertical axis).
+    const minY = Math.min(...snap.stops.map((s) => s.y));
+    const maxY = Math.max(...snap.stops.map((s) => s.y));
+    const axisMin = minY - 1;
+    const axisMax = maxY + 1;
+    const yRange = Math.max(axisMax - axisMin, 0.0001);
+    // Higher sim y = higher on screen (invert canvas coords).
+    const toScreenY = (y: number): number =>
+      h - PADDING - ((y - axisMin) / yRange) * (h - 2 * PADDING);
+
+    // One shaft per line id.
+    const lineIds = Array.from(new Set(snap.cars.map((c) => c.line))).sort((a, b) => a - b);
+    const laneCount = Math.max(lineIds.length, 1);
+    const laneWidth = (w - 2 * PADDING - 120) / laneCount;
+
+    // Draw the rider-count chip column at the left, stop labels next.
+    this.#drawStops(snap, toScreenY);
+
+    // Draw each shaft and its cars.
+    for (let i = 0; i < lineIds.length; i++) {
+      const lineId = lineIds[i];
+      const cx = PADDING + 120 + laneWidth * (i + 0.5);
+      this.#drawShaft(cx, h);
+      const carsOnLine = snap.cars.filter((c) => c.line === lineId);
+      for (const car of carsOnLine) {
+        this.#drawCar(car, cx, toScreenY);
+      }
+    }
+  }
+
+  #drawStops(snap: Snapshot, toScreenY: (y: number) => number): void {
+    const ctx = this.#ctx;
+    ctx.font = "12px ui-sans-serif, system-ui, sans-serif";
+    ctx.textBaseline = "middle";
+
+    for (const stop of snap.stops) {
+      const y = toScreenY(stop.y);
+      // Full-width separator line.
+      ctx.strokeStyle = "#1f2937";
+      ctx.lineWidth = STOP_LINE_WIDTH;
+      ctx.beginPath();
+      ctx.moveTo(PADDING + 100, y);
+      ctx.lineTo(this.#canvas.clientWidth - PADDING, y);
+      ctx.stroke();
+
+      // Label.
+      ctx.fillStyle = "#d1d5db";
+      ctx.textAlign = "left";
+      ctx.fillText(stop.name, PADDING, y);
+
+      // Waiting chip.
+      if (stop.waiting > 0) {
+        const chipX = PADDING + 80;
+        ctx.fillStyle = stop.waiting > 5 ? "#ef4444" : "#f59e0b";
+        const chipR = 9;
+        ctx.beginPath();
+        ctx.arc(chipX, y, chipR, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.fillStyle = "#0f172a";
+        ctx.textAlign = "center";
+        ctx.fillText(String(stop.waiting), chipX, y);
+      }
+    }
+  }
+
+  #drawShaft(cx: number, h: number): void {
+    const ctx = this.#ctx;
+    ctx.strokeStyle = "#111827";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(cx, PADDING);
+    ctx.lineTo(cx, h - PADDING);
+    ctx.stroke();
+  }
+
+  #drawCar(car: Car, cx: number, toScreenY: (y: number) => number): void {
+    const ctx = this.#ctx;
+    const cy = toScreenY(car.y);
+    ctx.fillStyle = PHASE_COLORS[car.phase] ?? "#9ca3af";
+    ctx.fillRect(cx - CAR_WIDTH / 2, cy - CAR_HEIGHT / 2, CAR_WIDTH, CAR_HEIGHT);
+    ctx.strokeStyle = "#0b1220";
+    ctx.lineWidth = 1;
+    ctx.strokeRect(cx - CAR_WIDTH / 2, cy - CAR_HEIGHT / 2, CAR_WIDTH, CAR_HEIGHT);
+
+    // Load fraction as a filled inset bar.
+    const frac = car.capacity > 0 ? Math.min(car.load / car.capacity, 1) : 0;
+    if (frac > 0) {
+      const innerH = (CAR_HEIGHT - 4) * frac;
+      ctx.fillStyle = "rgba(15, 23, 42, 0.45)";
+      ctx.fillRect(cx - CAR_WIDTH / 2 + 2, cy + CAR_HEIGHT / 2 - 2 - innerH, CAR_WIDTH - 4, innerH);
+    }
+
+    // Rider count.
+    ctx.fillStyle = "#f9fafb";
+    ctx.font = "10px ui-sans-serif, system-ui, sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(String(car.riders), cx, cy);
+  }
+
+  /** Expose the underlying canvas for GIF recording. */
+  get canvas(): HTMLCanvasElement {
+    return this.#canvas;
+  }
+}

--- a/playground/src/charts.ts
+++ b/playground/src/charts.ts
@@ -1,0 +1,185 @@
+import type { Snapshot } from "./types";
+
+// Minimal chart primitives used by the metrics dashboard. No dependency on a
+// chart library — everything is drawn with raw canvas calls on offscreen-sized
+// canvases that slot into the page grid.
+
+const AXIS = "#334155";
+const GRID = "#1e293b";
+const TEXT = "#94a3b8";
+
+function withDpr(canvas: HTMLCanvasElement): CanvasRenderingContext2D {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("2D context unavailable");
+  const dpr = window.devicePixelRatio || 1;
+  const { clientWidth, clientHeight } = canvas;
+  if (canvas.width !== clientWidth * dpr || canvas.height !== clientHeight * dpr) {
+    canvas.width = clientWidth * dpr;
+    canvas.height = clientHeight * dpr;
+  }
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  return ctx;
+}
+
+/** Single sparkline of a numeric series. */
+export function drawSparkline(
+  canvas: HTMLCanvasElement,
+  series: number[],
+  label: string,
+): void {
+  const ctx = withDpr(canvas);
+  const { clientWidth: w, clientHeight: h } = canvas;
+  ctx.clearRect(0, 0, w, h);
+
+  ctx.fillStyle = TEXT;
+  ctx.font = "11px ui-sans-serif, system-ui, sans-serif";
+  ctx.textBaseline = "top";
+  ctx.fillText(label, 4, 4);
+
+  if (series.length < 2) return;
+  const min = 0;
+  const max = Math.max(1, ...series);
+  const xStep = (w - 8) / Math.max(series.length - 1, 1);
+  const toY = (v: number): number => h - 4 - ((v - min) / (max - min)) * (h - 24);
+
+  // Grid line at max.
+  ctx.strokeStyle = GRID;
+  ctx.beginPath();
+  ctx.moveTo(4, toY(max));
+  ctx.lineTo(w - 4, toY(max));
+  ctx.stroke();
+
+  ctx.strokeStyle = "#38bdf8";
+  ctx.lineWidth = 1.5;
+  ctx.beginPath();
+  series.forEach((v, i) => {
+    const x = 4 + i * xStep;
+    const y = toY(v);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  });
+  ctx.stroke();
+
+  // Latest value label (right).
+  const last = series[series.length - 1];
+  ctx.fillStyle = "#e2e8f0";
+  ctx.textAlign = "right";
+  ctx.textBaseline = "top";
+  ctx.fillText(last.toFixed(1), w - 4, 4);
+  ctx.textAlign = "left";
+}
+
+/** Vertical bar chart of a numeric series (fixed width). */
+export function drawBars(
+  canvas: HTMLCanvasElement,
+  series: number[],
+  label: string,
+): void {
+  const ctx = withDpr(canvas);
+  const { clientWidth: w, clientHeight: h } = canvas;
+  ctx.clearRect(0, 0, w, h);
+
+  ctx.fillStyle = TEXT;
+  ctx.font = "11px ui-sans-serif, system-ui, sans-serif";
+  ctx.textBaseline = "top";
+  ctx.fillText(label, 4, 4);
+
+  if (series.length === 0) return;
+  const max = Math.max(1, ...series);
+  const barW = (w - 8) / series.length;
+  for (let i = 0; i < series.length; i++) {
+    const v = series[i];
+    const bh = (v / max) * (h - 24);
+    const x = 4 + i * barW;
+    const y = h - 4 - bh;
+    ctx.fillStyle = "#22d3ee";
+    ctx.fillRect(x + 0.5, y, Math.max(barW - 1, 1), bh);
+  }
+}
+
+/**
+ * Per-stop heatmap of waiting counts over time. Each row is a stop, each
+ * column is a time bucket, colored by intensity.
+ */
+export class Heatmap {
+  #canvas: HTMLCanvasElement;
+  /** rows[stopIndex] = FIFO queue of recent waiting counts. */
+  #rows: number[][] = [];
+  #labels: string[] = [];
+  readonly #bucketCount: number;
+
+  constructor(canvas: HTMLCanvasElement, bucketCount = 60) {
+    this.#canvas = canvas;
+    this.#bucketCount = bucketCount;
+  }
+
+  record(snap: Snapshot): void {
+    if (snap.stops.length !== this.#rows.length) {
+      this.#rows = snap.stops.map(() => []);
+      this.#labels = snap.stops.map((s) => s.name);
+    }
+    snap.stops.forEach((stop, i) => {
+      const row = this.#rows[i];
+      row.push(stop.waiting);
+      if (row.length > this.#bucketCount) row.shift();
+    });
+  }
+
+  draw(): void {
+    const ctx = withDpr(this.#canvas);
+    const { clientWidth: w, clientHeight: h } = this.#canvas;
+    ctx.clearRect(0, 0, w, h);
+    ctx.fillStyle = TEXT;
+    ctx.font = "11px ui-sans-serif, system-ui, sans-serif";
+    ctx.textBaseline = "top";
+    ctx.fillText("Queue heatmap", 4, 4);
+
+    if (this.#rows.length === 0) return;
+
+    const labelW = 56;
+    const plotX = labelW;
+    const plotY = 20;
+    const plotW = w - plotX - 4;
+    const plotH = h - plotY - 4;
+    const rowH = plotH / this.#rows.length;
+    const colW = plotW / this.#bucketCount;
+    const globalMax = Math.max(
+      1,
+      ...this.#rows.flatMap((r) => r),
+    );
+
+    ctx.textBaseline = "middle";
+    ctx.textAlign = "right";
+    this.#rows.forEach((row, i) => {
+      const ry = plotY + i * rowH;
+      ctx.fillStyle = TEXT;
+      ctx.fillText(this.#labels[i] ?? `#${i}`, labelW - 4, ry + rowH / 2);
+      for (let c = 0; c < row.length; c++) {
+        const v = row[row.length - 1 - c];
+        const intensity = Math.min(1, v / globalMax);
+        ctx.fillStyle = heatColor(intensity);
+        const cx = plotX + (this.#bucketCount - 1 - c) * colW;
+        ctx.fillRect(cx, ry + 1, Math.max(colW - 0.5, 1), Math.max(rowH - 2, 1));
+      }
+    });
+
+    // Grid border.
+    ctx.strokeStyle = AXIS;
+    ctx.strokeRect(plotX, plotY, plotW, plotH);
+    ctx.textAlign = "left";
+  }
+
+  reset(): void {
+    this.#rows = [];
+    this.#labels = [];
+  }
+}
+
+function heatColor(t: number): string {
+  // Black → teal → amber gradient.
+  if (t <= 0) return "#0b1220";
+  const r = Math.round(255 * Math.min(1, t * 1.4));
+  const g = Math.round(80 + 120 * t);
+  const b = Math.round(120 * (1 - t));
+  return `rgb(${r}, ${g}, ${b})`;
+}

--- a/playground/src/eventLog.ts
+++ b/playground/src/eventLog.ts
@@ -1,0 +1,80 @@
+import type { SimEvent } from "./types";
+
+// Scrollable event log. Keeps the most recent N events in memory and renders
+// as a <ul> with auto-scroll-to-bottom unless the user has scrolled up.
+
+const CAP = 500;
+
+const KIND_LABELS: Record<SimEvent["kind"], string> = {
+  "rider-spawned": "spawn",
+  "rider-boarded": "board",
+  "rider-exited": "exit",
+  "rider-abandoned": "abandon",
+  "elevator-arrived": "arrive",
+  "elevator-departed": "depart",
+  "door-opened": "door+",
+  "door-closed": "door-",
+  "elevator-assigned": "assign",
+  other: "other",
+};
+
+export class EventLog {
+  #root: HTMLElement;
+  #buf: SimEvent[] = [];
+  #follow = true;
+
+  constructor(root: HTMLElement) {
+    this.#root = root;
+    root.addEventListener("scroll", () => {
+      const atBottom = root.scrollHeight - root.scrollTop - root.clientHeight < 24;
+      this.#follow = atBottom;
+    });
+  }
+
+  append(events: SimEvent[]): void {
+    if (events.length === 0) return;
+    this.#buf.push(...events);
+    if (this.#buf.length > CAP) {
+      this.#buf = this.#buf.slice(this.#buf.length - CAP);
+    }
+    this.#render();
+  }
+
+  reset(): void {
+    this.#buf = [];
+    this.#follow = true;
+    this.#render();
+  }
+
+  #render(): void {
+    const frag = document.createDocumentFragment();
+    for (const ev of this.#buf) {
+      const li = document.createElement("li");
+      li.className = `evt evt-${ev.kind}`;
+      li.textContent = formatLine(ev);
+      frag.appendChild(li);
+    }
+    this.#root.replaceChildren(frag);
+    if (this.#follow) {
+      this.#root.scrollTop = this.#root.scrollHeight;
+    }
+  }
+
+  /** Snapshot of the buffer for CSV export. */
+  snapshot(): SimEvent[] {
+    return this.#buf.slice();
+  }
+}
+
+function formatLine(ev: SimEvent): string {
+  const kind = KIND_LABELS[ev.kind];
+  const parts: string[] = [`t=${ev.tick}`, kind];
+  if (ev.rider !== undefined) parts.push(`r${ev.rider}`);
+  if (ev.elevator !== undefined) parts.push(`e${ev.elevator}`);
+  if (ev.stop !== undefined) parts.push(`s${ev.stop}`);
+  if (ev.origin !== undefined && ev.destination !== undefined) {
+    parts.push(`${ev.origin}→${ev.destination}`);
+  }
+  if (ev.label) parts.push(ev.label);
+  return parts.join("  ");
+}

--- a/playground/src/export.ts
+++ b/playground/src/export.ts
@@ -15,10 +15,25 @@ export function downloadEventsCsv(events: SimEvent[], filename: string): void {
       e.stop ?? "",
       e.origin ?? "",
       e.destination ?? "",
-      (e.label ?? "").replace(/,/g, ";"),
+      csvEscape(e.label ?? ""),
     ].join(","),
   );
   download(`${header}\n${rows.join("\n")}`, filename, "text/csv");
+}
+
+/**
+ * RFC 4180-ish escape for a single CSV field. Quotes the field and doubles
+ * any embedded double-quotes when the value contains `,`, `"`, `\n`, or `\r`
+ * — all of which would otherwise break the row/column structure.
+ *
+ * `Other`-variant event labels come from Rust's `Debug` output and may in
+ * principle contain arbitrary punctuation, so we can't assume cleanliness.
+ */
+function csvEscape(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
 }
 
 /** Trigger a CSV file download of metrics snapshots over time. */

--- a/playground/src/export.ts
+++ b/playground/src/export.ts
@@ -1,0 +1,141 @@
+import type { Metrics, SimEvent } from "./types";
+
+// CSV + GIF export helpers. GIF recording uses gif.js.optimized which runs the
+// encoder in a Web Worker so frame capture doesn't block rendering.
+
+/** Trigger a CSV file download from an array of events. */
+export function downloadEventsCsv(events: SimEvent[], filename: string): void {
+  const header = "tick,kind,rider,elevator,stop,origin,destination,label";
+  const rows = events.map((e) =>
+    [
+      e.tick,
+      e.kind,
+      e.rider ?? "",
+      e.elevator ?? "",
+      e.stop ?? "",
+      e.origin ?? "",
+      e.destination ?? "",
+      (e.label ?? "").replace(/,/g, ";"),
+    ].join(","),
+  );
+  download(`${header}\n${rows.join("\n")}`, filename, "text/csv");
+}
+
+/** Trigger a CSV file download of metrics snapshots over time. */
+export function downloadMetricsCsv(
+  samples: Array<{ tick: number; metrics: Metrics }>,
+  filename: string,
+): void {
+  const header =
+    "tick,delivered,abandoned,spawned,throughput,avg_wait_s,max_wait_s,avg_ride_s,utilization";
+  const rows = samples.map(({ tick, metrics: m }) =>
+    [
+      tick,
+      m.delivered,
+      m.abandoned,
+      m.spawned,
+      m.throughput,
+      m.avg_wait_s.toFixed(3),
+      m.max_wait_s.toFixed(3),
+      m.avg_ride_s.toFixed(3),
+      m.utilization.toFixed(4),
+    ].join(","),
+  );
+  download(`${header}\n${rows.join("\n")}`, filename, "text/csv");
+}
+
+function download(content: string, filename: string, mime: string): void {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+// GIF recorder. We dynamically import the library so it only loads when the
+// user actually presses "Record" — saves ~60KB on first paint.
+//
+// gif.js.optimized is a drop-in replacement for gif.js that bundles its worker.
+
+interface GifInstance {
+  addFrame(canvas: HTMLCanvasElement, opts?: { delay?: number; copy?: boolean }): void;
+  on(event: "finished", cb: (blob: Blob) => void): void;
+  render(): void;
+  abort(): void;
+}
+interface GifCtor {
+  new (opts: {
+    workers: number;
+    quality: number;
+    workerScript?: string;
+    width: number;
+    height: number;
+    transparent?: number | null;
+  }): GifInstance;
+}
+
+export class GifRecorder {
+  #gif: GifInstance | null = null;
+  #canvas: HTMLCanvasElement;
+  #lastCapture = 0;
+  #frameIntervalMs = 66; // ~15 fps
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.#canvas = canvas;
+  }
+
+  get isRecording(): boolean {
+    return this.#gif !== null;
+  }
+
+  async start(): Promise<void> {
+    if (this.#gif) return;
+    const mod = (await import("gif.js.optimized")) as unknown as { default: GifCtor };
+    const { width, height } = this.#canvas;
+    this.#gif = new mod.default({
+      workers: 2,
+      quality: 10,
+      width,
+      height,
+      transparent: null,
+    });
+    this.#lastCapture = performance.now();
+  }
+
+  captureIfDue(): void {
+    if (!this.#gif) return;
+    const now = performance.now();
+    if (now - this.#lastCapture < this.#frameIntervalMs) return;
+    this.#gif.addFrame(this.#canvas, { delay: this.#frameIntervalMs, copy: true });
+    this.#lastCapture = now;
+  }
+
+  async finish(filename: string): Promise<void> {
+    if (!this.#gif) return;
+    const gif = this.#gif;
+    this.#gif = null;
+    await new Promise<void>((resolve) => {
+      gif.on("finished", (blob) => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+        resolve();
+      });
+      gif.render();
+    });
+  }
+
+  abort(): void {
+    this.#gif?.abort();
+    this.#gif = null;
+  }
+}

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -1,0 +1,309 @@
+import { CanvasRenderer } from "./canvas";
+import { drawBars, drawSparkline, Heatmap } from "./charts";
+import { EventLog } from "./eventLog";
+import { GifRecorder, downloadEventsCsv, downloadMetricsCsv } from "./export";
+import { DEFAULT_STATE, decodePermalink, encodePermalink, type PermalinkState } from "./permalink";
+import { SCENARIOS, scenarioById } from "./scenarios";
+import { Sim } from "./sim";
+import { TrafficDriver } from "./traffic";
+import type { Metrics, StrategyName } from "./types";
+
+// Premium playground entry point. Composes: sim + traffic driver + canvas
+// renderer + 3 charts + event log + export tools + permalink state + a small
+// requestAnimationFrame loop. Designed to feel snappy at 60 FPS with a 60 Hz
+// sim clock (one sim tick per animation frame per speed multiplier).
+
+const SIM_TICK_PER_FRAME = 1;
+const METRICS_HISTORY = 120;
+
+interface UiState {
+  running: boolean;
+  speed: number;
+  permalink: PermalinkState;
+  sim: Sim | null;
+  traffic: TrafficDriver;
+  metricsHistory: Metrics[];
+  metricsSamples: Array<{ tick: number; metrics: Metrics }>;
+  lastFrameTime: number;
+  heatmap: Heatmap;
+  renderer: CanvasRenderer;
+  eventLog: EventLog;
+  gifRecorder: GifRecorder;
+}
+
+async function boot(): Promise<void> {
+  const ui = wireUi();
+  const permalink = { ...DEFAULT_STATE, ...decodePermalink(window.location.search) };
+  const state: UiState = {
+    running: true,
+    speed: permalink.speed,
+    permalink,
+    sim: null,
+    traffic: new TrafficDriver(permalink.seed),
+    metricsHistory: [],
+    metricsSamples: [],
+    lastFrameTime: performance.now(),
+    heatmap: new Heatmap(ui.heatmapCanvas, 90),
+    renderer: new CanvasRenderer(ui.shaftCanvas),
+    eventLog: new EventLog(ui.eventLogList),
+    gifRecorder: new GifRecorder(ui.shaftCanvas),
+  };
+
+  await resetSim(state, ui);
+  attachListeners(state, ui);
+  loop(state, ui);
+}
+
+interface UiHandles {
+  scenarioSelect: HTMLSelectElement;
+  strategySelect: HTMLSelectElement;
+  seedInput: HTMLInputElement;
+  speedInput: HTMLInputElement;
+  speedLabel: HTMLElement;
+  trafficInput: HTMLInputElement;
+  trafficLabel: HTMLElement;
+  playBtn: HTMLButtonElement;
+  resetBtn: HTMLButtonElement;
+  shareBtn: HTMLButtonElement;
+  csvEventsBtn: HTMLButtonElement;
+  csvMetricsBtn: HTMLButtonElement;
+  gifBtn: HTMLButtonElement;
+  shaftCanvas: HTMLCanvasElement;
+  waitChart: HTMLCanvasElement;
+  queueChart: HTMLCanvasElement;
+  heatmapCanvas: HTMLCanvasElement;
+  eventLogList: HTMLElement;
+  metricsPanel: HTMLElement;
+  toast: HTMLElement;
+}
+
+function wireUi(): UiHandles {
+  const q = <T extends HTMLElement>(id: string): T => {
+    const el = document.getElementById(id);
+    if (!el) throw new Error(`missing element #${id}`);
+    return el as T;
+  };
+  const ui: UiHandles = {
+    scenarioSelect: q<HTMLSelectElement>("scenario"),
+    strategySelect: q<HTMLSelectElement>("strategy"),
+    seedInput: q<HTMLInputElement>("seed"),
+    speedInput: q<HTMLInputElement>("speed"),
+    speedLabel: q("speed-label"),
+    trafficInput: q<HTMLInputElement>("traffic"),
+    trafficLabel: q("traffic-label"),
+    playBtn: q<HTMLButtonElement>("play"),
+    resetBtn: q<HTMLButtonElement>("reset"),
+    shareBtn: q<HTMLButtonElement>("share"),
+    csvEventsBtn: q<HTMLButtonElement>("csv-events"),
+    csvMetricsBtn: q<HTMLButtonElement>("csv-metrics"),
+    gifBtn: q<HTMLButtonElement>("gif"),
+    shaftCanvas: q<HTMLCanvasElement>("shaft"),
+    waitChart: q<HTMLCanvasElement>("wait-chart"),
+    queueChart: q<HTMLCanvasElement>("queue-chart"),
+    heatmapCanvas: q<HTMLCanvasElement>("heatmap"),
+    eventLogList: q("event-log"),
+    metricsPanel: q("metrics"),
+    toast: q("toast"),
+  };
+
+  for (const s of SCENARIOS) {
+    const opt = document.createElement("option");
+    opt.value = s.id;
+    opt.textContent = s.label;
+    opt.title = s.description;
+    ui.scenarioSelect.appendChild(opt);
+  }
+  for (const strat of ["scan", "look", "nearest", "etd", "destination"] as StrategyName[]) {
+    const opt = document.createElement("option");
+    opt.value = strat;
+    opt.textContent = strat.toUpperCase();
+    ui.strategySelect.appendChild(opt);
+  }
+
+  return ui;
+}
+
+async function resetSim(state: UiState, ui: UiHandles): Promise<void> {
+  state.sim?.dispose();
+  state.sim = null;
+  state.metricsHistory = [];
+  state.metricsSamples = [];
+  state.eventLog.reset();
+  state.heatmap.reset();
+
+  const scenario = scenarioById(state.permalink.scenario);
+  applyPermalinkToUi(state.permalink, ui);
+
+  const sim = await Sim.create(scenario.ron, state.permalink.strategy);
+  sim.setTrafficRate(state.permalink.trafficRate);
+  state.sim = sim;
+  state.traffic = new TrafficDriver(state.permalink.seed);
+  toast(ui, `${scenario.label} · ${state.permalink.strategy.toUpperCase()}`);
+}
+
+function applyPermalinkToUi(p: PermalinkState, ui: UiHandles): void {
+  ui.scenarioSelect.value = p.scenario;
+  ui.strategySelect.value = p.strategy;
+  ui.seedInput.value = String(p.seed);
+  ui.speedInput.value = String(p.speed);
+  ui.speedLabel.textContent = `${p.speed}×`;
+  ui.trafficInput.value = String(p.trafficRate);
+  ui.trafficLabel.textContent = `${p.trafficRate} / min`;
+}
+
+function attachListeners(state: UiState, ui: UiHandles): void {
+  ui.scenarioSelect.addEventListener("change", () => {
+    state.permalink = { ...state.permalink, scenario: ui.scenarioSelect.value };
+    const scenario = scenarioById(state.permalink.scenario);
+    state.permalink.trafficRate = scenario.suggestedTrafficRate;
+    void resetSim(state, ui);
+  });
+  ui.strategySelect.addEventListener("change", () => {
+    state.permalink = { ...state.permalink, strategy: ui.strategySelect.value as StrategyName };
+    state.sim?.setStrategy(state.permalink.strategy);
+    toast(ui, `strategy → ${state.permalink.strategy.toUpperCase()}`);
+  });
+  ui.seedInput.addEventListener("change", () => {
+    const seed = Number(ui.seedInput.value);
+    if (Number.isFinite(seed)) {
+      state.permalink = { ...state.permalink, seed };
+      void resetSim(state, ui);
+    }
+  });
+  ui.speedInput.addEventListener("input", () => {
+    const v = Number(ui.speedInput.value);
+    state.permalink.speed = v;
+    state.speed = v;
+    ui.speedLabel.textContent = `${v}×`;
+  });
+  ui.trafficInput.addEventListener("input", () => {
+    const v = Number(ui.trafficInput.value);
+    state.permalink.trafficRate = v;
+    state.sim?.setTrafficRate(v);
+    ui.trafficLabel.textContent = `${v} / min`;
+  });
+
+  ui.playBtn.addEventListener("click", () => {
+    state.running = !state.running;
+    ui.playBtn.textContent = state.running ? "Pause" : "Play";
+  });
+  ui.resetBtn.addEventListener("click", () => {
+    void resetSim(state, ui);
+  });
+  ui.shareBtn.addEventListener("click", async () => {
+    const qs = encodePermalink(state.permalink);
+    const url = `${window.location.origin}${window.location.pathname}${qs}`;
+    window.history.replaceState(null, "", qs);
+    await navigator.clipboard.writeText(url).catch(() => {});
+    toast(ui, "Permalink copied");
+  });
+  ui.csvEventsBtn.addEventListener("click", () => {
+    downloadEventsCsv(state.eventLog.snapshot(), "elevator-events.csv");
+  });
+  ui.csvMetricsBtn.addEventListener("click", () => {
+    downloadMetricsCsv(state.metricsSamples, "elevator-metrics.csv");
+  });
+  ui.gifBtn.addEventListener("click", async () => {
+    if (state.gifRecorder.isRecording) {
+      toast(ui, "Encoding GIF…");
+      await state.gifRecorder.finish("elevator-playground.gif");
+      ui.gifBtn.textContent = "Record";
+      toast(ui, "GIF saved");
+    } else {
+      await state.gifRecorder.start();
+      ui.gifBtn.textContent = "Stop & save";
+      toast(ui, "Recording GIF");
+    }
+  });
+}
+
+function loop(state: UiState, ui: UiHandles): void {
+  const frame = (): void => {
+    const now = performance.now();
+    const elapsed = (now - state.lastFrameTime) / 1000;
+    state.lastFrameTime = now;
+
+    if (state.running && state.sim) {
+      const ticks = SIM_TICK_PER_FRAME * state.speed;
+      state.sim.step(ticks);
+      const snapshot = state.sim.snapshot();
+      state.traffic.tickSpawns(state.sim, snapshot, state.permalink.trafficRate, elapsed);
+
+      state.renderer.draw(snapshot);
+      const metrics = state.sim.metrics();
+      state.metricsHistory.push(metrics);
+      if (state.metricsHistory.length > METRICS_HISTORY) state.metricsHistory.shift();
+      state.metricsSamples.push({ tick: snapshot.tick, metrics });
+      if (state.metricsSamples.length > 1000) state.metricsSamples.shift();
+
+      state.heatmap.record(snapshot);
+      drawMetricsPanel(ui.metricsPanel, metrics, snapshot.tick, snapshot.dt);
+      drawSparkline(
+        ui.waitChart,
+        state.metricsHistory.map((m) => m.avg_wait_s),
+        "Avg wait (s)",
+      );
+      drawBars(
+        ui.queueChart,
+        snapshot.stops.map((s) => s.waiting),
+        "Waiting per stop",
+      );
+      state.heatmap.draw();
+
+      state.eventLog.append(state.sim.drainEvents());
+      state.gifRecorder.captureIfDue();
+    }
+
+    requestAnimationFrame(frame);
+  };
+  requestAnimationFrame(frame);
+}
+
+function drawMetricsPanel(root: HTMLElement, m: Metrics, tick: number, dt: number): void {
+  const simSeconds = tick * dt;
+  const rows: Array<[string, string]> = [
+    ["sim time", fmtDuration(simSeconds)],
+    ["delivered", String(m.delivered)],
+    ["abandoned", String(m.abandoned)],
+    ["throughput (hr)", String(Math.round(m.throughput * (3600 / 60)))],
+    ["avg wait", `${m.avg_wait_s.toFixed(1)} s`],
+    ["max wait", `${m.max_wait_s.toFixed(1)} s`],
+    ["avg ride", `${m.avg_ride_s.toFixed(1)} s`],
+    ["utilization", `${(m.utilization * 100).toFixed(0)}%`],
+    ["abandonment", `${(m.abandonment_rate * 100).toFixed(1)}%`],
+    ["distance", `${m.total_distance.toFixed(1)} m`],
+  ];
+  // Build via DOM APIs instead of innerHTML to keep this XSS-safe even when
+  // future metric labels come from untrusted config or user input.
+  const frag = document.createDocumentFragment();
+  for (const [k, v] of rows) {
+    const row = document.createElement("div");
+    row.className = "row";
+    const ks = document.createElement("span");
+    ks.className = "k";
+    ks.textContent = k;
+    const vs = document.createElement("span");
+    vs.className = "v";
+    vs.textContent = v;
+    row.append(ks, vs);
+    frag.appendChild(row);
+  }
+  root.replaceChildren(frag);
+}
+
+function fmtDuration(s: number): string {
+  if (s < 60) return `${s.toFixed(0)} s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.floor(s % 60);
+  return `${m}m ${rem}s`;
+}
+
+let toastTimer = 0;
+function toast(ui: UiHandles, msg: string): void {
+  ui.toast.textContent = msg;
+  ui.toast.classList.add("show");
+  window.clearTimeout(toastTimer);
+  toastTimer = window.setTimeout(() => ui.toast.classList.remove("show"), 1800);
+}
+
+void boot();

--- a/playground/src/permalink.ts
+++ b/playground/src/permalink.ts
@@ -1,0 +1,50 @@
+import type { StrategyName } from "./types";
+
+// URL state encoding. Keeps the sim reproducible: sharing the URL replays
+// exactly what the sender saw. Only knobs that affect behavior go here.
+
+export interface PermalinkState {
+  scenario: string;
+  strategy: StrategyName;
+  seed: number;
+  trafficRate: number;
+  speed: number;
+}
+
+export const DEFAULT_STATE: PermalinkState = {
+  scenario: "office-5",
+  strategy: "look",
+  seed: 42,
+  trafficRate: 8,
+  speed: 4,
+};
+
+export function encodePermalink(state: PermalinkState): string {
+  const p = new URLSearchParams();
+  p.set("s", state.scenario);
+  p.set("d", state.strategy);
+  p.set("k", String(state.seed));
+  p.set("t", String(state.trafficRate));
+  p.set("x", String(state.speed));
+  return `?${p.toString()}`;
+}
+
+export function decodePermalink(search: string): PermalinkState {
+  const p = new URLSearchParams(search);
+  const strategy = (p.get("d") ?? DEFAULT_STATE.strategy) as StrategyName;
+  return {
+    scenario: p.get("s") ?? DEFAULT_STATE.scenario,
+    strategy: ["scan", "look", "nearest", "etd", "destination"].includes(strategy)
+      ? strategy
+      : DEFAULT_STATE.strategy,
+    seed: parseNum(p.get("k"), DEFAULT_STATE.seed),
+    trafficRate: parseNum(p.get("t"), DEFAULT_STATE.trafficRate),
+    speed: parseNum(p.get("x"), DEFAULT_STATE.speed),
+  };
+}
+
+function parseNum(raw: string | null, fallback: number): number {
+  if (raw === null) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : fallback;
+}

--- a/playground/src/scenarios.ts
+++ b/playground/src/scenarios.ts
@@ -1,0 +1,174 @@
+import type { ScenarioMeta } from "./types";
+
+// Scenarios are embedded as RON strings so the playground is a single static
+// bundle with no extra fetches. Each scenario is validated by elevator-core's
+// `Simulation::new`, so a malformed RON here surfaces as a JS error from
+// `new WasmSim(...)`.
+
+const office5: ScenarioMeta = {
+  id: "office-5",
+  label: "5-floor office",
+  description: "Five stops, one car. Moderate traffic. A good warm-up.",
+  suggestedTrafficRate: 8,
+  ron: `SimConfig(
+    building: BuildingConfig(
+        name: "5-Floor Office",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby",   position: 0.0),
+            StopConfig(id: StopId(1), name: "Floor 2", position: 4.0),
+            StopConfig(id: StopId(2), name: "Floor 3", position: 8.0),
+            StopConfig(id: StopId(3), name: "Floor 4", position: 12.0),
+            StopConfig(id: StopId(4), name: "Floor 5", position: 16.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car 1",
+            max_speed: 2.0, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 60, door_transition_ticks: 15,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 180,
+        weight_range: (50.0, 100.0),
+    ),
+)`,
+};
+
+const skyscraper: ScenarioMeta = {
+  id: "skyscraper-12",
+  label: "12-floor skyscraper",
+  description: "Twelve stops, three cars. Heavier traffic stresses dispatch.",
+  suggestedTrafficRate: 30,
+  ron: `SimConfig(
+    building: BuildingConfig(
+        name: "12-Floor Skyscraper",
+        stops: [
+            StopConfig(id: StopId(0),  name: "Lobby",    position: 0.0),
+            StopConfig(id: StopId(1),  name: "Floor 2",  position: 4.0),
+            StopConfig(id: StopId(2),  name: "Floor 3",  position: 8.0),
+            StopConfig(id: StopId(3),  name: "Floor 4",  position: 12.0),
+            StopConfig(id: StopId(4),  name: "Floor 5",  position: 16.0),
+            StopConfig(id: StopId(5),  name: "Floor 6",  position: 20.0),
+            StopConfig(id: StopId(6),  name: "Floor 7",  position: 24.0),
+            StopConfig(id: StopId(7),  name: "Floor 8",  position: 28.0),
+            StopConfig(id: StopId(8),  name: "Floor 9",  position: 32.0),
+            StopConfig(id: StopId(9),  name: "Floor 10", position: 36.0),
+            StopConfig(id: StopId(10), name: "Floor 11", position: 40.0),
+            StopConfig(id: StopId(11), name: "Floor 12", position: 44.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car A",
+            max_speed: 4.0, acceleration: 2.0, deceleration: 2.5,
+            weight_capacity: 1200.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 60, door_transition_ticks: 18,
+        ),
+        ElevatorConfig(
+            id: 1, name: "Car B",
+            max_speed: 4.0, acceleration: 2.0, deceleration: 2.5,
+            weight_capacity: 1200.0,
+            starting_stop: StopId(4),
+            door_open_ticks: 60, door_transition_ticks: 18,
+        ),
+        ElevatorConfig(
+            id: 2, name: "Car C",
+            max_speed: 4.0, acceleration: 2.0, deceleration: 2.5,
+            weight_capacity: 1200.0,
+            starting_stop: StopId(8),
+            door_open_ticks: 60, door_transition_ticks: 18,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 60,
+        weight_range: (50.0, 100.0),
+    ),
+)`,
+};
+
+const rushHour: ScenarioMeta = {
+  id: "rush-hour",
+  label: "Rush-hour office",
+  description: "5-floor office with 2 cars and very high arrival rate.",
+  suggestedTrafficRate: 60,
+  ron: `SimConfig(
+    building: BuildingConfig(
+        name: "Rush-Hour Office",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby",   position: 0.0),
+            StopConfig(id: StopId(1), name: "Floor 2", position: 4.0),
+            StopConfig(id: StopId(2), name: "Floor 3", position: 8.0),
+            StopConfig(id: StopId(3), name: "Floor 4", position: 12.0),
+            StopConfig(id: StopId(4), name: "Floor 5", position: 16.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car 1",
+            max_speed: 2.5, acceleration: 1.8, deceleration: 2.2,
+            weight_capacity: 900.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 45, door_transition_ticks: 12,
+        ),
+        ElevatorConfig(
+            id: 1, name: "Car 2",
+            max_speed: 2.5, acceleration: 1.8, deceleration: 2.2,
+            weight_capacity: 900.0,
+            starting_stop: StopId(4),
+            door_open_ticks: 45, door_transition_ticks: 12,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 30,
+        weight_range: (50.0, 100.0),
+    ),
+)`,
+};
+
+const spaceElevator: ScenarioMeta = {
+  id: "space-elevator",
+  label: "Space elevator",
+  description: "Two stops 1,000 km apart. Same engine, different scale.",
+  suggestedTrafficRate: 3,
+  ron: `SimConfig(
+    building: BuildingConfig(
+        name: "Orbital Tether",
+        stops: [
+            StopConfig(id: StopId(0), name: "Ground Station",     position: 0.0),
+            StopConfig(id: StopId(1), name: "Orbital Platform",  position: 1000.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Climber Alpha",
+            max_speed: 50.0, acceleration: 10.0, deceleration: 15.0,
+            weight_capacity: 10000.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 120, door_transition_ticks: 30,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 600,
+        weight_range: (60.0, 90.0),
+    ),
+)`,
+};
+
+export const SCENARIOS: ScenarioMeta[] = [
+  office5,
+  skyscraper,
+  rushHour,
+  spaceElevator,
+];
+
+export function scenarioById(id: string): ScenarioMeta {
+  return SCENARIOS.find((s) => s.id === id) ?? office5;
+}

--- a/playground/src/sim.ts
+++ b/playground/src/sim.ts
@@ -1,0 +1,120 @@
+import type { Metrics, SimEvent, Snapshot, StrategyName } from "./types";
+
+// Thin TS wrapper around `WasmSim` that narrows JS values returned by
+// serde-wasm-bindgen to our typed DTOs. Kept deliberately small — we don't
+// want a leaky abstraction over the bindgen surface.
+
+interface WasmModule {
+  default: (input?: unknown) => Promise<unknown>;
+  WasmSim: WasmSimCtor;
+  builtinStrategies: () => string[];
+}
+
+interface WasmSimCtor {
+  new (configRon: string, strategy: string): WasmSimInstance;
+}
+
+interface WasmSimInstance {
+  stepMany(n: number): void;
+  dt(): number;
+  currentTick(): bigint;
+  strategyName(): string;
+  setStrategy(name: string): boolean;
+  spawnRider(origin: number, destination: number, weight: number): void;
+  setTrafficRate(ridersPerMinute: number): void;
+  trafficRate(): number;
+  snapshot(): unknown;
+  drainEvents(): unknown;
+  metrics(): unknown;
+  waitingCountAt(stopId: number): number;
+  free(): void;
+}
+
+let modPromise: Promise<WasmModule> | null = null;
+
+/** Load the wasm-pack bundle exactly once and cache the resolved module. */
+export async function loadWasm(): Promise<WasmModule> {
+  if (!modPromise) {
+    // Resolve relative to Vite's `BASE_URL` so the playground works under a
+    // subpath deploy (e.g. /elevator-core/playground/ on GitHub Pages).
+    const base = import.meta.env.BASE_URL.endsWith("/")
+      ? import.meta.env.BASE_URL
+      : `${import.meta.env.BASE_URL}/`;
+    const url = `${base}pkg/elevator_wasm.js`;
+    modPromise = import(/* @vite-ignore */ url).then(async (mod) => {
+      const wasmUrl = `${base}pkg/elevator_wasm_bg.wasm`;
+      await (mod as WasmModule).default(wasmUrl);
+      return mod as WasmModule;
+    });
+  }
+  return modPromise;
+}
+
+/** Typed, disposable wrapper around `WasmSim`. */
+export class Sim {
+  #inner: WasmSimInstance;
+  #dt: number;
+
+  constructor(inner: WasmSimInstance) {
+    this.#inner = inner;
+    this.#dt = inner.dt();
+  }
+
+  static async create(ron: string, strategy: StrategyName): Promise<Sim> {
+    const mod = await loadWasm();
+    return new Sim(new mod.WasmSim(ron, strategy));
+  }
+
+  step(n: number): void {
+    this.#inner.stepMany(n);
+  }
+
+  get dt(): number {
+    return this.#dt;
+  }
+
+  tick(): number {
+    // bigint → number is safe for any realistic playground session.
+    return Number(this.#inner.currentTick());
+  }
+
+  strategyName(): StrategyName {
+    return this.#inner.strategyName() as StrategyName;
+  }
+
+  setStrategy(name: StrategyName): boolean {
+    return this.#inner.setStrategy(name);
+  }
+
+  spawnRider(origin: number, destination: number, weight: number): void {
+    this.#inner.spawnRider(origin, destination, weight);
+  }
+
+  setTrafficRate(ridersPerMinute: number): void {
+    this.#inner.setTrafficRate(ridersPerMinute);
+  }
+
+  trafficRate(): number {
+    return this.#inner.trafficRate();
+  }
+
+  snapshot(): Snapshot {
+    return this.#inner.snapshot() as Snapshot;
+  }
+
+  drainEvents(): SimEvent[] {
+    return this.#inner.drainEvents() as SimEvent[];
+  }
+
+  metrics(): Metrics {
+    return this.#inner.metrics() as Metrics;
+  }
+
+  waitingCountAt(stopId: number): number {
+    return this.#inner.waitingCountAt(stopId);
+  }
+
+  dispose(): void {
+    this.#inner.free();
+  }
+}

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -1,0 +1,236 @@
+:root {
+  --bg: #0b1220;
+  --fg: #e2e8f0;
+  --muted: #94a3b8;
+  --panel: #111827;
+  --panel-border: #1f2937;
+  --accent: #10b981;
+  --accent-2: #38bdf8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: var(--bg);
+  color: var(--fg);
+  font: 14px / 1.4 ui-sans-serif, system-ui, -apple-system, sans-serif;
+}
+
+.top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--panel-border);
+}
+.top h1 {
+  margin: 0;
+  font-size: 16px;
+  letter-spacing: 0.01em;
+  color: var(--accent);
+}
+.top nav a {
+  margin-left: 14px;
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 13px;
+}
+.top nav a:hover {
+  color: var(--fg);
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  align-items: center;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--panel-border);
+  background: rgba(17, 24, 39, 0.6);
+}
+
+.controls label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+.controls label .value {
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--fg);
+  font-size: 12px;
+}
+
+select,
+input[type="number"] {
+  background: var(--panel);
+  color: var(--fg);
+  border: 1px solid var(--panel-border);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font: inherit;
+}
+
+input[type="range"] {
+  width: 160px;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+button {
+  background: var(--panel);
+  color: var(--fg);
+  border: 1px solid var(--panel-border);
+  border-radius: 4px;
+  padding: 6px 10px;
+  cursor: pointer;
+  font: inherit;
+}
+button:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+button:active {
+  transform: translateY(1px);
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 1fr 340px;
+  grid-template-rows: 1fr 220px;
+  gap: 10px;
+  padding: 10px;
+  height: calc(100vh - 120px);
+}
+
+.shaft-wrap {
+  grid-column: 1;
+  grid-row: 1;
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 6px;
+  overflow: hidden;
+  min-height: 0;
+}
+#shaft {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.right {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  display: grid;
+  grid-template-rows: auto 80px 80px 1fr;
+  gap: 10px;
+  min-height: 0;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 6px;
+  padding: 10px;
+  min-height: 0;
+}
+.panel h2 {
+  margin: 0 0 8px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.metrics {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-variant-numeric: tabular-nums;
+}
+.metrics .row {
+  display: flex;
+  justify-content: space-between;
+  border-bottom: 1px solid rgba(31, 41, 55, 0.5);
+  padding: 2px 0;
+}
+.metrics .row .k {
+  color: var(--muted);
+}
+
+.chart-small {
+  width: 100%;
+  height: 80px;
+  display: block;
+}
+.chart-heatmap {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.event-log-panel {
+  grid-column: 1;
+  grid-row: 2;
+  display: flex;
+  flex-direction: column;
+}
+.event-log {
+  list-style: none;
+  margin: 0;
+  padding: 4px;
+  overflow: auto;
+  font: 11px/1.4 ui-monospace, SFMono-Regular, monospace;
+  flex: 1;
+  min-height: 0;
+}
+.event-log li {
+  padding: 2px 6px;
+  color: var(--muted);
+  border-bottom: 1px solid rgba(31, 41, 55, 0.3);
+}
+.event-log li.evt-rider-exited,
+.event-log li.evt-rider-boarded {
+  color: var(--accent);
+}
+.event-log li.evt-rider-abandoned {
+  color: #f87171;
+}
+.event-log li.evt-elevator-arrived,
+.event-log li.evt-elevator-departed {
+  color: var(--accent-2);
+}
+
+.toast {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%) translateY(30px);
+  background: var(--panel);
+  color: var(--fg);
+  border: 1px solid var(--panel-border);
+  padding: 8px 14px;
+  border-radius: 4px;
+  font-size: 12px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 150ms ease, transform 150ms ease;
+}
+.toast.show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}

--- a/playground/src/traffic.ts
+++ b/playground/src/traffic.ts
@@ -19,7 +19,12 @@ export class TrafficDriver {
   /** Consume pending spawns and emit them. Call once per UI frame. */
   tickSpawns(sim: Sim, snapshot: Snapshot, ridersPerMinute: number, elapsedSeconds: number): void {
     if (ridersPerMinute <= 0 || snapshot.stops.length < 2) return;
-    this.#accumulator += (ridersPerMinute / 60) * elapsedSeconds;
+    // Clamp to ~4 frames at 60 Hz. When the browser tab is hidden
+    // requestAnimationFrame pauses entirely, so on restore the first
+    // `elapsedSeconds` is the full hidden duration — which at 120 riders/min
+    // would dump ~20 spawns in a single frame and visibly jolt the sim.
+    const dt = Math.min(elapsedSeconds, 4 / 60);
+    this.#accumulator += (ridersPerMinute / 60) * dt;
     while (this.#accumulator >= 1.0) {
       this.#accumulator -= 1.0;
       this.#spawnOne(sim, snapshot);

--- a/playground/src/traffic.ts
+++ b/playground/src/traffic.ts
@@ -1,0 +1,65 @@
+import type { Sim } from "./sim";
+import type { Snapshot } from "./types";
+
+// Deterministic traffic driver. The wasm sim itself stays pure — we generate
+// spawns out here so:
+//   1. The user can replay a run from a seed by re-running the same stream.
+//   2. Strategy swaps don't change which riders exist, only how they're moved.
+// A simple LCG (splitmix-style seeded) is more than sufficient for a UI demo.
+
+export class TrafficDriver {
+  #state: bigint;
+  #accumulator = 0; // fractional riders accumulated from rate * elapsed
+
+  constructor(seed: number) {
+    // splitmix64 seeding so sequential seeds (1, 2, 3) produce uncorrelated streams.
+    this.#state = mixSeed(BigInt(seed >>> 0));
+  }
+
+  /** Consume pending spawns and emit them. Call once per UI frame. */
+  tickSpawns(sim: Sim, snapshot: Snapshot, ridersPerMinute: number, elapsedSeconds: number): void {
+    if (ridersPerMinute <= 0 || snapshot.stops.length < 2) return;
+    this.#accumulator += (ridersPerMinute / 60) * elapsedSeconds;
+    while (this.#accumulator >= 1.0) {
+      this.#accumulator -= 1.0;
+      this.#spawnOne(sim, snapshot);
+    }
+  }
+
+  #spawnOne(sim: Sim, snap: Snapshot): void {
+    const stops = snap.stops;
+    const originIdx = this.#nextInt(stops.length);
+    let destIdx = this.#nextInt(stops.length);
+    if (destIdx === originIdx) destIdx = (destIdx + 1) % stops.length;
+    const weight = 50 + this.#nextFloat() * 50;
+    try {
+      sim.spawnRider(stops[originIdx].stop_id, stops[destIdx].stop_id, weight);
+    } catch {
+      // spawn_rider can reject if no group serves both stops; ignore.
+    }
+  }
+
+  #nextU64(): bigint {
+    // splitmix64 step
+    let z = (this.#state = (this.#state + 0x9e3779b97f4a7c15n) & 0xffffffffffffffffn);
+    z = ((z ^ (z >> 30n)) * 0xbf58476d1ce4e5b9n) & 0xffffffffffffffffn;
+    z = ((z ^ (z >> 27n)) * 0x94d049bb133111ebn) & 0xffffffffffffffffn;
+    return z ^ (z >> 31n);
+  }
+
+  #nextInt(n: number): number {
+    return Number(this.#nextU64() % BigInt(n));
+  }
+
+  #nextFloat(): number {
+    // Upper 53 bits → [0, 1).
+    return Number(this.#nextU64() >> 11n) / 2 ** 53;
+  }
+}
+
+function mixSeed(seed: bigint): bigint {
+  let z = (seed + 0x9e3779b97f4a7c15n) & 0xffffffffffffffffn;
+  z = ((z ^ (z >> 30n)) * 0xbf58476d1ce4e5b9n) & 0xffffffffffffffffn;
+  z = ((z ^ (z >> 27n)) * 0x94d049bb133111ebn) & 0xffffffffffffffffn;
+  return z ^ (z >> 31n);
+}

--- a/playground/src/types.ts
+++ b/playground/src/types.ts
@@ -1,0 +1,88 @@
+// Mirrors of the DTO shapes returned by crates/elevator-wasm/src/dto.rs.
+// Keep this file narrow — only what the UI actually reads.
+
+export interface Car {
+  id: number;
+  line: number;
+  y: number;
+  v: number;
+  phase:
+    | "idle"
+    | "moving"
+    | "repositioning"
+    | "door-opening"
+    | "loading"
+    | "door-closing"
+    | "stopped"
+    | "unknown";
+  target: number | null;
+  load: number;
+  capacity: number;
+  riders: number;
+}
+
+export interface Stop {
+  entity_id: number;
+  stop_id: number;
+  name: string;
+  y: number;
+  waiting: number;
+  residents: number;
+}
+
+export interface Snapshot {
+  tick: number;
+  dt: number;
+  cars: Car[];
+  stops: Stop[];
+}
+
+export interface Metrics {
+  delivered: number;
+  abandoned: number;
+  spawned: number;
+  settled: number;
+  rerouted: number;
+  throughput: number;
+  avg_wait_s: number;
+  max_wait_s: number;
+  avg_ride_s: number;
+  utilization: number;
+  abandonment_rate: number;
+  total_distance: number;
+  total_moves: number;
+}
+
+export type EventKind =
+  | "rider-spawned"
+  | "rider-boarded"
+  | "rider-exited"
+  | "rider-abandoned"
+  | "elevator-arrived"
+  | "elevator-departed"
+  | "door-opened"
+  | "door-closed"
+  | "elevator-assigned"
+  | "other";
+
+export interface SimEvent {
+  kind: EventKind;
+  tick: number;
+  rider?: number;
+  elevator?: number;
+  stop?: number;
+  origin?: number;
+  destination?: number;
+  label?: string;
+}
+
+export type StrategyName = "scan" | "look" | "nearest" | "etd" | "destination";
+
+export interface ScenarioMeta {
+  id: string;
+  label: string;
+  description: string;
+  ron: string;
+  /** A sensible traffic rate (riders/min) for this scenario at start. */
+  suggestedTrafficRate: number;
+}

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": false,
+    "noEmit": true,
+    "jsx": "preserve"
+  },
+  "include": ["src"]
+}

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite";
+
+// The playground loads the wasm-pack bundle from `public/pkg/` at runtime.
+// That directory is populated by CI (`wasm-pack build --target web --out-dir
+// playground/public/pkg`) before `vite build`, or by the local dev script in
+// the playground README. Vite serves anything under `public/` unchanged, and
+// wasm-pack's emitted JS uses `import.meta.url` to resolve its sibling .wasm
+// file relative to its own location — no bundler plumbing required.
+
+export default defineConfig({
+  base: "./",
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+    target: "es2022",
+  },
+});


### PR DESCRIPTION
## Summary
- Adds `playground/` — a static Vite + vanilla TypeScript app that loads the `elevator-wasm` module and lets users explore the simulation live in a browser.
- Premium scope: canvas renderer, dashboard with sparkline/bars/heatmap, event log, CSV exports, GIF recording, shareable permalink.
- This is PR 2 of 3. **Base branch is `feat/wasm-crate` (PR 1)** — merge that first, then this retargets to `main`. PR 3 wires the CI deploy.

## Architecture
- `src/sim.ts` — typed TS wrapper around the `WasmSim` bindgen surface.
- `src/types.ts` — DTO mirrors of `crates/elevator-wasm/src/dto.rs`. These are *hand-written* rather than codegen-from-bindgen so a future core enum addition doesn't silently break TS.
- `src/canvas.ts`, `src/charts.ts` — zero-dep canvas primitives (sparkline, bar chart, rolling heatmap). No chart libraries.
- `src/traffic.ts` — splitmix64-seeded LCG so the same URL replays the same stream of spawns, preserving determinism.
- `src/export.ts` — CSV via `Blob` download; GIF via `gif.js.optimized` imported *dynamically* so the ~60 KB encoder only loads when the user clicks Record.
- `src/permalink.ts` — short query-string encoding (`?s=...&d=...&k=42&t=...&x=...`).

## Bundle size
Production: `22.68 KB` main + `3.34 KB` CSS + `3.02 KB` HTML (gzipped: `7.34 / 1.15 / 1.09 KB` respectively). The GIF encoder is code-split: `11.18 KB` (`3.95 KB` gzipped), fetched only on Record.

## Security
- All DOM updates use `textContent` / `document.createElement` / `replaceChildren` — no `innerHTML`. A plugin hook flagged the initial draft and was resolved.
- `navigator.clipboard.writeText` is wrapped in `.catch(() => {})` so a clipboard-permission denial doesn't crash the share button.
- No external fetches at runtime; everything is bundled or served from the same origin.

## Visual overview
- Controls bar: scenario dropdown, dispatch dropdown, seed input, speed slider (1–16×), traffic-rate slider (0–120 /min), and action buttons.
- Main canvas: one shaft per elevator group, cars colored by phase, inset load bars, waiting chips at each stop with count.
- Right column: metrics table → wait-time sparkline → per-stop bar chart → rolling queue-depth heatmap.
- Bottom: scrolling event log with color-coded event kinds.

## Local dev
```sh
wasm-pack build crates/elevator-wasm --target web --out-dir ../../playground/public/pkg
cd playground
pnpm install
pnpm dev
```

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — vite production build succeeds
- [ ] End-to-end load test: requires `wasm-pack` (fails locally on missing `libbz2`) — will be verified in PR 3's CI run
- [ ] Visual smoke test on the deployed GitHub Pages site after PR 3 merges