### PR TITLE
feat: commercial elevator behaviors — bypass, arrival rates, group-time, deferred DCS, predictive parking

### DIFF
--- a/crates/elevator-core/benches/common/mod.rs
+++ b/crates/elevator-core/benches/common/mod.rs
@@ -32,5 +32,9 @@ pub fn elevator_cfg(
         energy_profile: None,
         service_mode: None,
         inspection_speed_factor: 0.25,
+
+        bypass_load_up_pct: None,
+
+        bypass_load_down_pct: None,
     }
 }

--- a/crates/elevator-core/examples/dispatch_comparison.rs
+++ b/crates/elevator-core/examples/dispatch_comparison.rs
@@ -76,6 +76,10 @@ fn make_config() -> SimConfig {
             energy_profile: None,
             service_mode: None,
             inspection_speed_factor: 0.25,
+
+            bypass_load_up_pct: None,
+
+            bypass_load_down_pct: None,
         })
         .collect();
 

--- a/crates/elevator-core/examples/scenario.rs
+++ b/crates/elevator-core/examples/scenario.rs
@@ -45,6 +45,10 @@ fn main() {
                 energy_profile: None,
                 service_mode: None,
                 inspection_speed_factor: 0.25,
+
+                bypass_load_up_pct: None,
+
+                bypass_load_down_pct: None,
             }],
             simulation: SimulationParams {
                 ticks_per_second: 60.0,

--- a/crates/elevator-core/examples/showcase.rs
+++ b/crates/elevator-core/examples/showcase.rs
@@ -400,6 +400,10 @@ fn part6_configuration() {
                 energy_profile: None,
                 service_mode: None,
                 inspection_speed_factor: 0.25,
+
+                bypass_load_up_pct: None,
+
+                bypass_load_down_pct: None,
             },
             ElevatorConfig {
                 id: 1,
@@ -416,6 +420,10 @@ fn part6_configuration() {
                 energy_profile: None,
                 service_mode: None,
                 inspection_speed_factor: 0.25,
+
+                bypass_load_up_pct: None,
+
+                bypass_load_down_pct: None,
             },
         ],
         simulation: SimulationParams {

--- a/crates/elevator-core/src/arrival_log.rs
+++ b/crates/elevator-core/src/arrival_log.rs
@@ -43,6 +43,24 @@ pub struct CurrentTick(
 /// use to detect up-peak / down-peak transitions.
 pub const DEFAULT_ARRIVAL_WINDOW_TICKS: u64 = 18_000;
 
+/// World resource controlling how far back the [`ArrivalLog`] retains
+/// entries before `Simulation::advance_tick` prunes them.
+///
+/// Defaults to [`DEFAULT_ARRIVAL_WINDOW_TICKS`]. Strategies that query
+/// a longer window (e.g.
+/// [`PredictiveParking::with_window_ticks`](crate::dispatch::reposition::PredictiveParking::with_window_ticks)
+/// with a value greater than the default) will silently see only the
+/// last `DEFAULT_ARRIVAL_WINDOW_TICKS` unless this retention is
+/// widened via [`Simulation::set_arrival_log_retention_ticks`](crate::sim::Simulation::set_arrival_log_retention_ticks).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ArrivalLogRetention(pub u64);
+
+impl Default for ArrivalLogRetention {
+    fn default() -> Self {
+        Self(DEFAULT_ARRIVAL_WINDOW_TICKS)
+    }
+}
+
 /// Append-only log of per-stop arrival events used to compute rolling
 /// arrival-rate signals.
 ///

--- a/crates/elevator-core/src/arrival_log.rs
+++ b/crates/elevator-core/src/arrival_log.rs
@@ -95,4 +95,18 @@ impl ArrivalLog {
     pub const fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
+
+    /// Rewrite every entry's stop `EntityId` through `id_remap`, dropping
+    /// entries whose stop isn't present in the map. Used by snapshot
+    /// restore to translate pre-restore stop IDs to the new allocations.
+    pub fn remap_entity_ids(&mut self, id_remap: &std::collections::HashMap<EntityId, EntityId>) {
+        self.entries
+            .retain_mut(|(_, stop)| match id_remap.get(stop) {
+                Some(&new) => {
+                    *stop = new;
+                    true
+                }
+                None => false,
+            });
+    }
 }

--- a/crates/elevator-core/src/arrival_log.rs
+++ b/crates/elevator-core/src/arrival_log.rs
@@ -1,5 +1,12 @@
 //! Rolling per-stop arrival log.
 //!
+//! Carries a `CurrentTick` sibling resource that mirrors
+//! [`Simulation::current_tick`](crate::sim::Simulation::current_tick)
+//! so strategies reading the log from phases without direct access to
+//! `PhaseContext` (e.g. [`RepositionStrategy`](crate::dispatch::RepositionStrategy))
+//! can still compute windowed queries.
+//!
+//!
 //! Commercial group controllers sample per-stop arrival rates to pick
 //! traffic modes (up-peak, down-peak) and to pre-position idle cars
 //! ahead of expected demand (Otis Compass Infinity's *predictive
@@ -14,6 +21,19 @@
 
 use crate::entity::EntityId;
 use serde::{Deserialize, Serialize};
+
+/// World resource mirroring the current simulation tick.
+///
+/// Kept in sync by [`Simulation::step`](crate::sim::Simulation::step).
+/// Lets phases that don't receive a `PhaseContext` (reposition
+/// strategies, custom `World` consumers) compute rolling-window queries
+/// against [`ArrivalLog`] without plumbing tick through their
+/// signatures.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct CurrentTick(
+    /// Tick value at the start of the last `step()` entry.
+    pub u64,
+);
 
 /// Default rolling window (in ticks).
 ///

--- a/crates/elevator-core/src/arrival_log.rs
+++ b/crates/elevator-core/src/arrival_log.rs
@@ -1,0 +1,78 @@
+//! Rolling per-stop arrival log.
+//!
+//! Commercial group controllers sample per-stop arrival rates to pick
+//! traffic modes (up-peak, down-peak) and to pre-position idle cars
+//! ahead of expected demand (Otis Compass Infinity's *predictive
+//! parking*, KONE Polaris's pattern-driven mode switch). This log is
+//! the signal source: dispatch strategies read it via
+//! [`DispatchManifest::arrivals_at`](crate::dispatch::DispatchManifest::arrivals_at),
+//! reposition strategies read it directly from `World` resources.
+//!
+//! The log is append-only during a tick and pruned at the start of each
+//! tick to keep memory bounded under long runs. Stored entries are
+//! `(tick, stop)` pairs; queries are by stop and time window only.
+
+use crate::entity::EntityId;
+use serde::{Deserialize, Serialize};
+
+/// Default rolling window (in ticks).
+///
+/// Used by [`DispatchManifest::arrivals_at`](crate::dispatch::DispatchManifest::arrivals_at)
+/// when the sim doesn't override it. Five minutes of real time at the
+/// default 60 Hz tick rate, matching the window commercial controllers
+/// use to detect up-peak / down-peak transitions.
+pub const DEFAULT_ARRIVAL_WINDOW_TICKS: u64 = 18_000;
+
+/// Append-only log of per-stop arrival events used to compute rolling
+/// arrival-rate signals.
+///
+/// Stored as a `Vec<(tick, stop)>` sorted by tick (records are appended
+/// in tick order during normal sim execution). Queries are `O(n)` worst
+/// case but typically `O(window_size)`; `prune_before` keeps the tail
+/// short enough that this is a non-issue for practical window sizes.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ArrivalLog {
+    /// `(tick, stop)` pairs. Entries are appended in tick order.
+    entries: Vec<(u64, EntityId)>,
+}
+
+impl ArrivalLog {
+    /// Record an arrival at `stop` on `tick`.
+    pub fn record(&mut self, tick: u64, stop: EntityId) {
+        self.entries.push((tick, stop));
+    }
+
+    /// Count arrivals at `stop` within the window `[now - window, now]`
+    /// inclusive. `window_ticks = 0` always returns 0.
+    #[must_use]
+    pub fn arrivals_in_window(&self, stop: EntityId, now: u64, window_ticks: u64) -> u64 {
+        if window_ticks == 0 {
+            return 0;
+        }
+        let lower = now.saturating_sub(window_ticks);
+        self.entries
+            .iter()
+            .filter(|(t, s)| *s == stop && *t >= lower && *t <= now)
+            .count() as u64
+    }
+
+    /// Drop every entry with tick strictly before `cutoff`. Called each
+    /// tick by the sim with `cutoff = current_tick - max_window` so the
+    /// log can't grow without bound.
+    pub fn prune_before(&mut self, cutoff: u64) {
+        self.entries.retain(|(t, _)| *t >= cutoff);
+    }
+
+    /// Number of recorded events currently in the log. Intended for
+    /// snapshot inspection and tests.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the log has no recorded events.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}

--- a/crates/elevator-core/src/builder.rs
+++ b/crates/elevator-core/src/builder.rs
@@ -97,6 +97,8 @@ impl SimulationBuilder {
     ///         # energy_profile: None,
     ///         service_mode: None,
     ///         inspection_speed_factor: 0.25,
+    ///         bypass_load_up_pct: None,
+    ///         bypass_load_down_pct: None,
     ///     })
     ///     .build()
     ///     .unwrap();
@@ -187,6 +189,8 @@ impl SimulationBuilder {
             energy_profile: None,
             service_mode: None,
             inspection_speed_factor: 0.25,
+            bypass_load_up_pct: None,
+            bypass_load_down_pct: None,
         }];
         b
     }

--- a/crates/elevator-core/src/components/elevator.rs
+++ b/crates/elevator-core/src/components/elevator.rs
@@ -175,6 +175,21 @@ pub struct Elevator {
     /// [`Elevator::manual_target_velocity`].
     #[serde(default)]
     pub(crate) manual_target_velocity: Option<f64>,
+    /// Load-ratio threshold (0..=1) above which this car ignores new
+    /// upward hall calls. Modeled on Otis Elevonic 411's full-load
+    /// bypass (patent US5490580A). `None` disables the bypass — the
+    /// default for backwards compatibility.
+    ///
+    /// Aboard riders still get delivered regardless; the threshold
+    /// affects *pickup* decisions only.
+    #[serde(default)]
+    pub(crate) bypass_load_up_pct: Option<f64>,
+    /// Load-ratio threshold for downward-direction pickups. Typically
+    /// set lower than `bypass_load_up_pct` because down-peak riders
+    /// accumulate more gradually and a half-full car has less incentive
+    /// to skip the next stop. `None` disables the bypass.
+    #[serde(default)]
+    pub(crate) bypass_load_down_pct: Option<f64>,
 }
 
 /// Default inspection speed factor (25% of normal speed).
@@ -276,6 +291,31 @@ impl Elevator {
     #[must_use]
     pub const fn inspection_speed_factor(&self) -> f64 {
         self.inspection_speed_factor
+    }
+
+    /// Load-ratio threshold above which upward-direction pickups are
+    /// skipped (full-load bypass). `None` disables the bypass. See the
+    /// field docs on [`Elevator`] for the underlying model.
+    #[must_use]
+    pub const fn bypass_load_up_pct(&self) -> Option<f64> {
+        self.bypass_load_up_pct
+    }
+
+    /// Load-ratio threshold above which downward-direction pickups are
+    /// skipped. `None` disables the bypass.
+    #[must_use]
+    pub const fn bypass_load_down_pct(&self) -> Option<f64> {
+        self.bypass_load_down_pct
+    }
+
+    /// Mutator for the upward full-load bypass threshold.
+    pub const fn set_bypass_load_up_pct(&mut self, pct: Option<f64>) {
+        self.bypass_load_up_pct = pct;
+    }
+
+    /// Mutator for the downward full-load bypass threshold.
+    pub const fn set_bypass_load_down_pct(&mut self, pct: Option<f64>) {
+        self.bypass_load_down_pct = pct;
     }
 
     /// Whether this car's up-direction indicator lamp is lit.

--- a/crates/elevator-core/src/config.rs
+++ b/crates/elevator-core/src/config.rs
@@ -131,6 +131,19 @@ pub struct ElevatorConfig {
     /// Speed multiplier for Inspection mode (0.0..1.0). Defaults to 0.25.
     #[serde(default = "default_inspection_speed_factor")]
     pub inspection_speed_factor: f64,
+    /// Full-load bypass threshold for upward pickups, as a fraction of
+    /// `weight_capacity` in `0.0..=1.0`. When the car is above this
+    /// ratio and travelling up, it skips new upward hall calls — aboard
+    /// riders still get delivered. `None` disables the bypass. Modeled
+    /// on Otis Elevonic 411 (patent US5490580A); commercial defaults
+    /// sit near 0.80.
+    #[serde(default)]
+    pub bypass_load_up_pct: Option<f64>,
+    /// Full-load bypass threshold for downward pickups. Typically
+    /// lower than the upward threshold — commercial defaults sit near
+    /// 0.50. `None` disables.
+    #[serde(default)]
+    pub bypass_load_down_pct: Option<f64>,
 }
 
 /// Default inspection speed factor (25% of normal speed).
@@ -175,6 +188,8 @@ impl Default for ElevatorConfig {
             energy_profile: None,
             service_mode: None,
             inspection_speed_factor: default_inspection_speed_factor(),
+            bypass_load_up_pct: None,
+            bypass_load_down_pct: None,
         }
     }
 }

--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -156,25 +156,19 @@ impl DispatchStrategy for DestinationDispatch {
         for (_, riders) in manifest.iter_waiting_stops() {
             for info in riders {
                 if let Some(AssignedCar(c)) = world.ext::<AssignedCar>(info.id) {
-                    if world.elevator(c).is_some() && !world.is_disabled(c) {
-                        // Deferred commitment: when a window is configured
-                        // and the assigned car is still farther than the
-                        // window, strip the assignment so this rider
-                        // re-competes. Inside the window the commitment
-                        // latches — the assignment stays.
-                        if self
-                            .commitment_window_ticks
-                            .is_some_and(|w| !assigned_car_within_window(world, info.id, c, w))
-                        {
-                            stale_assignments.push(info.id);
-                            // Fall through so this rider joins `pending`
-                            // and gets re-assigned below.
-                        } else {
-                            continue; // sticky and live
-                        }
-                    } else {
-                        stale_assignments.push(info.id);
+                    // An assignment stays sticky only when the target
+                    // car is still alive and (no commitment window is
+                    // configured, or the car is already inside the
+                    // latch window). Otherwise strip it so the rider
+                    // re-competes below.
+                    let alive = world.elevator(c).is_some() && !world.is_disabled(c);
+                    let latched = self
+                        .commitment_window_ticks
+                        .is_none_or(|w| assigned_car_within_window(world, info.id, c, w));
+                    if alive && latched {
+                        continue; // sticky and live
                     }
+                    stale_assignments.push(info.id);
                 }
                 let Some(dest) = info.destination else {
                     continue;

--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -400,11 +400,17 @@ fn assigned_car_within_window(
         return false;
     };
     let speed = car_data.max_speed().value();
-    if speed <= 0.0 {
+    if !speed.is_finite() || speed <= 0.0 {
         return false;
     }
-    let eta = ((car_pos - origin_pos).abs() / speed).round() as u64;
-    eta <= window
+    let eta_ticks = (car_pos - origin_pos).abs() / speed;
+    // A non-finite ETA (NaN from corrupted position) would saturate
+    // the `as u64` cast to 0 and erroneously latch the commitment —
+    // refuse to latch instead.
+    if !eta_ticks.is_finite() {
+        return false;
+    }
+    eta_ticks.round() as u64 <= window
 }
 
 /// Drop every sticky [`AssignedCar`] assignment that points at `car_eid`.

--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -63,13 +63,25 @@ pub struct DestinationDispatch {
     /// Units: ticks per newly-added stop. `None` ⇒ derive from the car's
     /// own door timings (~`open + 2 * transition`).
     stop_penalty: Option<f64>,
+    /// Deferred-commitment window. When `Some(window)`, a rider's
+    /// sticky assignment is re-evaluated each pass until the assigned
+    /// car is within `window` ticks of the rider's origin — modelling
+    /// KONE Polaris's two-button reallocation regime (DCS calls fix on
+    /// press; two-button hall calls re-allocate continuously until
+    /// commitment). `None` ⇒ immediate sticky (the default), matching
+    /// fixed-on-press DCS behavior.
+    commitment_window_ticks: Option<u64>,
 }
 
 impl DestinationDispatch {
-    /// Create a new `DestinationDispatch` with defaults.
+    /// Create a new `DestinationDispatch` with defaults (immediate sticky,
+    /// no commitment window).
     #[must_use]
     pub const fn new() -> Self {
-        Self { stop_penalty: None }
+        Self {
+            stop_penalty: None,
+            commitment_window_ticks: None,
+        }
     }
 
     /// Override the fresh-stop penalty (ticks per new stop added to a
@@ -77,6 +89,16 @@ impl DestinationDispatch {
     #[must_use]
     pub const fn with_stop_penalty(mut self, penalty: f64) -> Self {
         self.stop_penalty = Some(penalty);
+        self
+    }
+
+    /// Enable deferred commitment: riders' sticky assignments are
+    /// re-evaluated each pass until the currently-assigned car is
+    /// within `window` ticks of the rider's origin. At that point the
+    /// commitment latches and later ticks leave the assignment alone.
+    #[must_use]
+    pub const fn with_commitment_window_ticks(mut self, window: u64) -> Self {
+        self.commitment_window_ticks = Some(window);
         self
     }
 }
@@ -88,6 +110,7 @@ impl Default for DestinationDispatch {
 }
 
 impl DispatchStrategy for DestinationDispatch {
+    #[allow(clippy::too_many_lines)]
     fn pre_dispatch(
         &mut self,
         group: &ElevatorGroup,
@@ -134,9 +157,24 @@ impl DispatchStrategy for DestinationDispatch {
             for info in riders {
                 if let Some(AssignedCar(c)) = world.ext::<AssignedCar>(info.id) {
                     if world.elevator(c).is_some() && !world.is_disabled(c) {
-                        continue; // sticky and live
+                        // Deferred commitment: when a window is configured
+                        // and the assigned car is still farther than the
+                        // window, strip the assignment so this rider
+                        // re-competes. Inside the window the commitment
+                        // latches — the assignment stays.
+                        if self
+                            .commitment_window_ticks
+                            .is_some_and(|w| !assigned_car_within_window(world, info.id, c, w))
+                        {
+                            stale_assignments.push(info.id);
+                            // Fall through so this rider joins `pending`
+                            // and gets re-assigned below.
+                        } else {
+                            continue; // sticky and live
+                        }
+                    } else {
+                        stale_assignments.push(info.id);
                     }
-                    stale_assignments.push(info.id);
                 }
                 let Some(dest) = info.destination else {
                     continue;
@@ -338,6 +376,35 @@ impl DestinationDispatch {
 
         pickup_time + ride_time + penalty * new_stops + idle_bonus + load_penalty
     }
+}
+
+/// True when the `car` assigned to `rider` is within `window` ticks of
+/// the rider's origin, measured by raw distance / `max_speed`. Used to
+/// decide whether a deferred commitment has latched.
+fn assigned_car_within_window(
+    world: &crate::world::World,
+    rider: EntityId,
+    car: EntityId,
+    window: u64,
+) -> bool {
+    let Some(leg) = world.route(rider).and_then(|r| r.current()) else {
+        return false;
+    };
+    let Some(origin_pos) = world.stop_position(leg.from) else {
+        return false;
+    };
+    let Some(car_pos) = world.position(car).map(|p| p.value) else {
+        return false;
+    };
+    let Some(car_data) = world.elevator(car) else {
+        return false;
+    };
+    let speed = car_data.max_speed().value();
+    if speed <= 0.0 {
+        return false;
+    }
+    let eta = ((car_pos - origin_pos).abs() / speed).round() as u64;
+    eta <= window
 }
 
 /// Drop every sticky [`AssignedCar`] assignment that points at `car_eid`.

--- a/crates/elevator-core/src/dispatch/etd.rs
+++ b/crates/elevator-core/src/dispatch/etd.rs
@@ -83,8 +83,18 @@ impl EtdDispatch {
 
     /// Turn on the squared-wait fairness bonus. Higher values prefer
     /// older waiters more aggressively; `0.0` (the default) disables.
+    ///
+    /// # Panics
+    /// Panics on non-finite or negative weights. A `NaN` weight would
+    /// propagate through `mul_add` and silently disable every dispatch
+    /// rank; a negative weight would invert the fairness ordering.
+    /// Either is a programming error rather than a valid configuration.
     #[must_use]
-    pub const fn with_wait_squared_weight(mut self, weight: f64) -> Self {
+    pub fn with_wait_squared_weight(mut self, weight: f64) -> Self {
+        assert!(
+            weight.is_finite() && weight >= 0.0,
+            "wait_squared_weight must be finite and non-negative, got {weight}"
+        );
         self.wait_squared_weight = weight;
         self
     }

--- a/crates/elevator-core/src/dispatch/etd.rs
+++ b/crates/elevator-core/src/dispatch/etd.rs
@@ -28,6 +28,13 @@ pub struct EtdDispatch {
     pub delay_weight: f64,
     /// Weight for door open/close overhead at intermediate stops.
     pub door_weight: f64,
+    /// Weight for the squared-wait "group-time" fairness bonus. Each
+    /// candidate stop's cost is reduced by this weight times the sum
+    /// of `wait_ticks²` across waiting riders at the stop, so stops
+    /// hosting older calls win ties. Defaults to `0.0` (no bias);
+    /// positive values damp the long-wait tail (Aalto EJOR 2016
+    /// group-time assignment model).
+    pub wait_squared_weight: f64,
     /// Positions of every demanded stop in the group, cached by
     /// [`DispatchStrategy::pre_dispatch`] so `rank` avoids rebuilding the
     /// list for every `(car, stop)` pair.
@@ -37,13 +44,15 @@ pub struct EtdDispatch {
 impl EtdDispatch {
     /// Create a new `EtdDispatch` with default weights.
     ///
-    /// Defaults: `wait_weight = 1.0`, `delay_weight = 1.0`, `door_weight = 0.5`.
+    /// Defaults: `wait_weight = 1.0`, `delay_weight = 1.0`,
+    /// `door_weight = 0.5`, `wait_squared_weight = 0.0`.
     #[must_use]
     pub fn new() -> Self {
         Self {
             wait_weight: 1.0,
             delay_weight: 1.0,
             door_weight: 0.5,
+            wait_squared_weight: 0.0,
             pending_positions: SmallVec::new(),
         }
     }
@@ -55,6 +64,7 @@ impl EtdDispatch {
             wait_weight: 1.0,
             delay_weight,
             door_weight: 0.5,
+            wait_squared_weight: 0.0,
             pending_positions: SmallVec::new(),
         }
     }
@@ -66,8 +76,17 @@ impl EtdDispatch {
             wait_weight,
             delay_weight,
             door_weight,
+            wait_squared_weight: 0.0,
             pending_positions: SmallVec::new(),
         }
+    }
+
+    /// Turn on the squared-wait fairness bonus. Higher values prefer
+    /// older waiters more aggressively; `0.0` (the default) disables.
+    #[must_use]
+    pub const fn with_wait_squared_weight(mut self, weight: f64) -> Self {
+        self.wait_squared_weight = weight;
+        self
     }
 }
 
@@ -105,7 +124,19 @@ impl DispatchStrategy for EtdDispatch {
         if !pair_can_do_work(ctx) {
             return None;
         }
-        let cost = self.compute_cost(ctx.car, ctx.car_position, ctx.stop_position, ctx.world);
+        let mut cost = self.compute_cost(ctx.car, ctx.car_position, ctx.stop_position, ctx.world);
+        if self.wait_squared_weight > 0.0 {
+            let wait_sq: f64 = ctx
+                .manifest
+                .waiting_riders_at(ctx.stop)
+                .iter()
+                .map(|r| {
+                    let w = r.wait_ticks as f64;
+                    w * w
+                })
+                .sum();
+            cost = self.wait_squared_weight.mul_add(-wait_sq, cost).max(0.0);
+        }
         if cost.is_finite() { Some(cost) } else { None }
     }
 }

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -940,6 +940,8 @@ pub enum BuiltinReposition {
     DemandWeighted,
     /// Keep idle elevators where they are (no-op).
     NearestIdle,
+    /// Pre-position cars near stops with the highest recent arrival rate.
+    PredictiveParking,
     /// Custom strategy identified by name.
     Custom(String),
 }
@@ -951,6 +953,7 @@ impl std::fmt::Display for BuiltinReposition {
             Self::ReturnToLobby => write!(f, "ReturnToLobby"),
             Self::DemandWeighted => write!(f, "DemandWeighted"),
             Self::NearestIdle => write!(f, "NearestIdle"),
+            Self::PredictiveParking => write!(f, "PredictiveParking"),
             Self::Custom(name) => write!(f, "Custom({name})"),
         }
     }
@@ -968,6 +971,7 @@ impl BuiltinReposition {
             Self::ReturnToLobby => Some(Box::new(reposition::ReturnToLobby::new())),
             Self::DemandWeighted => Some(Box::new(reposition::DemandWeighted)),
             Self::NearestIdle => Some(Box::new(reposition::NearestIdle)),
+            Self::PredictiveParking => Some(Box::new(reposition::PredictiveParking::new())),
             Self::Custom(_) => None,
         }
     }

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -134,6 +134,16 @@ pub struct DispatchManifest {
     /// entity. Strategies read this to plan intermediate stops without
     /// poking into `World` directly.
     pub(crate) car_calls_by_car: BTreeMap<EntityId, Vec<CarCall>>,
+    /// Recent arrivals per stop, counted over
+    /// [`DispatchManifest::arrival_window_ticks`] ticks. Populated from
+    /// the [`crate::arrival_log::ArrivalLog`] world resource each pass
+    /// so strategies can read a traffic-rate signal without touching
+    /// world state directly.
+    pub(crate) arrivals_at_stop: BTreeMap<EntityId, u64>,
+    /// Window the `arrivals_at_stop` counts cover, in ticks. Exposed so
+    /// strategies interpreting the raw counts can convert them to a
+    /// rate (per tick or per second).
+    pub(crate) arrival_window_ticks: u64,
 }
 
 impl DispatchManifest {
@@ -185,6 +195,25 @@ impl DispatchManifest {
     #[must_use]
     pub fn resident_count_at(&self, stop: EntityId) -> usize {
         self.resident_count_at_stop.get(&stop).copied().unwrap_or(0)
+    }
+
+    /// Rider arrivals at `stop` within the last
+    /// [`arrival_window_ticks`](Self::arrival_window_ticks) ticks. The
+    /// signal is the rolling-window per-stop arrival rate that
+    /// commercial controllers use to pick a traffic mode and that
+    /// [`crate::dispatch::reposition::PredictiveParking`] uses to
+    /// forecast demand. Unvisited stops return 0.
+    #[must_use]
+    pub fn arrivals_at(&self, stop: EntityId) -> u64 {
+        self.arrivals_at_stop.get(&stop).copied().unwrap_or(0)
+    }
+
+    /// Window size (in ticks) over which [`arrivals_at`](Self::arrivals_at)
+    /// counts events. Strategies convert counts to rates by dividing
+    /// by this.
+    #[must_use]
+    pub const fn arrival_window_ticks(&self) -> u64 {
+        self.arrival_window_ticks
     }
 
     /// The hall call at `(stop, direction)`, if pressed.

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -86,6 +86,16 @@ pub fn pair_can_do_work(ctx: &RankContext<'_>) -> bool {
     if can_exit_here {
         return true;
     }
+
+    // Direction-dependent full-load bypass (Otis Elevonic 411 model,
+    // patent US5490580A). A car loaded above its configured threshold
+    // in the current travel direction ignores hall calls in that same
+    // direction. Aboard riders still get delivered — the `can_exit_here`
+    // short-circuit above guarantees their destinations remain rank-able.
+    if bypass_in_current_direction(car, ctx) {
+        return false;
+    }
+
     let remaining_capacity = car.weight_capacity.value() - car.current_load.value();
     if remaining_capacity <= 0.0 {
         return false;
@@ -95,6 +105,45 @@ pub fn pair_can_do_work(ctx: &RankContext<'_>) -> bool {
         || waiting
             .iter()
             .any(|r| r.weight.value() <= remaining_capacity)
+}
+
+/// True when a full-load bypass applies: the car has a configured
+/// threshold for its current travel direction, is above that threshold,
+/// and the candidate stop lies in that same direction.
+fn bypass_in_current_direction(car: &crate::components::Elevator, ctx: &RankContext<'_>) -> bool {
+    // Derive travel direction from the car's current target, if any.
+    // An Idle or Stopped car has no committed direction → no bypass.
+    let Some(target) = car.phase().moving_target() else {
+        return false;
+    };
+    let Some(target_pos) = ctx.world.stop_position(target) else {
+        return false;
+    };
+    let going_up = target_pos > ctx.car_position;
+    let going_down = target_pos < ctx.car_position;
+    if !going_up && !going_down {
+        return false;
+    }
+    let threshold = if going_up {
+        car.bypass_load_up_pct()
+    } else {
+        car.bypass_load_down_pct()
+    };
+    let Some(pct) = threshold else {
+        return false;
+    };
+    let capacity = car.weight_capacity().value();
+    if capacity <= 0.0 {
+        return false;
+    }
+    let load_ratio = car.current_load().value() / capacity;
+    if load_ratio < pct {
+        return false;
+    }
+    // Only same-direction pickups get bypassed.
+    let stop_above = ctx.stop_position > ctx.car_position;
+    let stop_below = ctx.stop_position < ctx.car_position;
+    (going_up && stop_above) || (going_down && stop_below)
 }
 
 /// Metadata about a single rider, available to dispatch strategies.

--- a/crates/elevator-core/src/dispatch/reposition.rs
+++ b/crates/elevator-core/src/dispatch/reposition.rs
@@ -156,7 +156,10 @@ impl RepositionStrategy for DemandWeighted {
         }
 
         let tags = world.resource::<MetricTags>();
-        let mut scored_stops: Vec<(EntityId, f64, f64)> = stop_positions
+        // `demand + 1.0` keeps zero-demand stops in the running — the
+        // strategy still produces a spread at sim start before any
+        // deliveries have been recorded.
+        let mut scored: Vec<(EntityId, f64, f64)> = stop_positions
             .iter()
             .map(|&(stop_eid, stop_pos)| {
                 let demand = tags
@@ -170,48 +173,9 @@ impl RepositionStrategy for DemandWeighted {
                 (stop_eid, stop_pos, demand + 1.0)
             })
             .collect();
+        scored.sort_by(|a, b| b.2.total_cmp(&a.2));
 
-        scored_stops.sort_by(|a, b| b.2.total_cmp(&a.2));
-
-        let mut occupied: Vec<f64> = group
-            .elevator_entities()
-            .iter()
-            .filter_map(|&eid| {
-                if idle_elevators.iter().any(|(ie, _)| *ie == eid) {
-                    return None;
-                }
-                world.position(eid).map(|p| p.value)
-            })
-            .collect();
-
-        let mut assigned_elevators: Vec<EntityId> = Vec::new();
-
-        for (stop_eid, stop_pos, _demand) in &scored_stops {
-            if min_distance_to(*stop_pos, &occupied) < 1e-6 {
-                continue;
-            }
-
-            let closest = idle_elevators
-                .iter()
-                .filter(|(eid, _)| !assigned_elevators.contains(eid))
-                .min_by(|a, b| {
-                    let da = (a.1 - stop_pos).abs();
-                    let db = (b.1 - stop_pos).abs();
-                    da.total_cmp(&db)
-                });
-
-            if let Some(&(elev_eid, elev_pos)) = closest
-                && (elev_pos - stop_pos).abs() > 1e-6
-            {
-                out.push((elev_eid, *stop_eid));
-                assigned_elevators.push(elev_eid);
-                occupied.push(*stop_pos);
-            }
-
-            if assigned_elevators.len() == idle_elevators.len() {
-                break;
-            }
-        }
+        assign_greedy_by_score(&scored, idle_elevators, group, world, out);
     }
 }
 
@@ -291,11 +255,7 @@ impl RepositionStrategy for PredictiveParking {
             .iter()
             .filter_map(|&(sid, pos)| {
                 let count = log.arrivals_in_window(sid, now, self.window_ticks);
-                if count == 0 {
-                    None
-                } else {
-                    Some((sid, pos, count))
-                }
+                (count > 0).then_some((sid, pos, count))
             })
             .collect();
         if scored.is_empty() {
@@ -305,43 +265,7 @@ impl RepositionStrategy for PredictiveParking {
         // order on ties so the result stays deterministic.
         scored.sort_by_key(|(_, _, count)| std::cmp::Reverse(*count));
 
-        // Positions of non-idle elevators — we want to avoid parking
-        // on top of cars already in service.
-        let mut occupied: Vec<f64> = group
-            .elevator_entities()
-            .iter()
-            .filter_map(|&eid| {
-                if idle_elevators.iter().any(|(ie, _)| *ie == eid) {
-                    return None;
-                }
-                world.position(eid).map(|p| p.value)
-            })
-            .collect();
-
-        let mut assigned_elevators: Vec<EntityId> = Vec::new();
-        for (stop_eid, stop_pos, _count) in &scored {
-            if min_distance_to(*stop_pos, &occupied) < 1e-6 {
-                continue;
-            }
-            let closest = idle_elevators
-                .iter()
-                .filter(|(eid, _)| !assigned_elevators.contains(eid))
-                .min_by(|a, b| {
-                    let da = (a.1 - stop_pos).abs();
-                    let db = (b.1 - stop_pos).abs();
-                    da.total_cmp(&db)
-                });
-            if let Some(&(elev_eid, elev_pos)) = closest
-                && (elev_pos - stop_pos).abs() > 1e-6
-            {
-                out.push((elev_eid, *stop_eid));
-                assigned_elevators.push(elev_eid);
-                occupied.push(*stop_pos);
-            }
-            if assigned_elevators.len() == idle_elevators.len() {
-                break;
-            }
-        }
+        assign_greedy_by_score(&scored, idle_elevators, group, world, out);
     }
 }
 
@@ -360,6 +284,61 @@ impl RepositionStrategy for NearestIdle {
         _world: &World,
         _out: &mut Vec<(EntityId, EntityId)>,
     ) {
+    }
+}
+
+/// Shared greedy-assign step for score-driven parking strategies.
+///
+/// `scored` is the list of `(stop_id, stop_pos, _score)` in descending
+/// priority order (strategies sort/filter upstream). For each stop in
+/// that order, pick the closest still-unassigned idle elevator and
+/// send it there — unless the stop is already covered by a non-idle
+/// car or the closest idle car is already parked on it.
+///
+/// The tuple's third element is ignored here; it exists only to keep
+/// the caller's scoring type visible at the call site.
+fn assign_greedy_by_score<S>(
+    scored: &[(EntityId, f64, S)],
+    idle_elevators: &[(EntityId, f64)],
+    group: &ElevatorGroup,
+    world: &World,
+    out: &mut Vec<(EntityId, EntityId)>,
+) {
+    // Positions of non-idle elevators — avoid parking on top of cars
+    // already in service.
+    let mut occupied: Vec<f64> = group
+        .elevator_entities()
+        .iter()
+        .filter_map(|&eid| {
+            if idle_elevators.iter().any(|(ie, _)| *ie == eid) {
+                return None;
+            }
+            world.position(eid).map(|p| p.value)
+        })
+        .collect();
+
+    let mut assigned: Vec<EntityId> = Vec::new();
+    for (stop_eid, stop_pos, _) in scored {
+        if min_distance_to(*stop_pos, &occupied) < 1e-6 {
+            continue;
+        }
+
+        let closest = idle_elevators
+            .iter()
+            .filter(|(eid, _)| !assigned.contains(eid))
+            .min_by(|a, b| (a.1 - stop_pos).abs().total_cmp(&(b.1 - stop_pos).abs()));
+
+        if let Some(&(elev_eid, elev_pos)) = closest
+            && (elev_pos - stop_pos).abs() > 1e-6
+        {
+            out.push((elev_eid, *stop_eid));
+            assigned.push(elev_eid);
+            occupied.push(*stop_pos);
+        }
+
+        if assigned.len() == idle_elevators.len() {
+            break;
+        }
     }
 }
 

--- a/crates/elevator-core/src/dispatch/reposition.rs
+++ b/crates/elevator-core/src/dispatch/reposition.rs
@@ -12,6 +12,7 @@
 //!     .unwrap();
 //! ```
 
+use crate::arrival_log::{ArrivalLog, CurrentTick, DEFAULT_ARRIVAL_WINDOW_TICKS};
 use crate::entity::EntityId;
 use crate::tagged_metrics::{MetricTags, TaggedMetric};
 use crate::world::World;
@@ -207,6 +208,126 @@ impl RepositionStrategy for DemandWeighted {
                 occupied.push(*stop_pos);
             }
 
+            if assigned_elevators.len() == idle_elevators.len() {
+                break;
+            }
+        }
+    }
+}
+
+/// Predictive parking: park idle elevators near stops with the
+/// highest recent per-stop arrival rate.
+///
+/// Reads the [`ArrivalLog`] and [`CurrentTick`] world resources
+/// (always present under a built sim) to compute a rolling window of
+/// arrivals. Cars are greedily assigned to the highest-rate stops that
+/// don't already have a car nearby, so the group spreads across the
+/// hottest floors rather than clustering on one.
+///
+/// Parallels the headline feature of Otis Compass Infinity — forecast
+/// demand from recent traffic, pre-position cars accordingly. Falls
+/// back to no-op when no arrivals have been logged.
+pub struct PredictiveParking {
+    /// Rolling window (ticks) used to compute per-stop arrival counts.
+    /// Shorter windows react faster; longer windows smooth noise.
+    window_ticks: u64,
+}
+
+impl PredictiveParking {
+    /// Create with the default rolling window
+    /// ([`DEFAULT_ARRIVAL_WINDOW_TICKS`]).
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            window_ticks: DEFAULT_ARRIVAL_WINDOW_TICKS,
+        }
+    }
+
+    /// Create with a custom rolling window (ticks). Shorter windows
+    /// react faster to traffic shifts; longer windows smooth out noise.
+    #[must_use]
+    pub const fn with_window_ticks(window_ticks: u64) -> Self {
+        Self { window_ticks }
+    }
+}
+
+impl Default for PredictiveParking {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RepositionStrategy for PredictiveParking {
+    fn reposition(
+        &mut self,
+        idle_elevators: &[(EntityId, f64)],
+        stop_positions: &[(EntityId, f64)],
+        group: &ElevatorGroup,
+        world: &World,
+        out: &mut Vec<(EntityId, EntityId)>,
+    ) {
+        if idle_elevators.is_empty() || stop_positions.is_empty() {
+            return;
+        }
+        let Some(log) = world.resource::<ArrivalLog>() else {
+            return;
+        };
+        let now = world.resource::<CurrentTick>().map_or(0, |ct| ct.0);
+
+        // Score each stop by its arrival count over the window. Keep
+        // only positives — stops with zero recent arrivals are not
+        // parking targets (no signal to act on).
+        let mut scored: Vec<(EntityId, f64, u64)> = stop_positions
+            .iter()
+            .filter_map(|&(sid, pos)| {
+                let count = log.arrivals_in_window(sid, now, self.window_ticks);
+                if count == 0 {
+                    None
+                } else {
+                    Some((sid, pos, count))
+                }
+            })
+            .collect();
+        if scored.is_empty() {
+            return;
+        }
+        // Highest arrival count first; stable sort preserves stop-id
+        // order on ties so the result stays deterministic.
+        scored.sort_by_key(|(_, _, count)| std::cmp::Reverse(*count));
+
+        // Positions of non-idle elevators — we want to avoid parking
+        // on top of cars already in service.
+        let mut occupied: Vec<f64> = group
+            .elevator_entities()
+            .iter()
+            .filter_map(|&eid| {
+                if idle_elevators.iter().any(|(ie, _)| *ie == eid) {
+                    return None;
+                }
+                world.position(eid).map(|p| p.value)
+            })
+            .collect();
+
+        let mut assigned_elevators: Vec<EntityId> = Vec::new();
+        for (stop_eid, stop_pos, _count) in &scored {
+            if min_distance_to(*stop_pos, &occupied) < 1e-6 {
+                continue;
+            }
+            let closest = idle_elevators
+                .iter()
+                .filter(|(eid, _)| !assigned_elevators.contains(eid))
+                .min_by(|a, b| {
+                    let da = (a.1 - stop_pos).abs();
+                    let db = (b.1 - stop_pos).abs();
+                    da.total_cmp(&db)
+                });
+            if let Some(&(elev_eid, elev_pos)) = closest
+                && (elev_pos - stop_pos).abs() > 1e-6
+            {
+                out.push((elev_eid, *stop_eid));
+                assigned_elevators.push(elev_eid);
+                occupied.push(*stop_pos);
+            }
             if assigned_elevators.len() == idle_elevators.len() {
                 break;
             }

--- a/crates/elevator-core/src/dispatch/reposition.rs
+++ b/crates/elevator-core/src/dispatch/reposition.rs
@@ -245,8 +245,18 @@ impl PredictiveParking {
 
     /// Create with a custom rolling window (ticks). Shorter windows
     /// react faster to traffic shifts; longer windows smooth out noise.
+    ///
+    /// # Panics
+    /// Panics on `window_ticks == 0`. A zero window would cause
+    /// `ArrivalLog::arrivals_in_window` to return 0 for every stop —
+    /// the strategy would silently no-op, which is almost never what
+    /// the caller meant.
     #[must_use]
     pub const fn with_window_ticks(window_ticks: u64) -> Self {
+        assert!(
+            window_ticks > 0,
+            "PredictiveParking::with_window_ticks requires a positive window"
+        );
         Self { window_ticks }
     }
 }

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -362,6 +362,9 @@ pub mod systems;
 /// Central entity/component storage.
 pub mod world;
 
+/// Rolling per-stop arrival log, the signal source for rate-driven
+/// dispatch and repositioning.
+pub mod arrival_log;
 /// Fluent builder for constructing a Simulation programmatically.
 pub mod builder;
 /// Building and elevator configuration (RON deserialization).

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -505,7 +505,8 @@ macro_rules! register_extensions {
 ///   [`NearestIdle`](crate::dispatch::reposition::NearestIdle),
 ///   [`ReturnToLobby`](crate::dispatch::reposition::ReturnToLobby),
 ///   [`SpreadEvenly`](crate::dispatch::reposition::SpreadEvenly),
-///   [`DemandWeighted`](crate::dispatch::reposition::DemandWeighted)
+///   [`DemandWeighted`](crate::dispatch::reposition::DemandWeighted),
+///   [`PredictiveParking`](crate::dispatch::reposition::PredictiveParking)
 /// - **Identity:** [`EntityId`](crate::entity::EntityId),
 ///   [`StopId`](crate::stop::StopId), [`StopRef`](crate::stop::StopRef),
 ///   [`GroupId`](crate::ids::GroupId)
@@ -534,7 +535,7 @@ pub mod prelude {
     };
     pub use crate::config::{ElevatorConfig, GroupConfig, LineConfig, SimConfig};
     pub use crate::dispatch::reposition::{
-        DemandWeighted, NearestIdle, ReturnToLobby, SpreadEvenly,
+        DemandWeighted, NearestIdle, PredictiveParking, ReturnToLobby, SpreadEvenly,
     };
     pub use crate::dispatch::{
         AssignedCar, DestinationDispatch, DispatchDecision, DispatchManifest, DispatchStrategy,

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -117,6 +117,11 @@ pub struct ElevatorParams {
     pub restricted_stops: HashSet<EntityId>,
     /// Speed multiplier for Inspection mode (0.0..1.0).
     pub inspection_speed_factor: f64,
+    /// Full-load bypass threshold for upward pickups (see
+    /// [`Elevator::bypass_load_up_pct`](crate::components::Elevator::bypass_load_up_pct)).
+    pub bypass_load_up_pct: Option<f64>,
+    /// Full-load bypass threshold for downward pickups.
+    pub bypass_load_down_pct: Option<f64>,
 }
 
 impl Default for ElevatorParams {
@@ -130,6 +135,8 @@ impl Default for ElevatorParams {
             door_open_ticks: 10,
             restricted_stops: HashSet::new(),
             inspection_speed_factor: 0.25,
+            bypass_load_up_pct: None,
+            bypass_load_down_pct: None,
         }
     }
 }

--- a/crates/elevator-core/src/sim/accessors.rs
+++ b/crates/elevator-core/src/sim/accessors.rs
@@ -125,6 +125,21 @@ impl super::Simulation {
             .unwrap_or_default()
     }
 
+    /// Set how far back the arrival log retains entries before
+    /// `advance_tick` prunes them. Strategies querying a window longer
+    /// than the default (`5` minutes at 60 Hz, see
+    /// [`DEFAULT_ARRIVAL_WINDOW_TICKS`](crate::arrival_log::DEFAULT_ARRIVAL_WINDOW_TICKS))
+    /// must call this with a matching retention or they will silently
+    /// see only the last 5 minutes of arrivals.
+    pub fn set_arrival_log_retention_ticks(&mut self, retention_ticks: u64) {
+        if let Some(r) = self
+            .world
+            .resource_mut::<crate::arrival_log::ArrivalLogRetention>()
+        {
+            r.0 = retention_ticks;
+        }
+    }
+
     /// Mutable access to the group collection. Use this to flip a group
     /// into [`HallCallMode::Destination`](crate::dispatch::HallCallMode)
     /// or tune its `ack_latency_ticks` after construction. Changing the

--- a/crates/elevator-core/src/sim/accessors.rs
+++ b/crates/elevator-core/src/sim/accessors.rs
@@ -103,6 +103,28 @@ impl super::Simulation {
         &self.groups
     }
 
+    /// Build the [`DispatchManifest`](crate::dispatch::DispatchManifest)
+    /// for `group` as it would appear at the start of the next dispatch
+    /// pass. Intended for tests and tools that need to inspect the
+    /// demand/arrival-rate picture without stepping the sim.
+    #[must_use]
+    pub fn build_dispatch_manifest(
+        &self,
+        group: &ElevatorGroup,
+    ) -> crate::dispatch::DispatchManifest {
+        crate::systems::dispatch::build_manifest(&self.world, group, self.tick, &self.rider_index)
+    }
+
+    /// Convenience wrapper returning the manifest for the first group —
+    /// what a single-group default-topology sim would dispatch against.
+    #[must_use]
+    pub fn peek_dispatch_manifest(&self) -> crate::dispatch::DispatchManifest {
+        self.groups
+            .first()
+            .map(|g| self.build_dispatch_manifest(g))
+            .unwrap_or_default()
+    }
+
     /// Mutable access to the group collection. Use this to flip a group
     /// into [`HallCallMode::Destination`](crate::dispatch::HallCallMode)
     /// or tune its `ack_latency_ticks` after construction. Changing the

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -47,6 +47,7 @@ type TopologyResult = (
 /// the runtime `add_elevator` path call this so an invalid set of params
 /// can never reach the world (zeroes blow up movement; zero door ticks
 /// stall the door FSM).
+#[allow(clippy::too_many_arguments)]
 pub(super) fn validate_elevator_physics(
     max_speed: f64,
     acceleration: f64,
@@ -55,6 +56,8 @@ pub(super) fn validate_elevator_physics(
     inspection_speed_factor: f64,
     door_transition_ticks: u32,
     door_open_ticks: u32,
+    bypass_load_up_pct: Option<f64>,
+    bypass_load_down_pct: Option<f64>,
 ) -> Result<(), SimError> {
     if !max_speed.is_finite() || max_speed <= 0.0 {
         return Err(SimError::InvalidConfig {
@@ -96,6 +99,25 @@ pub(super) fn validate_elevator_physics(
         return Err(SimError::InvalidConfig {
             field: "elevators.door_open_ticks",
             reason: "must be > 0".into(),
+        });
+    }
+    validate_bypass_pct("elevators.bypass_load_up_pct", bypass_load_up_pct)?;
+    validate_bypass_pct("elevators.bypass_load_down_pct", bypass_load_down_pct)?;
+    Ok(())
+}
+
+/// `bypass_load_{up,down}_pct` must be a finite fraction in `(0.0, 1.0]`
+/// when set. `pct = 0.0` would bypass at an empty car (nonsense); `NaN`
+/// and infinities silently disable the bypass under the dispatch guard,
+/// which is a silent foot-gun. Reject at config time instead.
+fn validate_bypass_pct(field: &'static str, pct: Option<f64>) -> Result<(), SimError> {
+    let Some(pct) = pct else {
+        return Ok(());
+    };
+    if !pct.is_finite() || pct <= 0.0 || pct > 1.0 {
+        return Err(SimError::InvalidConfig {
+            field,
+            reason: format!("must be finite in (0.0, 1.0] when set, got {pct}"),
         });
     }
     Ok(())
@@ -696,6 +718,8 @@ impl Simulation {
             elev.inspection_speed_factor,
             elev.door_transition_ticks,
             elev.door_open_ticks,
+            elev.bypass_load_up_pct,
+            elev.bypass_load_down_pct,
         )?;
         if !building.stops.iter().any(|s| s.id == elev.starting_stop) {
             return Err(SimError::InvalidConfig {

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -184,6 +184,7 @@ impl Simulation {
         // switches and predictive parking.
         world.insert_resource(crate::arrival_log::ArrivalLog::default());
         world.insert_resource(crate::arrival_log::CurrentTick::default());
+        world.insert_resource(crate::arrival_log::ArrivalLogRetention::default());
 
         let (groups, dispatchers, strategy_ids) = if let Some(line_configs) = &config.building.lines
         {

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -287,6 +287,8 @@ impl Simulation {
                 move_count: 0,
                 door_command_queue: Vec::new(),
                 manual_target_velocity: None,
+                bypass_load_up_pct: ec.bypass_load_up_pct,
+                bypass_load_down_pct: ec.bypass_load_down_pct,
             },
         );
         #[cfg(feature = "energy")]

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -161,6 +161,7 @@ impl Simulation {
         // by dispatch/reposition strategies to drive traffic-mode
         // switches and predictive parking.
         world.insert_resource(crate::arrival_log::ArrivalLog::default());
+        world.insert_resource(crate::arrival_log::CurrentTick::default());
 
         let (groups, dispatchers, strategy_ids) = if let Some(line_configs) = &config.building.lines
         {

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -157,6 +157,11 @@ impl Simulation {
         sorted.sort_by(|a, b| a.0.total_cmp(&b.0));
         world.insert_resource(crate::world::SortedStops(sorted));
 
+        // Per-stop arrival signal, appended on rider spawn and queried
+        // by dispatch/reposition strategies to drive traffic-mode
+        // switches and predictive parking.
+        world.insert_resource(crate::arrival_log::ArrivalLog::default());
+
         let (groups, dispatchers, strategy_ids) = if let Some(line_configs) = &config.building.lines
         {
             Self::build_explicit_topology(

--- a/crates/elevator-core/src/sim/rider.rs
+++ b/crates/elevator-core/src/sim/rider.rs
@@ -169,6 +169,9 @@ impl super::Simulation {
         );
         self.world.set_route(eid, route);
         self.rider_index.insert_waiting(origin, eid);
+        if let Some(log) = self.world.resource_mut::<crate::arrival_log::ArrivalLog>() {
+            log.record(self.tick, origin);
+        }
         self.events.emit(Event::RiderSpawned {
             rider: eid,
             origin,

--- a/crates/elevator-core/src/sim/substep.rs
+++ b/crates/elevator-core/src/sim/substep.rs
@@ -301,6 +301,12 @@ impl super::Simulation {
     /// assert_eq!(sim.current_tick(), 1);
     /// ```
     pub fn step(&mut self) {
+        // Mirror the current tick into the world so reposition strategies
+        // and other world-only consumers can query rolling arrival-rate
+        // windows without `PhaseContext`.
+        if let Some(ct) = self.world.resource_mut::<crate::arrival_log::CurrentTick>() {
+            ct.0 = self.tick;
+        }
         self.world.snapshot_prev_positions();
         self.run_advance_transient();
         self.run_dispatch();

--- a/crates/elevator-core/src/sim/substep.rs
+++ b/crates/elevator-core/src/sim/substep.rs
@@ -66,6 +66,7 @@ impl super::Simulation {
     /// across tick boundaries.
     pub fn run_advance_transient(&mut self) {
         self.tick_in_progress = true;
+        self.sync_world_tick();
         self.hooks
             .run_before(Phase::AdvanceTransient, &mut self.world);
         for group in &self.groups {
@@ -89,6 +90,7 @@ impl super::Simulation {
 
     /// Run only the dispatch phase (with hooks).
     pub fn run_dispatch(&mut self) {
+        self.sync_world_tick();
         self.hooks.run_before(Phase::Dispatch, &mut self.world);
         for group in &self.groups {
             self.hooks
@@ -212,6 +214,7 @@ impl super::Simulation {
     /// repositioner — this differs from other phases where per-group hooks
     /// fire unconditionally.
     pub fn run_reposition(&mut self) {
+        self.sync_world_tick();
         self.hooks.run_before(Phase::Reposition, &mut self.world);
         if !self.repositioners.is_empty() {
             // Only run per-group hooks for groups that have a repositioner.
@@ -285,6 +288,30 @@ impl super::Simulation {
         self.pending_output.extend(self.events.drain());
         self.tick += 1;
         self.tick_in_progress = false;
+        // Keep the `CurrentTick` world resource in lockstep after the tick
+        // counter advances; substep consumers driving phases manually
+        // will see the fresh value on their next call.
+        self.sync_world_tick();
+        // Drop arrival-log entries older than the default rolling window.
+        // Unbounded growth would turn `arrivals_in_window` into an O(n)
+        // per-stop per-tick scan.
+        let cutoff = self
+            .tick
+            .saturating_sub(crate::arrival_log::DEFAULT_ARRIVAL_WINDOW_TICKS);
+        if let Some(log) = self.world.resource_mut::<crate::arrival_log::ArrivalLog>() {
+            log.prune_before(cutoff);
+        }
+    }
+
+    /// Mirror `self.tick` into the `CurrentTick` world resource so
+    /// phases that only have `&World` (reposition strategies, custom
+    /// consumers) can compute rolling-window queries without plumbing
+    /// `PhaseContext`. Called from `step()` and `advance_tick()` so
+    /// manual-phase callers stay in sync too.
+    fn sync_world_tick(&mut self) {
+        if let Some(ct) = self.world.resource_mut::<crate::arrival_log::CurrentTick>() {
+            ct.0 = self.tick;
+        }
     }
 
     /// Advance the simulation by one tick.
@@ -301,12 +328,7 @@ impl super::Simulation {
     /// assert_eq!(sim.current_tick(), 1);
     /// ```
     pub fn step(&mut self) {
-        // Mirror the current tick into the world so reposition strategies
-        // and other world-only consumers can query rolling arrival-rate
-        // windows without `PhaseContext`.
-        if let Some(ct) = self.world.resource_mut::<crate::arrival_log::CurrentTick>() {
-            ct.0 = self.tick;
-        }
+        self.sync_world_tick();
         self.world.snapshot_prev_positions();
         self.run_advance_transient();
         self.run_dispatch();

--- a/crates/elevator-core/src/sim/substep.rs
+++ b/crates/elevator-core/src/sim/substep.rs
@@ -292,12 +292,16 @@ impl super::Simulation {
         // counter advances; substep consumers driving phases manually
         // will see the fresh value on their next call.
         self.sync_world_tick();
-        // Drop arrival-log entries older than the default rolling window.
+        // Drop arrival-log entries older than the configured retention.
         // Unbounded growth would turn `arrivals_in_window` into an O(n)
         // per-stop per-tick scan.
-        let cutoff = self
-            .tick
-            .saturating_sub(crate::arrival_log::DEFAULT_ARRIVAL_WINDOW_TICKS);
+        let retention = self
+            .world
+            .resource::<crate::arrival_log::ArrivalLogRetention>()
+            .copied()
+            .unwrap_or_default()
+            .0;
+        let cutoff = self.tick.saturating_sub(retention);
         if let Some(log) = self.world.resource_mut::<crate::arrival_log::ArrivalLog>() {
             log.prune_before(cutoff);
         }

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -183,6 +183,8 @@ impl Simulation {
                 move_count: 0,
                 door_command_queue: Vec::new(),
                 manual_target_velocity: None,
+                bypass_load_up_pct: params.bypass_load_up_pct,
+                bypass_load_down_pct: params.bypass_load_down_pct,
             },
         );
         self.world

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -122,6 +122,8 @@ impl Simulation {
             params.inspection_speed_factor,
             params.door_transition_ticks,
             params.door_open_ticks,
+            params.bypass_load_up_pct,
+            params.bypass_load_down_pct,
         )?;
         if !starting_position.is_finite() {
             return Err(SimError::InvalidConfig {

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -125,6 +125,13 @@ pub struct WorldSnapshot {
     /// allocated entity IDs.
     #[serde(default)]
     pub arrival_log: crate::arrival_log::ArrivalLog,
+    /// Retention window for the arrival log (ticks). Captured so a
+    /// host-configured value (e.g. via
+    /// `Simulation::set_arrival_log_retention_ticks`) survives
+    /// snapshot round-trip; legacy snapshots default to
+    /// [`DEFAULT_ARRIVAL_WINDOW_TICKS`](crate::arrival_log::DEFAULT_ARRIVAL_WINDOW_TICKS).
+    #[serde(default)]
+    pub arrival_log_retention: crate::arrival_log::ArrivalLogRetention,
 }
 
 /// Per-line snapshot info within a group.
@@ -283,10 +290,15 @@ impl WorldSnapshot {
         // Restore the arrival log (per-stop spawn counts) and the
         // tick-mirror resource — without these `PredictiveParking` and
         // `DispatchManifest::arrivals_at` silently no-op post-restore.
+        // Also re-seat `ArrivalLogRetention`: post-restore the first
+        // `advance_tick` prunes the log, and missing this resource
+        // quietly falls back to the default window, clipping any
+        // longer retention the host configured.
         let mut log = self.arrival_log;
         log.remap_entity_ids(&id_remap);
         world.insert_resource(log);
         world.insert_resource(crate::arrival_log::CurrentTick(self.tick));
+        world.insert_resource(self.arrival_log_retention);
 
         let mut sim = crate::sim::Simulation::from_parts(
             world,
@@ -869,6 +881,10 @@ impl crate::sim::Simulation {
             arrival_log: world
                 .resource::<crate::arrival_log::ArrivalLog>()
                 .cloned()
+                .unwrap_or_default(),
+            arrival_log_retention: world
+                .resource::<crate::arrival_log::ArrivalLogRetention>()
+                .copied()
                 .unwrap_or_default(),
         }
     }

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -119,6 +119,12 @@ pub struct WorldSnapshot {
     /// All pending hall calls across every stop. Absent in legacy snapshots.
     #[serde(default)]
     pub hall_calls: Vec<HallCall>,
+    /// Rolling per-stop arrival log. Empty in legacy snapshots; on
+    /// restore the log's `(tick, stop)` entries have their stop IDs
+    /// remapped through `id_remap` so they line up with the newly
+    /// allocated entity IDs.
+    #[serde(default)]
+    pub arrival_log: crate::arrival_log::ArrivalLog,
 }
 
 /// Per-line snapshot info within a group.
@@ -273,6 +279,14 @@ impl WorldSnapshot {
         let mut tags = self.metric_tags;
         tags.remap_entity_ids(&id_remap);
         world.insert_resource(tags);
+
+        // Restore the arrival log (per-stop spawn counts) and the
+        // tick-mirror resource — without these `PredictiveParking` and
+        // `DispatchManifest::arrivals_at` silently no-op post-restore.
+        let mut log = self.arrival_log;
+        log.remap_entity_ids(&id_remap);
+        world.insert_resource(log);
+        world.insert_resource(crate::arrival_log::CurrentTick(self.tick));
 
         let mut sim = crate::sim::Simulation::from_parts(
             world,
@@ -852,6 +866,10 @@ impl crate::sim::Simulation {
             extensions: self.world().serialize_extensions(),
             ticks_per_second: 1.0 / self.dt(),
             hall_calls: world.iter_hall_calls().cloned().collect(),
+            arrival_log: world
+                .resource::<crate::arrival_log::ArrivalLog>()
+                .cloned()
+                .unwrap_or_default(),
         }
     }
 

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -322,7 +322,8 @@ pub fn update_indicators(
 }
 
 /// Build a dispatch manifest with per-rider metadata for a group.
-fn build_manifest(
+#[allow(clippy::too_many_lines)]
+pub fn build_manifest(
     world: &World,
     group: &ElevatorGroup,
     tick: u64,
@@ -439,6 +440,20 @@ fn build_manifest(
             .collect();
         if !calls.is_empty() {
             manifest.car_calls_by_car.insert(car, calls);
+        }
+    }
+
+    // Snapshot rolling per-stop arrival rates. Strategies read this via
+    // `DispatchManifest::arrivals_at` to drive mode switches and
+    // predictive parking without touching world state directly.
+    let window = crate::arrival_log::DEFAULT_ARRIVAL_WINDOW_TICKS;
+    manifest.arrival_window_ticks = window;
+    if let Some(log) = world.resource::<crate::arrival_log::ArrivalLog>() {
+        for &stop in group.stop_entities() {
+            let count = log.arrivals_in_window(stop, tick, window);
+            if count > 0 {
+                manifest.arrivals_at_stop.insert(stop, count);
+            }
         }
     }
 

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -603,6 +603,10 @@ fn iter_repositioning_elevators_returns_elevator_during_reposition() {
             energy_profile: None,
             service_mode: None,
             inspection_speed_factor: 0.25,
+
+            bypass_load_up_pct: None,
+
+            bypass_load_down_pct: None,
         })
         .dispatch(EtdDispatch::new())
         .reposition(ReturnToLobby::new(), BuiltinReposition::ReturnToLobby)
@@ -664,6 +668,10 @@ fn iter_repositioning_elevators_empty_after_reposition_completes() {
             energy_profile: None,
             service_mode: None,
             inspection_speed_factor: 0.25,
+
+            bypass_load_up_pct: None,
+
+            bypass_load_down_pct: None,
         })
         .dispatch(EtdDispatch::new())
         .reposition(ReturnToLobby::new(), BuiltinReposition::ReturnToLobby)
@@ -895,6 +903,10 @@ fn rider_builder_no_route_when_stops_not_in_same_group() {
             energy_profile: None,
             service_mode: None,
             inspection_speed_factor: 0.25,
+
+            bypass_load_up_pct: None,
+
+            bypass_load_down_pct: None,
         })
         .build()
         .unwrap();

--- a/crates/elevator-core/src/tests/arrival_log_tests.rs
+++ b/crates/elevator-core/src/tests/arrival_log_tests.rs
@@ -6,7 +6,7 @@
 //! (predictive parking). This module pins the core data structure that
 //! surfaces that signal to strategies.
 
-use crate::arrival_log::ArrivalLog;
+use crate::arrival_log::{ArrivalLog, CurrentTick, DEFAULT_ARRIVAL_WINDOW_TICKS};
 use crate::sim::Simulation;
 use crate::stop::StopId;
 use crate::world::World;
@@ -68,6 +68,64 @@ fn simulation_records_spawns_in_arrival_log() {
         .expect("ArrivalLog resource must be registered at construction")
         .arrivals_in_window(origin, sim.current_tick(), 60);
     assert_eq!(count, 2);
+}
+
+#[test]
+fn arrival_log_survives_snapshot_round_trip() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.step();
+
+    let origin = sim.stop_entity(StopId(0)).unwrap();
+    let before = sim
+        .world()
+        .resource::<ArrivalLog>()
+        .unwrap()
+        .arrivals_in_window(origin, sim.current_tick(), 120);
+    assert!(before >= 2, "precondition: snapshot source has arrivals");
+
+    let snap = sim.snapshot();
+    let restored = snap.restore(None).unwrap();
+
+    let origin_after = restored.stop_entity(StopId(0)).unwrap();
+    let log_after = restored
+        .world()
+        .resource::<ArrivalLog>()
+        .expect("restore must reinstall the ArrivalLog resource");
+    assert_eq!(
+        log_after.arrivals_in_window(origin_after, restored.current_tick(), 120),
+        before,
+        "arrival counts must survive snapshot → restore"
+    );
+    // The tick mirror must also be re-installed and in sync.
+    let ct = restored
+        .world()
+        .resource::<CurrentTick>()
+        .expect("restore must reinstall the CurrentTick resource");
+    assert_eq!(ct.0, restored.current_tick());
+}
+
+#[test]
+fn arrival_log_is_pruned_by_step() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+
+    // Step long enough that the original spawn ages out of the default
+    // rolling window. The log must have been pruned, not just ignored.
+    let target = DEFAULT_ARRIVAL_WINDOW_TICKS + 100;
+    while sim.current_tick() < target {
+        sim.step();
+    }
+
+    let log = sim.world().resource::<ArrivalLog>().unwrap();
+    assert_eq!(
+        log.len(),
+        0,
+        "entries older than the rolling window must be pruned, not merely filtered"
+    );
 }
 
 #[test]

--- a/crates/elevator-core/src/tests/arrival_log_tests.rs
+++ b/crates/elevator-core/src/tests/arrival_log_tests.rs
@@ -74,6 +74,10 @@ fn simulation_records_spawns_in_arrival_log() {
 fn arrival_log_survives_snapshot_round_trip() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
+    // Configure a non-default retention window so the round-trip
+    // actually exercises the retention-persistence path.
+    let custom_retention = 72_000;
+    sim.set_arrival_log_retention_ticks(custom_retention);
     sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     sim.step();
@@ -105,6 +109,13 @@ fn arrival_log_survives_snapshot_round_trip() {
         .resource::<CurrentTick>()
         .expect("restore must reinstall the CurrentTick resource");
     assert_eq!(ct.0, restored.current_tick());
+    // Retention survives round-trip too — otherwise
+    // `set_arrival_log_retention_ticks` silently no-ops post-restore.
+    let retention = restored
+        .world()
+        .resource::<crate::arrival_log::ArrivalLogRetention>()
+        .expect("restore must reinstall the ArrivalLogRetention resource");
+    assert_eq!(retention.0, custom_retention);
 }
 
 #[test]

--- a/crates/elevator-core/src/tests/arrival_log_tests.rs
+++ b/crates/elevator-core/src/tests/arrival_log_tests.rs
@@ -1,0 +1,96 @@
+//! Tests for [`crate::arrival_log::ArrivalLog`] and its exposure through
+//! [`DispatchManifest::arrivals_at`].
+//!
+//! Real elevator controllers observe recent arrival rates per floor to
+//! switch modes (up-peak, down-peak) and to pre-position idle cars
+//! (predictive parking). This module pins the core data structure that
+//! surfaces that signal to strategies.
+
+use crate::arrival_log::ArrivalLog;
+use crate::sim::Simulation;
+use crate::stop::StopId;
+use crate::world::World;
+
+use super::helpers::{default_config, scan};
+
+#[test]
+fn arrival_log_counts_events_within_window() {
+    let mut world = World::new();
+    let stop_a = world.spawn();
+    let stop_b = world.spawn();
+
+    let mut log = ArrivalLog::default();
+    log.record(100, stop_a);
+    log.record(150, stop_a);
+    log.record(200, stop_b);
+    log.record(300, stop_a);
+
+    // Window of 200 ticks ending at tick 300 covers [100, 300].
+    assert_eq!(log.arrivals_in_window(stop_a, 300, 200), 3);
+    assert_eq!(log.arrivals_in_window(stop_b, 300, 200), 1);
+
+    // Narrow window of 150 ticks ending at tick 300 covers [150, 300].
+    assert_eq!(log.arrivals_in_window(stop_a, 300, 150), 2);
+
+    // Window of 0 → empty.
+    assert_eq!(log.arrivals_in_window(stop_a, 300, 0), 0);
+}
+
+#[test]
+fn arrival_log_prunes_old_events() {
+    let mut world = World::new();
+    let stop = world.spawn();
+
+    let mut log = ArrivalLog::default();
+    for tick in 0..1_000u64 {
+        log.record(tick, stop);
+    }
+    log.prune_before(900);
+
+    // After pruning everything before tick 900, only [900, 999] remain.
+    assert_eq!(log.arrivals_in_window(stop, 999, 1_000), 100);
+    assert_eq!(log.arrivals_in_window(stop, 999, 200), 100);
+}
+
+#[test]
+fn simulation_records_spawns_in_arrival_log() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    let origin = sim.stop_entity(StopId(0)).unwrap();
+    let _ = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    let _ = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+
+    // Both spawns land at tick 0 → a generous window centered on the
+    // current tick must find them both.
+    let count = sim
+        .world()
+        .resource::<ArrivalLog>()
+        .expect("ArrivalLog resource must be registered at construction")
+        .arrivals_in_window(origin, sim.current_tick(), 60);
+    assert_eq!(count, 2);
+}
+
+#[test]
+fn dispatch_manifest_exposes_recent_arrivals() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    let origin = sim.stop_entity(StopId(0)).unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+
+    // Advance a few ticks so the sim builds its own manifest.
+    for _ in 0..5 {
+        sim.step();
+    }
+
+    // Peek the manifest the dispatch phase would see this tick.
+    let manifest = sim.peek_dispatch_manifest();
+    assert_eq!(
+        manifest.arrivals_at(origin),
+        2,
+        "manifest must surface recent-arrival counts for strategies"
+    );
+    // A stop with no spawns reports zero (not missing / not panic).
+    let other = sim.stop_entity(StopId(2)).unwrap();
+    assert_eq!(manifest.arrivals_at(other), 0);
+}

--- a/crates/elevator-core/src/tests/builder_tests.rs
+++ b/crates/elevator-core/src/tests/builder_tests.rs
@@ -64,6 +64,10 @@ fn from_config_produces_valid_sim() {
             energy_profile: None,
             service_mode: None,
             inspection_speed_factor: 0.25,
+
+            bypass_load_up_pct: None,
+
+            bypass_load_down_pct: None,
         }],
         simulation: SimulationParams {
             ticks_per_second: 30.0,
@@ -121,6 +125,10 @@ fn builder_with_stops_and_elevators() {
             energy_profile: None,
             service_mode: None,
             inspection_speed_factor: 0.25,
+
+            bypass_load_up_pct: None,
+
+            bypass_load_down_pct: None,
         })
         .ticks_per_second(120.0)
         .build();
@@ -206,6 +214,10 @@ fn from_config_honours_config_group_dispatch() {
                     energy_profile: None,
                     service_mode: None,
                     inspection_speed_factor: 0.25,
+
+                    bypass_load_up_pct: None,
+
+                    bypass_load_down_pct: None,
                 }],
                 orientation: crate::components::Orientation::Vertical,
                 position: None,
@@ -285,6 +297,10 @@ fn from_config_dispatch_override_marks_strategy_as_custom() {
                     energy_profile: None,
                     service_mode: None,
                     inspection_speed_factor: 0.25,
+
+                    bypass_load_up_pct: None,
+
+                    bypass_load_down_pct: None,
                 }],
                 orientation: crate::components::Orientation::Vertical,
                 position: None,

--- a/crates/elevator-core/src/tests/bypass_tests.rs
+++ b/crates/elevator-core/src/tests/bypass_tests.rs
@@ -9,10 +9,12 @@
 use super::dispatch_tests::{
     add_demand, decide_all, decide_one, spawn_elevator, test_group, test_world,
 };
+use super::helpers::default_config;
 use crate::components::{ElevatorPhase, Route, Weight};
 use crate::dispatch::etd::EtdDispatch;
 use crate::dispatch::nearest_car::NearestCarDispatch;
 use crate::dispatch::{DispatchDecision, DispatchManifest, RiderInfo};
+use crate::sim::Simulation;
 
 #[test]
 fn etd_upward_bypass_skips_pickup_above_threshold() {
@@ -149,6 +151,66 @@ fn bypass_below_threshold_still_picks_up() {
     );
 }
 
+/// Multi-car regression: per-car thresholds must be isolated. Car A
+/// is above its up-bypass threshold, car B below — a pickup above
+/// both must be ranked only by B, not silently by both. Without
+/// per-car gating a refactor could make the bypass group-wide.
+#[test]
+fn bypass_is_per_car_not_group_wide() {
+    let (mut world, stops) = test_world();
+    let elev_full = spawn_elevator(&mut world, 0.0);
+    let elev_empty = spawn_elevator(&mut world, 4.0);
+    {
+        let car = world.elevator_mut(elev_full).unwrap();
+        car.current_load = Weight::from(car.weight_capacity.value() * 0.9);
+        car.set_bypass_load_up_pct(Some(0.80));
+        car.phase = ElevatorPhase::MovingToStop(stops[3]);
+    }
+    {
+        let car = world.elevator_mut(elev_empty).unwrap();
+        car.set_bypass_load_up_pct(Some(0.80));
+        car.phase = ElevatorPhase::MovingToStop(stops[3]);
+    }
+    // Aboard rider on the loaded car to pin direction.
+    let aboard = world.spawn();
+    world.elevator_mut(elev_full).unwrap().riders.push(aboard);
+    world.set_route(
+        aboard,
+        Route::direct(stops[0], stops[3], crate::ids::GroupId(0)),
+    );
+
+    let group = test_group(&stops, vec![elev_full, elev_empty]);
+    let mut manifest = DispatchManifest::default();
+    // Pickup above both cars — above the loaded car's threshold so
+    // the loaded one bypasses, but the empty one must still take it.
+    add_demand(&mut manifest, &mut world, stops[2], 70.0);
+    manifest
+        .riding_to_stop
+        .entry(stops[3])
+        .or_default()
+        .push(RiderInfo {
+            id: aboard,
+            destination: Some(stops[3]),
+            weight: Weight::from(70.0),
+            wait_ticks: 0,
+        });
+
+    let mut etd = EtdDispatch::new();
+    let decisions = decide_all(
+        &mut etd,
+        &[(elev_full, 0.0), (elev_empty, 4.0)],
+        &group,
+        &manifest,
+        &mut world,
+    );
+    let empty_dec = decisions.iter().find(|(e, _)| *e == elev_empty).unwrap();
+    assert_eq!(
+        empty_dec.1,
+        DispatchDecision::GoToStop(stops[2]),
+        "the below-threshold car must take the pickup even when a peer bypasses"
+    );
+}
+
 #[test]
 fn bypass_never_blocks_aboard_exit() {
     let (mut world, stops) = test_world();
@@ -188,4 +250,39 @@ fn bypass_never_blocks_aboard_exit() {
         DispatchDecision::GoToStop(stops[2]),
         "bypass must never prevent the car from reaching an aboard rider's destination"
     );
+}
+
+/// `(0.0, 1.0]` is the only valid range. Reject NaN / negative / zero
+/// / >1 at construction time so the rank-time guard can trust the
+/// stored threshold.
+#[test]
+fn bypass_pct_out_of_range_rejected_at_construction() {
+    for bad in [f64::NAN, -0.1, 0.0, 1.01, f64::INFINITY] {
+        let mut config = default_config();
+        config.elevators[0].bypass_load_up_pct = Some(bad);
+        let err = Simulation::new(&config, crate::dispatch::scan::ScanDispatch::new())
+            .expect_err(&format!("Simulation::new must reject bypass pct = {bad}"));
+        assert!(
+            matches!(err, crate::error::SimError::InvalidConfig { field, .. } if field.contains("bypass_load_up_pct")),
+            "expected InvalidConfig on bypass_load_up_pct for {bad}, got {err:?}"
+        );
+    }
+}
+
+#[test]
+#[should_panic(expected = "wait_squared_weight must be finite and non-negative")]
+fn etd_wait_squared_weight_rejects_nan() {
+    let _ = EtdDispatch::new().with_wait_squared_weight(f64::NAN);
+}
+
+#[test]
+#[should_panic(expected = "wait_squared_weight must be finite and non-negative")]
+fn etd_wait_squared_weight_rejects_negative() {
+    let _ = EtdDispatch::new().with_wait_squared_weight(-1.0);
+}
+
+#[test]
+#[should_panic(expected = "PredictiveParking::with_window_ticks requires a positive window")]
+fn predictive_parking_rejects_zero_window() {
+    let _ = crate::dispatch::reposition::PredictiveParking::with_window_ticks(0);
 }

--- a/crates/elevator-core/src/tests/bypass_tests.rs
+++ b/crates/elevator-core/src/tests/bypass_tests.rs
@@ -254,18 +254,25 @@ fn bypass_never_blocks_aboard_exit() {
 
 /// `(0.0, 1.0]` is the only valid range. Reject NaN / negative / zero
 /// / >1 at construction time so the rank-time guard can trust the
-/// stored threshold.
+/// stored threshold. Covers both directions — the validator is
+/// symmetric, a regression touching only one branch should still fail.
 #[test]
 fn bypass_pct_out_of_range_rejected_at_construction() {
     for bad in [f64::NAN, -0.1, 0.0, 1.01, f64::INFINITY] {
-        let mut config = default_config();
-        config.elevators[0].bypass_load_up_pct = Some(bad);
-        let err = Simulation::new(&config, crate::dispatch::scan::ScanDispatch::new())
-            .expect_err(&format!("Simulation::new must reject bypass pct = {bad}"));
-        assert!(
-            matches!(err, crate::error::SimError::InvalidConfig { field, .. } if field.contains("bypass_load_up_pct")),
-            "expected InvalidConfig on bypass_load_up_pct for {bad}, got {err:?}"
-        );
+        for (field_name, up, down) in [
+            ("bypass_load_up_pct", Some(bad), None),
+            ("bypass_load_down_pct", None, Some(bad)),
+        ] {
+            let mut config = default_config();
+            config.elevators[0].bypass_load_up_pct = up;
+            config.elevators[0].bypass_load_down_pct = down;
+            let err = Simulation::new(&config, crate::dispatch::scan::ScanDispatch::new())
+                .expect_err(&format!("Simulation::new must reject {field_name} = {bad}"));
+            assert!(
+                matches!(&err, crate::error::SimError::InvalidConfig { field, .. } if field.contains(field_name)),
+                "expected InvalidConfig on {field_name} for {bad}, got {err:?}"
+            );
+        }
     }
 }
 

--- a/crates/elevator-core/src/tests/bypass_tests.rs
+++ b/crates/elevator-core/src/tests/bypass_tests.rs
@@ -1,0 +1,191 @@
+//! Tests for the direction-dependent full-load bypass
+//! (see `Elevator::bypass_load_up_pct` / `bypass_load_down_pct`).
+//!
+//! Commercial controllers skip hall-call pickups in the current travel
+//! direction once the car exceeds a load threshold — typically ~80 %
+//! going up, ~50 % going down (Otis Elevonic 411, patent US5490580A).
+//! Aboard riders are still delivered; only pickup ranking is affected.
+
+use super::dispatch_tests::{
+    add_demand, decide_all, decide_one, spawn_elevator, test_group, test_world,
+};
+use crate::components::{ElevatorPhase, Route, Weight};
+use crate::dispatch::etd::EtdDispatch;
+use crate::dispatch::nearest_car::NearestCarDispatch;
+use crate::dispatch::{DispatchDecision, DispatchManifest, RiderInfo};
+
+#[test]
+fn etd_upward_bypass_skips_pickup_above_threshold() {
+    let (mut world, stops) = test_world();
+    let elev = spawn_elevator(&mut world, 0.0);
+    {
+        let car = world.elevator_mut(elev).unwrap();
+        // Load the car to 90 % capacity and set an 80 % up-bypass threshold.
+        car.current_load = Weight::from(car.weight_capacity.value() * 0.9);
+        car.set_bypass_load_up_pct(Some(0.80));
+        // The car is committed to travelling up (MovingToStop aimed at
+        // a higher stop). Required so the bypass check can pick a direction.
+        car.phase = ElevatorPhase::MovingToStop(stops[3]);
+    }
+    // An aboard rider bound for stops[3] keeps the car's ranks finite
+    // for the exit stop and pins down the travel direction.
+    let aboard = world.spawn();
+    world.elevator_mut(elev).unwrap().riders.push(aboard);
+    world.set_route(
+        aboard,
+        Route::direct(stops[0], stops[3], crate::ids::GroupId(0)),
+    );
+
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    // Pickup stop between the car and the aboard rider's destination.
+    add_demand(&mut manifest, &mut world, stops[1], 70.0);
+    // Aboard-rider destination demand, as the production builder produces.
+    manifest
+        .riding_to_stop
+        .entry(stops[3])
+        .or_default()
+        .push(RiderInfo {
+            id: aboard,
+            destination: Some(stops[3]),
+            weight: Weight::from(70.0),
+            wait_ticks: 0,
+        });
+
+    let mut etd = EtdDispatch::new();
+    let decision = decide_one(&mut etd, elev, 0.0, &group, &manifest, &mut world);
+    assert_eq!(
+        decision,
+        DispatchDecision::GoToStop(stops[3]),
+        "a car above the up-bypass threshold must skip pickups and head to the aboard \
+         rider's destination"
+    );
+}
+
+#[test]
+fn nearest_car_downward_bypass_skips_pickup_above_threshold() {
+    let (mut world, stops) = test_world();
+    let elev = spawn_elevator(&mut world, 12.0);
+    {
+        let car = world.elevator_mut(elev).unwrap();
+        car.current_load = Weight::from(car.weight_capacity.value() * 0.6);
+        // Down-bypass at 50 % — 60 % load exceeds it, but up-bypass is
+        // unset so an upward pickup would still be fair game.
+        car.set_bypass_load_down_pct(Some(0.50));
+        car.phase = ElevatorPhase::MovingToStop(stops[0]);
+    }
+    let aboard = world.spawn();
+    world.elevator_mut(elev).unwrap().riders.push(aboard);
+    world.set_route(
+        aboard,
+        Route::direct(stops[3], stops[0], crate::ids::GroupId(0)),
+    );
+
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    // Pickup below the car — same direction as travel, above threshold,
+    // must be skipped.
+    add_demand(&mut manifest, &mut world, stops[1], 70.0);
+    manifest
+        .riding_to_stop
+        .entry(stops[0])
+        .or_default()
+        .push(RiderInfo {
+            id: aboard,
+            destination: Some(stops[0]),
+            weight: Weight::from(70.0),
+            wait_ticks: 0,
+        });
+
+    let mut nc = NearestCarDispatch::new();
+    let decision = decide_one(&mut nc, elev, 12.0, &group, &manifest, &mut world);
+    assert_eq!(
+        decision,
+        DispatchDecision::GoToStop(stops[0]),
+        "a downward-moving car above its down-bypass threshold must not detour for a pickup"
+    );
+}
+
+#[test]
+fn bypass_below_threshold_still_picks_up() {
+    let (mut world, stops) = test_world();
+    let elev = spawn_elevator(&mut world, 0.0);
+    {
+        let car = world.elevator_mut(elev).unwrap();
+        // Loaded only 50 %, threshold at 80 %: pickup allowed.
+        car.current_load = Weight::from(car.weight_capacity.value() * 0.5);
+        car.set_bypass_load_up_pct(Some(0.80));
+        car.phase = ElevatorPhase::MovingToStop(stops[3]);
+    }
+    let aboard = world.spawn();
+    world.elevator_mut(elev).unwrap().riders.push(aboard);
+    world.set_route(
+        aboard,
+        Route::direct(stops[0], stops[3], crate::ids::GroupId(0)),
+    );
+
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    add_demand(&mut manifest, &mut world, stops[1], 70.0);
+    manifest
+        .riding_to_stop
+        .entry(stops[3])
+        .or_default()
+        .push(RiderInfo {
+            id: aboard,
+            destination: Some(stops[3]),
+            weight: Weight::from(70.0),
+            wait_ticks: 0,
+        });
+
+    let mut etd = EtdDispatch::new();
+    let decisions = decide_all(&mut etd, &[(elev, 0.0)], &group, &manifest, &mut world);
+    // On-the-way pickup is closer, so under a normal ETD rank the car
+    // should visit it before continuing to the aboard destination.
+    assert_eq!(
+        decisions[0].1,
+        DispatchDecision::GoToStop(stops[1]),
+        "below-threshold car must still honor on-the-way pickups"
+    );
+}
+
+#[test]
+fn bypass_never_blocks_aboard_exit() {
+    let (mut world, stops) = test_world();
+    let elev = spawn_elevator(&mut world, 0.0);
+    {
+        let car = world.elevator_mut(elev).unwrap();
+        // Fully loaded, aggressive thresholds.
+        car.current_load = car.weight_capacity;
+        car.set_bypass_load_up_pct(Some(0.10));
+        car.set_bypass_load_down_pct(Some(0.10));
+        car.phase = ElevatorPhase::MovingToStop(stops[2]);
+    }
+    let aboard = world.spawn();
+    world.elevator_mut(elev).unwrap().riders.push(aboard);
+    world.set_route(
+        aboard,
+        Route::direct(stops[0], stops[2], crate::ids::GroupId(0)),
+    );
+
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    manifest
+        .riding_to_stop
+        .entry(stops[2])
+        .or_default()
+        .push(RiderInfo {
+            id: aboard,
+            destination: Some(stops[2]),
+            weight: Weight::from(70.0),
+            wait_ticks: 0,
+        });
+
+    let mut etd = EtdDispatch::new();
+    let decision = decide_one(&mut etd, elev, 0.0, &group, &manifest, &mut world);
+    assert_eq!(
+        decision,
+        DispatchDecision::GoToStop(stops[2]),
+        "bypass must never prevent the car from reaching an aboard rider's destination"
+    );
+}

--- a/crates/elevator-core/src/tests/destination_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/destination_dispatch_tests.rs
@@ -577,3 +577,88 @@ fn loading_ignores_dangling_assignment_to_dead_car() {
         "rider must be delivered despite dangling AssignedCar"
     );
 }
+
+/// Deferred commitment: when `commitment_window_ticks` is `Some(window)`,
+/// a rider's sticky assignment is re-evaluated each pass until the
+/// assigned car is within `window` ticks of the rider's origin. The
+/// original car stays chosen once inside the window, even if a closer
+/// car appears. Models KONE Polaris's two-button reallocation regime
+/// (DCS calls remain fixed on press; two-button hall calls re-allocate
+/// continuously until commitment).
+#[test]
+fn commitment_window_reassigns_when_current_car_is_far() {
+    let mut sim = Simulation::new(
+        &two_cars_same_group_config(),
+        DestinationDispatch::new().with_commitment_window_ticks(3),
+    )
+    .unwrap();
+    sim.world_mut()
+        .register_ext::<AssignedCar>(ASSIGNED_CAR_KEY);
+
+    // Identify the two elevators by name.
+    let elevs: Vec<_> = sim
+        .world()
+        .iter_elevators()
+        .map(|(eid, _, _)| eid)
+        .collect();
+    // Map by config name: A at stop 0 (pos 0), B at stop 3 (pos 12).
+    let car_a = elevs[0];
+    let car_b = elevs[1];
+
+    // Spawn a rider at stop 1 (pos 4) going to stop 2 (pos 8). Force the
+    // sticky assignment onto the far car (B, pos 12 → 8 units to origin).
+    let rid = sim.spawn_rider(StopId(1), StopId(2), 70.0).unwrap();
+    sim.world_mut()
+        .insert_ext(rid.entity(), AssignedCar(car_b), ASSIGNED_CAR_KEY);
+
+    // One dispatch pass: with `commitment_window_ticks = 3` and B's ETA
+    // of 4 ticks (8 units / 2 speed), the commitment hasn't latched yet,
+    // so the rider is free to migrate to car A (ETA 2 ticks).
+    sim.step();
+
+    assert_eq!(
+        sim.world().ext::<AssignedCar>(rid.entity()),
+        Some(AssignedCar(car_a)),
+        "a far-away sticky assignment must be re-evaluated when outside the commitment window"
+    );
+}
+
+/// Counterpart to the reassignment case: a car already inside the
+/// commitment window keeps its rider even if a closer car appears.
+#[test]
+fn commitment_window_locks_when_current_car_is_close() {
+    let mut sim = Simulation::new(
+        &two_cars_same_group_config(),
+        DestinationDispatch::new().with_commitment_window_ticks(10),
+    )
+    .unwrap();
+    sim.world_mut()
+        .register_ext::<AssignedCar>(ASSIGNED_CAR_KEY);
+
+    let elevs: Vec<_> = sim
+        .world()
+        .iter_elevators()
+        .map(|(eid, _, _)| eid)
+        .collect();
+    let car_a = elevs[0]; // at pos 0
+    let car_b = elevs[1]; // at pos 12
+
+    // Spawn rider at stop 1 (pos 4). Sticky to B. B's ETA ≈ 4 ticks,
+    // well inside the 10-tick commitment window — reassignment denied.
+    let rid = sim.spawn_rider(StopId(1), StopId(2), 70.0).unwrap();
+    sim.world_mut()
+        .insert_ext(rid.entity(), AssignedCar(car_b), ASSIGNED_CAR_KEY);
+
+    sim.step();
+
+    assert_eq!(
+        sim.world().ext::<AssignedCar>(rid.entity()),
+        Some(AssignedCar(car_b)),
+        "inside the commitment window, sticky must hold even when a closer car is available"
+    );
+    // A didn't steal the rider.
+    assert_ne!(
+        sim.world().ext::<AssignedCar>(rid.entity()),
+        Some(AssignedCar(car_a)),
+    );
+}

--- a/crates/elevator-core/src/tests/destination_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/destination_dispatch_tests.rs
@@ -52,6 +52,10 @@ fn single_car_config() -> SimConfig {
             energy_profile: None,
             service_mode: None,
             inspection_speed_factor: 0.25,
+
+            bypass_load_up_pct: None,
+
+            bypass_load_down_pct: None,
         }],
         simulation: SimulationParams {
             ticks_per_second: 60.0,
@@ -110,6 +114,10 @@ fn two_cars_same_group_config() -> SimConfig {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     },
                     ElevatorConfig {
                         id: 2,
@@ -126,6 +134,10 @@ fn two_cars_same_group_config() -> SimConfig {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     },
                 ],
                 orientation: Orientation::Vertical,

--- a/crates/elevator-core/src/tests/dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/dispatch_tests.rs
@@ -110,6 +110,8 @@ pub(super) fn spawn_elevator(world: &mut World, position: f64) -> crate::entity:
             move_count: 0,
             door_command_queue: Vec::new(),
             manual_target_velocity: None,
+            bypass_load_up_pct: None,
+            bypass_load_down_pct: None,
         },
     );
     eid

--- a/crates/elevator-core/src/tests/eta_tests.rs
+++ b/crates/elevator-core/src/tests/eta_tests.rs
@@ -231,6 +231,10 @@ fn best_eta_picks_min_across_elevators() {
         energy_profile: None,
         service_mode: None,
         inspection_speed_factor: 0.25,
+
+        bypass_load_up_pct: None,
+
+        bypass_load_down_pct: None,
     });
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
     let elevs: Vec<_> = sim.world().iter_elevators().map(|(e, _, _)| e).collect();

--- a/crates/elevator-core/src/tests/etd_mutant_tests.rs
+++ b/crates/elevator-core/src/tests/etd_mutant_tests.rs
@@ -429,6 +429,96 @@ fn etd_full_car_skips_unreachable_pickup_on_the_way() {
     );
 }
 
+// ── Group-time / squared-wait cost ──────────────────────────────────
+
+/// With a positive `wait_squared_weight`, two equidistant pickups
+/// break the tie in favor of the stop hosting the older waiter —
+/// models commercial DCS's fairness-weighted throughput claim that
+/// damps the long-wait tail (Aalto EJOR 2016).
+#[test]
+fn etd_squared_wait_prefers_older_waiting_rider() {
+    let (mut world, stops) = test_world();
+    let elev = spawn_elevator(&mut world, 4.0); // at stops[1] (pos 4)
+
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    // Stop at pos 0 — rider waiting 1000 ticks.
+    let old_waiter = world.spawn();
+    manifest
+        .waiting_at_stop
+        .entry(stops[0])
+        .or_default()
+        .push(RiderInfo {
+            id: old_waiter,
+            destination: None,
+            weight: Weight::from(70.0),
+            wait_ticks: 1000,
+        });
+    // Stop at pos 8 — rider waiting only 1 tick.
+    let new_waiter = world.spawn();
+    manifest
+        .waiting_at_stop
+        .entry(stops[2])
+        .or_default()
+        .push(RiderInfo {
+            id: new_waiter,
+            destination: None,
+            weight: Weight::from(70.0),
+            wait_ticks: 1,
+        });
+
+    let mut etd = EtdDispatch::new().with_wait_squared_weight(1.0);
+    let decision = decide_one(&mut etd, elev, 4.0, &group, &manifest, &mut world);
+    assert_eq!(
+        decision,
+        DispatchDecision::GoToStop(stops[0]),
+        "positive `wait_squared_weight` must bias ETD toward the stop with an older waiter"
+    );
+}
+
+/// A modest fairness weight must not override travel-time dominance
+/// when the far stop's extra wait isn't large enough to justify the
+/// detour. Regression guard against picking a too-aggressive bias
+/// scale that wrecks normal efficiency.
+#[test]
+fn etd_squared_wait_does_not_override_travel_time() {
+    let (mut world, stops) = test_world();
+    let elev = spawn_elevator(&mut world, 0.0);
+
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    let new_waiter = world.spawn();
+    manifest
+        .waiting_at_stop
+        .entry(stops[1])
+        .or_default()
+        .push(RiderInfo {
+            id: new_waiter,
+            destination: None,
+            weight: Weight::from(70.0),
+            wait_ticks: 5,
+        });
+    let older = world.spawn();
+    manifest
+        .waiting_at_stop
+        .entry(stops[3])
+        .or_default()
+        .push(RiderInfo {
+            id: older,
+            destination: None,
+            weight: Weight::from(70.0),
+            wait_ticks: 20,
+        });
+
+    let mut etd = EtdDispatch::new().with_wait_squared_weight(0.001);
+    let decision = decide_one(&mut etd, elev, 0.0, &group, &manifest, &mut world);
+    assert_eq!(
+        decision,
+        DispatchDecision::GoToStop(stops[1]),
+        "modest wait_squared_weight must not reverse travel-time dominance"
+    );
+}
+
 // ── Equivalent mutants (documented, not tested) ─────────────────────
 //
 // The following mutants are observationally **equivalent** to the

--- a/crates/elevator-core/src/tests/feature_tests.rs
+++ b/crates/elevator-core/src/tests/feature_tests.rs
@@ -354,6 +354,10 @@ fn double_board_guard_rider_appears_in_exactly_one_elevator() {
         door_open_ticks: 10,
         restricted_stops: HashSet::new(),
         inspection_speed_factor: 0.25,
+
+        bypass_load_up_pct: None,
+
+        bypass_load_down_pct: None,
     };
     let line = sim.lines_in_group(GroupId(0))[0];
     let elev2 = ElevatorId::from(sim.add_elevator(&params, line, 0.0).unwrap());
@@ -559,6 +563,8 @@ fn despawn_elevator_resets_rider_to_waiting() {
             move_count: 0,
             door_command_queue: Vec::new(),
             manual_target_velocity: None,
+            bypass_load_up_pct: None,
+            bypass_load_down_pct: None,
         },
     );
 
@@ -645,6 +651,8 @@ fn despawn_rider_mid_transit_removes_from_elevator_load() {
             move_count: 0,
             door_command_queue: Vec::new(),
             manual_target_velocity: None,
+            bypass_load_up_pct: None,
+            bypass_load_down_pct: None,
         },
     );
 
@@ -757,6 +765,10 @@ fn weight_rejection_boundary() {
             energy_profile: None,
             service_mode: None,
             inspection_speed_factor: 0.25,
+
+            bypass_load_up_pct: None,
+
+            bypass_load_down_pct: None,
         }],
         simulation: crate::config::SimulationParams {
             ticks_per_second: 60.0,
@@ -849,6 +861,10 @@ fn passing_floor_events_emitted() {
             energy_profile: None,
             service_mode: None,
             inspection_speed_factor: 0.25,
+
+            bypass_load_up_pct: None,
+
+            bypass_load_down_pct: None,
         }],
         simulation: crate::config::SimulationParams {
             ticks_per_second: 60.0,

--- a/crates/elevator-core/src/tests/helpers.rs
+++ b/crates/elevator-core/src/tests/helpers.rs
@@ -44,6 +44,8 @@ pub fn default_config() -> SimConfig {
             energy_profile: None,
             service_mode: None,
             inspection_speed_factor: 0.25,
+            bypass_load_up_pct: None,
+            bypass_load_down_pct: None,
         }],
         simulation: SimulationParams {
             ticks_per_second: 60.0,

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -39,6 +39,7 @@ mod world_tests;
 
 mod abort_movement_tests;
 mod api_surface_tests;
+mod arrival_log_tests;
 mod boundary_tests;
 mod braking_tests;
 mod destination_dispatch_tests;

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -42,6 +42,7 @@ mod api_surface_tests;
 mod arrival_log_tests;
 mod boundary_tests;
 mod braking_tests;
+mod bypass_tests;
 mod destination_dispatch_tests;
 mod destination_queue_tests;
 mod direction_indicator_tests;

--- a/crates/elevator-core/src/tests/move_count_tests.rs
+++ b/crates/elevator-core/src/tests/move_count_tests.rs
@@ -48,6 +48,10 @@ fn two_elevator_config() -> SimConfig {
                 energy_profile: None,
                 service_mode: None,
                 inspection_speed_factor: 0.25,
+
+                bypass_load_up_pct: None,
+
+                bypass_load_down_pct: None,
             },
             ElevatorConfig {
                 id: 1,
@@ -64,6 +68,10 @@ fn two_elevator_config() -> SimConfig {
                 energy_profile: None,
                 service_mode: None,
                 inspection_speed_factor: 0.25,
+
+                bypass_load_up_pct: None,
+
+                bypass_load_down_pct: None,
             },
         ],
         simulation: SimulationParams {

--- a/crates/elevator-core/src/tests/multi_elevator_tests.rs
+++ b/crates/elevator-core/src/tests/multi_elevator_tests.rs
@@ -47,6 +47,10 @@ fn two_elevator_config() -> SimConfig {
                 energy_profile: None,
                 service_mode: None,
                 inspection_speed_factor: 0.25,
+
+                bypass_load_up_pct: None,
+
+                bypass_load_down_pct: None,
             },
             ElevatorConfig {
                 id: 1,
@@ -63,6 +67,10 @@ fn two_elevator_config() -> SimConfig {
                 energy_profile: None,
                 service_mode: None,
                 inspection_speed_factor: 0.25,
+
+                bypass_load_up_pct: None,
+
+                bypass_load_down_pct: None,
             },
         ],
         simulation: SimulationParams {

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -65,6 +65,10 @@ fn two_group_config() -> SimConfig {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     }],
                     orientation: Orientation::Vertical,
                     position: None,
@@ -91,6 +95,10 @@ fn two_group_config() -> SimConfig {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     }],
                     orientation: Orientation::Vertical,
                     position: None,
@@ -168,6 +176,10 @@ fn overlapping_groups_config() -> SimConfig {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     }],
                     orientation: Orientation::Vertical,
                     position: None,
@@ -194,6 +206,10 @@ fn overlapping_groups_config() -> SimConfig {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     }],
                     orientation: Orientation::Vertical,
                     position: None,
@@ -617,6 +633,10 @@ fn line_pinned_rider_boards_only_specified_line_elevator() {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     }],
                     orientation: Orientation::Vertical,
                     position: None,
@@ -643,6 +663,10 @@ fn line_pinned_rider_boards_only_specified_line_elevator() {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     }],
                     orientation: Orientation::Vertical,
                     position: None,
@@ -931,6 +955,10 @@ fn reachable_stops_from_isolated_stop_returns_empty() {
                     energy_profile: None,
                     service_mode: None,
                     inspection_speed_factor: 0.25,
+
+                    bypass_load_up_pct: None,
+
+                    bypass_load_down_pct: None,
                 }],
                 orientation: Orientation::Vertical,
                 position: None,
@@ -1079,6 +1107,10 @@ fn shortest_route_returns_none_for_unreachable_stop() {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     }],
                     orientation: Orientation::Vertical,
                     position: None,
@@ -1105,6 +1137,10 @@ fn shortest_route_returns_none_for_unreachable_stop() {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     }],
                     orientation: Orientation::Vertical,
                     position: None,
@@ -1825,6 +1861,10 @@ fn reassign_elevator_to_line_at_max_cars_returns_error() {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     }],
                     orientation: Orientation::Vertical,
                     position: None,
@@ -1851,6 +1891,10 @@ fn reassign_elevator_to_line_at_max_cars_returns_error() {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     }],
                     orientation: Orientation::Vertical,
                     position: None,
@@ -1981,6 +2025,10 @@ fn max_cars_exactly_met_at_config_time_succeeds() {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     },
                     ElevatorConfig {
                         id: 2,
@@ -1997,6 +2045,10 @@ fn max_cars_exactly_met_at_config_time_succeeds() {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     },
                 ],
                 orientation: Orientation::Vertical,
@@ -2062,6 +2114,10 @@ fn max_cars_exceeded_at_config_time_fails_validation() {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     },
                     ElevatorConfig {
                         id: 2,
@@ -2078,6 +2134,10 @@ fn max_cars_exceeded_at_config_time_fails_validation() {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     },
                 ],
                 orientation: Orientation::Vertical,
@@ -2148,6 +2208,10 @@ fn runtime_add_elevator_to_line_at_max_cars_returns_error() {
                     energy_profile: None,
                     service_mode: None,
                     inspection_speed_factor: 0.25,
+
+                    bypass_load_up_pct: None,
+
+                    bypass_load_down_pct: None,
                 }],
                 orientation: Orientation::Vertical,
                 position: None,
@@ -2240,6 +2304,10 @@ fn three_group_config() -> SimConfig {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     }],
                     orientation: Orientation::Vertical,
                     position: None,
@@ -2266,6 +2334,10 @@ fn three_group_config() -> SimConfig {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     }],
                     orientation: Orientation::Vertical,
                     position: None,
@@ -2292,6 +2364,10 @@ fn three_group_config() -> SimConfig {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     }],
                     orientation: Orientation::Vertical,
                     position: None,
@@ -2815,6 +2891,10 @@ fn orphan_line_not_referenced_by_any_group_fails_validation() {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     }],
                     orientation: Orientation::Vertical,
                     position: None,
@@ -2841,6 +2921,10 @@ fn orphan_line_not_referenced_by_any_group_fails_validation() {
                         energy_profile: None,
                         service_mode: None,
                         inspection_speed_factor: 0.25,
+
+                        bypass_load_up_pct: None,
+
+                        bypass_load_down_pct: None,
                     }],
                     orientation: Orientation::Vertical,
                     position: None,

--- a/crates/elevator-core/src/tests/mutation_kills_tests.rs
+++ b/crates/elevator-core/src/tests/mutation_kills_tests.rs
@@ -218,6 +218,8 @@ fn spawn_elev(world: &mut World, pos: f64, n: usize) -> Vec<EntityId> {
                     move_count: 0,
                     door_command_queue: Vec::new(),
                     manual_target_velocity: None,
+                    bypass_load_up_pct: None,
+                    bypass_load_down_pct: None,
                 },
             );
             eid

--- a/crates/elevator-core/src/tests/proptest_tests.rs
+++ b/crates/elevator-core/src/tests/proptest_tests.rs
@@ -122,6 +122,10 @@ fn make_config(stop_count: u32, elevator_count: u32) -> SimConfig {
             energy_profile: None,
             service_mode: None,
             inspection_speed_factor: 0.25,
+
+            bypass_load_up_pct: None,
+
+            bypass_load_down_pct: None,
         })
         .collect();
 
@@ -262,6 +266,10 @@ proptest! {
                 energy_profile: None,
                 service_mode: None,
                 inspection_speed_factor: 0.25,
+
+                bypass_load_up_pct: None,
+
+                bypass_load_down_pct: None,
             }],
             simulation: SimulationParams { ticks_per_second: 60.0 },
             passenger_spawning: PassengerSpawnConfig {

--- a/crates/elevator-core/src/tests/query_tests.rs
+++ b/crates/elevator-core/src/tests/query_tests.rs
@@ -52,6 +52,8 @@ fn test_world() -> (World, EntityId, EntityId, EntityId) {
             move_count: 0,
             door_command_queue: Vec::new(),
             manual_target_velocity: None,
+            bypass_load_up_pct: None,
+            bypass_load_down_pct: None,
         },
     );
 

--- a/crates/elevator-core/src/tests/reposition_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_tests.rs
@@ -81,6 +81,8 @@ fn spawn_elevator(world: &mut World, position: f64) -> EntityId {
             move_count: 0,
             door_command_queue: Vec::new(),
             manual_target_velocity: None,
+            bypass_load_up_pct: None,
+            bypass_load_down_pct: None,
         },
     );
     eid
@@ -499,6 +501,10 @@ fn build_lobby_sim() -> crate::sim::Simulation {
             energy_profile: None,
             service_mode: None,
             inspection_speed_factor: 0.25,
+
+            bypass_load_up_pct: None,
+
+            bypass_load_down_pct: None,
         }])
         .dispatch(EtdDispatch::new())
         .reposition(ReturnToLobby::new(), BuiltinReposition::ReturnToLobby)

--- a/crates/elevator-core/src/tests/reposition_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_tests.rs
@@ -338,6 +338,57 @@ fn predictive_parking_spreads_across_hot_stops() {
     );
 }
 
+/// Asymmetric topology: 3 idle cars but only 2 hot stops — the third
+/// car must stay put rather than park on a cold stop or pile onto a
+/// hot one. Catches a regression where `assign_greedy_by_score` kept
+/// iterating after running out of hot stops.
+#[test]
+fn predictive_parking_asymmetric_extra_car_stays_put() {
+    let (mut world, stops) = test_world_n(4);
+    let elev_a = spawn_elevator(&mut world, 0.0);
+    let elev_b = spawn_elevator(&mut world, 4.0);
+    let elev_c = spawn_elevator(&mut world, 8.0);
+    let group = test_group(&stops, vec![elev_a, elev_b, elev_c]);
+
+    let mut log = ArrivalLog::default();
+    for _ in 0..10 {
+        log.record(50, stops[2]);
+    }
+    for _ in 0..5 {
+        log.record(50, stops[3]);
+    }
+    world.insert_resource(log);
+    world.insert_resource(CurrentTick(100));
+
+    let idle = vec![(elev_a, 0.0), (elev_b, 4.0), (elev_c, 8.0)];
+    let stop_pos: Vec<(EntityId, f64)> = stops
+        .iter()
+        .map(|&sid| (sid, world.stop_position(sid).unwrap()))
+        .collect();
+
+    let mut strategy = PredictiveParking::new();
+    let mut result = Vec::new();
+    strategy.reposition(&idle, &stop_pos, &group, &world, &mut result);
+
+    // At most two moves — one per hot stop. No car parks on a cold
+    // stop and no car doubles up on an already-claimed hot stop.
+    assert!(
+        result.len() <= 2,
+        "must not generate more moves than hot stops; got {result:?}"
+    );
+    let targets: std::collections::HashSet<_> = result.iter().map(|(_, s)| *s).collect();
+    for &(_, target) in &result {
+        assert!(
+            target == stops[2] || target == stops[3],
+            "target {target:?} is not one of the hot stops"
+        );
+    }
+    assert!(
+        targets.len() == result.len(),
+        "each hot stop must appear at most once; got {result:?}"
+    );
+}
+
 // ReturnToLobby with `with_home(2)`.
 #[test]
 fn return_to_lobby_custom_home() {

--- a/crates/elevator-core/src/tests/reposition_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_tests.rs
@@ -1,9 +1,12 @@
 //! Tests for the repositioning system and ETD dispatch overhaul.
 
+use crate::arrival_log::{ArrivalLog, CurrentTick};
 use crate::builder::SimulationBuilder;
 use crate::components::{Accel, ElevatorPhase, RiderPhase, Speed, Weight};
 use crate::dispatch::etd::EtdDispatch;
-use crate::dispatch::reposition::{DemandWeighted, NearestIdle, ReturnToLobby, SpreadEvenly};
+use crate::dispatch::reposition::{
+    DemandWeighted, NearestIdle, PredictiveParking, ReturnToLobby, SpreadEvenly,
+};
 use crate::dispatch::{
     self, BuiltinReposition, DispatchManifest, ElevatorGroup, LineInfo, RepositionStrategy,
 };
@@ -234,6 +237,105 @@ fn return_to_lobby_sends_to_home() {
 
     assert_eq!(result.len(), 1);
     assert_eq!(result[0], (elev, stops[0]));
+}
+
+// PredictiveParking: idle car parks near the stop with the highest
+// recent arrival rate (Otis Compass Infinity model).
+#[test]
+fn predictive_parking_targets_highest_arrival_rate_stop() {
+    let (mut world, stops) = test_world_n(4);
+    let elev = spawn_elevator(&mut world, 0.0);
+    let group = test_group(&stops, vec![elev]);
+
+    // Seed the arrival log: stop 2 gets 10 recent arrivals, stop 3 gets
+    // 3, others zero. Current tick = 100, default window covers 0..100.
+    let mut log = ArrivalLog::default();
+    for _ in 0..10 {
+        log.record(50, stops[2]);
+    }
+    for _ in 0..3 {
+        log.record(80, stops[3]);
+    }
+    world.insert_resource(log);
+    world.insert_resource(CurrentTick(100));
+
+    let idle = vec![(elev, 0.0)];
+    let stop_pos: Vec<(EntityId, f64)> = stops
+        .iter()
+        .map(|&sid| (sid, world.stop_position(sid).unwrap()))
+        .collect();
+
+    let mut strategy = PredictiveParking::new();
+    let mut result = Vec::new();
+    strategy.reposition(&idle, &stop_pos, &group, &world, &mut result);
+
+    assert_eq!(result.len(), 1, "expected one parking move");
+    assert_eq!(
+        result[0],
+        (elev, stops[2]),
+        "highest recent-arrival stop must be the parking target"
+    );
+}
+
+#[test]
+fn predictive_parking_no_movement_when_log_empty() {
+    let (mut world, stops) = test_world_n(4);
+    let elev = spawn_elevator(&mut world, 0.0);
+    let group = test_group(&stops, vec![elev]);
+
+    world.insert_resource(ArrivalLog::default());
+    world.insert_resource(CurrentTick(100));
+
+    let idle = vec![(elev, 0.0)];
+    let stop_pos: Vec<(EntityId, f64)> = stops
+        .iter()
+        .map(|&sid| (sid, world.stop_position(sid).unwrap()))
+        .collect();
+
+    let mut strategy = PredictiveParking::new();
+    let mut result = Vec::new();
+    strategy.reposition(&idle, &stop_pos, &group, &world, &mut result);
+
+    assert!(
+        result.is_empty(),
+        "no recent arrivals ⇒ no basis to move; got {result:?}"
+    );
+}
+
+#[test]
+fn predictive_parking_spreads_across_hot_stops() {
+    let (mut world, stops) = test_world_n(4);
+    let elev_a = spawn_elevator(&mut world, 0.0);
+    let elev_b = spawn_elevator(&mut world, 4.0);
+    let group = test_group(&stops, vec![elev_a, elev_b]);
+
+    // Two hot stops (different counts so the ordering is determinstic);
+    // two cars should end up at each rather than both at the hottest.
+    let mut log = ArrivalLog::default();
+    for _ in 0..10 {
+        log.record(50, stops[2]);
+    }
+    for _ in 0..5 {
+        log.record(50, stops[3]);
+    }
+    world.insert_resource(log);
+    world.insert_resource(CurrentTick(100));
+
+    let idle = vec![(elev_a, 0.0), (elev_b, 4.0)];
+    let stop_pos: Vec<(EntityId, f64)> = stops
+        .iter()
+        .map(|&sid| (sid, world.stop_position(sid).unwrap()))
+        .collect();
+
+    let mut strategy = PredictiveParking::new();
+    let mut result = Vec::new();
+    strategy.reposition(&idle, &stop_pos, &group, &world, &mut result);
+
+    let targets: std::collections::HashSet<_> = result.iter().map(|(_, s)| *s).collect();
+    assert!(
+        targets.contains(&stops[2]) && targets.contains(&stops[3]),
+        "both hot stops must receive coverage, not both cars the single hottest; got {result:?}"
+    );
 }
 
 // ReturnToLobby with `with_home(2)`.

--- a/crates/elevator-core/src/tests/reroute_tests.rs
+++ b/crates/elevator-core/src/tests/reroute_tests.rs
@@ -49,6 +49,10 @@ fn three_stop_config() -> SimConfig {
             energy_profile: None,
             service_mode: None,
             inspection_speed_factor: 0.25,
+
+            bypass_load_up_pct: None,
+
+            bypass_load_down_pct: None,
         }],
         simulation: SimulationParams {
             ticks_per_second: 60.0,
@@ -154,6 +158,10 @@ fn disable_only_stop_causes_abandonment() {
             energy_profile: None,
             service_mode: None,
             inspection_speed_factor: 0.25,
+
+            bypass_load_up_pct: None,
+
+            bypass_load_down_pct: None,
         }],
         simulation: SimulationParams {
             ticks_per_second: 60.0,

--- a/crates/elevator-core/src/tests/topology_tests.rs
+++ b/crates/elevator-core/src/tests/topology_tests.rs
@@ -48,6 +48,10 @@ fn add_elevator_at_runtime() {
         door_open_ticks: 8,
         restricted_stops: HashSet::new(),
         inspection_speed_factor: 0.25,
+
+        bypass_load_up_pct: None,
+
+        bypass_load_down_pct: None,
     };
 
     let elev = sim.add_elevator(&params, line, 4.0).unwrap();
@@ -89,6 +93,10 @@ fn add_elevator_rejects_invalid_params() {
         door_open_ticks: 10,
         restricted_stops: HashSet::new(),
         inspection_speed_factor: 0.25,
+
+        bypass_load_up_pct: None,
+
+        bypass_load_down_pct: None,
     };
 
     // Note: Speed/Weight/Accel constructors panic on NaN/Inf/negative, so
@@ -198,6 +206,10 @@ fn add_elevator_rejects_non_finite_starting_position() {
         door_open_ticks: 10,
         restricted_stops: HashSet::new(),
         inspection_speed_factor: 0.25,
+
+        bypass_load_up_pct: None,
+
+        bypass_load_down_pct: None,
     };
 
     for (label, value) in [
@@ -267,6 +279,10 @@ fn add_to_nonexistent_line_returns_error() {
         door_open_ticks: 1,
         restricted_stops: HashSet::new(),
         inspection_speed_factor: 0.25,
+
+        bypass_load_up_pct: None,
+
+        bypass_load_down_pct: None,
     };
     let result = sim.add_elevator(&params, bogus, 0.0);
     assert!(result.is_err());

--- a/crates/elevator-core/src/tests/world_tests.rs
+++ b/crates/elevator-core/src/tests/world_tests.rs
@@ -67,6 +67,8 @@ fn elevator_query_returns_entities_with_both_components() {
             move_count: 0,
             door_command_queue: Vec::new(),
             manual_target_velocity: None,
+            bypass_load_up_pct: None,
+            bypass_load_down_pct: None,
         },
     );
 
@@ -269,6 +271,8 @@ fn despawn_cleans_up_hall_and_car_calls() {
             move_count: 0,
             door_command_queue: Vec::new(),
             manual_target_velocity: None,
+            bypass_load_up_pct: None,
+            bypass_load_down_pct: None,
         },
     );
 

--- a/crates/elevator-core/tests/deterministic_replay.rs
+++ b/crates/elevator-core/tests/deterministic_replay.rs
@@ -110,6 +110,10 @@ fn build_sim() -> Simulation {
         energy_profile: None,
         service_mode: None,
         inspection_speed_factor: 0.25,
+
+        bypass_load_up_pct: None,
+
+        bypass_load_down_pct: None,
     };
 
     SimulationBuilder::new()


### PR DESCRIPTION
Stacked on #317 (dispatch-stall bugfixes). Merge that first; GitHub will then retarget this PR to main.

Adds the five commercial-controller behaviors the research survey flagged as highest-impact gaps for a didactic elevator sim. Each feature is opt-in and backwards-compatible — no existing behavior changes unless a user enables it. TDD throughout: every feature is red-green-refactor with unit tests pinning the behavior.

## Changes

1. **Rolling arrival-rate signals** (`feat(dispatch): surface per-stop rolling arrival rate`) — `ArrivalLog` world resource recording `(tick, stop)` on each rider spawn; `DispatchManifest::arrivals_at` + `arrival_window_ticks` surface a 5-minute window for strategies. No strategy changes; unblocks #4 and #5 below.
2. **Direction-dependent full-load bypass** (`feat(dispatch): direction-dependent full-load bypass`) — `Elevator::bypass_load_up_pct` / `bypass_load_down_pct` (also on `ElevatorConfig` / `ElevatorParams`). A loaded car skips same-direction pickups above its threshold; aboard exits are always honored. Modeled on Otis Elevonic 411 (patent US5490580A). Default `None` disables.
3. **Group-time / squared-wait ETD cost** (`feat(etd): group-time (squared-wait) fairness bonus`) — new `wait_squared_weight` on `EtdDispatch`. Non-zero values subtract `weight * sum(wait_ticks²)` from per-pair cost, preferring stops hosting older waiters. Damps the long-wait tail (Aalto EJOR 2016). Default 0.
4. **Deferred DCS commitment window** (`feat(dcs): deferred commitment window for reallocation until near arrival`) — `DestinationDispatch::with_commitment_window_ticks`. While the assigned car is farther than `window` ticks from the rider's origin, the sticky assignment re-competes; inside the window, it locks. Models KONE Polaris's two-button reallocation regime.
5. **PredictiveParking reposition strategy** (`feat(reposition): PredictiveParking strategy driven by arrival rate`) — greedy park-at-hottest-stops using the rolling window. New `CurrentTick` world resource kept in sync at `step()` so reposition phases can query the log. Parallels Otis Compass Infinity's predictive parking.

## Tests

- \`arrival_log_tests\` — 4 tests covering window counts, pruning, sim recording, and manifest exposure.
- \`bypass_tests\` — 4 tests: up/down bypass above threshold, below-threshold allows pickup, aboard-exit never blocked.
- \`etd_mutant_tests\` — 2 new tests for squared-wait preference + non-domination of travel time.
- \`destination_dispatch_tests\` — 2 new tests: reassignment when outside window, lock when inside.
- \`reposition_tests\` — 3 new tests: highest-rate parking, empty-log no-op, spread across hot stops.

All 677 unit tests + 156 doc tests + integration tests pass. Clippy clean. `cargo check --workspace --all-features` clean.

## Test plan

- [x] \`cargo test -p elevator-core --all-features\`
- [x] \`cargo clippy -p elevator-core --all-features --all-targets\` clean
- [x] \`cargo check --workspace --all-features\`
- [ ] greptile review