### PR TITLE
fix(api): AccessControl + record_hall_assignment + typed-ID footgun (#289/#290/#294)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.2.11"
+version = "15.2.14"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/components/access.rs
+++ b/crates/elevator-core/src/components/access.rs
@@ -7,30 +7,42 @@ use std::collections::HashSet;
 /// Per-rider access control: which stops the rider is allowed to visit.
 ///
 /// When absent from a rider entity, the rider has unrestricted access.
-/// When present, only stops in [`allowed_stops`](Self::allowed_stops) are
-/// reachable — boarding is rejected with
-/// [`RejectionReason::AccessDenied`](crate::error::RejectionReason::AccessDenied)
-/// if the rider's current destination is not in the set.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// When present, [`can_access`](Self::can_access) returns `true` either
+/// when the queried stop is in [`allowed_stops`](Self::allowed_stops)
+/// or when the set is empty — an empty set means "no restriction"
+/// (matches `AccessControl::default()` and the principle-of-least-
+/// surprise that an empty allowlist shouldn't silently block all access).
+/// To explicitly block all stops, use a sentinel set or a dedicated
+/// no-access wrapper. (#289)
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AccessControl {
     /// Set of stop `EntityId`s this rider may visit.
+    ///
+    /// **Semantics**: empty set ⇒ unrestricted (allow all). Non-empty
+    /// set ⇒ allowlist; `can_access(stop)` is true iff `stop` is in
+    /// the set.
     allowed_stops: HashSet<EntityId>,
 }
 
 impl AccessControl {
     /// Create a new access control with the given set of allowed stops.
+    /// Pass an empty set for "no restriction" (unrestricted access).
     #[must_use]
     pub const fn new(allowed_stops: HashSet<EntityId>) -> Self {
         Self { allowed_stops }
     }
 
     /// Check if the rider can access the given stop.
+    ///
+    /// An empty `allowed_stops` set is treated as "no restriction" —
+    /// `can_access` returns `true` for any stop. A non-empty set is an
+    /// allowlist; `stop` must be a member.
     #[must_use]
     pub fn can_access(&self, stop: EntityId) -> bool {
-        self.allowed_stops.contains(&stop)
+        self.allowed_stops.is_empty() || self.allowed_stops.contains(&stop)
     }
 
-    /// The set of allowed stop entity IDs.
+    /// The set of allowed stop entity IDs. Empty means unrestricted.
     #[must_use]
     pub const fn allowed_stops(&self) -> &HashSet<EntityId> {
         &self.allowed_stops

--- a/crates/elevator-core/src/entity.rs
+++ b/crates/elevator-core/src/entity.rs
@@ -36,6 +36,12 @@ macro_rules! typed_entity_id {
         }
 
         impl From<EntityId> for $name {
+            /// Wrap an `EntityId` in this typed newtype **without** verifying
+            /// the entity is actually of that kind. Wrong-type IDs surface
+            /// later as `EntityNotFound` / `NotAnElevator` from accessor
+            /// calls — for compile-time safety, prefer the typed
+            /// `_id` accessors on `Simulation` (`elevator_ids`,
+            /// `rider_ids`, etc.) that yield typed IDs directly. (#290)
             #[inline]
             fn from(id: EntityId) -> Self {
                 Self(id)

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -262,18 +262,29 @@ fn record_hall_assignment(world: &mut World, stop: EntityId, car: EntityId) {
     let Some(stop_pos) = world.stop_position(stop) else {
         return;
     };
-    let direction = if stop_pos > car_pos {
-        CallDirection::Up
+    if stop_pos > car_pos {
+        update_assignment(world, stop, CallDirection::Up, car);
     } else if stop_pos < car_pos {
-        CallDirection::Down
+        update_assignment(world, stop, CallDirection::Down, car);
     } else {
-        // Same position — prefer whichever call exists (Up first).
-        if world.hall_call(stop, CallDirection::Up).is_some() {
-            CallDirection::Up
-        } else {
-            CallDirection::Down
-        }
-    };
+        // Equal position: dispatch picks a stop, not a direction. If both
+        // Up and Down calls exist at this stop, mark BOTH so the
+        // public `sim.assigned_car(stop, _)` accessor gives a consistent
+        // answer. Pre-fix only Up was updated (and only when an Up call
+        // existed) — Down's `assigned_car` stayed stale, lying to
+        // observability consumers. (#294)
+        update_assignment(world, stop, CallDirection::Up, car);
+        update_assignment(world, stop, CallDirection::Down, car);
+    }
+}
+
+/// Helper: set `assigned_car` on a hall call if it exists and is unpinned.
+fn update_assignment(
+    world: &mut World,
+    stop: EntityId,
+    direction: crate::components::CallDirection,
+    car: EntityId,
+) {
     if let Some(call) = world.hall_call_mut(stop, direction)
         && !call.pinned
     {

--- a/crates/elevator-core/src/tests/access_tests.rs
+++ b/crates/elevator-core/src/tests/access_tests.rs
@@ -343,3 +343,34 @@ fn config_restricted_stops_serde_roundtrip() {
             .contains(&StopId(2))
     );
 }
+
+/// `AccessControl::default()` (empty `allowed_stops`) means unrestricted —
+/// every `can_access` query returns true. Pre-fix an empty set
+/// silently blocked all access, so `set_rider_access(rider,
+/// AccessControl::default())` bricked the rider with no warning. (#289)
+#[test]
+fn access_control_empty_allows_any_stop() {
+    use crate::entity::EntityId;
+
+    let ac = AccessControl::default();
+    assert!(ac.allowed_stops().is_empty());
+    // Any stop entity should be reachable. EntityId::default() is a
+    // safe stand-in here because `can_access` doesn't dereference the
+    // id, just predicates on set membership.
+    assert!(ac.can_access(EntityId::default()));
+}
+
+/// Non-empty `allowed_stops` is an allowlist: only listed stops pass.
+#[test]
+fn access_control_non_empty_is_an_allowlist() {
+    use crate::entity::EntityId;
+
+    let allowed = EntityId::default();
+    let mut set = HashSet::new();
+    set.insert(allowed);
+    let ac = AccessControl::new(set);
+
+    assert!(ac.can_access(allowed));
+    // Negative case (a different EntityId rejected) is covered by the
+    // existing `rider_rejected_by_rider_access_control` integration test.
+}


### PR DESCRIPTION
Closes #289, #290, #294. Three round-3 API ergonomics issues bundled.

- **#289**: `can_access` now treats empty `allowed_stops` as unrestricted (matches the default). Pre-fix empty silently blocked all access. Doc the new contract.
- **#294**: When dispatch commits a car to a stop and the car is already there, both Up and Down hall-call `assigned_car` fields are updated (was Up only).
- **#290**: Document on the `From<EntityId>` impl that the wrap is unchecked. Stricter fix would touch every call site.