### PR TITLE
feat(playground): rider abandonment + headless audit tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.4.0"
+version = "15.4.1"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/examples/playground_audit.rs
+++ b/crates/elevator-core/examples/playground_audit.rs
@@ -1,0 +1,571 @@
+//! Headless audit of the playground scenarios.
+//!
+//! Mirrors the playground's six scenarios (RON configs + phase tables +
+//! `abandonAfterSec` budgets) against a deterministic rider driver,
+//! then reports the metrics a human would be squinting at in the
+//! browser: delivered, abandoned, abandonment rate, avg/max wait, peak
+//! waiting-queue length across the whole run.
+//!
+//! Purpose: verify that playground-level tuning changes (demand rates,
+//! elevator counts, abandonment budgets) produce bounded queues and
+//! realistic abandonment rates *without* needing to spin up a browser
+//! and watch the UI for minutes at a time. If the office's abandonment
+//! fix landed correctly, its peak-queue figure here should be finite
+//! and its `abandoned > 0` should reflect the demand/supply gap.
+//!
+//! This intentionally **duplicates** the scenario data from
+//! `playground/src/scenarios.ts` — one RON string and phase table per
+//! scenario, copied verbatim. A single-source-of-truth refactor would
+//! require a JSON pivot that both TS and Rust consume; not worth the
+//! scope cost right now. If the scenarios.ts numbers change, this file
+//! needs a mirror edit. Comments at the top of each scenario anchor to
+//! the TS side's cruise-capacity docstring so divergence is easy to
+//! spot in review.
+//!
+//! Run with:
+//! ```sh
+//! cargo run --example playground_audit --release
+//! cargo run --example playground_audit --release -- office  # single scenario
+//! ```
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::missing_docs_in_private_items,
+    clippy::print_stdout,
+    clippy::too_many_lines,
+    clippy::panic,
+    clippy::option_if_let_else,
+    clippy::missing_const_for_fn,
+    clippy::suboptimal_flops,
+    clippy::while_float
+)]
+
+use elevator_core::config::SimConfig;
+use elevator_core::dispatch::{
+    DestinationDispatch, EtdDispatch, LookDispatch, NearestCarDispatch, ScanDispatch,
+};
+use elevator_core::sim::Simulation;
+use elevator_core::stop::StopId;
+
+const TICKS_PER_SECOND: u64 = 60;
+
+/// One phase of a scenario's day cycle. Mirrors `playground/src/types.ts`
+/// `Phase` — duration in sim-seconds, rate in riders/min, unnormalized
+/// stop weights.
+struct Phase {
+    duration_sec: u32,
+    riders_per_min: f64,
+    /// Unnormalized; 0.0 in a slot excludes that stop. Length must match stop count.
+    origin_weights: &'static [f64],
+    /// Same shape. If drawn `dest == origin`, rotated forward.
+    dest_weights: &'static [f64],
+}
+
+struct Scenario {
+    id: &'static str,
+    label: &'static str,
+    ron: &'static str,
+    phases: &'static [Phase],
+    /// `None` = riders never abandon (matches `abandonAfterSec` omission).
+    abandon_after_sec: Option<u32>,
+    /// Seed pre-loaded spawns before measurement starts. Mirrors
+    /// `ScenarioMeta.seedSpawns` — used by convention burst.
+    seed_spawns: u32,
+}
+
+/// Seconds of sim-time to run per (scenario, strategy). Covers at least
+/// one full day-cycle for the scenarios whose phase total is ≤ 5 min.
+const RUN_SEC: u32 = 360;
+
+fn main() {
+    // Poor-man's CLI: positional filter + optional `--no-abandon` flag.
+    // Full `clap` would be overkill — this is an audit tool, not a
+    // user-facing binary.
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let no_abandon = args.iter().any(|a| a == "--no-abandon");
+    let filter = args.iter().find(|a| !a.starts_with("--")).cloned();
+    let mut any = false;
+    for scenario in SCENARIOS {
+        if let Some(f) = &filter
+            && !scenario.id.contains(f.as_str())
+        {
+            continue;
+        }
+        any = true;
+        let effective_budget = if no_abandon {
+            None
+        } else {
+            scenario.abandon_after_sec
+        };
+        println!("\n=== {} ({}) ===", scenario.label, scenario.id);
+        println!(
+            "  abandon_after: {}  run: {}s",
+            effective_budget.map_or_else(|| "never".to_string(), |s| format!("{s}s")),
+            RUN_SEC
+        );
+        println!(
+            "  {:<12} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10}",
+            "strategy", "delivered", "abandoned", "aband%", "avg_wait", "max_wait", "peak_q"
+        );
+        for strategy in ["scan", "look", "nearest", "etd", "destination"] {
+            let report = run_once(scenario, strategy, effective_budget);
+            println!(
+                "  {:<12} {:>10} {:>10} {:>9.1}% {:>9.1}s {:>9.1}s {:>10}",
+                strategy,
+                report.delivered,
+                report.abandoned,
+                report.abandonment_pct,
+                report.avg_wait_s,
+                report.max_wait_s,
+                report.peak_waiting,
+            );
+        }
+    }
+    if !any {
+        eprintln!("no scenario matched filter {filter:?}");
+        std::process::exit(1);
+    }
+}
+
+struct Report {
+    delivered: u64,
+    abandoned: u64,
+    abandonment_pct: f64,
+    avg_wait_s: f64,
+    max_wait_s: f64,
+    peak_waiting: usize,
+}
+
+fn run_once(scenario: &Scenario, strategy_name: &str, abandon_override: Option<u32>) -> Report {
+    let config: SimConfig = ron::from_str(scenario.ron).expect("scenario RON must parse");
+
+    // `Simulation::new` wants `impl DispatchStrategy + 'static`, not a
+    // trait object — the generic monomorphizes per strategy. Dispatch
+    // on the name here rather than box/dyn'ing to avoid the `Sized`
+    // bound mismatch.
+    let mut sim = match strategy_name {
+        "scan" => Simulation::new(&config, ScanDispatch::new()),
+        "look" => Simulation::new(&config, LookDispatch::new()),
+        "nearest" => Simulation::new(&config, NearestCarDispatch::new()),
+        "etd" => Simulation::new(&config, EtdDispatch::new()),
+        "destination" => Simulation::new(&config, DestinationDispatch::new()),
+        _ => panic!("unknown strategy: {strategy_name}"),
+    }
+    .expect("sim build");
+    if strategy_name == "destination" {
+        // DCS needs Destination hall-call mode + the AssignedCar
+        // extension registered, otherwise `pre_dispatch` early-returns
+        // and dispatch silently falls back to Idle.
+        for g in sim.groups_mut() {
+            g.set_hall_call_mode(elevator_core::dispatch::HallCallMode::Destination);
+        }
+        sim.world_mut()
+            .register_ext::<elevator_core::dispatch::AssignedCar>(
+                elevator_core::dispatch::destination::ASSIGNED_CAR_KEY,
+            );
+    }
+
+    let stop_ids: Vec<StopId> = config.building.stops.iter().map(|s| s.id).collect();
+    // Resolve StopId → EntityId once; `waiting_count_at` wants the
+    // entity form. `stop_entity` is None for unknown StopIds — shouldn't
+    // happen for a freshly-built sim, but filter defensively.
+    let stop_entities: Vec<_> = stop_ids
+        .iter()
+        .filter_map(|id| sim.stop_entity(*id))
+        .collect();
+    let mut driver = Driver::new(42, scenario.phases);
+
+    // Pre-seed — convention scenario burst. Each spawn call advances the
+    // driver's internal accumulator by a fixed dt; 300 steps at 1/60s is
+    // enough to drain 300 × (rate/60) ticks of scheduled spawns from the
+    // first phase. Matches the playground's seedSpawns loop shape.
+    for _ in 0..scenario.seed_spawns {
+        let specs = driver.drain(1.0 / 60.0);
+        for spec in specs {
+            spawn(
+                &mut sim,
+                spec.origin,
+                spec.dest,
+                spec.weight,
+                abandon_override,
+            );
+        }
+    }
+
+    let mut peak_waiting = 0usize;
+    let dt = 1.0 / f64::from(TICKS_PER_SECOND as u32);
+    let total_ticks = u64::from(RUN_SEC) * TICKS_PER_SECOND;
+    for _ in 0..total_ticks {
+        for spec in driver.drain(dt) {
+            spawn(
+                &mut sim,
+                spec.origin,
+                spec.dest,
+                spec.weight,
+                abandon_override,
+            );
+        }
+        sim.step();
+        sim.drain_events();
+        let waiting: usize = stop_entities.iter().map(|&e| sim.waiting_count_at(e)).sum();
+        if waiting > peak_waiting {
+            peak_waiting = waiting;
+        }
+    }
+
+    let m = sim.metrics();
+    let delivered = m.total_delivered();
+    let abandoned = m.total_abandoned();
+    let spawned = m.total_spawned();
+    let abandonment_pct = if spawned > 0 {
+        100.0 * abandoned as f64 / spawned as f64
+    } else {
+        0.0
+    };
+    Report {
+        delivered,
+        abandoned,
+        abandonment_pct,
+        // Metrics store times in ticks; convert for human-friendly output.
+        avg_wait_s: m.avg_wait_time() / TICKS_PER_SECOND as f64,
+        max_wait_s: m.max_wait_time() as f64 / TICKS_PER_SECOND as f64,
+        peak_waiting,
+    }
+}
+
+fn spawn(
+    sim: &mut Simulation,
+    origin: StopId,
+    dest: StopId,
+    weight: f64,
+    abandon_after_sec: Option<u32>,
+) {
+    let mut builder = match sim.build_rider(origin, dest) {
+        Ok(b) => b.weight(weight),
+        Err(_) => return, // unreachable pairs silently drop
+    };
+    if let Some(sec) = abandon_after_sec {
+        builder = builder.patience(u64::from(sec) * TICKS_PER_SECOND);
+    }
+    let _ = builder.spawn();
+}
+
+/// Deterministic traffic driver — straight port of
+/// `playground/src/traffic.ts` minus the intensity slider (headless
+/// audit doesn't need a multiplier). Uses the same splitmix64 seed
+/// mixing and weighted-index draw so the same seed produces the same
+/// rider stream across Rust and JS.
+struct Driver {
+    state: u64,
+    accumulator: f64,
+    elapsed_in_cycle_sec: f64,
+    total_duration_sec: f64,
+    phases: &'static [Phase],
+}
+
+struct Spec {
+    origin: StopId,
+    dest: StopId,
+    weight: f64,
+}
+
+impl Driver {
+    fn new(seed: u32, phases: &'static [Phase]) -> Self {
+        let total = phases.iter().map(|p| f64::from(p.duration_sec)).sum();
+        Self {
+            state: mix_seed(u64::from(seed)),
+            accumulator: 0.0,
+            elapsed_in_cycle_sec: 0.0,
+            total_duration_sec: total,
+            phases,
+        }
+    }
+
+    fn current_phase(&self) -> &'static Phase {
+        if self.phases.is_empty() {
+            unreachable!("called current_phase with no phases installed");
+        }
+        let mut t = self.elapsed_in_cycle_sec;
+        for phase in self.phases {
+            t -= f64::from(phase.duration_sec);
+            if t < 0.0 {
+                return phase;
+            }
+        }
+        self.phases.last().unwrap()
+    }
+
+    fn drain(&mut self, elapsed_sec: f64) -> Vec<Spec> {
+        if self.phases.is_empty() {
+            return Vec::new();
+        }
+        // Snapshot the phase pointer so we can mutate `self` inside
+        // the emission loop. Phase data is `&'static` so a raw copy
+        // of the reference is cheap and borrow-free.
+        let phase: &'static Phase = self.current_phase();
+        // Clamp dt the same way the TS driver does (4 frames @ 60Hz).
+        let dt = elapsed_sec.min(4.0 / 60.0);
+        self.accumulator += phase.riders_per_min / 60.0 * dt;
+        self.elapsed_in_cycle_sec =
+            (self.elapsed_in_cycle_sec + dt) % self.total_duration_sec.max(1.0);
+        let mut out = Vec::new();
+        while self.accumulator >= 1.0 {
+            self.accumulator -= 1.0;
+            out.push(self.next_spec(phase));
+        }
+        out
+    }
+
+    fn next_spec(&mut self, phase: &Phase) -> Spec {
+        let n = phase.origin_weights.len();
+        let origin_idx = self.pick_weighted(n, phase.origin_weights);
+        let mut dest_idx = self.pick_weighted(n, phase.dest_weights);
+        if dest_idx == origin_idx {
+            dest_idx = (dest_idx + 1) % n;
+        }
+        Spec {
+            origin: StopId(origin_idx as u32),
+            dest: StopId(dest_idx as u32),
+            weight: 50.0 + self.next_float() * 50.0,
+        }
+    }
+
+    fn pick_weighted(&mut self, n: usize, weights: &[f64]) -> usize {
+        let total: f64 = weights.iter().map(|w| w.max(0.0)).sum();
+        if total <= 0.0 {
+            return self.next_int(n);
+        }
+        let mut r = self.next_float() * total;
+        for (i, &w) in weights.iter().enumerate() {
+            r -= w.max(0.0);
+            if r < 0.0 {
+                return i;
+            }
+        }
+        n - 1
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        z ^ (z >> 31)
+    }
+
+    fn next_int(&mut self, n: usize) -> usize {
+        (self.next_u64() % n as u64) as usize
+    }
+
+    fn next_float(&mut self) -> f64 {
+        (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64
+    }
+}
+
+fn mix_seed(seed: u64) -> u64 {
+    let mut z = seed.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    z ^ (z >> 31)
+}
+
+// ─── Scenario data — mirrors playground/src/scenarios.ts ───────────
+// KEEP IN SYNC: changes to rates, weights, elevator configs, or
+// abandonment budgets in the TS file require a mirror edit here.
+
+// Helper constructors for weight arrays; Rust can't express JS's
+// array-spread-fill succinctly, so the vectors are written out.
+const OFFICE_PHASES: &[Phase] = &[
+    Phase {
+        duration_sec: 45,
+        riders_per_min: 3.0,
+        origin_weights: &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+        dest_weights: &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+    },
+    Phase {
+        duration_sec: 60,
+        riders_per_min: 55.0,
+        origin_weights: &[8.5, 0.3, 0.3, 0.3, 0.3, 0.3],
+        // topBias(6) × (i==0 ? 0 : w): 0, 1.1, 1.2, 1.3, 1.4, 1.5
+        dest_weights: &[0.0, 1.1, 1.2, 1.3, 1.4, 1.5],
+    },
+    Phase {
+        duration_sec: 60,
+        riders_per_min: 30.0,
+        origin_weights: &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+        dest_weights: &[1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+    },
+    Phase {
+        duration_sec: 45,
+        riders_per_min: 65.0,
+        origin_weights: &[0.3, 3.0, 2.0, 2.0, 2.0, 2.0],
+        dest_weights: &[0.3, 3.0, 2.0, 2.0, 2.0, 2.0],
+    },
+    Phase {
+        duration_sec: 60,
+        riders_per_min: 55.0,
+        // topBias(6) × (i==0 ? 0 : w): 0, 1.1, 1.2, 1.3, 1.4, 1.5
+        origin_weights: &[0.0, 1.1, 1.2, 1.3, 1.4, 1.5],
+        dest_weights: &[1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    },
+];
+
+const OFFICE_RON: &str = r#"SimConfig(
+    building: BuildingConfig(
+        name: "Mid-Rise Office",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby",   position: 0.0),
+            StopConfig(id: StopId(1), name: "Floor 2", position: 4.0),
+            StopConfig(id: StopId(2), name: "Floor 3", position: 8.0),
+            StopConfig(id: StopId(3), name: "Floor 4", position: 12.0),
+            StopConfig(id: StopId(4), name: "Floor 5", position: 16.0),
+            StopConfig(id: StopId(5), name: "Floor 6", position: 20.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car 1",
+            max_speed: 2.2, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+        ElevatorConfig(
+            id: 1, name: "Car 2",
+            max_speed: 2.2, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(3),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 90,
+        weight_range: (50.0, 100.0),
+    ),
+)"#;
+
+// Skyscraper phase data. 13 stops (lobby + 12). topBias(12) = [1.0,
+// 1.045, 1.09, 1.136, 1.18, 1.227, 1.273, 1.318, 1.364, 1.409, 1.455,
+// 1.5]. The `[14, ...0.25 × 12]` and its mirror encode lobby-heavy
+// origin/dest for morning and evening rushes.
+const SKY_PHASES: &[Phase] = &[
+    Phase {
+        duration_sec: 45,
+        riders_per_min: 6.0,
+        origin_weights: &[1.0; 13],
+        dest_weights: &[1.0; 13],
+    },
+    Phase {
+        duration_sec: 75,
+        riders_per_min: 120.0,
+        origin_weights: &[
+            14.0, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25,
+        ],
+        dest_weights: &[
+            0.0, 1.0, 1.045, 1.091, 1.136, 1.182, 1.227, 1.273, 1.318, 1.364, 1.409, 1.455, 1.5,
+        ],
+    },
+    Phase {
+        duration_sec: 60,
+        riders_per_min: 45.0,
+        origin_weights: &[1.0; 13],
+        dest_weights: &[1.0; 13],
+    },
+    Phase {
+        duration_sec: 45,
+        riders_per_min: 100.0,
+        // Sky lobby at index 6 weighted 3× as origin, 4× as dest.
+        origin_weights: &[
+            1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+        ],
+        dest_weights: &[
+            1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 4.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+        ],
+    },
+    Phase {
+        duration_sec: 75,
+        riders_per_min: 115.0,
+        origin_weights: &[
+            0.0, 1.0, 1.045, 1.091, 1.136, 1.182, 1.227, 1.273, 1.318, 1.364, 1.409, 1.455, 1.5,
+        ],
+        dest_weights: &[
+            14.0, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25,
+        ],
+    },
+];
+
+const SKY_RON: &str = r#"SimConfig(
+    building: BuildingConfig(
+        name: "Skyscraper (Sky Lobby)",
+        stops: [
+            StopConfig(id: StopId(0),  name: "Lobby",      position: 0.0),
+            StopConfig(id: StopId(1),  name: "Floor 2",    position: 4.0),
+            StopConfig(id: StopId(2),  name: "Floor 3",    position: 8.0),
+            StopConfig(id: StopId(3),  name: "Floor 4",    position: 12.0),
+            StopConfig(id: StopId(4),  name: "Floor 5",    position: 16.0),
+            StopConfig(id: StopId(5),  name: "Floor 6",    position: 20.0),
+            StopConfig(id: StopId(6),  name: "Sky Lobby",  position: 24.0),
+            StopConfig(id: StopId(7),  name: "Floor 8",    position: 28.0),
+            StopConfig(id: StopId(8),  name: "Floor 9",    position: 32.0),
+            StopConfig(id: StopId(9),  name: "Floor 10",   position: 36.0),
+            StopConfig(id: StopId(10), name: "Floor 11",   position: 40.0),
+            StopConfig(id: StopId(11), name: "Floor 12",   position: 44.0),
+            StopConfig(id: StopId(12), name: "Penthouse",  position: 48.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car A",
+            max_speed: 4.0, acceleration: 2.0, deceleration: 2.5,
+            weight_capacity: 1200.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 16,
+            bypass_load_up_pct: Some(0.80), bypass_load_down_pct: Some(0.50),
+        ),
+        ElevatorConfig(
+            id: 1, name: "Car B",
+            max_speed: 4.0, acceleration: 2.0, deceleration: 2.5,
+            weight_capacity: 1200.0,
+            starting_stop: StopId(6),
+            door_open_ticks: 55, door_transition_ticks: 16,
+            bypass_load_up_pct: Some(0.80), bypass_load_down_pct: Some(0.50),
+        ),
+        ElevatorConfig(
+            id: 2, name: "Car C",
+            max_speed: 4.0, acceleration: 2.0, deceleration: 2.5,
+            weight_capacity: 1200.0,
+            starting_stop: StopId(12),
+            door_open_ticks: 55, door_transition_ticks: 16,
+            bypass_load_up_pct: Some(0.80), bypass_load_down_pct: Some(0.50),
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 30,
+        weight_range: (55.0, 100.0),
+    ),
+)"#;
+
+const SCENARIOS: &[Scenario] = &[
+    Scenario {
+        id: "office",
+        label: "Mid-rise office",
+        ron: OFFICE_RON,
+        phases: OFFICE_PHASES,
+        abandon_after_sec: Some(90),
+        seed_spawns: 0,
+    },
+    Scenario {
+        id: "skyscraper",
+        label: "Skyscraper (sky lobby)",
+        ron: SKY_RON,
+        phases: SKY_PHASES,
+        abandon_after_sec: Some(120),
+        seed_spawns: 0,
+    },
+];

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -152,19 +152,42 @@ impl WasmSim {
 
     /// Spawn a single rider between two stop ids at the given weight.
     ///
+    /// When `patience_ticks` is provided (non-zero), the rider gets a
+    /// [`Patience`](elevator_core::components::Patience) budget —
+    /// riders waiting longer than that transition to `Abandoned` in
+    /// the `advance_transient` phase. Heavy-load scenarios need this
+    /// so queues can self-regulate: without abandonment, a two-car
+    /// office under a 65-riders/min lunchtime pattern grows its
+    /// waiting-count monotonically because demand persistently
+    /// exceeds cruise throughput and no one ever leaves.
+    ///
+    /// Pass `0` (or omit on the JS side via `undefined`) to disable
+    /// abandonment for this rider — preserves the pre-patience
+    /// behavior for scenarios that want bounded queues.
+    ///
     /// # Errors
     ///
-    /// Returns a JS error if either stop id is unknown or the rider is
-    /// rejected by the sim.
+    /// Returns a JS error if either stop id is unknown, the rider is
+    /// rejected by the sim, or the `(origin, destination)` route
+    /// can't be auto-detected.
     #[wasm_bindgen(js_name = spawnRider)]
     pub fn spawn_rider(
         &mut self,
         origin: u32,
         destination: u32,
         weight: f64,
+        patience_ticks: Option<u32>,
     ) -> Result<(), JsError> {
-        self.inner
-            .spawn_rider(StopId(origin), StopId(destination), weight)
+        let mut builder = self
+            .inner
+            .build_rider(StopId(origin), StopId(destination))
+            .map_err(|e| JsError::new(&format!("spawn: {e}")))?
+            .weight(weight);
+        if let Some(ticks) = patience_ticks.filter(|&t| t > 0) {
+            builder = builder.patience(u64::from(ticks));
+        }
+        builder
+            .spawn()
             .map(|_| ())
             .map_err(|e| JsError::new(&format!("spawn: {e}")))
     }

--- a/playground/src/__tests__/traffic.test.ts
+++ b/playground/src/__tests__/traffic.test.ts
@@ -155,6 +155,44 @@ describe("TrafficDriver — phase schedule", () => {
     expect(checked).toBeGreaterThan(0);
   });
 
+  it("stamps patienceTicks on every spec when set, omits when unset", () => {
+    const d = new TrafficDriver(3);
+    d.setPhases([FLAT(60, 600)]);
+    const snap = snapshotWithStops(3);
+
+    // Unset (default 0): specs must carry no patienceTicks field.
+    let hadAny = false;
+    for (let i = 0; i < 30; i += 1) {
+      for (const s of d.drainSpawns(snap, 1 / 60)) {
+        hadAny = true;
+        expect(s.patienceTicks).toBeUndefined();
+      }
+    }
+    expect(hadAny).toBe(true);
+
+    // Set: every emitted spec carries the configured budget.
+    d.setPatienceTicks(5400); // 90 s at 60 Hz
+    let stamped = 0;
+    for (let i = 0; i < 30; i += 1) {
+      for (const s of d.drainSpawns(snap, 1 / 60)) {
+        expect(s.patienceTicks).toBe(5400);
+        stamped += 1;
+      }
+    }
+    expect(stamped).toBeGreaterThan(0);
+
+    // Zero disables again — a scenario that changes its mind on reset.
+    d.setPatienceTicks(0);
+    let afterZero = 0;
+    for (let i = 0; i < 30; i += 1) {
+      for (const s of d.drainSpawns(snap, 1 / 60)) {
+        expect(s.patienceTicks).toBeUndefined();
+        afterZero += 1;
+      }
+    }
+    expect(afterZero).toBeGreaterThan(0);
+  });
+
   it("is deterministic for a given seed", () => {
     const phases = [FLAT(120, 120)];
     const snap = snapshotWithStops(3);

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -243,6 +243,13 @@ async function resetAll(state: State, ui: UiHandles): Promise<void> {
   state.traffic = new TrafficDriver(state.permalink.seed);
   state.traffic.setPhases(scenario.phases);
   state.traffic.setIntensity(state.permalink.intensity);
+  // Scenario-level abandonment — converted from seconds to ticks using
+  // the sim's 60 Hz canonical rate. Scenarios omitting `abandonAfterSec`
+  // (convention burst) keep the pre-patience "wait forever" behavior
+  // so their stress tests stay punishing.
+  state.traffic.setPatienceTicks(
+    scenario.abandonAfterSec ? Math.round(scenario.abandonAfterSec * 60) : 0,
+  );
   // Tear the old panes down *before* building new ones so the freed wasm
   // memory is released before we allocate the replacements.
   disposePane(state.paneA);
@@ -275,7 +282,12 @@ async function resetAll(state: State, ui: UiHandles): Promise<void> {
         const specs = state.traffic.drainSpawns(snapForSeed, 1 / 300);
         for (const spec of specs) {
           forEachPane(state, (pane) =>
-            pane.sim.spawnRider(spec.originStopId, spec.destStopId, spec.weight),
+            pane.sim.spawnRider(
+              spec.originStopId,
+              spec.destStopId,
+              spec.weight,
+              spec.patienceTicks,
+            ),
           );
         }
         // Break once we've seeded enough — drainSpawns caps per-frame
@@ -399,7 +411,12 @@ function loop(state: State): void {
       const specs = state.traffic.drainSpawns(snapA, simElapsed);
       for (const spec of specs) {
         forEachPane(state, (pane) =>
-          pane.sim.spawnRider(spec.originStopId, spec.destStopId, spec.weight),
+          pane.sim.spawnRider(
+            spec.originStopId,
+            spec.destStopId,
+            spec.weight,
+            spec.patienceTicks,
+          ),
         );
       }
 

--- a/playground/src/scenarios.ts
+++ b/playground/src/scenarios.ts
@@ -99,6 +99,11 @@ const office: ScenarioMeta = {
   defaultStrategy: "etd",
   phases: officePhases,
   seedSpawns: 0,
+  // 90 s patience: office workers won't wait forever during a lunch
+  // burst — they take the stairs, grab the other bank, or skip the
+  // trip. Without this, lunchtime demand (65/min) above the pair's
+  // ~54/min cruise capacity grew the queue monotonically.
+  abandonAfterSec: 90,
   hook: { kind: "etd_group_time", waitSquaredWeight: 0.002 },
   featureHint:
     "Group-time ETD (`wait_squared_weight = 0.002`) — stops hosting older waiters win ties, damping long-wait tail during lunchtime bursts.",
@@ -191,6 +196,9 @@ const skyscraper: ScenarioMeta = {
   defaultStrategy: "etd",
   phases: skyPhases,
   seedSpawns: 0,
+  // 120 s patience: big buildings get a longer leash than mid-rise
+  // since the alternative (stairs) is less viable for 12 floors.
+  abandonAfterSec: 120,
   hook: { kind: "bypass_narration" },
   featureHint:
     "Direction-dependent bypass (80 % up / 50 % down) on all three cars — baked into the RON below. Watch the fullest car skip hall calls.",
@@ -303,6 +311,11 @@ const residential: ScenarioMeta = {
   defaultStrategy: "etd",
   phases: residentialPhases,
   seedSpawns: 0,
+  // 180 s: residents are less flighty than office workers (groceries,
+  // kids in tow, shared building) and the load stays well under cruise
+  // capacity, so abandonment rarely fires — it exists as a safety
+  // valve for user-triggered 2× intensity bursts.
+  abandonAfterSec: 180,
   hook: { kind: "predictive_parking", windowTicks: 9000 }, // 2.5 min at 60 Hz
   featureHint:
     "Predictive parking with a 2.5-min window — during the midday slump, idle cars pre-position toward the floors that spiked most recently.",
@@ -404,6 +417,11 @@ const hotel: ScenarioMeta = {
   defaultStrategy: "destination",
   phases: hotelPhases,
   seedSpawns: 0,
+  // 150 s: hotel guests with luggage are more patient than office
+  // workers but less than residents; tuned so check-in bursts still
+  // produce a visible queue without the queue ever running away
+  // under 2× intensity.
+  abandonAfterSec: 150,
   hook: { kind: "deferred_dcs", commitmentWindowTicks: 180 },
   featureHint:
     "Deferred DCS with a 3-s (180-tick) commitment window — sticky assignments keep re-competing until a car is close to the rider, yielding better matches under bursty demand.",
@@ -499,6 +517,10 @@ const convention: ScenarioMeta = {
   defaultStrategy: "etd",
   phases: conventionPhases,
   seedSpawns: 120,
+  // Intentionally omits `abandonAfterSec` — the whole point of this
+  // scenario is to stress-test dispatch under a real pile-up. Letting
+  // attendees abandon would gut the `arrival_log` rate signal's
+  // purpose, which is "how punishing is *persistent* demand?"
   hook: { kind: "arrival_log" },
   featureHint:
     "Arrival-rate signal lights up as the burst hits — `DispatchManifest::arrivals_at` feeds downstream strategies the per-stop intensity for the next 5 minutes.",

--- a/playground/src/sim.ts
+++ b/playground/src/sim.ts
@@ -20,7 +20,12 @@ interface WasmSimInstance {
   currentTick(): bigint;
   strategyName(): string;
   setStrategy(name: string): boolean;
-  spawnRider(origin: number, destination: number, weight: number): void;
+  spawnRider(
+    origin: number,
+    destination: number,
+    weight: number,
+    patienceTicks?: number,
+  ): void;
   setTrafficRate(ridersPerMinute: number): void;
   trafficRate(): number;
   snapshot(): unknown;
@@ -100,8 +105,13 @@ export class Sim {
     return this.#inner.setStrategy(name);
   }
 
-  spawnRider(origin: number, destination: number, weight: number): void {
-    this.#inner.spawnRider(origin, destination, weight);
+  spawnRider(
+    origin: number,
+    destination: number,
+    weight: number,
+    patienceTicks?: number,
+  ): void {
+    this.#inner.spawnRider(origin, destination, weight, patienceTicks);
   }
 
   setTrafficRate(ridersPerMinute: number): void {

--- a/playground/src/traffic.ts
+++ b/playground/src/traffic.ts
@@ -20,6 +20,13 @@ export interface RiderSpec {
   originStopId: number;
   destStopId: number;
   weight: number;
+  /**
+   * Optional wait budget (in sim ticks) before this rider abandons
+   * the queue. Set per-scenario by the caller via {@link TrafficDriver.setPatienceTicks}
+   * so every rider in a scenario inherits the same patience — per-rider
+   * variability is nice but this is a UI demo, not a human-model study.
+   */
+  patienceTicks?: number;
 }
 
 export class TrafficDriver {
@@ -30,6 +37,8 @@ export class TrafficDriver {
   #elapsedInCycleSec = 0;
   /** User-facing intensity multiplier, 0.5×–2×. Applied on top of phase rate. */
   #intensity = 1.0;
+  /** Patience budget stamped onto each emitted spec. 0 = abandonment off. */
+  #patienceTicks = 0;
 
   constructor(seed: number) {
     this.#state = mixSeed(BigInt(seed >>> 0));
@@ -52,6 +61,15 @@ export class TrafficDriver {
     // Clamp defensively even though the UI already bounds the slider —
     // a bad permalink could push it negative and the driver would never spawn.
     this.#intensity = Math.max(0, multiplier);
+  }
+
+  /**
+   * Stamp every emitted {@link RiderSpec} with this patience budget
+   * (in sim ticks). Zero or negative values disable abandonment —
+   * riders wait forever. Set once when a scenario loads.
+   */
+  setPatienceTicks(ticks: number): void {
+    this.#patienceTicks = Math.max(0, Math.floor(ticks));
   }
 
   /**
@@ -120,6 +138,7 @@ export class TrafficDriver {
       originStopId: stops[originIdx].stop_id,
       destStopId: stops[destIdx].stop_id,
       weight,
+      patienceTicks: this.#patienceTicks > 0 ? this.#patienceTicks : undefined,
     };
   }
 

--- a/playground/src/types.ts
+++ b/playground/src/types.ts
@@ -121,4 +121,21 @@ export interface ScenarioMeta {
   hook: ScenarioHook;
   /** One-line narrative shown alongside the feature hook to frame what to watch for. */
   featureHint: string;
+  /**
+   * Time a rider will wait before abandoning the queue, in simulated
+   * seconds. Prevents scenarios whose peak phases run above the
+   * building's cruise capacity from accumulating an unbounded wait
+   * line — old waiters leave, new ones arrive, queue reaches a
+   * bounded steady state matching the demand/supply gap.
+   *
+   * Pre-fix, office-lunchtime under two cars at 65 riders/min vs.
+   * ~54/min cruise grew the queue forever; 90–120 s is a realistic
+   * human patience budget for commercial elevators (shorter during
+   * bursty peaks, longer during midday lulls — we use one value per
+   * scenario for simplicity).
+   *
+   * Omit to disable abandonment (convention burst leaves it off so
+   * the full 170-riders/min stress test actually applies pressure).
+   */
+  abandonAfterSec?: number;
 }


### PR DESCRIPTION
## Summary

Addresses the "mid-rise office still gets overwhelmed" feedback on the previous tuning pass by wiring core's existing `Patience` / abandonment system through to the playground scenarios. Also adds a headless audit example so future tuning changes can be validated without spinning up a browser.

### Changes

1. **wasm**: `spawnRider` takes an optional `patience_ticks: Option<u32>`. Zero / omitted preserves the pre-existing "wait forever" behavior.
2. **playground**: `ScenarioMeta.abandonAfterSec` threaded through `TrafficDriver` → `RiderSpec.patienceTicks` → `Sim.spawnRider`. Per-scenario budgets reflect the alternatives available to a waiter (office 90s, skyscraper 120s, residential 180s, hotel 150s; convention burst omits it on purpose).
3. **examples/playground_audit.rs**: headless runner that mirrors the scenarios against a deterministic driver and prints per-strategy `delivered / abandoned / aband% / avg_wait / max_wait / peak_q`. Supports a `--no-abandon` flag for before/after comparisons.

### Audit output (post-change)

```
=== Mid-rise office (office) ===
  abandon_after: 90s  run: 360s
  strategy      delivered  abandoned     aband%   avg_wait   max_wait     peak_q
  scan                193         19       8.1%      26.8s      89.8s         40
  look                193         19       8.1%      26.8s      89.8s         40
  nearest             205          0       0.0%      20.9s      82.7s         25
  etd                 208          0       0.0%      20.5s      83.2s         25
  destination         199          7       3.0%      23.3s      89.6s         30
```

Office with ETD: **0% abandonment**, max wait 83s, peak queue 25. The pair is sized correctly and abandonment catches only the small residual for SCAN/LOOK (less efficient multi-car strategies).

```
=== Skyscraper (sky lobby) (skyscraper) ===
  abandon_after: 120s  run: 360s
  strategy      delivered  abandoned     aband%   avg_wait   max_wait     peak_q
  scan                284         97      21.5%      36.0s     119.8s        144
  look                284         97      21.5%      36.0s     119.8s        144
  nearest             310         82      18.1%      36.8s     119.8s        136
  etd                 321         64      14.2%      41.1s     119.8s        131
  destination         296         51      11.3%      49.2s     117.2s        121
```

Skyscraper retains some abandonment during morning rush — the 120 riders/min peak against ~100/min sustained throughput is realistic rush-hour pressure. Without abandonment, max wait would hit 219s (unreasonable for a browser demo).

## Test plan

- [x] `cargo test -p elevator-core --all-features` — 691 unit + 156 doc tests pass.
- [x] `cargo clippy --workspace --all-features --all-targets` clean.
- [x] `pnpm tsc --noEmit` clean; `pnpm test` (playground) — 20 tests pass (new: `stamps patienceTicks on every spec when set, omits when unset`).
- [x] `cargo run -p elevator-core --example playground_audit --release` reports bounded queues for both scenarios.
- [x] `cargo run -p elevator-core --example playground_audit --release -- --no-abandon` shows the unbounded-wait baseline for comparison.
- [ ] Visual smoke test on Pages post-merge (requires wasm rebuild).

## What I didn't do

- Didn't port residential / hotel / convention / space-elevator scenarios into the audit example. Office + skyscraper cover the two distinct topologies and both direction patterns; porting the others is straightforward if we keep tuning.
- Didn't centralize scenario data into a shared JSON file. A refactor that feeds both TS and Rust from one source would prevent drift but costs more than an audit tool deserves today.