### PR TITLE
ci(bench): publish nightly Criterion history dashboard

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -12,6 +12,12 @@ jobs:
     if: github.repository == 'andymai/elevator-core'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    # Serialize gh-pages pushes against `docs.yml` (which uses the same
+    # group). Otherwise a docs deploy and a manually-triggered bench run
+    # can race and the second `git push` is rejected as non-fast-forward.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     permissions:
       # `contents: write` is needed to push the time-series dashboard data
       # to gh-pages. `issues: write` keeps the existing regression-issue
@@ -89,25 +95,10 @@ jobs:
           path: target/criterion
           key: criterion-baseline-${{ github.ref_name }}-${{ github.run_id }}
 
-      # Publish a time-series dashboard at andymai.github.io/elevator-core/bench/.
-      # Parses Criterion's output from `bench-output.log` (already captured by
-      # `tee -a` above) and pushes per-bench history to gh-pages/bench/. The
-      # docs.yml workflow uses `keep_files: true` to preserve this directory
-      # across docs deploys.
-      - name: Publish bench history
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          tool: 'cargo'
-          output-file-path: bench-output.log
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: true
-          gh-pages-branch: gh-pages
-          benchmark-data-dir-path: bench
-          # Non-blocking — the existing `Open issue on regression` step
-          # already alerts on Criterion's own regression detection.
-          alert-threshold: '110%'
-          fail-on-alert: false
-
+      # Open the regression issue *before* publishing to gh-pages so a
+      # `git push` failure in the publish step (rate-limit, non-fast-forward,
+      # auth hiccup) does not silently suppress the alert via the implicit
+      # `success()` gate on the issue step's `if:` condition.
       - name: Open issue on regression
         if: steps.detect.outputs.regressed == 'true'
         uses: actions/github-script@v7
@@ -131,3 +122,22 @@ jobs:
               body,
               labels: ['perf', 'automated'],
             });
+
+      # Publish a time-series dashboard at andymai.github.io/elevator-core/bench/.
+      # Parses Criterion's output from `bench-output.log` (already captured by
+      # `tee -a` above) and pushes per-bench history to gh-pages/bench/. The
+      # docs.yml workflow uses `keep_files: true` to preserve this directory
+      # across docs deploys.
+      - name: Publish bench history
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'cargo'
+          output-file-path: bench-output.log
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: bench
+          # Non-blocking — the existing `Open issue on regression` step
+          # already alerts on Criterion's own regression detection.
+          alert-threshold: '110%'
+          fail-on-alert: false

--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -13,7 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
-      contents: read
+      # `contents: write` is needed to push the time-series dashboard data
+      # to gh-pages. `issues: write` keeps the existing regression-issue
+      # creation behaviour working.
+      contents: write
       issues: write
     env:
       CARGO_TERM_COLOR: always
@@ -85,6 +88,25 @@ jobs:
         with:
           path: target/criterion
           key: criterion-baseline-${{ github.ref_name }}-${{ github.run_id }}
+
+      # Publish a time-series dashboard at andymai.github.io/elevator-core/bench/.
+      # Parses Criterion's output from `bench-output.log` (already captured by
+      # `tee -a` above) and pushes per-bench history to gh-pages/bench/. The
+      # docs.yml workflow uses `keep_files: true` to preserve this directory
+      # across docs deploys.
+      - name: Publish bench history
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'cargo'
+          output-file-path: bench-output.log
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: bench
+          # Non-blocking — the existing `Open issue on regression` step
+          # already alerts on Criterion's own regression detection.
+          alert-threshold: '110%'
+          fail-on-alert: false
 
       - name: Open issue on regression
         if: steps.detect.outputs.regressed == 'true'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,9 +13,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  pages: write
-  id-token: write
-  contents: read
+  contents: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -90,17 +88,18 @@ jobs:
           mkdir -p target/book/playground
           cp -r playground/dist/. target/book/playground/
 
-      - uses: actions/upload-pages-artifact@v3
+      # Publish to gh-pages branch (not the workflow Pages artifact) so the
+      # nightly-bench dashboard at /bench/ — pushed by
+      # benchmark-action/github-action-benchmark — can coexist on the same
+      # branch. `keep_files: true` preserves /bench/ across docs deploys.
+      #
+      # NOTE: requires repo Settings → Pages → "Build and deployment: Deploy
+      # from a branch / gh-pages / (root)". Without that, Pages will not
+      # serve the published files.
+      - uses: peaceiris/actions-gh-pages@v4
+        if: github.ref == 'refs/heads/main'
         with:
-          path: target/book
-
-  deploy:
-    name: Deploy
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
-    steps:
-      - id: deploy
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: target/book
+          keep_files: true

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Plug it into Bevy, Unity, your own renderer, or run headless.
 [![CI](https://img.shields.io/github/actions/workflow/status/andymai/elevator-core/ci.yml?label=CI)](https://github.com/andymai/elevator-core/actions)
 [![License](https://img.shields.io/crates/l/elevator-core.svg)](LICENSE-MIT)
 
-[Guide](https://andymai.github.io/elevator-core/) · [API Reference](https://docs.rs/elevator-core) · [Examples](crates/elevator-core/examples/) · [Changelog](CHANGELOG.md) · [Stability](STABILITY.md)
+[Guide](https://andymai.github.io/elevator-core/) · [API Reference](https://docs.rs/elevator-core) · [Examples](crates/elevator-core/examples/) · [Changelog](CHANGELOG.md) · [Stability](STABILITY.md) · [Bench history](https://andymai.github.io/elevator-core/bench/)
 
 **[▶ Try the live playground](https://andymai.github.io/elevator-core/playground/)** — swap dispatch strategies, tune traffic, and share seeds right in your browser.
 


### PR DESCRIPTION
## Summary

Nightly-bench infra is green again post-#232, but absolute Criterion numbers live only in the GHA cache and the per-bench artifacts that GC after 30 days. Downstream users and contributors can't see trends.

This PR publishes a time-series dashboard at https://andymai.github.io/elevator-core/bench/ via `benchmark-action/github-action-benchmark@v1`, which parses the existing `bench-output.log` (already captured by the `tee -a` pipeline in `Run benchmarks`) and pushes per-bench history to `gh-pages/bench/`. The existing regression detection + auto-issue-creation behaviour is preserved unchanged.

To make the bench dashboard coexist with the mdBook docs on the same Pages site, this PR also switches `docs.yml` from workflow-based deployment (`actions/upload-pages-artifact` + `actions/deploy-pages`) to branch-based deployment via `peaceiris/actions-gh-pages@v4` with `keep_files: true` — so the docs deploy doesn't wipe `/bench/` and the bench publish doesn't wipe the docs.

## :warning: REQUIRED SETTINGS CHANGE before/at merge

GitHub Pages is currently set to "Build and deployment: GitHub Actions" (verified via `gh api repos/andymai/elevator-core/pages` → `build_type: \"workflow\"`). The new flow needs branch-based serving:

> **Settings → Pages → Build and deployment → "Deploy from a branch"**
> **Branch: `gh-pages`, Folder: `/ (root)`**

Without this change, Pages will continue serving the now-empty workflow-deployment artifact and the live site will go blank after merge. Recommended sequence:

1. Land this PR.
2. Wait for the next docs deploy (auto-triggered by the merge) to populate `gh-pages` branch.
3. Flip the Pages source setting (above).
4. Trigger one bench-nightly run via `gh workflow run bench-nightly.yml` to populate `/bench/`.
5. Visit https://andymai.github.io/elevator-core/bench/ to confirm.

## Test plan

- [x] Workflow YAML syntactically valid (no manual `act`/`actionlint` run; will be checked by CI on push)
- [ ] After merge + setting flip + one bench-nightly run: confirm chart renders at /bench/
- [ ] Subsequent docs deploy doesn't wipe /bench/ (verified by `keep_files: true` semantics)
- [ ] Subsequent bench-nightly run doesn't wipe docs (verified by isolated `/bench/` subdir)

## Files

- `.github/workflows/docs.yml` — switched to peaceiris (gh-pages branch + `keep_files: true`); dropped the workflow-deploy permissions and the standalone `deploy` job.
- `.github/workflows/bench-nightly.yml` — added `permissions: contents: write` and the `benchmark-action/github-action-benchmark@v1` step.
- `README.md` — added "Bench history" link to the badge row.