### PR TITLE
ci(bench): include bench name and change% in regression issue body

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -66,12 +66,17 @@ jobs:
           cargo bench -p elevator-core --bench query_bench       -- --save-baseline nightly 2>&1 | tee -a bench-output.log
 
       # Extract any line tagged by Criterion as a significant regression
-      # (`change: ... Performance has regressed.`) and flag them.
+      # (`change: ... Performance has regressed.`) and flag them. `-B 3`
+      # captures the preceding bench-name, `time:`, and `change:` lines so
+      # the resulting issue body actually identifies *which* bench regressed
+      # and by how much, rather than a stack of bare "Performance has
+      # regressed." lines.
       - name: Detect regressions
         id: detect
         run: |
-          if grep -E 'Performance has regressed' bench-output.log > regressions.txt; then
+          if grep -qE 'Performance has regressed' bench-output.log; then
             echo "regressed=true"  >> "$GITHUB_OUTPUT"
+            grep -B 3 -E 'Performance has regressed' bench-output.log > regressions.txt
             echo "== Regressions detected =="
             cat regressions.txt
           else

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.5.2"
+version = "15.5.3"
 dependencies = [
  "criterion",
  "ordered-float",


### PR DESCRIPTION
## Summary

- The nightly bench workflow's regression detector (`grep 'Performance has regressed'`) captured only the bare verdict lines, so the auto-filed issue (#242) read as eight copies of "Performance has regressed." with no bench names or deltas — unactionable.
- Switch to `grep -B 3` so each block in the issue body carries the Criterion bench name, `time:`, and `change:` lines before the verdict.

## What the issue body will look like next run

```
scaling_extreme/500e_5000s_50000r_10ticks
                        time:   [1.4481 s 1.4500 s 1.4517 s]
                        change: [+12.627% +13.254% +13.767%] (p = 0.00 < 0.05)
                        Performance has regressed.
--
query_tuple/10000_entities
                        time:   [1.1589 ms 1.1601 ms 1.1618 ms]
                        change: [+10.660% +11.508% +12.201%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

Verified by re-running the new grep against #242's archived log.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [x] Simulated the new `grep -B 3` pattern locally against the `#242` run log — produces the block layout shown above for all 8 regressions.
- [ ] Next scheduled (or `workflow_dispatch`) nightly will exercise the full path. No way to run end-to-end without a real bench divergence.

Refs #242.