### PR TITLE
fix(dispatch): hall calls + restricted_stops + group-reassign leak (#255/#256/#257)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.2.11"
+version = "15.2.14"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -121,10 +121,28 @@ impl DispatchManifest {
         self.riding_to_stop.get(&stop).map_or(0, Vec::len)
     }
 
-    /// Whether a stop has any demand (waiting riders or riders heading there).
+    /// Whether a stop has any demand for this group: waiting riders,
+    /// riders heading there, or a *rider-less* hall call (one that
+    /// `press_hall_button` placed without a backing rider). Pre-fix
+    /// the rider-less case was invisible to every built-in dispatcher,
+    /// so explicit button presses with no associated rider went
+    /// unanswered indefinitely (#255).
+    ///
+    /// Hall calls *with* `pending_riders` are not double-counted —
+    /// those riders already appear in `waiting_count_at` for the
+    /// groups whose dispatch surface they belong to. Adding the call
+    /// to `has_demand` for *every* group that serves the stop would
+    /// pull cars from groups the rider doesn't even want, causing
+    /// open/close oscillation regression that the multi-group test
+    /// `dispatch_ignores_waiting_rider_targeting_another_group` pins.
     #[must_use]
     pub fn has_demand(&self, stop: EntityId) -> bool {
-        self.waiting_count_at(stop) > 0 || self.riding_count_to(stop) > 0
+        self.waiting_count_at(stop) > 0
+            || self.riding_count_to(stop) > 0
+            || self
+                .hall_calls_at_stop
+                .get(&stop)
+                .is_some_and(|calls| calls.iter().any(|c| c.pending_riders.is_empty()))
     }
 
     /// Number of residents at a stop (read-only hint, not active demand).
@@ -713,7 +731,19 @@ pub(crate) fn assign(
     let mut data: Vec<i64> = vec![ASSIGNMENT_SENTINEL; n * cols];
     for (i, &(car_eid, car_pos)) in idle_cars.iter().enumerate() {
         strategy.prepare_car(car_eid, car_pos, group, manifest, world);
+        // Cache the car's restricted-stops set for this row so each
+        // (car, stop) pair can short-circuit before calling rank().
+        // Pre-fix only DCS consulted restricted_stops; SCAN/LOOK/NC/ETD
+        // happily ranked restricted pairs and `commit_go_to_stop` later
+        // silently dropped the assignment, starving the call. (#256)
+        let restricted = world
+            .elevator(car_eid)
+            .map(|c| c.restricted_stops().clone())
+            .unwrap_or_default();
         for (j, &(stop_eid, stop_pos)) in pending_stops.iter().enumerate() {
+            if restricted.contains(&stop_eid) {
+                continue; // leave SENTINEL — this pair is unavailable
+            }
             let ctx = RankContext {
                 car: car_eid,
                 car_position: car_pos,

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -488,6 +488,19 @@ impl Simulation {
 
         let old_group_id = self.groups[old_group_idx].id();
 
+        // Notify the old dispatcher that these elevators are leaving — its
+        // per-elevator state (e.g. ScanDispatch.direction keyed by EntityId)
+        // would otherwise leak indefinitely as lines move between groups.
+        // Mirrors the cleanup `reassign_elevator_to_line` already does. (#257)
+        let elevators_to_notify: Vec<EntityId> = self.groups[old_group_idx].lines()[line_idx]
+            .elevators()
+            .to_vec();
+        if let Some(dispatcher) = self.dispatchers.get_mut(&old_group_id) {
+            for eid in &elevators_to_notify {
+                dispatcher.notify_removed(*eid);
+            }
+        }
+
         // Remove LineInfo from old group.
         let line_info = self.groups[old_group_idx].lines_mut().remove(line_idx);
         self.groups[old_group_idx].rebuild_caches();

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -917,3 +917,37 @@ fn unacknowledged_hall_calls_hidden_from_manifest() {
         "after ack-latency elapses, the call should appear in the manifest",
     );
 }
+
+/// `press_hall_button` without a backing rider must summon an idle car.
+/// Pre-fix `manifest.has_demand(stop)` was rider-only so rider-less
+/// hall calls (scripted NPCs, player input) were invisible to every
+/// built-in dispatcher. (#255)
+#[test]
+fn press_hall_button_alone_dispatches_idle_elevator() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    let target = sim.stop_entity(StopId(2)).unwrap();
+    let elev = sim.world().elevator_ids()[0];
+    assert!(sim.world().elevator(elev).unwrap().target_stop.is_none());
+
+    sim.press_hall_button(target, CallDirection::Down).unwrap();
+
+    let target_pos = sim.world().stop_position(target).unwrap();
+    let mut summoned = false;
+    for _ in 0..500 {
+        sim.step();
+        let car = sim.world().elevator(elev).unwrap();
+        if car.target_stop == Some(target)
+            || sim
+                .world()
+                .position(elev)
+                .is_some_and(|p| (p.value - target_pos).abs() < 1.0)
+        {
+            summoned = true;
+            break;
+        }
+    }
+    assert!(
+        summoned,
+        "rider-less hall call must summon idle car within 500 ticks"
+    );
+}


### PR DESCRIPTION
Closes #255, #256, #257.

- **#255**: `has_demand` now also returns true for rider-less hall calls (the press_hall_button-only case). Narrow not broad: hall calls with pending_riders are already counted by `waiting_count_at`, and counting them per-group would summon cars from the wrong group.
- **#256**: Move `restricted_stops` check into `dispatch::assign` so all strategies short-circuit before `rank()`. Pre-fix only DCS honoured it; SCAN/LOOK/NC/ETD ranked restricted pairs and commit_go_to_stop silently dropped them.
- **#257**: `assign_line_to_group` calls `notify_removed` on the old dispatcher for moved elevators \u2014 mirrors what `reassign_elevator_to_line` already did.