### PR TITLE
ci: deploy playground + wasm32 gate + live demo button

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,33 @@ jobs:
         working-directory: examples/csharp-harness
         run: dotnet run -c Release --no-build -- ../../assets/config/default.ron
 
+  wasm-gate:
+    name: wasm32 gate (elevator-core)
+    # Enforces the "core stays engine-agnostic" invariant: if anyone adds a
+    # non-wasm-safe dependency to elevator-core (rayon, tokio, mio, etc.) or
+    # pulls in a native-only system API, this job fails before the playground
+    # deploy ever sees the regression.
+    if: |
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.user.login != 'release-kun[bot]' ||
+      !startsWith(github.event.pull_request.title, 'chore(main): release')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check core (default features, wasm32)
+        run: cargo check -p elevator-core --target wasm32-unknown-unknown
+
+      - name: Check core (no default features, wasm32)
+        run: cargo check -p elevator-core --target wasm32-unknown-unknown --no-default-features
+
+      - name: Check elevator-wasm bindgen crate
+        run: cargo check -p elevator-wasm --target wasm32-unknown-unknown
+
   msrv:
     name: MSRV (elevator-core)
     if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,14 @@ jobs:
       - name: Check core (no default features, wasm32)
         run: cargo check -p elevator-core --target wasm32-unknown-unknown --no-default-features
 
+      - name: Check core (energy feature, wasm32)
+        # Covers the non-default `energy` feature in isolation. Using
+        # `--features energy --no-default-features` rather than
+        # `--all-features` because enabling `traffic` pulls in `rand` →
+        # `getrandom`, whose `wasm_js` backend is deliberately only wired
+        # up in `elevator-wasm` so the core crate stays engine-agnostic.
+        run: cargo check -p elevator-core --target wasm32-unknown-unknown --no-default-features --features energy
+
       - name: Check elevator-wasm bindgen crate
         run: cargo check -p elevator-wasm --target wasm32-unknown-unknown
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,21 +162,23 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
 
-      - name: Check core (default features, wasm32)
-        run: cargo check -p elevator-core --target wasm32-unknown-unknown
-
+      # Core is only required to compile to wasm32 in its pure form (no
+      # browser runtime deps). The `traffic` feature pulls `rand` →
+      # `getrandom`, whose `wasm_js` backend is deliberately provided by
+      # `elevator-wasm` — not core — to keep core engine-agnostic. So we
+      # verify core is pure-wasm with no features and with each non-default
+      # feature in isolation; the `elevator-wasm` check below proves the
+      # full stack (core + traffic + shim) compiles end-to-end.
       - name: Check core (no default features, wasm32)
         run: cargo check -p elevator-core --target wasm32-unknown-unknown --no-default-features
 
       - name: Check core (energy feature, wasm32)
-        # Covers the non-default `energy` feature in isolation. Using
-        # `--features energy --no-default-features` rather than
-        # `--all-features` because enabling `traffic` pulls in `rand` →
-        # `getrandom`, whose `wasm_js` backend is deliberately only wired
-        # up in `elevator-wasm` so the core crate stays engine-agnostic.
         run: cargo check -p elevator-core --target wasm32-unknown-unknown --no-default-features --features energy
 
-      - name: Check elevator-wasm bindgen crate
+      - name: Check elevator-wasm bindgen crate (full stack)
+        # Exercises elevator-core with default features (incl. `traffic`)
+        # alongside the `wasm_js` getrandom shim — the only target+feature
+        # combination where core with `traffic` is expected to reach wasm.
         run: cargo check -p elevator-wasm --target wasm32-unknown-unknown
 
   msrv:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,9 @@ jobs:
         # Use the prebuilt binary so runners don't need libbz2-dev / openssl-dev.
         uses: jetli/wasm-pack-action@v0.4.0
         with:
-          version: latest
+          # Pinned: a new wasm-pack release with breaking CLI changes could
+          # otherwise silently break this job. Bump deliberately.
+          version: "0.13.1"
 
       - name: Lint docs
         run: scripts/lint-docs.sh --quick

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,9 @@ on:
       - docs/**
       - scripts/lint-docs.sh
       - .github/workflows/docs.yml
+      - crates/elevator-wasm/**
+      - crates/elevator-core/**
+      - playground/**
   workflow_dispatch:
 
 permissions:
@@ -31,16 +34,59 @@ jobs:
         with:
           mdbook-version: latest
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
 
       - name: Install mdbook-mermaid
         run: cargo install mdbook-mermaid --locked
+
+      - name: Install wasm-pack
+        # Use the prebuilt binary so runners don't need libbz2-dev / openssl-dev.
+        uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: latest
 
       - name: Lint docs
         run: scripts/lint-docs.sh --quick
 
       - name: Build book
         run: mdbook build docs
+
+      - name: Build elevator-wasm
+        # Populates playground/public/pkg/ so Vite serves the wasm at runtime.
+        # --no-typescript: TS types live hand-written in playground/src/types.ts.
+        run: |
+          wasm-pack build crates/elevator-wasm \
+            --target web \
+            --out-dir ../../playground/public/pkg \
+            --release \
+            --no-typescript
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: playground/pnpm-lock.yaml
+
+      - name: Build playground
+        working-directory: playground
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
+      - name: Stage playground into mdBook output
+        # mdBook emits to target/book. Drop the playground bundle under
+        # /playground/ there so the deployed Pages site has both.
+        run: |
+          mkdir -p target/book/playground
+          cp -r playground/dist/. target/book/playground/
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Plug it into Bevy, Unity, your own renderer, or run headless.
 
 [Guide](https://andymai.github.io/elevator-core/) · [API Reference](https://docs.rs/elevator-core) · [Examples](crates/elevator-core/examples/) · [Changelog](CHANGELOG.md)
 
+**[▶ Try the live playground](https://andymai.github.io/elevator-core/playground/)** — swap dispatch strategies, tune traffic, and share seeds right in your browser.
+
 </div>
 
 <!-- Drop a GIF of the Bevy demo here when you have one -->

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,5 +1,7 @@
 # Introduction
 
+> **Try it live:** the [in-browser playground](./playground/index.html) runs the full simulation — swap dispatch strategies, tune traffic, and share seeds without installing anything.
+
 **elevator-core** is an engine-agnostic elevator simulation library written in pure Rust. It gives you a tick-based simulation with realistic trapezoidal motion profiles, pluggable dispatch algorithms, and a typed event bus -- everything you need to build elevator games, building management tools, or algorithm testbeds without coupling to any particular game engine or rendering framework.
 
 ## Who is this for?


### PR DESCRIPTION
## Summary
- Docs workflow now builds and deploys the in-browser playground alongside the mdBook docs — installs `wasm-pack` + pnpm + Node, runs `wasm-pack build` then `pnpm build`, and drops `playground/dist/` into `target/book/playground/` before uploading to Pages. Trigger expands to `crates/elevator-wasm/**`, `crates/elevator-core/**`, `playground/**` so core fixes redeploy.
- New **`wasm32 gate (elevator-core)`** CI job runs `cargo check -p elevator-core --target wasm32-unknown-unknown` with and without default features, plus `cargo check -p elevator-wasm --target wasm32-unknown-unknown`. Enforces the "core stays engine-agnostic" invariant as a first-class CI check — no more relying on discipline to keep rayon/tokio/mio out of core.
- README gets a prominent **Try the live playground** button linking to the deployed `/playground/` subpath; mdBook introduction gets a matching callout. No auto-embedded iframe — explicit button, per the UX convention.
- This is PR 3 of 3. **Base branch is `feat/playground-ui` (PR 2)** — PR 1 merges first, then PR 2 retargets to `main`, then this retargets to `main`.

## Why wasm-pack-action instead of `cargo install wasm-pack`
A source build pulls `libbz2-dev` / `openssl-dev` / `pkg-config` and takes ~3 minutes on a cold runner. The prebuilt binary action completes in seconds. Pinned to `v0.4.0` (last audited version).

## Workflow safety
- No `run:` block consumes untrusted input (issue/PR titles, commit messages, etc.) — only standard `${{ github.event_name }}` and user-login predicates in `if:` guards, matching the existing `msrv:` job's pattern.
- Concurrency group `pages` unchanged.
- `permissions` unchanged: `pages: write`, `id-token: write`, `contents: read`.

## Test plan
- [x] Both workflow YAML files parse (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [ ] Manual smoke test after merge: visit `andymai.github.io/elevator-core/playground/` — dropdowns work, cars animate, metrics update
- [ ] First CI run on this PR exercises the full wasm32 gate across core + elevator-wasm
- [ ] Deploy run after merge exercises the new wasm-pack + pnpm + mdBook staging path

## Follow-ups (not in this stack)
- Could add a Lighthouse CI step once the deploy is working, to catch perf regressions.
- Consider caching `playground/node_modules` via the `cache: pnpm` setting — already wired.