### PR TITLE
chore: address greptile P2 follow-ups from #306/#308/#310

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.2.14"
+version = "15.2.17"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -488,6 +488,14 @@ impl Simulation {
 
         let old_group_id = self.groups[old_group_idx].id();
 
+        // Same-group reassign is a no-op. Skip BEFORE the notify_removed
+        // calls or we'd needlessly clear each elevator's dispatcher state
+        // (direction tracking in SCAN/LOOK, etc.) on a redundant move.
+        // Matches the early-return pattern in `reassign_elevator_to_line`.
+        if old_group_id == new_group {
+            return Ok(old_group_id);
+        }
+
         // Notify the old dispatcher that these elevators are leaving — its
         // per-elevator state (e.g. ScanDispatch.direction keyed by EntityId)
         // would otherwise leak indefinitely as lines move between groups.
@@ -505,10 +513,10 @@ impl Simulation {
         let line_info = self.groups[old_group_idx].lines_mut().remove(line_idx);
         self.groups[old_group_idx].rebuild_caches();
 
-        // Add LineInfo to new group.
-        // Re-lookup new_group_idx since removal may have shifted indices
-        // (only possible if old and new are different groups; if same group
-        // the line_info was already removed above).
+        // Re-lookup new_group_idx by ID — we didn't capture it before the
+        // mutation. (Removal of a `LineInfo` from a group's inner `lines`
+        // vec doesn't shift `self.groups` indices, so this is purely about
+        // not having stored the index earlier, not about index invalidation.)
         let new_group_idx = self
             .groups
             .iter()

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -693,7 +693,6 @@ impl crate::sim::Simulation {
     /// [`SimError::MidTickSnapshot`](crate::error::SimError::MidTickSnapshot)
     /// when invoked between `run_*` and `advance_tick`. (#297)
     #[must_use]
-    #[allow(clippy::too_many_lines)]
     pub fn snapshot(&self) -> WorldSnapshot {
         self.snapshot_inner()
     }

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -951,3 +951,40 @@ fn press_hall_button_alone_dispatches_idle_elevator() {
         "rider-less hall call must summon idle car within 500 ticks"
     );
 }
+
+/// When a car is already at a stop and dispatch commits to that stop,
+/// `record_hall_assignment` must update BOTH Up and Down hall-call
+/// `assigned_car` fields if both calls exist there. Pre-fix only Up was
+/// written, leaving `sim.assigned_car(stop, Down)` lying about the
+/// observability state. (#294)
+///
+/// Uses the per-phase substep API to inspect state between `dispatch`
+/// (which sets `assigned_car`) and `doors` (which clears the hall call
+/// once the door opens). A full `step()` would race past the assertion
+/// because both phases run in the same tick.
+#[test]
+fn assigned_car_set_on_both_directions_when_car_at_stop() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    let here = sim.stop_entity(StopId(0)).unwrap();
+    let elev = sim.world().elevator_ids()[0];
+    sim.press_hall_button(here, CallDirection::Up).unwrap();
+    sim.press_hall_button(here, CallDirection::Down).unwrap();
+
+    // Drive the tick by hand: ack the calls, then run dispatch, then
+    // check assigned_car on both directions BEFORE the doors phase
+    // clears the calls.
+    sim.run_advance_transient();
+    sim.run_dispatch();
+
+    assert_eq!(
+        sim.assigned_car(here, CallDirection::Up),
+        Some(elev),
+        "Up assigned_car must reflect the dispatched car"
+    );
+    assert_eq!(
+        sim.assigned_car(here, CallDirection::Down),
+        Some(elev),
+        "Down assigned_car must also reflect the dispatched car \
+         (pre-fix Down stayed None, lying about dispatch state)"
+    );
+}

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -622,11 +622,14 @@ fn snapshot_bytes_rejects_mid_tick() {
     assert!(matches!(result, Err(SimError::MidTickSnapshot)));
 }
 
-/// Snapshot bytes are deterministic across processes — using `BTreeMap`
-/// for `stop_lookup`, `extensions`, and `metric_tags` removes the
-/// `HashMap` iteration-order non-determinism. (#254)
+/// Snapshot bytes are stable within a process. The actual cross-process
+/// determinism guarantee comes from the `BTreeMap` key-sort invariant
+/// applied to `stop_lookup`, `extensions`, and `metric_tags` (#254) —
+/// `HashMap`'s `RandomState` seed is fixed per-process, so this in-process
+/// test would pass even with the old `HashMap` code. The cross-process
+/// property is enforced by the type choice rather than a runtime test.
 #[test]
-fn snapshot_bytes_are_deterministic() {
+fn snapshot_bytes_are_stable_in_process() {
     let config = helpers::default_config();
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
     let stop0 = sim.stop_entity(StopId(0)).unwrap();


### PR DESCRIPTION
Five small post-merge cleanups (P2 polish).

- **#306**: drop redundant `#[allow]` on `snapshot()` wrapper; rename determinism test + clarify cross-process guarantee comes from `BTreeMap`, not this in-process test.
- **#308**: add same-group short-circuit in `assign_line_to_group`; fix misleading index-shifting comment.
- **#310**: add missing #294 regression test using the per-phase substep API.