### PR TITLE
docs(stability): publish stability policy and per-module classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Plug it into Bevy, Unity, your own renderer, or run headless.
 [![CI](https://img.shields.io/github/actions/workflow/status/andymai/elevator-core/ci.yml?label=CI)](https://github.com/andymai/elevator-core/actions)
 [![License](https://img.shields.io/crates/l/elevator-core.svg)](LICENSE-MIT)
 
-[Guide](https://andymai.github.io/elevator-core/) · [API Reference](https://docs.rs/elevator-core) · [Examples](crates/elevator-core/examples/) · [Changelog](CHANGELOG.md)
+[Guide](https://andymai.github.io/elevator-core/) · [API Reference](https://docs.rs/elevator-core) · [Examples](crates/elevator-core/examples/) · [Changelog](CHANGELOG.md) · [Stability](STABILITY.md)
 
 **[▶ Try the live playground](https://andymai.github.io/elevator-core/playground/)** — swap dispatch strategies, tune traffic, and share seeds right in your browser.
 

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -88,6 +88,8 @@ These items are **experimental** and may change in any minor version:
   blocks but not committed.
 - `energy::*` (feature-gated) — simplified per-elevator energy model.
   Opt-in via the `energy` feature; the accounting model may shift.
+- `time::TimeAdapter` — tick-to-wall-clock conversion utility.
+- `ids::*` — config-level typed identifiers (`GroupId`, etc.).
 
 These items are **internal**:
 

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -62,6 +62,7 @@ As of `elevator-core` v15.1.0, these items are **stable**:
 - `builder::SimulationBuilder` (entire public surface)
 - `events::Event` (enum, `#[non_exhaustive]`)
 - `error::SimError` (enum, `#[non_exhaustive]`)
+- `metrics::Metrics` (entire public surface)
 - `stop::{StopId, StopConfig}`
 - `entity::{ElevatorId, RiderId, EntityId}`
 - `components::{Weight, Speed, Accel}` and `components::units::UnitError`
@@ -85,12 +86,14 @@ These items are **experimental** and may change in any minor version:
   changes can happen here.
 - `movement::*` — trapezoidal-motion primitives. Useful as building
   blocks but not committed.
+- `energy::*` (feature-gated) — simplified per-elevator energy model.
+  Opt-in via the `energy` feature; the accounting model may shift.
 
 These items are **internal**:
 
 - `systems::*` — per-phase tick logic (`pub(crate)`).
-- `door::*`, `energy::*`, `eta::*` — low-level building blocks
-  re-exported only where practical.
+- `door::*`, `eta::*` — low-level building blocks re-exported only
+  where practical.
 - Anything `#[doc(hidden)]`.
 
 ## Wrapper crates

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -1,0 +1,125 @@
+# Stability Policy
+
+This document defines what **stability** means for `elevator-core` and the
+other crates in this workspace. It is a promise about the rate at which
+APIs change, not a promise that they never will.
+
+## Status levels
+
+Each public item (module, type, function, feature flag) is classified as
+**Stable**, **Experimental**, or **Internal**. The
+[crate layout table](crates/elevator-core/src/lib.rs) in the `elevator-core`
+rustdoc shows the per-module assignment.
+
+### Stable
+
+A stable API has earned the following pledge:
+
+- **Breaking changes ship only in planned major versions.** A major bump
+  that touches a stable API is announced in a GitHub issue at least
+  **60 days** before the release, along with a migration note in the
+  CHANGELOG preamble.
+- **Deprecation precedes removal.** A stable API scheduled for removal
+  is marked `#[deprecated]` for **at least one major version** before it
+  is actually deleted. Users get a compiler warning with a pointer to
+  the replacement.
+- **Semver is honored strictly.** No sneaking a breaking change into a
+  minor or patch release. If you want to fix a bug whose fix changes
+  behavior, either ship the fix behind a new function or wait for a
+  major.
+
+### Experimental
+
+An experimental API signals: *the shape is still being discovered*.
+Expect breakage in any minor version, with no deprecation cycle. The
+API is real, not a stub — it's fully implemented and tested — but its
+contract may shift as the design matures.
+
+If you depend on an experimental API, pin to an exact minor version in
+your `Cargo.toml` and expect a migration task when you upgrade:
+
+```toml
+# Depending on an experimental API? Pin the minor, not the major.
+elevator-core = "=15.1"
+```
+
+Experimental APIs graduate to stable by explicit CHANGELOG entry. The
+table in the crate-root docs is the source of truth.
+
+### Internal
+
+Internal items are `pub(crate)` or `#[doc(hidden)]`. They are not part
+of the supported surface; using them from outside the crate (via reflection,
+macros, or forks) is unsupported and subject to change without notice.
+
+## Day-one classification
+
+As of `elevator-core` v15.1.0, these items are **stable**:
+
+- `sim::Simulation::{new, step, spawn_rider, build_rider, drain_events,
+  drain_events_where, metrics, snapshot, current_tick, dt, world,
+  world_mut}`
+- `builder::SimulationBuilder` (entire public surface)
+- `events::Event` (enum, `#[non_exhaustive]`)
+- `error::SimError` (enum, `#[non_exhaustive]`)
+- `stop::{StopId, StopConfig}`
+- `entity::{ElevatorId, RiderId, EntityId}`
+- `components::{Weight, Speed, Accel}` and `components::units::UnitError`
+- `snapshot::WorldSnapshot`
+
+These items are **experimental** and may change in any minor version:
+
+- `dispatch::DispatchStrategy` and all built-in strategies
+  (`ScanDispatch`, `LookDispatch`, `NearestCarDispatch`, `EtdDispatch`,
+  `DestinationDispatch`). The plugin contract may shift as we
+  incorporate more dispatch algorithms.
+- `hooks::{Phase, PhaseHooks}` — the phase-hook registration surface.
+- `topology::*` — connectivity graph and multi-line routing queries.
+- `tagged_metrics::*` — per-tag metric accumulators.
+- `scenario::*` — deterministic scenario replay.
+- `traffic::*` (feature-gated) — traffic generation.
+- `query::*` — the query builder.
+- `world::World::{insert_ext, ext, ext_mut, ...}` — extension-component APIs.
+- `config::*` — RON deserialization surface. Field additions are
+  `#[serde(default)]`-gated when possible, but removals and type
+  changes can happen here.
+- `movement::*` — trapezoidal-motion primitives. Useful as building
+  blocks but not committed.
+
+These items are **internal**:
+
+- `systems::*` — per-phase tick logic (`pub(crate)`).
+- `door::*`, `energy::*`, `eta::*` — low-level building blocks
+  re-exported only where practical.
+- Anything `#[doc(hidden)]`.
+
+## Wrapper crates
+
+The wrapper crates — `elevator-bevy`, `elevator-ffi`, `elevator-gdext`,
+`elevator-wasm` — have their own versioning cadence. Their stability
+is **not** covered by this document. They pin specific minor/major
+releases of `elevator-core` and may evolve independently.
+
+## How this evolves
+
+- When an experimental API stabilizes, a dedicated `feat:` entry in the
+  CHANGELOG calls it out (title begins with `stabilize: <module>`).
+- When a stable API is scheduled for breaking change, a GitHub issue
+  opens at least 60 days in advance with a migration guide.
+- This document is kept in sync with the crate-root stability table;
+  the table is the canonical list and this document explains the rules.
+
+## Cadence commitment
+
+`elevator-core` shipped 15 major versions between v1.0.0 (2025) and
+v15.0.0 (2026-04-16). That cadence is driven by API discovery, not
+instability of the implementation — the library has had 604 lib tests,
+156 doc tests, and a mutation-tested kernel throughout. Going forward:
+
+- **Stable surface**: at most one breaking change per 60 days.
+  Experimental surface has no such bound.
+- **Planned majors** will bundle breaking changes together to minimize
+  consumer-side churn.
+
+This cadence commitment applies **going forward only**; it is not
+retroactive.

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -82,6 +82,7 @@
 //! | [`tagged_metrics`] | Per-tag metric accumulators for zone/line/priority breakdowns | experimental |
 //! | [`movement`] | Trapezoidal velocity-profile primitives ([`braking_distance`](movement::braking_distance), [`tick_movement`](movement::tick_movement)) | experimental |
 //! | [`door`] | Door finite-state machine ([`DoorState`](door::DoorState)) | internal |
+//! | [`eta`] | Per-stop arrival-time estimation used by dispatch | internal |
 //! | [`time`] | Tick-to-wall-clock conversion ([`TimeAdapter`](time::TimeAdapter)) | experimental |
 //! | `energy` | Simplified per-elevator energy modeling (gated behind the `energy` feature) | experimental |
 //! | [`stop`] | [`StopId`](stop::StopId) and [`StopConfig`](stop::StopConfig) | stable |

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -53,32 +53,41 @@
 //!
 //! ## Crate layout
 //!
-//! | Module | Purpose |
-//! |--------|---------|
-//! | [`builder`] | Fluent [`SimulationBuilder`](builder::SimulationBuilder) API |
-//! | [`sim`] | Top-level [`Simulation`](sim::Simulation) runner and tick loop |
-//! | [`dispatch`] | Dispatch strategies and the [`DispatchStrategy`](dispatch::DispatchStrategy) trait |
-//! | [`world`] | ECS-style [`World`](world::World) with typed component storage |
-//! | [`components`] | Entity data types: [`Rider`](components::Rider), [`Elevator`](components::Elevator), [`Stop`](components::Stop), [`Line`](components::Line), [`Route`](components::Route), [`Patience`](components::Patience), [`Preferences`](components::Preferences), [`AccessControl`](components::AccessControl), [`DestinationQueue`](components::DestinationQueue), [`ServiceMode`](components::ServiceMode), [`Orientation`](components::Orientation), [`Position`](components::Position), [`Velocity`](components::Velocity), [`SpatialPosition`](components::SpatialPosition) |
-//! | [`config`] | RON-deserializable [`SimConfig`](config::SimConfig), [`GroupConfig`](config::GroupConfig), [`LineConfig`](config::LineConfig) |
-//! | [`events`] | [`Event`](events::Event) variants and the [`EventBus`](events::EventBus) |
-//! | [`metrics`] | Aggregate [`Metrics`](metrics::Metrics) (wait time, throughput, etc.) |
-//! | [`hooks`] | Lifecycle hook registration by [`Phase`](hooks::Phase) |
-//! | [`query`] | Entity query builder for filtering by component composition |
-//! | [`systems`] | Per-phase tick logic (dispatch, movement, doors, loading, ...) |
-//! | [`snapshot`] | [`WorldSnapshot`](snapshot::WorldSnapshot) save/restore with custom-strategy factory |
-//! | [`scenario`] | Deterministic scenario replay from recorded event streams |
-//! | [`topology`] | Lazy-rebuilt connectivity graph for cross-line routing |
-//! | [`traffic`] | [`TrafficSource`](traffic::TrafficSource) trait + `PoissonSource` (feature-gated) |
-//! | [`tagged_metrics`] | Per-tag metric accumulators for zone/line/priority breakdowns |
-//! | [`movement`] | Trapezoidal velocity-profile primitives ([`braking_distance`](movement::braking_distance), [`tick_movement`](movement::tick_movement)) |
-//! | [`door`] | Door finite-state machine ([`DoorState`](door::DoorState)) |
-//! | [`time`] | Tick-to-wall-clock conversion ([`TimeAdapter`](time::TimeAdapter)) |
-//! | `energy` | Simplified per-elevator energy modeling (gated behind the `energy` feature) |
-//! | [`stop`] | [`StopId`](stop::StopId) and [`StopConfig`](stop::StopConfig) |
-//! | [`entity`] | Opaque [`EntityId`](entity::EntityId) runtime identity |
-//! | [`ids`] | Config-level typed identifiers ([`GroupId`](ids::GroupId), etc.) |
-//! | [`error`] | [`SimError`](error::SimError), [`RejectionReason`](error::RejectionReason), [`RejectionContext`](error::RejectionContext) |
+//! ## Stability
+//!
+//! Every module below is classified as **stable**, **experimental**, or
+//! **internal**. Stable items break only in planned major versions
+//! with a deprecation cycle; experimental items may change in any
+//! minor version; internal items are not part of the supported surface.
+//! See [`STABILITY.md`](https://github.com/andymai/elevator-core/blob/main/STABILITY.md)
+//! for the full policy and cadence commitment.
+//!
+//! | Module | Purpose | Stability |
+//! |--------|---------|-----------|
+//! | [`builder`] | Fluent [`SimulationBuilder`](builder::SimulationBuilder) API | stable |
+//! | [`sim`] | Top-level [`Simulation`](sim::Simulation) runner and tick loop | stable (selected methods — see [`STABILITY.md`](https://github.com/andymai/elevator-core/blob/main/STABILITY.md)) |
+//! | [`dispatch`] | Dispatch strategies and the [`DispatchStrategy`](dispatch::DispatchStrategy) trait | experimental |
+//! | [`world`] | ECS-style [`World`](world::World) with typed component storage | experimental |
+//! | [`components`] | Entity data types: [`Rider`](components::Rider), [`Elevator`](components::Elevator), [`Stop`](components::Stop), [`Line`](components::Line), [`Route`](components::Route), [`Patience`](components::Patience), [`Preferences`](components::Preferences), [`AccessControl`](components::AccessControl), [`DestinationQueue`](components::DestinationQueue), [`ServiceMode`](components::ServiceMode), [`Orientation`](components::Orientation), [`Position`](components::Position), [`Velocity`](components::Velocity), [`SpatialPosition`](components::SpatialPosition) | stable (units + core), experimental (rest) |
+//! | [`config`] | RON-deserializable [`SimConfig`](config::SimConfig), [`GroupConfig`](config::GroupConfig), [`LineConfig`](config::LineConfig) | experimental |
+//! | [`events`] | [`Event`](events::Event) variants and the [`EventBus`](events::EventBus) | stable ([`Event`](events::Event)) |
+//! | [`metrics`] | Aggregate [`Metrics`](metrics::Metrics) (wait time, throughput, etc.) | stable |
+//! | [`hooks`] | Lifecycle hook registration by [`Phase`](hooks::Phase) | experimental |
+//! | [`query`] | Entity query builder for filtering by component composition | experimental |
+//! | [`systems`] | Per-phase tick logic (dispatch, movement, doors, loading, ...) | internal |
+//! | [`snapshot`] | [`WorldSnapshot`](snapshot::WorldSnapshot) save/restore with custom-strategy factory | stable |
+//! | [`scenario`] | Deterministic scenario replay from recorded event streams | experimental |
+//! | [`topology`] | Lazy-rebuilt connectivity graph for cross-line routing | experimental |
+//! | [`traffic`] | [`TrafficSource`](traffic::TrafficSource) trait + `PoissonSource` (feature-gated) | experimental |
+//! | [`tagged_metrics`] | Per-tag metric accumulators for zone/line/priority breakdowns | experimental |
+//! | [`movement`] | Trapezoidal velocity-profile primitives ([`braking_distance`](movement::braking_distance), [`tick_movement`](movement::tick_movement)) | experimental |
+//! | [`door`] | Door finite-state machine ([`DoorState`](door::DoorState)) | internal |
+//! | [`time`] | Tick-to-wall-clock conversion ([`TimeAdapter`](time::TimeAdapter)) | experimental |
+//! | `energy` | Simplified per-elevator energy modeling (gated behind the `energy` feature) | experimental |
+//! | [`stop`] | [`StopId`](stop::StopId) and [`StopConfig`](stop::StopConfig) | stable |
+//! | [`entity`] | Opaque [`EntityId`](entity::EntityId) runtime identity | stable |
+//! | [`ids`] | Config-level typed identifiers ([`GroupId`](ids::GroupId), etc.) | experimental |
+//! | [`error`] | [`SimError`](error::SimError), [`RejectionReason`](error::RejectionReason), [`RejectionContext`](error::RejectionContext) | stable ([`SimError`](error::SimError)) |
 //!
 //! ## Architecture overview
 //!

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -41,6 +41,7 @@
 - [Traffic Generation](traffic-generation.md)
 - [Snapshots and Determinism](snapshots-determinism.md)
 - [Testing Your Simulation](testing.md)
+- [Stability and Versioning](stability.md)
 
 ---
 

--- a/docs/src/stability.md
+++ b/docs/src/stability.md
@@ -12,11 +12,7 @@
 
 ## Where to find the current classification
 
-The module table at the top of the [`elevator-core` crate docs](https://docs.rs/elevator-core) is the canonical list. Every row has a Stability column. That table and `STABILITY.md` move together — if you're deciding whether to depend on a specific module, check the table first.
-
-As of v15.1.0 these items are stable: [`Simulation`](https://docs.rs/elevator-core/latest/elevator_core/sim/struct.Simulation.html)'s core methods, [`SimulationBuilder`](https://docs.rs/elevator-core/latest/elevator_core/builder/struct.SimulationBuilder.html), [`Event`](https://docs.rs/elevator-core/latest/elevator_core/events/enum.Event.html), [`SimError`](https://docs.rs/elevator-core/latest/elevator_core/error/enum.SimError.html), the ID newtypes, the physical-unit newtypes (`Weight`, `Speed`, `Accel`), and [`WorldSnapshot`](https://docs.rs/elevator-core/latest/elevator_core/snapshot/struct.WorldSnapshot.html).
-
-Experimental areas: `dispatch::*`, `hooks::*`, `topology::*`, `tagged_metrics::*`, `scenario::*`, `traffic::*`, `query::*`, `world` extension APIs, `config::*`, and `movement::*`.
+The module table at the top of the [`elevator-core` crate docs](https://docs.rs/elevator-core) has a Stability column for every row and is the canonical list. `STABILITY.md` lists the per-item day-one classification — check it before taking a dependency on a specific module.
 
 ## Depending on experimental APIs
 
@@ -32,9 +28,7 @@ When you bump the minor, expect a short migration task. The CHANGELOG will call 
 
 ## Cadence commitment
 
-`elevator-core` shipped 15 majors between v1.0 and v15.0 during API discovery. Going forward: **at most one breaking change to the stable surface per 60 days**, with planned majors bundling breaks together. Experimental surface isn't bound by this cap.
-
-The cadence commitment is not retroactive — it applies to releases after v15.1.0.
+The stable surface has a bounded break rate; planned majors bundle changes together. Experimental surface has no such cap. The commitment applies to releases after v15.1.0 — see [`STABILITY.md`](https://github.com/andymai/elevator-core/blob/main/STABILITY.md) for the specific bound and retroactivity note.
 
 ## Next steps
 

--- a/docs/src/stability.md
+++ b/docs/src/stability.md
@@ -1,0 +1,43 @@
+# Stability and Versioning
+
+`elevator-core` classifies every public item as **stable**, **experimental**, or **internal**, and the crate makes a specific promise about how quickly each kind can break. This chapter summarises the rules; the repo's [`STABILITY.md`](https://github.com/andymai/elevator-core/blob/main/STABILITY.md) is the authoritative source.
+
+## Three status levels
+
+**Stable.** Breaking changes ship only in planned major versions. Majors that touch a stable API are announced in a GitHub issue at least 60 days before the release, with a CHANGELOG migration note. `#[deprecated]` precedes removal by at least one major.
+
+**Experimental.** The shape is still being discovered. May break in any minor version with no deprecation cycle. The API is real — fully implemented and tested — but the contract can shift as the design matures.
+
+**Internal.** `pub(crate)` or `#[doc(hidden)]`. Not supported for use outside the crate.
+
+## Where to find the current classification
+
+The module table at the top of the [`elevator-core` crate docs](https://docs.rs/elevator-core) is the canonical list. Every row has a Stability column. That table and `STABILITY.md` move together — if you're deciding whether to depend on a specific module, check the table first.
+
+As of v15.1.0 these items are stable: [`Simulation`](https://docs.rs/elevator-core/latest/elevator_core/sim/struct.Simulation.html)'s core methods, [`SimulationBuilder`](https://docs.rs/elevator-core/latest/elevator_core/builder/struct.SimulationBuilder.html), [`Event`](https://docs.rs/elevator-core/latest/elevator_core/events/enum.Event.html), [`SimError`](https://docs.rs/elevator-core/latest/elevator_core/error/enum.SimError.html), the ID newtypes, the physical-unit newtypes (`Weight`, `Speed`, `Accel`), and [`WorldSnapshot`](https://docs.rs/elevator-core/latest/elevator_core/snapshot/struct.WorldSnapshot.html).
+
+Experimental areas: `dispatch::*`, `hooks::*`, `topology::*`, `tagged_metrics::*`, `scenario::*`, `traffic::*`, `query::*`, `world` extension APIs, `config::*`, and `movement::*`.
+
+## Depending on experimental APIs
+
+Pin to an exact minor version:
+
+```toml
+# Use this if you touch dispatch, hooks, topology, traffic, extensions,
+# or any other experimental area:
+elevator-core = "=15.1"
+```
+
+When you bump the minor, expect a short migration task. The CHANGELOG will call out what changed.
+
+## Cadence commitment
+
+`elevator-core` shipped 15 majors between v1.0 and v15.0 during API discovery. Going forward: **at most one breaking change to the stable surface per 60 days**, with planned majors bundling breaks together. Experimental surface isn't bound by this cap.
+
+The cadence commitment is not retroactive — it applies to releases after v15.1.0.
+
+## Next steps
+
+- [`STABILITY.md`](https://github.com/andymai/elevator-core/blob/main/STABILITY.md) — full policy text, deprecation rules, and per-item day-one classification.
+- [Introduction](introduction.md) — what the library does and doesn't do.
+- [Testing Your Simulation](testing.md) — the invariants you can rely on under the stability policy.


### PR DESCRIPTION
## Summary

- Publishes a stability policy so downstream users can tell at a glance which APIs are load-bearing, which are still evolving, and which are internal plumbing.
- The 15 major versions between v1.0 and v15.0 came from API discovery, not from implementation instability (604 lib + 156 doc tests + mutation-tested kernel throughout). This PR converts that reality into a published contract *going forward*.

Changes:
- **New `STABILITY.md`** at repo root. Defines three status levels (stable, experimental, internal), deprecation policy (stable items get `#[deprecated]` for ≥1 major before removal), cadence commitment (≤1 stable-surface break per 60 days, not retroactive), and day-one classification by module.
- **Extends the crate-root "Crate layout" table** in `crates/elevator-core/src/lib.rs` with a **Stability** column, and adds a `## Stability` section above the table linking to STABILITY.md.
- **New `docs/src/stability.md`** mdBook chapter under "Advanced Topics". Summarizes the policy and links to STABILITY.md for the full text. Registered in `docs/src/SUMMARY.md`.
- **README badge row** now includes a "Stability" link.

### Day-one classification

**Stable:** `Simulation` core methods, `SimulationBuilder`, `Event`, `SimError`, `StopId`/`StopConfig`, `ElevatorId`/`RiderId`/`EntityId`, `Weight`/`Speed`/`Accel` (+ `UnitError`), `WorldSnapshot`.

**Experimental:** `dispatch::*`, `hooks::*`, `topology::*`, `tagged_metrics::*`, `scenario::*`, `traffic::*`, `query::*`, world extension APIs, `config::*`, `movement::*`.

**Internal:** `systems::*`, `door::*`, `energy::*`, `eta::*`.

## Dependency note

This branch is based on `main`; the workspace rustdoc pass with `-D warnings` is not yet clean on main because of pre-existing redundant-link-target warnings in `sim.rs` that PR #232 (and #234 after rebase) fixes. Verification here is scoped to `cargo doc --no-deps -p elevator-core` + docs-lint; both pass.

No code changes beyond doc comments.

## Test plan

- [x] `cargo test -p elevator-core --all-features` — 604 lib + 156 doc tests pass
- [x] `scripts/lint-docs.sh` — all 7 checks pass (including the `Next steps` rule on the new chapter)
- [x] `cargo doc --no-deps -p elevator-core --all-features` — crate-root table renders with Stability column
- [x] `mdbook build docs/` — new chapter renders; SUMMARY link resolves
- [x] README link to `STABILITY.md` resolves