### PR TITLE
fix(docs): strip wasm-pack .gitignore before Pages deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -84,9 +84,18 @@ jobs:
       - name: Stage playground into mdBook output
         # mdBook emits to target/book. Drop the playground bundle under
         # /playground/ there so the deployed Pages site has both.
+        #
+        # wasm-pack emits a `.gitignore` containing `*` inside `public/pkg/`
+        # so the source tree never tracks generated artifacts. Vite copies
+        # publicDir verbatim, so that file rides into `dist/pkg/.gitignore`
+        # and then into the staged tree. `peaceiris/actions-gh-pages` uses
+        # `git add` under the hood, which honors the nested ignore and
+        # silently drops every pkg/ file from the publish — the deploy
+        # succeeds but the playground 404s on its wasm. Strip it here.
         run: |
           mkdir -p target/book/playground
           cp -r playground/dist/. target/book/playground/
+          rm -f target/book/playground/pkg/.gitignore
 
       # Publish to gh-pages branch (not the workflow Pages artifact) so the
       # nightly-bench dashboard at /bench/ — pushed by


### PR DESCRIPTION
## Summary
- `wasm-pack` emits a `.gitignore` (just `*`) inside its output dir so the source tree never tracks the generated pkg.
- Vite copies `public/*` verbatim → `dist/pkg/.gitignore` → `target/book/playground/pkg/.gitignore`.
- `peaceiris/actions-gh-pages` publishes via `git add`, which honors nested ignores → every file under `pkg/` was silently dropped from the publish.
- Result: CI green, deploy succeeded, but `https://andymai.github.io/elevator-core/playground/pkg/elevator_wasm.js` 404'd → browser console showed "failed to import dynamic module".
- Fix: `rm -f target/book/playground/pkg/.gitignore` after the `cp` during the stage step.

## Evidence
Before: `git ls-tree -r origin/gh-pages` shows `playground/index.html` and `playground/assets/*` only — no `playground/pkg/`. After this workflow runs the next time, `pkg/` should be present.

Curl confirms the symptom on current main:
- `GET /elevator-core/playground/pkg/elevator_wasm.js` → 404
- `GET /elevator-core/playground/pkg/elevator_wasm_bg.wasm` → 404
- `GET /elevator-core/playground/assets/index-*.js` → 200

Local `pnpm build` produces `dist/pkg/` correctly — confirms the bug is in the publish step, not the build.

## Test plan
- [ ] Wait for greptile review.
- [ ] After merge, the next `Docs` workflow run should populate `playground/pkg/` on `gh-pages`.
- [ ] Verify with `curl -I https://andymai.github.io/elevator-core/playground/pkg/elevator_wasm.js` returning 200.
- [ ] Hard-reload the deployed playground and confirm the sim runs.