### PR TITLE
feat(metrics): add p95_wait_time + percentile_wait_time to Metrics

### DIFF
--- a/crates/elevator-core/src/metrics.rs
+++ b/crates/elevator-core/src/metrics.rs
@@ -105,8 +105,7 @@ impl Default for Metrics {
 
 impl Metrics {
     /// Create a new `Metrics` with default throughput window (3600 ticks)
-    /// and default wait-sample capacity
-    /// ([`default_wait_sample_capacity`], 10 000).
+    /// and default wait-sample capacity (10 000).
     #[must_use]
     pub const fn new() -> Self {
         Self {
@@ -182,10 +181,9 @@ impl Metrics {
         self.max_wait_time
     }
 
-    /// 95th-percentile wait time over the last
-    /// [`wait_sample_capacity`](Self::wait_sample_capacity) boardings (ticks).
-    /// Shorthand for `percentile_wait_time(95.0)`. Returns `0` when no
-    /// samples have been recorded.
+    /// 95th-percentile wait time over the last `wait_sample_capacity`
+    /// boardings (ticks). Shorthand for `percentile_wait_time(95.0)`.
+    /// Returns `0` when no samples have been recorded.
     ///
     /// CIBSE and community-benchmark traffic studies score against
     /// percentiles rather than the `(avg, max)` pair alone — max is

--- a/crates/elevator-core/src/metrics.rs
+++ b/crates/elevator-core/src/metrics.rs
@@ -71,14 +71,35 @@ pub struct Metrics {
     delivery_window: VecDeque<u64>,
     /// Window size for throughput calculation.
     pub(crate) throughput_window_ticks: u64,
+    /// Ring buffer of the most-recent wait samples (spawn-to-board ticks).
+    /// Powers [`percentile_wait_time`](Metrics::percentile_wait_time). Capped
+    /// by [`wait_sample_capacity`](Self::wait_sample_capacity); oldest samples
+    /// are evicted when full.
+    #[serde(default)]
+    wait_samples: VecDeque<u64>,
+    /// Maximum number of wait samples retained. `0` disables sampling; the
+    /// default matches [`default_wait_sample_capacity`], ~80 KB of RAM.
+    #[serde(default = "default_wait_sample_capacity")]
+    pub(crate) wait_sample_capacity: usize,
+}
+
+/// Default capacity for the wait-sample ring buffer. 10 000 samples is
+/// enough to keep a stable p95 over multi-hour simulations while bounding
+/// memory at ~80 KB. Exposed as a named function so serde's
+/// `#[serde(default = "...")]` can reference it for schema evolution.
+const fn default_wait_sample_capacity() -> usize {
+    10_000
 }
 
 impl Metrics {
-    /// Create a new `Metrics` with default throughput window (3600 ticks).
+    /// Create a new `Metrics` with default throughput window (3600 ticks)
+    /// and default wait-sample capacity
+    /// ([`default_wait_sample_capacity`], 10 000).
     #[must_use]
     pub fn new() -> Self {
         Self {
             throughput_window_ticks: 3600, // default: 1 minute at 60 tps
+            wait_sample_capacity: default_wait_sample_capacity(),
             ..Default::default()
         }
     }
@@ -87,6 +108,22 @@ impl Metrics {
     #[must_use]
     pub const fn with_throughput_window(mut self, window_ticks: u64) -> Self {
         self.throughput_window_ticks = window_ticks;
+        self
+    }
+
+    /// Set the wait-sample ring buffer capacity (builder pattern). `0`
+    /// disables wait sampling entirely; [`percentile_wait_time`](Self::percentile_wait_time)
+    /// will return 0 once the buffer is empty.
+    ///
+    /// Shrinking below the current sample count truncates from the front
+    /// (oldest samples evicted first) so the retained window always
+    /// represents the most recent waits.
+    #[must_use]
+    pub fn with_wait_sample_capacity(mut self, capacity: usize) -> Self {
+        self.wait_sample_capacity = capacity;
+        while self.wait_samples.len() > capacity {
+            self.wait_samples.pop_front();
+        }
         self
     }
 
@@ -108,6 +145,55 @@ impl Metrics {
     #[must_use]
     pub const fn max_wait_time(&self) -> u64 {
         self.max_wait_time
+    }
+
+    /// 95th-percentile wait time over the last
+    /// [`wait_sample_capacity`](Self::wait_sample_capacity) boardings (ticks).
+    /// Shorthand for `percentile_wait_time(95.0)`. Returns `0` when no
+    /// samples have been recorded.
+    ///
+    /// CIBSE and community-benchmark traffic studies score against
+    /// percentiles rather than the `(avg, max)` pair alone — max is
+    /// dominated by rare outliers, avg hides the tail.
+    #[must_use]
+    pub fn p95_wait_time(&self) -> u64 {
+        self.percentile_wait_time(95.0)
+    }
+
+    /// Wait-time percentile over the retained sample window (ticks).
+    ///
+    /// Uses the "nearest-rank" method: `ceil(p/100 * n)`-th smallest
+    /// sample, clamped into `0..n`. `p = 0.0` returns the minimum,
+    /// `p = 100.0` returns the maximum. Returns `0` when the buffer
+    /// is empty.
+    ///
+    /// # Panics
+    /// Panics if `p` is NaN or outside `[0.0, 100.0]`.
+    #[must_use]
+    pub fn percentile_wait_time(&self, p: f64) -> u64 {
+        assert!(
+            p.is_finite() && (0.0..=100.0).contains(&p),
+            "percentile must be finite and in [0, 100], got {p}"
+        );
+        if self.wait_samples.is_empty() {
+            return 0;
+        }
+        let mut sorted: Vec<u64> = self.wait_samples.iter().copied().collect();
+        sorted.sort_unstable();
+        let n = sorted.len();
+        #[allow(clippy::cast_precision_loss)] // n ≤ capacity, set by user
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let rank = ((p / 100.0) * n as f64).ceil() as usize;
+        let idx = rank.saturating_sub(1).min(n - 1);
+        sorted[idx]
+    }
+
+    /// Number of wait samples currently retained in the ring buffer.
+    /// Useful for tests and HUDs that want to display "5 000 samples
+    /// over last window" style diagnostics.
+    #[must_use]
+    pub fn wait_sample_count(&self) -> usize {
+        self.wait_samples.len()
     }
 
     /// Riders delivered in the current throughput window.
@@ -229,6 +315,12 @@ impl Metrics {
         self.avg_wait_time = self.sum_wait_ticks as f64 / self.boarded_count as f64;
         if wait_ticks > self.max_wait_time {
             self.max_wait_time = wait_ticks;
+        }
+        if self.wait_sample_capacity > 0 {
+            if self.wait_samples.len() == self.wait_sample_capacity {
+                self.wait_samples.pop_front();
+            }
+            self.wait_samples.push_back(wait_ticks);
         }
     }
 

--- a/crates/elevator-core/src/metrics.rs
+++ b/crates/elevator-core/src/metrics.rs
@@ -9,7 +9,7 @@ use std::fmt;
 ///
 /// Games query this via `sim.metrics()` for HUD display, scoring,
 /// or scenario evaluation.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct Metrics {
     // -- Queryable metrics (accessed via getters) --
@@ -91,16 +91,51 @@ const fn default_wait_sample_capacity() -> usize {
     10_000
 }
 
+impl Default for Metrics {
+    /// Delegates to [`Metrics::new`] so `#[derive(Default)]`-on-holders and
+    /// direct `Metrics::default()` callers get the same 3600-tick throughput
+    /// window and 10 000-sample wait buffer that `new()` wires up. Without
+    /// this, the derived `Default` would zero every field — silently
+    /// disabling `p95_wait_time` sampling and collapsing the throughput
+    /// window to an empty range (greptile review of #347).
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Metrics {
     /// Create a new `Metrics` with default throughput window (3600 ticks)
     /// and default wait-sample capacity
     /// ([`default_wait_sample_capacity`], 10 000).
     #[must_use]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
+            avg_wait_time: 0.0,
+            avg_ride_time: 0.0,
+            max_wait_time: 0,
+            throughput: 0,
+            total_delivered: 0,
+            total_abandoned: 0,
+            total_spawned: 0,
+            abandonment_rate: 0.0,
+            total_distance: 0.0,
+            utilization_by_group: BTreeMap::new(),
+            reposition_distance: 0.0,
+            total_moves: 0,
+            total_settled: 0,
+            total_rerouted: 0,
+            #[cfg(feature = "energy")]
+            total_energy_consumed: 0.0,
+            #[cfg(feature = "energy")]
+            total_energy_regenerated: 0.0,
+            sum_wait_ticks: 0,
+            sum_ride_ticks: 0,
+            boarded_count: 0,
+            delivered_count: 0,
+            delivery_window: VecDeque::new(),
             throughput_window_ticks: 3600, // default: 1 minute at 60 tps
+            wait_samples: VecDeque::new(),
             wait_sample_capacity: default_wait_sample_capacity(),
-            ..Default::default()
         }
     }
 

--- a/crates/elevator-core/src/tests/metrics_percentile_tests.rs
+++ b/crates/elevator-core/src/tests/metrics_percentile_tests.rs
@@ -1,0 +1,162 @@
+//! Unit tests for [`crate::metrics::Metrics::percentile_wait_time`] and
+//! the backing wait-sample ring buffer.
+//!
+//! End-to-end sim-driven coverage lives in [`super::metrics_tests`];
+//! these tests exercise the percentile math and buffer eviction logic
+//! in isolation so a regression in either shows up fast and precisely.
+
+use crate::metrics::Metrics;
+
+#[test]
+fn p95_is_zero_on_empty_metrics() {
+    let m = Metrics::new();
+    assert_eq!(m.p95_wait_time(), 0);
+    assert_eq!(m.wait_sample_count(), 0);
+}
+
+#[test]
+fn p95_of_single_sample_equals_that_sample() {
+    let mut m = Metrics::new();
+    m.record_board(42);
+    assert_eq!(m.p95_wait_time(), 42);
+    assert_eq!(m.wait_sample_count(), 1);
+}
+
+/// With uniform samples 1..=100, the 95th-percentile (nearest-rank,
+/// `ceil(0.95 * 100) = 95`, zero-indexed → 94) is 95. This is the
+/// canonical textbook example and pins the percentile formula.
+#[test]
+fn p95_over_uniform_distribution() {
+    let mut m = Metrics::new();
+    for w in 1..=100u64 {
+        m.record_board(w);
+    }
+    assert_eq!(m.p95_wait_time(), 95);
+    // Sanity: p50 ≈ median, p100 = max, p0 = min.
+    assert_eq!(m.percentile_wait_time(50.0), 50);
+    assert_eq!(m.percentile_wait_time(100.0), 100);
+    assert_eq!(m.percentile_wait_time(0.0), 1);
+}
+
+/// Insertion order must not influence the percentile — the ring buffer
+/// is sorted at query time, not insertion time.
+#[test]
+fn percentile_is_insertion_order_independent() {
+    let mut ascending = Metrics::new();
+    let mut descending = Metrics::new();
+    for w in 1..=50u64 {
+        ascending.record_board(w);
+    }
+    for w in (1..=50u64).rev() {
+        descending.record_board(w);
+    }
+    assert_eq!(
+        ascending.p95_wait_time(),
+        descending.p95_wait_time(),
+        "p95 must not depend on record order"
+    );
+}
+
+/// The ring buffer is capacity-bounded; old samples are evicted when
+/// the buffer fills. With capacity 3 and four pushes (10, 20, 30, 40),
+/// the retained window is `[20, 30, 40]`, so p100 = 40 and p0 = 20.
+#[test]
+fn wait_buffer_evicts_oldest_when_full() {
+    let mut m = Metrics::new().with_wait_sample_capacity(3);
+    m.record_board(10);
+    m.record_board(20);
+    m.record_board(30);
+    m.record_board(40); // evicts the 10
+    assert_eq!(m.wait_sample_count(), 3);
+    assert_eq!(m.percentile_wait_time(0.0), 20);
+    assert_eq!(m.percentile_wait_time(100.0), 40);
+}
+
+/// `avg_wait_time` and `max_wait_time` are running accumulators; they
+/// must survive buffer eviction. A regression here would mean a long
+/// sim with many samples starts "forgetting" its own max once the
+/// buffer cycles.
+#[test]
+fn avg_and_max_persist_after_buffer_eviction() {
+    let mut m = Metrics::new().with_wait_sample_capacity(2);
+    m.record_board(1000); // evicted after two more pushes
+    m.record_board(5);
+    m.record_board(10);
+    assert_eq!(
+        m.max_wait_time(),
+        1000,
+        "max_wait_time must reflect all history, not just the ring buffer"
+    );
+    assert_eq!(m.wait_sample_count(), 2);
+}
+
+/// A capacity of 0 disables sampling entirely: record_board still
+/// updates avg/max (checked in a sibling test) but p95 stays 0.
+#[test]
+fn zero_capacity_disables_sampling() {
+    let mut m = Metrics::new().with_wait_sample_capacity(0);
+    for w in 1..=100u64 {
+        m.record_board(w);
+    }
+    assert_eq!(m.wait_sample_count(), 0);
+    assert_eq!(m.p95_wait_time(), 0);
+    // But avg/max still track all boardings.
+    assert_eq!(m.max_wait_time(), 100);
+    assert!(m.avg_wait_time() > 0.0);
+}
+
+/// Shrinking capacity via `with_wait_sample_capacity` truncates from
+/// the oldest end so the retained window is always the most recent
+/// samples.
+#[test]
+fn shrinking_capacity_evicts_oldest_samples() {
+    let mut m = Metrics::new();
+    for w in 1..=10u64 {
+        m.record_board(w);
+    }
+    m = m.with_wait_sample_capacity(3);
+    assert_eq!(m.wait_sample_count(), 3);
+    // Oldest (1, 2, ..., 7) evicted; newest (8, 9, 10) retained.
+    assert_eq!(m.percentile_wait_time(0.0), 8);
+    assert_eq!(m.percentile_wait_time(100.0), 10);
+}
+
+#[test]
+#[should_panic(expected = "percentile must be finite and in [0, 100]")]
+fn percentile_panics_on_nan() {
+    let m = Metrics::new();
+    let _ = m.percentile_wait_time(f64::NAN);
+}
+
+#[test]
+#[should_panic(expected = "percentile must be finite and in [0, 100]")]
+fn percentile_panics_on_negative() {
+    let m = Metrics::new();
+    let _ = m.percentile_wait_time(-1.0);
+}
+
+#[test]
+#[should_panic(expected = "percentile must be finite and in [0, 100]")]
+fn percentile_panics_above_hundred() {
+    let m = Metrics::new();
+    let _ = m.percentile_wait_time(100.5);
+}
+
+/// Snapshot round-trip must preserve the wait samples so post-restore
+/// percentile queries return consistent values — otherwise a scenario
+/// that pauses-and-resumes would see its p95 reset at each restore.
+#[test]
+fn wait_samples_survive_serde_roundtrip() {
+    let mut m = Metrics::new();
+    for w in [10, 20, 30, 40, 50] {
+        m.record_board(w);
+    }
+    let serialized = ron::to_string(&m).expect("serialize");
+    let restored: Metrics = ron::from_str(&serialized).expect("deserialize");
+    assert_eq!(restored.wait_sample_count(), 5);
+    assert_eq!(restored.p95_wait_time(), m.p95_wait_time());
+    assert_eq!(
+        restored.percentile_wait_time(50.0),
+        m.percentile_wait_time(50.0)
+    );
+}

--- a/crates/elevator-core/src/tests/metrics_percentile_tests.rs
+++ b/crates/elevator-core/src/tests/metrics_percentile_tests.rs
@@ -14,6 +14,28 @@ fn p95_is_zero_on_empty_metrics() {
     assert_eq!(m.wait_sample_count(), 0);
 }
 
+/// `Metrics::default()` must match `Metrics::new()` so downstream structs
+/// that derive `Default` and hold a `Metrics` don't silently get wait
+/// sampling disabled (greptile review of #347).
+#[test]
+fn default_matches_new_for_sampling_capacity() {
+    let from_default = Metrics::default();
+    let from_new = Metrics::new();
+    assert_eq!(
+        from_default.wait_sample_capacity,
+        from_new.wait_sample_capacity
+    );
+    assert_eq!(
+        from_default.throughput_window_ticks,
+        from_new.throughput_window_ticks
+    );
+    // Spot-check that the default actually samples: push one, it should retain.
+    let mut m = Metrics::default();
+    m.record_board(100);
+    assert_eq!(m.wait_sample_count(), 1);
+    assert_eq!(m.p95_wait_time(), 100);
+}
+
 #[test]
 fn p95_of_single_sample_equals_that_sample() {
     let mut m = Metrics::new();
@@ -90,7 +112,7 @@ fn avg_and_max_persist_after_buffer_eviction() {
     assert_eq!(m.wait_sample_count(), 2);
 }
 
-/// A capacity of 0 disables sampling entirely: record_board still
+/// A capacity of 0 disables sampling entirely: `record_board` still
 /// updates avg/max (checked in a sibling test) but p95 stays 0.
 #[test]
 fn zero_capacity_disables_sampling() {

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -21,6 +21,7 @@ mod error_tests;
 mod event_serde_tests;
 mod feature_tests;
 mod hooks_tests;
+mod metrics_percentile_tests;
 mod metrics_tests;
 mod movement_tests;
 mod proptest_tests;

--- a/docs/src/events-metrics.md
+++ b/docs/src/events-metrics.md
@@ -113,6 +113,7 @@ let m = sim.metrics();
 println!("Avg wait time:     {:.1} ticks", m.avg_wait_time());
 println!("Avg ride time:     {:.1} ticks", m.avg_ride_time());
 println!("Max wait time:     {} ticks", m.max_wait_time());
+println!("p95 wait time:     {} ticks", m.p95_wait_time());
 println!("Throughput:        {} riders/window", m.throughput());
 println!("Total delivered:   {}", m.total_delivered());
 println!("Total abandoned:   {}", m.total_abandoned());
@@ -128,6 +129,9 @@ println!("Total distance:    {:.1} units", m.total_distance());
 | `avg_wait_time()` | Average ticks from spawn to board, across all riders that boarded |
 | `avg_ride_time()` | Average ticks from board to exit, across all delivered riders |
 | `max_wait_time()` | Longest wait observed (ticks) |
+| `p95_wait_time()` | 95th-percentile wait over the most recent boardings (ticks). CIBSE and community benchmarks score against percentiles rather than avg/max. |
+| `percentile_wait_time(p)` | Wait-time percentile (`0.0..=100.0`) over the retained sample window |
+| `wait_sample_count()` | Number of wait samples currently retained in the ring buffer |
 | `throughput()` | Riders delivered in the current throughput window (default: 3600 ticks) |
 | `total_delivered()` | Cumulative riders successfully delivered |
 | `total_spawned()` | Cumulative riders spawned |


### PR DESCRIPTION
## Summary

- Adds a bounded ring buffer of recent wait samples to `Metrics`.
- New public API: `p95_wait_time()`, `percentile_wait_time(p)`, `wait_sample_count()`.
- Tunable via `Metrics::with_wait_sample_capacity(cap)`; default 10 000 samples (~80 KB), `0` disables sampling.
- 12 new unit tests; 709 total lib tests (+12 net).

## Why

CIBSE traffic studies and community benchmark suites score against wait-time percentiles, not the `(avg, max)` pair alone: `max` is dominated by rare outliers, `avg` hides the tail. This is prerequisite infrastructure for the canonical benchmark scenarios planned in the PR stack (up-peak rate sweep, down-peak mirror, burst-then-silence, full-load cycle, strategy-comparison matrix).

Second in a small stack following research into dispatch algorithms; see #345 for context on the overall plan.

## What changed

- `crates/elevator-core/src/metrics.rs`:
  - New `wait_samples: VecDeque<u64>` ring buffer with `#[serde(default)]`.
  - New `wait_sample_capacity: usize` with `#[serde(default = "default_wait_sample_capacity")]` (returns 10 000).
  - New `with_wait_sample_capacity(cap)` builder; shrinking evicts oldest samples.
  - New `p95_wait_time()`, `percentile_wait_time(p)`, `wait_sample_count()` getters.
  - `record_board` pushes to the ring, evicting the oldest when full.
- `crates/elevator-core/src/tests/metrics_percentile_tests.rs`: 12 new unit tests — empty, single sample, uniform distribution, insertion-order independence, eviction, avg/max persistence after eviction, zero-capacity disable, shrinking, panic on NaN/negative/>100, serde round-trip.
- `crates/elevator-core/src/tests/mod.rs`: register new module.
- `docs/src/events-metrics.md`: add to metric reference table and the usage example.
- `Cargo.lock`: same release-please drift sync as #345.

## Percentile semantics

Uses the nearest-rank method: the `p`-th percentile is the `ceil((p/100) * n)`-th smallest sample (1-indexed), clamped into `0..n` (0-indexed). Canonical behaviour for the textbook 1..=100 distribution:

| `p`   | Expected | Test |
|-------|----------|------|
| 0.0   | 1 | `p95_over_uniform_distribution` |
| 50.0  | 50 | same |
| 95.0  | 95 | same |
| 100.0 | 100 | same |

O(n log n) per query (sort-on-demand). Acceptable for the 10k-sample default; users querying inside a tight loop can configure a smaller capacity.

## Out of scope / follow-ups

- `max_wait_time` continues to track all-time history (not just the ring-buffer window). That's intentional — changing its semantics would be breaking; keeping both is useful. Test `avg_and_max_persist_after_buffer_eviction` pins this.
- Streaming-quantile algorithms (t-digest, P²) not used — simplicity wins for the simulation-library scale; revisit if 10k samples becomes insufficient.
- `sum_of_squares` / stddev / p99 are trivial to add on top; will do in a follow-up if the benchmark scenarios need them.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p elevator-core --all-features -- -D warnings`
- [x] `cargo test -p elevator-core --all-features --lib` — 709 passed (+12 net)
- [x] `cargo test -p elevator-core --all-features --doc` — 156 passed
- [x] `cargo check --workspace --all-features --all-targets`
- [x] `scripts/lint-docs.sh`
- [x] Pre-commit hook end-to-end