### PR TITLE
fix(dispatch): close direction-filter self-assign stall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.3.0"
+version = "15.3.1"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -104,7 +104,41 @@ pub fn pair_can_do_work(ctx: &RankContext<'_>) -> bool {
     waiting.is_empty()
         || waiting
             .iter()
-            .any(|r| r.weight.value() <= remaining_capacity)
+            .any(|r| rider_can_board(r, car, ctx, remaining_capacity))
+}
+
+/// Whether a waiting rider could actually board this car, matching the
+/// same filters the loading phase applies. Prevents `pair_can_do_work`
+/// from approving a pickup whose only demand is direction-filtered or
+/// over-capacity — the loading phase would reject the rider, doors
+/// would cycle, and dispatch would re-pick the zero-cost self-pair.
+fn rider_can_board(
+    rider: &RiderInfo,
+    car: &crate::components::Elevator,
+    ctx: &RankContext<'_>,
+    remaining_capacity: f64,
+) -> bool {
+    if rider.weight.value() > remaining_capacity {
+        return false;
+    }
+    // Match `systems::loading`'s direction filter: a rider whose trip
+    // goes the opposite way of the car's committed direction will not
+    // be boarded. An unknown destination (no route yet) is treated as
+    // unconstrained — let the rider through and let the loading phase
+    // make the final call.
+    let Some(dest) = rider.destination else {
+        return true;
+    };
+    let Some(dest_pos) = ctx.world.stop_position(dest) else {
+        return true;
+    };
+    if dest_pos > ctx.stop_position && !car.going_up() {
+        return false;
+    }
+    if dest_pos < ctx.stop_position && !car.going_down() {
+        return false;
+    }
+    true
 }
 
 /// True when a full-load bypass applies: the car has a configured

--- a/crates/elevator-core/src/tests/direction_stall_tests.rs
+++ b/crates/elevator-core/src/tests/direction_stall_tests.rs
@@ -1,0 +1,189 @@
+//! Tests for the direction-filter stall fix.
+//!
+//! A car carrying riders with downward destinations has direction
+//! indicator Down. At a waypoint where a waiting rider wants Up, the
+//! loading phase silently direction-filters the rider and no boarding
+//! happens. Pre-fix, `pair_can_do_work` looked only at weight fit and
+//! approved the pair — cost collapsed to 0 at the self-pair, the
+//! Hungarian picked it every tick, doors cycled open → filter →
+//! close forever, and aboard riders never reached their destinations.
+
+use super::dispatch_tests::{spawn_elevator, test_group, test_world};
+use crate::components::{ElevatorPhase, Route, Weight};
+use crate::dispatch::etd::EtdDispatch;
+use crate::dispatch::nearest_car::NearestCarDispatch;
+use crate::dispatch::{self, DispatchDecision, DispatchManifest, DispatchStrategy, RiderInfo};
+
+#[test]
+fn etd_skips_pickup_whose_riders_are_all_direction_filtered() {
+    let (mut world, stops) = test_world();
+    // Car at stops[2] (pos 8), going down to serve an aboard rider
+    // whose destination is stops[0] (pos 0).
+    let elev = spawn_elevator(&mut world, 8.0);
+    {
+        let car = world.elevator_mut(elev).unwrap();
+        car.going_up = false;
+        car.going_down = true;
+        car.phase = ElevatorPhase::MovingToStop(stops[0]);
+    }
+    let aboard = world.spawn();
+    world.elevator_mut(elev).unwrap().riders.push(aboard);
+    world.set_route(
+        aboard,
+        Route::direct(stops[3], stops[0], crate::ids::GroupId(0)),
+    );
+
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+
+    // A waiting rider at the car's current stop — but they want to go
+    // *up* to stops[3] (pos 12). Direction-filter in loading will
+    // reject their boarding while the car is committed downward.
+    let up_waiter = world.spawn();
+    manifest
+        .waiting_at_stop
+        .entry(stops[2])
+        .or_default()
+        .push(RiderInfo {
+            id: up_waiter,
+            destination: Some(stops[3]),
+            weight: Weight::from(70.0),
+            wait_ticks: 0,
+        });
+    // Aboard rider's own destination demand (mirrors what
+    // `build_manifest` produces under normal operation).
+    manifest
+        .riding_to_stop
+        .entry(stops[0])
+        .or_default()
+        .push(RiderInfo {
+            id: aboard,
+            destination: Some(stops[0]),
+            weight: Weight::from(70.0),
+            wait_ticks: 0,
+        });
+
+    let mut etd = EtdDispatch::new();
+    etd.pre_dispatch(&group, &manifest, &mut world);
+    let decisions = dispatch::assign(&mut etd, &[(elev, 8.0)], &group, &manifest, &world).decisions;
+    assert_eq!(
+        decisions[0].1,
+        DispatchDecision::GoToStop(stops[0]),
+        "car must continue to the aboard rider's destination, not self-assign to a \
+         waypoint whose only waiting rider is direction-filtered"
+    );
+}
+
+/// Same scenario on `NearestCar` — the `pair_can_do_work` guard is
+/// shared, so the fix must apply uniformly.
+#[test]
+fn nearest_car_skips_pickup_whose_riders_are_all_direction_filtered() {
+    let (mut world, stops) = test_world();
+    let elev = spawn_elevator(&mut world, 8.0);
+    {
+        let car = world.elevator_mut(elev).unwrap();
+        car.going_up = false;
+        car.going_down = true;
+        car.phase = ElevatorPhase::MovingToStop(stops[0]);
+    }
+    let aboard = world.spawn();
+    world.elevator_mut(elev).unwrap().riders.push(aboard);
+    world.set_route(
+        aboard,
+        Route::direct(stops[3], stops[0], crate::ids::GroupId(0)),
+    );
+
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    let up_waiter = world.spawn();
+    manifest
+        .waiting_at_stop
+        .entry(stops[2])
+        .or_default()
+        .push(RiderInfo {
+            id: up_waiter,
+            destination: Some(stops[3]),
+            weight: Weight::from(70.0),
+            wait_ticks: 0,
+        });
+    manifest
+        .riding_to_stop
+        .entry(stops[0])
+        .or_default()
+        .push(RiderInfo {
+            id: aboard,
+            destination: Some(stops[0]),
+            weight: Weight::from(70.0),
+            wait_ticks: 0,
+        });
+
+    let mut nc = NearestCarDispatch::new();
+    nc.pre_dispatch(&group, &manifest, &mut world);
+    let decisions = dispatch::assign(&mut nc, &[(elev, 8.0)], &group, &manifest, &world).decisions;
+    assert_eq!(
+        decisions[0].1,
+        DispatchDecision::GoToStop(stops[0]),
+        "NearestCar must honor the direction filter too"
+    );
+}
+
+/// Direction filter doesn't block riders going the same way as the car.
+/// Regression guard against over-zealous filtering — a down-going car
+/// at a waypoint must still consider a down-going waiting rider.
+#[test]
+fn pickup_of_matching_direction_rider_still_passes() {
+    let (mut world, stops) = test_world();
+    let elev = spawn_elevator(&mut world, 8.0);
+    {
+        let car = world.elevator_mut(elev).unwrap();
+        car.going_up = false;
+        car.going_down = true;
+        car.phase = ElevatorPhase::MovingToStop(stops[0]);
+    }
+    let aboard = world.spawn();
+    world.elevator_mut(elev).unwrap().riders.push(aboard);
+    world.set_route(
+        aboard,
+        Route::direct(stops[3], stops[0], crate::ids::GroupId(0)),
+    );
+
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    let down_waiter = world.spawn();
+    // Down-going waiting rider at the car's stop — direction matches,
+    // board is allowed.
+    manifest
+        .waiting_at_stop
+        .entry(stops[2])
+        .or_default()
+        .push(RiderInfo {
+            id: down_waiter,
+            destination: Some(stops[1]),
+            weight: Weight::from(70.0),
+            wait_ticks: 0,
+        });
+    manifest
+        .riding_to_stop
+        .entry(stops[0])
+        .or_default()
+        .push(RiderInfo {
+            id: aboard,
+            destination: Some(stops[0]),
+            weight: Weight::from(70.0),
+            wait_ticks: 0,
+        });
+
+    let mut etd = EtdDispatch::new();
+    etd.pre_dispatch(&group, &manifest, &mut world);
+    let decisions = dispatch::assign(&mut etd, &[(elev, 8.0)], &group, &manifest, &world).decisions;
+    // With a valid same-direction waiter at the car's stop, ETD is
+    // free to route either to the pickup or straight to the aboard
+    // destination; either is correct. The invariant we pin here is
+    // that the decision is *not* `Idle` — the pair must remain
+    // serviceable, unlike the filtered case above.
+    assert!(
+        matches!(decisions[0].1, DispatchDecision::GoToStop(_)),
+        "a same-direction waiter must not be spuriously filtered; got {:?}",
+        decisions[0].1
+    );
+}

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -46,6 +46,7 @@ mod bypass_tests;
 mod destination_dispatch_tests;
 mod destination_queue_tests;
 mod direction_indicator_tests;
+mod direction_stall_tests;
 mod door_control_tests;
 #[cfg(feature = "energy")]
 mod energy_tests;


### PR DESCRIPTION
Residual stall the playground was showing after #317 landed.

\`pair_can_do_work\` approved pickup stops whenever any waiting rider fit by weight — but the loading phase's direction filter rejects every up-going waiter at the car's current stop while the car is committed downward (and vice versa). The stop's cost collapses to 0 for the self-pair, the Hungarian picks it every tick, doors cycle open → direction-filter → close, and aboard riders are never delivered.

Scenario that hits in the playground: car carrying riders to lower floors stops at a mid-floor waypoint whose only waiting rider wants to go up. ETD keeps selecting the self-pair (cost 0) and never advances to the aboard rider's destination.

Fix: extract \`rider_can_board\` mirroring the loading direction filter, have \`pair_can_do_work\` require at least one waiting rider to pass it before approving a pickup-only stop. Applies to ETD and NearestCar; SCAN/LOOK already reject behind-direction stops via their sweep rank.

## Test plan
- [x] \`cargo test -p elevator-core --all-features\` (688 unit + 156 doc tests pass)
- [x] \`cargo clippy -p elevator-core --all-features --all-targets\` clean
- [x] New tests: \`etd_skips_pickup_whose_riders_are_all_direction_filtered\`, \`nearest_car_skips_pickup_whose_riders_are_all_direction_filtered\`, \`pickup_of_matching_direction_rider_still_passes\`