### PR TITLE
fix(dispatch): clear DCS sticky assignment when assigned car is lost

### DIFF
--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -174,9 +174,10 @@ impl DispatchStrategy for DestinationDispatch {
             // Count riders whose weight is "committed" to a specific car:
             // actively aboard (Boarding/Riding) or still-Waiting with a
             // sticky assignment. Terminal phases (Exiting, Arrived,
-            // Abandoned, Resident, Walking) must not contribute — AssignedCar
-            // is sticky and never cleared, so including them would permanently
-            // inflate the former car's committed load over long runs.
+            // Abandoned, Resident, Walking) must not contribute — they no
+            // longer need elevator service, and stale `AssignedCar`
+            // extensions on them would inflate the former car's committed
+            // load until cleared.
             let car = match rider.phase() {
                 RiderPhase::Riding(c) | RiderPhase::Boarding(c) => Some(c),
                 RiderPhase::Waiting => world.ext::<AssignedCar>(rid).map(|AssignedCar(c)| c),

--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -123,12 +123,20 @@ impl DispatchStrategy for DestinationDispatch {
             return;
         }
 
-        // Collect unassigned waiting riders in this group.
+        // Collect unassigned waiting riders in this group. A sticky
+        // assignment whose target car is dead or disabled is treated as
+        // void — re-assign rather than strand. (Lifecycle hooks in
+        // `disable`/`remove_elevator` normally clear these; this is the
+        // defense layer if cleanup is ever missed.)
+        let mut stale_assignments: Vec<EntityId> = Vec::new();
         let mut pending: Vec<(EntityId, EntityId, EntityId, f64)> = Vec::new();
         for (_, riders) in manifest.iter_waiting_stops() {
             for info in riders {
-                if world.ext::<AssignedCar>(info.id).is_some() {
-                    continue; // sticky
+                if let Some(AssignedCar(c)) = world.ext::<AssignedCar>(info.id) {
+                    if world.elevator(c).is_some() && !world.is_disabled(c) {
+                        continue; // sticky and live
+                    }
+                    stale_assignments.push(info.id);
                 }
                 let Some(dest) = info.destination else {
                     continue;
@@ -151,6 +159,10 @@ impl DispatchStrategy for DestinationDispatch {
             }
         }
         pending.sort_by_key(|(rid, ..)| *rid);
+        // Drop stale extensions so subsequent ticks see them as unassigned.
+        for rid in stale_assignments {
+            world.remove_ext::<AssignedCar>(rid);
+        }
 
         // Pre-compute committed-load per car (riders aboard + already-
         // assigned waiting riders not yet boarded). Used by cost function
@@ -313,6 +325,26 @@ impl DestinationDispatch {
         };
 
         pickup_time + ride_time + penalty * new_stops + idle_bonus + load_penalty
+    }
+}
+
+/// Drop every sticky [`AssignedCar`] assignment that points at `car_eid`.
+///
+/// Called by `Simulation::disable` and `Simulation::remove_elevator` when an
+/// elevator leaves service so DCS-routed riders are not stranded behind a
+/// dead reference. Assignments are sticky by design — if no one clears them,
+/// no other car will pick the rider up — so the lifecycle layer is responsible
+/// for invoking this helper at car-loss boundaries.
+pub fn clear_assignments_to(world: &mut crate::world::World, car_eid: EntityId) {
+    let stale: Vec<EntityId> = world
+        .iter_riders()
+        .filter_map(|(rid, _)| match world.ext::<AssignedCar>(rid) {
+            Some(AssignedCar(c)) if c == car_eid => Some(rid),
+            _ => None,
+        })
+        .collect();
+    for rid in stale {
+        world.remove_ext::<AssignedCar>(rid);
     }
 }
 

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -448,6 +448,10 @@ impl Simulation {
             let pos = self.world.position(id).map_or(0.0, |p| p.value);
             let nearest_stop = self.world.find_nearest_stop(pos);
 
+            // Drop any sticky DCS assignments pointing at this car so
+            // routed riders are not stranded behind a dead reference.
+            crate::dispatch::destination::clear_assignments_to(&mut self.world, id);
+
             for rid in &rider_ids {
                 if let Some(r) = self.world.rider_mut(*rid) {
                     r.phase = RiderPhase::Waiting;

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -139,10 +139,14 @@ fn collect_actions(world: &World, elevator_ids: &[EntityId]) -> Vec<LoadAction> 
             }
             // Sticky hall-call destination assignment: if this rider has been
             // assigned to another car, the current car must skip them so the
-            // assigned car can pick them up.
+            // assigned car can pick them up. Stale assignments to a dead or
+            // disabled car are ignored — the rider is fair game for any car —
+            // as a defense against missed cleanup at car-loss boundaries.
             if let Some(crate::dispatch::AssignedCar(assigned)) =
                 world.ext::<crate::dispatch::AssignedCar>(rid)
                 && assigned != eid
+                && world.elevator(assigned).is_some()
+                && !world.is_disabled(assigned)
             {
                 return None;
             }

--- a/crates/elevator-core/src/tests/destination_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/destination_dispatch_tests.rs
@@ -407,3 +407,159 @@ fn dcs_gated_to_destination_mode() {
         "DCS must not assign when group is in Classic mode",
     );
 }
+
+// ── Sticky-assignment cleanup on car loss (#245) ─────────────────────
+
+#[test]
+fn disable_assigned_car_clears_sticky_and_lets_other_car_deliver() {
+    // Two cars, A and B. A rider is assigned to A; A is disabled before
+    // it can pick up. The cleanup hook in `disable()` must clear the
+    // sticky assignment so B can take the rider.
+    let mut sim =
+        Simulation::new(&two_cars_same_group_config(), DestinationDispatch::new()).unwrap();
+    sim.world_mut()
+        .register_ext::<AssignedCar>(ASSIGNED_CAR_KEY);
+
+    let elevs: Vec<_> = sim
+        .world()
+        .iter_elevators()
+        .map(|(eid, _, _)| eid)
+        .collect();
+    let car_a = elevs
+        .iter()
+        .copied()
+        .find(|&e| sim.world().position(e).map_or(0.0, |p| p.value) < 1.0)
+        .unwrap();
+    let car_b = elevs.iter().copied().find(|e| *e != car_a).unwrap();
+
+    // Rider at F2 → F3 — DCS will assign to the closer car (A).
+    let rid = sim.spawn_rider(StopId(1), StopId(2), 75.0).unwrap();
+    sim.step();
+    let assigned = sim.world().ext::<AssignedCar>(rid.entity()).unwrap();
+    assert_eq!(
+        assigned.0, car_a,
+        "precondition: rider assigned to closer car A"
+    );
+
+    sim.disable(car_a).unwrap();
+    assert!(
+        sim.world().ext::<AssignedCar>(rid.entity()).is_none(),
+        "stale assignment to disabled car must be cleared"
+    );
+
+    // Run to completion — B must deliver.
+    for _ in 0..10_000 {
+        sim.step();
+        if sim
+            .world()
+            .rider(rid.entity())
+            .is_some_and(|r| r.phase() == RiderPhase::Arrived)
+        {
+            break;
+        }
+    }
+    assert_eq!(
+        sim.world().rider(rid.entity()).map(|r| r.phase()),
+        Some(RiderPhase::Arrived),
+        "rider should be delivered by the surviving car"
+    );
+    let new_assignment = sim.world().ext::<AssignedCar>(rid.entity()).map(|a| a.0);
+    assert_eq!(
+        new_assignment,
+        Some(car_b),
+        "rider should be re-assigned to car B"
+    );
+}
+
+#[test]
+fn remove_assigned_car_clears_sticky_and_lets_other_car_deliver() {
+    // Same scenario as disable, but with `remove_elevator` (which calls
+    // disable internally and then despawns).
+    let mut sim =
+        Simulation::new(&two_cars_same_group_config(), DestinationDispatch::new()).unwrap();
+    sim.world_mut()
+        .register_ext::<AssignedCar>(ASSIGNED_CAR_KEY);
+
+    let elevs: Vec<_> = sim
+        .world()
+        .iter_elevators()
+        .map(|(eid, _, _)| eid)
+        .collect();
+    let car_a = elevs
+        .iter()
+        .copied()
+        .find(|&e| sim.world().position(e).map_or(0.0, |p| p.value) < 1.0)
+        .unwrap();
+
+    let rid = sim.spawn_rider(StopId(1), StopId(2), 75.0).unwrap();
+    sim.step();
+    assert_eq!(
+        sim.world().ext::<AssignedCar>(rid.entity()).map(|a| a.0),
+        Some(car_a),
+        "precondition: rider assigned to A"
+    );
+
+    sim.remove_elevator(car_a).unwrap();
+    assert!(
+        sim.world().ext::<AssignedCar>(rid.entity()).is_none(),
+        "assignment to removed car must be cleared"
+    );
+    assert!(!sim.world().is_alive(car_a), "car A should be despawned");
+
+    for _ in 0..10_000 {
+        sim.step();
+        if sim
+            .world()
+            .rider(rid.entity())
+            .is_some_and(|r| r.phase() == RiderPhase::Arrived)
+        {
+            break;
+        }
+    }
+    assert_eq!(
+        sim.world().rider(rid.entity()).map(|r| r.phase()),
+        Some(RiderPhase::Arrived),
+        "rider should be delivered by the surviving car after removal"
+    );
+}
+
+#[test]
+fn loading_ignores_dangling_assignment_to_dead_car() {
+    // Defense-in-depth: even if cleanup misses an assignment, loading
+    // must not strand the rider behind a dead reference. Forge a sticky
+    // assignment pointing at a despawned EntityId and verify the live
+    // car still picks the rider up.
+    let mut sim = Simulation::new(&single_car_config(), DestinationDispatch::new()).unwrap();
+    for g in sim.groups_mut() {
+        g.set_hall_call_mode(crate::dispatch::HallCallMode::Destination);
+    }
+    sim.world_mut()
+        .register_ext::<AssignedCar>(ASSIGNED_CAR_KEY);
+
+    let rid = sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
+
+    // Forge a dangling AssignedCar pointing at a despawned id, *before*
+    // any tick runs DCS pre_dispatch (which would otherwise overwrite).
+    let dead_id = sim.world_mut().spawn();
+    sim.world_mut().despawn(dead_id);
+    sim.world_mut()
+        .insert_ext(rid.entity(), AssignedCar(dead_id), ASSIGNED_CAR_KEY);
+
+    // Step. DCS sees the (dangling) AssignedCar and skips re-assignment;
+    // loading sees the assigned car is dead and ignores the sticky guard.
+    for _ in 0..10_000 {
+        sim.step();
+        if sim
+            .world()
+            .rider(rid.entity())
+            .is_some_and(|r| r.phase() == RiderPhase::Arrived)
+        {
+            break;
+        }
+    }
+    assert_eq!(
+        sim.world().rider(rid.entity()).map(|r| r.phase()),
+        Some(RiderPhase::Arrived),
+        "rider must be delivered despite dangling AssignedCar"
+    );
+}

--- a/crates/elevator-core/src/tests/destination_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/destination_dispatch_tests.rs
@@ -459,7 +459,7 @@ fn disable_assigned_car_clears_sticky_and_lets_other_car_deliver() {
         }
     }
     assert_eq!(
-        sim.world().rider(rid.entity()).map(|r| r.phase()),
+        sim.world().rider(rid.entity()).map(Rider::phase),
         Some(RiderPhase::Arrived),
         "rider should be delivered by the surviving car"
     );
@@ -517,7 +517,7 @@ fn remove_assigned_car_clears_sticky_and_lets_other_car_deliver() {
         }
     }
     assert_eq!(
-        sim.world().rider(rid.entity()).map(|r| r.phase()),
+        sim.world().rider(rid.entity()).map(Rider::phase),
         Some(RiderPhase::Arrived),
         "rider should be delivered by the surviving car after removal"
     );
@@ -545,8 +545,10 @@ fn loading_ignores_dangling_assignment_to_dead_car() {
     sim.world_mut()
         .insert_ext(rid.entity(), AssignedCar(dead_id), ASSIGNED_CAR_KEY);
 
-    // Step. DCS sees the (dangling) AssignedCar and skips re-assignment;
-    // loading sees the assigned car is dead and ignores the sticky guard.
+    // Step. The dangling AssignedCar exercises BOTH defense layers:
+    // DCS pre_dispatch (layer 2) detects target is dead, drops the
+    // extension, and re-assigns to the live car. Loading's liveness
+    // check (layer 3) is the fallback if cleanup is missed entirely.
     for _ in 0..10_000 {
         sim.step();
         if sim
@@ -558,7 +560,7 @@ fn loading_ignores_dangling_assignment_to_dead_car() {
         }
     }
     assert_eq!(
-        sim.world().rider(rid.entity()).map(|r| r.phase()),
+        sim.world().rider(rid.entity()).map(Rider::phase),
         Some(RiderPhase::Arrived),
         "rider must be delivered despite dangling AssignedCar"
     );


### PR DESCRIPTION
## Summary

`DestinationDispatch` wrote a permanent `AssignedCar` extension on each routed rider, but nothing cleared it when that car was disabled or removed. Loading then read the stale assignment, saw `assigned != eid`, and skipped the rider on every other car — silent stranding under DCS + disable.

Three layers of fix, defense in depth:

1. **`dispatch::destination::clear_assignments_to(world, car)`** walks all riders and removes `AssignedCar(car)` extensions. Called from `Simulation::disable()` (which `remove_elevator()` already invokes internally).
2. **`DestinationDispatch::pre_dispatch`** now treats an assignment whose target is dead or disabled as void — the stale extension is dropped and the rider re-enters the candidate pool.
3. **The loading-phase sticky filter** ignores `AssignedCar` whose target is dead or disabled, so even if both upstream cleanups are missed, a live car can still pick the rider up.

Closes #245

## Test plan

- [x] `cargo test -p elevator-core --all-features` — all 782 tests pass (added 3)
  - `disable_assigned_car_clears_sticky_and_lets_other_car_deliver`
  - `remove_assigned_car_clears_sticky_and_lets_other_car_deliver`
  - `loading_ignores_dangling_assignment_to_dead_car`
- [x] `cargo clippy -p elevator-core --all-features` — clean
- [x] Pre-commit hook — green