### PR TITLE
chore(ci): fix bench drift, widen lint scope, clear rustdoc warnings

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -32,10 +32,9 @@ cargo test -p elevator-core --all-features --doc --quiet
 cargo test -p elevator-bevy --doc --quiet
 
 echo "pre-commit: checking workspace..."
-cargo check --workspace --all-features --quiet
-# Also check --all-targets to catch benches / examples / integration-test
-# drift. The nightly bench workflow compiles these, but silent drift here
-# would only surface there — too late and out-of-band.
+# --all-targets catches benches / examples / integration-test drift. The
+# nightly bench workflow compiles these, but silent drift here would only
+# surface there — too late and out-of-band.
 cargo check --workspace --all-features --all-targets --quiet
 
 # Lint docs if any docs/ files or the README are staged. README.md is

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -33,6 +33,10 @@ cargo test -p elevator-bevy --doc --quiet
 
 echo "pre-commit: checking workspace..."
 cargo check --workspace --all-features --quiet
+# Also check --all-targets to catch benches / examples / integration-test
+# drift. The nightly bench workflow compiles these, but silent drift here
+# would only surface there — too late and out-of-band.
+cargo check --workspace --all-features --all-targets --quiet
 
 # Lint docs if any docs/ files or the README are staged. README.md is
 # pulled into the doctest harness, so it is under the same ignore-fence

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: cargo fmt --check
 
       - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Test workspace
         run: cargo test --workspace
@@ -50,7 +50,7 @@ jobs:
         run: cargo build --workspace
 
       - name: Doc check
-        run: cargo doc --no-deps
+        run: cargo doc --no-deps --workspace --all-features
         env:
           RUSTDOCFLAGS: -D warnings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Test workspace
-        run: cargo test --workspace
+        run: cargo test --workspace --all-features
 
       - name: Build workspace
         run: cargo build --workspace

--- a/crates/elevator-core/benches/common/mod.rs
+++ b/crates/elevator-core/benches/common/mod.rs
@@ -1,10 +1,5 @@
-//! Shared bench configuration helpers.
-//!
-//! Each bench file compiles as its own binary, so this module is included
-//! via `mod common;` in each bench that needs it. Centralizes the
-//! `ElevatorConfig` construction so a field-type change (e.g. `f64` →
-//! `Accel`/`Speed`/`Weight`) lands in one place instead of drifting across
-//! bench files.
+//! Shared bench configuration helpers — centralises `ElevatorConfig`
+//! construction so a field-type change lands in one place.
 
 #![allow(dead_code)]
 
@@ -12,8 +7,8 @@ use elevator_core::components::{Accel, Speed, Weight};
 use elevator_core::config::ElevatorConfig;
 use elevator_core::stop::StopId;
 
-/// Build an `ElevatorConfig` with the given physics and benchmark-default
-/// door / service-mode / inspection settings.
+/// `(id, starting_stop, max_speed, acceleration, deceleration, weight_capacity)`
+/// — benchmark-default door/service/inspection settings are applied.
 pub fn elevator_cfg(
     id: u32,
     starting_stop: StopId,

--- a/crates/elevator-core/benches/common/mod.rs
+++ b/crates/elevator-core/benches/common/mod.rs
@@ -1,0 +1,41 @@
+//! Shared bench configuration helpers.
+//!
+//! Each bench file compiles as its own binary, so this module is included
+//! via `mod common;` in each bench that needs it. Centralizes the
+//! `ElevatorConfig` construction so a field-type change (e.g. `f64` →
+//! `Accel`/`Speed`/`Weight`) lands in one place instead of drifting across
+//! bench files.
+
+#![allow(dead_code)]
+
+use elevator_core::components::{Accel, Speed, Weight};
+use elevator_core::config::ElevatorConfig;
+use elevator_core::stop::StopId;
+
+/// Build an `ElevatorConfig` with the given physics and benchmark-default
+/// door / service-mode / inspection settings.
+pub fn elevator_cfg(
+    id: u32,
+    starting_stop: StopId,
+    max_speed: f64,
+    acceleration: f64,
+    deceleration: f64,
+    weight_capacity: f64,
+) -> ElevatorConfig {
+    ElevatorConfig {
+        id,
+        name: format!("E{id}"),
+        max_speed: Speed::from(max_speed),
+        acceleration: Accel::from(acceleration),
+        deceleration: Accel::from(deceleration),
+        weight_capacity: Weight::from(weight_capacity),
+        starting_stop,
+        door_open_ticks: 5,
+        door_transition_ticks: 3,
+        restricted_stops: Vec::new(),
+        #[cfg(feature = "energy")]
+        energy_profile: None,
+        service_mode: None,
+        inspection_speed_factor: 0.25,
+    }
+}

--- a/crates/elevator-core/benches/dispatch_bench.rs
+++ b/crates/elevator-core/benches/dispatch_bench.rs
@@ -22,6 +22,8 @@ use elevator_core::dispatch::scan::ScanDispatch;
 use elevator_core::sim::Simulation;
 use elevator_core::stop::{StopConfig, StopId};
 
+mod common;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -36,22 +38,7 @@ fn make_config(num_stops: u32, num_elevators: u32) -> SimConfig {
         .collect();
 
     let elevators: Vec<ElevatorConfig> = (0..num_elevators)
-        .map(|i| ElevatorConfig {
-            id: i,
-            name: format!("E{i}"),
-            max_speed: 3.0,
-            acceleration: 1.5,
-            deceleration: 2.0,
-            weight_capacity: 1200.0,
-            starting_stop: StopId(i % num_stops),
-            door_open_ticks: 5,
-            door_transition_ticks: 3,
-            restricted_stops: Vec::new(),
-            #[cfg(feature = "energy")]
-            energy_profile: None,
-            service_mode: None,
-            inspection_speed_factor: 0.25,
-        })
+        .map(|i| common::elevator_cfg(i, StopId(i % num_stops), 3.0, 1.5, 2.0, 1200.0))
         .collect();
 
     SimConfig {

--- a/crates/elevator-core/benches/multi_line_bench.rs
+++ b/crates/elevator-core/benches/multi_line_bench.rs
@@ -21,6 +21,8 @@ use elevator_core::ids::GroupId;
 use elevator_core::sim::{LineParams, Simulation};
 use elevator_core::stop::{StopConfig, StopId};
 
+mod common;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -73,22 +75,7 @@ fn multi_group_config(
                 .map(|_| {
                     let eid = elevator_id;
                     elevator_id += 1;
-                    ElevatorConfig {
-                        id: eid,
-                        name: format!("E{eid}"),
-                        max_speed: 3.0,
-                        acceleration: 1.5,
-                        deceleration: 2.0,
-                        weight_capacity: 1200.0,
-                        starting_stop: serves[0],
-                        door_open_ticks: 5,
-                        door_transition_ticks: 3,
-                        restricted_stops: Vec::new(),
-                        #[cfg(feature = "energy")]
-                        energy_profile: None,
-                        service_mode: None,
-                        inspection_speed_factor: 0.25,
-                    }
+                    common::elevator_cfg(eid, serves[0], 3.0, 1.5, 2.0, 1200.0)
                 })
                 .collect();
 
@@ -154,22 +141,7 @@ fn single_group_config(num_stops: u32, num_elevators: u32) -> SimConfig {
         .collect();
 
     let elevators: Vec<ElevatorConfig> = (0..num_elevators)
-        .map(|i| ElevatorConfig {
-            id: i,
-            name: format!("E{i}"),
-            max_speed: 3.0,
-            acceleration: 1.5,
-            deceleration: 2.0,
-            weight_capacity: 1200.0,
-            starting_stop: StopId(i % num_stops),
-            door_open_ticks: 5,
-            door_transition_ticks: 3,
-            restricted_stops: Vec::new(),
-            #[cfg(feature = "energy")]
-            energy_profile: None,
-            service_mode: None,
-            inspection_speed_factor: 0.25,
-        })
+        .map(|i| common::elevator_cfg(i, StopId(i % num_stops), 3.0, 1.5, 2.0, 1200.0))
         .collect();
 
     SimConfig {

--- a/crates/elevator-core/benches/query_bench.rs
+++ b/crates/elevator-core/benches/query_bench.rs
@@ -18,6 +18,8 @@ use elevator_core::prelude::*;
 use elevator_core::sim::Simulation;
 use elevator_core::stop::{StopConfig, StopId};
 
+mod common;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -32,22 +34,7 @@ fn make_config(num_stops: u32, num_elevators: u32) -> SimConfig {
         .collect();
 
     let elevators: Vec<ElevatorConfig> = (0..num_elevators)
-        .map(|i| ElevatorConfig {
-            id: i,
-            name: format!("E{i}"),
-            max_speed: 3.0,
-            acceleration: 1.5,
-            deceleration: 2.0,
-            weight_capacity: 1200.0,
-            starting_stop: StopId(i % num_stops),
-            door_open_ticks: 5,
-            door_transition_ticks: 3,
-            restricted_stops: Vec::new(),
-            #[cfg(feature = "energy")]
-            energy_profile: None,
-            service_mode: None,
-            inspection_speed_factor: 0.25,
-        })
+        .map(|i| common::elevator_cfg(i, StopId(i % num_stops), 3.0, 1.5, 2.0, 1200.0))
         .collect();
 
     SimConfig {

--- a/crates/elevator-core/benches/scaling_bench.rs
+++ b/crates/elevator-core/benches/scaling_bench.rs
@@ -16,6 +16,8 @@ use elevator_core::dispatch::scan::ScanDispatch;
 use elevator_core::sim::Simulation;
 use elevator_core::stop::{StopConfig, StopId};
 
+mod common;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -30,22 +32,7 @@ fn make_config(num_stops: u32, num_elevators: u32) -> SimConfig {
         .collect();
 
     let elevators: Vec<ElevatorConfig> = (0..num_elevators)
-        .map(|i| ElevatorConfig {
-            id: i,
-            name: format!("E{i}"),
-            max_speed: 3.0,
-            acceleration: 1.5,
-            deceleration: 2.0,
-            weight_capacity: 1200.0,
-            starting_stop: StopId(i % num_stops),
-            door_open_ticks: 5,
-            door_transition_ticks: 3,
-            restricted_stops: Vec::new(),
-            #[cfg(feature = "energy")]
-            energy_profile: None,
-            service_mode: None,
-            inspection_speed_factor: 0.25,
-        })
+        .map(|i| common::elevator_cfg(i, StopId(i % num_stops), 3.0, 1.5, 2.0, 1200.0))
         .collect();
 
     SimConfig {

--- a/crates/elevator-core/benches/sim_bench.rs
+++ b/crates/elevator-core/benches/sim_bench.rs
@@ -17,6 +17,8 @@ use elevator_core::movement::tick_movement;
 use elevator_core::sim::Simulation;
 use elevator_core::stop::{StopConfig, StopId};
 
+mod common;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -32,22 +34,7 @@ fn make_config(num_stops: u32, num_elevators: u32) -> SimConfig {
         .collect();
 
     let elevators: Vec<ElevatorConfig> = (0..num_elevators)
-        .map(|i| ElevatorConfig {
-            id: i,
-            name: format!("E{i}"),
-            max_speed: 2.0,
-            acceleration: 1.0,
-            deceleration: 1.0,
-            weight_capacity: 1000.0,
-            starting_stop: StopId(0),
-            door_open_ticks: 5,
-            door_transition_ticks: 3,
-            restricted_stops: Vec::new(),
-            #[cfg(feature = "energy")]
-            energy_profile: None,
-            service_mode: None,
-            inspection_speed_factor: 0.25,
-        })
+        .map(|i| common::elevator_cfg(i, StopId(0), 2.0, 1.0, 1.0, 1000.0))
         .collect();
 
     SimConfig {

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -620,11 +620,11 @@ impl Simulation {
     /// [`future_stop_position`](Self::future_stop_position)), picks the
     /// closest stop at or past that position in the current direction of
     /// travel, re-targets there via
-    /// [`ElevatorPhase::Repositioning`](crate::components::ElevatorPhase::Repositioning)
+    /// [`ElevatorPhase::Repositioning`](crate::components::ElevatorPhase)
     /// so the car arrives **without opening doors**, and clears any queued
     /// destinations. Onboard riders stay aboard.
     ///
-    /// Emits [`Event::MovementAborted`](crate::events::Event::MovementAborted)
+    /// Emits [`Event::MovementAborted`](crate::events::Event)
     /// when an abort occurs.
     ///
     /// # No-op conditions

--- a/crates/elevator-core/src/tests/abort_movement_tests.rs
+++ b/crates/elevator-core/src/tests/abort_movement_tests.rs
@@ -22,7 +22,7 @@ fn first_elevator(sim: &crate::sim::Simulation) -> ElevatorId {
 }
 
 /// Drive the sim until the elevator is actively moving (phase is
-/// MovingToStop), then return the elevator's current phase. Panics if it
+/// `MovingToStop`), then return the elevator's current phase. Panics if it
 /// does not start moving within the budget.
 fn step_until_moving(sim: &mut crate::sim::Simulation, elev: ElevatorId) {
     for _ in 0..200 {

--- a/crates/elevator-core/src/tests/boundary_tests.rs
+++ b/crates/elevator-core/src/tests/boundary_tests.rs
@@ -56,14 +56,15 @@ fn patience_one_abandons_after_one_tick() {
     );
 }
 
-/// Document: max_wait_ticks = 0 and max_wait_ticks = 1 both abandon on the first tick.
+/// Document: `max_wait_ticks` = 0 and `max_wait_ticks` = 1 both abandon on the first tick.
 ///
 /// The abandon condition is `waited_ticks >= max_wait_ticks.saturating_sub(1)`.
-/// - max_wait_ticks=0: saturating_sub(1) → 0, so 0 >= 0 is true → abandons before increment.
-/// - max_wait_ticks=1: saturating_sub(1) → 0, so 0 >= 0 is true → same behavior.
+/// - `max_wait_ticks=0`: `saturating_sub(1)` → 0, so 0 >= 0 is true → abandons before increment.
+/// - `max_wait_ticks=1`: `saturating_sub(1)` → 0, so 0 >= 0 is true → same behavior.
+///
 /// This equivalence is intentional: there is no meaningful difference between
 /// "zero patience" and "one-tick patience" since the check runs before the
-/// waited_ticks counter increments.
+/// `waited_ticks` counter increments.
 #[test]
 fn patience_zero_and_one_are_equivalent() {
     for max_wait in [0, 1] {
@@ -249,7 +250,7 @@ fn weight_exceeds_capacity_by_epsilon_rejects() {
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
     let r1 = sim.spawn_rider(StopId(0), StopId(2), 799.5).unwrap();
-    let r2 = sim.spawn_rider(StopId(0), StopId(2), 0.500001).unwrap();
+    let r2 = sim.spawn_rider(StopId(0), StopId(2), 0.500_001).unwrap();
 
     // Run until r1 is aboard.
     for _ in 0..100 {

--- a/crates/elevator-core/src/tests/config_tests.rs
+++ b/crates/elevator-core/src/tests/config_tests.rs
@@ -1,3 +1,4 @@
+use crate::components::Orientation;
 use crate::config::SimConfig;
 use crate::error::SimError;
 
@@ -127,7 +128,7 @@ fn rejects_empty_line_serves() {
         name: "Empty".into(),
         serves: vec![],
         elevators: config.elevators.clone(),
-        orientation: Default::default(),
+        orientation: Orientation::default(),
         position: None,
         min_position: None,
         max_position: None,

--- a/crates/elevator-core/src/tests/dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/dispatch_tests.rs
@@ -605,7 +605,7 @@ fn assign_handles_large_group_without_overflow() {
 
 // ===== Single-elevator, single-stop edge case tests (#179) =====
 
-/// Build a `World` with 1 stop and return (world, stop_entities).
+/// Build a `World` with 1 stop and return (world, `stop_entities`).
 fn single_stop_world() -> (World, Vec<crate::entity::EntityId>) {
     let mut world = World::new();
     let eid = world.spawn();

--- a/crates/elevator-core/src/tests/energy_tests.rs
+++ b/crates/elevator-core/src/tests/energy_tests.rs
@@ -185,13 +185,10 @@ fn energy_consumed_events_emitted() {
 
     sim.step();
     let events = sim.drain_events();
-    let energy_events: Vec<_> = events
-        .iter()
-        .filter(|e| matches!(e, Event::EnergyConsumed { .. }))
-        .collect();
-
     assert!(
-        !energy_events.is_empty(),
+        events
+            .iter()
+            .any(|e| matches!(e, Event::EnergyConsumed { .. })),
         "expected at least one EnergyConsumed event per tick"
     );
 }

--- a/crates/elevator-core/src/tests/move_count_tests.rs
+++ b/crates/elevator-core/src/tests/move_count_tests.rs
@@ -319,7 +319,7 @@ fn move_count_counts_reposition_arrivals() {
         "expected at least 2 moves (passing + arrival) during reposition, got {count}",
     );
     assert_eq!(
-        count as u64,
+        count,
         sim.metrics().total_moves(),
         "aggregate must equal sum of per-elevator counts",
     );

--- a/crates/elevator-core/src/tests/world_tests.rs
+++ b/crates/elevator-core/src/tests/world_tests.rs
@@ -188,7 +188,7 @@ fn extension_components() {
     assert!(world.ext::<VipTag>(e).is_none());
 }
 
-/// Verify that despawn cleans up hall_calls and car_calls.
+/// Verify that despawn cleans up `hall_calls` and `car_calls`.
 #[test]
 fn despawn_cleans_up_hall_and_car_calls() {
     let mut world = World::new();

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -1860,7 +1860,7 @@ mod tests {
         unsafe { ev_sim_destroy(handle) };
     }
 
-    /// Helper: create an EvSim handle from default.ron.
+    /// Helper: create an `EvSim` handle from default.ron.
     fn create_test_handle() -> *mut EvSim {
         let manifest = env!("CARGO_MANIFEST_DIR");
         let root = std::path::Path::new(manifest)
@@ -1874,7 +1874,7 @@ mod tests {
         handle
     }
 
-    /// Helper: get (first_stop_entity_id, last_stop_entity_id) from frame.
+    /// Helper: get (`first_stop_entity_id`, `last_stop_entity_id`) from frame.
     fn stop_entities(handle: *mut EvSim) -> (u64, u64) {
         let mut frame = EvFrame {
             elevators: std::ptr::null(),

--- a/crates/elevator-gdext/src/lib.rs
+++ b/crates/elevator-gdext/src/lib.rs
@@ -6,6 +6,8 @@
 
 mod sim_node;
 
+pub use sim_node::ElevatorSim;
+
 use godot::prelude::*;
 
 /// GDExtension entry point.

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -155,7 +155,7 @@ impl WasmSim {
     }
 
     /// Pull a cheap snapshot for rendering. Returns a plain JS object matching
-    /// [`dto::Snapshot`].
+    /// the internal `dto::Snapshot` shape.
     ///
     /// # Errors
     ///
@@ -168,7 +168,7 @@ impl WasmSim {
     }
 
     /// Drain all queued events since the last call. Returns an array of tagged
-    /// objects (matching [`dto::EventDto`]).
+    /// objects (matching the internal `dto::EventDto` shape).
     ///
     /// # Errors
     ///


### PR DESCRIPTION
## Summary

- Bench files in `crates/elevator-core/benches/` silently drifted since the `Accel`/`Speed`/`Weight` newtypes landed in #153 — nightly-bench has been red while main CI stayed green because `cargo clippy --all-targets` at `.github/workflows/ci.yml:44` was missing `--workspace` and was only linting the default member (`elevator-bevy`). This PR closes that gap.
- Adds `benches/common/mod.rs` with a shared `elevator_cfg()` helper so a future field-type change lands in one place. Each bench now calls `common::elevator_cfg(id, starting_stop, max_speed, accel, decel, capacity)`.
- Widens CI's clippy to `--workspace --all-targets --all-features -D warnings`, and CI's doc check to the full workspace with `RUSTDOCFLAGS: -D warnings`.
- Adds `cargo check --workspace --all-features --all-targets` to `.githooks/pre-commit` so this class of drift fails pre-push.
- Fixes the clippy warnings the widened scope surfaces (doc_markdown, needless_collect, unnecessary_cast, long-literal separators, doc_lazy_continuation, `Default::default` in a typed context) — mostly auto-applied by `cargo clippy --fix`, reviewed, committed.
- Fixes three rustdoc warnings: redundant explicit link targets in `sim.rs:623,627`, broken `ElevatorSim` intra-doc link in `elevator-gdext/src/lib.rs:4` (added `pub use sim_node::ElevatorSim;`), private-item links in `elevator-wasm/src/lib.rs:158,171` (unlinked, kept as prose references to the internal `dto` shape).

No public API changes.

## Test plan

- [x] `cargo check --workspace --all-features --all-targets` — green
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — green, zero warnings
- [x] `cargo test --workspace --all-features` — 782 tests pass, 0 failures
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace --all-features` — green, zero warnings
- [x] `cargo bench -p elevator-core --no-run` — all 5 bench binaries build
- [x] `.githooks/pre-commit` runs end-to-end green with the new check
- [ ] After merge: manually trigger `Benchmarks (nightly)` via `gh workflow run bench-nightly.yml` and confirm green baseline