### PR TITLE
fix(sim): require_elevator now rejects disabled elevators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.2.6"
+version = "15.2.9"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/sim/manual.rs
+++ b/crates/elevator-core/src/sim/manual.rs
@@ -259,14 +259,23 @@ impl super::Simulation {
         Ok(())
     }
 
-    /// Internal: resolve an elevator entity or return a clear error.
+    /// Internal: resolve an elevator entity that is alive and not
+    /// disabled. Returns `NotAnElevator` if the entity is missing,
+    /// `ElevatorDisabled` if it has been disabled. Used by runtime
+    /// upgrade setters in `runtime.rs` so they can't silently mutate
+    /// an out-of-service car (#265).
     pub(super) fn require_elevator(
         &self,
         elevator: EntityId,
     ) -> Result<&crate::components::Elevator, SimError> {
-        self.world
+        let car = self
+            .world
             .elevator(elevator)
-            .ok_or(SimError::NotAnElevator(elevator))
+            .ok_or(SimError::NotAnElevator(elevator))?;
+        if self.world.is_disabled(elevator) {
+            return Err(SimError::ElevatorDisabled(elevator));
+        }
+        Ok(car)
     }
 
     /// Internal: positive-finite validator matching the construction-time

--- a/crates/elevator-core/src/tests/runtime_upgrades_tests.rs
+++ b/crates/elevator-core/src/tests/runtime_upgrades_tests.rs
@@ -282,6 +282,31 @@ fn set_on_non_elevator_returns_invalid_state() {
     assert!(matches!(err, SimError::NotAnElevator(_)));
 }
 
+/// Runtime setters must reject disabled elevators (#265). Pre-fix,
+/// `require_elevator` only checked existence, so `set_max_speed` etc.
+/// would silently mutate a disabled car and emit `ElevatorUpgraded`.
+#[test]
+fn set_on_disabled_elevator_returns_disabled_error() {
+    let (mut sim, elev) = make_sim();
+    let before = sim.world().elevator(elev.entity()).unwrap().max_speed();
+
+    sim.disable(elev.entity()).unwrap();
+
+    let err = sim.set_max_speed(elev, 99.0).unwrap_err();
+    assert!(
+        matches!(err, SimError::ElevatorDisabled(_)),
+        "expected ElevatorDisabled, got {err:?}"
+    );
+
+    // The setter must not have mutated the disabled car.
+    sim.enable(elev.entity()).unwrap();
+    assert_eq!(
+        sim.world().elevator(elev.entity()).unwrap().max_speed(),
+        before,
+        "disabled-elevator setter must not mutate state"
+    );
+}
+
 // ── Velocity preservation ────────────────────────────────────────────
 
 /// When `max_speed` is raised mid-flight the current velocity is preserved


### PR DESCRIPTION
Closes #265. Runtime upgrade setters silently mutated disabled cars because `require_elevator` only checked existence. Add the disabled check inside the helper; brings the runtime-upgrade path to parity with the manual-control APIs which already used `require_enabled_elevator`.