### PR TITLE
feat(dispatch): stabilize DispatchStrategy and built-in strategies

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -67,13 +67,13 @@ As of `elevator-core` v15.1.0, these items are **stable**:
 - `entity::{ElevatorId, RiderId, EntityId}`
 - `components::{Weight, Speed, Accel}` and `components::units::UnitError`
 - `snapshot::WorldSnapshot`
+- `dispatch::DispatchStrategy` trait and the five built-in strategies
+  (`ScanDispatch`, `LookDispatch`, `NearestCarDispatch`, `EtdDispatch`,
+  `DestinationDispatch`). Trait method signatures and built-in public
+  API are frozen; covered by the standard deprecation policy.
 
 These items are **experimental** and may change in any minor version:
 
-- `dispatch::DispatchStrategy` and all built-in strategies
-  (`ScanDispatch`, `LookDispatch`, `NearestCarDispatch`, `EtdDispatch`,
-  `DestinationDispatch`). The plugin contract may shift as we
-  incorporate more dispatch algorithms.
 - `hooks::{Phase, PhaseHooks}` — the phase-hook registration surface.
 - `topology::*` — connectivity graph and multi-line routing queries.
 - `tagged_metrics::*` — per-tag metric accumulators.
@@ -128,3 +128,13 @@ instability of the implementation — the library has had 604 lib tests,
 
 This cadence commitment applies **going forward only**; it is not
 retroactive.
+
+## History
+
+Graduations from experimental to stable. The first entry doubles as
+proof-by-example that the policy mechanism works.
+
+- **v15.2.0** — `dispatch::DispatchStrategy` trait and the five built-in
+  strategies (`ScanDispatch`, `LookDispatch`, `NearestCarDispatch`,
+  `EtdDispatch`, `DestinationDispatch`) graduated from experimental to
+  stable.

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -71,6 +71,7 @@ As of `elevator-core` v15.1.0, these items are **stable**:
   (`ScanDispatch`, `LookDispatch`, `NearestCarDispatch`, `EtdDispatch`,
   `DestinationDispatch`). Trait method signatures and built-in public
   API are frozen; covered by the standard deprecation policy.
+  *(Graduated from experimental in v15.2.0 — see [History](#history).)*
 
 These items are **experimental** and may change in any minor version:
 

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -9,10 +9,10 @@
 //!
 //! ## Key capabilities
 //!
-//! - **Pluggable dispatch** — four built-in algorithms ([`dispatch::scan::ScanDispatch`],
+//! - **Pluggable dispatch** — five built-in algorithms ([`dispatch::scan::ScanDispatch`],
 //!   [`dispatch::look::LookDispatch`], [`dispatch::nearest_car::NearestCarDispatch`],
-//!   [`dispatch::etd::EtdDispatch`]) plus the [`dispatch::DispatchStrategy`] trait
-//!   for custom implementations.
+//!   [`dispatch::etd::EtdDispatch`], [`dispatch::destination::DestinationDispatch`])
+//!   plus the [`dispatch::DispatchStrategy`] trait for custom implementations.
 //! - **Trapezoidal motion profiles** — realistic acceleration, cruise, and
 //!   deceleration computed per-tick.
 //! - **Extension components** — attach arbitrary `Serialize + DeserializeOwned`

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -66,7 +66,7 @@
 //! |--------|---------|-----------|
 //! | [`builder`] | Fluent [`SimulationBuilder`](builder::SimulationBuilder) API | stable |
 //! | [`sim`] | Top-level [`Simulation`](sim::Simulation) runner and tick loop | stable (selected methods — see [`STABILITY.md`](https://github.com/andymai/elevator-core/blob/main/STABILITY.md)) |
-//! | [`dispatch`] | Dispatch strategies and the [`DispatchStrategy`](dispatch::DispatchStrategy) trait | experimental |
+//! | [`dispatch`] | Dispatch strategies and the [`DispatchStrategy`](dispatch::DispatchStrategy) trait | stable |
 //! | [`world`] | ECS-style [`World`](world::World) with typed component storage | experimental |
 //! | [`components`] | Entity data types: [`Rider`](components::Rider), [`Elevator`](components::Elevator), [`Stop`](components::Stop), [`Line`](components::Line), [`Route`](components::Route), [`Patience`](components::Patience), [`Preferences`](components::Preferences), [`AccessControl`](components::AccessControl), [`DestinationQueue`](components::DestinationQueue), [`ServiceMode`](components::ServiceMode), [`Orientation`](components::Orientation), [`Position`](components::Position), [`Velocity`](components::Velocity), [`SpatialPosition`](components::SpatialPosition) | stable (units + core), experimental (rest) |
 //! | [`config`] | RON-deserializable [`SimConfig`](config::SimConfig), [`GroupConfig`](config::GroupConfig), [`LineConfig`](config::LineConfig) | experimental |

--- a/docs/src/stability.md
+++ b/docs/src/stability.md
@@ -19,9 +19,9 @@ The module table at the top of the [`elevator-core` crate docs](https://docs.rs/
 Pin to an exact minor version:
 
 ```toml
-# Use this if you touch dispatch, hooks, topology, traffic, extensions,
-# or any other experimental area:
-elevator-core = "=15.1"
+# Use this if you touch hooks, topology, traffic, extensions, or any
+# other experimental area:
+elevator-core = "=15.2"
 ```
 
 When you bump the minor, expect a short migration task. The CHANGELOG will call out what changed.


### PR DESCRIPTION
## Summary

Per `STABILITY.md`'s graduation process, the `dispatch` trait and the five built-in strategies (`ScanDispatch`, `LookDispatch`, `NearestCarDispatch`, `EtdDispatch`, `DestinationDispatch`) move from **experimental** to **stable** in this minor release.

The plugin contract has been stable in practice across multiple releases: trait method signatures and the built-in strategies' public API have not changed. Elevating the classification commits us to the standard deprecation policy going forward — `#[deprecated]` for at least one major before removal, breaking changes only in planned majors with 60-day pre-announce.

This is the **first real graduation event** under STABILITY.md (published in #235), doubling as proof-by-example that the policy mechanism works. A new `## History` section in `STABILITY.md` records the event for future reference.

**Not a breaking change** — tightening promises only.

## Changes

- `STABILITY.md` — moves the dispatch bullet from the experimental list (lines 73-76) to the stable day-one list; adds a `## History` section at the bottom recording the v15.2 graduation.
- `crates/elevator-core/src/lib.rs:69` — flips the `dispatch` row in the crate-layout Stability column from `experimental` to `stable`.
- `docs/src/stability.md` — drops `dispatch` from the experimental-example pinning toml; bumps the version anchor to `=15.2`.

No code changes.

## Test plan

- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps -p elevator-core --all-features` — clean; the `dispatch` row in the rendered table now reads `stable`.
- [x] `scripts/lint-docs.sh` — all 7 checks pass.
- [x] `cargo test -p elevator-core --all-features --doc` — 156 doc tests still pass.
- [ ] After merge: release-please will open `chore(main): release elevator-core 15.2.0` with the stabilization auto-included in `CHANGELOG.md`.