### PR TITLE
fix(dispatch): three correctness-hygiene fixes

### DIFF
--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -397,7 +397,14 @@ fn assigned_car_within_window(
     if !speed.is_finite() || speed <= 0.0 {
         return false;
     }
-    let eta_ticks = (car_pos - origin_pos).abs() / speed;
+    // `distance / speed` is seconds (speed is distance/second); convert
+    // to ticks so `window` is apples-to-apples. Same class of unit fix
+    // as ETD's door-cost conversion (see `etd.rs`). Fall back to 60 Hz
+    // for bare-World fixtures that don't seat a `TickRate` resource.
+    let tick_rate = world
+        .resource::<crate::time::TickRate>()
+        .map_or(60.0, |r| r.0);
+    let eta_ticks = (car_pos - origin_pos).abs() / speed * tick_rate;
     // A non-finite ETA (NaN from corrupted position) would saturate
     // the `as u64` cast to 0 and erroneously latch the commitment —
     // refuse to latch instead.

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -323,6 +323,12 @@ impl Simulation {
             tags.remove_entity(id);
         }
 
+        // Purge stale `pending_riders` entries before the entity slot
+        // is reused. `world.despawn` cleans ext storage keyed on this
+        // rider (e.g. `AssignedCar`) but not back-references living on
+        // stop/car entities.
+        self.world.scrub_rider_from_pending_calls(id);
+
         self.world.despawn(id);
 
         self.events.emit(Event::RiderDespawned {

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -690,6 +690,10 @@ impl Simulation {
                 if let Some(r) = self.world.rider_mut(rid) {
                     r.phase = RiderPhase::Abandoned;
                 }
+                // Fourth abandonment site (alongside the two in
+                // `advance_transient`); same stale-ID hazard. Scrub
+                // the rider from every hall/car-call pending list.
+                self.world.scrub_rider_from_pending_calls(rid);
                 if let Some(stop) = rider_current_stop {
                     self.rider_index.remove_waiting(stop, rid);
                     self.rider_index.insert_abandoned(stop, rid);

--- a/crates/elevator-core/src/systems/advance_transient.rs
+++ b/crates/elevator-core/src/systems/advance_transient.rs
@@ -188,6 +188,10 @@ pub fn run(
         if let Some(r) = world.rider_mut(id) {
             r.phase = RiderPhase::Abandoned;
         }
+        // An abandoned rider is not a waiter any more; leaving their
+        // ID in `pending_riders` would spuriously hold car calls open
+        // and count them in mode-detection `is_empty()` checks.
+        world.scrub_rider_from_pending_calls(id);
         rider_index.remove_waiting(stop, id);
         rider_index.insert_abandoned(stop, id);
         events.emit(Event::RiderAbandoned {
@@ -229,6 +233,7 @@ pub fn run(
         if let Some(r) = world.rider_mut(id) {
             r.phase = RiderPhase::Abandoned;
         }
+        world.scrub_rider_from_pending_calls(id);
         rider_index.remove_waiting(stop, id);
         rider_index.insert_abandoned(stop, id);
         events.emit(Event::RiderAbandoned {

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -437,8 +437,12 @@ pub fn build_manifest(
 
     // Snapshot rolling per-stop arrival rates. Strategies read this via
     // `DispatchManifest::arrivals_at` to drive mode switches and
-    // predictive parking without touching world state directly.
-    let window = crate::arrival_log::DEFAULT_ARRIVAL_WINDOW_TICKS;
+    // predictive parking without touching world state directly. The
+    // window tracks `ArrivalLogRetention` so `set_arrival_log_retention_ticks`
+    // widens what strategies see, not just what the log keeps.
+    let window = world
+        .resource::<crate::arrival_log::ArrivalLogRetention>()
+        .map_or(crate::arrival_log::DEFAULT_ARRIVAL_WINDOW_TICKS, |r| r.0);
     manifest.arrival_window_ticks = window;
     if let Some(log) = world.resource::<crate::arrival_log::ArrivalLog>() {
         for &stop in group.stop_entities() {

--- a/crates/elevator-core/src/tests/destination_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/destination_dispatch_tests.rs
@@ -589,7 +589,10 @@ fn loading_ignores_dangling_assignment_to_dead_car() {
 fn commitment_window_reassigns_when_current_car_is_far() {
     let mut sim = Simulation::new(
         &two_cars_same_group_config(),
-        DestinationDispatch::new().with_commitment_window_ticks(3),
+        // B's travel time to origin is ~240 ticks at 60 Hz (8 units /
+        // 2 m/s = 4 s); a 180-tick window is still outside, so the
+        // commitment has not yet latched.
+        DestinationDispatch::new().with_commitment_window_ticks(180),
     )
     .unwrap();
     sim.world_mut()
@@ -611,9 +614,8 @@ fn commitment_window_reassigns_when_current_car_is_far() {
     sim.world_mut()
         .insert_ext(rid.entity(), AssignedCar(car_b), ASSIGNED_CAR_KEY);
 
-    // One dispatch pass: with `commitment_window_ticks = 3` and B's ETA
-    // of 4 ticks (8 units / 2 speed), the commitment hasn't latched yet,
-    // so the rider is free to migrate to car A (ETA 2 ticks).
+    // One dispatch pass: B is outside the 180-tick commitment window,
+    // so the rider is free to migrate to car A (ETA ~120 ticks).
     sim.step();
 
     assert_eq!(
@@ -629,7 +631,9 @@ fn commitment_window_reassigns_when_current_car_is_far() {
 fn commitment_window_locks_when_current_car_is_close() {
     let mut sim = Simulation::new(
         &two_cars_same_group_config(),
-        DestinationDispatch::new().with_commitment_window_ticks(10),
+        // B's ETA is ~240 ticks at 60 Hz; a 600-tick window comfortably
+        // covers it, so the sticky assignment stays locked.
+        DestinationDispatch::new().with_commitment_window_ticks(600),
     )
     .unwrap();
     sim.world_mut()
@@ -643,8 +647,8 @@ fn commitment_window_locks_when_current_car_is_close() {
     let car_a = elevs[0]; // at pos 0
     let car_b = elevs[1]; // at pos 12
 
-    // Spawn rider at stop 1 (pos 4). Sticky to B. B's ETA ≈ 4 ticks,
-    // well inside the 10-tick commitment window — reassignment denied.
+    // Spawn rider at stop 1 (pos 4). Sticky to B. B's ETA ≈ 240 ticks,
+    // well inside the 600-tick commitment window — reassignment denied.
     let rid = sim.spawn_rider(StopId(1), StopId(2), 70.0).unwrap();
     sim.world_mut()
         .insert_ext(rid.entity(), AssignedCar(car_b), ASSIGNED_CAR_KEY);

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -988,3 +988,61 @@ fn assigned_car_set_on_both_directions_when_car_at_stop() {
          (pre-fix Down stayed None, lying about dispatch state)"
     );
 }
+
+/// Despawning a waiting rider must remove them from the stop's
+/// `HallCall::pending_riders`; leaving their ID in the list keeps a
+/// stale back-reference alive until a car happens to clear the call.
+#[test]
+fn despawn_rider_scrubs_hall_call_pending_riders() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    let rid = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    let origin = sim.stop_entity(StopId(0)).unwrap();
+    assert!(
+        sim.world()
+            .hall_call(origin, CallDirection::Up)
+            .unwrap()
+            .pending_riders
+            .contains(&rid.entity())
+    );
+
+    sim.despawn_rider(rid).unwrap();
+
+    let call = sim.world().hall_call(origin, CallDirection::Up).unwrap();
+    assert!(
+        !call.pending_riders.contains(&rid.entity()),
+        "despawn_rider must scrub the rider from pending_riders"
+    );
+}
+
+/// An abandoning rider stays alive in the world but has stopped
+/// competing for service — their ID must be removed from
+/// `pending_riders` so the call's mode-detection (`is_empty()`) and
+/// load accounting stay accurate.
+#[test]
+fn abandonment_scrubs_hall_call_pending_riders() {
+    use crate::components::Preferences;
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    let rid = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    // Attach a 1-tick patience so the rider abandons immediately.
+    sim.world_mut().set_preferences(
+        rid.entity(),
+        Preferences::default().with_abandon_after_ticks(Some(1)),
+    );
+    let origin = sim.stop_entity(StopId(0)).unwrap();
+
+    // Step enough ticks for time-triggered abandonment to fire.
+    for _ in 0..3 {
+        sim.step();
+    }
+
+    let call = sim.world().hall_call(origin, CallDirection::Up);
+    // The call may either be entirely gone (if cleared by a car
+    // opening doors) or still present — but if present, must not
+    // contain the abandoned rider.
+    if let Some(call) = call {
+        assert!(
+            !call.pending_riders.contains(&rid.entity()),
+            "abandonment must scrub the rider from pending_riders"
+        );
+    }
+}

--- a/crates/elevator-core/src/tests/reroute_tests.rs
+++ b/crates/elevator-core/src/tests/reroute_tests.rs
@@ -198,6 +198,22 @@ fn disable_only_stop_causes_abandonment() {
         })
         .count();
     assert_eq!(invalidated_count, 1);
+
+    // `invalidate_routes_for_stop`'s abandon path is the fourth
+    // rider-abandonment site in the codebase; like the two in
+    // `advance_transient` it must scrub the rider from every hall call
+    // so `pending_riders.is_empty()` stays accurate for mode detection
+    // and car-call cleanup.
+    let origin = sim.stop_entity(StopId(0)).unwrap();
+    let up = sim
+        .world()
+        .hall_call(origin, crate::components::CallDirection::Up);
+    if let Some(call) = up {
+        assert!(
+            !call.pending_riders.contains(&rider.entity()),
+            "stop-disable abandonment must scrub pending_riders"
+        );
+    }
 }
 
 #[test]

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -612,6 +612,27 @@ impl World {
         Some(self.car_calls.entry(car)?.or_default())
     }
 
+    /// Remove `rider` from every hall- and car-call's `pending_riders`
+    /// list, and drop car calls whose list becomes empty as a result.
+    ///
+    /// Call on despawn or abandonment so stale rider IDs don't hold
+    /// calls open past the rider's life. Mirrors the per-exit cleanup
+    /// in `systems::loading` (for `Exit`-time car-call pruning). Hall
+    /// calls stay alive after the list empties: they may still represent
+    /// a script-driven press with no associated rider, and are cleared
+    /// the usual way when an eligible car opens doors.
+    pub(crate) fn scrub_rider_from_pending_calls(&mut self, rider: EntityId) {
+        for call in self.iter_hall_calls_mut() {
+            call.pending_riders.retain(|r| *r != rider);
+        }
+        for calls in self.car_calls.values_mut() {
+            for c in calls.iter_mut() {
+                c.pending_riders.retain(|r| *r != rider);
+            }
+            calls.retain(|c| !c.pending_riders.is_empty());
+        }
+    }
+
     // ── Typed query helpers ──────────────────────────────────────────
 
     /// Iterate all elevator entities (have `Elevator` + `Position`).


### PR DESCRIPTION
## Summary
Three high-confidence bugs surfaced by a parallel gap-finder + reviewer pass on recent dispatch work. All are consistency gaps where one part of the codebase was updated without its siblings.

1. **DCS commitment window was seconds, not ticks.** `assigned_car_within_window` computed `distance / speed` (seconds) and compared against a `u64` window documented as ticks — same class as the ETD audit in #324 (5fcd09d), but in a different call site. Existing tests passed only because both sides of the comparison were wrong the same way. Now reads `TickRate` and converts, mirroring `etd.rs:188-190`.
2. **`build_manifest` ignored `ArrivalLogRetention`.** `set_arrival_log_retention_ticks` widened the log's retention, but dispatch still sampled the last 5 min regardless. Now reads the resource with fallback to `DEFAULT_ARRIVAL_WINDOW_TICKS`.
3. **Stale rider IDs in `pending_riders` on despawn/abandon.** `despawn_rider` and the two abandonment paths in `advance_transient` left the rider's `EntityId` in every `HallCall::pending_riders` / `CarCall::pending_riders`. Slotmap generational keys prevent aliasing, but the garbage breaks `pending_riders.is_empty()` mode-detection (`dispatch/mod.rs:124, 291`) and the empty-list cleanup that drops car calls (`loading.rs:354`). New `World::scrub_rider_from_pending_calls` helper; invoked from all three sites.

## Test plan
- [x] `cargo test -p elevator-core --all-features` — 694 lib + 156 doc, 0 failed
- [x] `cargo clippy --workspace --all-features --tests` — clean
- [x] `cargo check --workspace` — clean
- [x] Two new hall_call tests cover the despawn + abandonment scrub behavior
- [x] Two DCS commitment-window tests updated to realistic 60 Hz values (180 / 600 ticks instead of 3 / 10)
- [x] Pre-commit hook ran clean on all three commits