### PR TITLE
fix(config): validate PassengerSpawnConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.2.3"
+version = "15.2.6"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -583,6 +583,45 @@ impl Simulation {
             });
         }
 
+        Self::validate_passenger_spawning(&config.passenger_spawning)?;
+
+        Ok(())
+    }
+
+    /// Validate `PassengerSpawnConfig`. Without this, bad inputs reach
+    /// `PoissonSource::from_config` and panic later (NaN/negative weights
+    /// crash `random_range`/`Weight::from`; zero `mean_interval_ticks`
+    /// burst-fires every catch-up tick). (#272)
+    fn validate_passenger_spawning(
+        spawn: &crate::config::PassengerSpawnConfig,
+    ) -> Result<(), SimError> {
+        let (lo, hi) = spawn.weight_range;
+        if !lo.is_finite() || !hi.is_finite() {
+            return Err(SimError::InvalidConfig {
+                field: "passenger_spawning.weight_range",
+                reason: format!("both endpoints must be finite, got ({lo}, {hi})"),
+            });
+        }
+        if lo < 0.0 || hi < 0.0 {
+            return Err(SimError::InvalidConfig {
+                field: "passenger_spawning.weight_range",
+                reason: format!("both endpoints must be non-negative, got ({lo}, {hi})"),
+            });
+        }
+        if lo > hi {
+            return Err(SimError::InvalidConfig {
+                field: "passenger_spawning.weight_range",
+                reason: format!("min must be <= max, got ({lo}, {hi})"),
+            });
+        }
+        if spawn.mean_interval_ticks == 0 {
+            return Err(SimError::InvalidConfig {
+                field: "passenger_spawning.mean_interval_ticks",
+                reason: "must be > 0; mean_interval_ticks=0 burst-fires \
+                         every catch-up tick"
+                    .into(),
+            });
+        }
         Ok(())
     }
 

--- a/crates/elevator-core/src/tests/config_tests.rs
+++ b/crates/elevator-core/src/tests/config_tests.rs
@@ -146,6 +146,69 @@ fn rejects_non_finite_ticks_per_second() {
     }
 }
 
+/// `PassengerSpawnConfig` is now validated; previously bad inputs survived
+/// to `PoissonSource::from_config` and panicked later (#272).
+#[test]
+fn rejects_invalid_passenger_spawning() {
+    use super::helpers;
+    use crate::config::PassengerSpawnConfig;
+
+    let cases: Vec<(&'static str, PassengerSpawnConfig, &'static str)> = vec![
+        (
+            "weight_range=(NaN, 50)",
+            PassengerSpawnConfig {
+                mean_interval_ticks: 120,
+                weight_range: (f64::NAN, 50.0),
+            },
+            "passenger_spawning.weight_range",
+        ),
+        (
+            "weight_range=(50, +inf)",
+            PassengerSpawnConfig {
+                mean_interval_ticks: 120,
+                weight_range: (50.0, f64::INFINITY),
+            },
+            "passenger_spawning.weight_range",
+        ),
+        (
+            "weight_range=(-50, -50)",
+            PassengerSpawnConfig {
+                mean_interval_ticks: 120,
+                weight_range: (-50.0, -50.0),
+            },
+            "passenger_spawning.weight_range",
+        ),
+        (
+            "weight_range=(100, 50) inverted",
+            PassengerSpawnConfig {
+                mean_interval_ticks: 120,
+                weight_range: (100.0, 50.0),
+            },
+            "passenger_spawning.weight_range",
+        ),
+        (
+            "mean_interval_ticks=0",
+            PassengerSpawnConfig {
+                mean_interval_ticks: 0,
+                weight_range: (50.0, 100.0),
+            },
+            "passenger_spawning.mean_interval_ticks",
+        ),
+    ];
+
+    for (label, spawn, expected_field) in cases {
+        let mut config = helpers::default_config();
+        config.passenger_spawning = spawn;
+        let result = crate::sim::Simulation::new(&config, helpers::scan());
+        match result {
+            Err(SimError::InvalidConfig { field, .. }) if field == expected_field => {}
+            _ => panic!(
+                "{label} should produce InvalidConfig{{field={expected_field}}}, got {result:?}"
+            ),
+        }
+    }
+}
+
 #[test]
 fn rejects_empty_line_serves() {
     use super::helpers;


### PR DESCRIPTION
Closes #272. Bad inputs (NaN/+inf/negative weight, mean_interval=0) survived parse and panicked inside `PoissonSource` later. Adds `validate_passenger_spawning` to `validate_config`. Test covers 5 rejection cases.