### PR TITLE
feat(dispatch): add age_linear_weight to EtdDispatch for starvation avoidance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.5.4"
+version = "15.6.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/dispatch/etd.rs
+++ b/crates/elevator-core/src/dispatch/etd.rs
@@ -35,6 +35,18 @@ pub struct EtdDispatch {
     /// positive values damp the long-wait tail (Aalto EJOR 2016
     /// group-time assignment model).
     pub wait_squared_weight: f64,
+    /// Weight for the linear waiting-age fairness term. Each candidate
+    /// stop's cost is reduced by this weight times the sum of
+    /// `wait_ticks` across waiting riders at the stop, so stops hosting
+    /// older calls win ties without the quadratic blow-up of
+    /// [`wait_squared_weight`](Self::wait_squared_weight). Defaults to
+    /// `0.0` (no bias); positive values implement the linear
+    /// collective-group-control fairness term from Lim 1983 /
+    /// Barney–dos Santos 1985 CGC.
+    ///
+    /// Composes additively with `wait_squared_weight`: users wanting
+    /// the full CGC shape can set both (`k·Σw + λ·Σw²`).
+    pub age_linear_weight: f64,
     /// Positions of every demanded stop in the group, cached by
     /// [`DispatchStrategy::pre_dispatch`] so `rank` avoids rebuilding the
     /// list for every `(car, stop)` pair.
@@ -45,7 +57,8 @@ impl EtdDispatch {
     /// Create a new `EtdDispatch` with default weights.
     ///
     /// Defaults: `wait_weight = 1.0`, `delay_weight = 1.0`,
-    /// `door_weight = 0.5`, `wait_squared_weight = 0.0`.
+    /// `door_weight = 0.5`, `wait_squared_weight = 0.0`,
+    /// `age_linear_weight = 0.0`.
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -53,6 +66,7 @@ impl EtdDispatch {
             delay_weight: 1.0,
             door_weight: 0.5,
             wait_squared_weight: 0.0,
+            age_linear_weight: 0.0,
             pending_positions: SmallVec::new(),
         }
     }
@@ -65,6 +79,7 @@ impl EtdDispatch {
             delay_weight,
             door_weight: 0.5,
             wait_squared_weight: 0.0,
+            age_linear_weight: 0.0,
             pending_positions: SmallVec::new(),
         }
     }
@@ -77,6 +92,7 @@ impl EtdDispatch {
             delay_weight,
             door_weight,
             wait_squared_weight: 0.0,
+            age_linear_weight: 0.0,
             pending_positions: SmallVec::new(),
         }
     }
@@ -96,6 +112,24 @@ impl EtdDispatch {
             "wait_squared_weight must be finite and non-negative, got {weight}"
         );
         self.wait_squared_weight = weight;
+        self
+    }
+
+    /// Turn on the linear waiting-age fairness term. Higher values
+    /// prefer older waiters more aggressively; `0.0` (the default)
+    /// disables. Composes additively with
+    /// [`with_wait_squared_weight`](Self::with_wait_squared_weight).
+    ///
+    /// # Panics
+    /// Panics on non-finite or negative weights, for the same reasons
+    /// as [`with_wait_squared_weight`](Self::with_wait_squared_weight).
+    #[must_use]
+    pub fn with_age_linear_weight(mut self, weight: f64) -> Self {
+        assert!(
+            weight.is_finite() && weight >= 0.0,
+            "age_linear_weight must be finite and non-negative, got {weight}"
+        );
+        self.age_linear_weight = weight;
         self
     }
 }
@@ -146,6 +180,15 @@ impl DispatchStrategy for EtdDispatch {
                 })
                 .sum();
             cost = self.wait_squared_weight.mul_add(-wait_sq, cost).max(0.0);
+        }
+        if self.age_linear_weight > 0.0 {
+            let wait_sum: f64 = ctx
+                .manifest
+                .waiting_riders_at(ctx.stop)
+                .iter()
+                .map(|r| r.wait_ticks as f64)
+                .sum();
+            cost = self.age_linear_weight.mul_add(-wait_sum, cost).max(0.0);
         }
         if cost.is_finite() { Some(cost) } else { None }
     }

--- a/crates/elevator-core/src/tests/etd_age_weight_tests.rs
+++ b/crates/elevator-core/src/tests/etd_age_weight_tests.rs
@@ -1,0 +1,122 @@
+//! Tests for [`crate::dispatch::etd::EtdDispatch::age_linear_weight`] —
+//! the linear waiting-age fairness term (Lim 1983 / Barney–dos Santos
+//! 1985 CGC). Mirrors the existing `wait_squared_weight` test shape in
+//! [`super::etd_mutant_tests`] so the two fairness terms can be
+//! diff-compared by reviewers.
+
+use super::dispatch_tests::{decide_one, spawn_elevator, test_group, test_world};
+use crate::components::Weight;
+use crate::dispatch::etd::EtdDispatch;
+use crate::dispatch::{DispatchDecision, DispatchManifest, RiderInfo};
+
+/// All three constructors default `age_linear_weight` to `0.0`, keeping
+/// ETD's pre-existing behaviour unchanged for callers that don't opt in.
+#[test]
+fn age_linear_weight_default_is_zero() {
+    assert_eq!(EtdDispatch::new().age_linear_weight, 0.0);
+    assert_eq!(EtdDispatch::with_delay_weight(1.5).age_linear_weight, 0.0);
+    assert_eq!(
+        EtdDispatch::with_weights(1.0, 1.0, 0.5).age_linear_weight,
+        0.0
+    );
+}
+
+/// With a positive `age_linear_weight`, two equidistant pickups break
+/// the tie in favor of the stop hosting the older waiter. Counterpart
+/// to `etd_squared_wait_prefers_older_waiting_rider` for the linear
+/// fairness term.
+#[test]
+fn age_linear_weight_prefers_older_waiting_rider() {
+    let (mut world, stops) = test_world();
+    let elev = spawn_elevator(&mut world, 4.0); // at stops[1] (pos 4)
+
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    // Stop at pos 0 — rider waiting 1000 ticks.
+    let old_waiter = world.spawn();
+    manifest
+        .waiting_at_stop
+        .entry(stops[0])
+        .or_default()
+        .push(RiderInfo {
+            id: old_waiter,
+            destination: None,
+            weight: Weight::from(70.0),
+            wait_ticks: 1000,
+        });
+    // Stop at pos 8 — rider waiting only 1 tick.
+    let new_waiter = world.spawn();
+    manifest
+        .waiting_at_stop
+        .entry(stops[2])
+        .or_default()
+        .push(RiderInfo {
+            id: new_waiter,
+            destination: None,
+            weight: Weight::from(70.0),
+            wait_ticks: 1,
+        });
+
+    let mut etd = EtdDispatch::new().with_age_linear_weight(1.0);
+    let decision = decide_one(&mut etd, elev, 4.0, &group, &manifest, &mut world);
+    assert_eq!(
+        decision,
+        DispatchDecision::GoToStop(stops[0]),
+        "positive `age_linear_weight` must bias ETD toward the stop with an older waiter"
+    );
+}
+
+/// A modest `age_linear_weight` must not flip travel-time dominance
+/// when the far stop's extra wait isn't large enough to justify the
+/// detour. Regression guard against too-aggressive bias scales.
+/// Counterpart to `etd_squared_wait_does_not_override_travel_time`.
+#[test]
+fn age_linear_weight_does_not_override_travel_time() {
+    let (mut world, stops) = test_world();
+    let elev = spawn_elevator(&mut world, 0.0);
+
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    let new_waiter = world.spawn();
+    manifest
+        .waiting_at_stop
+        .entry(stops[1])
+        .or_default()
+        .push(RiderInfo {
+            id: new_waiter,
+            destination: None,
+            weight: Weight::from(70.0),
+            wait_ticks: 5,
+        });
+    let older = world.spawn();
+    manifest
+        .waiting_at_stop
+        .entry(stops[3])
+        .or_default()
+        .push(RiderInfo {
+            id: older,
+            destination: None,
+            weight: Weight::from(70.0),
+            wait_ticks: 20,
+        });
+
+    let mut etd = EtdDispatch::new().with_age_linear_weight(0.001);
+    let decision = decide_one(&mut etd, elev, 0.0, &group, &manifest, &mut world);
+    assert_eq!(
+        decision,
+        DispatchDecision::GoToStop(stops[1]),
+        "modest age_linear_weight must not reverse travel-time dominance"
+    );
+}
+
+#[test]
+#[should_panic(expected = "age_linear_weight must be finite and non-negative")]
+fn age_linear_weight_rejects_nan() {
+    let _ = EtdDispatch::new().with_age_linear_weight(f64::NAN);
+}
+
+#[test]
+#[should_panic(expected = "age_linear_weight must be finite and non-negative")]
+fn age_linear_weight_rejects_negative() {
+    let _ = EtdDispatch::new().with_age_linear_weight(-1.0);
+}

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -51,6 +51,7 @@ mod door_control_tests;
 #[cfg(feature = "energy")]
 mod energy_tests;
 mod eta_tests;
+mod etd_age_weight_tests;
 mod etd_mutant_tests;
 mod event_payload_tests;
 mod hall_call_tests;

--- a/docs/src/dispatch-strategies.md
+++ b/docs/src/dispatch-strategies.md
@@ -107,6 +107,7 @@ use elevator_core::dispatch::etd::EtdDispatch;
 
 let etd = EtdDispatch::new();                         // default delay_weight = 1.0
 let etd_conservative = EtdDispatch::with_delay_weight(1.5);  // favor existing riders
+let etd_fair = EtdDispatch::new().with_age_linear_weight(1.0); // linear starvation-avoidance (CGC)
 ```
 
 ## Multi-group dispatch


### PR DESCRIPTION
## Summary

- Adds a linear waiting-age cost term (`age_linear_weight`) to `EtdDispatch`, complementing the existing `wait_squared_weight` with a non-explosive, state-free variant.
- Defaults to `0.0` so existing callers see no behavior change; opt-in via `EtdDispatch::new().with_age_linear_weight(1.0)`.
- Implements the linear piece of Lim 1983 / Barney–dos Santos 1985 collective-group-control (CGC) fairness.

## Why

Convergent finding across three research passes (academic literature, community-authored puzzle-game solutions, and our benchmark coverage gap analysis):
- Academic: dos Santos CGC flags age-based urgency as the cheapest starvation fix.
- Community: leading composite-cost solutions weight call-age as a first-order term (e.g. Bisqwit's 1/10/500 AgeCoeff/DistanceCoeff/WaitingCoeff).
- Our existing `wait_squared_weight` only covers the quadratic form. A linear term is complementary — it captures "total person-ticks waited" without the quadratic's under-prioritisation of a single old waiter vs. several moderate ones (60² = 3600 < 2·30² = 1800).

This PR is the first in a short stack deriving from that research. The brief lives in a throwaway worktree (not in-tree); subsequent PRs will cover `p95_wait_time` metric, `SpawnSchedule` + canonical benchmark scenarios, and `RsrDispatch`.

## What changed

- `crates/elevator-core/src/dispatch/etd.rs`: new public field + builder; new cost-term block in `rank` mirroring the `wait_squared_weight` shape.
- `crates/elevator-core/src/tests/etd_age_weight_tests.rs`: 5 new tests (default is zero, prefers older waiter, doesn't override travel time, rejects NaN, rejects negative).
- `crates/elevator-core/src/tests/mod.rs`: register new test module.
- `docs/src/dispatch-strategies.md`: one-line usage example.
- `Cargo.lock`: sync to `15.6.0` (release-please left it at `15.5.4` on `main`; first cargo build after the release regenerates it).

## Out of scope / deferred

- Quadratic exceedance variant (`age_exceedance_weight` keyed off a rolling wait quantile `T_hi` per CGC) — needs the `p95_wait_time` sample buffer from PR #2 to compute `T_hi` cheaply. Will follow.
- RON config surface exposure for the four ETD weights — scope creep for this PR; proposed as a separate one if there's demand.

## References

- Barney, *History of Lift Traffic Control* (covers Lim 1983 / Barney–dos Santos 1985 CGC): https://liftescalatorlibrary.org/paper_indexing/papers/00000073.pdf
- Aalto EJOR 2016 group-time assignment (already cited in `wait_squared_weight`).

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p elevator-core --all-features -- -D warnings`
- [x] `cargo test -p elevator-core --all-features --lib` — 702 passed (net +5)
- [x] `cargo test -p elevator-core --all-features --doc` — 156 passed
- [x] `cargo check --workspace --all-features --all-targets`
- [x] `scripts/lint-docs.sh`
- [x] Pre-commit hook end-to-end