### PR TITLE
fix(sim): pending_events flushes event bus to match drain semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.2.6"
+version = "15.2.9"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/sim/accessors.rs
+++ b/crates/elevator-core/src/sim/accessors.rs
@@ -138,8 +138,19 @@ impl super::Simulation {
     }
 
     /// Peek at events pending for consumer retrieval.
-    #[must_use]
-    pub fn pending_events(&self) -> &[Event] {
+    ///
+    /// Flushes the active event bus into the output buffer first so the
+    /// returned slice reflects every event emitted up to this call —
+    /// matching what [`drain_events`](Self::drain_events) would return.
+    /// Without the flush, events emitted outside the tick loop
+    /// (`spawn_rider`, `disable`, …) would be invisible to peek but
+    /// visible to drain — observed during round-2 audit (#264).
+    ///
+    /// Takes `&mut self` because the flush mutates internal state. If
+    /// you only need a count or a quick check after `step()`, prefer
+    /// `pending_events().len()` or pattern-matching the slice directly.
+    pub fn pending_events(&mut self) -> &[Event] {
+        self.pending_output.extend(self.events.drain());
         &self.pending_output
     }
 }

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -283,6 +283,39 @@ fn remove_nonexistent_stop_returns_entity_not_found() {
 
 // ── drain_events_where ────────────────────────────────────────────────────────
 
+/// `pending_events` and `drain_events` must agree on what events exist.
+/// Pre-fix, `pending_events` returned only the post-step output buffer
+/// and missed events emitted outside the tick loop (`spawn_rider`,
+/// `disable`, etc.) — `drain_events` flushed first so it saw them.
+/// (#264)
+#[test]
+fn pending_events_matches_drain_events() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    // Emit RiderSpawned outside the tick loop. Pre-fix, peek would be
+    // empty while drain returned [RiderSpawned] — peek and drain disagreed.
+    sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
+
+    let peek_count = sim.pending_events().len();
+    assert!(
+        peek_count >= 1,
+        "pending_events should flush the event bus and see RiderSpawned, got {peek_count}"
+    );
+
+    let drained = sim.drain_events();
+    assert_eq!(
+        drained.len(),
+        peek_count,
+        "drain must yield the same count peek reported"
+    );
+    assert!(
+        drained
+            .iter()
+            .any(|e| matches!(e, Event::RiderSpawned { .. }))
+    );
+}
+
 #[test]
 fn drain_events_where_returns_only_matching_events() {
     let config = default_config();

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -468,12 +468,12 @@ pub unsafe extern "C" fn ev_sim_step(handle: *mut EvSim) -> EvStatus {
         // Safety: validity guaranteed by caller; no aliasing across threads.
         let ev = unsafe { &mut *handle };
         ev.sim.step();
-        forward_pending_events(&ev.sim);
+        forward_pending_events(&mut ev.sim);
         EvStatus::Ok
     })
 }
 
-fn forward_pending_events(sim: &Simulation) {
+fn forward_pending_events(sim: &mut Simulation) {
     with_log_callback(|cb| {
         for event in sim.pending_events() {
             let msg = format!("{event:?}");


### PR DESCRIPTION
Closes #264. `pending_events` now takes `&mut self` and flushes the event bus before returning the slice, matching `drain_events`. Pre-fix, events emitted outside the tick loop (spawn_rider, disable) were invisible to peek but visible to drain. FFI helper updated to match.