### PR TITLE
fix(topology): remove_stop drops CarCalls referencing the removed stop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.2.9"
+version = "15.2.11"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -408,6 +408,13 @@ impl Simulation {
             if let Some(q) = self.world.destination_queue_mut(eid) {
                 q.retain(|s| s != stop);
             }
+            // Drop any car-call whose floor is the removed stop. Built-in
+            // strategies don't currently route on car_calls but the public
+            // `sim.car_calls(car)` accessor and custom strategies (via
+            // `car_calls_for`) would otherwise return dangling refs (#293).
+            if let Some(calls) = self.world.car_calls_mut(eid) {
+                calls.retain(|c| c.floor != stop);
+            }
         }
 
         // Remove from all lines and groups.

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -268,6 +268,42 @@ fn remove_stop_clears_dangling_references_on_elevator() {
     );
 }
 
+/// Pre-fix, `remove_stop` left `CarCall.floor` references pointing at the
+/// despawned stop entity — visible through the public `sim.car_calls()`
+/// accessor and consumed by custom dispatch strategies. (#293)
+#[test]
+fn remove_stop_drops_car_calls_referencing_stop() {
+    use crate::components::CarCall;
+
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let stop2 = sim.stop_entity(StopId(2)).unwrap();
+    let elev = sim.groups()[0].elevator_entities()[0];
+
+    // Pre-load a CarCall whose floor is stop2.
+    let tick = sim.current_tick();
+    sim.world_mut()
+        .car_calls_mut(elev)
+        .unwrap()
+        .push(CarCall::new(elev, stop2, tick));
+    assert!(
+        sim.car_calls(ElevatorId::from(elev))
+            .iter()
+            .any(|c| c.floor == stop2),
+        "precondition: car has a CarCall pointing at stop2"
+    );
+
+    sim.remove_stop(stop2).unwrap();
+
+    assert!(
+        sim.car_calls(ElevatorId::from(elev))
+            .iter()
+            .all(|c| c.floor != stop2),
+        "remove_stop must drop CarCall entries whose floor is the removed stop"
+    );
+}
+
 #[test]
 fn remove_nonexistent_stop_returns_entity_not_found() {
     let config = default_config();


### PR DESCRIPTION
Closes #293. Add a `car_calls.retain` step to the existing per-elevator scrub loop in `remove_stop`. HallCall.stop refs are dropped by the existing `world.despawn(stop)` (hall calls are keyed on the stop entity and disappear with it). Test pre-loads a CarCall and asserts it's gone after `remove_stop`.