### PR TITLE
fix(playground): resolve wasm URL relative to the document, not the bundle

### DIFF
--- a/playground/src/sim.ts
+++ b/playground/src/sim.ts
@@ -35,14 +35,17 @@ let modPromise: Promise<WasmModule> | null = null;
 /** Load the wasm-pack bundle exactly once and cache the resolved module. */
 export async function loadWasm(): Promise<WasmModule> {
   if (!modPromise) {
-    // Resolve relative to Vite's `BASE_URL` so the playground works under a
-    // subpath deploy (e.g. /elevator-core/playground/ on GitHub Pages).
-    const base = import.meta.env.BASE_URL.endsWith("/")
-      ? import.meta.env.BASE_URL
-      : `${import.meta.env.BASE_URL}/`;
-    const url = `${base}pkg/elevator_wasm.js`;
+    // Resolve relative to the document, not the bundled module URL. Vite's
+    // `base: "./"` rewrites static hrefs in HTML to be page-relative, but
+    // `import.meta.env.BASE_URL` evaluates to the literal `"./"` at runtime.
+    // A dynamic `import("./pkg/...")` from a module under `/assets/` then
+    // resolves against the module's URL → `/assets/pkg/...` → 404. Building
+    // the URL via `document.baseURI` resolves against the page in both
+    // local dev (`http://localhost:5173/`) and the subpath deploy
+    // (`https://andymai.github.io/elevator-core/playground/`).
+    const url = new URL("pkg/elevator_wasm.js", document.baseURI).href;
+    const wasmUrl = new URL("pkg/elevator_wasm_bg.wasm", document.baseURI).href;
     modPromise = import(/* @vite-ignore */ url).then(async (mod) => {
-      const wasmUrl = `${base}pkg/elevator_wasm_bg.wasm`;
       await (mod as WasmModule).default(wasmUrl);
       return mod as WasmModule;
     });


### PR DESCRIPTION
## Summary

The live playground at https://andymai.github.io/elevator-core/playground/ has been broken since the last deploy — the bundled JS tries to load `/elevator-core/playground/assets/pkg/elevator_wasm.js` (404) instead of the actual file at `/elevator-core/playground/pkg/elevator_wasm.js`.

**Root cause:** \`vite.config.ts\` sets \`base: \"./\"\`, which makes Vite bake \`import.meta.env.BASE_URL = \"./\"\` into the bundle. The previous \`loadWasm\` constructed \`\${BASE_URL}pkg/elevator_wasm.js\` = \`\"./pkg/...\"\` and called \`import()\` on it. Dynamic \`import()\` with a relative specifier resolves against the **calling module's URL**, not the page URL — so from a module under \`/assets/\` the specifier resolves to \`/assets/pkg/...\` and 404s.

**Fix:** build the URL with \`new URL(\"pkg/...\", document.baseURI).href\`. \`document.baseURI\` is the HTML page's URL in both local dev (\`http://localhost:5173/\`) and the GitHub Pages subpath deploy (\`https://andymai.github.io/elevator-core/playground/\`), so the resolved URL always lands next to \`index.html\` where wasm-pack output actually lives. One file changed; no config changes; no semantic change beyond the URL-resolution fix.

Verified locally: \`pnpm build\` produces a bundle whose \`loadWasm\` emits \`new URL(\"pkg/elevator_wasm.js\", document.baseURI).href\` instead of the broken \`\${BASE_URL}pkg/...\` pattern.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm build\` — succeeds, bundled \`loadWasm\` emits \`new URL(...).href\` form
- [ ] After merge: \`docs.yml\` auto-deploys (it watches \`playground/**\`); visit https://andymai.github.io/elevator-core/playground/ and confirm the simulation runs (elevator moves, riders spawn, no console errors)