### PR TITLE
fix(sim): reject spawn_rider(s, s, _) self-loops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.2.0"
+version = "15.2.3"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -268,14 +268,28 @@ impl RiderBuilder<'_> {
                 });
             }
             route
-        } else if let Some(group) = self.group {
-            if !self.sim.groups.iter().any(|g| g.id() == group) {
-                return Err(SimError::GroupNotFound(group));
-            }
-            Route::direct(self.origin, self.destination, group)
         } else {
-            let group = self.sim.auto_detect_group(self.origin, self.destination)?;
-            Route::direct(self.origin, self.destination, group)
+            // No explicit route: must build one from origin → destination.
+            // Same origin/destination produces a Route::direct that no hall
+            // call can summon a car for — rider deadlocks Waiting (#273).
+            // Trust users that supply their own route.
+            if self.origin == self.destination {
+                return Err(SimError::InvalidConfig {
+                    field: "destination",
+                    reason: "origin and destination must differ; same-stop \
+                             spawns deadlock with no hall call to summon a car"
+                        .into(),
+                });
+            }
+            if let Some(group) = self.group {
+                if !self.sim.groups.iter().any(|g| g.id() == group) {
+                    return Err(SimError::GroupNotFound(group));
+                }
+                Route::direct(self.origin, self.destination, group)
+            } else {
+                let group = self.sim.auto_detect_group(self.origin, self.destination)?;
+                Route::direct(self.origin, self.destination, group)
+            }
         };
 
         let eid = self

--- a/crates/elevator-core/src/sim/rider.rs
+++ b/crates/elevator-core/src/sim/rider.rs
@@ -76,6 +76,17 @@ impl super::Simulation {
     ) -> Result<RiderId, SimError> {
         let origin = self.resolve_stop(origin.into())?;
         let destination = self.resolve_stop(destination.into())?;
+        // Same origin & destination = no hall call gets registered (the
+        // direction is undefined), so the rider would sit Waiting forever
+        // while inflating `total_spawned`. Reject up front. (#273)
+        if origin == destination {
+            return Err(SimError::InvalidConfig {
+                field: "destination",
+                reason: "origin and destination must differ; same-stop \
+                         spawns deadlock with no hall call to summon a car"
+                    .into(),
+            });
+        }
         let weight: Weight = weight.into();
         let group = self.auto_detect_group(origin, destination)?;
 

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -759,6 +759,42 @@ fn rider_builder_invalid_stop_id_returns_stop_not_found() {
     );
 }
 
+/// `spawn_rider` and `RiderBuilder::spawn` (when no explicit route is
+/// provided) reject `origin == destination`. Same-stop spawns produce
+/// no hall call so the rider would deadlock Waiting forever (#273).
+#[test]
+fn spawn_rider_rejects_origin_equals_destination() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let direct = sim.spawn_rider(StopId(0), StopId(0), 70.0);
+    assert!(
+        matches!(
+            direct,
+            Err(SimError::InvalidConfig {
+                field: "destination",
+                ..
+            })
+        ),
+        "spawn_rider with same stop must error, got {direct:?}"
+    );
+
+    let builder = sim.build_rider(StopId(1), StopId(1)).unwrap().spawn();
+    assert!(
+        matches!(
+            builder,
+            Err(SimError::InvalidConfig {
+                field: "destination",
+                ..
+            })
+        ),
+        "RiderBuilder::spawn with same stop must error, got {builder:?}"
+    );
+
+    // No rider was actually spawned.
+    assert_eq!(sim.metrics().total_spawned(), 0);
+}
+
 #[test]
 fn rider_builder_no_route_when_stops_not_in_same_group() {
     // Build a sim with two separate groups, each with its own stops.


### PR DESCRIPTION
Closes #273. `origin == destination` produced a deadlocked rider — `Route::direct` succeeded, but no hall call was registered (`CallDirection::between(p, p)` returns None), so no car was ever summoned. Reject up front in `spawn_rider` and `RiderBuilder::spawn` (when no explicit route is supplied).