### PR TITLE
fix(playground): skyscraper peak rates were 1.5-4x realistic capacity

### DIFF
--- a/crates/elevator-core/examples/playground_audit.rs
+++ b/crates/elevator-core/examples/playground_audit.rs
@@ -462,7 +462,7 @@ const SKY_PHASES: &[Phase] = &[
     },
     Phase {
         duration_sec: 75,
-        riders_per_min: 120.0,
+        riders_per_min: 48.0,
         origin_weights: &[
             14.0, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25,
         ],
@@ -472,13 +472,13 @@ const SKY_PHASES: &[Phase] = &[
     },
     Phase {
         duration_sec: 60,
-        riders_per_min: 45.0,
+        riders_per_min: 30.0,
         origin_weights: &[1.0; 13],
         dest_weights: &[1.0; 13],
     },
     Phase {
         duration_sec: 45,
-        riders_per_min: 100.0,
+        riders_per_min: 42.0,
         // Sky lobby at index 6 weighted 3× as origin, 4× as dest.
         origin_weights: &[
             1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
@@ -489,7 +489,7 @@ const SKY_PHASES: &[Phase] = &[
     },
     Phase {
         duration_sec: 75,
-        riders_per_min: 115.0,
+        riders_per_min: 42.0,
         origin_weights: &[
             0.0, 1.0, 1.045, 1.091, 1.136, 1.182, 1.227, 1.273, 1.318, 1.364, 1.409, 1.455, 1.5,
         ],
@@ -565,7 +565,7 @@ const SCENARIOS: &[Scenario] = &[
         label: "Skyscraper (sky lobby)",
         ron: SKY_RON,
         phases: SKY_PHASES,
-        abandon_after_sec: Some(120),
+        abandon_after_sec: Some(180),
         seed_spawns: 0,
     },
 ];

--- a/playground/src/scenarios.ts
+++ b/playground/src/scenarios.ts
@@ -146,9 +146,15 @@ const office: ScenarioMeta = {
 // ─── Skyscraper with sky lobby — full-load bypass hook ──────────────
 
 const SKY_STOPS = 13; // Lobby + 12 floors
-// Three 1200 kg cars at 4 m/s over a 48 m shaft cycle ~90 riders/min
-// combined when healthy. Rates target ~1.3–1.4× that during peaks so
-// the bypass hook actually sees full cars and gets to show its work.
+// Three 1200 kg cars at 4 m/s through a 48 m shaft. Asymmetric
+// lobby-heavy traffic is much slower than the symmetric-cruise
+// number would suggest — each round trip is ~40 s and carries only
+// ~6–8 riders (demand spreads across 12 destination floors), giving
+// ~30 riders/min combined during peaks. Phase rates target just
+// above that so bypass still triggers (cars hit 80 % during rush)
+// but the queue doesn't snowball and mass-abandon on first paint.
+// The original 120 riders/min peak was ~4× peak capacity — visibly
+// broken as a first-impression scenario.
 const skyPhases: Phase[] = [
   {
     name: "Overnight",
@@ -160,21 +166,21 @@ const skyPhases: Phase[] = [
   {
     name: "Morning rush",
     durationSec: 75,
-    ridersPerMin: 120,
+    ridersPerMin: 48,
     originWeights: [14, ...Array.from({ length: SKY_STOPS - 1 }, () => 0.25)],
     destWeights: [0, ...topBias(SKY_STOPS - 1)],
   },
   {
     name: "Midday interfloor",
     durationSec: 60,
-    ridersPerMin: 45,
+    ridersPerMin: 30,
     originWeights: uniform(SKY_STOPS),
     destWeights: uniform(SKY_STOPS),
   },
   {
     name: "Lunchtime",
     durationSec: 45,
-    ridersPerMin: 100,
+    ridersPerMin: 42,
     // Sky lobby (stop 6) doubles as the canteen floor.
     originWeights: Array.from({ length: SKY_STOPS }, (_, i) => (i === 6 ? 3 : 1)),
     destWeights: Array.from({ length: SKY_STOPS }, (_, i) => (i === 6 ? 4 : 1)),
@@ -182,7 +188,7 @@ const skyPhases: Phase[] = [
   {
     name: "Evening exodus",
     durationSec: 75,
-    ridersPerMin: 115,
+    ridersPerMin: 42,
     originWeights: [0, ...topBias(SKY_STOPS - 1)],
     destWeights: [14, ...Array.from({ length: SKY_STOPS - 1 }, () => 0.25)],
   },
@@ -196,9 +202,12 @@ const skyscraper: ScenarioMeta = {
   defaultStrategy: "etd",
   phases: skyPhases,
   seedSpawns: 0,
-  // 120 s patience: big buildings get a longer leash than mid-rise
-  // since the alternative (stairs) is less viable for 12 floors.
-  abandonAfterSec: 120,
+  // 180 s patience: 3 minutes is the realistic commercial-lobby
+  // threshold before a hurried commuter peels off to the stairs or
+  // another bank. 120 s (the original) caused riders to hit the cap
+  // at the tail of morning rush even with well-tuned rates; 180 s
+  // gives ETD room to drain the queue between phases.
+  abandonAfterSec: 180,
   hook: { kind: "bypass_narration" },
   featureHint:
     "Direction-dependent bypass (80 % up / 50 % down) on all three cars — baked into the RON below. Watch the fullest car skip hall calls.",


### PR DESCRIPTION
## Summary

Skyscraper became the first-impression default in #328, but its peak rates (tuned against an optimistic symmetric-cruise estimate) were producing 15–22 % abandonment during morning rush — visible as abandon-tween dots flooding the canvas on page load. Not the first impression we want.

## The math was wrong

Earlier tuning assumed ~90 riders/min cruise across 3 cars. That's the *symmetric-traffic* number. Lobby-outbound rush flips it: cars go `lobby → floor` with a full load, then return empty. Effective per-car throughput drops ~3× vs. interfloor, giving ~30–35 riders/min across 3 cars during asymmetric peaks.

Morning rush at 120 riders/min was therefore 3.5–4× realistic peak capacity. Queue snowballed, 120 s patience was tight, riders abandoned en masse.

## Changes

- Morning rush `120 → 48` (1.4× peak capacity — queue builds, doesn't run away)
- Lunchtime `100 → 42`
- Evening exodus `115 → 42`
- Midday interfloor `45 → 30`
- `abandonAfterSec 120 → 180` (3 min is realistic commercial-lobby patience)
- Audit example mirrored so `cargo run --example playground_audit -- skyscraper` stays authoritative.

## Audit (post-change)

```
=== Skyscraper (sky lobby) (skyscraper) ===
  abandon_after: 180s  run: 360s
  strategy      delivered  abandoned     aband%   avg_wait   max_wait     peak_q
  scan                177          0       0.0%      53.3s     150.8s         68
  look                177          0       0.0%      53.3s     150.8s         68
  nearest             179          0       0.0%      34.4s     122.4s         47
  etd                 176          0       0.0%      40.1s     146.0s         49
  destination         175          0       0.0%      25.5s     114.7s         30
```

All strategies at 0 % abandonment. ETD now cleanly wins the ETD vs SCAN scoreboard (avg wait 40 s vs 53 s, peak queue 49 vs 68) — which is the intended first-impression story.

Queues still build (peak 47–68), so the bypass hook has cars at the 80 % threshold to fire against; the fix doesn't soften the scenario below the feature's trigger point.

## Test plan

- [x] `cargo test -p elevator-core --all-features` — 691 tests.
- [x] `cargo run --example playground_audit --release` shows zero abandonment across all strategies in skyscraper.
- [x] Office unchanged (ETD still 0 %, SCAN still 8 % — the mid-rise scoreboard story is intact).
- [ ] Visual smoke test post-merge (wasm rebuild needed).