### PR TITLE
fix(config): reject non-finite ticks_per_second

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.2.0"
+version = "15.2.3"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -571,11 +571,13 @@ impl Simulation {
             Self::validate_legacy_elevators(&config.elevators, &config.building)?;
         }
 
-        if config.simulation.ticks_per_second <= 0.0 {
+        if !config.simulation.ticks_per_second.is_finite()
+            || config.simulation.ticks_per_second <= 0.0
+        {
             return Err(SimError::InvalidConfig {
                 field: "simulation.ticks_per_second",
                 reason: format!(
-                    "must be positive, got {}",
+                    "must be finite and positive, got {}",
                     config.simulation.ticks_per_second
                 ),
             });

--- a/crates/elevator-core/src/tests/config_tests.rs
+++ b/crates/elevator-core/src/tests/config_tests.rs
@@ -118,6 +118,34 @@ fn rejects_zero_door_open_ticks() {
     );
 }
 
+/// Non-finite `ticks_per_second` produces NaN/zero `dt` that silently
+/// corrupts every physics step (#261).
+#[test]
+fn rejects_non_finite_ticks_per_second() {
+    use super::helpers;
+    for (label, value) in [
+        ("NaN", f64::NAN),
+        ("+inf", f64::INFINITY),
+        ("-inf", f64::NEG_INFINITY),
+        ("zero", 0.0),
+        ("negative", -1.0),
+    ] {
+        let mut config = helpers::default_config();
+        config.simulation.ticks_per_second = value;
+        let result = crate::sim::Simulation::new(&config, helpers::scan());
+        assert!(
+            matches!(
+                result,
+                Err(SimError::InvalidConfig {
+                    field: "simulation.ticks_per_second",
+                    ..
+                })
+            ),
+            "ticks_per_second={label} should be rejected, got {result:?}"
+        );
+    }
+}
+
 #[test]
 fn rejects_empty_line_serves() {
     use super::helpers;


### PR DESCRIPTION
Closes #261. Adds is_finite() check to ticks_per_second validation; NaN and +Inf both passed the previous `<= 0.0` check, producing NaN-poisoned positions or frozen-time corruption. Mirrors the validation pattern in PR #253. Test covers NaN/+inf/-inf/zero/negative.