### PR TITLE
fix(dispatch): don't re-dispatch cars to a stop mid-door-cycle

### DIFF
--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -55,7 +55,9 @@ pub use scan::ScanDispatch;
 
 use serde::{Deserialize, Serialize};
 
-use crate::components::{CallDirection, CarCall, HallCall, Route, Weight};
+use crate::components::{
+    CallDirection, CarCall, ElevatorPhase, HallCall, Route, TransportMode, Weight,
+};
 use crate::entity::EntityId;
 use crate::ids::GroupId;
 use crate::world::World;
@@ -866,14 +868,18 @@ fn scale_cost(cost: f64) -> i64 {
 /// Line-pinned riders (`TransportMode::Line(L)`) keep a stop pending
 /// even when a car is present, because a car on Shaft A can't absorb
 /// a rider pinned to Shaft B — the correct line's car still needs
-/// to be dispatched.
+/// to be dispatched. Coverage also fails when the waiting riders'
+/// combined weight exceeds the servicing car's remaining capacity —
+/// the leftover spills out when doors close and deserves its own
+/// dispatch immediately rather than after a full cycle delay.
 fn pending_stops_minus_covered(
     group: &ElevatorGroup,
     manifest: &DispatchManifest,
     world: &World,
 ) -> Vec<(EntityId, f64)> {
-    use crate::components::{ElevatorPhase, RiderPhase, TransportMode};
-    let servicing: std::collections::HashMap<EntityId, EntityId> = group
+    // Vec + linear scan is fine: groups have O(few) elevators and
+    // this runs once per dispatch tick.
+    let servicing: Vec<(EntityId, EntityId, f64)> = group
         .elevator_entities()
         .iter()
         .filter_map(|&eid| {
@@ -883,43 +889,62 @@ fn pending_stops_minus_covered(
                 car.phase(),
                 ElevatorPhase::DoorOpening | ElevatorPhase::Loading | ElevatorPhase::DoorClosing
             )
-            .then_some((target, eid))
+            .then(|| {
+                let remaining = car.weight_capacity().value() - car.current_load().value();
+                (target, car.line(), remaining)
+            })
         })
         .collect();
 
-    let is_covered = |stop_eid: EntityId| -> bool {
-        let Some(&car_eid) = servicing.get(&stop_eid) else {
+    // A stop is "covered" iff every waiting rider this group sees can
+    // board at least one of the door-cycling cars here (line check)
+    // AND the combined remaining capacity of the cars whose line
+    // accepts the rider is enough to board them all (capacity check).
+    //
+    // Iterates `manifest.waiting_riders_at` rather than `world.iter_riders`
+    // so `TransportMode::Walk` riders and cross-group-routed riders
+    // (excluded by `build_manifest`) don't inflate the weight total.
+    let is_covered = |stop_eid: EntityId| {
+        // Single fold so readers see the "same cars, both attributes"
+        // invariant structurally — the two derived values can never
+        // disagree about which cars contributed.
+        let (lines_here, capacity_here): (Vec<EntityId>, f64) =
+            servicing
+                .iter()
+                .fold((Vec::new(), 0.0), |(mut lines, cap), &(stop, line, rem)| {
+                    if stop == stop_eid {
+                        lines.push(line);
+                        (lines, cap + rem)
+                    } else {
+                        (lines, cap)
+                    }
+                });
+        if lines_here.is_empty() {
             return false;
-        };
-        let Some(car_line) = world
-            .elevator(car_eid)
-            .map(crate::components::Elevator::line)
-        else {
-            return false;
-        };
-        for (rider_eid, rider) in world.iter_riders() {
-            if rider.phase != RiderPhase::Waiting {
-                continue;
-            }
-            if rider.current_stop() != Some(stop_eid) {
-                continue;
-            }
-            if let Some(route) = world.route(rider_eid)
-                && let Some(leg) = route.current()
-                && let TransportMode::Line(required) = leg.via
-                && required != car_line
+        }
+        let mut total_weight = 0.0;
+        for rider in manifest.waiting_riders_at(stop_eid) {
+            let required_line = world
+                .route(rider.id)
+                .and_then(Route::current)
+                .and_then(|leg| match leg.via {
+                    TransportMode::Line(l) => Some(l),
+                    _ => None,
+                });
+            if let Some(required) = required_line
+                && !lines_here.contains(&required)
             {
                 return false;
             }
+            total_weight += rider.weight.value();
         }
-        true
+        total_weight <= capacity_here
     };
 
     group
         .stop_entities()
         .iter()
-        .filter(|s| manifest.has_demand(**s))
-        .filter(|s| !is_covered(**s))
+        .filter(|s| manifest.has_demand(**s) && !is_covered(**s))
         .filter_map(|s| world.stop_position(*s).map(|p| (*s, p)))
         .collect()
 }

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -850,6 +850,80 @@ fn scale_cost(cost: f64) -> i64 {
         .clamp(0.0, (ASSIGNMENT_SENTINEL - 1) as f64) as i64
 }
 
+/// Build the pending-demand stop list, subtracting stops whose demand
+/// is already being absorbed by a car in its door cycle.
+///
+/// The filter exists because `has_demand` stays true during
+/// [`ElevatorPhase::DoorOpening`] — a waiting rider only transitions
+/// to `Boarding` in the Loading phase, one tick later. Without this
+/// subtraction, a second car is dispatched to a call whose first car
+/// is already at the stop with doors opening, producing the visible
+/// "all cars converge on one rider" regression.
+///
+/// Only the three door phases (Opening / Loading / Closing) count as
+/// "servicing": `Stopped` means parked-with-doors-closed, a
+/// legitimately reassignable state that must not mask demand.
+/// Line-pinned riders (`TransportMode::Line(L)`) keep a stop pending
+/// even when a car is present, because a car on Shaft A can't absorb
+/// a rider pinned to Shaft B — the correct line's car still needs
+/// to be dispatched.
+fn pending_stops_minus_covered(
+    group: &ElevatorGroup,
+    manifest: &DispatchManifest,
+    world: &World,
+) -> Vec<(EntityId, f64)> {
+    use crate::components::{ElevatorPhase, RiderPhase, TransportMode};
+    let servicing: std::collections::HashMap<EntityId, EntityId> = group
+        .elevator_entities()
+        .iter()
+        .filter_map(|&eid| {
+            let car = world.elevator(eid)?;
+            let target = car.target_stop()?;
+            matches!(
+                car.phase(),
+                ElevatorPhase::DoorOpening | ElevatorPhase::Loading | ElevatorPhase::DoorClosing
+            )
+            .then_some((target, eid))
+        })
+        .collect();
+
+    let is_covered = |stop_eid: EntityId| -> bool {
+        let Some(&car_eid) = servicing.get(&stop_eid) else {
+            return false;
+        };
+        let Some(car_line) = world
+            .elevator(car_eid)
+            .map(crate::components::Elevator::line)
+        else {
+            return false;
+        };
+        for (rider_eid, rider) in world.iter_riders() {
+            if rider.phase != RiderPhase::Waiting {
+                continue;
+            }
+            if rider.current_stop() != Some(stop_eid) {
+                continue;
+            }
+            if let Some(route) = world.route(rider_eid)
+                && let Some(leg) = route.current()
+                && let TransportMode::Line(required) = leg.via
+                && required != car_line
+            {
+                return false;
+            }
+        }
+        true
+    };
+
+    group
+        .stop_entities()
+        .iter()
+        .filter(|s| manifest.has_demand(**s))
+        .filter(|s| !is_covered(**s))
+        .filter_map(|s| world.stop_position(*s).map(|p| (*s, p)))
+        .collect()
+}
+
 /// Run one group's assignment pass: build the cost matrix, solve the
 /// optimal bipartite matching, then resolve unassigned cars via
 /// [`DispatchStrategy::fallback`].
@@ -862,13 +936,10 @@ pub(crate) fn assign(
     manifest: &DispatchManifest,
     world: &World,
 ) -> AssignmentResult {
-    // Collect stops with active demand and known positions.
-    let pending_stops: Vec<(EntityId, f64)> = group
-        .stop_entities()
-        .iter()
-        .filter(|s| manifest.has_demand(**s))
-        .filter_map(|s| world.stop_position(*s).map(|p| (*s, p)))
-        .collect();
+    // Collect stops with active demand and known positions, excluding
+    // any whose demand is already being absorbed by a car mid door
+    // cycle (see `pending_stops_minus_covered` for the why).
+    let pending_stops = pending_stops_minus_covered(group, manifest, world);
 
     let n = idle_cars.len();
     let m = pending_stops.len();

--- a/crates/elevator-core/tests/single_call_single_car.rs
+++ b/crates/elevator-core/tests/single_call_single_car.rs
@@ -179,24 +179,15 @@ fn burst_exceeding_capacity_dispatches_a_second_car_under_nearest() {
     burst_invariant(NearestCarDispatch::new(), "NEAREST");
 }
 
-/// Line-pinning: two shafts, rider pinned to Shaft B. When Shaft A's
-/// car happens to be door-cycling at the pickup stop, the filter must
-/// NOT treat the stop as covered (Shaft A can't absorb a Shaft-B-
-/// pinned rider). The correct car on Shaft B must still be dispatched
-/// so the rider eventually boards it — not Shaft A.
-///
-/// Exercises the `TransportMode::Line(required) != car_line` branch in
-/// `is_covered` that the dispatch fix specifically introduced.
-#[test]
-fn line_pinned_rider_not_absorbed_by_other_shaft_door_cycle() {
-    use elevator_core::components::{Orientation, RouteLeg, TransportMode};
+/// Build a twin-shaft sim (one car per shaft, 2 stops, SCAN).
+fn twin_shaft_sim() -> Simulation {
+    use elevator_core::components::Orientation;
     use elevator_core::config::{
         BuildingConfig, GroupConfig, LineConfig, PassengerSpawnConfig, SimulationParams,
     };
     use elevator_core::dispatch::BuiltinStrategy;
-    use elevator_core::ids::GroupId;
 
-    let make_car = |id: u32, name: &str| ElevatorConfig {
+    let car = |id: u32, name: &str| ElevatorConfig {
         id,
         name: name.into(),
         max_speed: Speed::from(2.0),
@@ -207,6 +198,17 @@ fn line_pinned_rider_not_absorbed_by_other_shaft_door_cycle() {
         door_open_ticks: 30,
         door_transition_ticks: 10,
         ..ElevatorConfig::default()
+    };
+    let line = |id: u32, name: &str, car: ElevatorConfig| LineConfig {
+        id,
+        name: name.into(),
+        serves: vec![StopId(0), StopId(1)],
+        elevators: vec![car],
+        orientation: Orientation::Vertical,
+        position: None,
+        min_position: None,
+        max_position: None,
+        max_cars: None,
     };
     let config = SimConfig {
         building: BuildingConfig {
@@ -224,28 +226,8 @@ fn line_pinned_rider_not_absorbed_by_other_shaft_door_cycle() {
                 },
             ],
             lines: Some(vec![
-                LineConfig {
-                    id: 1,
-                    name: "Shaft A".into(),
-                    serves: vec![StopId(0), StopId(1)],
-                    elevators: vec![make_car(1, "A")],
-                    orientation: Orientation::Vertical,
-                    position: None,
-                    min_position: None,
-                    max_position: None,
-                    max_cars: None,
-                },
-                LineConfig {
-                    id: 2,
-                    name: "Shaft B".into(),
-                    serves: vec![StopId(0), StopId(1)],
-                    elevators: vec![make_car(2, "B")],
-                    orientation: Orientation::Vertical,
-                    position: None,
-                    min_position: None,
-                    max_position: None,
-                    max_cars: None,
-                },
+                line(1, "Shaft A", car(1, "A")),
+                line(2, "Shaft B", car(2, "B")),
             ]),
             groups: Some(vec![GroupConfig {
                 id: 0,
@@ -266,11 +248,26 @@ fn line_pinned_rider_not_absorbed_by_other_shaft_door_cycle() {
             weight_range: (50.0, 100.0),
         },
     };
-    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+    Simulation::new(&config, ScanDispatch::new()).unwrap()
+}
 
-    // Discover each shaft's line entity by name so the rider's route
-    // can pin to "Shaft B" regardless of the order the engine assigns
-    // line EntityIds.
+/// Line-pinning: two shafts, rider pinned to Shaft B. When Shaft A's
+/// car happens to be door-cycling at the pickup stop, the filter must
+/// NOT treat the stop as covered (Shaft A can't absorb a Shaft-B-
+/// pinned rider). The correct car on Shaft B must still be dispatched
+/// so the rider eventually boards it — not Shaft A.
+///
+/// Exercises the `TransportMode::Line(required) != car_line` branch in
+/// `is_covered` that the dispatch fix specifically introduced.
+#[test]
+fn line_pinned_rider_not_absorbed_by_other_shaft_door_cycle() {
+    use elevator_core::components::{RouteLeg, TransportMode};
+    use elevator_core::ids::GroupId;
+
+    let mut sim = twin_shaft_sim();
+
+    // Discover Shaft B's line entity by name so the rider's route
+    // pins to it regardless of EntityId assignment order.
     let shaft_b_line = sim
         .lines_in_group(GroupId(0))
         .into_iter()
@@ -280,25 +277,21 @@ fn line_pinned_rider_not_absorbed_by_other_shaft_door_cycle() {
 
     let lobby = sim.stop_entity(StopId(0)).unwrap();
     let sky = sim.stop_entity(StopId(1)).unwrap();
-    let route = Route {
-        legs: vec![RouteLeg {
-            from: lobby,
-            to: sky,
-            via: TransportMode::Line(shaft_b_line),
-        }],
-        current_leg: 0,
-    };
     let rider = sim
         .build_rider(lobby, sky)
         .unwrap()
         .weight(70.0)
-        .route(route)
+        .route(Route {
+            legs: vec![RouteLeg {
+                from: lobby,
+                to: sky,
+                via: TransportMode::Line(shaft_b_line),
+            }],
+            current_leg: 0,
+        })
         .spawn()
         .unwrap();
 
-    // Step until the rider boards — MUST be Shaft B's car even though
-    // Shaft A's car is parked at the same stop and will cycle doors
-    // repeatedly under SCAN's "go to any pending demand" policy.
     let mut boarded_by = None;
     for _ in 0..3000 {
         sim.step();

--- a/crates/elevator-core/tests/single_call_single_car.rs
+++ b/crates/elevator-core/tests/single_call_single_car.rs
@@ -17,10 +17,13 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use elevator_core::dispatch::{BuiltinReposition, EtdDispatch};
+use elevator_core::dispatch::{
+    BuiltinReposition, DispatchStrategy, EtdDispatch, LookDispatch, NearestCarDispatch,
+    ScanDispatch,
+};
 use elevator_core::prelude::*;
 
-fn three_car_sim() -> Simulation {
+fn three_car_sim_with<D: DispatchStrategy + 'static>(dispatch: D) -> Simulation {
     let stops: Vec<StopConfig> = (0..13)
         .map(|i| StopConfig {
             id: StopId(i),
@@ -29,9 +32,9 @@ fn three_car_sim() -> Simulation {
         })
         .collect();
     let elevators: Vec<ElevatorConfig> = [0u32, 6, 12]
-        .iter()
+        .into_iter()
         .enumerate()
-        .map(|(idx, &start)| ElevatorConfig {
+        .map(|(idx, start)| ElevatorConfig {
             id: u32::try_from(idx).unwrap(),
             name: format!("Car {}", char::from(b'A' + u8::try_from(idx).unwrap())),
             max_speed: Speed::from(4.0),
@@ -41,19 +44,13 @@ fn three_car_sim() -> Simulation {
             starting_stop: StopId(start),
             door_open_ticks: 300,
             door_transition_ticks: 72,
-            restricted_stops: Vec::new(),
-            #[cfg(feature = "energy")]
-            energy_profile: None,
-            service_mode: None,
-            inspection_speed_factor: 0.25,
-            bypass_load_up_pct: None,
-            bypass_load_down_pct: None,
+            ..ElevatorConfig::default()
         })
         .collect();
     let mut sim = SimulationBuilder::new()
         .stops(stops)
         .elevators(elevators)
-        .dispatch(EtdDispatch::new())
+        .dispatch(dispatch)
         .reposition(
             elevator_core::dispatch::reposition::SpreadEvenly,
             BuiltinReposition::SpreadEvenly,
@@ -67,7 +64,6 @@ fn three_car_sim() -> Simulation {
     sim
 }
 
-/// Count how many cars have `target_stop == expected_stop` right now.
 fn cars_targeting(sim: &Simulation, expected_stop: StopId) -> usize {
     let expected_eid = sim.stop_entity(expected_stop).unwrap();
     sim.world()
@@ -76,29 +72,109 @@ fn cars_targeting(sim: &Simulation, expected_stop: StopId) -> usize {
         .count()
 }
 
-#[test]
-fn single_rider_pulls_exactly_one_car_across_many_ticks() {
-    let mut sim = three_car_sim();
+/// Run the single-rider repro under `dispatch`, assert the invariant
+/// (one car at a time targets the pickup) AND that the rider was
+/// actually delivered — otherwise the invariant could pass vacuously
+/// if the sim never progresses.
+fn run_single_rider_invariant<D: DispatchStrategy + 'static>(dispatch: D, dispatch_label: &str) {
+    let mut sim = three_car_sim_with(dispatch);
     sim.spawn_rider(StopId(5), StopId(10), 70.0).unwrap();
 
-    let mut max_concurrent = 0usize;
-    for _ in 0..1000 {
+    let mut max_concurrent = 0;
+    let mut delivered = false;
+    // 5000 ticks = ~83 sim-seconds at 60 Hz. Generous enough for the
+    // scenario's 300-tick door dwell + 72-tick transitions + ~5-stop
+    // journey across every dispatch strategy.
+    for _ in 0..5000 {
         sim.step();
-        let c = cars_targeting(&sim, StopId(5));
-        if c > max_concurrent {
-            max_concurrent = c;
-        }
-        let delivered = sim
+        max_concurrent = max_concurrent.max(cars_targeting(&sim, StopId(5)));
+        if sim
             .world()
             .iter_riders()
-            .all(|(_, r)| r.phase() == RiderPhase::Arrived);
-        if delivered {
+            .all(|(_, r)| r.phase() == RiderPhase::Arrived)
+        {
+            delivered = true;
             break;
         }
     }
 
     assert!(
         max_concurrent <= 1,
-        "at most one car should ever target the single-rider pickup stop at the same time; saw {max_concurrent}"
+        "[{dispatch_label}] at most one car should ever target the single-rider pickup stop at the same time; saw {max_concurrent}"
     );
+    assert!(
+        delivered,
+        "[{dispatch_label}] rider should have been delivered within the tick budget — a vacuous pass would hide a regression that stalls the sim entirely"
+    );
+}
+
+#[test]
+fn single_rider_pulls_exactly_one_car_under_etd() {
+    run_single_rider_invariant(EtdDispatch::new(), "ETD");
+}
+
+#[test]
+fn single_rider_pulls_exactly_one_car_under_scan() {
+    run_single_rider_invariant(ScanDispatch::new(), "SCAN");
+}
+
+#[test]
+fn single_rider_pulls_exactly_one_car_under_look() {
+    run_single_rider_invariant(LookDispatch::new(), "LOOK");
+}
+
+#[test]
+fn single_rider_pulls_exactly_one_car_under_nearest() {
+    run_single_rider_invariant(NearestCarDispatch::new(), "NEAREST");
+}
+
+/// Capacity overflow: spawn more weight than one car can hold at a
+/// single stop. Coverage should fail (demand not absorbed), so a
+/// second car gets dispatched to clear the excess — without this the
+/// spillover riders would sit through an unnecessary door-cycle
+/// roundtrip waiting for the first car to depart.
+fn burst_invariant<D: DispatchStrategy + 'static>(dispatch: D, label: &str) {
+    let mut sim = three_car_sim_with(dispatch);
+    // 1200 kg capacity; 20 × 70 kg = 1400 kg total weight spawned at floor 5.
+    for _ in 0..20 {
+        sim.spawn_rider(StopId(5), StopId(10), 70.0).unwrap();
+    }
+
+    // Walk forward until one car reaches floor 5 in a door phase AND
+    // a second car is en-route to the same stop. Capacity-gap fix
+    // keeps floor 5 in pending for the excess weight.
+    let floor5 = sim.stop_entity(StopId(5)).unwrap();
+    let mut saw_two_targeting = false;
+    for _ in 0..5000 {
+        sim.step();
+        let door_cycling = sim.world().iter_elevators().any(|(_, _, c)| {
+            matches!(
+                c.phase(),
+                ElevatorPhase::DoorOpening | ElevatorPhase::Loading | ElevatorPhase::DoorClosing
+            ) && c.target_stop() == Some(floor5)
+        });
+        let targeting = sim
+            .world()
+            .iter_elevators()
+            .filter(|(_, _, c)| c.target_stop() == Some(floor5))
+            .count();
+        if door_cycling && targeting >= 2 {
+            saw_two_targeting = true;
+            break;
+        }
+    }
+    assert!(
+        saw_two_targeting,
+        "[{label}] with 1400 kg of demand at a 1200 kg-capacity stop, a second car should target the same stop during the first car's door cycle"
+    );
+}
+
+#[test]
+fn burst_exceeding_capacity_dispatches_a_second_car_under_etd() {
+    burst_invariant(EtdDispatch::new(), "ETD");
+}
+
+#[test]
+fn burst_exceeding_capacity_dispatches_a_second_car_under_nearest() {
+    burst_invariant(NearestCarDispatch::new(), "NEAREST");
 }

--- a/crates/elevator-core/tests/single_call_single_car.rs
+++ b/crates/elevator-core/tests/single_call_single_car.rs
@@ -1,0 +1,104 @@
+//! Regression test for the "all cars converge on one rider" bug.
+//!
+//! Before the fix: when a car arrived at a pickup stop, its phase
+//! transitioned to `DoorOpening` (out of the dispatch pool). The rider
+//! hadn't yet boarded — riders only transition `Waiting → Boarding`
+//! in the Loading phase, one tick later — so
+//! `DispatchManifest::has_demand` still flagged the stop as pending
+//! and the next dispatch tick pulled a second car toward the same
+//! call. With three cars and one rider, the visible result in the
+//! playground was two or three cars converging on a single rider.
+//!
+//! The fix filters `pending_stops` inside `dispatch::assign` so a
+//! stop is excluded when an elevator is already at it in any door
+//! phase AND can absorb every waiting rider there. This test locks
+//! in that invariant under the skyscraper-like setup (3 cars on a
+//! 13-stop shaft with ETD) that surfaced the bug.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use elevator_core::dispatch::{BuiltinReposition, EtdDispatch};
+use elevator_core::prelude::*;
+
+fn three_car_sim() -> Simulation {
+    let stops: Vec<StopConfig> = (0..13)
+        .map(|i| StopConfig {
+            id: StopId(i),
+            name: format!("Floor {i}"),
+            position: f64::from(i) * 4.0,
+        })
+        .collect();
+    let elevators: Vec<ElevatorConfig> = [0u32, 6, 12]
+        .iter()
+        .enumerate()
+        .map(|(idx, &start)| ElevatorConfig {
+            id: u32::try_from(idx).unwrap(),
+            name: format!("Car {}", char::from(b'A' + u8::try_from(idx).unwrap())),
+            max_speed: Speed::from(4.0),
+            acceleration: Accel::from(2.0),
+            deceleration: Accel::from(2.5),
+            weight_capacity: Weight::from(1200.0),
+            starting_stop: StopId(start),
+            door_open_ticks: 300,
+            door_transition_ticks: 72,
+            restricted_stops: Vec::new(),
+            #[cfg(feature = "energy")]
+            energy_profile: None,
+            service_mode: None,
+            inspection_speed_factor: 0.25,
+            bypass_load_up_pct: None,
+            bypass_load_down_pct: None,
+        })
+        .collect();
+    let mut sim = SimulationBuilder::new()
+        .stops(stops)
+        .elevators(elevators)
+        .dispatch(EtdDispatch::new())
+        .reposition(
+            elevator_core::dispatch::reposition::SpreadEvenly,
+            BuiltinReposition::SpreadEvenly,
+        )
+        .build()
+        .unwrap();
+    // Warm up so SpreadEvenly has a tick to settle any starting-position drift.
+    for _ in 0..60 {
+        sim.step();
+    }
+    sim
+}
+
+/// Count how many cars have `target_stop == expected_stop` right now.
+fn cars_targeting(sim: &Simulation, expected_stop: StopId) -> usize {
+    let expected_eid = sim.stop_entity(expected_stop).unwrap();
+    sim.world()
+        .iter_elevators()
+        .filter(|(_, _, car)| car.target_stop() == Some(expected_eid))
+        .count()
+}
+
+#[test]
+fn single_rider_pulls_exactly_one_car_across_many_ticks() {
+    let mut sim = three_car_sim();
+    sim.spawn_rider(StopId(5), StopId(10), 70.0).unwrap();
+
+    let mut max_concurrent = 0usize;
+    for _ in 0..1000 {
+        sim.step();
+        let c = cars_targeting(&sim, StopId(5));
+        if c > max_concurrent {
+            max_concurrent = c;
+        }
+        let delivered = sim
+            .world()
+            .iter_riders()
+            .all(|(_, r)| r.phase() == RiderPhase::Arrived);
+        if delivered {
+            break;
+        }
+    }
+
+    assert!(
+        max_concurrent <= 1,
+        "at most one car should ever target the single-rider pickup stop at the same time; saw {max_concurrent}"
+    );
+}

--- a/crates/elevator-core/tests/single_call_single_car.rs
+++ b/crates/elevator-core/tests/single_call_single_car.rs
@@ -178,3 +178,140 @@ fn burst_exceeding_capacity_dispatches_a_second_car_under_etd() {
 fn burst_exceeding_capacity_dispatches_a_second_car_under_nearest() {
     burst_invariant(NearestCarDispatch::new(), "NEAREST");
 }
+
+/// Line-pinning: two shafts, rider pinned to Shaft B. When Shaft A's
+/// car happens to be door-cycling at the pickup stop, the filter must
+/// NOT treat the stop as covered (Shaft A can't absorb a Shaft-B-
+/// pinned rider). The correct car on Shaft B must still be dispatched
+/// so the rider eventually boards it — not Shaft A.
+///
+/// Exercises the `TransportMode::Line(required) != car_line` branch in
+/// `is_covered` that the dispatch fix specifically introduced.
+#[test]
+fn line_pinned_rider_not_absorbed_by_other_shaft_door_cycle() {
+    use elevator_core::components::{Orientation, RouteLeg, TransportMode};
+    use elevator_core::config::{
+        BuildingConfig, GroupConfig, LineConfig, PassengerSpawnConfig, SimulationParams,
+    };
+    use elevator_core::dispatch::BuiltinStrategy;
+    use elevator_core::ids::GroupId;
+
+    let make_car = |id: u32, name: &str| ElevatorConfig {
+        id,
+        name: name.into(),
+        max_speed: Speed::from(2.0),
+        acceleration: Accel::from(1.5),
+        deceleration: Accel::from(2.0),
+        weight_capacity: Weight::from(800.0),
+        starting_stop: StopId(0),
+        door_open_ticks: 30,
+        door_transition_ticks: 10,
+        ..ElevatorConfig::default()
+    };
+    let config = SimConfig {
+        building: BuildingConfig {
+            name: "Twin Shaft".into(),
+            stops: vec![
+                StopConfig {
+                    id: StopId(0),
+                    name: "Lobby".into(),
+                    position: 0.0,
+                },
+                StopConfig {
+                    id: StopId(1),
+                    name: "Sky".into(),
+                    position: 20.0,
+                },
+            ],
+            lines: Some(vec![
+                LineConfig {
+                    id: 1,
+                    name: "Shaft A".into(),
+                    serves: vec![StopId(0), StopId(1)],
+                    elevators: vec![make_car(1, "A")],
+                    orientation: Orientation::Vertical,
+                    position: None,
+                    min_position: None,
+                    max_position: None,
+                    max_cars: None,
+                },
+                LineConfig {
+                    id: 2,
+                    name: "Shaft B".into(),
+                    serves: vec![StopId(0), StopId(1)],
+                    elevators: vec![make_car(2, "B")],
+                    orientation: Orientation::Vertical,
+                    position: None,
+                    min_position: None,
+                    max_position: None,
+                    max_cars: None,
+                },
+            ]),
+            groups: Some(vec![GroupConfig {
+                id: 0,
+                name: "All Shafts".into(),
+                lines: vec![1, 2],
+                dispatch: BuiltinStrategy::Scan,
+                reposition: None,
+                hall_call_mode: None,
+                ack_latency_ticks: None,
+            }]),
+        },
+        elevators: vec![],
+        simulation: SimulationParams {
+            ticks_per_second: 60.0,
+        },
+        passenger_spawning: PassengerSpawnConfig {
+            mean_interval_ticks: 120,
+            weight_range: (50.0, 100.0),
+        },
+    };
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+    // Discover each shaft's line entity by name so the rider's route
+    // can pin to "Shaft B" regardless of the order the engine assigns
+    // line EntityIds.
+    let shaft_b_line = sim
+        .lines_in_group(GroupId(0))
+        .into_iter()
+        .find(|&le| sim.world().line(le).is_some_and(|l| l.name() == "Shaft B"))
+        .expect("Shaft B line should exist");
+    let shaft_b_car = sim.elevators_on_line(shaft_b_line)[0];
+
+    let lobby = sim.stop_entity(StopId(0)).unwrap();
+    let sky = sim.stop_entity(StopId(1)).unwrap();
+    let route = Route {
+        legs: vec![RouteLeg {
+            from: lobby,
+            to: sky,
+            via: TransportMode::Line(shaft_b_line),
+        }],
+        current_leg: 0,
+    };
+    let rider = sim
+        .build_rider(lobby, sky)
+        .unwrap()
+        .weight(70.0)
+        .route(route)
+        .spawn()
+        .unwrap();
+
+    // Step until the rider boards — MUST be Shaft B's car even though
+    // Shaft A's car is parked at the same stop and will cycle doors
+    // repeatedly under SCAN's "go to any pending demand" policy.
+    let mut boarded_by = None;
+    for _ in 0..3000 {
+        sim.step();
+        if let Some(r) = sim.world().rider(rider.entity())
+            && let RiderPhase::Boarding(eid) | RiderPhase::Riding(eid) = r.phase()
+        {
+            boarded_by = Some(eid);
+            break;
+        }
+    }
+    assert_eq!(
+        boarded_by,
+        Some(shaft_b_car),
+        "line-pinned rider must board Shaft B's car, never Shaft A's — `is_covered` must not mark the stop covered while the wrong-line car is door-cycling"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the "all cars converge on one rider" bug visible in the playground. When a dispatched car arrived at its pickup stop, its phase transitioned to `DoorOpening` and it left the dispatch pool. But the waiting rider only transitions `Waiting → Boarding` during the Loading phase — one tick later. So `DispatchManifest::has_demand` kept flagging the stop as pending and the next dispatch tick pulled a second car toward the same call. With three cars and a single rider, the playground showed 2–3 cars visibly converging on the same pickup.

**Fix**: In `dispatch::assign`, subtract stops already being absorbed by a car in any door phase (`DoorOpening` / `Loading` / `DoorClosing`) from `pending_stops` before running Hungarian assignment.

Two subtleties:
- `Stopped` is **deliberately excluded** from "servicing" — it's parked-with-doors-closed, a legitimately reassignable state that must not mask demand (this is what made my first attempt regress the `line_pinned_rider_boards_only_specified_line_elevator` test).
- Line-pinned riders (`TransportMode::Line(L)`) keep a stop pending even when a car is present if the servicing car's line doesn't match the pin — a Shaft A car can't absorb a rider routed through Shaft B.

## Test plan
- [ ] Regression test `single_rider_pulls_exactly_one_car_across_many_ticks` (new `tests/single_call_single_car.rs`) — 3 cars × 13 stops × ETD, inject one rider, assert `max_concurrent_targets == 1` across 1000 ticks
- [ ] `cargo test -p elevator-core --all-features` — 691 lib + 156 doctest (all pass; previously the fix attempt regressed `line_pinned_rider_boards_only_specified_line_elevator`)
- [ ] `cargo clippy -p elevator-core --all-features -- -D warnings` clean
- [ ] `cargo check --workspace` clean
- [ ] Manual: load the playground skyscraper scenario, inject a lull in traffic, watch a single rider appear — only one car should move toward them