### PR TITLE
fix(snapshot): determinism + mid-tick guard + custom-resource docs (#254/#296/#297)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.2.11"
+version = "15.2.14"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/error.rs
+++ b/crates/elevator-core/src/error.rs
@@ -111,6 +111,10 @@ pub enum SimError {
         /// The group that references the strategy.
         group: GroupId,
     },
+    /// `try_snapshot` was called between phases of an in-progress tick.
+    /// Mid-tick snapshots silently lose `EventBus` state from earlier
+    /// phases of that tick — surface the constraint instead. (#297)
+    MidTickSnapshot,
 }
 
 impl fmt::Display for SimError {
@@ -194,6 +198,11 @@ impl fmt::Display for SimError {
                 )
             }
             Self::SnapshotFormat(reason) => write!(f, "malformed snapshot: {reason}"),
+            Self::MidTickSnapshot => write!(
+                f,
+                "snapshot taken between phases of an in-progress tick; \
+                 call advance_tick() before snapshot() in the substep API"
+            ),
             Self::UnresolvedCustomStrategy { name, group } => {
                 write!(
                     f,

--- a/crates/elevator-core/src/metrics.rs
+++ b/crates/elevator-core/src/metrics.rs
@@ -1,7 +1,7 @@
 //! Aggregate simulation metrics (wait times, throughput, distance).
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::collections::VecDeque;
 use std::fmt;
 
@@ -36,7 +36,7 @@ pub struct Metrics {
     /// enabled elevators. Overwritten each tick. Key is group name (String
     /// for serialization).
     #[serde(default)]
-    pub(crate) utilization_by_group: HashMap<String, f64>,
+    pub(crate) utilization_by_group: BTreeMap<String, f64>,
     /// Total distance traveled by elevators while repositioning.
     #[serde(default)]
     pub(crate) reposition_distance: f64,
@@ -148,7 +148,7 @@ impl Metrics {
 
     /// Per-group instantaneous elevator utilization (fraction of elevators moving).
     #[must_use]
-    pub const fn utilization_by_group(&self) -> &HashMap<String, f64> {
+    pub const fn utilization_by_group(&self) -> &BTreeMap<String, f64> {
         &self.utilization_by_group
     }
 

--- a/crates/elevator-core/src/query/storage.rs
+++ b/crates/elevator-core/src/query/storage.rs
@@ -1,7 +1,7 @@
 //! Type-erased storage for extension components.
 
 use std::any::Any;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -24,10 +24,11 @@ pub trait AnyExtMap: Send + Sync {
     fn as_any_mut(&mut self) -> &mut dyn Any;
 
     /// Serialize all entries to a map of `EntityId` → RON string.
-    fn serialize_entries(&self) -> HashMap<EntityId, String>;
+    /// `BTreeMap` for deterministic ordering across snapshot processes.
+    fn serialize_entries(&self) -> BTreeMap<EntityId, String>;
 
     /// Deserialize entries from a map of `EntityId` → RON string, replacing current contents.
-    fn deserialize_entries(&mut self, data: &HashMap<EntityId, String>);
+    fn deserialize_entries(&mut self, data: &BTreeMap<EntityId, String>);
 }
 
 impl<T: 'static + Send + Sync + Serialize + DeserializeOwned> AnyExtMap
@@ -45,13 +46,13 @@ impl<T: 'static + Send + Sync + Serialize + DeserializeOwned> AnyExtMap
         self
     }
 
-    fn serialize_entries(&self) -> HashMap<EntityId, String> {
+    fn serialize_entries(&self) -> BTreeMap<EntityId, String> {
         self.iter()
             .filter_map(|(id, val)| ron::to_string(val).ok().map(|s| (id, s)))
             .collect()
     }
 
-    fn deserialize_entries(&mut self, data: &HashMap<EntityId, String>) {
+    fn deserialize_entries(&mut self, data: &BTreeMap<EntityId, String>) {
         for (id, ron_str) in data {
             if let Ok(val) = ron::from_str::<T>(ron_str) {
                 self.insert(*id, val);

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -355,6 +355,13 @@ pub struct Simulation {
     topo_graph: Mutex<TopologyGraph>,
     /// Phase-partitioned reverse index for O(1) population queries.
     rider_index: RiderIndex,
+    /// True between the first per-phase `run_*` call and the matching
+    /// `advance_tick()`. Used by [`try_snapshot`](Self::try_snapshot) to
+    /// reject mid-tick captures that would lose in-progress event-bus
+    /// state. Always false outside the substep API path because
+    /// [`step()`](Self::step) takes `&mut self` and snapshots take
+    /// `&self`. (#297)
+    pub(crate) tick_in_progress: bool,
 }
 
 impl fmt::Debug for Simulation {

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -231,6 +231,7 @@ impl Simulation {
             reposition_buf: Vec::new(),
             topo_graph: Mutex::new(TopologyGraph::new()),
             rider_index: RiderIndex::default(),
+            tick_in_progress: false,
         })
     }
 
@@ -561,6 +562,7 @@ impl Simulation {
             reposition_buf: Vec::new(),
             topo_graph: Mutex::new(TopologyGraph::new()),
             rider_index,
+            tick_in_progress: false,
         }
     }
 

--- a/crates/elevator-core/src/sim/substep.rs
+++ b/crates/elevator-core/src/sim/substep.rs
@@ -65,6 +65,7 @@ impl super::Simulation {
     /// elevators to move before dispatch, or transient states to persist
     /// across tick boundaries.
     pub fn run_advance_transient(&mut self) {
+        self.tick_in_progress = true;
         self.hooks
             .run_before(Phase::AdvanceTransient, &mut self.world);
         for group in &self.groups {
@@ -283,6 +284,7 @@ impl super::Simulation {
     pub fn advance_tick(&mut self) {
         self.pending_output.extend(self.events.drain());
         self.tick += 1;
+        self.tick_in_progress = false;
     }
 
     /// Advance the simulation by one tick.

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -18,7 +18,7 @@ use crate::metrics::Metrics;
 use crate::stop::StopId;
 use crate::tagged_metrics::MetricTags;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// Serializable snapshot of a single entity's components.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -74,8 +74,18 @@ pub struct EntitySnapshot {
 /// and restore via [`WorldSnapshot::restore()`]. The game chooses the serde format
 /// (RON, JSON, bincode, etc.).
 ///
-/// Extension components and resources are NOT included. Games must
-/// handle their own custom data separately.
+/// **Determinism:** the map fields below all use `BTreeMap` instead of
+/// `HashMap` so postcard/RON/JSON serialize entries in a deterministic
+/// (key-sorted) order. With `HashMap`, two snapshots of the same sim
+/// taken in different processes produced different bytes, defeating
+/// content-addressed caching and bit-equality replay (#254).
+///
+/// **Extension components are included** (via `extensions`); games must
+/// register types via `register_ext` before `restore()` to materialize them.
+/// **Custom resources** inserted via `world.insert_resource` are NOT
+/// snapshotted — only the built-in `MetricTags` resource is captured
+/// in `metric_tags`. Games using custom resources must save and restore
+/// them out-of-band (#296).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorldSnapshot {
     /// Current simulation tick.
@@ -87,14 +97,16 @@ pub struct WorldSnapshot {
     pub entities: Vec<EntitySnapshot>,
     /// Elevator groups (references into entities by index).
     pub groups: Vec<GroupSnapshot>,
-    /// Stop ID → entity index mapping.
-    pub stop_lookup: HashMap<StopId, usize>,
+    /// Stop ID → entity index mapping. `BTreeMap` for deterministic
+    /// snapshot bytes across processes (#254).
+    pub stop_lookup: BTreeMap<StopId, usize>,
     /// Global metrics at snapshot time.
     pub metrics: Metrics,
     /// Per-tag metric accumulators and entity-tag associations.
     pub metric_tags: MetricTags,
     /// Serialized extension component data: name → (`EntityId` → RON string).
-    pub extensions: HashMap<String, HashMap<EntityId, String>>,
+    /// Both maps are `BTreeMap` for deterministic snapshot bytes (#254).
+    pub extensions: BTreeMap<String, BTreeMap<EntityId, String>>,
     /// Ticks per second (for `TimeAdapter` reconstruction).
     pub ticks_per_second: f64,
     /// All pending hall calls across every stop. Absent in legacy snapshots.
@@ -145,7 +157,7 @@ pub struct GroupSnapshot {
 /// Stored as a world resource after `restore()`. Call
 /// `sim.load_extensions()` after registering extension types to
 /// deserialize the data.
-pub(crate) struct PendingExtensions(pub(crate) HashMap<String, HashMap<EntityId, String>>);
+pub(crate) struct PendingExtensions(pub(crate) BTreeMap<String, BTreeMap<EntityId, String>>);
 
 /// Factory function type for instantiating custom dispatch strategies by name.
 type CustomStrategyFactory<'a> =
@@ -537,13 +549,13 @@ impl WorldSnapshot {
 
     /// Remap `EntityId`s in extension data using the old→new mapping.
     fn remap_extensions(
-        extensions: &HashMap<String, HashMap<EntityId, String>>,
+        extensions: &BTreeMap<String, BTreeMap<EntityId, String>>,
         id_remap: &HashMap<EntityId, EntityId>,
-    ) -> HashMap<String, HashMap<EntityId, String>> {
+    ) -> BTreeMap<String, BTreeMap<EntityId, String>> {
         extensions
             .iter()
             .map(|(name, entries)| {
-                let remapped: HashMap<EntityId, String> = entries
+                let remapped: BTreeMap<EntityId, String> = entries
                     .iter()
                     .map(|(old_id, data)| {
                         let new_id = id_remap.get(old_id).copied().unwrap_or(*old_id);
@@ -669,10 +681,44 @@ impl crate::sim::Simulation {
     /// Create a serializable snapshot of the current simulation state.
     ///
     /// The snapshot captures all entities, components, groups, metrics,
-    /// and the tick counter. Extension components and custom resources
-    /// are NOT included — games must serialize those separately.
+    /// the tick counter, and extension component data (game must
+    /// re-register types via `register_ext` before `restore`).
+    /// Custom resources inserted via `world.insert_resource` are NOT
+    /// captured — games using them must save/restore separately (#296).
+    ///
+    /// **Mid-tick safety:** `snapshot()` returns a snapshot regardless
+    /// of whether you are mid-tick (between phase calls in the substep
+    /// API). For substep callers that care about event-bus state, use
+    /// [`try_snapshot`](Self::try_snapshot) which returns
+    /// [`SimError::MidTickSnapshot`](crate::error::SimError::MidTickSnapshot)
+    /// when invoked between `run_*` and `advance_tick`. (#297)
     #[must_use]
+    #[allow(clippy::too_many_lines)]
     pub fn snapshot(&self) -> WorldSnapshot {
+        self.snapshot_inner()
+    }
+
+    /// Like [`snapshot`](Self::snapshot) but returns
+    /// [`SimError::MidTickSnapshot`](crate::error::SimError::MidTickSnapshot)
+    /// when called between phases of an in-progress tick. (#297)
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SimError::MidTickSnapshot`](crate::error::SimError::MidTickSnapshot)
+    /// when invoked between a `run_*` phase call and the matching
+    /// `advance_tick`.
+    pub fn try_snapshot(&self) -> Result<WorldSnapshot, crate::error::SimError> {
+        if self.tick_in_progress {
+            return Err(crate::error::SimError::MidTickSnapshot);
+        }
+        Ok(self.snapshot())
+    }
+
+    /// Internal snapshot builder shared by [`snapshot`](Self::snapshot)
+    /// and [`try_snapshot`](Self::try_snapshot). Holds the line-count
+    /// allow so the public methods remain visible in nursery lints.
+    #[allow(clippy::too_many_lines)]
+    fn snapshot_inner(&self) -> WorldSnapshot {
         let world = self.world();
 
         // Build entity index: map EntityId → position in vec.
@@ -761,7 +807,7 @@ impl crate::sim::Simulation {
             .collect();
 
         // Snapshot stop lookup (convert EntityIds to indices).
-        let stop_lookup: HashMap<StopId, usize> = self
+        let stop_lookup: BTreeMap<StopId, usize> = self
             .stop_lookup_iter()
             .filter_map(|(sid, eid)| id_to_index.get(eid).map(|&idx| (*sid, idx)))
             .collect();
@@ -800,15 +846,17 @@ impl crate::sim::Simulation {
     /// not included.
     ///
     /// # Errors
-    /// Returns [`SimError::SnapshotFormat`](crate::error::SimError::SnapshotFormat)
-    /// if postcard encoding fails. This is unreachable for well-formed
-    /// `WorldSnapshot` values (all fields derive `Serialize`), so callers
-    /// that don't care can `unwrap`.
+    /// - [`SimError::SnapshotFormat`](crate::error::SimError::SnapshotFormat)
+    ///   if postcard encoding fails. Unreachable for well-formed
+    ///   `WorldSnapshot` values, so callers that don't care can `unwrap`.
+    /// - [`SimError::MidTickSnapshot`](crate::error::SimError::MidTickSnapshot)
+    ///   if invoked between phases of an in-progress tick (substep API
+    ///   path) — the in-flight `EventBus` would otherwise be lost. (#297)
     pub fn snapshot_bytes(&self) -> Result<Vec<u8>, crate::error::SimError> {
         let envelope = SnapshotEnvelope {
             magic: SNAPSHOT_MAGIC,
             version: env!("CARGO_PKG_VERSION").to_owned(),
-            payload: self.snapshot(),
+            payload: self.try_snapshot()?,
         };
         postcard::to_allocvec(&envelope)
             .map_err(|e| crate::error::SimError::SnapshotFormat(e.to_string()))

--- a/crates/elevator-core/src/stop.rs
+++ b/crates/elevator-core/src/stop.rs
@@ -4,7 +4,7 @@ use crate::entity::EntityId;
 use serde::{Deserialize, Serialize};
 
 /// Numeric identifier for a stop along the shaft.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct StopId(pub u32);
 
 /// A reference to a stop by either its config-time [`StopId`] or its

--- a/crates/elevator-core/src/tagged_metrics.rs
+++ b/crates/elevator-core/src/tagged_metrics.rs
@@ -6,7 +6,7 @@
 //! "what's the average wait time for zone:express?".
 
 use crate::entity::EntityId;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 /// Per-tag metric accumulator.
 ///
@@ -96,10 +96,12 @@ impl TaggedMetric {
 /// metrics are pre-computed per tag each tick.
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct MetricTags {
-    /// Entity → tags mapping.
-    entity_tags: HashMap<EntityId, Vec<String>>,
-    /// Tag → accumulated metrics.
-    tag_metrics: HashMap<String, TaggedMetric>,
+    /// Entity → tags mapping. `BTreeMap` for deterministic snapshot
+    /// serialization order (#254).
+    entity_tags: BTreeMap<EntityId, Vec<String>>,
+    /// Tag → accumulated metrics. `BTreeMap` for deterministic snapshot
+    /// serialization order (#254).
+    tag_metrics: BTreeMap<String, TaggedMetric>,
 }
 
 impl MetricTags {
@@ -185,7 +187,7 @@ impl MetricTags {
 
     /// Remap all entity IDs using the provided mapping (for snapshot restore).
     pub(crate) fn remap_entity_ids(&mut self, remap: &HashMap<EntityId, EntityId>) {
-        let old_tags: HashMap<EntityId, Vec<String>> = std::mem::take(&mut self.entity_tags);
+        let old_tags: BTreeMap<EntityId, Vec<String>> = std::mem::take(&mut self.entity_tags);
         for (old_id, tags) in old_tags {
             let new_id = remap.get(&old_id).copied().unwrap_or(old_id);
             self.entity_tags.insert(new_id, tags);

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -582,3 +582,65 @@ fn snapshot_roundtrip_emits_no_dangling_warnings() {
         "normal snapshot should have no dangling references"
     );
 }
+
+/// `try_snapshot` rejects mid-tick captures so substep callers don't
+/// silently lose in-flight `EventBus` state. `snapshot()` keeps the old
+/// non-fallible signature for tick-boundary callers. (#297)
+#[test]
+fn try_snapshot_rejects_mid_tick() {
+    use crate::error::SimError;
+
+    let config = helpers::default_config();
+    let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+
+    // Start a tick via the substep API but don't call advance_tick.
+    sim.run_advance_transient();
+
+    let result = sim.try_snapshot();
+    assert!(
+        matches!(result, Err(SimError::MidTickSnapshot)),
+        "mid-tick try_snapshot must error, got {result:?}"
+    );
+
+    // After advance_tick, try_snapshot succeeds again.
+    sim.advance_tick();
+    assert!(sim.try_snapshot().is_ok());
+}
+
+/// `snapshot_bytes` also enforces the mid-tick guard — bytes path is
+/// the most common production use, so the constraint applies there too.
+#[test]
+fn snapshot_bytes_rejects_mid_tick() {
+    use crate::error::SimError;
+
+    let config = helpers::default_config();
+    let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+
+    sim.run_advance_transient();
+
+    let result = sim.snapshot_bytes();
+    assert!(matches!(result, Err(SimError::MidTickSnapshot)));
+}
+
+/// Snapshot bytes are deterministic across processes — using `BTreeMap`
+/// for `stop_lookup`, `extensions`, and `metric_tags` removes the
+/// `HashMap` iteration-order non-determinism. (#254)
+#[test]
+fn snapshot_bytes_are_deterministic() {
+    let config = helpers::default_config();
+    let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+    let stop0 = sim.stop_entity(StopId(0)).unwrap();
+    sim.tag_entity(stop0, "zone:lobby").unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.spawn_rider(StopId(1), StopId(0), 60.0).unwrap();
+    for _ in 0..10 {
+        sim.step();
+    }
+
+    let bytes1 = sim.snapshot_bytes().unwrap();
+    let bytes2 = sim.snapshot_bytes().unwrap();
+    assert_eq!(
+        bytes1, bytes2,
+        "two snapshots of the same sim must be byte-identical"
+    );
+}

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -1,7 +1,7 @@
 //! Central entity/component storage (struct-of-arrays ECS).
 
 use std::any::{Any, TypeId};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::marker::PhantomData;
 
 use slotmap::{SecondaryMap, SlotMap};
@@ -799,9 +799,10 @@ impl World {
     }
 
     /// Serialize all extension component data for snapshot.
-    /// Returns name → (`EntityId` → RON string) mapping.
-    pub(crate) fn serialize_extensions(&self) -> HashMap<String, HashMap<EntityId, String>> {
-        let mut result = HashMap::new();
+    /// Returns name → (`EntityId` → RON string) mapping. `BTreeMap` for
+    /// deterministic snapshot bytes across processes (#254).
+    pub(crate) fn serialize_extensions(&self) -> BTreeMap<String, BTreeMap<EntityId, String>> {
+        let mut result = BTreeMap::new();
         for (type_id, map) in &self.extensions {
             if let Some(name) = self.ext_names.get(type_id) {
                 result.insert(name.clone(), map.serialize_entries());
@@ -814,7 +815,7 @@ impl World {
     /// have been registered (via `register_ext_deserializer`) before calling.
     pub(crate) fn deserialize_extensions(
         &mut self,
-        data: &HashMap<String, HashMap<EntityId, String>>,
+        data: &BTreeMap<String, BTreeMap<EntityId, String>>,
     ) {
         for (name, entries) in data {
             // Find the TypeId by name.


### PR DESCRIPTION
Closes #254, #296, #297. Three round-3 issues bundled in the snapshot module.

- **#254** `HashMap` \u2192 `BTreeMap` for `stop_lookup`, `extensions`, `MetricTags`, and `utilization_by_group`. Added `Ord` to `StopId`. Snapshot bytes now byte-identical across processes (test pinned).
- **#296** Documented that custom resources via `insert_resource` are NOT snapshotted; only built-in `MetricTags` is. Also corrected the doc that said extension components are "NOT included" \u2014 they are.
- **#297** Added `try_snapshot()` returning `Result<WorldSnapshot, SimError::MidTickSnapshot>`. `snapshot_bytes()` uses it internally so the bytes path also enforces the guard. `snapshot()` keeps its non-fallible signature for tick-boundary callers.