### PR TITLE
fix(traffic): make PoissonSource::with_rng deterministic at construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.2.0"
+version = "15.2.3"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/tests/traffic_tests.rs
+++ b/crates/elevator-core/src/tests/traffic_tests.rs
@@ -495,6 +495,63 @@ fn traffic_schedule_serde_roundtrip() {
     assert_eq!(deserialized.pattern_at(999), &TrafficPattern::Mixed);
 }
 
+/// `with_rng` at construction time must reset the schedule anchor so
+/// the seeded RNG drives sampling — pre-fix, the OS-RNG-sampled
+/// `next_arrival_tick` from `new()` polluted the deterministic schedule
+/// (#268). Two sources built with the same seed must produce identical
+/// `next_arrival_tick` values.
+#[test]
+fn with_rng_at_construction_is_deterministic() {
+    use rand::SeedableRng;
+
+    let make = || {
+        PoissonSource::new(
+            vec![StopId(0), StopId(1)],
+            TrafficSchedule::constant(TrafficPattern::Uniform),
+            120,
+            (60.0, 90.0),
+        )
+        .with_rng(rand::rngs::StdRng::seed_from_u64(42))
+    };
+
+    let a = make().next_arrival_tick();
+    let b = make().next_arrival_tick();
+    assert_eq!(a, b, "with_rng at construction must be deterministic");
+}
+
+/// Mid-simulation `with_rng` (after `generate` has advanced the schedule)
+/// must NOT rewind the anchor — that would cause a catch-up burst of
+/// every backlogged arrival on the next `generate(t)`.
+#[test]
+fn with_rng_mid_simulation_keeps_anchor() {
+    use rand::SeedableRng;
+
+    let mut source = PoissonSource::new(
+        vec![StopId(0), StopId(1)],
+        TrafficSchedule::constant(TrafficPattern::Uniform),
+        100,
+        (60.0, 90.0),
+    )
+    .with_rng(rand::rngs::StdRng::seed_from_u64(1));
+
+    // Advance the schedule to tick 1000.
+    let _ = source.generate(1000);
+    let anchor_before = source.next_arrival_tick();
+    assert!(
+        anchor_before > 1000,
+        "after generate(1000), next_arrival should be in the future"
+    );
+
+    // Swap RNG mid-simulation. The new anchor must be >= anchor_before
+    // (sampled forward from current), not < 1000 (which would burst).
+    let source = source.with_rng(rand::rngs::StdRng::seed_from_u64(2));
+    let anchor_after = source.next_arrival_tick();
+    assert!(
+        anchor_after >= anchor_before,
+        "mid-sim with_rng must not rewind the anchor: before={anchor_before}, after={anchor_after}"
+    );
+}
+
 /// `with_mean_interval` must resample `next_arrival_tick` so the builder
 /// chain `PoissonSource::new(..., tiny_mean, ...).with_mean_interval(big_mean)`
 /// does not leak the tick-0 arrival drawn from `tiny_mean`.

--- a/crates/elevator-core/src/traffic.rs
+++ b/crates/elevator-core/src/traffic.rs
@@ -388,6 +388,12 @@ pub struct PoissonSource {
     rng: rand::rngs::StdRng,
     /// Tick of the next scheduled arrival.
     next_arrival_tick: u64,
+    /// True once the schedule is "committed" — either `generate()` has
+    /// processed at least one tick, or `with_mean_interval()` has been
+    /// called. Used by [`Self::with_rng`] to decide whether to reset the
+    /// anchor (so the new RNG drives sampling from tick 0) or keep the
+    /// current anchor (so a mid-simulation RNG swap does not rewind).
+    rng_committed: bool,
 }
 
 impl PoissonSource {
@@ -418,6 +424,7 @@ impl PoissonSource {
             weight_range,
             rng,
             next_arrival_tick: next,
+            rng_committed: false,
         }
     }
 
@@ -471,6 +478,9 @@ impl PoissonSource {
         self.mean_interval = ticks;
         self.next_arrival_tick =
             sample_next_arrival(self.next_arrival_tick, self.mean_interval, &mut self.rng);
+        // Treat an explicit interval change as committing to the current
+        // schedule; a later `with_rng` will not rewind the anchor.
+        self.rng_committed = true;
         self
     }
 
@@ -521,8 +531,18 @@ impl PoissonSource {
     #[must_use]
     pub fn with_rng(mut self, rng: rand::rngs::StdRng) -> Self {
         self.rng = rng;
-        self.next_arrival_tick =
-            sample_next_arrival(self.next_arrival_tick, self.mean_interval, &mut self.rng);
+        // If the schedule has not yet been committed (no `generate` calls,
+        // no `with_mean_interval`), reset the anchor to 0 so the new RNG
+        // drives sampling deterministically from the start. Otherwise the
+        // OS-seeded `next_arrival_tick` from `new()` would still anchor
+        // the schedule, defeating the determinism contract (#268).
+        let anchor = if self.rng_committed {
+            self.next_arrival_tick
+        } else {
+            0
+        };
+        self.next_arrival_tick = sample_next_arrival(anchor, self.mean_interval, &mut self.rng);
+        self.rng_committed = true;
         self
     }
 
@@ -543,6 +563,9 @@ impl PoissonSource {
 impl TrafficSource for PoissonSource {
     fn generate(&mut self, tick: u64) -> Vec<SpawnRequest> {
         let mut requests = Vec::new();
+        // First call locks in the current schedule — subsequent `with_rng`
+        // must not rewind the anchor.
+        self.rng_committed = true;
 
         while tick >= self.next_arrival_tick {
             // Use the scheduled arrival tick (not the current tick) so catch-up


### PR DESCRIPTION
Closes #268. Add `rng_committed: bool` flag so `with_rng` resets the schedule anchor when not yet advanced (deterministic construction-time use), but preserves it after `generate`/`with_mean_interval` (mid-sim use). Tests cover both paths.