### PR TITLE
fix(world): panic on ExtKey name collision to prevent silent serde corruption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.2.0"
+version = "15.2.3"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/tests/world_tests.rs
+++ b/crates/elevator-core/src/tests/world_tests.rs
@@ -188,6 +188,50 @@ fn extension_components() {
     assert!(world.ext::<VipTag>(e).is_none());
 }
 
+/// `register_ext` panics if a different type already owns this name (#262).
+/// Two extension types sharing one `ExtKey` name silently corrupts snapshot
+/// serde — `serialize_extensions` collapses both into one slot, and
+/// `deserialize_extensions` routes data via non-deterministic `HashMap::iter`.
+#[test]
+#[should_panic(expected = "already registered")]
+fn register_ext_panics_on_name_collision_via_register() {
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct A;
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct B;
+
+    let mut world = World::new();
+    world.register_ext::<A>(ExtKey::new("foo"));
+    world.register_ext::<B>(ExtKey::new("foo")); // same name, different type → panic
+}
+
+#[test]
+#[should_panic(expected = "already registered")]
+fn register_ext_panics_on_name_collision_via_insert() {
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct A;
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct B;
+
+    let mut world = World::new();
+    let e = world.spawn();
+    world.insert_ext(e, A, ExtKey::new("foo"));
+    world.insert_ext(e, B, ExtKey::new("foo")); // panic
+}
+
+#[test]
+fn register_ext_same_type_same_name_idempotent() {
+    // Re-registering the SAME type with the SAME name is a no-op (used for
+    // snapshot restore where `register_ext` is called per-type before
+    // `deserialize_extensions`).
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct A;
+
+    let mut world = World::new();
+    world.register_ext::<A>(ExtKey::new("foo"));
+    world.register_ext::<A>(ExtKey::new("foo")); // idempotent — no panic
+}
+
 /// Verify that despawn cleans up `hall_calls` and `car_calls`.
 #[test]
 fn despawn_cleans_up_hall_and_car_calls() {

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -745,6 +745,7 @@ impl World {
         key: ExtKey<T>,
     ) {
         let type_id = TypeId::of::<T>();
+        Self::assert_ext_name_unique(&self.ext_names, type_id, key.name());
         let map = self
             .extensions
             .entry(type_id)
@@ -849,11 +850,41 @@ impl World {
         key: ExtKey<T>,
     ) -> ExtKey<T> {
         let type_id = TypeId::of::<T>();
+        Self::assert_ext_name_unique(&self.ext_names, type_id, key.name());
         self.extensions
             .entry(type_id)
             .or_insert_with(|| Box::new(SecondaryMap::<EntityId, T>::new()));
         self.ext_names.insert(type_id, key.name().to_owned());
         key
+    }
+
+    /// Panic if `name` is already registered to a different `TypeId`.
+    ///
+    /// Two extension types sharing one `ExtKey` name silently corrupts
+    /// snapshot serde: `serialize_extensions` collapses both types' data
+    /// into one slot in the result map, and `deserialize_extensions`
+    /// routes the data to whichever `TypeId` `HashMap::iter().find` returns
+    /// first — a non-deterministic choice. Failing fast here prevents
+    /// the corruption from ever being written.
+    ///
+    /// Panic chosen over `Result` because [`register_ext`](Self::register_ext)
+    /// and [`insert_ext`](Self::insert_ext) are non-fallible by design and
+    /// changing their signatures would break every consumer. Name collisions
+    /// are programmer errors discoverable at startup, not runtime conditions
+    /// to recover from.
+    #[allow(clippy::panic)]
+    fn assert_ext_name_unique(ext_names: &HashMap<TypeId, String>, type_id: TypeId, name: &str) {
+        if let Some((existing_tid, _)) = ext_names
+            .iter()
+            .find(|(tid, n)| **tid != type_id && n.as_str() == name)
+        {
+            panic!(
+                "ExtKey name {name:?} is already registered to a different type \
+                 ({existing_tid:?}); each extension type needs a unique key name. \
+                 If renaming is impractical, use ExtKey::from_type_name() so the \
+                 name embeds the fully-qualified Rust type name."
+            );
+        }
     }
 
     // ── Disabled entity management ──────────────────────────────────


### PR DESCRIPTION
Closes #262.

Two extension types sharing one `ExtKey` name silently corrupts snapshot serde — `serialize_extensions` collapses both into one slot, and `deserialize_extensions` resolves names via non-deterministic `HashMap::iter`. Adds `assert_ext_name_unique` called from both `register_ext` and `insert_ext`. Same-type re-registration remains idempotent (snapshot restore depends on it). Three new tests cover collision-via-register, collision-via-insert, and idempotent same-type cases.