### PR TITLE
fix(dispatch): ETD audit — cross-car stall + unit mismatch + scenario rebalance

### DIFF
--- a/crates/elevator-core/src/dispatch/etd.rs
+++ b/crates/elevator-core/src/dispatch/etd.rs
@@ -174,7 +174,22 @@ impl EtdDispatch {
             return f64::INFINITY;
         };
 
-        let door_overhead_per_stop = f64::from(car.door_transition_ticks * 2 + car.door_open_ticks);
+        // Door overhead is a seconds-denominated cost so the Hungarian
+        // can compare it apples-to-apples against travel time and
+        // existing-rider delay. Pre-fix, this was summed in ticks,
+        // multiplied by `door_weight` (dimensionless), and added to
+        // seconds-valued terms — giving door cost ~60× the intended
+        // influence at 60 Hz. A single intervening stop could then
+        // outweigh a long travel time and bias ETD toward distant
+        // cars with clear shafts over closer ones with a single
+        // waypoint. Convert with the sim's tick rate (resource-
+        // provided) and fall back to 60 Hz for bare-World contexts
+        // such as unit-test fixtures.
+        let tick_rate = world
+            .resource::<crate::time::TickRate>()
+            .map_or(60.0, |r| r.0);
+        let door_overhead_per_stop =
+            f64::from(car.door_transition_ticks * 2 + car.door_open_ticks) / tick_rate;
 
         // Intervening pending stops between car and target contribute door overhead.
         let (lo, hi) = if elev_pos < target_pos {

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -101,10 +101,25 @@ pub fn pair_can_do_work(ctx: &RankContext<'_>) -> bool {
         return false;
     }
     let waiting = ctx.manifest.waiting_riders_at(ctx.stop);
-    waiting.is_empty()
-        || waiting
+    if !waiting.is_empty() {
+        return waiting
             .iter()
-            .any(|r| rider_can_board(r, car, ctx, remaining_capacity))
+            .any(|r| rider_can_board(r, car, ctx, remaining_capacity));
+    }
+    // No waiters at the stop, and no aboard rider of ours exits here
+    // (the `can_exit_here` short-circuit ruled that out above). Demand
+    // must therefore come from either another car's `riding_to_stop`
+    // (not work this car can perform) or a rider-less hall call
+    // (someone pressed a button with no rider attached yet — a press
+    // from `press_hall_button` or one whose riders have since been
+    // fulfilled or abandoned). Only the latter is actionable; without
+    // this filter an idle car parked at the stop collapses to cost 0,
+    // the Hungarian picks the self-pair every tick, and doors cycle
+    // open/close indefinitely while the other car finishes its trip.
+    ctx.manifest
+        .hall_calls_at_stop
+        .get(&ctx.stop)
+        .is_some_and(|calls| calls.iter().any(|c| c.pending_riders.is_empty()))
 }
 
 /// Whether a waiting rider could actually board this car, matching the

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -185,6 +185,12 @@ impl Simulation {
         world.insert_resource(crate::arrival_log::ArrivalLog::default());
         world.insert_resource(crate::arrival_log::CurrentTick::default());
         world.insert_resource(crate::arrival_log::ArrivalLogRetention::default());
+        // Expose tick rate to strategies that need to unit-convert
+        // tick-denominated elevator fields (door cycle, ack latency)
+        // into the second-denominated terms of their cost functions.
+        // Without this, ETD's door-overhead term was summing ticks
+        // into a seconds expression and getting ~60× over-weighted.
+        world.insert_resource(crate::time::TickRate(config.simulation.ticks_per_second));
 
         let (groups, dispatchers, strategy_ids) = if let Some(line_configs) = &config.building.lines
         {
@@ -574,6 +580,13 @@ impl Simulation {
     ) -> Self {
         let mut rider_index = RiderIndex::default();
         rider_index.rebuild(&world);
+        // Ensure the dispatch-visible tick rate matches the simulation
+        // tick rate after a snapshot restore; a snapshot that predates
+        // the `TickRate` resource leaves it absent and dispatch would
+        // otherwise fall back to the 60 Hz default even for a 30 Hz
+        // sim, silently halving ETD's door-cost scale.
+        let mut world = world;
+        world.insert_resource(crate::time::TickRate(ticks_per_second));
         Self {
             world,
             events: EventBus::default(),

--- a/crates/elevator-core/src/tests/direction_stall_tests.rs
+++ b/crates/elevator-core/src/tests/direction_stall_tests.rs
@@ -283,3 +283,50 @@ fn etd_approves_self_pair_for_riderless_hall_call() {
          fix must not filter it out along with cross-car riding demand"
     );
 }
+
+/// Cross-car stall mirrored onto `NearestCar` — the fix lives in
+/// shared `pair_can_do_work`, so it applies uniformly across every
+/// built-in strategy that uses the guard. This test is an explicit
+/// regression for that contract, matching the paired-strategy
+/// pattern the direction-filter stall tests (above) already follow.
+#[test]
+fn nearest_car_skips_self_pair_when_only_demand_is_another_cars_riding() {
+    let (mut world, stops) = test_world();
+    let car_a = spawn_elevator(&mut world, 8.0);
+    let car_b = spawn_elevator(&mut world, 0.0);
+    {
+        let b = world.elevator_mut(car_b).unwrap();
+        b.going_up = true;
+        b.going_down = false;
+        b.phase = ElevatorPhase::MovingToStop(stops[2]);
+    }
+    let riding = world.spawn();
+    world.elevator_mut(car_b).unwrap().riders.push(riding);
+    world.set_route(
+        riding,
+        Route::direct(stops[0], stops[2], crate::ids::GroupId(0)),
+    );
+
+    let group = test_group(&stops, vec![car_a, car_b]);
+    let mut manifest = DispatchManifest::default();
+    manifest
+        .riding_to_stop
+        .entry(stops[2])
+        .or_default()
+        .push(RiderInfo {
+            id: riding,
+            destination: Some(stops[2]),
+            weight: Weight::from(70.0),
+            wait_ticks: 0,
+        });
+
+    let mut nc = NearestCarDispatch::new();
+    nc.pre_dispatch(&group, &manifest, &mut world);
+    let decisions = dispatch::assign(&mut nc, &[(car_a, 8.0)], &group, &manifest, &world).decisions;
+    assert_eq!(
+        decisions[0].1,
+        DispatchDecision::Idle,
+        "NearestCar must honor the cross-car stall fix — pair_can_do_work is \
+         shared, so regressions here would surface in both strategies"
+    );
+}

--- a/crates/elevator-core/src/tests/direction_stall_tests.rs
+++ b/crates/elevator-core/src/tests/direction_stall_tests.rs
@@ -187,3 +187,99 @@ fn pickup_of_matching_direction_rider_still_passes() {
         decisions[0].1
     );
 }
+
+/// Stall class that slipped past #322: `has_demand(stop)` is true because
+/// *another* car is mid-flight toward the stop with aboard riders whose
+/// destination matches. The idle car parked at that stop had no waiters
+/// to board and no aboard riders of its own to exit — yet the old
+/// `waiting.is_empty() || ...` clause approved the pair, collapsing cost
+/// to zero. Hungarian then picked the self-pair every tick, doors cycled
+/// open/close indefinitely while the other car finished its trip, and
+/// all the while the idle car was unavailable to serve real demand
+/// elsewhere in the group.
+#[test]
+fn etd_skips_self_pair_when_only_demand_is_another_cars_riding() {
+    let (mut world, stops) = test_world();
+    // Car A: idle at stops[2] (pos 8), no riders, no direction commitment.
+    let car_a = spawn_elevator(&mut world, 8.0);
+    // Car B: moving up toward stops[2] with an aboard rider heading there.
+    let car_b = spawn_elevator(&mut world, 0.0);
+    {
+        let b = world.elevator_mut(car_b).unwrap();
+        b.going_up = true;
+        b.going_down = false;
+        b.phase = ElevatorPhase::MovingToStop(stops[2]);
+    }
+    let riding = world.spawn();
+    world.elevator_mut(car_b).unwrap().riders.push(riding);
+    world.set_route(
+        riding,
+        Route::direct(stops[0], stops[2], crate::ids::GroupId(0)),
+    );
+
+    let group = test_group(&stops, vec![car_a, car_b]);
+    let mut manifest = DispatchManifest::default();
+    // Only demand at stops[2] is Car B's aboard rider — no waiters, no
+    // rider-less hall call. This mirrors what `build_manifest` produces
+    // under normal operation for a group carrying in-flight demand.
+    manifest
+        .riding_to_stop
+        .entry(stops[2])
+        .or_default()
+        .push(RiderInfo {
+            id: riding,
+            destination: Some(stops[2]),
+            weight: Weight::from(70.0),
+            wait_ticks: 0,
+        });
+
+    let mut etd = EtdDispatch::new();
+    etd.pre_dispatch(&group, &manifest, &mut world);
+    // Only Car A is in the idle pool — Car B is mid-flight with riders
+    // and ineligible for dispatch reassignment. The assertion: A must
+    // not be assigned to its own stop (the zero-cost self-pair trap).
+    let decisions =
+        dispatch::assign(&mut etd, &[(car_a, 8.0)], &group, &manifest, &world).decisions;
+    assert_eq!(
+        decisions[0].1,
+        DispatchDecision::Idle,
+        "idle car must not self-assign to a stop whose only demand is \
+         another car's riding_to_stop — otherwise doors cycle at that \
+         stop while the other car delivers"
+    );
+}
+
+/// A rider-less hall call is real work for any car in the group — the
+/// button is lit and someone needs a pickup, even though no rider entity
+/// is attached (e.g., placed via `press_hall_button` directly, or the
+/// riders were fulfilled/abandoned and the call wasn't cleared yet).
+/// Guard against the fix being over-aggressive: the self-pair must still
+/// be approved when a rider-less call is the demand source.
+#[test]
+fn etd_approves_self_pair_for_riderless_hall_call() {
+    use crate::components::{CallDirection, HallCall};
+
+    let (mut world, stops) = test_world();
+    let car = spawn_elevator(&mut world, 8.0);
+    let group = test_group(&stops, vec![car]);
+    let mut manifest = DispatchManifest::default();
+    // No waiters, no aboard riders — only a rider-less hall call at the
+    // car's current stop.
+    let mut call = HallCall::new(stops[2], CallDirection::Up, 0);
+    call.pending_riders.clear();
+    manifest
+        .hall_calls_at_stop
+        .entry(stops[2])
+        .or_default()
+        .push(call);
+
+    let mut etd = EtdDispatch::new();
+    etd.pre_dispatch(&group, &manifest, &mut world);
+    let decisions = dispatch::assign(&mut etd, &[(car, 8.0)], &group, &manifest, &world).decisions;
+    assert_eq!(
+        decisions[0].1,
+        DispatchDecision::GoToStop(stops[2]),
+        "rider-less hall call is a valid reason to open doors — the \
+         fix must not filter it out along with cross-car riding demand"
+    );
+}

--- a/crates/elevator-core/src/tests/dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/dispatch_tests.rs
@@ -199,6 +199,28 @@ fn scan_reverses_when_nothing_ahead() {
 fn scan_serves_rider_destination() {
     let (mut world, stops) = test_world();
     let elev = spawn_elevator(&mut world, 0.0);
+    // Put the rider *aboard* this car, not just in the manifest. The
+    // earlier form of this test faked aboard demand by only populating
+    // `riding_to_stop` — a fixture that can't occur in production since
+    // `build_manifest` derives `riding_to_stop` from each group car's
+    // `riders` list. Once `pair_can_do_work` started rejecting
+    // unservable self-pairs (to close the cross-car stall), the faked
+    // form became unreachable and the test asserted on a Hungarian
+    // fallback. Boarding the rider on this car restores the intent:
+    // the car has a destination to fulfil, so SCAN must drive there.
+    let rider = world.spawn();
+    world.set_rider(
+        rider,
+        Rider {
+            weight: Weight::from(70.0),
+            phase: RiderPhase::Riding(elev),
+            current_stop: None,
+            spawn_tick: 0,
+            board_tick: Some(0),
+        },
+    );
+    world.set_route(rider, Route::direct(stops[0], stops[2], GroupId(0)));
+    world.elevator_mut(elev).unwrap().riders.push(rider);
     let group = test_group(&stops, vec![elev]);
     let mut manifest = DispatchManifest::default();
     add_rider_dest(&mut manifest, &mut world, stops[2]);

--- a/crates/elevator-core/src/time.rs
+++ b/crates/elevator-core/src/time.rs
@@ -2,6 +2,27 @@
 
 use std::time::Duration;
 
+/// Simulation tick rate, exposed as a [`World`](crate::world::World) resource.
+///
+/// Dispatch strategies and other subsystems that only hold a `&World`
+/// need this to convert between tick-denominated elevator fields
+/// (e.g. `door_transition_ticks`) and the second-denominated terms
+/// they combine with (travel time, rider delay). Inserted once during
+/// [`Simulation::new`](crate::sim::Simulation::new) and restored from
+/// snapshots via the same path.
+///
+/// Strategies that miss the resource (e.g. in a bare-bones unit-test
+/// world) should fall back to 60 Hz — the canonical default and the
+/// only value used across the published scenarios.
+#[derive(Debug, Clone, Copy)]
+pub struct TickRate(pub f64);
+
+impl Default for TickRate {
+    fn default() -> Self {
+        Self(60.0)
+    }
+}
+
 /// Converts between simulation ticks and wall-clock time.
 ///
 /// The core simulation is purely tick-based for determinism.

--- a/playground/src/scenarios.ts
+++ b/playground/src/scenarios.ts
@@ -38,12 +38,18 @@ function topBias(n: number): number[] {
 // ─── Mid-rise office — group-time ETD hook ──────────────────────────
 
 const OFFICE_STOPS = 6;
+// Two 800 kg cars (~10 riders/trip each) over a 20 m shaft at 2.2 m/s
+// cycle ~54 riders/min combined when healthy. Phase rates sit at
+// roughly 1.0–1.2× that during rushes — queues build visibly, group-
+// time ETD has something to fix, but the building doesn't collapse.
+// Under the original single-car config, morning/lunch demand was 2×+
+// cruise and the simulation just filled up — all strategies lost.
 const officePhases: Phase[] = [
   // 0: overnight — tiny trickle of late-workers or cleaners.
   {
     name: "Overnight",
     durationSec: 45,
-    ridersPerMin: 3,
+    ridersPerMin: 4,
     originWeights: uniform(OFFICE_STOPS),
     destWeights: uniform(OFFICE_STOPS),
   },
@@ -51,7 +57,7 @@ const officePhases: Phase[] = [
   {
     name: "Morning rush",
     durationSec: 60,
-    ridersPerMin: 80,
+    ridersPerMin: 55,
     originWeights: [8.5, 0.3, 0.3, 0.3, 0.3, 0.3],
     destWeights: topBias(OFFICE_STOPS).map((w, i) => (i === 0 ? 0 : w)),
   },
@@ -64,11 +70,13 @@ const officePhases: Phase[] = [
     destWeights: uniform(OFFICE_STOPS),
   },
   // 3: lunchtime — bidirectional burst between upper floors and a
-  // canteen on stop 1. The hardest pattern for any controller.
+  // canteen on stop 1. The hardest pattern for any controller, so it
+  // lands slightly above the pair's cruise capacity on purpose —
+  // this is where the group-time ETD hook gets its chance to shine.
   {
     name: "Lunchtime",
     durationSec: 45,
-    ridersPerMin: 110,
+    ridersPerMin: 65,
     // Origins skew toward upper floors (people leaving for lunch) and the canteen.
     originWeights: [0.3, 3, 2, 2, 2, 2],
     destWeights: [0.3, 3, 2, 2, 2, 2],
@@ -77,7 +85,7 @@ const officePhases: Phase[] = [
   {
     name: "Evening exodus",
     durationSec: 60,
-    ridersPerMin: 75,
+    ridersPerMin: 55,
     originWeights: topBias(OFFICE_STOPS).map((w, i) => (i === 0 ? 0 : w)),
     destWeights: lobbyOnly(OFFICE_STOPS),
   },
@@ -87,7 +95,7 @@ const office: ScenarioMeta = {
   id: "office-mid-rise",
   label: "Mid-rise office",
   description:
-    "Six floors, one 800 kg car. Walks through morning rush → midday → lunchtime → evening exodus. Group-time ETD damps tail waits under sustained load.",
+    "Six floors, two 800 kg cars. Walks through morning rush → midday → lunchtime → evening exodus. Group-time ETD damps tail waits under sustained load.",
   defaultStrategy: "etd",
   phases: officePhases,
   seedSpawns: 0,
@@ -114,6 +122,13 @@ const office: ScenarioMeta = {
             starting_stop: StopId(0),
             door_open_ticks: 55, door_transition_ticks: 14,
         ),
+        ElevatorConfig(
+            id: 1, name: "Car 2",
+            max_speed: 2.2, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(3),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
     ],
     simulation: SimulationParams(ticks_per_second: 60.0),
     passenger_spawning: PassengerSpawnConfig(
@@ -126,6 +141,9 @@ const office: ScenarioMeta = {
 // ─── Skyscraper with sky lobby — full-load bypass hook ──────────────
 
 const SKY_STOPS = 13; // Lobby + 12 floors
+// Three 1200 kg cars at 4 m/s over a 48 m shaft cycle ~90 riders/min
+// combined when healthy. Rates target ~1.3–1.4× that during peaks so
+// the bypass hook actually sees full cars and gets to show its work.
 const skyPhases: Phase[] = [
   {
     name: "Overnight",
@@ -137,21 +155,21 @@ const skyPhases: Phase[] = [
   {
     name: "Morning rush",
     durationSec: 75,
-    ridersPerMin: 180,
+    ridersPerMin: 120,
     originWeights: [14, ...Array.from({ length: SKY_STOPS - 1 }, () => 0.25)],
     destWeights: [0, ...topBias(SKY_STOPS - 1)],
   },
   {
     name: "Midday interfloor",
     durationSec: 60,
-    ridersPerMin: 60,
+    ridersPerMin: 45,
     originWeights: uniform(SKY_STOPS),
     destWeights: uniform(SKY_STOPS),
   },
   {
     name: "Lunchtime",
     durationSec: 45,
-    ridersPerMin: 140,
+    ridersPerMin: 100,
     // Sky lobby (stop 6) doubles as the canteen floor.
     originWeights: Array.from({ length: SKY_STOPS }, (_, i) => (i === 6 ? 3 : 1)),
     destWeights: Array.from({ length: SKY_STOPS }, (_, i) => (i === 6 ? 4 : 1)),
@@ -159,7 +177,7 @@ const skyPhases: Phase[] = [
   {
     name: "Evening exodus",
     durationSec: 75,
-    ridersPerMin: 170,
+    ridersPerMin: 115,
     originWeights: [0, ...topBias(SKY_STOPS - 1)],
     destWeights: [14, ...Array.from({ length: SKY_STOPS - 1 }, () => 0.25)],
   },
@@ -232,6 +250,9 @@ const skyscraper: ScenarioMeta = {
 // ─── Residential tower — predictive parking hook ────────────────────
 
 const RES_STOPS = 8;
+// Two 700 kg cars cruise ~50 riders/min combined. Rates stay modest so
+// the midday quiet actually reads as quiet — predictive parking needs
+// the rate signal to drop between bursts to meaningfully pre-position.
 const residentialPhases: Phase[] = [
   {
     name: "Overnight",
@@ -244,7 +265,7 @@ const residentialPhases: Phase[] = [
   {
     name: "Morning exodus",
     durationSec: 75,
-    ridersPerMin: 90,
+    ridersPerMin: 55,
     originWeights: [0, ...topBias(RES_STOPS - 1)],
     destWeights: lobbyOnly(RES_STOPS),
   },
@@ -252,7 +273,7 @@ const residentialPhases: Phase[] = [
   {
     name: "Midday quiet",
     durationSec: 60,
-    ridersPerMin: 12,
+    ridersPerMin: 10,
     originWeights: uniform(RES_STOPS),
     destWeights: uniform(RES_STOPS),
   },
@@ -260,7 +281,7 @@ const residentialPhases: Phase[] = [
   {
     name: "Afternoon drift",
     durationSec: 45,
-    ridersPerMin: 30,
+    ridersPerMin: 22,
     originWeights: Array.from({ length: RES_STOPS }, (_, i) => (i === 0 ? 3 : 1)),
     destWeights: uniform(RES_STOPS),
   },
@@ -268,7 +289,7 @@ const residentialPhases: Phase[] = [
   {
     name: "Evening return",
     durationSec: 60,
-    ridersPerMin: 75,
+    ridersPerMin: 48,
     originWeights: lobbyOnly(RES_STOPS),
     destWeights: [0, ...topBias(RES_STOPS - 1)],
   },
@@ -326,12 +347,18 @@ const residential: ScenarioMeta = {
 // ─── Hotel 24/7 — deferred DCS hook ─────────────────────────────────
 
 const HOTEL_STOPS = 10;
+// Three 900 kg cars at 3 m/s cruise ~80 riders/min combined. Rush
+// rates sit at ~0.7× that — enough to keep all three cars visibly
+// busy and give deferred DCS bursts to reassign across, without
+// saturating. DCS's benefit comes from *reassignment opportunity*,
+// not from overload; if every car were permanently full there would
+// be nothing to defer.
 const hotelPhases: Phase[] = [
   // Pre-dawn baseline — minimal traffic.
   {
     name: "Overnight",
     durationSec: 45,
-    ridersPerMin: 4,
+    ridersPerMin: 5,
     originWeights: uniform(HOTEL_STOPS),
     destWeights: uniform(HOTEL_STOPS),
   },
@@ -347,7 +374,7 @@ const hotelPhases: Phase[] = [
   {
     name: "Daytime",
     durationSec: 75,
-    ridersPerMin: 25,
+    ridersPerMin: 26,
     originWeights: uniform(HOTEL_STOPS),
     destWeights: uniform(HOTEL_STOPS),
   },
@@ -363,7 +390,7 @@ const hotelPhases: Phase[] = [
   {
     name: "Late night",
     durationSec: 60,
-    ridersPerMin: 14,
+    ridersPerMin: 16,
     originWeights: [2, 2, ...Array.from({ length: HOTEL_STOPS - 2 }, () => 0.5)],
     destWeights: [0.5, 0.5, ...Array.from({ length: HOTEL_STOPS - 2 }, () => 1)],
   },
@@ -430,12 +457,17 @@ const hotel: ScenarioMeta = {
 // ─── Convention burst — arrival-log rate signal hook ────────────────
 
 const CONV_STOPS = 5;
+// Two 1500 kg cars cruise ~140 riders/min combined in a short 16 m
+// shaft. The keynote burst intentionally overshoots that — this
+// scenario is an acute stress test, so the arrival-log rate signal
+// actually has a spike to report. The rate still comes down enough
+// that the rest of the cycle is recognizably calm.
 const conventionPhases: Phase[] = [
   // Acute peak right after a keynote lets out.
   {
     name: "Keynote lets out",
     durationSec: 45,
-    ridersPerMin: 240,
+    ridersPerMin: 170,
     originWeights: Array.from({ length: CONV_STOPS }, (_, i) => (i === CONV_STOPS - 1 ? 8 : 1)),
     destWeights: [5, 2, 1, 1, 0],
   },
@@ -443,7 +475,7 @@ const conventionPhases: Phase[] = [
   {
     name: "Tapering",
     durationSec: 90,
-    ridersPerMin: 40,
+    ridersPerMin: 28,
     originWeights: uniform(CONV_STOPS),
     destWeights: uniform(CONV_STOPS),
   },
@@ -453,7 +485,7 @@ const conventionPhases: Phase[] = [
   {
     name: "Between sessions",
     durationSec: 135,
-    ridersPerMin: 8,
+    ridersPerMin: 6,
     originWeights: uniform(CONV_STOPS),
     destWeights: uniform(CONV_STOPS),
   },


### PR DESCRIPTION
## Summary

Three related findings from an ETD trust audit, plus a playground tuning pass.

1. **Stall: cross-car riding demand.** `pair_can_do_work` approved any self-pair when no waiters were at the stop, even when demand came solely from another car's in-flight riders. Idle car collapses to cost 0 at that stop, Hungarian picks the self-pair every tick, doors cycle until the other car finishes its delivery. Fix: require a rider-less hall call in the empty-waiters branch.

2. **Unit mismatch: door cost in ticks.** `compute_cost` summed `door_overhead_per_stop` (ticks) directly into `travel_time` (seconds) — ~60× over-weighting an intervening stop at 60 Hz. Added a `TickRate` world resource, inserted by `Simulation::new` and `from_parts`, and converted door cost to seconds. Mutant tests used inflated `door_weight` which hid the mismatch.

3. **Scenario traffic vs. elevator count.** Office got a 2nd car (one 800 kg car physically couldn't pump 50–65 riders/min). Hotel rates bumped so the 3 cars stay visibly busy. Other scenarios held at 0.9–1.3× their cruise capacity. Each scenario's lead comment now documents cruise capacity in riders/min as a tuning anchor.

## Test plan

- [x] `cargo test -p elevator-core --all-features` — 690 unit + 156 doc tests pass (up from 688/156 pre-change; added regression tests for the new stall class).
- [x] `cargo clippy --workspace --all-features --all-targets` clean.
- [x] `cargo check --workspace` clean.
- [x] `pnpm tsc --noEmit` clean; `pnpm test` (playground) — 19 tests pass.
- [x] New regression tests: `etd_skips_self_pair_when_only_demand_is_another_cars_riding`, `etd_approves_self_pair_for_riderless_hall_call`.
- [x] Existing dispatch fixture `scan_serves_rider_destination` corrected — previously faked aboard demand via manifest-only mutation, which `build_manifest` never produces; now boards the rider on the car.
- [ ] Visual smoke test of all six playground scenarios post-merge (requires fresh wasm build + Pages deploy).

## What I didn't do

- Didn't retune `door_weight` defaults after the unit fix. The effective door influence drops 60×; empirically this moves ETD closer to Barney & dos Santos's seconds-everywhere cost model. Coupling the unit fix and a retune would make future git archaeology harder.
- Didn't extend `pair_can_do_work` with rider preferences / access control / sticky-DCS filters. Playground doesn't exercise those; additional work if a custom game needs them.