### PR TITLE
fix(dispatch): multi-leg wait-time accounting + drop full-rider scans

### DIFF
--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -28,7 +28,7 @@ use std::collections::HashSet;
 
 use serde::{Deserialize, Serialize};
 
-use crate::components::{DestinationQueue, Direction, ElevatorPhase, TransportMode};
+use crate::components::{DestinationQueue, Direction, ElevatorPhase};
 use crate::entity::EntityId;
 use crate::world::{ExtKey, World};
 
@@ -179,12 +179,7 @@ impl DispatchStrategy for DestinationDispatch {
                 let Some(leg) = route.current() else {
                     continue;
                 };
-                let group_ok = match leg.via {
-                    TransportMode::Group(g) => g == group.id(),
-                    TransportMode::Line(l) => group.lines().iter().any(|li| li.entity() == l),
-                    TransportMode::Walk => false,
-                };
-                if !group_ok {
+                if !group.accepts_leg(leg) {
                     continue;
                 }
                 pending.push((info.id, leg.from, dest, info.weight.value()));
@@ -196,27 +191,26 @@ impl DispatchStrategy for DestinationDispatch {
             world.remove_ext::<AssignedCar>(rid);
         }
 
-        // Pre-compute committed-load per car (riders aboard + already-
-        // assigned waiting riders not yet boarded). Used by cost function
-        // to discourage piling more riders onto an already-full car.
+        // Pre-compute committed-load per candidate car: aboard total
+        // (`current_load`) plus Waiting riders sticky-assigned to it.
+        // Terminal-phase riders whose `AssignedCar` was not cleaned up
+        // are filtered by the `RiderPhase::Waiting` check below.
         let mut committed_load: std::collections::BTreeMap<EntityId, f64> =
             std::collections::BTreeMap::new();
-        for (rid, rider) in world.iter_riders() {
-            use crate::components::RiderPhase;
-            // Count riders whose weight is "committed" to a specific car:
-            // actively aboard (Boarding/Riding) or still-Waiting with a
-            // sticky assignment. Terminal phases (Exiting, Arrived,
-            // Abandoned, Resident, Walking) must not contribute — they no
-            // longer need elevator service, and stale `AssignedCar`
-            // extensions on them would inflate the former car's committed
-            // load until cleared.
-            let car = match rider.phase() {
-                RiderPhase::Riding(c) | RiderPhase::Boarding(c) => Some(c),
-                RiderPhase::Waiting => world.ext::<AssignedCar>(rid).map(|AssignedCar(c)| c),
-                _ => None,
-            };
-            if let Some(c) = car {
-                *committed_load.entry(c).or_insert(0.0) += rider.weight.value();
+        for &eid in &candidate_cars {
+            if let Some(car) = world.elevator(eid) {
+                committed_load.insert(eid, car.current_load().value());
+            }
+        }
+        let waiting_assignments: Vec<(EntityId, EntityId)> = world
+            .ext_map::<AssignedCar>()
+            .map(|m| m.iter().map(|(rid, AssignedCar(c))| (rid, *c)).collect())
+            .unwrap_or_default();
+        for (rid, car) in waiting_assignments {
+            if let Some(rider) = world.rider(rid)
+                && rider.phase() == crate::components::RiderPhase::Waiting
+            {
+                *committed_load.entry(car).or_insert(0.0) += rider.weight.value();
             }
         }
 
@@ -339,15 +333,21 @@ impl DestinationDispatch {
         let ride_time = ride_dist / car.max_speed().value() + door_overhead;
 
         // Fresh stops added: 0, 1, or 2 depending on whether origin/dest
-        // are already queued for this car.
-        let existing: Vec<EntityId> = world
-            .destination_queue(eid)
-            .map_or_else(Vec::new, |q| q.queue().to_vec());
+        // are already queued for this car. Probe the queue slice directly
+        // instead of cloning it — `compute_cost` runs once per
+        // (car, candidate-rider) pair each DCS tick, and at the scale of a
+        // busy commercial group the Vec clone was the dominant allocation
+        // in `pre_dispatch`.
+        let queue_contains = |s: EntityId| {
+            world
+                .destination_queue(eid)
+                .is_some_and(|q| q.queue().contains(&s))
+        };
         let mut new_stops = 0f64;
-        if !existing.contains(&origin) {
+        if !queue_contains(origin) {
             new_stops += 1.0;
         }
-        if !existing.contains(&dest) && dest != origin {
+        if dest != origin && !queue_contains(dest) {
             new_stops += 1.0;
         }
 
@@ -410,18 +410,17 @@ fn assigned_car_within_window(
 /// Drop every sticky [`AssignedCar`] assignment that points at `car_eid`.
 ///
 /// Called by `Simulation::disable` and `Simulation::remove_elevator` when an
-/// elevator leaves service so DCS-routed riders are not stranded behind a
-/// dead reference. Assignments are sticky by design — if no one clears them,
-/// no other car will pick the rider up — so the lifecycle layer is responsible
-/// for invoking this helper at car-loss boundaries.
+/// elevator leaves service, so DCS-routed riders are not stranded behind a
+/// dead reference.
 pub fn clear_assignments_to(world: &mut crate::world::World, car_eid: EntityId) {
     let stale: Vec<EntityId> = world
-        .iter_riders()
-        .filter_map(|(rid, _)| match world.ext::<AssignedCar>(rid) {
-            Some(AssignedCar(c)) if c == car_eid => Some(rid),
-            _ => None,
+        .ext_map::<AssignedCar>()
+        .map(|m| {
+            m.iter()
+                .filter_map(|(rid, AssignedCar(c))| (*c == car_eid).then_some(rid))
+                .collect()
         })
-        .collect();
+        .unwrap_or_default();
     for rid in stale {
         world.remove_ext::<AssignedCar>(rid);
     }
@@ -471,15 +470,21 @@ fn rebuild_car_queue(world: &mut crate::world::World, car_eid: EntityId) {
         }
     };
 
-    // Gather (origin?, dest) pairs from all sticky-assigned riders for this car.
+    // Gather (origin?, dest) pairs from sticky-assigned riders on this car.
+    let assigned_ids: Vec<EntityId> = world
+        .ext_map::<AssignedCar>()
+        .map(|m| {
+            m.iter()
+                .filter_map(|(rid, AssignedCar(c))| (*c == car_eid).then_some(rid))
+                .collect()
+        })
+        .unwrap_or_default();
+
     let mut trips: Vec<Trip> = Vec::new();
-    for (rid, rider) in world.iter_riders() {
-        let Some(AssignedCar(assigned)) = world.ext::<AssignedCar>(rid) else {
+    for rid in assigned_ids {
+        let Some(rider) = world.rider(rid) else {
             continue;
         };
-        if assigned != car_eid {
-            continue;
-        }
         let Some(dest) = world
             .route(rid)
             .and_then(crate::components::Route::current_destination)

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -654,6 +654,20 @@ impl ElevatorGroup {
         &self.stop_entities
     }
 
+    /// Whether this group can serve a rider on `leg`. A `Group(g)` leg
+    /// matches by group id; a `Line(l)` leg matches if `l` belongs to
+    /// this group; `Walk` never rides an elevator.
+    #[must_use]
+    pub fn accepts_leg(&self, leg: &crate::components::RouteLeg) -> bool {
+        match leg.via {
+            crate::components::TransportMode::Group(g) => g == self.id,
+            crate::components::TransportMode::Line(l) => {
+                self.lines.iter().any(|li| li.entity() == l)
+            }
+            crate::components::TransportMode::Walk => false,
+        }
+    }
+
     /// Push a stop entity directly into the group's stop cache.
     ///
     /// Use when a stop belongs to the group for dispatch purposes but is

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -264,12 +264,21 @@ impl Simulation {
 
         if let Some(r) = self.world.rider_mut(id) {
             r.phase = RiderPhase::Waiting;
+            // Reset spawn_tick so manifest wait_ticks measures time since
+            // reroute, not time since the original spawn as a Resident.
+            r.spawn_tick = self.tick;
         }
         self.world.set_route(id, route);
 
         // Reset patience if present.
         if let Some(p) = self.world.patience_mut(id) {
             p.waited_ticks = 0;
+        }
+
+        // A rerouted resident is indistinguishable from a fresh arrival —
+        // record it so predictive parking and `arrivals_at` see the demand.
+        if let Some(log) = self.world.resource_mut::<crate::arrival_log::ArrivalLog>() {
+            log.record(self.tick, stop);
         }
 
         self.metrics.record_reroute();

--- a/crates/elevator-core/src/systems/advance_transient.rs
+++ b/crates/elevator-core/src/systems/advance_transient.rs
@@ -64,12 +64,17 @@ fn handle_exit(
             .rider(id)
             .is_some_and(|r| r.phase() != RiderPhase::Arrived)
         {
-            if let Some(r) = world.rider_mut(id) {
-                r.phase = RiderPhase::Waiting;
-            }
             // Record arrival at transfer stops so the arrival log and
             // dispatch manifest count demand at sky-lobby floors. Reset
-            // `waited_ticks` so per-leg wait is measured, not lifetime.
+            // both `spawn_tick` and `Patience::waited_ticks` so per-leg
+            // wait is measured, not lifetime — `build_manifest` falls
+            // back to `spawn_tick` for riders without Patience, so
+            // resetting only one of the two would leave that path stuck
+            // on the lifetime counter. Matches `reroute_rider`.
+            if let Some(r) = world.rider_mut(id) {
+                r.phase = RiderPhase::Waiting;
+                r.spawn_tick = ctx.tick;
+            }
             if let Some(stop) = world.rider(id).and_then(|r| r.current_stop) {
                 rider_index.insert_waiting(stop, id);
                 if let Some(log) = world.resource_mut::<crate::arrival_log::ArrivalLog>() {
@@ -195,11 +200,11 @@ pub fn run(
     // Time-triggered abandonment: riders with `Preferences::abandon_after_ticks`
     // give up once their *waiting* time exceeds their budget. Uses
     // `Patience::waited_ticks` when available — that counter only
-    // increments while the rider is in `Waiting`, so it correctly
-    // excludes ride time for multi-leg routes. Riders without
-    // `Patience` fall back to `tick - spawn_tick` (a lifetime budget)
-    // which is accurate for single-leg trips, the common case. Runs
-    // after the patience path so both limits can coexist.
+    // increments while the rider is in `Waiting`, so it excludes ride
+    // time for multi-leg routes. Riders without `Patience` fall back
+    // to `tick - spawn_tick`; `handle_exit` and `reroute_rider` reset
+    // `spawn_tick` on every Waiting re-entry, so the fallback is also
+    // per-leg. Runs after the patience path so both limits can coexist.
     let time_abandon: Vec<(EntityId, EntityId)> = world
         .iter_riders()
         .filter_map(|(id, r)| {

--- a/crates/elevator-core/src/systems/advance_transient.rs
+++ b/crates/elevator-core/src/systems/advance_transient.rs
@@ -67,9 +67,17 @@ fn handle_exit(
             if let Some(r) = world.rider_mut(id) {
                 r.phase = RiderPhase::Waiting;
             }
-            // Rider is now Waiting at their current_stop — add to index.
+            // Record arrival at transfer stops so the arrival log and
+            // dispatch manifest count demand at sky-lobby floors. Reset
+            // `waited_ticks` so per-leg wait is measured, not lifetime.
             if let Some(stop) = world.rider(id).and_then(|r| r.current_stop) {
                 rider_index.insert_waiting(stop, id);
+                if let Some(log) = world.resource_mut::<crate::arrival_log::ArrivalLog>() {
+                    log.record(ctx.tick, stop);
+                }
+                if let Some(p) = world.patience_mut(id) {
+                    p.waited_ticks = 0;
+                }
             }
         }
     } else if let Some(r) = world.rider_mut(id) {

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -1,6 +1,6 @@
 //! Phase 2: assign idle/stopped elevators to stops via the dispatch strategy.
 
-use crate::components::{ElevatorPhase, RiderPhase, Route, TransportMode};
+use crate::components::{ElevatorPhase, Route};
 use crate::dispatch::{
     self, DispatchDecision, DispatchManifest, DispatchStrategy, ElevatorGroup, RiderInfo,
 };
@@ -331,39 +331,31 @@ pub fn build_manifest(
 ) -> DispatchManifest {
     let mut manifest = DispatchManifest::default();
 
-    // Waiting riders at this group's stops.
-    for (rid, rider) in world.iter_riders() {
-        if world.is_disabled(rid) {
-            continue;
-        }
-        if rider.phase != RiderPhase::Waiting {
-            continue;
-        }
-        if let Some(stop) = rider.current_stop
-            && group.stop_entities().contains(&stop)
-        {
-            // Group/line match: only include riders whose current route leg targets
-            // this group (or one of its lines). Mirrors the filter in systems/loading.rs
-            // so dispatch and loading agree about which riders this group can serve.
-            if let Some(route) = world.route(rid)
-                && let Some(leg) = route.current()
-            {
-                match leg.via {
-                    TransportMode::Group(g) => {
-                        if g != group.id() {
-                            continue;
-                        }
-                    }
-                    TransportMode::Line(l) => {
-                        if !group.lines().iter().any(|line| line.entity() == l) {
-                            continue;
-                        }
-                    }
-                    TransportMode::Walk => continue,
-                }
+    // Per-stop index is O(waiting_riders_in_group); iter_riders would be
+    // O(total_riders · groups) and would include residents.
+    for &stop in group.stop_entities() {
+        for &rid in rider_index.waiting_at(stop) {
+            if world.is_disabled(rid) {
+                continue;
             }
-            let destination = world.route(rid).and_then(Route::current_destination);
-            let wait_ticks = tick.saturating_sub(rider.spawn_tick);
+            let Some(rider) = world.rider(rid) else {
+                continue;
+            };
+            // Route-less riders are untargeted demand; routed riders must
+            // match a leg this group can serve.
+            let route = world.route(rid);
+            if let Some(leg) = route.and_then(Route::current)
+                && !group.accepts_leg(leg)
+            {
+                continue;
+            }
+            let destination = route.and_then(Route::current_destination);
+            // `Patience::waited_ticks` resets each leg; `spawn_tick` is a
+            // lifetime counter that overcounts wait at transfer stops.
+            let wait_ticks = world.patience(rid).map_or_else(
+                || tick.saturating_sub(rider.spawn_tick),
+                crate::components::Patience::waited_ticks,
+            );
             manifest
                 .waiting_at_stop
                 .entry(stop)

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -66,7 +66,11 @@ enum LoadAction {
 
 /// Read-only pass: inspect world state and collect one `LoadAction` per elevator.
 #[allow(clippy::too_many_lines)]
-fn collect_actions(world: &World, elevator_ids: &[EntityId]) -> Vec<LoadAction> {
+fn collect_actions(
+    world: &World,
+    elevator_ids: &[EntityId],
+    rider_index: &RiderIndex,
+) -> Vec<LoadAction> {
     let mut actions: Vec<LoadAction> = Vec::new();
 
     for &eid in elevator_ids {
@@ -123,109 +127,112 @@ fn collect_actions(world: &World, elevator_ids: &[EntityId]) -> Vec<LoadAction> 
         // rider wants to go the opposite direction from the car's indicator.
         let mut direction_filtered: Option<EntityId> = None;
 
-        let board_rider = world.iter_riders().find_map(|(rid, rider)| {
-            if world.is_disabled(rid) {
-                return None;
-            }
-            if rider.phase != RiderPhase::Waiting || rider.current_stop != Some(current_stop) {
-                return None;
-            }
-            // Must want to depart from this stop (check route leg origin).
-            let route_ok = world
-                .route(rid)
-                .is_none_or(|route| route.current().is_none_or(|leg| leg.from == current_stop));
-            if !route_ok {
-                return None;
-            }
-            // Sticky hall-call destination assignment: if this rider has been
-            // assigned to another car, the current car must skip them so the
-            // assigned car can pick them up. Stale assignments to a dead or
-            // disabled car are ignored — the rider is fair game for any car —
-            // as a defense against missed cleanup at car-loss boundaries.
-            if let Some(crate::dispatch::AssignedCar(assigned)) =
-                world.ext::<crate::dispatch::AssignedCar>(rid)
-                && assigned != eid
-                && world.elevator(assigned).is_some()
-                && !world.is_disabled(assigned)
-            {
-                return None;
-            }
-            // Group/line match: rider must want this elevator's group (or specific line).
-            if let Some(route) = world.route(rid)
-                && let Some(leg) = route.current()
-            {
-                match leg.via {
-                    TransportMode::Group(g) => {
-                        if elev_group != Some(g) {
-                            return None;
-                        }
-                    }
-                    TransportMode::Line(l) => {
-                        if elev_line != l {
-                            return None;
-                        }
-                    }
-                    TransportMode::Walk => {
-                        return None; // Walking riders don't board elevators.
-                    }
-                }
-            }
-            // Access control: check rider can reach destination via this elevator.
-            if let Some(dest) = world.route(rid).and_then(Route::current_destination) {
-                if car_restricted_stops.contains(&dest) {
-                    if access_rejected.is_none() {
-                        access_rejected = Some(rid);
-                    }
+        // Per-stop index excludes Residents; iter_riders would scan them all.
+        let board_rider = rider_index
+            .waiting_at(current_stop)
+            .iter()
+            .copied()
+            .find_map(|rid| {
+                if world.is_disabled(rid) {
                     return None;
                 }
-                if let Some(ac) = world.access_control(rid)
-                    && !ac.can_access(dest)
+                let rider = world.rider(rid)?;
+                // Must want to depart from this stop (check route leg origin).
+                let route_ok = world
+                    .route(rid)
+                    .is_none_or(|route| route.current().is_none_or(|leg| leg.from == current_stop));
+                if !route_ok {
+                    return None;
+                }
+                // Sticky hall-call destination assignment: if this rider has been
+                // assigned to another car, the current car must skip them so the
+                // assigned car can pick them up. Stale assignments to a dead or
+                // disabled car are ignored — the rider is fair game for any car —
+                // as a defense against missed cleanup at car-loss boundaries.
+                if let Some(crate::dispatch::AssignedCar(assigned)) =
+                    world.ext::<crate::dispatch::AssignedCar>(rid)
+                    && assigned != eid
+                    && world.elevator(assigned).is_some()
+                    && !world.is_disabled(assigned)
                 {
-                    if access_rejected.is_none() {
-                        access_rejected = Some(rid);
+                    return None;
+                }
+                // Group/line match: rider must want this elevator's group (or specific line).
+                if let Some(route) = world.route(rid)
+                    && let Some(leg) = route.current()
+                {
+                    match leg.via {
+                        TransportMode::Group(g) => {
+                            if elev_group != Some(g) {
+                                return None;
+                            }
+                        }
+                        TransportMode::Line(l) => {
+                            if elev_line != l {
+                                return None;
+                            }
+                        }
+                        TransportMode::Walk => {
+                            return None; // Walking riders don't board elevators.
+                        }
+                    }
+                }
+                // Access control: check rider can reach destination via this elevator.
+                if let Some(dest) = world.route(rid).and_then(Route::current_destination) {
+                    if car_restricted_stops.contains(&dest) {
+                        if access_rejected.is_none() {
+                            access_rejected = Some(rid);
+                        }
+                        return None;
+                    }
+                    if let Some(ac) = world.access_control(rid)
+                        && !ac.can_access(dest)
+                    {
+                        if access_rejected.is_none() {
+                            access_rejected = Some(rid);
+                        }
+                        return None;
+                    }
+                    // Direction indicator filter: rider must be going in a direction
+                    // this car will serve. A filtered rider silently stays waiting —
+                    // no rejection event — so a later car in the right direction can
+                    // pick them up.
+                    let cur_pos = world.position(current_stop).map(|p| p.value);
+                    let dest_pos = world.position(dest).map(|p| p.value);
+                    if let (Some(cp), Some(dp)) = (cur_pos, dest_pos) {
+                        if dp > cp && !car.going_up {
+                            if direction_filtered.is_none() {
+                                direction_filtered = Some(rid);
+                            }
+                            return None;
+                        }
+                        if dp < cp && !car.going_down {
+                            if direction_filtered.is_none() {
+                                direction_filtered = Some(rid);
+                            }
+                            return None;
+                        }
+                    }
+                }
+                // Rider preferences: skip crowded elevators.
+                if let Some(prefs) = world.preferences(rid)
+                    && prefs.skip_full_elevator
+                    && load_ratio > prefs.max_crowding_factor
+                {
+                    if preference_rejected.is_none() {
+                        preference_rejected = Some(rid);
                     }
                     return None;
                 }
-                // Direction indicator filter: rider must be going in a direction
-                // this car will serve. A filtered rider silently stays waiting —
-                // no rejection event — so a later car in the right direction can
-                // pick them up.
-                let cur_pos = world.position(current_stop).map(|p| p.value);
-                let dest_pos = world.position(dest).map(|p| p.value);
-                if let (Some(cp), Some(dp)) = (cur_pos, dest_pos) {
-                    if dp > cp && !car.going_up {
-                        if direction_filtered.is_none() {
-                            direction_filtered = Some(rid);
-                        }
-                        return None;
+                if rider.weight.value() <= remaining_capacity {
+                    Some((rid, rider.weight.value()))
+                } else {
+                    if rejected_candidate.is_none() {
+                        rejected_candidate = Some(rid);
                     }
-                    if dp < cp && !car.going_down {
-                        if direction_filtered.is_none() {
-                            direction_filtered = Some(rid);
-                        }
-                        return None;
-                    }
+                    None
                 }
-            }
-            // Rider preferences: skip crowded elevators.
-            if let Some(prefs) = world.preferences(rid)
-                && prefs.skip_full_elevator
-                && load_ratio > prefs.max_crowding_factor
-            {
-                if preference_rejected.is_none() {
-                    preference_rejected = Some(rid);
-                }
-                return None;
-            }
-            if rider.weight.value() <= remaining_capacity {
-                Some((rid, rider.weight.value()))
-            } else {
-                if rejected_candidate.is_none() {
-                    rejected_candidate = Some(rid);
-                }
-                None
-            }
-        });
+            });
 
         if let Some((rid, weight)) = board_rider {
             actions.push(LoadAction::Board {
@@ -505,6 +512,6 @@ pub fn run(
     elevator_ids: &[EntityId],
     rider_index: &mut RiderIndex,
 ) {
-    let actions = collect_actions(world, elevator_ids);
+    let actions = collect_actions(world, elevator_ids, rider_index);
     apply_actions(actions, world, events, ctx, rider_index);
 }

--- a/crates/elevator-core/src/tests/arrival_log_tests.rs
+++ b/crates/elevator-core/src/tests/arrival_log_tests.rs
@@ -140,6 +140,64 @@ fn arrival_log_is_pruned_by_step() {
 }
 
 #[test]
+fn reroute_records_arrival_and_resets_spawn_tick() {
+    // When `reroute_rider` flips a `Resident` back to `Waiting`, the
+    // controller should see the change as a fresh arrival — otherwise
+    // predictive parking and the dispatch manifest's `arrivals_at`
+    // signal undercount real demand (the resident pressed the button
+    // and is waiting *now*, not at the tick they were settled). The
+    // rider's `spawn_tick` must also be reset so ETD's wait-squared
+    // bonus doesn't treat them as if they'd been waiting since original
+    // spawn, which would saturate the fairness penalty.
+    use crate::components::{RiderPhase, Route};
+    use crate::ids::GroupId;
+
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+
+    // Take the rider to arrival and settle them at StopId(2).
+    for _ in 0..10_000 {
+        sim.step();
+        if sim
+            .world()
+            .rider(rider.entity())
+            .is_some_and(|r| r.phase() == RiderPhase::Arrived)
+        {
+            break;
+        }
+    }
+    sim.settle_rider(rider).unwrap();
+
+    let stop2 = sim.stop_entity(StopId(2)).unwrap();
+    let stop0 = sim.stop_entity(StopId(0)).unwrap();
+    let settle_tick = sim.current_tick();
+
+    // Drop the arrival log so we measure only the reroute-driven entry.
+    if let Some(log) = sim.world_mut().resource_mut::<ArrivalLog>() {
+        log.prune_before(settle_tick + 1);
+    }
+
+    // Reroute: head back down to StopId(0).
+    let route = Route::direct(stop2, stop0, GroupId(0));
+    sim.reroute_rider(rider.entity(), route).unwrap();
+
+    // ArrivalLog must have a fresh entry at StopId(2) — this is where
+    // the rider "appeared" as waiting demand.
+    let count = sim
+        .world()
+        .resource::<ArrivalLog>()
+        .unwrap()
+        .arrivals_in_window(stop2, sim.current_tick(), 10);
+    assert_eq!(count, 1, "reroute must record an arrival at the new origin");
+
+    // spawn_tick advanced so downstream wait-time calcs use the reroute
+    // boundary as their reference, not the original spawn.
+    let r = sim.world().rider(rider.entity()).unwrap();
+    assert_eq!(r.spawn_tick(), sim.current_tick());
+}
+
+#[test]
 fn dispatch_manifest_exposes_recent_arrivals() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();

--- a/playground/src/traffic.ts
+++ b/playground/src/traffic.ts
@@ -97,7 +97,7 @@ export class TrafficDriver {
     const out: RiderSpec[] = [];
     while (this.#accumulator >= 1.0) {
       this.#accumulator -= 1.0;
-      out.push(this.#nextSpec(snapshot, phase));
+      out.push(this.#nextSpec(addressable, phase));
     }
     return out;
   }
@@ -132,8 +132,7 @@ export class TrafficDriver {
     return this.#phases;
   }
 
-  #nextSpec(snap: Snapshot, phase: Phase): RiderSpec {
-    const stops = snap.stops.filter((s) => s.stop_id !== 0xffffffff);
+  #nextSpec(stops: Snapshot["stops"], phase: Phase): RiderSpec {
     const originIdx = this.#pickWeighted(stops.length, phase.originWeights);
     let destIdx = this.#pickWeighted(stops.length, phase.destWeights);
     // Same-stop collisions are a natural result of zero-weight entries

--- a/playground/src/traffic.ts
+++ b/playground/src/traffic.ts
@@ -78,7 +78,14 @@ export class TrafficDriver {
    * dispatching the specs to one or more sims.
    */
   drainSpawns(snapshot: Snapshot, elapsedSeconds: number): RiderSpec[] {
-    if (snapshot.stops.length < 2 || this.#phases.length === 0) return [];
+    if (this.#phases.length === 0) return [];
+    // `stop_id === 0xFFFFFFFF` is the wasm DTO sentinel for stops added
+    // at runtime (absent from the initial config lookup). Feeding it to
+    // `spawn_rider` throws a JsError the scenario caller usually swallows,
+    // so spawns would silently drop. Gate addressable stops here so a
+    // snapshot with &lt;2 addressable stops produces no specs at all.
+    const addressable = snapshot.stops.filter((s) => s.stop_id !== 0xffffffff);
+    if (addressable.length < 2) return [];
     // Clamp to ~4 frames at 60 Hz. When the browser tab is hidden
     // requestAnimationFrame pauses entirely, so on restore the first
     // `elapsedSeconds` is the full hidden duration — which at 120 riders/min
@@ -126,7 +133,7 @@ export class TrafficDriver {
   }
 
   #nextSpec(snap: Snapshot, phase: Phase): RiderSpec {
-    const stops = snap.stops;
+    const stops = snap.stops.filter((s) => s.stop_id !== 0xffffffff);
     const originIdx = this.#pickWeighted(stops.length, phase.originWeights);
     let destIdx = this.#pickWeighted(stops.length, phase.destWeights);
     // Same-stop collisions are a natural result of zero-weight entries


### PR DESCRIPTION
## Summary

Fixes wait-time accounting for multi-leg trips (transfer stops + reroutes) and drops four `iter_riders()` scans that were redundant given existing indexes.

**Correctness (multi-leg fairness):**
- `advance_transient`: transfer-stop re-wait now records to `ArrivalLog` and resets `Patience::waited_ticks` — fixes `PredictiveParking` / `DispatchManifest::arrivals_at` undercounting sky-lobby demand.
- `reroute_rider`: resets `spawn_tick` to the reroute tick and records an arrival — otherwise metrics and ETD treat a rerouted resident as if they'd been waiting since settlement.
- `build_manifest`: `wait_ticks` prefers `Patience::waited_ticks` (per-leg counter) over `tick - spawn_tick` (lifetime counter) — matches `advance_transient`'s abandonment logic.

**Scan cleanup:**
- `build_manifest` + `loading::collect_actions` walk `rider_index.waiting_at(stop)` instead of iterating all riders.
- DCS `pre_dispatch::committed_load` reads `Elevator::current_load` (aboard sum already maintained) + walks the `AssignedCar` ext map for sticky-waiters.
- `rebuild_car_queue` + `clear_assignments_to` walk the ext map directly.
- New `ElevatorGroup::accepts_leg` helper collapses three near-identical group/line-match blocks.

**Playground:** traffic driver filters `stop_id === 0xFFFFFFFF` wasm sentinels so runtime-added stops can't silently drop spawns.

Net: +272/-172 across 8 files. New regression test `reroute_records_arrival_and_resets_spawn_tick`.

## Test plan

- [x] \`cargo test -p elevator-core --all-features\` — 860 tests pass
- [x] \`cargo clippy --workspace --all-features\` — clean
- [x] \`cd playground && npm test\` — 47 tests pass
- [x] Pre-commit hook passes (fmt, clippy, core tests, doc tests, workspace check, Cargo.lock drift guard)