### PR TITLE
fix(scenario): sort spawns by tick in ScenarioRunner::new

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.2.0"
+version = "15.2.3"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/scenario.rs
+++ b/crates/elevator-core/src/scenario.rs
@@ -112,9 +112,15 @@ impl ScenarioRunner {
         dispatch: impl DispatchStrategy + 'static,
     ) -> Result<Self, SimError> {
         let sim = Simulation::new(&scenario.config, dispatch)?;
+        // Sort spawns by tick so the cursor advance in `tick()` cannot
+        // gate an earlier spawn behind a later one. `sort_by_key` is
+        // stable, so spawns with the same tick keep their declaration
+        // order — important for replay determinism (#271).
+        let mut spawns = scenario.spawns;
+        spawns.sort_by_key(|s| s.tick);
         Ok(Self {
             sim,
-            spawns: scenario.spawns,
+            spawns,
             spawn_cursor: 0,
             conditions: scenario.conditions,
             max_ticks: scenario.max_ticks,

--- a/crates/elevator-core/src/tests/scenario_tests.rs
+++ b/crates/elevator-core/src/tests/scenario_tests.rs
@@ -289,3 +289,60 @@ fn deterministic_replay() {
         "Deterministic simulation should take identical tick counts"
     );
 }
+
+// ── ScenarioRunner — spawn ordering (#271) ───────────────────────────────────
+
+/// `ScenarioRunner::new` must sort spawns by tick. Pre-fix, the cursor
+/// advance in `tick()` would gate an earlier-tick spawn behind a
+/// later-tick predecessor declared first in the vec, silently moving
+/// the earlier rider to the later tick (#271).
+#[test]
+fn scenario_runner_sorts_out_of_order_spawns() {
+    use crate::scenario::{Scenario, ScenarioRunner, TimedSpawn};
+
+    let scenario = Scenario {
+        name: "out-of-order".into(),
+        config: default_config(),
+        spawns: vec![
+            TimedSpawn {
+                tick: 10,
+                origin: StopId(0),
+                destination: StopId(2),
+                weight: 70.0,
+            },
+            TimedSpawn {
+                tick: 5,
+                origin: StopId(0),
+                destination: StopId(1),
+                weight: 70.0,
+            },
+        ],
+        conditions: vec![],
+        max_ticks: 100,
+    };
+
+    let mut runner = ScenarioRunner::new(scenario, scan()).unwrap();
+
+    // Step through to tick 5. Only the tick=5 spawn should have fired.
+    for _ in 0..6 {
+        runner.tick();
+    }
+    assert_eq!(
+        runner.sim().metrics().total_spawned(),
+        1,
+        "only the tick=5 spawn should have happened by tick 5"
+    );
+
+    // Step to tick 10. Now the tick=10 spawn fires too.
+    for _ in 0..5 {
+        runner.tick();
+    }
+    assert_eq!(
+        runner.sim().metrics().total_spawned(),
+        2,
+        "both spawns should have happened by tick 10"
+    );
+
+    let _ = Weight::from(70.0); // suppress unused-import warning
+    let _: Option<Event> = None;
+}


### PR DESCRIPTION
Closes #271. The cursor advance assumed spawns were sorted; out-of-order entries silently moved to the predecessor's tick. Sort with stable `sort_by_key` so declaration order within the same tick is preserved.