### PR TITLE
fix(topology): validate ElevatorParams in runtime add_elevator

### DIFF
--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -42,6 +42,65 @@ type TopologyResult = (
     BTreeMap<GroupId, BuiltinStrategy>,
 );
 
+/// Validate the physics fields shared by [`crate::config::ElevatorConfig`]
+/// and [`super::ElevatorParams`]. Both construction-time validation and
+/// the runtime `add_elevator` path call this so an invalid set of params
+/// can never reach the world (zeroes blow up movement; zero door ticks
+/// stall the door FSM).
+pub fn validate_elevator_physics(
+    max_speed: f64,
+    acceleration: f64,
+    deceleration: f64,
+    weight_capacity: f64,
+    inspection_speed_factor: f64,
+    door_transition_ticks: u32,
+    door_open_ticks: u32,
+) -> Result<(), SimError> {
+    if !max_speed.is_finite() || max_speed <= 0.0 {
+        return Err(SimError::InvalidConfig {
+            field: "elevators.max_speed",
+            reason: format!("must be finite and positive, got {max_speed}"),
+        });
+    }
+    if !acceleration.is_finite() || acceleration <= 0.0 {
+        return Err(SimError::InvalidConfig {
+            field: "elevators.acceleration",
+            reason: format!("must be finite and positive, got {acceleration}"),
+        });
+    }
+    if !deceleration.is_finite() || deceleration <= 0.0 {
+        return Err(SimError::InvalidConfig {
+            field: "elevators.deceleration",
+            reason: format!("must be finite and positive, got {deceleration}"),
+        });
+    }
+    if !weight_capacity.is_finite() || weight_capacity <= 0.0 {
+        return Err(SimError::InvalidConfig {
+            field: "elevators.weight_capacity",
+            reason: format!("must be finite and positive, got {weight_capacity}"),
+        });
+    }
+    if !inspection_speed_factor.is_finite() || inspection_speed_factor <= 0.0 {
+        return Err(SimError::InvalidConfig {
+            field: "elevators.inspection_speed_factor",
+            reason: format!("must be finite and positive, got {inspection_speed_factor}"),
+        });
+    }
+    if door_transition_ticks == 0 {
+        return Err(SimError::InvalidConfig {
+            field: "elevators.door_transition_ticks",
+            reason: "must be > 0".into(),
+        });
+    }
+    if door_open_ticks == 0 {
+        return Err(SimError::InvalidConfig {
+            field: "elevators.door_open_ticks",
+            reason: "must be > 0".into(),
+        });
+    }
+    Ok(())
+}
+
 impl Simulation {
     /// Create a new simulation from config and a dispatch strategy.
     ///
@@ -549,48 +608,15 @@ impl Simulation {
         elev: &crate::config::ElevatorConfig,
         building: &crate::config::BuildingConfig,
     ) -> Result<(), SimError> {
-        if elev.max_speed.value() <= 0.0 {
-            return Err(SimError::InvalidConfig {
-                field: "elevators.max_speed",
-                reason: format!("must be positive, got {}", elev.max_speed.value()),
-            });
-        }
-        if elev.acceleration.value() <= 0.0 {
-            return Err(SimError::InvalidConfig {
-                field: "elevators.acceleration",
-                reason: format!("must be positive, got {}", elev.acceleration.value()),
-            });
-        }
-        if elev.deceleration.value() <= 0.0 {
-            return Err(SimError::InvalidConfig {
-                field: "elevators.deceleration",
-                reason: format!("must be positive, got {}", elev.deceleration.value()),
-            });
-        }
-        if elev.weight_capacity.value() <= 0.0 {
-            return Err(SimError::InvalidConfig {
-                field: "elevators.weight_capacity",
-                reason: format!("must be positive, got {}", elev.weight_capacity.value()),
-            });
-        }
-        if elev.inspection_speed_factor <= 0.0 {
-            return Err(SimError::InvalidConfig {
-                field: "elevators.inspection_speed_factor",
-                reason: format!("must be positive, got {}", elev.inspection_speed_factor),
-            });
-        }
-        if elev.door_transition_ticks == 0 {
-            return Err(SimError::InvalidConfig {
-                field: "elevators.door_transition_ticks",
-                reason: "must be > 0".into(),
-            });
-        }
-        if elev.door_open_ticks == 0 {
-            return Err(SimError::InvalidConfig {
-                field: "elevators.door_open_ticks",
-                reason: "must be > 0".into(),
-            });
-        }
+        validate_elevator_physics(
+            elev.max_speed.value(),
+            elev.acceleration.value(),
+            elev.deceleration.value(),
+            elev.weight_capacity.value(),
+            elev.inspection_speed_factor,
+            elev.door_transition_ticks,
+            elev.door_open_ticks,
+        )?;
         if !building.stops.iter().any(|s| s.id == elev.starting_stop) {
             return Err(SimError::InvalidConfig {
                 field: "elevators.starting_stop",

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -47,7 +47,7 @@ type TopologyResult = (
 /// the runtime `add_elevator` path call this so an invalid set of params
 /// can never reach the world (zeroes blow up movement; zero door ticks
 /// stall the door FSM).
-pub fn validate_elevator_physics(
+pub(super) fn validate_elevator_physics(
     max_speed: f64,
     acceleration: f64,
     deceleration: f64,

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -112,6 +112,18 @@ impl Simulation {
         line: EntityId,
         starting_position: f64,
     ) -> Result<EntityId, SimError> {
+        // Reject malformed params before they reach the world. Without this,
+        // zero/negative physics or zero door ticks crash later phases.
+        super::construction::validate_elevator_physics(
+            params.max_speed.value(),
+            params.acceleration.value(),
+            params.deceleration.value(),
+            params.weight_capacity.value(),
+            params.inspection_speed_factor,
+            params.door_transition_ticks,
+            params.door_open_ticks,
+        )?;
+
         let group_id = self
             .world
             .line(line)

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -123,6 +123,15 @@ impl Simulation {
             params.door_transition_ticks,
             params.door_open_ticks,
         )?;
+        if !starting_position.is_finite() {
+            return Err(SimError::InvalidConfig {
+                field: "starting_position",
+                reason: format!(
+                    "must be finite (got {starting_position}); NaN/±inf corrupt \
+                     SortedStops ordering and find_stop_at_position lookup"
+                ),
+            });
+        }
 
         let group_id = self
             .world

--- a/crates/elevator-core/src/tests/topology_tests.rs
+++ b/crates/elevator-core/src/tests/topology_tests.rs
@@ -68,6 +68,117 @@ fn add_elevator_at_runtime() {
     )));
 }
 
+/// `add_elevator` runtime path must validate physics & door params (#247).
+/// Construction-time validation rejects these; the runtime path was
+/// previously silent, letting zero/negative speed or zero door ticks
+/// reach the world and crash later phases.
+#[test]
+fn add_elevator_rejects_invalid_params() {
+    use crate::error::SimError;
+
+    let config = default_config();
+    let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
+    let line = sim.lines_in_group(GroupId(0))[0];
+
+    let valid = || ElevatorParams {
+        max_speed: Speed::from(2.0),
+        acceleration: Accel::from(1.5),
+        deceleration: Accel::from(2.0),
+        weight_capacity: Weight::from(800.0),
+        door_transition_ticks: 5,
+        door_open_ticks: 10,
+        restricted_stops: HashSet::new(),
+        inspection_speed_factor: 0.25,
+    };
+
+    // Note: Speed/Weight/Accel constructors panic on NaN/Inf/negative, so
+    // those cases can't reach `add_elevator` through the public API. Cover
+    // the values that *can* — zeroes for unit-typed fields, plus NaN/Inf
+    // for the raw f64 inspection_speed_factor.
+    let cases: Vec<(&'static str, ElevatorParams)> = vec![
+        (
+            "max_speed=0",
+            ElevatorParams {
+                max_speed: Speed::from(0.0),
+                ..valid()
+            },
+        ),
+        (
+            "acceleration=0",
+            ElevatorParams {
+                acceleration: Accel::from(0.0),
+                ..valid()
+            },
+        ),
+        (
+            "deceleration=0",
+            ElevatorParams {
+                deceleration: Accel::from(0.0),
+                ..valid()
+            },
+        ),
+        (
+            "weight_capacity=0",
+            ElevatorParams {
+                weight_capacity: Weight::from(0.0),
+                ..valid()
+            },
+        ),
+        (
+            "door_transition_ticks=0",
+            ElevatorParams {
+                door_transition_ticks: 0,
+                ..valid()
+            },
+        ),
+        (
+            "door_open_ticks=0",
+            ElevatorParams {
+                door_open_ticks: 0,
+                ..valid()
+            },
+        ),
+        (
+            "inspection_speed_factor=0",
+            ElevatorParams {
+                inspection_speed_factor: 0.0,
+                ..valid()
+            },
+        ),
+        (
+            "inspection_speed_factor=NaN",
+            ElevatorParams {
+                inspection_speed_factor: f64::NAN,
+                ..valid()
+            },
+        ),
+        (
+            "inspection_speed_factor=-1",
+            ElevatorParams {
+                inspection_speed_factor: -1.0,
+                ..valid()
+            },
+        ),
+    ];
+
+    for (label, params) in cases {
+        let elev_count_before = sim.world().elevator_ids().len();
+        let result = sim.add_elevator(&params, line, 0.0);
+        assert!(
+            matches!(result, Err(SimError::InvalidConfig { .. })),
+            "expected InvalidConfig for {label}, got {result:?}"
+        );
+        assert_eq!(
+            sim.world().elevator_ids().len(),
+            elev_count_before,
+            "{label} must not add an elevator"
+        );
+    }
+
+    // Sanity: a valid params set still succeeds afterwards.
+    sim.add_elevator(&valid(), line, 0.0).unwrap();
+}
+
 /// `add_stop` must reject non-finite positions instead of silently
 /// inserting them into `SortedStops` (where `partition_point` on NaN
 /// is undefined behavior for ordering) and the position map (where

--- a/crates/elevator-core/src/tests/topology_tests.rs
+++ b/crates/elevator-core/src/tests/topology_tests.rs
@@ -179,6 +179,52 @@ fn add_elevator_rejects_invalid_params() {
     sim.add_elevator(&valid(), line, 0.0).unwrap();
 }
 
+/// Non-finite `starting_position` corrupts `SortedStops` and movement-phase
+/// distance math. Reject it the same way `add_stop` does for stop position.
+#[test]
+fn add_elevator_rejects_non_finite_starting_position() {
+    use crate::error::SimError;
+
+    let config = default_config();
+    let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
+    let line = sim.lines_in_group(GroupId(0))[0];
+
+    let params = ElevatorParams {
+        max_speed: Speed::from(2.0),
+        acceleration: Accel::from(1.5),
+        deceleration: Accel::from(2.0),
+        weight_capacity: Weight::from(800.0),
+        door_transition_ticks: 5,
+        door_open_ticks: 10,
+        restricted_stops: HashSet::new(),
+        inspection_speed_factor: 0.25,
+    };
+
+    for (label, value) in [
+        ("NaN", f64::NAN),
+        ("+inf", f64::INFINITY),
+        ("-inf", f64::NEG_INFINITY),
+    ] {
+        let elev_count_before = sim.world().elevator_ids().len();
+        let result = sim.add_elevator(&params, line, value);
+        assert!(
+            matches!(
+                result,
+                Err(SimError::InvalidConfig {
+                    field: "starting_position",
+                    ..
+                })
+            ),
+            "expected InvalidConfig{{field=starting_position}} for {label}, got {result:?}"
+        );
+        assert_eq!(
+            sim.world().elevator_ids().len(),
+            elev_count_before,
+            "{label} must not add an elevator"
+        );
+    }
+}
+
 /// `add_stop` must reject non-finite positions instead of silently
 /// inserting them into `SortedStops` (where `partition_point` on NaN
 /// is undefined behavior for ordering) and the position map (where


### PR DESCRIPTION
## Summary

`Simulation::add_elevator` accepted any `ElevatorParams` and wrote it straight to the world without invoking the validation that construction-time setup applies. Zero/negative speed or zero door ticks silently corrupted the sim and crashed later phases — divides-by-zero in movement, stalled door FSM.

- Extracted physics checks into `sim::construction::validate_elevator_physics`
- Called from both `validate_elevator_config` (construction) and `add_elevator` (runtime)
- Catches:
  - `max_speed`/`acceleration`/`deceleration`/`weight_capacity`/`inspection_speed_factor` ≤ 0
  - `door_transition_ticks` / `door_open_ticks` == 0
  - NaN / Inf for raw f64 fields (the unit-typed Speed/Weight/Accel already filter at construction)

Closes #247

## Test plan

- [x] New `add_elevator_rejects_invalid_params` covers each rejection case and verifies no elevator is added on failure
- [x] `cargo test -p elevator-core --all-features` — all 780 tests pass
- [x] `cargo clippy -p elevator-core --all-features` — clean
- [x] Pre-commit hook — green