### PR TITLE
fix(snapshot): reject legacy/mismatched schema versions on restore

### DIFF
--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -88,6 +88,13 @@ pub struct EntitySnapshot {
 /// them out-of-band (#296).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorldSnapshot {
+    /// Schema version of this snapshot. Bumped on incompatible changes
+    /// to the snapshot layout. Loading a snapshot whose version differs
+    /// from the current crate's expected version returns
+    /// [`SimError::SnapshotVersion`](crate::error::SimError::SnapshotVersion).
+    /// Legacy snapshots default to `0` (#295).
+    #[serde(default)]
+    pub version: u32,
     /// Current simulation tick.
     pub tick: u64,
     /// Time delta per tick.
@@ -182,6 +189,18 @@ impl WorldSnapshot {
         custom_strategy_factory: CustomStrategyFactory<'_>,
     ) -> Result<crate::sim::Simulation, crate::error::SimError> {
         use crate::world::{SortedStops, World};
+
+        // Reject snapshots from incompatible schema versions. The bytes
+        // envelope path also checks the crate semver string, but the RON/
+        // JSON path was previously unguarded — older snapshots silently
+        // deserialized with `#[serde(default)]` filling new fields, masking
+        // schema mismatches. (#295)
+        if self.version != SNAPSHOT_SCHEMA_VERSION {
+            return Err(crate::error::SimError::SnapshotVersion {
+                saved: format!("schema {}", self.version),
+                current: format!("schema {SNAPSHOT_SCHEMA_VERSION}"),
+            });
+        }
 
         let mut world = World::new();
 
@@ -662,6 +681,11 @@ impl WorldSnapshot {
 /// Magic bytes identifying a bincode snapshot blob.
 const SNAPSHOT_MAGIC: [u8; 8] = *b"ELEVSNAP";
 
+/// Schema version for [`WorldSnapshot`]. Bump on incompatible layout
+/// changes so RON/JSON restore can reject older snapshots loudly
+/// instead of silently filling new fields with `#[serde(default)]`.
+const SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
 /// Byte-level snapshot envelope: magic + crate version + payload.
 ///
 /// Serialized via bincode. The magic and version fields are checked on
@@ -693,6 +717,7 @@ impl crate::sim::Simulation {
     /// [`SimError::MidTickSnapshot`](crate::error::SimError::MidTickSnapshot)
     /// when invoked between `run_*` and `advance_tick`. (#297)
     #[must_use]
+    #[allow(clippy::too_many_lines)]
     pub fn snapshot(&self) -> WorldSnapshot {
         self.snapshot_inner()
     }
@@ -812,6 +837,7 @@ impl crate::sim::Simulation {
             .collect();
 
         WorldSnapshot {
+            version: SNAPSHOT_SCHEMA_VERSION,
             tick: self.current_tick(),
             dt: self.dt(),
             entities,

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -558,6 +558,40 @@ fn snapshot_preserves_hall_call_ack_state_under_latency() {
     assert_eq!(call.ack_latency_ticks, 10);
 }
 
+/// `WorldSnapshot::restore` rejects a snapshot whose `version` differs
+/// from the current schema. Pre-fix the RON/JSON path silently accepted
+/// older snapshots and let `#[serde(default)]` fill new fields with
+/// zeros — masking schema mismatches. (#295)
+#[test]
+fn restore_rejects_mismatched_schema_version() {
+    use crate::error::SimError;
+
+    let config = helpers::default_config();
+    let sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+    let mut snap = sim.snapshot();
+    snap.version = u32::MAX;
+    let result = snap.restore(None);
+    assert!(
+        matches!(result, Err(SimError::SnapshotVersion { .. })),
+        "mismatched schema version must be rejected, got {result:?}"
+    );
+}
+
+/// Legacy snapshots (`version = 0`, the `#[serde(default)]` fallback)
+/// are also rejected — confirms the field is consulted on the RON/JSON
+/// path even when missing from the source.
+#[test]
+fn restore_rejects_legacy_zero_version() {
+    use crate::error::SimError;
+
+    let config = helpers::default_config();
+    let sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+    let mut snap = sim.snapshot();
+    snap.version = 0;
+    let result = snap.restore(None);
+    assert!(matches!(result, Err(SimError::SnapshotVersion { .. })));
+}
+
 /// Normal snapshot roundtrip should produce no `SnapshotDanglingReference` events.
 #[test]
 fn snapshot_roundtrip_emits_no_dangling_warnings() {


### PR DESCRIPTION
Closes #295. Adds `version: u32` to `WorldSnapshot` (`#[serde(default)]` so legacy snapshots load as `0`) and rejects mismatches in `restore()`. Bytes envelope semver check stays as a second layer.