### PR TITLE
fix(ci): pin wasm-pack to v0.14.0 (action expects v-prefix)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           # Pinned: a new wasm-pack release with breaking CLI changes could
           # otherwise silently break this job. Bump deliberately.
-          version: "0.13.1"
+          version: "v0.14.0"
 
       - name: Lint docs
         run: scripts/lint-docs.sh --quick


### PR DESCRIPTION
## Summary
The deploy workflow broke immediately after PR #229 merged: `jetli/wasm-pack-action` resolves the `version:` input against wasm-pack's GitHub release tags, which carry a `v` prefix. The pin `0.13.1` (sans prefix) returned 404 on download and blocked the first run.

Fixed by switching to `v0.14.0` — latest stable (released 2026-01-20), matches the action's expected format.

## Failed run
https://github.com/andymai/elevator-core/actions/runs/24554113917

## Test plan
- [ ] Docs workflow run on this PR's merge succeeds end-to-end
- [ ] Playground loads at andymai.github.io/elevator-core/playground/