### PR TITLE
fix(metrics): only count multi-leg journey as one delivery

### DIFF
--- a/crates/elevator-core/src/components/route.rs
+++ b/crates/elevator-core/src/components/route.rs
@@ -70,6 +70,17 @@ impl Route {
         self.current_leg >= self.legs.len()
     }
 
+    /// Whether the current leg is the final leg of the route.
+    ///
+    /// Useful when an event fires *before* [`advance`](Self::advance) runs
+    /// — e.g. `RiderExited` (loading phase) precedes the route advance
+    /// (transient phase next tick), so consumers that need to know if the
+    /// exit terminates the journey check `is_last_leg`, not `is_complete`.
+    #[must_use]
+    pub const fn is_last_leg(&self) -> bool {
+        self.current_leg + 1 == self.legs.len()
+    }
+
     /// The destination of the current leg.
     #[must_use]
     pub fn current_destination(&self) -> Option<EntityId> {

--- a/crates/elevator-core/src/systems/metrics.rs
+++ b/crates/elevator-core/src/systems/metrics.rs
@@ -1,5 +1,6 @@
 //! Phase 6: update aggregate metrics from events emitted this tick.
 
+use crate::components::Route;
 use crate::dispatch::ElevatorGroup;
 use crate::events::{Event, EventBus};
 use crate::metrics::Metrics;
@@ -36,7 +37,13 @@ pub fn run(
                 }
             }
             Event::RiderExited { rider, tick, .. } => {
-                if let Some(rd) = world.rider(*rider) {
+                // RiderExited fires per leg (loading phase). Count it as a
+                // delivery only when this exit terminates the journey:
+                // route absent (manual rider) or this is the final leg.
+                // Counting every leg would inflate throughput and corrupt
+                // tagged metrics by stripping tags after the first transfer.
+                let terminal = world.route(*rider).is_none_or(Route::is_last_leg);
+                if terminal && let Some(rd) = world.rider(*rider) {
                     let ride_ticks = rd.board_tick.map_or(0, |bt| tick.saturating_sub(bt));
                     metrics.record_delivery(ride_ticks, *tick);
                     tag_terminals.push((*rider, true));

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -464,6 +464,68 @@ fn cross_group_rider_arrives_via_explicit_two_leg_route() {
     );
 }
 
+/// Regression: a multi-leg journey is one delivery, not one per leg (#246).
+///
+/// Before the fix, `RiderExited` fired at every transfer and the metrics
+/// handler treated each as terminal — `total_delivered` became leg-count
+/// instead of rider-count.
+#[test]
+fn multi_leg_journey_counts_as_single_delivery() {
+    let config = two_group_config();
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+    let ground = sim.stop_entity(StopId(0)).unwrap();
+    let transfer = sim.stop_entity(StopId(1)).unwrap();
+    let top = sim.stop_entity(StopId(2)).unwrap();
+
+    let route = Route {
+        legs: vec![
+            RouteLeg {
+                from: ground,
+                to: transfer,
+                via: TransportMode::Group(GroupId(0)),
+            },
+            RouteLeg {
+                from: transfer,
+                to: top,
+                via: TransportMode::Group(GroupId(1)),
+            },
+        ],
+        current_leg: 0,
+    };
+
+    let rider = sim
+        .build_rider(ground, top)
+        .unwrap()
+        .weight(70.0)
+        .route(route)
+        .spawn()
+        .unwrap();
+
+    for _ in 0..10_000 {
+        sim.step();
+        if sim
+            .world()
+            .rider(rider.entity())
+            .is_some_and(|r| r.phase == RiderPhase::Arrived)
+        {
+            break;
+        }
+    }
+
+    assert_eq!(
+        sim.world().rider(rider.entity()).map(|r| r.phase),
+        Some(RiderPhase::Arrived),
+        "rider should arrive at Top via transfer"
+    );
+    assert_eq!(
+        sim.metrics().total_delivered,
+        1,
+        "two-leg journey must count as one delivery, not two"
+    );
+    assert_eq!(sim.metrics().total_spawned, 1, "spawn count should be one");
+}
+
 // ── 6. Loading group filter ───────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

`RiderExited` fires per leg from the loading phase, but the metrics handler counted each as a terminal delivery — inflating `total_delivered`/`throughput` by leg count and stripping the rider's metric tags after the first transfer. Single-leg routes (the dominant case) were unaffected; multi-line topologies silently corrupted stats.

- Gate `record_delivery` and the tag-terminal handler on `route.is_last_leg()`.
- New `Route::is_last_leg` helper. Required because `RiderExited` precedes `Route::advance` (which runs in `advance_transient` next tick), so `is_complete()` is always false at emission time — the new helper checks "this is the final leg" rather than "the route is past its end."

Closes #246

## Test plan

- [x] New regression test `multi_leg_journey_counts_as_single_delivery` runs a Ground→Top trip across two groups and asserts `total_delivered == 1`
- [x] `cargo test -p elevator-core --all-features` — all 780 tests pass
- [x] `cargo clippy -p elevator-core --all-features` — clean
- [x] Pre-commit hook — green

## Follow-up not in this PR

Leg-2+ `RiderBoarded` still records `wait_ticks = tick - spawn_tick`, so per-tag `avg_wait_time`/`max_wait_time` are still polluted by transfer time on multi-leg journeys. Fixing this requires a per-leg wait timestamp on `Rider`. Tracking separately to keep this PR scoped.