### PR TITLE
fix(sim): clear HallCall assignments when assigned car is disabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.2.9"
+version = "15.2.11"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -451,6 +451,16 @@ impl Simulation {
             // Drop any sticky DCS assignments pointing at this car so
             // routed riders are not stranded behind a dead reference.
             crate::dispatch::destination::clear_assignments_to(&mut self.world, id);
+            // Same for hall-call assignments — pre-fix, a pinned hall
+            // call to the disabled car was permanently stranded because
+            // dispatch kept committing the disabled car as the assignee
+            // and other cars couldn't take the call. (#292)
+            for hc in self.world.iter_hall_calls_mut() {
+                if hc.assigned_car == Some(id) {
+                    hc.assigned_car = None;
+                    hc.pinned = false;
+                }
+            }
 
             for rid in &rider_ids {
                 if let Some(r) = self.world.rider_mut(*rid) {

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -84,6 +84,35 @@ fn pin_assignment_pins_and_assigns() {
     assert!(!call.pinned);
 }
 
+/// Pre-fix, disabling a car holding a pinned hall-call assignment left
+/// `assigned_car=Some(disabled)` and `pinned=true` — dispatch kept
+/// committing the disabled car as the assignee, but movement skips
+/// disabled cars so the call was permanently stranded (#292).
+#[test]
+fn disable_clears_pinned_hall_call_assignment() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    let stop = sim.stop_entity(StopId(1)).unwrap();
+    let car = ElevatorId::from(sim.world().elevator_ids()[0]);
+
+    sim.press_hall_button(stop, CallDirection::Up).unwrap();
+    sim.pin_assignment(car, stop, CallDirection::Up).unwrap();
+    assert_eq!(
+        sim.assigned_car(stop, CallDirection::Up),
+        Some(car.entity()),
+        "precondition: pinned to disabled car"
+    );
+
+    sim.disable(car.entity()).unwrap();
+
+    assert_eq!(
+        sim.assigned_car(stop, CallDirection::Up),
+        None,
+        "disabled-car assignment must be cleared"
+    );
+    let call = sim.world().hall_call(stop, CallDirection::Up).unwrap();
+    assert!(!call.pinned, "pinned flag must be cleared");
+}
+
 /// Nonzero `ack_latency_ticks`: a hall call pressed at tick T only
 /// becomes acknowledged at tick T+N, and `HallCallAcknowledged` fires
 /// on exactly that tick. Locks in the deferred-ack path in


### PR DESCRIPTION
Closes #292. Mirror the existing DCS `clear_assignments_to` cleanup for hall calls — pre-fix, a pinned hall call to a disabled car was permanently stranded (dispatch kept the assignment, movement skipped the car). Walks hall calls in `disable` and resets `assigned_car`/`pinned` for any pointing at the dropped car.