### PR TITLE
fix(dispatch): guard against full-car self-assign stalls across strategies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.2.18"
+version = "15.3.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -32,7 +32,7 @@ use crate::components::{DestinationQueue, Direction, ElevatorPhase, TransportMod
 use crate::entity::EntityId;
 use crate::world::{ExtKey, World};
 
-use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext};
+use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext, pair_can_do_work};
 
 /// Sticky rider → car assignment produced by [`DestinationDispatch`].
 ///
@@ -234,11 +234,22 @@ impl DispatchStrategy for DestinationDispatch {
         // its own queue front. Every other stop is unavailable for this
         // car, so the Hungarian assignment reduces to the identity match
         // between each car and the stop it has already committed to.
+        //
+        // The `pair_can_do_work` gate guards against the same full-car
+        // self-assign stall the other built-ins close: a sticky DCS
+        // assignment whose car has filled up with earlier riders and
+        // whose queue front is still the *pickup* for an un-boarded
+        // rider would otherwise rank 0.0, win the Hungarian every tick,
+        // and cycle doors forever.
         let front = ctx
             .world
             .destination_queue(ctx.car)
             .and_then(DestinationQueue::front)?;
-        if front == ctx.stop { Some(0.0) } else { None }
+        if front == ctx.stop && pair_can_do_work(ctx) {
+            Some(0.0)
+        } else {
+            None
+        }
     }
 }
 

--- a/crates/elevator-core/src/dispatch/etd.rs
+++ b/crates/elevator-core/src/dispatch/etd.rs
@@ -12,7 +12,7 @@ use crate::components::{ElevatorPhase, Route};
 use crate::entity::EntityId;
 use crate::world::World;
 
-use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext};
+use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext, pair_can_do_work};
 
 /// Estimated Time to Destination (ETD) dispatch algorithm.
 ///
@@ -95,6 +95,16 @@ impl DispatchStrategy for EtdDispatch {
     }
 
     fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+        // Exclude `(car, stop)` pairs that can't produce any useful work.
+        // Without this guard, a full car whose only candidate stop is a
+        // pickup it lacks capacity to serve collapses to a zero-cost
+        // self-assignment (travel, detour, and door terms are all 0 when
+        // the car is already at the stop). Dispatch then re-selects that
+        // stop every tick — doors cycle open, reject, close, repeat — and
+        // the aboard riders are never carried to their destinations.
+        if !pair_can_do_work(ctx) {
+            return None;
+        }
         let cost = self.compute_cost(ctx.car, ctx.car_position, ctx.stop_position, ctx.world);
         if cost.is_finite() { Some(cost) } else { None }
     }

--- a/crates/elevator-core/src/dispatch/look.rs
+++ b/crates/elevator-core/src/dispatch/look.rs
@@ -16,7 +16,7 @@ use crate::entity::EntityId;
 use crate::world::World;
 
 use super::sweep::{self, SweepDirection, SweepMode};
-use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext};
+use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext, pair_can_do_work};
 
 /// Elevator dispatch using the LOOK algorithm. See module docs.
 pub struct LookDispatch {
@@ -75,6 +75,12 @@ impl DispatchStrategy for LookDispatch {
     }
 
     fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+        // Same guard as SCAN: deny un-servable pairs so an over-capacity
+        // waiting rider at the car's own stop can't pull the car into a
+        // cost-0 self-assignment during the Lenient reversal tick.
+        if !pair_can_do_work(ctx) {
+            return None;
+        }
         sweep::rank(
             self.mode_for(ctx.car),
             self.direction_for(ctx.car),

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -55,11 +55,47 @@ pub use scan::ScanDispatch;
 
 use serde::{Deserialize, Serialize};
 
-use crate::components::{CallDirection, CarCall, HallCall, Weight};
+use crate::components::{CallDirection, CarCall, HallCall, Route, Weight};
 use crate::entity::EntityId;
 use crate::ids::GroupId;
 use crate::world::World;
 use std::collections::BTreeMap;
+
+/// Whether assigning `ctx.car` to `ctx.stop` can perform useful work.
+///
+/// "Useful" here means one of: exit an aboard rider, board a waiting
+/// rider that fits, or answer a rider-less hall call with at least some
+/// spare capacity. A pair that can do none of those is a no-op move —
+/// and worse, a zero-cost one when the car is already parked at the
+/// stop — which dispatch strategies must exclude to avoid door-cycle
+/// stalls against unservable demand.
+///
+/// Built-in strategies use this as a universal floor; delivery-safety
+/// guarantees are only as strong as this guard. Custom strategies
+/// should call it at the top of their `rank` implementations when
+/// capacity-based stalls are a concern.
+#[must_use]
+pub fn pair_can_do_work(ctx: &RankContext<'_>) -> bool {
+    let Some(car) = ctx.world.elevator(ctx.car) else {
+        return false;
+    };
+    let can_exit_here = car
+        .riders()
+        .iter()
+        .any(|&rid| ctx.world.route(rid).and_then(Route::current_destination) == Some(ctx.stop));
+    if can_exit_here {
+        return true;
+    }
+    let remaining_capacity = car.weight_capacity.value() - car.current_load.value();
+    if remaining_capacity <= 0.0 {
+        return false;
+    }
+    let waiting = ctx.manifest.waiting_riders_at(ctx.stop);
+    waiting.is_empty()
+        || waiting
+            .iter()
+            .any(|r| r.weight.value() <= remaining_capacity)
+}
 
 /// Metadata about a single rider, available to dispatch strategies.
 #[derive(Debug, Clone)]

--- a/crates/elevator-core/src/dispatch/nearest_car.rs
+++ b/crates/elevator-core/src/dispatch/nearest_car.rs
@@ -1,12 +1,26 @@
 //! Nearest-car dispatch — assigns each call to the closest idle elevator.
 
-use super::{DispatchStrategy, RankContext};
+use crate::components::Route;
+
+use super::{DispatchStrategy, RankContext, pair_can_do_work};
 
 /// Scores `(car, stop)` by absolute distance between the car and the stop.
 ///
 /// Paired with the Hungarian assignment in the dispatch system, this
 /// yields the globally minimum-total-distance matching across the group
 /// — no two cars can be sent to the same hall call.
+///
+/// Two guards are applied on top of the raw distance:
+///
+/// 1. The `(car, stop)` pair must be serviceable — at least one aboard
+///    rider can exit, or at least one waiting rider can fit. A full car
+///    at a pickup stop it cannot serve otherwise self-assigns at zero
+///    cost (doors cycle open → reject → close forever).
+/// 2. A car carrying riders refuses pickups that would pull it backward
+///    (off the path to every aboard rider's destination). Without this,
+///    a stream of closer-destination boarders can indefinitely preempt
+///    a farther aboard rider's delivery — the reported "never reaches
+///    the passenger's desired stop" loop.
 pub struct NearestCarDispatch;
 
 impl NearestCarDispatch {
@@ -25,6 +39,46 @@ impl Default for NearestCarDispatch {
 
 impl DispatchStrategy for NearestCarDispatch {
     fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+        if !pair_is_useful(ctx) {
+            return None;
+        }
         Some((ctx.car_position - ctx.stop_position).abs())
     }
+}
+
+/// Decide whether assigning `ctx.car` to `ctx.stop` is on the path to
+/// any aboard rider's destination. Combined with
+/// [`pair_can_do_work`](super::pair_can_do_work), this keeps a car
+/// carrying riders from being pulled backward by closer pickups.
+fn pair_is_useful(ctx: &RankContext<'_>) -> bool {
+    if !pair_can_do_work(ctx) {
+        return false;
+    }
+
+    let Some(car) = ctx.world.elevator(ctx.car) else {
+        return false;
+    };
+    // Exiting an aboard rider is always on-the-way for that rider.
+    let can_exit_here = car
+        .riders()
+        .iter()
+        .any(|&rid| ctx.world.route(rid).and_then(Route::current_destination) == Some(ctx.stop));
+    if can_exit_here || car.riders().is_empty() {
+        return true;
+    }
+
+    // Pickups allowed only on the path to an aboard rider's destination.
+    // Candidate at the car's position (to_cand = 0) trivially qualifies —
+    // useful for same-floor boards.
+    let to_cand = ctx.stop_position - ctx.car_position;
+    car.riders().iter().any(|&rid| {
+        let Some(dest) = ctx.world.route(rid).and_then(Route::current_destination) else {
+            return false;
+        };
+        let Some(dest_pos) = ctx.world.stop_position(dest) else {
+            return false;
+        };
+        let to_dest = dest_pos - ctx.car_position;
+        to_dest * to_cand >= 0.0 && to_cand.abs() <= to_dest.abs()
+    })
 }

--- a/crates/elevator-core/src/dispatch/nearest_car.rs
+++ b/crates/elevator-core/src/dispatch/nearest_car.rs
@@ -67,6 +67,21 @@ fn pair_is_useful(ctx: &RankContext<'_>) -> bool {
         return true;
     }
 
+    // Route-less aboard riders (game-managed manual riders) don't
+    // publish a destination, so there's no committed path to protect.
+    // Any pickup is trivially on-the-way — fall back to the raw
+    // servability check. Otherwise we'd refuse every pickup the moment
+    // the car carried its first manually-managed passenger.
+    let has_routed_rider = car.riders().iter().any(|&rid| {
+        ctx.world
+            .route(rid)
+            .and_then(Route::current_destination)
+            .is_some()
+    });
+    if !has_routed_rider {
+        return true;
+    }
+
     // Pickups allowed only on the path to an aboard rider's destination.
     // Candidate at the car's position (to_cand = 0) trivially qualifies —
     // useful for same-floor boards.

--- a/crates/elevator-core/src/dispatch/reposition.rs
+++ b/crates/elevator-core/src/dispatch/reposition.rs
@@ -51,10 +51,23 @@ impl RepositionStrategy for SpreadEvenly {
             .collect();
 
         for &(elev_eid, elev_pos) in idle_elevators {
+            // Primary criterion: maximize the minimum distance from any
+            // already-occupied position (true "spread"). Tie-breaker:
+            // prefer the stop closest to the elevator's current position
+            // — otherwise, with no occupied positions at sim start, every
+            // stop is tied at `INFINITY` and `max_by`'s last-wins default
+            // ships every car to the topmost stop. That was the reported
+            // "cars travel to the top at sim start with no demand" bug.
             let best = stop_positions.iter().max_by(|a, b| {
                 let min_a = min_distance_to(a.1, &occupied);
                 let min_b = min_distance_to(b.1, &occupied);
-                min_a.total_cmp(&min_b)
+                min_a.total_cmp(&min_b).then_with(|| {
+                    let dist_a = (a.1 - elev_pos).abs();
+                    let dist_b = (b.1 - elev_pos).abs();
+                    // `max_by` returns the greater element; invert so the
+                    // closer stop to the elevator is considered greater.
+                    dist_b.total_cmp(&dist_a)
+                })
             });
 
             if let Some(&(stop_eid, stop_pos)) = best {

--- a/crates/elevator-core/src/dispatch/scan.rs
+++ b/crates/elevator-core/src/dispatch/scan.rs
@@ -11,7 +11,7 @@ use crate::entity::EntityId;
 use crate::world::World;
 
 use super::sweep::{self, SweepDirection, SweepMode};
-use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext};
+use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext, pair_can_do_work};
 
 /// Elevator dispatch using the SCAN (elevator) algorithm.
 ///
@@ -77,6 +77,15 @@ impl DispatchStrategy for ScanDispatch {
     }
 
     fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+        // Reject un-servable pairs so a full car with only
+        // over-capacity waiting demand at its own stop can't open/close
+        // doors indefinitely. SCAN's direction reversal normally lifts
+        // it out of the self-stop within one tick (strict-ahead excludes
+        // the current position), but the Lenient transition tick would
+        // still rank the self-pair at cost 0 without this guard.
+        if !pair_can_do_work(ctx) {
+            return None;
+        }
         sweep::rank(
             self.mode_for(ctx.car),
             self.direction_for(ctx.car),

--- a/crates/elevator-core/src/tests/dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/dispatch_tests.rs
@@ -292,6 +292,127 @@ fn nearest_car_multiple_stops() {
     assert_eq!(b_dec.1, DispatchDecision::GoToStop(stops[3]));
 }
 
+/// A full nearest-car at a pickup stop whose only demand is a waiting
+/// rider it can't board must not be re-dispatched to that same stop.
+/// Pre-fix the pure distance rank collapses to 0 for the self-pair,
+/// winning over any real move — the car cycles doors forever.
+#[test]
+fn nearest_car_full_car_at_pickup_stop_prefers_rider_destination() {
+    let (mut world, stops) = test_world();
+    let elev = spawn_elevator(&mut world, 4.0); // at stops[1]
+    {
+        let car = world.elevator_mut(elev).unwrap();
+        car.current_load = car.weight_capacity;
+    }
+    let aboard = world.spawn();
+    world.elevator_mut(elev).unwrap().riders.push(aboard);
+    world.set_route(
+        aboard,
+        Route::direct(stops[0], stops[3], crate::ids::GroupId(0)),
+    );
+
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    add_demand(&mut manifest, &mut world, stops[1], 70.0);
+    manifest
+        .riding_to_stop
+        .entry(stops[3])
+        .or_default()
+        .push(RiderInfo {
+            id: aboard,
+            destination: Some(stops[3]),
+            weight: Weight::from(70.0),
+            wait_ticks: 0,
+        });
+
+    let mut nc = NearestCarDispatch::new();
+    let decision = decide_one(&mut nc, elev, 4.0, &group, &manifest, &mut world);
+    assert_eq!(
+        decision,
+        DispatchDecision::GoToStop(stops[3]),
+        "full car must be routed to its aboard rider's destination, not \
+         the un-serveable pickup at its current position"
+    );
+}
+
+/// A car carrying a rider whose destination lies *ahead* (upward) must
+/// reject a backward pickup even when that pickup is numerically closer.
+/// Pre-fix, the pure distance rank would pull the car backward to serve
+/// the pickup, indefinitely deferring the aboard rider's trip.
+#[test]
+fn nearest_car_skips_backward_pickup_when_rider_aboard() {
+    let (mut world, stops) = test_world();
+    // Car at stops[2] (pos 8), rider aboard going *up* to stops[3] (pos 12).
+    let elev = spawn_elevator(&mut world, 8.0);
+    let aboard = world.spawn();
+    world.elevator_mut(elev).unwrap().riders.push(aboard);
+    world.set_route(
+        aboard,
+        Route::direct(stops[0], stops[3], crate::ids::GroupId(0)),
+    );
+
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    // Pickup below the car — closer in raw distance but opposite direction.
+    add_demand(&mut manifest, &mut world, stops[1], 70.0);
+    manifest
+        .riding_to_stop
+        .entry(stops[3])
+        .or_default()
+        .push(RiderInfo {
+            id: aboard,
+            destination: Some(stops[3]),
+            weight: Weight::from(70.0),
+            wait_ticks: 0,
+        });
+
+    let mut nc = NearestCarDispatch::new();
+    let decision = decide_one(&mut nc, elev, 8.0, &group, &manifest, &mut world);
+    assert_eq!(
+        decision,
+        DispatchDecision::GoToStop(stops[3]),
+        "backward pickup must not preempt an aboard rider's forward destination"
+    );
+}
+
+/// Regression guard: on-the-way pickups are still allowed. The car at
+/// the origin with a rider bound for the top should pick up at the
+/// middle floor — serving passengers in transit is the whole point.
+#[test]
+fn nearest_car_accepts_on_the_way_pickup_when_rider_aboard() {
+    let (mut world, stops) = test_world();
+    let elev = spawn_elevator(&mut world, 0.0);
+    let aboard = world.spawn();
+    world.elevator_mut(elev).unwrap().riders.push(aboard);
+    world.set_route(
+        aboard,
+        Route::direct(stops[0], stops[3], crate::ids::GroupId(0)),
+    );
+
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    // Pickup at stops[1] (pos 4), between car (pos 0) and aboard dest (pos 12).
+    add_demand(&mut manifest, &mut world, stops[1], 70.0);
+    manifest
+        .riding_to_stop
+        .entry(stops[3])
+        .or_default()
+        .push(RiderInfo {
+            id: aboard,
+            destination: Some(stops[3]),
+            weight: Weight::from(70.0),
+            wait_ticks: 0,
+        });
+
+    let mut nc = NearestCarDispatch::new();
+    let decision = decide_one(&mut nc, elev, 0.0, &group, &manifest, &mut world);
+    assert_eq!(
+        decision,
+        DispatchDecision::GoToStop(stops[1]),
+        "an en-route pickup must still win over the farther aboard destination"
+    );
+}
+
 // ===== ETD Tests =====
 
 #[test]

--- a/crates/elevator-core/src/tests/etd_mutant_tests.rs
+++ b/crates/elevator-core/src/tests/etd_mutant_tests.rs
@@ -20,9 +20,9 @@
 use super::dispatch_tests::{
     add_demand, decide_all, decide_one, spawn_elevator, test_group, test_world,
 };
-use crate::components::{ElevatorPhase, Route, Speed};
+use crate::components::{ElevatorPhase, Route, Speed, Weight};
 use crate::dispatch::etd::EtdDispatch;
-use crate::dispatch::{DispatchDecision, DispatchManifest};
+use crate::dispatch::{DispatchDecision, DispatchManifest, RiderInfo};
 
 // ── Travel-time component (lines 119-124) ───────────────────────────
 
@@ -330,6 +330,102 @@ fn etd_idle_short_trip_does_not_break_assignment() {
         decision,
         DispatchDecision::GoToStop(stops[2]),
         "lone idle elevator with negative raw cost (post-clamp 0) must still be assigned"
+    );
+}
+
+// ── Full-car stall guard ────────────────────────────────────────────
+
+/// A full car stopped at a pickup stop whose demand it can't serve
+/// (capacity = 0) must not be re-dispatched to that same stop. Pre-fix
+/// ETD's cost collapsed to 0 for the self-pair — travel time was 0,
+/// detour was 0, door overhead was 0 — which always beat any real
+/// move, producing an indefinite door-cycle loop that never delivered
+/// the aboard rider to their destination.
+#[test]
+fn etd_full_car_at_pickup_stop_prefers_rider_destination() {
+    let (mut world, stops) = test_world();
+    let elev = spawn_elevator(&mut world, 4.0); // at stops[1]
+    // Fill the car to capacity with a single aboard rider whose weight
+    // equals the car's capacity. Add another fully-weighted waiting rider
+    // at stops[1] that the car cannot board (over capacity).
+    {
+        let car = world.elevator_mut(elev).unwrap();
+        car.current_load = car.weight_capacity;
+    }
+    let aboard = world.spawn();
+    world.elevator_mut(elev).unwrap().riders.push(aboard);
+    world.set_route(
+        aboard,
+        Route::direct(stops[0], stops[3], crate::ids::GroupId(0)),
+    );
+
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    // Waiting rider at stops[1] — where the car is parked, car can't board.
+    add_demand(&mut manifest, &mut world, stops[1], 70.0);
+    // Aboard rider destination at stops[3] — matches production build_manifest.
+    manifest
+        .riding_to_stop
+        .entry(stops[3])
+        .or_default()
+        .push(RiderInfo {
+            id: aboard,
+            destination: Some(stops[3]),
+            weight: Weight::from(70.0),
+            wait_ticks: 0,
+        });
+
+    let mut etd = EtdDispatch::new();
+    let decision = decide_one(&mut etd, elev, 4.0, &group, &manifest, &mut world);
+    assert_eq!(
+        decision,
+        DispatchDecision::GoToStop(stops[3]),
+        "full car at a pickup-only stop must be routed to its rider's destination \
+         instead of self-assigning to the un-serveable stop"
+    );
+}
+
+/// Symmetric case: full car not at the stall stop, but the pickup
+/// candidate it would otherwise prefer (on-the-way, zero detour) is one
+/// it cannot board. Choose the aboard rider's destination.
+#[test]
+fn etd_full_car_skips_unreachable_pickup_on_the_way() {
+    let (mut world, stops) = test_world();
+    let elev = spawn_elevator(&mut world, 0.0);
+    {
+        let car = world.elevator_mut(elev).unwrap();
+        car.current_load = car.weight_capacity;
+    }
+    let aboard = world.spawn();
+    world.elevator_mut(elev).unwrap().riders.push(aboard);
+    world.set_route(
+        aboard,
+        Route::direct(stops[0], stops[3], crate::ids::GroupId(0)),
+    );
+
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    // Pickup at stops[1] — on the way to stops[3] (pos 4 vs 12). Cheaper
+    // travel time than stops[3] but car can't board (full).
+    add_demand(&mut manifest, &mut world, stops[1], 70.0);
+    manifest
+        .riding_to_stop
+        .entry(stops[3])
+        .or_default()
+        .push(RiderInfo {
+            id: aboard,
+            destination: Some(stops[3]),
+            weight: Weight::from(70.0),
+            wait_ticks: 0,
+        });
+
+    let mut etd = EtdDispatch::new();
+    let decision = decide_one(&mut etd, elev, 0.0, &group, &manifest, &mut world);
+    assert_eq!(
+        decision,
+        DispatchDecision::GoToStop(stops[3]),
+        "a full car en route must skip pickup stops it can't serve and \
+         head straight to the aboard rider's destination"
     );
 }
 

--- a/crates/elevator-core/src/tests/reposition_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_tests.rs
@@ -130,14 +130,42 @@ fn spread_evenly_distributes_elevators() {
     if result.len() == 2 {
         assert_ne!(result[0].1, result[1].1, "should spread to different stops");
     }
-    // `elev_b` is also idle so it's excluded from `occupied` when elev_a is
-    // placed — the `occupied` set is empty, `min_distance_to` returns
-    // INFINITY for every stop, and `max_by(..total_cmp)` deterministically
-    // returns the last element (`stops[4]`). The outcome is correct but
-    // the "farthest from other occupied positions" intuition is only what
-    // the strategy *would* do once `elev_b` is assigned a position — here
-    // elev_a is processed first while `occupied` is still empty.
-    assert_eq!(result[0].1, stops[4]);
+    // With the no-spurious-movement tiebreak, elev_a (first iterated) is
+    // processed while `occupied` is empty, so every stop ties at INFINITY
+    // and the tie-break picks the stop closest to elev_a's current
+    // position — stops[0], which elev_a is already at. No move is pushed.
+    // Only elev_b (with `occupied=[0]` after elev_a is placed) actually
+    // moves, landing on stops[4] as the farthest-from-occupied.
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0], (elev_b, stops[4]));
+}
+
+/// Regression for the "cars travel to the top at sim start" bug: a
+/// single idle car already parked at a stop, with no other occupied
+/// positions to spread against, must not be told to move. Pre-fix,
+/// `max_by` resolved the all-INFINITY tie by returning the last stop
+/// in iteration order — so every car got shipped to the topmost stop
+/// whenever the sim started with no demand.
+#[test]
+fn spread_evenly_no_movement_with_lone_idle_car() {
+    let (mut world, stops) = test_world_n(5);
+    let elev = spawn_elevator(&mut world, 0.0); // at stops[0]
+    let group = test_group(&stops, vec![elev]);
+
+    let idle = vec![(elev, 0.0)];
+    let stop_pos: Vec<(EntityId, f64)> = stops
+        .iter()
+        .map(|&sid| (sid, world.stop_position(sid).unwrap()))
+        .collect();
+
+    let mut strategy = SpreadEvenly;
+    let mut result = Vec::new();
+    strategy.reposition(&idle, &stop_pos, &group, &world, &mut result);
+
+    assert!(
+        result.is_empty(),
+        "a lone idle car at a stop must not be repositioned; got {result:?}"
+    );
 }
 
 // SpreadEvenly edge case: single stop — no movement needed if already there.

--- a/crates/elevator-core/src/tests/scenario_tests.rs
+++ b/crates/elevator-core/src/tests/scenario_tests.rs
@@ -349,10 +349,23 @@ fn etd_full_car_delivers_aboard_rider_despite_unservable_pickup() {
 /// strategy happens to be default.
 #[test]
 fn every_builtin_strategy_eventually_delivers_all_riders() {
-    fn run_with<S: DispatchStrategy + 'static>(name: &str, strategy: S) {
+    fn run_with<S: DispatchStrategy + 'static>(name: &str, strategy: S, dcs: bool) {
         let mut config = default_config();
         config.elevators[0].weight_capacity = Weight::from(100.0);
         let mut sim = Simulation::new(&config, strategy).unwrap();
+        if dcs {
+            // DCS requires Destination hall-call mode and an
+            // `AssignedCar` extension registration; otherwise
+            // `pre_dispatch` early-returns and the test silently
+            // degrades to "no dispatch happens." Flip both here.
+            for g in sim.groups_mut() {
+                g.set_hall_call_mode(crate::dispatch::HallCallMode::Destination);
+            }
+            sim.world_mut()
+                .register_ext::<crate::dispatch::AssignedCar>(
+                    crate::dispatch::destination::ASSIGNED_CAR_KEY,
+                );
+        }
         sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
         sim.spawn_rider(StopId(1), StopId(2), 70.0).unwrap();
 
@@ -375,10 +388,15 @@ fn every_builtin_strategy_eventually_delivers_all_riders() {
         );
     }
 
-    run_with("SCAN", ScanDispatch::new());
-    run_with("LOOK", LookDispatch::new());
-    run_with("NearestCar", NearestCarDispatch::new());
-    run_with("ETD", EtdDispatch::new());
+    run_with("SCAN", ScanDispatch::new(), false);
+    run_with("LOOK", LookDispatch::new(), false);
+    run_with("NearestCar", NearestCarDispatch::new(), false);
+    run_with("ETD", EtdDispatch::new(), false);
+    run_with(
+        "Destination",
+        crate::dispatch::DestinationDispatch::new(),
+        true,
+    );
 }
 
 // ── ScenarioRunner — spawn ordering (#271) ───────────────────────────────────

--- a/crates/elevator-core/src/tests/scenario_tests.rs
+++ b/crates/elevator-core/src/tests/scenario_tests.rs
@@ -1,5 +1,10 @@
 use crate::components::RiderPhase;
 use crate::components::Weight;
+use crate::dispatch::DispatchStrategy;
+use crate::dispatch::etd::EtdDispatch;
+use crate::dispatch::look::LookDispatch;
+use crate::dispatch::nearest_car::NearestCarDispatch;
+use crate::dispatch::scan::ScanDispatch;
 use crate::events::Event;
 use crate::sim::Simulation;
 use crate::stop::StopId;
@@ -288,6 +293,92 @@ fn deterministic_replay() {
         ticks1, ticks2,
         "Deterministic simulation should take identical tick counts"
     );
+}
+
+// ── ETD full-car stall regression ───────────────────────────────────────────
+
+/// Pre-fix, ETD would send a full car to any pickup stop whose only
+/// demand it couldn't serve — and if that stop happened to be the car's
+/// current position, the cost collapsed to zero and dispatch re-selected
+/// it forever. The car would cycle `(door-open, reject, door-close)`,
+/// never carrying its aboard rider to the destination.
+///
+/// Repro: small-capacity car, one rider it does carry, a second rider
+/// waiting on-the-way whose weight exceeds remaining capacity. With the
+/// bug the car parks at the pickup stop and never reaches the target.
+#[test]
+fn etd_full_car_delivers_aboard_rider_despite_unservable_pickup() {
+    let mut config = default_config();
+    // Capacity fits exactly one 70 kg rider.
+    config.elevators[0].weight_capacity = Weight::from(100.0);
+
+    let mut sim = Simulation::new(&config, EtdDispatch::new()).unwrap();
+    // Rider A at stops[0] → stops[2]. Will board and fill the car.
+    let a = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    // Rider B at stops[1] → stops[2]. Won't fit once A is aboard; the
+    // call at stops[1] stays active until the car comes back empty.
+    sim.spawn_rider(StopId(1), StopId(2), 70.0).unwrap();
+
+    let max_ticks = 20_000;
+    for _ in 0..max_ticks {
+        sim.step();
+        sim.drain_events();
+        if sim.world().rider(a.entity()).map(|r| r.phase) == Some(RiderPhase::Arrived) {
+            break;
+        }
+    }
+
+    assert_eq!(
+        sim.world().rider(a.entity()).map(|r| r.phase),
+        Some(RiderPhase::Arrived),
+        "aboard rider must reach their destination; ETD cannot stall the car \
+         at a pickup stop it lacks capacity to serve"
+    );
+}
+
+// ── Cross-strategy delivery safety ──────────────────────────────────────────
+
+/// Delivery guarantee: in a traffic mix that *exposes* the full-car
+/// self-assign stall (one 70 kg rider boards and saturates a 100 kg car,
+/// then a 70 kg rider waits at every other floor), every built-in
+/// strategy must still deliver both riders within a bounded tick count.
+///
+/// Runs SCAN, LOOK, `NearestCar`, and ETD through the same scenario so a
+/// regression in any one of them shows up as a test failure at the
+/// strategy that broke — not as a flaky timeout only hitting whichever
+/// strategy happens to be default.
+#[test]
+fn every_builtin_strategy_eventually_delivers_all_riders() {
+    fn run_with<S: DispatchStrategy + 'static>(name: &str, strategy: S) {
+        let mut config = default_config();
+        config.elevators[0].weight_capacity = Weight::from(100.0);
+        let mut sim = Simulation::new(&config, strategy).unwrap();
+        sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+        sim.spawn_rider(StopId(1), StopId(2), 70.0).unwrap();
+
+        let max_ticks = 20_000;
+        for _ in 0..max_ticks {
+            sim.step();
+            sim.drain_events();
+            if all_riders_arrived(&sim) {
+                break;
+            }
+        }
+
+        assert!(
+            all_riders_arrived(&sim),
+            "{name} must deliver both riders; phases: {:?}",
+            sim.world()
+                .iter_riders()
+                .map(|(_, r)| r.phase)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    run_with("SCAN", ScanDispatch::new());
+    run_with("LOOK", LookDispatch::new());
+    run_with("NearestCar", NearestCarDispatch::new());
+    run_with("ETD", EtdDispatch::new());
 }
 
 // ── ScenarioRunner — spawn ordering (#271) ───────────────────────────────────


### PR DESCRIPTION
## Summary

Every built-in dispatcher could permanently park a full car at a pickup stop it lacked capacity to serve. The `(car, current_stop)` self-pair collapsed to cost 0 (zero travel time, zero detour, zero door overhead), beating any real move; dispatch kept re-selecting the same stop every tick, doors cycled open → reject → close forever, aboard riders were never delivered.

- Factor out \`pair_can_do_work\` as a public helper in \`dispatch/mod.rs\` (serviceability guard — can we exit, board, or answer a hall call here?).
- Wire it into ETD, NearestCar, SCAN, and LOOK.
- NearestCar also gets an \"on-the-way\" commitment so closer pickups can't indefinitely preempt a far aboard rider's destination (the \"never reaches desired stop in a loop\" case).
- SpreadEvenly tiebreak now prefers the elevator's current position when all stops tie at \`INFINITY\`, so lone idle cars don't get shipped to the top at sim start.

## Tests

- \`every_builtin_strategy_eventually_delivers_all_riders\` — cross-strategy regression: runs the stall scenario through SCAN, LOOK, NearestCar, ETD. Future regressions surface at whichever strategy breaks.
- Per-strategy unit tests (ETD full-car, NearestCar backward-pickup + on-the-way, SpreadEvenly lone idle car).

## Test plan

- [x] \`cargo test -p elevator-core --all-features\` (662 unit + 156 doc + integration, all pass)
- [x] \`cargo clippy -p elevator-core --all-features --all-targets\` clean
- [x] \`cargo check --workspace --all-features\` clean