### PR TITLE
fix(movement): brake at deceleration rate when velocity opposes target

### DIFF
--- a/crates/elevator-core/src/movement.rs
+++ b/crates/elevator-core/src/movement.rs
@@ -63,8 +63,12 @@ pub fn tick_movement(
     let speed = velocity.abs();
     let safe_decel = deceleration.max(EPSILON);
     let stopping_distance = speed * speed / (2.0 * safe_decel);
+    // Opposing direction: car is moving away from the (possibly retargeted)
+    // destination. Must brake at `deceleration` before accelerating back —
+    // not at `acceleration`, which is the wrong physics when accel ≠ decel.
+    let opposing = velocity * sign < 0.0;
 
-    let new_velocity = if stopping_distance >= distance_remaining - EPSILON {
+    let new_velocity = if opposing || stopping_distance >= distance_remaining - EPSILON {
         // Decelerate
         let v = (-safe_decel * dt).mul_add(velocity.signum(), velocity);
         // Clamp to zero if sign would flip.

--- a/crates/elevator-core/src/tests/movement_tests.rs
+++ b/crates/elevator-core/src/tests/movement_tests.rs
@@ -283,6 +283,46 @@ fn moving_downward() {
     panic!("did not arrive within 2000 ticks");
 }
 
+// ── Reversing-direction braking (#244) ─────────────────────────────
+
+#[test]
+fn opposing_velocity_brakes_at_deceleration_rate() {
+    // Car moving up at v=+2 is retargeted to a stop below (target=0). With
+    // asymmetric accel=1, decel=4, the slowdown must use decel (braking) not
+    // accel — `velocity - decel·dt` rather than `velocity + accel·dt·sign`.
+    let r = tick_movement(
+        5.0, 2.0, 0.0, 3.0, /*accel*/ 1.0, /*decel*/ 4.0, 0.1,
+    );
+    let expected_v = 2.0 - 4.0 * 0.1; // 1.6
+    assert!(
+        (r.velocity - expected_v).abs() < 1e-9,
+        "expected decel-rate slowdown to {expected_v}, got {}",
+        r.velocity
+    );
+}
+
+#[test]
+fn opposing_velocity_clamps_to_zero_then_reverses() {
+    // Same scenario but with a dt large enough that one decel step would
+    // flip the sign of velocity. The clamp must zero out velocity instead
+    // of letting it reverse mid-step.
+    let r = tick_movement(5.0, 1.0, 0.0, 3.0, 1.0, 4.0, 1.0); // decel*dt = 4 > v
+    assert!(
+        r.velocity.abs() < 1e-9,
+        "sign-flip clamp should zero velocity, got {}",
+        r.velocity
+    );
+
+    // On the next tick, with v=0 and target still below, the accelerate
+    // branch fires and the car begins moving downward at the accel rate.
+    let r2 = tick_movement(r.position, r.velocity, 0.0, 3.0, 1.0, 4.0, 0.1);
+    assert!(
+        r2.velocity < 0.0,
+        "after reaching v=0, should accelerate downward toward target, got {}",
+        r2.velocity
+    );
+}
+
 // ── Zero deceleration guard (#165) ─────────────────────────────────
 
 #[test]

--- a/crates/elevator-core/src/tests/movement_tests.rs
+++ b/crates/elevator-core/src/tests/movement_tests.rs
@@ -293,7 +293,8 @@ fn opposing_velocity_brakes_at_deceleration_rate() {
     let r = tick_movement(
         5.0, 2.0, 0.0, 3.0, /*accel*/ 1.0, /*decel*/ 4.0, 0.1,
     );
-    let expected_v = 2.0 - 4.0 * 0.1; // 1.6
+    // velocity - decel·dt = 2.0 - 4.0·0.1 = 1.6
+    let expected_v = 1.6_f64;
     assert!(
         (r.velocity - expected_v).abs() < 1e-9,
         "expected decel-rate slowdown to {expected_v}, got {}",


### PR DESCRIPTION
## Summary

- When an elevator is moving toward an old target and is retargeted to a stop on the *opposite* side, `tick_movement` now slows the car at the **deceleration** rate instead of `acceleration`.
- The decel branch was previously gated only on `stopping_distance >= distance_remaining`, which is false when the car is moving away from the new target — letting the accelerate branch fire with sign opposite to velocity, applying `acceleration` as a brake.
- New regression tests in `movement_tests.rs` exercise asymmetric `accel ≠ decel` with opposing velocity/displacement.

Closes #244

## Test plan

- [x] `cargo test -p elevator-core --all-features` — all 781 tests pass (added 2)
- [x] `cargo clippy -p elevator-core --all-features` — clean
- [x] Pre-commit hook (fmt, clippy, core tests, doc tests, workspace check, lock drift) — green