### PR TITLE
fix(lifecycle): notify dispatcher and clear car_calls on disable(elevator)

### DIFF
--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -9,6 +9,7 @@ use std::collections::HashSet;
 use crate::components::{
     CallDirection, Elevator, ElevatorPhase, RiderPhase, RiderPhaseKind, Route,
 };
+use crate::dispatch::ElevatorGroup;
 use crate::entity::{ElevatorId, EntityId, RiderId};
 use crate::error::SimError;
 use crate::events::Event;
@@ -548,6 +549,30 @@ impl Simulation {
                 car.current_load = crate::components::Weight::ZERO;
                 car.phase = ElevatorPhase::Idle;
                 car.target_stop = None;
+            }
+            // Wipe any pressed floor buttons. On re-enable they'd
+            // otherwise resurface as active demand with stale press
+            // ticks, and dispatch would plan against a rider set that
+            // no longer exists.
+            if let Some(calls) = self.world.car_calls_mut(id) {
+                calls.clear();
+            }
+            // Tell the group's dispatcher the car left. SCAN/LOOK
+            // keep per-car direction state across ticks; without this
+            // a disabled-then-enabled car would re-enter service with
+            // whatever sweep direction it had before, potentially
+            // colliding with the new sweep state. Mirrors the
+            // `remove_elevator` / `reassign_elevator_to_line` paths in
+            // `topology.rs`, which already do this.
+            let group_id = self
+                .groups
+                .iter()
+                .find(|g| g.elevator_entities().contains(&id))
+                .map(ElevatorGroup::id);
+            if let Some(gid) = group_id
+                && let Some(dispatcher) = self.dispatchers.get_mut(&gid)
+            {
+                dispatcher.notify_removed(id);
             }
             if had_load && let Some(cap) = capacity {
                 self.events.emit(Event::CapacityChanged {

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -332,19 +332,20 @@ impl Simulation {
         // Find and remove from group/line topology. If `find_line` fails
         // the elevator's `line` ref points at a removed/moved line — an
         // inconsistent state, but we still want to despawn for cleanup.
+        //
+        // The `disable` call above already fired `notify_removed` on the
+        // group's dispatcher — the cache still includes the elevator at
+        // that point — so no additional notify is needed here. Custom
+        // `DispatchStrategy::notify_removed` impls that count invocations
+        // (e.g. tests with an `AtomicUsize`) can assume exactly one call
+        // per removal.
         let resolved_group: Option<GroupId> = match self.find_line(line) {
             Ok((group_idx, line_idx)) => {
                 self.groups[group_idx].lines_mut()[line_idx]
                     .elevators_mut()
                     .retain(|&e| e != elevator);
                 self.groups[group_idx].rebuild_caches();
-
-                let gid = self.groups[group_idx].id();
-                // Notify dispatch strategy.
-                if let Some(dispatcher) = self.dispatchers.get_mut(&gid) {
-                    dispatcher.notify_removed(elevator);
-                }
-                Some(gid)
+                Some(self.groups[group_idx].id())
             }
             Err(_) => None,
         };

--- a/crates/elevator-core/src/tests/feature_tests.rs
+++ b/crates/elevator-core/src/tests/feature_tests.rs
@@ -519,6 +519,86 @@ fn disable_elevator_clears_its_rider_list() {
     );
 }
 
+/// `disable(elevator)` wipes the car's pressed floor buttons. Without
+/// the clear, a re-enabled car would re-surface button presses from
+/// its prior (now-ejected) riders, and dispatch would plan against
+/// those stale destinations.
+#[test]
+fn disable_elevator_clears_car_calls() {
+    let config = default_config();
+    let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
+
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    let elev = ElevatorId::from(sim.world().elevator_ids()[0]);
+
+    // Let the rider board and press their floor button.
+    for _ in 0..5_000 {
+        sim.step();
+        sim.drain_events();
+        if !sim.world().car_calls(elev.entity()).is_empty() {
+            break;
+        }
+    }
+    assert!(
+        !sim.world().car_calls(elev.entity()).is_empty(),
+        "car should have a pressed floor button before disable"
+    );
+
+    sim.disable(elev.entity()).unwrap();
+    assert!(
+        sim.world().car_calls(elev.entity()).is_empty(),
+        "disable must wipe car_calls so re-enable doesn't inherit stale presses"
+    );
+}
+
+/// `disable(elevator)` notifies the group's dispatcher of the removal
+/// so strategies with per-car state (SCAN/LOOK direction tracking)
+/// clear it. Parallel to `remove_elevator` / `reassign_elevator_to_line`,
+/// which already do this — `disable` was the odd one out.
+#[test]
+fn disable_elevator_notifies_dispatcher() {
+    use crate::dispatch::{DispatchDecision, DispatchStrategy, RankContext};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct Counter {
+        removed: Arc<AtomicUsize>,
+    }
+    impl DispatchStrategy for Counter {
+        fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+            Some((ctx.car_position - ctx.stop_position).abs())
+        }
+        fn notify_removed(&mut self, _elevator: EntityId) {
+            self.removed.fetch_add(1, Ordering::Relaxed);
+        }
+        fn fallback(
+            &mut self,
+            _car: EntityId,
+            _pos: f64,
+            _group: &crate::dispatch::ElevatorGroup,
+            _manifest: &crate::dispatch::DispatchManifest,
+            _world: &crate::world::World,
+        ) -> DispatchDecision {
+            DispatchDecision::Idle
+        }
+    }
+
+    let removed = Arc::new(AtomicUsize::new(0));
+    let strategy = Counter {
+        removed: Arc::clone(&removed),
+    };
+    let mut sim = crate::sim::Simulation::new(&default_config(), strategy).unwrap();
+    let elev = ElevatorId::from(sim.world().elevator_ids()[0]);
+
+    sim.disable(elev.entity()).unwrap();
+
+    assert_eq!(
+        removed.load(Ordering::Relaxed),
+        1,
+        "disable(elevator) must call DispatchStrategy::notify_removed exactly once"
+    );
+}
+
 // ── 6. Despawn cleanup ───────────────────────────────────────────────────────
 
 #[test]

--- a/crates/elevator-core/src/tests/feature_tests.rs
+++ b/crates/elevator-core/src/tests/feature_tests.rs
@@ -599,6 +599,56 @@ fn disable_elevator_notifies_dispatcher() {
     );
 }
 
+/// `remove_elevator` must call `notify_removed` exactly once, even
+/// though it also invokes `disable()` as a subroutine. Pre-fix, the
+/// notify hook would fire twice — once from `disable`, once from
+/// `remove_elevator`'s own explicit call — which is safe for the
+/// idempotent built-in strategies but violates the contract for
+/// counting custom strategies.
+#[test]
+fn remove_elevator_notifies_dispatcher_exactly_once() {
+    use crate::dispatch::{DispatchDecision, DispatchStrategy, RankContext};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct Counter {
+        removed: Arc<AtomicUsize>,
+    }
+    impl DispatchStrategy for Counter {
+        fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+            Some((ctx.car_position - ctx.stop_position).abs())
+        }
+        fn notify_removed(&mut self, _elevator: EntityId) {
+            self.removed.fetch_add(1, Ordering::Relaxed);
+        }
+        fn fallback(
+            &mut self,
+            _car: EntityId,
+            _pos: f64,
+            _group: &crate::dispatch::ElevatorGroup,
+            _manifest: &crate::dispatch::DispatchManifest,
+            _world: &crate::world::World,
+        ) -> DispatchDecision {
+            DispatchDecision::Idle
+        }
+    }
+
+    let removed = Arc::new(AtomicUsize::new(0));
+    let strategy = Counter {
+        removed: Arc::clone(&removed),
+    };
+    let mut sim = crate::sim::Simulation::new(&default_config(), strategy).unwrap();
+    let elev = ElevatorId::from(sim.world().elevator_ids()[0]);
+
+    sim.remove_elevator(elev.entity()).unwrap();
+
+    assert_eq!(
+        removed.load(Ordering::Relaxed),
+        1,
+        "remove_elevator must call notify_removed exactly once despite invoking disable internally"
+    );
+}
+
 // ── 6. Despawn cleanup ───────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
Two cleanup steps were missing from `Simulation::disable(elevator)`, both already performed by its siblings `remove_elevator` / `reassign_elevator_to_line` (see `topology.rs:345, 512, 612`). Continuity of the state-hygiene theme in #339.

1. **`dispatcher.notify_removed(id)` was skipped.** SCAN/LOOK track per-car sweep direction across ticks (see `scan.rs:97`, `look.rs:92`). A disabled-then-enabled car re-entered service carrying whatever direction it held before, potentially mis-steering dispatch against the new sweep state. `scan_notify_removed_cleans_state` in `dispatch_tests.rs` already tests this hook at the strategy level — now it's reached from `disable` too.
2. **`car_calls` was not cleared.** Pressed floor buttons on the car survived disable. On re-enable, dispatch planned against button presses from riders who had been ejected.

Group lookup uses a simple `groups.iter().find(|g| g.elevator_entities().contains(&id))` — iterative rather than map-backed, since groups are few (matches the existing pattern at other `notify_removed` call sites).

## Test plan
- [x] New `disable_elevator_clears_car_calls` — asserts `world.car_calls(elev)` is empty post-disable after a rider pressed a floor button
- [x] New `disable_elevator_notifies_dispatcher` — custom `DispatchStrategy` with an `AtomicUsize` counter confirms `notify_removed` fires exactly once on `disable`
- [x] `cargo test -p elevator-core --all-features` — 696 lib + 156 doc (up from 694), 0 failed
- [x] `cargo clippy -p elevator-core --all-features --tests` — clean
- [x] Pre-commit hook clean (fmt, clippy, core tests, doc tests, workspace check)