### PR TITLE
feat(playground): user-tweakable building physics drawer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.5.1"
+version = "15.5.2"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -258,6 +258,122 @@ impl WasmSim {
         })
     }
 
+    // ── Uniform elevator-physics setters ─────────────────────────────
+    //
+    // Apply a single value to every elevator in the sim. Wired to the
+    // playground "Tweak parameters" drawer so visitors can mutate
+    // building physics live without rebuilding the sim. Each calls into
+    // the underlying `Simulation::set_*` mutator, which validates input
+    // and emits an `ElevatorUpgraded` event per car. Errors from the
+    // first failing car short-circuit and surface to JS — typical
+    // failure modes are out-of-range values that the UI's slider
+    // bounds should already prevent.
+
+    /// Set `max_speed` (m/s) on every elevator in the sim.
+    ///
+    /// Velocity is preserved across the change; the movement integrator
+    /// clamps to the new cap on the next tick. See
+    /// [`Simulation::set_max_speed`](elevator_core::sim::Simulation::set_max_speed).
+    ///
+    /// # Errors
+    ///
+    /// Surfaces the underlying `SimError` as a `JsError` if `speed` is
+    /// not a positive finite number.
+    #[wasm_bindgen(js_name = setMaxSpeedAll)]
+    pub fn set_max_speed_all(&mut self, speed: f64) -> Result<(), JsError> {
+        let ids: Vec<_> = self
+            .inner
+            .world()
+            .iter_elevators()
+            .map(|(eid, _, _)| elevator_core::entity::ElevatorId::from(eid))
+            .collect();
+        for id in ids {
+            self.inner
+                .set_max_speed(id, speed)
+                .map_err(|e| JsError::new(&format!("set_max_speed: {e}")))?;
+        }
+        Ok(())
+    }
+
+    /// Set `weight_capacity` (kg) on every elevator in the sim.
+    ///
+    /// Applied immediately. A new cap below `current_load` leaves the
+    /// car temporarily overweight (no riders ejected); subsequent
+    /// boarding rejects further additions. See
+    /// [`Simulation::set_weight_capacity`](elevator_core::sim::Simulation::set_weight_capacity).
+    ///
+    /// # Errors
+    ///
+    /// Surfaces the underlying `SimError` as a `JsError` if `capacity`
+    /// is not a positive finite number.
+    #[wasm_bindgen(js_name = setWeightCapacityAll)]
+    pub fn set_weight_capacity_all(&mut self, capacity: f64) -> Result<(), JsError> {
+        let ids: Vec<_> = self
+            .inner
+            .world()
+            .iter_elevators()
+            .map(|(eid, _, _)| elevator_core::entity::ElevatorId::from(eid))
+            .collect();
+        for id in ids {
+            self.inner
+                .set_weight_capacity(id, capacity)
+                .map_err(|e| JsError::new(&format!("set_weight_capacity: {e}")))?;
+        }
+        Ok(())
+    }
+
+    /// Set `door_open_ticks` (dwell duration) on every elevator.
+    ///
+    /// Takes effect on the **next** door cycle — an in-progress dwell
+    /// completes its original timing to avoid visual glitches. See
+    /// [`Simulation::set_door_open_ticks`](elevator_core::sim::Simulation::set_door_open_ticks).
+    ///
+    /// # Errors
+    ///
+    /// Surfaces the underlying `SimError` as a `JsError` if `ticks`
+    /// is zero.
+    #[wasm_bindgen(js_name = setDoorOpenTicksAll)]
+    pub fn set_door_open_ticks_all(&mut self, ticks: u32) -> Result<(), JsError> {
+        let ids: Vec<_> = self
+            .inner
+            .world()
+            .iter_elevators()
+            .map(|(eid, _, _)| elevator_core::entity::ElevatorId::from(eid))
+            .collect();
+        for id in ids {
+            self.inner
+                .set_door_open_ticks(id, ticks)
+                .map_err(|e| JsError::new(&format!("set_door_open_ticks: {e}")))?;
+        }
+        Ok(())
+    }
+
+    /// Set `door_transition_ticks` (open- and close-transition duration)
+    /// on every elevator.
+    ///
+    /// Takes effect on the next door cycle. See
+    /// [`Simulation::set_door_transition_ticks`](elevator_core::sim::Simulation::set_door_transition_ticks).
+    ///
+    /// # Errors
+    ///
+    /// Surfaces the underlying `SimError` as a `JsError` if `ticks`
+    /// is zero.
+    #[wasm_bindgen(js_name = setDoorTransitionTicksAll)]
+    pub fn set_door_transition_ticks_all(&mut self, ticks: u32) -> Result<(), JsError> {
+        let ids: Vec<_> = self
+            .inner
+            .world()
+            .iter_elevators()
+            .map(|(eid, _, _)| elevator_core::entity::ElevatorId::from(eid))
+            .collect();
+        for id in ids {
+            self.inner
+                .set_door_transition_ticks(id, ticks)
+                .map_err(|e| JsError::new(&format!("set_door_transition_ticks: {e}")))?;
+        }
+        Ok(())
+    }
+
     /// Flip every group in the sim into the DCS hall-call mode. Required
     /// before `DestinationDispatch` can see rider destinations. Scenarios
     /// that want DCS (e.g. the hotel) call this once on load.

--- a/playground/index.html
+++ b/playground/index.html
@@ -57,9 +57,62 @@
         <input id="traffic" type="range" min="0.5" max="2" step="0.1" value="1" />
       </label>
       <div class="actions">
+        <button id="tweak" type="button" aria-expanded="false" aria-controls="tweak-panel">
+          Tweak parameters
+        </button>
         <button id="play" type="button">Pause</button>
         <button id="reset" type="button">Reset</button>
         <button id="share" type="button">Share</button>
+      </div>
+    </section>
+
+    <section class="tweak-panel" id="tweak-panel" hidden aria-label="Building physics parameters">
+      <div class="tweak-row" data-key="cars">
+        <span class="tweak-label">Cars</span>
+        <div class="tweak-stepper">
+          <button type="button" class="tweak-dec" aria-label="Decrease">&minus;</button>
+          <span class="tweak-value">2</span>
+          <button type="button" class="tweak-inc" aria-label="Increase">+</button>
+        </div>
+        <span class="tweak-default">default <span class="tweak-default-v">2</span></span>
+        <button type="button" class="tweak-reset" hidden aria-label="Reset to default">Reset</button>
+      </div>
+      <div class="tweak-row" data-key="maxSpeed">
+        <span class="tweak-label">Max speed <span class="tweak-unit">m/s</span></span>
+        <div class="tweak-stepper">
+          <button type="button" class="tweak-dec" aria-label="Decrease">&minus;</button>
+          <span class="tweak-value">2.5</span>
+          <button type="button" class="tweak-inc" aria-label="Increase">+</button>
+        </div>
+        <span class="tweak-default">default <span class="tweak-default-v">2.5</span></span>
+        <button type="button" class="tweak-reset" hidden aria-label="Reset to default">Reset</button>
+      </div>
+      <div class="tweak-row" data-key="weightCapacity">
+        <span class="tweak-label">Capacity <span class="tweak-unit">kg</span></span>
+        <div class="tweak-stepper">
+          <button type="button" class="tweak-dec" aria-label="Decrease">&minus;</button>
+          <span class="tweak-value">800</span>
+          <button type="button" class="tweak-inc" aria-label="Increase">+</button>
+        </div>
+        <span class="tweak-default">default <span class="tweak-default-v">800</span></span>
+        <button type="button" class="tweak-reset" hidden aria-label="Reset to default">Reset</button>
+      </div>
+      <div class="tweak-row" data-key="doorCycleSec">
+        <span class="tweak-label">Door cycle <span class="tweak-unit">s</span></span>
+        <div class="tweak-stepper">
+          <button type="button" class="tweak-dec" aria-label="Decrease">&minus;</button>
+          <span class="tweak-value">5.5</span>
+          <button type="button" class="tweak-inc" aria-label="Increase">+</button>
+        </div>
+        <span class="tweak-default">default <span class="tweak-default-v">5.5</span></span>
+        <button type="button" class="tweak-reset" hidden aria-label="Reset to default">Reset</button>
+      </div>
+      <div class="tweak-foot">
+        <span class="tweak-foot-hint">
+          Speed, capacity, and door cycle hot-swap live. Changing the
+          car count rebuilds the sim.
+        </span>
+        <button type="button" id="tweak-reset-all" hidden>Reset all</button>
       </div>
     </section>
 

--- a/playground/src/__tests__/params.test.ts
+++ b/playground/src/__tests__/params.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyPhysicsOverrides,
+  buildScenarioRon,
+  compactOverrides,
+  defaultFor,
+  doorCycleSecFromTicks,
+  doorCycleSecToTicks,
+  isOverridden,
+  pickStartingStops,
+  resolveParam,
+  type Overrides,
+} from "../params";
+import { SCENARIOS, scenarioById } from "../scenarios";
+
+describe("params: defaults extraction", () => {
+  it("structured defaults match the RON-literal physics", () => {
+    // Drift guard: every scenario duplicates its physics in two places —
+    // the embedded RON literal and the structured `elevatorDefaults` /
+    // `defaultCars` fields. A typo in one would silently drift from the
+    // other; this test catches it before greptile or production.
+    for (const s of SCENARIOS) {
+      const stopMatches = s.ron.match(/StopConfig\s*\(/g) ?? [];
+      expect(stopMatches.length, `${s.id} stops length`).toBe(s.stops.length);
+
+      const carMatches = s.ron.match(/ElevatorConfig\s*\(/g) ?? [];
+      expect(carMatches.length, `${s.id} default cars`).toBe(s.defaultCars);
+
+      // Spot-check physics fields against the first occurrence in the
+      // RON. These field names only appear inside ElevatorConfigs (not
+      // StopConfigs / SimulationParams), so a global match against the
+      // first hit is correct without parsing nested RON parens.
+      const speed = Number(/max_speed:\s*([\d.]+)/.exec(s.ron)?.[1] ?? "NaN");
+      expect(speed, `${s.id} max_speed`).toBeCloseTo(s.elevatorDefaults.maxSpeed, 5);
+      const cap = Number(/weight_capacity:\s*([\d.]+)/.exec(s.ron)?.[1] ?? "NaN");
+      expect(cap, `${s.id} weight_capacity`).toBeCloseTo(s.elevatorDefaults.weightCapacity, 5);
+      const dop = Number(/door_open_ticks:\s*(\d+)/.exec(s.ron)?.[1] ?? "NaN");
+      expect(dop, `${s.id} door_open_ticks`).toBe(s.elevatorDefaults.doorOpenTicks);
+      const dtr = Number(/door_transition_ticks:\s*(\d+)/.exec(s.ron)?.[1] ?? "NaN");
+      expect(dtr, `${s.id} door_transition_ticks`).toBe(s.elevatorDefaults.doorTransitionTicks);
+    }
+  });
+
+  it("defaultFor returns scenario default for each key", () => {
+    const office = scenarioById("office-mid-rise");
+    expect(defaultFor(office, "cars")).toBe(2);
+    expect(defaultFor(office, "maxSpeed")).toBe(2.2);
+    expect(defaultFor(office, "weightCapacity")).toBe(800);
+    // 210 ticks dwell + 2 × 60 ticks transition = 330 / 60 = 5.5 s
+    expect(defaultFor(office, "doorCycleSec")).toBeCloseTo(5.5, 5);
+  });
+});
+
+describe("params: resolution & overrides", () => {
+  const office = scenarioById("office-mid-rise");
+
+  it("resolveParam falls back to default for missing/non-finite overrides", () => {
+    expect(resolveParam(office, "maxSpeed", {})).toBe(2.2);
+    expect(resolveParam(office, "maxSpeed", { maxSpeed: NaN })).toBe(2.2);
+    expect(resolveParam(office, "maxSpeed", { maxSpeed: 4.5 })).toBe(4.5);
+  });
+
+  it("resolveParam clamps out-of-range overrides to the slider bounds", () => {
+    expect(resolveParam(office, "maxSpeed", { maxSpeed: -10 })).toBe(0.5);
+    expect(resolveParam(office, "maxSpeed", { maxSpeed: 999 })).toBe(12);
+    expect(resolveParam(office, "cars", { cars: 99 })).toBe(6);
+    expect(resolveParam(office, "cars", { cars: 0 })).toBe(1);
+  });
+
+  it("isOverridden tolerates within-half-step noise", () => {
+    // Step is 0.5 m/s; 2.2 ± 0.24 still counts as default.
+    expect(isOverridden(office, "maxSpeed", 2.2)).toBe(false);
+    expect(isOverridden(office, "maxSpeed", 2.4)).toBe(false);
+    expect(isOverridden(office, "maxSpeed", 2.5)).toBe(true);
+  });
+
+  it("compactOverrides drops keys that round back to the default", () => {
+    const overrides: Overrides = { maxSpeed: 2.2, weightCapacity: 1200 };
+    const compact = compactOverrides(office, overrides);
+    expect(compact).toEqual({ weightCapacity: 1200 });
+  });
+});
+
+describe("params: door cycle splitting", () => {
+  const office = scenarioById("office-mid-rise");
+
+  it("doorCycleSecFromTicks computes total seconds from tick fields", () => {
+    expect(doorCycleSecFromTicks(210, 60)).toBeCloseTo(5.5, 5);
+    expect(doorCycleSecFromTicks(180, 60)).toBeCloseTo(5.0, 5);
+  });
+
+  it("preserves the scenario's dwell-share when the user changes the cycle", () => {
+    // Office defaults to 5.5 s with dwell-share 3.5/5.5 ≈ 0.636.
+    // Doubling the cycle to 11 s should keep that share.
+    const split = doorCycleSecToTicks(office, 11);
+    const total = split.openTicks + 2 * split.transitionTicks;
+    expect(total).toBeGreaterThanOrEqual(660 - 2);
+    expect(total).toBeLessThanOrEqual(660 + 2);
+    expect(split.openTicks / total).toBeCloseTo(0.636, 1);
+  });
+
+  it("clamps both halves to ≥1 tick so engine validation passes", () => {
+    const split = doorCycleSecToTicks(office, 2);
+    expect(split.openTicks).toBeGreaterThanOrEqual(1);
+    expect(split.transitionTicks).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("params: starting-stop spread", () => {
+  it("spreads cars evenly across stops", () => {
+    expect(pickStartingStops(12, 3)).toEqual([0, 4, 8]);
+    expect(pickStartingStops(6, 2)).toEqual([0, 3]);
+    expect(pickStartingStops(8, 1)).toEqual([0]);
+  });
+
+  it("clamps to the last stop when cars exceed stops", () => {
+    expect(pickStartingStops(2, 6)).toEqual([0, 0, 0, 1, 1, 1]);
+  });
+
+  it("returns an empty array for nonsense inputs", () => {
+    expect(pickStartingStops(0, 3)).toEqual([]);
+    expect(pickStartingStops(5, 0)).toEqual([]);
+  });
+});
+
+describe("params: RON regeneration", () => {
+  const office = scenarioById("office-mid-rise");
+
+  it("default overrides round-trip to the same physics as the canonical RON", () => {
+    const ron = buildScenarioRon(office, {});
+    expect(ron).toMatch(/name: "Mid-Rise Office"/);
+    expect((ron.match(/ElevatorConfig\s*\(/g) ?? []).length).toBe(office.defaultCars);
+    expect(ron).toMatch(/max_speed: 2\.2/);
+    expect(ron).toMatch(/weight_capacity: 800\.0/);
+    expect(ron).toMatch(/door_open_ticks: 210/);
+    expect(ron).toMatch(/door_transition_ticks: 60/);
+  });
+
+  it("regenerates with a new car count using uniform physics across all cars", () => {
+    const ron = buildScenarioRon(office, { cars: 4 });
+    expect((ron.match(/ElevatorConfig\s*\(/g) ?? []).length).toBe(4);
+    expect((ron.match(/max_speed: 2\.2/g) ?? []).length).toBe(4);
+  });
+
+  it("bakes hot-swappable overrides into the RON so the initial sim already reflects them", () => {
+    const ron = buildScenarioRon(office, {
+      maxSpeed: 4.5,
+      weightCapacity: 1200,
+      doorCycleSec: 8,
+    });
+    expect(ron).toMatch(/max_speed: 4\.5/);
+    expect(ron).toMatch(/weight_capacity: 1200\.0/);
+    const open = Number(/door_open_ticks:\s*(\d+)/.exec(ron)?.[1] ?? "NaN");
+    const trans = Number(/door_transition_ticks:\s*(\d+)/.exec(ron)?.[1] ?? "NaN");
+    expect(open + 2 * trans).toBeGreaterThanOrEqual(478);
+    expect(open + 2 * trans).toBeLessThanOrEqual(482);
+  });
+
+  it("preserves the bypass percentages on scenarios that ship them", () => {
+    const sky = scenarioById("skyscraper-sky-lobby");
+    const ron = buildScenarioRon(sky, {});
+    expect((ron.match(/bypass_load_up_pct: Some\(0\.8\)/g) ?? []).length).toBe(sky.defaultCars);
+    expect((ron.match(/bypass_load_down_pct: Some\(0\.5\)/g) ?? []).length).toBe(sky.defaultCars);
+  });
+
+  it("omits bypass fields on scenarios that don't ship them", () => {
+    const ron = buildScenarioRon(office, {});
+    expect(ron).not.toMatch(/bypass_load_up_pct/);
+    expect(ron).not.toMatch(/bypass_load_down_pct/);
+  });
+});
+
+describe("params: applyPhysicsOverrides", () => {
+  const office = scenarioById("office-mid-rise");
+
+  it("returns scenario defaults when no overrides are present", () => {
+    const out = applyPhysicsOverrides(office, {});
+    expect(out.maxSpeed).toBe(2.2);
+    expect(out.weightCapacity).toBe(800);
+    expect(out.doorOpenTicks).toBe(210);
+    expect(out.doorTransitionTicks).toBe(60);
+    expect(out.acceleration).toBe(office.elevatorDefaults.acceleration);
+  });
+
+  it("respects user overrides for all four hot-swappable knobs", () => {
+    const out = applyPhysicsOverrides(office, {
+      maxSpeed: 5,
+      weightCapacity: 1500,
+      doorCycleSec: 7,
+    });
+    expect(out.maxSpeed).toBe(5);
+    expect(out.weightCapacity).toBe(1500);
+    expect(out.doorOpenTicks + 2 * out.doorTransitionTicks).toBeGreaterThanOrEqual(418);
+    expect(out.doorOpenTicks + 2 * out.doorTransitionTicks).toBeLessThanOrEqual(422);
+  });
+});

--- a/playground/src/__tests__/params.test.ts
+++ b/playground/src/__tests__/params.test.ts
@@ -38,6 +38,22 @@ describe("params: defaults extraction", () => {
       expect(dop, `${s.id} door_open_ticks`).toBe(s.elevatorDefaults.doorOpenTicks);
       const dtr = Number(/door_transition_ticks:\s*(\d+)/.exec(s.ron)?.[1] ?? "NaN");
       expect(dtr, `${s.id} door_transition_ticks`).toBe(s.elevatorDefaults.doorTransitionTicks);
+
+      // passenger_spawning fields feed buildScenarioRon too — a typo in
+      // the struct would silently desync from the RON literal on a
+      // car-count change (which regenerates RON) even though the default
+      // load still uses the literal directly.
+      const meanTicks = Number(/mean_interval_ticks:\s*(\d+)/.exec(s.ron)?.[1] ?? "NaN");
+      expect(meanTicks, `${s.id} mean_interval_ticks`).toBe(s.passengerMeanIntervalTicks);
+      const weightRangeMatch = /weight_range:\s*\(([\d.]+),\s*([\d.]+)\)/.exec(s.ron);
+      expect(Number(weightRangeMatch?.[1] ?? "NaN"), `${s.id} weight_range[0]`).toBeCloseTo(
+        s.passengerWeightRange[0],
+        5,
+      );
+      expect(Number(weightRangeMatch?.[2] ?? "NaN"), `${s.id} weight_range[1]`).toBeCloseTo(
+        s.passengerWeightRange[1],
+        5,
+      );
     }
   });
 

--- a/playground/src/__tests__/permalink.test.ts
+++ b/playground/src/__tests__/permalink.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { decodePermalink, encodePermalink, DEFAULT_STATE } from "../permalink";
+
+describe("permalink: core knobs", () => {
+  it("default state encodes to the expected canonical form", () => {
+    const qs = encodePermalink(DEFAULT_STATE);
+    expect(qs).toMatch(/s=skyscraper-sky-lobby/);
+    expect(qs).toMatch(/a=etd/);
+    expect(qs).toMatch(/c=1/);
+    expect(qs).toMatch(/k=42/);
+  });
+
+  it("decode of empty string returns the default state shape", () => {
+    const decoded = decodePermalink("");
+    expect(decoded.scenario).toBe(DEFAULT_STATE.scenario);
+    expect(decoded.strategyA).toBe(DEFAULT_STATE.strategyA);
+    expect(decoded.overrides).toEqual({});
+  });
+
+  it("round-trips through encode/decode without drift", () => {
+    const state = {
+      ...DEFAULT_STATE,
+      scenario: "office-mid-rise",
+      strategyA: "look" as const,
+      seed: 7,
+      intensity: 1.4,
+      speed: 8,
+    };
+    const decoded = decodePermalink(encodePermalink(state));
+    expect(decoded.scenario).toBe(state.scenario);
+    expect(decoded.strategyA).toBe(state.strategyA);
+    expect(decoded.seed).toBe(state.seed);
+    expect(decoded.intensity).toBe(state.intensity);
+    expect(decoded.speed).toBe(state.speed);
+  });
+});
+
+describe("permalink: overrides encoding", () => {
+  it("does not emit override keys when overrides are empty", () => {
+    const qs = encodePermalink(DEFAULT_STATE);
+    expect(qs).not.toMatch(/(^|&)ec=/);
+    expect(qs).not.toMatch(/(^|&)ms=/);
+    expect(qs).not.toMatch(/(^|&)wc=/);
+    expect(qs).not.toMatch(/(^|&)dc=/);
+  });
+
+  it("encodes only the keys present in overrides", () => {
+    const qs = encodePermalink({
+      ...DEFAULT_STATE,
+      overrides: { cars: 4, maxSpeed: 6 },
+    });
+    expect(qs).toMatch(/ec=4/);
+    expect(qs).toMatch(/ms=6/);
+    expect(qs).not.toMatch(/wc=/);
+    expect(qs).not.toMatch(/dc=/);
+  });
+
+  it("round-trips override values", () => {
+    const original = {
+      ...DEFAULT_STATE,
+      overrides: { cars: 5, maxSpeed: 4.5, weightCapacity: 1500, doorCycleSec: 7.5 },
+    };
+    const decoded = decodePermalink(encodePermalink(original));
+    expect(decoded.overrides).toEqual(original.overrides);
+  });
+
+  it("ignores non-numeric override values silently (defensive parse)", () => {
+    const decoded = decodePermalink("?ms=garbage&ec=3");
+    expect(decoded.overrides.cars).toBe(3);
+    expect(decoded.overrides.maxSpeed).toBeUndefined();
+  });
+
+  it("formats integer overrides without a trailing decimal", () => {
+    const qs = encodePermalink({
+      ...DEFAULT_STATE,
+      overrides: { weightCapacity: 1500 },
+    });
+    expect(qs).toMatch(/wc=1500(&|$)/);
+    expect(qs).not.toMatch(/wc=1500\.0/);
+  });
+});

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -1,4 +1,15 @@
 import { CanvasRenderer } from "./canvas";
+import {
+  PARAM_KEYS,
+  applyPhysicsOverrides,
+  buildScenarioRon,
+  compactOverrides,
+  defaultFor,
+  isOverridden,
+  resolveParam,
+  type Overrides,
+  type ParamKey,
+} from "./params";
 import { DEFAULT_STATE, decodePermalink, encodePermalink, type PermalinkState } from "./permalink";
 import { SCENARIOS, scenarioById } from "./scenarios";
 import { Sim } from "./sim";
@@ -59,6 +70,15 @@ interface PaneHandles {
   accent: string;
 }
 
+interface TweakRowHandles {
+  root: HTMLElement;
+  value: HTMLElement;
+  defaultV: HTMLElement;
+  dec: HTMLButtonElement;
+  inc: HTMLButtonElement;
+  reset: HTMLButtonElement;
+}
+
 interface UiHandles {
   scenarioSelect: HTMLSelectElement;
   strategyASelect: HTMLSelectElement;
@@ -73,6 +93,10 @@ interface UiHandles {
   playBtn: HTMLButtonElement;
   resetBtn: HTMLButtonElement;
   shareBtn: HTMLButtonElement;
+  tweakBtn: HTMLButtonElement;
+  tweakPanel: HTMLElement;
+  tweakResetAllBtn: HTMLButtonElement;
+  tweakRows: Record<ParamKey, TweakRowHandles>;
   layout: HTMLElement;
   loader: HTMLElement;
   toast: HTMLElement;
@@ -133,6 +157,29 @@ function wireUi(): UiHandles {
     metrics: q(`metrics-${suffix}`),
     accent,
   });
+  const tweakRow = (key: ParamKey): TweakRowHandles => {
+    const root = document.querySelector<HTMLElement>(`.tweak-row[data-key="${key}"]`);
+    if (!root) throw new Error(`missing tweak row for ${key}`);
+    const get = <T extends HTMLElement>(sel: string): T => {
+      const el = root.querySelector<T>(sel);
+      if (!el) throw new Error(`missing ${sel} in tweak row ${key}`);
+      return el;
+    };
+    return {
+      root,
+      value: get<HTMLElement>(".tweak-value"),
+      defaultV: get<HTMLElement>(".tweak-default-v"),
+      dec: get<HTMLButtonElement>(".tweak-dec"),
+      inc: get<HTMLButtonElement>(".tweak-inc"),
+      reset: get<HTMLButtonElement>(".tweak-reset"),
+    };
+  };
+  const tweakRows: Record<ParamKey, TweakRowHandles> = {
+    cars: tweakRow("cars"),
+    maxSpeed: tweakRow("maxSpeed"),
+    weightCapacity: tweakRow("weightCapacity"),
+    doorCycleSec: tweakRow("doorCycleSec"),
+  };
   const ui: UiHandles = {
     scenarioSelect: q<HTMLSelectElement>("scenario"),
     strategyASelect: q<HTMLSelectElement>("strategy-a"),
@@ -147,6 +194,10 @@ function wireUi(): UiHandles {
     playBtn: q<HTMLButtonElement>("play"),
     resetBtn: q<HTMLButtonElement>("reset"),
     shareBtn: q<HTMLButtonElement>("share"),
+    tweakBtn: q<HTMLButtonElement>("tweak"),
+    tweakPanel: q("tweak-panel"),
+    tweakResetAllBtn: q<HTMLButtonElement>("tweak-reset-all"),
+    tweakRows,
     layout: q("layout"),
     loader: q("loader"),
     toast: q("toast"),
@@ -197,6 +248,71 @@ function applyPermalinkToUi(p: PermalinkState, ui: UiHandles): void {
   ui.intensityLabel.textContent = intensityLabel(p.intensity);
   const scenario = scenarioById(p.scenario);
   if (ui.featureHint) ui.featureHint.textContent = scenario.featureHint;
+  // Auto-open the drawer when the permalink carries any override —
+  // the recipient sees what the sender customized without an extra
+  // click. A clean URL leaves the drawer closed so first-time
+  // visitors meet the unchanged playground.
+  if (Object.keys(p.overrides).length > 0) {
+    setTweakOpen(ui, true);
+  }
+  renderTweakPanel(scenario, p.overrides, ui);
+}
+
+/**
+ * Format a tweak value for the readout. `cars` and `weightCapacity`
+ * step in whole units so they read as integers; speed and door cycle
+ * use one decimal to match their step sizes.
+ */
+function formatTweakValue(key: ParamKey, value: number): string {
+  switch (key) {
+    case "cars":
+      return String(Math.round(value));
+    case "weightCapacity":
+      return String(Math.round(value));
+    case "maxSpeed":
+    case "doorCycleSec":
+      return value.toFixed(1);
+  }
+}
+
+/**
+ * Refresh every drawer row to reflect the current scenario + overrides.
+ * Called on boot, on scenario switch, and after each stepper click.
+ *
+ * Side effects beyond the displayed values:
+ *  - Disables `+`/`-` at the slider's bounds so users can't push the
+ *    value out of range (defensive — `resolveParam` clamps anyway).
+ *  - Toggles the per-row "Reset" button visibility based on whether
+ *    the row's value differs from the scenario default.
+ *  - Toggles the "Reset all" button visibility based on whether *any*
+ *    row is overridden.
+ */
+function renderTweakPanel(
+  scenario: ScenarioMeta,
+  overrides: Overrides,
+  ui: UiHandles,
+): void {
+  let anyOverridden = false;
+  for (const key of PARAM_KEYS) {
+    const row = ui.tweakRows[key];
+    const range = scenario.tweakRanges[key];
+    const value = resolveParam(scenario, key, overrides);
+    const def = defaultFor(scenario, key);
+    const overridden = isOverridden(scenario, key, value);
+    if (overridden) anyOverridden = true;
+    row.value.textContent = formatTweakValue(key, value);
+    row.defaultV.textContent = formatTweakValue(key, def);
+    row.dec.disabled = value <= range.min + 1e-9;
+    row.inc.disabled = value >= range.max - 1e-9;
+    row.root.dataset.overridden = String(overridden);
+    row.reset.hidden = !overridden;
+  }
+  ui.tweakResetAllBtn.hidden = !anyOverridden;
+}
+
+function setTweakOpen(ui: UiHandles, open: boolean): void {
+  ui.tweakBtn.setAttribute("aria-expanded", open ? "true" : "false");
+  ui.tweakPanel.hidden = !open;
 }
 
 /** Run `fn` against each active pane. Lets call sites fan out without null-checks. */
@@ -214,8 +330,16 @@ async function makePane(
   handles: PaneHandles,
   strategy: StrategyName,
   scenario: ScenarioMeta,
+  overrides: Overrides,
 ): Promise<Pane> {
-  const sim = await Sim.create(scenario.ron, strategy);
+  // Always regenerate RON so user overrides (including non-default
+  // car count) are baked into the initial sim. Hot-swappable knobs
+  // could in principle apply post-construction via `applyPhysicsLive`,
+  // but baking them in keeps the sim's initial state identical to
+  // a recipient who loads the same permalink — no transient first-
+  // tick using defaults followed by a setter call.
+  const ron = buildScenarioRon(scenario, overrides);
+  const sim = await Sim.create(ron, strategy);
   // Apply the scenario's commercial-feature hook once on load. The
   // user can still swap strategies afterwards; the hook's effects
   // stick only as long as the strategy it tuned remains active.
@@ -257,14 +381,24 @@ async function resetAll(state: State, ui: UiHandles): Promise<void> {
   state.paneA = null;
   state.paneB = null;
   try {
-    const paneA = await makePane(ui.paneA, state.permalink.strategyA, scenario);
+    const paneA = await makePane(
+      ui.paneA,
+      state.permalink.strategyA,
+      scenario,
+      state.permalink.overrides,
+    );
     if (token !== state.initToken) {
       disposePane(paneA);
       return;
     }
     state.paneA = paneA;
     if (state.permalink.compare) {
-      const paneB = await makePane(ui.paneB, state.permalink.strategyB, scenario);
+      const paneB = await makePane(
+        ui.paneB,
+        state.permalink.strategyB,
+        scenario,
+        state.permalink.overrides,
+      );
       if (token !== state.initToken) {
         disposePane(paneB);
         return;
@@ -298,6 +432,7 @@ async function resetAll(state: State, ui: UiHandles): Promise<void> {
     }
     if (ui.featureHint) ui.featureHint.textContent = scenario.featureHint;
     updatePhaseIndicator(state, ui);
+    renderTweakPanel(scenario, state.permalink.overrides, ui);
   } catch (err) {
     if (token === state.initToken) {
       toast(ui, `Init failed: ${(err as Error).message}`);
@@ -319,13 +454,20 @@ function attachListeners(state: State, ui: UiHandles): void {
     const nextStrategyA = state.permalink.compare
       ? state.permalink.strategyA
       : scenario.defaultStrategy;
+    // Clear all parameter overrides on scenario switch — every
+    // scenario has its own physics envelope (a 0.5 m/s slider value
+    // makes sense for residential, makes no sense for the space
+    // elevator) so cross-scenario carry-over surprised more than it
+    // helped during early prototyping.
     state.permalink = {
       ...state.permalink,
       scenario: scenario.id,
       strategyA: nextStrategyA,
+      overrides: {},
     };
     ui.strategyASelect.value = nextStrategyA;
     await resetAll(state, ui);
+    renderTweakPanel(scenario, state.permalink.overrides, ui);
     toast(ui, `${scenario.label} · ${STRATEGY_LABELS[nextStrategyA]}`);
   });
   // Strategy changes reset the whole comparator so both panes stay aligned
@@ -381,6 +523,21 @@ function attachListeners(state: State, ui: UiHandles): void {
   ui.resetBtn.addEventListener("click", () => {
     void resetAll(state, ui);
     toast(ui, "Reset");
+  });
+
+  // ── Tweak panel ──────────────────────────────────────────────────
+  ui.tweakBtn.addEventListener("click", () => {
+    const open = ui.tweakBtn.getAttribute("aria-expanded") !== "true";
+    setTweakOpen(ui, open);
+  });
+  for (const key of PARAM_KEYS) {
+    const row = ui.tweakRows[key];
+    row.dec.addEventListener("click", () => bumpParam(state, ui, key, -1));
+    row.inc.addEventListener("click", () => bumpParam(state, ui, key, +1));
+    row.reset.addEventListener("click", () => resetParam(state, ui, key));
+  }
+  ui.tweakResetAllBtn.addEventListener("click", () => {
+    void resetAllOverrides(state, ui);
   });
   ui.shareBtn.addEventListener("click", async () => {
     const qs = encodePermalink(state.permalink);
@@ -572,6 +729,139 @@ function toast(ui: UiHandles, msg: string): void {
   ui.toast.classList.add("show");
   window.clearTimeout(toastTimer);
   toastTimer = window.setTimeout(() => ui.toast.classList.remove("show"), 1600);
+}
+
+// ─── Tweak panel: state mutation ─────────────────────────────────────
+
+/**
+ * Step a single param up or down by its scenario-defined step size,
+ * then apply the change. Quietly clamps to the param's range so a
+ * disabled +/- button can't be activated via keyboard repeat.
+ */
+function bumpParam(state: State, ui: UiHandles, key: ParamKey, dir: number): void {
+  const scenario = scenarioById(state.permalink.scenario);
+  const range = scenario.tweakRanges[key];
+  const current = resolveParam(scenario, key, state.permalink.overrides);
+  const next = clampToRange(current + dir * range.step, range.min, range.max);
+  // Round to a multiple of `step` so the steppers always land on a
+  // canonical lattice point — protects against floating-point drift
+  // accumulating over repeated clicks.
+  const snapped = snapToStep(next, range.min, range.step);
+  setOverride(state, ui, scenario, key, snapped);
+}
+
+function resetParam(state: State, ui: UiHandles, key: ParamKey): void {
+  const scenario = scenarioById(state.permalink.scenario);
+  const next = { ...state.permalink.overrides };
+  delete next[key];
+  state.permalink = { ...state.permalink, overrides: next };
+  // Per-key reset of the live-mutated knobs goes through the same
+  // hot-swap path so metrics don't reset; cars-count reset rebuilds.
+  if (key === "cars") {
+    void resetAll(state, ui);
+    toast(ui, "Cars reset");
+  } else {
+    applyHotSwapAndRender(state, ui, scenario);
+    toast(ui, `${labelForKey(key)} reset`);
+  }
+}
+
+async function resetAllOverrides(state: State, ui: UiHandles): Promise<void> {
+  const scenario = scenarioById(state.permalink.scenario);
+  const hadCarsOverride = isOverridden(
+    scenario,
+    "cars",
+    resolveParam(scenario, "cars", state.permalink.overrides),
+  );
+  state.permalink = { ...state.permalink, overrides: {} };
+  if (hadCarsOverride) {
+    await resetAll(state, ui);
+  } else {
+    applyHotSwapAndRender(state, ui, scenario);
+  }
+  toast(ui, "Parameters reset");
+}
+
+/**
+ * Update one override and apply it: hot-swap for live-mutated keys,
+ * full sim rebuild for `cars`. Keeps the in-memory permalink in sync
+ * and re-renders the drawer.
+ */
+function setOverride(
+  state: State,
+  ui: UiHandles,
+  scenario: ScenarioMeta,
+  key: ParamKey,
+  value: number,
+): void {
+  const next: Overrides = { ...state.permalink.overrides, [key]: value };
+  state.permalink = {
+    ...state.permalink,
+    overrides: compactOverrides(scenario, next),
+  };
+  if (key === "cars") {
+    void resetAll(state, ui);
+  } else {
+    applyHotSwapAndRender(state, ui, scenario);
+  }
+}
+
+/**
+ * Push max-speed / capacity / door-cycle into the live sim via the
+ * uniform setters and refresh the drawer's display values. Used for
+ * every override change *except* cars-count, which needs a full
+ * `resetAll`.
+ *
+ * If the wasm build predates the setters (`applyPhysicsLive` returns
+ * `false`), fall back to a sim rebuild — same observable result, just
+ * with a metrics reset. This keeps local dev usable when the
+ * playground reloads ahead of a fresh `wasm-pack build`.
+ */
+function applyHotSwapAndRender(
+  state: State,
+  ui: UiHandles,
+  scenario: ScenarioMeta,
+): void {
+  const physics = applyPhysicsOverrides(scenario, state.permalink.overrides);
+  const params = {
+    maxSpeed: physics.maxSpeed,
+    weightCapacityKg: physics.weightCapacity,
+    doorOpenTicks: physics.doorOpenTicks,
+    doorTransitionTicks: physics.doorTransitionTicks,
+  };
+  let allLive = true;
+  forEachPane(state, (pane) => {
+    if (!pane.sim.applyPhysicsLive(params)) allLive = false;
+  });
+  renderTweakPanel(scenario, state.permalink.overrides, ui);
+  if (!allLive) void resetAll(state, ui);
+}
+
+function clampToRange(v: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, v));
+}
+
+/**
+ * Round `v` to the nearest multiple of `step` measured from `min`.
+ * Used by `bumpParam` so successive +/- clicks always land on
+ * canonical grid values regardless of the starting point.
+ */
+function snapToStep(v: number, min: number, step: number): number {
+  const stepsFromMin = Math.round((v - min) / step);
+  return min + stepsFromMin * step;
+}
+
+function labelForKey(key: ParamKey): string {
+  switch (key) {
+    case "cars":
+      return "Cars";
+    case "maxSpeed":
+      return "Max speed";
+    case "weightCapacity":
+      return "Capacity";
+    case "doorCycleSec":
+      return "Door cycle";
+  }
 }
 
 void boot();

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -113,6 +113,15 @@ async function boot(): Promise<void> {
   // scenario's `defaultStrategy` for pane A so "Share link from hotel"
   // doesn't deliver a mismatched config to the recipient.
   reconcileStrategyWithScenario(permalink);
+  // Compact decoded overrides against the resolved scenario so a URL
+  // that carries values matching the current default (possible if a
+  // scenario default shifted between share-time and load-time) doesn't
+  // spuriously auto-open the drawer with zero active highlights.
+  // `encodePermalink`'s contract is that callers compact first; this
+  // is the decode-side counterpart, done once at boot rather than in
+  // every subsequent write path.
+  const scenario = scenarioById(permalink.scenario);
+  permalink.overrides = compactOverrides(scenario, permalink.overrides);
   applyPermalinkToUi(permalink, ui);
   const state: State = {
     running: true,
@@ -131,15 +140,15 @@ async function boot(): Promise<void> {
 }
 
 /**
- * When the user switches to a scenario whose default strategy differs
- * from the one currently selected, and they haven't explicitly picked
- * a strategy for the new scenario, snap pane A to the scenario's
- * default. Pane B stays put — compare mode deliberately pins both
- * strategies across scenario switches.
+ * Canonicalise legacy scenario ids (e.g. `"office-5"`) through the
+ * `scenarioById` fallback so the rest of boot operates on the current
+ * canonical id. Strategy is intentionally left alone: on first load
+ * we honour whatever the permalink encoded — the snap-to-scenario-default
+ * behavior only fires on an interactive scenario change, not on boot.
  */
 function reconcileStrategyWithScenario(p: PermalinkState): void {
   const scenario = scenarioById(p.scenario);
-  p.scenario = scenario.id; // Canonicalise legacy ids through the fallback.
+  p.scenario = scenario.id;
 }
 
 function wireUi(): UiHandles {

--- a/playground/src/params.ts
+++ b/playground/src/params.ts
@@ -1,0 +1,262 @@
+import type { ElevatorPhysics, ScenarioMeta } from "./types";
+
+// Owner of the "Tweak parameters" drawer's domain logic. Independent of
+// the DOM and the wasm sim — both `main.ts` (drawer wiring) and
+// `permalink.ts` (URL encoding) consume this module's pure helpers.
+//
+// Two kinds of overrides exist, and they apply to the sim differently:
+//   - **Live-mutated**: max speed, weight capacity, door cycle. The
+//     wasm crate exposes uniform setters that mutate every elevator in
+//     place, so changing these does not reset the sim's accumulated
+//     metrics.
+//   - **Rebuild-on-change**: number of cars. Adding/removing elevators
+//     mid-tick is invasive engine work; the playground instead
+//     regenerates the RON and rebuilds the sim. Metrics reset.
+//
+// The drawer treats both kinds uniformly from the user's perspective —
+// the asymmetry is hidden behind `applyOverrides()` in `main.ts`.
+
+/** The user-facing knobs the drawer exposes. */
+export type ParamKey = "cars" | "maxSpeed" | "weightCapacity" | "doorCycleSec";
+
+/**
+ * User-applied overrides as a partial record. A key is present iff the
+ * user has moved that knob away from the scenario's default. Permalink
+ * encoding only emits keys that are present, so default scenarios still
+ * produce short, clean URLs.
+ */
+export type Overrides = Partial<Record<ParamKey, number>>;
+
+/**
+ * Resolve `overrides[key]` against the scenario's default, with
+ * defensive clamping. Used by `applyOverrides()` and by the drawer to
+ * compute what to display.
+ */
+export function resolveParam(
+  scenario: ScenarioMeta,
+  key: ParamKey,
+  overrides: Overrides,
+): number {
+  const def = defaultFor(scenario, key);
+  const raw = overrides[key];
+  if (raw === undefined || !Number.isFinite(raw)) return def;
+  const range = scenario.tweakRanges[key];
+  return clamp(raw, range.min, range.max);
+}
+
+/**
+ * The scenario's default value for `key`. For `doorCycleSec` this
+ * computes the combined `dwell + 2 × transition` from the tick fields.
+ */
+export function defaultFor(scenario: ScenarioMeta, key: ParamKey): number {
+  const e = scenario.elevatorDefaults;
+  switch (key) {
+    case "cars":
+      return scenario.defaultCars;
+    case "maxSpeed":
+      return e.maxSpeed;
+    case "weightCapacity":
+      return e.weightCapacity;
+    case "doorCycleSec":
+      return doorCycleSecFromTicks(e.doorOpenTicks, e.doorTransitionTicks);
+  }
+}
+
+/**
+ * Whether `value` differs from the scenario's default by enough to
+ * count as "overridden". Tolerance is half a step so a value that
+ * rounds back to the default doesn't get persisted as an override.
+ */
+export function isOverridden(scenario: ScenarioMeta, key: ParamKey, value: number): boolean {
+  const def = defaultFor(scenario, key);
+  const tolerance = scenario.tweakRanges[key].step / 2;
+  return Math.abs(value - def) > tolerance;
+}
+
+/**
+ * Strip override entries that match the scenario default within
+ * tolerance. Called before encoding so the URL doesn't carry no-op
+ * overrides.
+ */
+export function compactOverrides(scenario: ScenarioMeta, overrides: Overrides): Overrides {
+  const out: Overrides = {};
+  for (const k of PARAM_KEYS) {
+    const raw = overrides[k];
+    if (raw === undefined) continue;
+    if (isOverridden(scenario, k, raw)) out[k] = raw;
+  }
+  return out;
+}
+
+export const PARAM_KEYS: readonly ParamKey[] = [
+  "cars",
+  "maxSpeed",
+  "weightCapacity",
+  "doorCycleSec",
+] as const;
+
+/**
+ * Convert a desired total door cycle (seconds) back to (open_ticks,
+ * transition_ticks) using the scenario's default dwell-share so the
+ * proportional split feels stable as the user drags the slider.
+ *
+ * Both outputs are clamped to ≥1 tick so the engine's `nonzero_u32`
+ * validation never fails — the slider's min of 2 s already keeps both
+ * comfortably positive in practice.
+ */
+export function doorCycleSecToTicks(
+  scenario: ScenarioMeta,
+  cycleSec: number,
+): { openTicks: number; transitionTicks: number } {
+  const { doorOpenTicks, doorTransitionTicks } = scenario.elevatorDefaults;
+  const defaultCycleSec = doorCycleSecFromTicks(doorOpenTicks, doorTransitionTicks);
+  // Dwell share is computed against the full cycle (open + 2 × transition).
+  // Capped to [0.1, 0.9] so neither half ever rounds to zero ticks.
+  const dwellShare = clamp(doorOpenTicks / (defaultCycleSec * TICKS_PER_SEC), 0.1, 0.9);
+  const totalTicks = Math.max(2, Math.round(cycleSec * TICKS_PER_SEC));
+  const openTicks = Math.max(1, Math.round(totalTicks * dwellShare));
+  const transitionTicks = Math.max(1, Math.round((totalTicks - openTicks) / 2));
+  return { openTicks, transitionTicks };
+}
+
+/** Inverse of {@link doorCycleSecToTicks} for displaying the current value. */
+export function doorCycleSecFromTicks(
+  openTicks: number,
+  transitionTicks: number,
+): number {
+  return (openTicks + 2 * transitionTicks) / TICKS_PER_SEC;
+}
+
+/**
+ * Build a fresh `ElevatorPhysics` value with `maxSpeed`, `weightCapacity`,
+ * and door timings replaced by the user's overrides (if any). Used by
+ * `buildScenarioRon()` so a regenerated RON for a new car count also
+ * carries the user's hot-swappable tweaks (preserving them across the
+ * rebuild).
+ */
+export function applyPhysicsOverrides(
+  scenario: ScenarioMeta,
+  overrides: Overrides,
+): ElevatorPhysics {
+  const base = scenario.elevatorDefaults;
+  const maxSpeed = resolveParam(scenario, "maxSpeed", overrides);
+  const weightCapacity = resolveParam(scenario, "weightCapacity", overrides);
+  const doorCycleSec = resolveParam(scenario, "doorCycleSec", overrides);
+  const { openTicks, transitionTicks } = doorCycleSecToTicks(scenario, doorCycleSec);
+  return {
+    ...base,
+    maxSpeed,
+    weightCapacity,
+    doorOpenTicks: openTicks,
+    doorTransitionTicks: transitionTicks,
+  };
+}
+
+/**
+ * Spread `cars` evenly across `numStops` to pick each elevator's
+ * starting stop. With `cars = numStops` we get one car per stop; with
+ * fewer cars we land on `floor(i * numStops / cars)` so the spread
+ * stays even.
+ */
+export function pickStartingStops(numStops: number, cars: number): number[] {
+  if (numStops < 1 || cars < 1) return [];
+  const out: number[] = [];
+  for (let i = 0; i < cars; i += 1) {
+    out.push(Math.min(numStops - 1, Math.floor((i * numStops) / cars)));
+  }
+  return out;
+}
+
+/**
+ * Regenerate a scenario's RON with `cars` cars and the user's
+ * physics overrides baked into every car. Called whenever the cars
+ * count changes (the only override that can't be hot-swapped) and on
+ * initial sim construction so hot-swappable defaults are still
+ * honored before any setter call lands.
+ */
+export function buildScenarioRon(scenario: ScenarioMeta, overrides: Overrides): string {
+  const cars = Math.round(resolveParam(scenario, "cars", overrides));
+  const physics = applyPhysicsOverrides(scenario, overrides);
+  const startingStops = pickStartingStops(scenario.stops.length, cars);
+
+  const stopsBlock = scenario.stops
+    .map((s, i) => `        StopConfig(id: StopId(${i}), name: ${ronString(s.name)}, position: ${ronFloat(s.positionM)}),`)
+    .join("\n");
+
+  const elevatorsBlock = startingStops
+    .map((startIdx, i) => buildElevatorRon(i, physics, startIdx, defaultCarName(i, cars)))
+    .join("\n");
+
+  return `SimConfig(
+    building: BuildingConfig(
+        name: ${ronString(scenario.buildingName)},
+        stops: [
+${stopsBlock}
+        ],
+    ),
+    elevators: [
+${elevatorsBlock}
+    ],
+    simulation: SimulationParams(ticks_per_second: ${ronFloat(TICKS_PER_SEC)}),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: ${scenario.passengerMeanIntervalTicks},
+        weight_range: (${ronFloat(scenario.passengerWeightRange[0])}, ${ronFloat(scenario.passengerWeightRange[1])}),
+    ),
+)`;
+}
+
+// ─── Internals ──────────────────────────────────────────────────────
+
+const TICKS_PER_SEC = 60;
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, v));
+}
+
+/**
+ * Naming follows the existing scenarios: a single car is "Car 1"; with
+ * 2 cars they're "Car 1"/"Car 2"; 3+ cars switch to "Car A"/"Car B"/...
+ * mirroring the skyscraper/hotel convention so a regenerated RON reads
+ * naturally to anyone familiar with the scenario.
+ */
+function defaultCarName(index: number, total: number): string {
+  if (total >= 3) return `Car ${String.fromCharCode(65 + index)}`;
+  return `Car ${index + 1}`;
+}
+
+function buildElevatorRon(
+  id: number,
+  p: ElevatorPhysics,
+  startingStopIdx: number,
+  name: string,
+): string {
+  const bypassUp =
+    p.bypassLoadUpPct !== undefined ? `\n            bypass_load_up_pct: Some(${ronFloat(p.bypassLoadUpPct)}),` : "";
+  const bypassDown =
+    p.bypassLoadDownPct !== undefined ? `\n            bypass_load_down_pct: Some(${ronFloat(p.bypassLoadDownPct)}),` : "";
+  return `        ElevatorConfig(
+            id: ${id}, name: ${ronString(name)},
+            max_speed: ${ronFloat(p.maxSpeed)}, acceleration: ${ronFloat(p.acceleration)}, deceleration: ${ronFloat(p.deceleration)},
+            weight_capacity: ${ronFloat(p.weightCapacity)},
+            starting_stop: StopId(${startingStopIdx}),
+            door_open_ticks: ${p.doorOpenTicks}, door_transition_ticks: ${p.doorTransitionTicks},${bypassUp}${bypassDown}
+        ),`;
+}
+
+function ronString(s: string): string {
+  // RON strings reuse JSON-style escaping for our characters of interest
+  // (printable ASCII names with no backslashes). Bail loudly if anything
+  // unexpected slips in — protects against future scenario edits that
+  // sneak a quote into a stop name.
+  if (/[\\"\n]/.test(s)) {
+    throw new Error(`scenario name contains illegal RON character: ${JSON.stringify(s)}`);
+  }
+  return `"${s}"`;
+}
+
+function ronFloat(n: number): string {
+  // Always render with a decimal point so RON parses it as a float.
+  // `1` → `"1.0"`, `2.5` → `"2.5"`, `3.14` → `"3.14"`.
+  if (Number.isInteger(n)) return `${n}.0`;
+  return String(n);
+}

--- a/playground/src/permalink.ts
+++ b/playground/src/permalink.ts
@@ -1,3 +1,4 @@
+import { PARAM_KEYS, type Overrides, type ParamKey } from "./params";
 import type { StrategyName } from "./types";
 
 // URL state encoding. Keeps the sim reproducible: sharing the URL replays
@@ -19,7 +20,28 @@ export interface PermalinkState {
   intensity: number;
   /** Playback multiplier (sim ticks per rendered frame). */
   speed: number;
+  /**
+   * User overrides for building physics (cars, max speed, capacity,
+   * door cycle). Empty record means "everything at scenario default".
+   * Encoded compactly so default scenarios still produce short URLs;
+   * any present key auto-opens the drawer for the recipient so they
+   * see what was customized.
+   */
+  overrides: Overrides;
 }
+
+/**
+ * Compact two-letter URL keys per overridable param. Two letters
+ * because the existing core knobs already claim every short single
+ * letter (`s`/`a`/`b`/`c`/`k`/`i`/`x`); a separate two-letter
+ * namespace keeps readers oriented.
+ */
+const OVERRIDE_KEYS: Record<ParamKey, string> = {
+  cars: "ec",
+  maxSpeed: "ms",
+  weightCapacity: "wc",
+  doorCycleSec: "dc",
+};
 
 export const DEFAULT_STATE: PermalinkState = {
   // First-impression tuning: skyscraper is the visually richest
@@ -45,6 +67,7 @@ export const DEFAULT_STATE: PermalinkState = {
   // keeps dispatch decisions readable without making a cold visitor
   // wait a real minute to see morning rush develop.
   speed: 2,
+  overrides: {},
 };
 
 const STRATEGIES: readonly StrategyName[] = ["scan", "look", "nearest", "etd", "destination"];
@@ -67,11 +90,28 @@ export function encodePermalink(state: PermalinkState): string {
   p.set("k", String(state.seed));
   p.set("i", String(state.intensity));
   p.set("x", String(state.speed));
+  // Overrides: only emit keys the user has actually moved away from
+  // default. Caller (main.ts) is responsible for compacting via
+  // `compactOverrides()` before encoding so a value that rounds back
+  // to the default doesn't leak into the URL.
+  for (const k of PARAM_KEYS) {
+    const v = state.overrides[k];
+    if (v !== undefined && Number.isFinite(v)) {
+      p.set(OVERRIDE_KEYS[k], formatOverride(v));
+    }
+  }
   return `?${p.toString()}`;
 }
 
 export function decodePermalink(search: string): PermalinkState {
   const p = new URLSearchParams(search);
+  const overrides: Overrides = {};
+  for (const k of PARAM_KEYS) {
+    const raw = p.get(OVERRIDE_KEYS[k]);
+    if (raw === null) continue;
+    const n = Number(raw);
+    if (Number.isFinite(n)) overrides[k] = n;
+  }
   return {
     scenario: p.get("s") ?? DEFAULT_STATE.scenario,
     strategyA: parseStrategy(p.get("a") ?? p.get("d"), DEFAULT_STATE.strategyA),
@@ -83,6 +123,7 @@ export function decodePermalink(search: string): PermalinkState {
     // than try to re-interpret the value against an unknown scenario.
     intensity: parseNum(p.get("i"), DEFAULT_STATE.intensity),
     speed: parseNum(p.get("x"), DEFAULT_STATE.speed),
+    overrides,
   };
 }
 
@@ -90,4 +131,15 @@ function parseNum(raw: string | null, fallback: number): number {
   if (raw === null) return fallback;
   const n = Number(raw);
   return Number.isFinite(n) ? n : fallback;
+}
+
+/**
+ * Render a numeric override compactly. Integer-valued numbers (cars
+ * count, whole-kg capacity at default step, whole-second door cycle)
+ * round-trip without trailing `.0`; fractional values keep up to two
+ * decimals so `2.5 m/s` stays `"2.5"` rather than `"2.499999"`.
+ */
+function formatOverride(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  return Number(n.toFixed(2)).toString();
 }

--- a/playground/src/scenarios.ts
+++ b/playground/src/scenarios.ts
@@ -1,4 +1,18 @@
-import type { Phase, ScenarioMeta } from "./types";
+import type { Phase, ScenarioMeta, TweakRanges } from "./types";
+
+// ─── Default tweak bounds ───────────────────────────────────────────
+//
+// One set of bounds works for every commercial scenario (mid-rise
+// office through skyscraper). The space elevator overrides these
+// because its operating envelope (50 m/s climbers, 1000 m shaft, 2
+// stops) is two orders of magnitude away from a building.
+
+const COMMERCIAL_TWEAK_RANGES: TweakRanges = {
+  cars: { min: 1, max: 6, step: 1 },
+  maxSpeed: { min: 0.5, max: 12, step: 0.5 },
+  weightCapacity: { min: 200, max: 2500, step: 100 },
+  doorCycleSec: { min: 2, max: 12, step: 0.5 },
+};
 
 // Scenarios are embedded as RON strings so the playground is a single static
 // bundle with no extra fetches. Each scenario is validated by elevator-core's
@@ -106,6 +120,27 @@ const office: ScenarioMeta = {
   hook: { kind: "etd_group_time", waitSquaredWeight: 0.002 },
   featureHint:
     "Group-time ETD (`wait_squared_weight = 0.002`) — stops hosting older waiters win ties, damping long-wait tail during lunchtime bursts.",
+  buildingName: "Mid-Rise Office",
+  stops: [
+    { name: "Lobby", positionM: 0.0 },
+    { name: "Floor 2", positionM: 4.0 },
+    { name: "Floor 3", positionM: 8.0 },
+    { name: "Floor 4", positionM: 12.0 },
+    { name: "Floor 5", positionM: 16.0 },
+    { name: "Floor 6", positionM: 20.0 },
+  ],
+  defaultCars: 2,
+  elevatorDefaults: {
+    maxSpeed: 2.2,
+    acceleration: 1.5,
+    deceleration: 2.0,
+    weightCapacity: 800.0,
+    doorOpenTicks: 210,
+    doorTransitionTicks: 60,
+  },
+  tweakRanges: COMMERCIAL_TWEAK_RANGES,
+  passengerMeanIntervalTicks: 90,
+  passengerWeightRange: [50.0, 100.0],
   ron: `SimConfig(
     building: BuildingConfig(
         name: "Mid-Rise Office",
@@ -213,6 +248,36 @@ const skyscraper: ScenarioMeta = {
   hook: { kind: "bypass_narration" },
   featureHint:
     "Direction-dependent bypass (80 % up / 50 % down) on all three cars — baked into the RON below. Watch the fullest car skip hall calls.",
+  buildingName: "Skyscraper (Sky Lobby)",
+  stops: [
+    { name: "Lobby", positionM: 0.0 },
+    { name: "Floor 2", positionM: 4.0 },
+    { name: "Floor 3", positionM: 8.0 },
+    { name: "Floor 4", positionM: 12.0 },
+    { name: "Floor 5", positionM: 16.0 },
+    { name: "Floor 6", positionM: 20.0 },
+    { name: "Sky Lobby", positionM: 24.0 },
+    { name: "Floor 8", positionM: 28.0 },
+    { name: "Floor 9", positionM: 32.0 },
+    { name: "Floor 10", positionM: 36.0 },
+    { name: "Floor 11", positionM: 40.0 },
+    { name: "Floor 12", positionM: 44.0 },
+    { name: "Penthouse", positionM: 48.0 },
+  ],
+  defaultCars: 3,
+  elevatorDefaults: {
+    maxSpeed: 4.0,
+    acceleration: 2.0,
+    deceleration: 2.5,
+    weightCapacity: 1200.0,
+    doorOpenTicks: 300,
+    doorTransitionTicks: 72,
+    bypassLoadUpPct: 0.8,
+    bypassLoadDownPct: 0.5,
+  },
+  tweakRanges: COMMERCIAL_TWEAK_RANGES,
+  passengerMeanIntervalTicks: 30,
+  passengerWeightRange: [55.0, 100.0],
   ron: `SimConfig(
     building: BuildingConfig(
         name: "Skyscraper (Sky Lobby)",
@@ -345,6 +410,29 @@ const residential: ScenarioMeta = {
   hook: { kind: "predictive_parking", windowTicks: 9000 }, // 2.5 min at 60 Hz
   featureHint:
     "Predictive parking with a 2.5-min window — during the midday slump, idle cars pre-position toward the floors that spiked most recently.",
+  buildingName: "Residential Tower",
+  stops: [
+    { name: "Lobby", positionM: 0.0 },
+    { name: "Floor 2", positionM: 3.5 },
+    { name: "Floor 3", positionM: 7.0 },
+    { name: "Floor 4", positionM: 10.5 },
+    { name: "Floor 5", positionM: 14.0 },
+    { name: "Floor 6", positionM: 17.5 },
+    { name: "Floor 7", positionM: 21.0 },
+    { name: "Penthouse", positionM: 24.5 },
+  ],
+  defaultCars: 2,
+  elevatorDefaults: {
+    maxSpeed: 2.5,
+    acceleration: 1.6,
+    deceleration: 2.2,
+    weightCapacity: 700.0,
+    doorOpenTicks: 180,
+    doorTransitionTicks: 60,
+  },
+  tweakRanges: COMMERCIAL_TWEAK_RANGES,
+  passengerMeanIntervalTicks: 75,
+  passengerWeightRange: [50.0, 95.0],
   ron: `SimConfig(
     building: BuildingConfig(
         name: "Residential Tower",
@@ -455,6 +543,31 @@ const hotel: ScenarioMeta = {
   hook: { kind: "deferred_dcs", commitmentWindowTicks: 180 },
   featureHint:
     "Deferred DCS with a 3-s (180-tick) commitment window — sticky assignments keep re-competing until a car is close to the rider, yielding better matches under bursty demand.",
+  buildingName: "Hotel 24/7",
+  stops: [
+    { name: "Lobby", positionM: 0.0 },
+    { name: "Restaurant", positionM: 3.5 },
+    { name: "Floor 3", positionM: 7.0 },
+    { name: "Floor 4", positionM: 10.5 },
+    { name: "Floor 5", positionM: 14.0 },
+    { name: "Floor 6", positionM: 17.5 },
+    { name: "Floor 7", positionM: 21.0 },
+    { name: "Floor 8", positionM: 24.5 },
+    { name: "Floor 9", positionM: 28.0 },
+    { name: "Penthouse", positionM: 31.5 },
+  ],
+  defaultCars: 3,
+  elevatorDefaults: {
+    maxSpeed: 3.0,
+    acceleration: 1.8,
+    deceleration: 2.3,
+    weightCapacity: 900.0,
+    doorOpenTicks: 240,
+    doorTransitionTicks: 60,
+  },
+  tweakRanges: COMMERCIAL_TWEAK_RANGES,
+  passengerMeanIntervalTicks: 120,
+  passengerWeightRange: [50.0, 95.0],
   ron: `SimConfig(
     building: BuildingConfig(
         name: "Hotel 24/7",
@@ -564,6 +677,26 @@ const convention: ScenarioMeta = {
   hook: { kind: "arrival_log" },
   featureHint:
     "Arrival-rate signal lights up as the burst hits — `DispatchManifest::arrivals_at` feeds downstream strategies the per-stop intensity for the next 5 minutes.",
+  buildingName: "Convention Center",
+  stops: [
+    { name: "Lobby", positionM: 0.0 },
+    { name: "Exhibit Hall", positionM: 4.0 },
+    { name: "Mezzanine", positionM: 8.0 },
+    { name: "Ballroom", positionM: 12.0 },
+    { name: "Keynote Hall", positionM: 16.0 },
+  ],
+  defaultCars: 2,
+  elevatorDefaults: {
+    maxSpeed: 3.5,
+    acceleration: 2.0,
+    deceleration: 2.5,
+    weightCapacity: 1500.0,
+    doorOpenTicks: 300,
+    doorTransitionTicks: 60,
+  },
+  tweakRanges: { ...COMMERCIAL_TWEAK_RANGES, cars: { min: 1, max: 5, step: 1 } },
+  passengerMeanIntervalTicks: 30,
+  passengerWeightRange: [55.0, 100.0],
   ron: `SimConfig(
     building: BuildingConfig(
         name: "Convention Center",
@@ -628,6 +761,31 @@ const spaceElevator: ScenarioMeta = {
   hook: { kind: "none" },
   featureHint:
     "No controller feature to showcase — this scenario exists to demonstrate that the engine is topology-agnostic.",
+  buildingName: "Orbital Tether",
+  stops: [
+    { name: "Ground Station", positionM: 0.0 },
+    { name: "Orbital Platform", positionM: 1000.0 },
+  ],
+  defaultCars: 1,
+  elevatorDefaults: {
+    maxSpeed: 50.0,
+    acceleration: 10.0,
+    deceleration: 15.0,
+    weightCapacity: 10000.0,
+    doorOpenTicks: 120,
+    doorTransitionTicks: 30,
+  },
+  // Space elevator's operating envelope is two orders of magnitude
+  // away from a building. Bigger steps, no car-count tweaking
+  // (only 2 stops; multiple climbers on a tether is its own can of worms).
+  tweakRanges: {
+    cars: { min: 1, max: 1, step: 1 },
+    maxSpeed: { min: 5, max: 100, step: 5 },
+    weightCapacity: { min: 1000, max: 20000, step: 1000 },
+    doorCycleSec: { min: 2, max: 8, step: 0.5 },
+  },
+  passengerMeanIntervalTicks: 900,
+  passengerWeightRange: [60.0, 90.0],
   ron: `SimConfig(
     building: BuildingConfig(
         name: "Orbital Tether",

--- a/playground/src/sim.ts
+++ b/playground/src/sim.ts
@@ -39,6 +39,14 @@ interface WasmSimInstance {
   setEtdWithWaitSquaredWeight?(weight: number): void;
   setDcsWithCommitmentWindow?(windowTicks: bigint): void;
   setRepositionPredictiveParking?(windowTicks: bigint): void;
+  // Live elevator-physics setters (uniform across every car). Optional
+  // until a fresh wasm-pack build ships them; the playground falls back
+  // to a sim rebuild when absent so a stale `public/pkg/` doesn't break
+  // local dev.
+  setMaxSpeedAll?(speed: number): void;
+  setWeightCapacityAll?(capacityKg: number): void;
+  setDoorOpenTicksAll?(ticks: number): void;
+  setDoorTransitionTicksAll?(ticks: number): void;
 }
 
 let modPromise: Promise<WasmModule> | null = null;
@@ -132,6 +140,35 @@ export class Sim {
 
   waitingCountAt(stopId: number): number {
     return this.#inner.waitingCountAt(stopId);
+  }
+
+  /**
+   * Hot-swap building physics across every elevator. Returns `true`
+   * when the wasm setters were available and applied; `false` when
+   * the live build predates them (caller can fall back to a full
+   * sim rebuild). All four parameters are applied as a unit so a
+   * partial swap can't leave the sim in an inconsistent state.
+   */
+  applyPhysicsLive(params: {
+    maxSpeed: number;
+    weightCapacityKg: number;
+    doorOpenTicks: number;
+    doorTransitionTicks: number;
+  }): boolean {
+    const w = this.#inner;
+    if (
+      !w.setMaxSpeedAll ||
+      !w.setWeightCapacityAll ||
+      !w.setDoorOpenTicksAll ||
+      !w.setDoorTransitionTicksAll
+    ) {
+      return false;
+    }
+    w.setMaxSpeedAll(params.maxSpeed);
+    w.setWeightCapacityAll(params.weightCapacityKg);
+    w.setDoorOpenTicksAll(params.doorOpenTicks);
+    w.setDoorTransitionTicksAll(params.doorTransitionTicks);
+    return true;
   }
 
   /**

--- a/playground/src/sim.ts
+++ b/playground/src/sim.ts
@@ -164,11 +164,22 @@ export class Sim {
     ) {
       return false;
     }
-    w.setMaxSpeedAll(params.maxSpeed);
-    w.setWeightCapacityAll(params.weightCapacityKg);
-    w.setDoorOpenTicksAll(params.doorOpenTicks);
-    w.setDoorTransitionTicksAll(params.doorTransitionTicks);
-    return true;
+    // Each `setAll` is a `wasm_bindgen` function that throws on the
+    // underlying `SimError` (validation failures, non-finite inputs).
+    // Slider bounds plus `Math.max(1, ...)` in params.ts mean we
+    // shouldn't hit that path — but if we do, swallow the throw and
+    // report "not all live" so the caller falls back to a full
+    // `resetAll` rather than leaving the sim partially mutated (which
+    // in compare mode could desync the two panes).
+    try {
+      w.setMaxSpeedAll(params.maxSpeed);
+      w.setWeightCapacityAll(params.weightCapacityKg);
+      w.setDoorOpenTicksAll(params.doorOpenTicks);
+      w.setDoorTransitionTicksAll(params.doorTransitionTicks);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -189,6 +189,196 @@ select:focus-visible {
   white-space: nowrap;
 }
 
+/* ── Tweak panel ───────────────────────────────────────────────────── */
+
+.tweak-panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(290px, 1fr));
+  gap: 10px 18px;
+  padding: 12px 20px 14px;
+  background: linear-gradient(180deg, var(--ink-1) 0%, var(--ink-0) 100%);
+  border-bottom: 1px solid var(--line-1);
+  font-variant-numeric: tabular-nums;
+  animation: tweak-slide var(--t-norm) ease-out;
+}
+.tweak-panel[hidden] {
+  display: none;
+}
+@keyframes tweak-slide {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.tweak-row {
+  display: grid;
+  grid-template-columns: minmax(110px, 1fr) auto auto auto;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  background: var(--ink-2);
+  border: 1px solid var(--line-1);
+  border-radius: var(--r-2);
+  transition:
+    border-color var(--t-norm),
+    background var(--t-norm);
+}
+.tweak-row[data-overridden="true"] {
+  border-color: rgba(6, 194, 181, 0.35);
+  background: linear-gradient(180deg, var(--accent-soft) 0%, var(--ink-2) 100%);
+}
+
+.tweak-label {
+  font-size: 11.5px;
+  color: var(--fg-1);
+  font-weight: 500;
+  letter-spacing: 0.005em;
+}
+.tweak-unit {
+  color: var(--fg-3);
+  font-size: 10.5px;
+  margin-left: 4px;
+}
+
+.tweak-stepper {
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  background: var(--ink-1);
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-2);
+  overflow: hidden;
+}
+.tweak-stepper button {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--fg-1);
+  width: 26px;
+  height: 28px;
+  padding: 0;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background var(--t-quick),
+    color var(--t-quick);
+  box-shadow: none;
+  border-radius: 0;
+  letter-spacing: 0;
+}
+.tweak-stepper button:hover {
+  background: var(--ink-3);
+  color: var(--fg-0);
+  transform: none;
+  box-shadow: none;
+}
+.tweak-stepper button:active {
+  background: var(--ink-4);
+}
+.tweak-stepper button:disabled {
+  color: var(--fg-3);
+  cursor: not-allowed;
+  background: transparent;
+}
+.tweak-value {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 56px;
+  height: 28px;
+  padding: 0 8px;
+  color: var(--fg-0);
+  font-size: 12.5px;
+  font-weight: 500;
+  border-left: 1px solid var(--line-2);
+  border-right: 1px solid var(--line-2);
+  background: var(--ink-2);
+  font-variant-numeric: tabular-nums;
+}
+.tweak-row[data-overridden="true"] .tweak-value {
+  color: var(--accent);
+}
+
+.tweak-default {
+  font-size: 10.5px;
+  color: var(--fg-3);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+.tweak-default-v {
+  color: var(--fg-2);
+  font-variant-numeric: tabular-nums;
+}
+
+.tweak-reset {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--line-2);
+  color: var(--fg-2);
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  padding: 4px 8px;
+  border-radius: var(--r-1);
+  cursor: pointer;
+  transition:
+    color var(--t-quick),
+    border-color var(--t-quick),
+    background var(--t-quick);
+  box-shadow: none;
+}
+.tweak-reset:hover {
+  color: var(--fg-0);
+  border-color: var(--line-3);
+  background: var(--ink-3);
+  transform: none;
+  box-shadow: none;
+}
+
+.tweak-foot {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 4px;
+  font-size: 11px;
+  color: var(--fg-3);
+}
+.tweak-foot-hint {
+  flex: 1;
+}
+#tweak-reset-all {
+  font-size: 11px;
+  padding: 5px 10px;
+  background: transparent;
+  border: 1px solid var(--line-2);
+  color: var(--fg-2);
+  letter-spacing: 0.01em;
+}
+#tweak-reset-all:hover {
+  background: var(--ink-3);
+  color: var(--fg-0);
+  border-color: var(--line-3);
+  box-shadow: none;
+  transform: none;
+}
+
+/* The "Tweak parameters" trigger echoes the play button's accent
+ * treatment when the panel is open so it's visually clear the panel
+ * is the active surface. */
+#tweak[aria-expanded="true"] {
+  color: var(--accent);
+  border-color: rgba(6, 194, 181, 0.35);
+  background: linear-gradient(180deg, rgba(6, 194, 181, 0.12) 0%, rgba(6, 194, 181, 0.04) 100%);
+}
+
 .ctl {
   display: flex;
   flex-direction: column;

--- a/playground/src/types.ts
+++ b/playground/src/types.ts
@@ -102,6 +102,57 @@ export type ScenarioHook =
   // marker is purely for UI narration (label + description).
   | { kind: "bypass_narration" };
 
+/**
+ * Per-elevator physics defaults applied uniformly when the playground
+ * builds a scenario's RON. Mirrors a subset of `ElevatorConfig`'s
+ * fields — only the ones the "Tweak parameters" drawer surfaces (plus
+ * fixed-by-scenario fields like accel/decel and bypass that ride along
+ * but aren't user-tunable in v1).
+ *
+ * Times use ticks at the canonical 60 Hz simulation rate so they match
+ * the engine's storage form directly (no conversion at the boundary).
+ */
+export interface ElevatorPhysics {
+  /** Maximum travel speed (m/s). */
+  maxSpeed: number;
+  /** Acceleration (m/s²). Not user-tweakable in v1; kept here so RON regen is faithful. */
+  acceleration: number;
+  /** Deceleration (m/s²). Not user-tweakable in v1; kept here so RON regen is faithful. */
+  deceleration: number;
+  /** Weight capacity (kg). */
+  weightCapacity: number;
+  /** Door dwell ticks (60 Hz). */
+  doorOpenTicks: number;
+  /** Door open/close transition ticks (60 Hz). */
+  doorTransitionTicks: number;
+  /** Optional full-load up-direction bypass threshold (0..1). */
+  bypassLoadUpPct?: number;
+  /** Optional full-load down-direction bypass threshold (0..1). */
+  bypassLoadDownPct?: number;
+}
+
+/** Bounds for a single tweakable parameter (slider min/max/step). */
+export interface TweakRange {
+  min: number;
+  max: number;
+  step: number;
+}
+
+/**
+ * Per-scenario tweak bounds for the four user-facing knobs. Exists so
+ * the space elevator (50 m/s climbers, 1000 m shaft, 1 car) can have
+ * sane bounds distinct from a commercial building.
+ */
+export interface TweakRanges {
+  cars: TweakRange;
+  /** Max speed in m/s. */
+  maxSpeed: TweakRange;
+  /** Weight capacity in kg. */
+  weightCapacity: TweakRange;
+  /** Combined door cycle time in seconds (dwell + 2× transition). */
+  doorCycleSec: TweakRange;
+}
+
 export interface ScenarioMeta {
   id: string;
   label: string;
@@ -121,6 +172,33 @@ export interface ScenarioMeta {
   hook: ScenarioHook;
   /** One-line narrative shown alongside the feature hook to frame what to watch for. */
   featureHint: string;
+  /**
+   * Building name as it appears in the RON `BuildingConfig.name` field.
+   * Used by the "Tweak parameters" drawer to regenerate RON when the
+   * car count changes (every other RON section is preserved verbatim).
+   */
+  buildingName: string;
+  /** Stops in scenario order, mirroring the RON `stops:` array. */
+  stops: Array<{ name: string; positionM: number }>;
+  /**
+   * Number of elevators in the scenario's canonical RON. The drawer
+   * displays this as the "default" badge and resets to it when the
+   * user clicks the reset chevron on the cars stepper.
+   */
+  defaultCars: number;
+  /**
+   * Per-elevator defaults applied to every car when regenerating RON
+   * for a different car count or under user overrides. Single template
+   * because every scenario today uses identical physics across its
+   * cars; per-elevator tunability is a future expansion.
+   */
+  elevatorDefaults: ElevatorPhysics;
+  /** Bounds the drawer uses for each slider. */
+  tweakRanges: TweakRanges;
+  /** Mean spawn interval in ticks at 60 Hz (RON `passenger_spawning.mean_interval_ticks`). */
+  passengerMeanIntervalTicks: number;
+  /** Rider weight range in kg, for the RON `passenger_spawning.weight_range`. */
+  passengerWeightRange: [number, number];
   /**
    * Time a rider will wait before abandoning the queue, in simulated
    * seconds. Prevents scenarios whose peak phases run above the


### PR DESCRIPTION
## Summary

- Adds a "Tweak parameters" drawer to the playground with stepped controls for **car count**, **max speed**, **weight capacity**, and **door cycle time**.
- Three of the four knobs hot-swap **live** (no metric reset) via new uniform setters on `WasmSim` (`setMaxSpeedAll`, `setWeightCapacityAll`, `setDoorOpenTicksAll`, `setDoorTransitionTicksAll`) that wrap the existing `Simulation::set_*` mutators. Car-count changes regenerate the RON and rebuild the sim.
- Overrides are encoded **compactly** into the permalink (only non-default keys); shared customizations auto-open the drawer for the recipient.
- Each scenario now exposes a structured `elevatorDefaults` template + `tweakRanges`, with a drift-guard test that the parsed values match the embedded RON literal.

The drawer is closed by default — first-time visitors meet the unchanged playground; the curious click "Tweak parameters" to dive in. Switching scenarios clears overrides because each scenario has its own physics envelope (a 0.5 m/s slider value makes sense for residential, not for the space elevator).

## Test plan
- [ ] `cargo clippy -p elevator-wasm --target wasm32-unknown-unknown -- -D warnings` clean
- [ ] `cargo test -p elevator-core --all-features` passes
- [ ] `pnpm test` in `playground/` — 47 tests green (19 new in `params.test.ts`, 9 new in `permalink.test.ts`)
- [ ] `pnpm typecheck` clean
- [ ] `pnpm build` produces a static bundle without errors
- [ ] Manual: open the drawer, bump max speed → cars visibly accelerate without metrics resetting
- [ ] Manual: change cars from 3 → 1 on skyscraper → sim rebuilds, queue grows
- [ ] Manual: tweak a value, click Share → recipient sees the override + auto-opened drawer
- [ ] Manual: switch scenarios → overrides clear; new scenario's defaults appear in the drawer