### PR TITLE
feat(scenario): add SpawnSchedule builder + multi-floor test helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.6.0"
+version = "15.7.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/scenario.rs
+++ b/crates/elevator-core/src/scenario.rs
@@ -6,6 +6,8 @@ use crate::error::SimError;
 use crate::metrics::Metrics;
 use crate::sim::Simulation;
 use crate::stop::StopId;
+use crate::traffic::TrafficPattern;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 
 /// A timed rider spawn event within a scenario.
@@ -252,5 +254,209 @@ fn evaluate_condition(
             passed: metrics.abandonment_rate() < *threshold,
             actual_value: metrics.abandonment_rate(),
         },
+    }
+}
+
+// ── SpawnSchedule builder ───────────────────────────────────────────
+
+/// Fluent builder for [`TimedSpawn`] sequences that feed [`Scenario::spawns`].
+///
+/// Unifies two common authoring shapes in one place:
+/// - Deterministic bursts (fixed origin/destination, fixed tick or regular
+///   cadence), where exact tick counts matter — e.g. "20 riders leave the
+///   lobby at tick 0", "1 rider every 600 ticks for 10 minutes".
+/// - Poisson draws from a [`TrafficPattern`], where the origin/destination
+///   pair is stochastic but the arrival process is exponential.
+///
+/// The final [`Vec<TimedSpawn>`] is extracted via [`into_spawns`](Self::into_spawns)
+/// and handed to [`Scenario::spawns`]. Scenarios with mixed shapes chain
+/// builders via [`merge`](Self::merge):
+///
+/// ```
+/// use elevator_core::scenario::SpawnSchedule;
+/// use elevator_core::stop::StopId;
+///
+/// let schedule = SpawnSchedule::new()
+///     .burst(StopId(0), StopId(5), 10, 0, 70.0)
+///     .staggered(StopId(0), StopId(3), 5, 1_000, 300, 70.0);
+/// assert_eq!(schedule.len(), 15);
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct SpawnSchedule {
+    /// Accumulated spawns. Order is authoring order;
+    /// [`ScenarioRunner::new`] sorts by tick on construction.
+    spawns: Vec<TimedSpawn>,
+}
+
+impl SpawnSchedule {
+    /// Create an empty schedule.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { spawns: Vec::new() }
+    }
+
+    /// Append `count` identical spawns, all firing on `at_tick`. Use this
+    /// for the classic "crowd appears simultaneously" shape (morning
+    /// stand-up, event dismissal).
+    #[must_use]
+    pub fn burst(
+        mut self,
+        origin: StopId,
+        destination: StopId,
+        count: usize,
+        at_tick: u64,
+        weight: f64,
+    ) -> Self {
+        self.spawns.reserve(count);
+        for _ in 0..count {
+            self.spawns.push(TimedSpawn {
+                tick: at_tick,
+                origin,
+                destination,
+                weight,
+            });
+        }
+        self
+    }
+
+    /// Append `count` spawns starting at `start_tick`, each `stagger_ticks`
+    /// apart. A `stagger_ticks = 0` degenerates to [`burst`](Self::burst).
+    /// Use this for deterministic arrival cadences — e.g. "one rider every
+    /// 10 seconds" — where Poisson variance would obscure the test signal.
+    #[must_use]
+    pub fn staggered(
+        mut self,
+        origin: StopId,
+        destination: StopId,
+        count: usize,
+        start_tick: u64,
+        stagger_ticks: u64,
+        weight: f64,
+    ) -> Self {
+        self.spawns.reserve(count);
+        for i in 0..count as u64 {
+            self.spawns.push(TimedSpawn {
+                tick: start_tick + i * stagger_ticks,
+                origin,
+                destination,
+                weight,
+            });
+        }
+        self
+    }
+
+    /// Append Poisson-distributed spawns from a [`TrafficPattern`] over
+    /// `duration_ticks`, with exponential inter-arrival times of mean
+    /// `mean_interval_ticks`. `weight_range` is a uniform draw per spawn.
+    /// The supplied `rng` advances but is not taken — callers can continue
+    /// using it for other deterministic draws.
+    ///
+    /// `stops` must be sorted by position (lobby first) to match
+    /// [`TrafficPattern`]'s lobby-origin peak-pattern assumption. See
+    /// [`TrafficPattern::sample_stop_ids`].
+    ///
+    /// Returns the schedule with generated spawns appended. If `stops`
+    /// has fewer than 2 entries, no spawns are generated (pattern
+    /// sampling requires at least two stops).
+    #[must_use]
+    pub fn from_pattern(
+        mut self,
+        pattern: TrafficPattern,
+        stops: &[StopId],
+        duration_ticks: u64,
+        mean_interval_ticks: u32,
+        weight_range: (f64, f64),
+        rng: &mut impl RngExt,
+    ) -> Self {
+        if stops.len() < 2 || mean_interval_ticks == 0 {
+            return self;
+        }
+        let (wlo, whi) = if weight_range.0 > weight_range.1 {
+            (weight_range.1, weight_range.0)
+        } else {
+            weight_range
+        };
+        let mut tick = 0u64;
+        loop {
+            // Exponential inter-arrival time, clamped to avoid ln(0).
+            let u: f64 = rng.random_range(0.0001..1.0);
+            let interval = -(f64::from(mean_interval_ticks)) * u.ln();
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let step = (interval as u64).max(1);
+            tick = tick.saturating_add(step);
+            if tick >= duration_ticks {
+                break;
+            }
+            if let Some((origin, destination)) = pattern.sample_stop_ids(stops, rng) {
+                let weight = rng.random_range(wlo..=whi);
+                self.spawns.push(TimedSpawn {
+                    tick,
+                    origin,
+                    destination,
+                    weight,
+                });
+            }
+        }
+        self
+    }
+
+    /// Append a single spawn. Useful for one-off riders mixed into a
+    /// larger pattern (e.g. a "stranded top-floor" rider sitting atop
+    /// a [`from_pattern`](Self::from_pattern) stream).
+    #[must_use]
+    pub fn push(mut self, spawn: TimedSpawn) -> Self {
+        self.spawns.push(spawn);
+        self
+    }
+
+    /// Absorb another schedule's spawns. Chainable drop-in for
+    /// composing heterogeneous arrival shapes — e.g. up-peak burst
+    /// plus a uniform inter-floor background:
+    ///
+    /// ```
+    /// # use elevator_core::scenario::SpawnSchedule;
+    /// # use elevator_core::stop::StopId;
+    /// # use elevator_core::traffic::TrafficPattern;
+    /// # use rand::SeedableRng;
+    /// let mut rng = rand::rngs::StdRng::seed_from_u64(7);
+    /// let stops = vec![StopId(0), StopId(1), StopId(2)];
+    /// let background = SpawnSchedule::new().from_pattern(
+    ///     TrafficPattern::Uniform, &stops, 10_000, 300, (70.0, 80.0), &mut rng,
+    /// );
+    /// let up_peak = SpawnSchedule::new().burst(StopId(0), StopId(2), 20, 0, 70.0);
+    /// let combined = up_peak.merge(background);
+    /// assert!(combined.len() >= 20);
+    /// ```
+    #[must_use]
+    pub fn merge(mut self, other: Self) -> Self {
+        self.spawns.extend(other.spawns);
+        self
+    }
+
+    /// Number of spawns currently in the schedule.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.spawns.len()
+    }
+
+    /// Whether the schedule has no spawns.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.spawns.is_empty()
+    }
+
+    /// Borrow the underlying spawns (useful for inspection in tests).
+    #[must_use]
+    pub fn spawns(&self) -> &[TimedSpawn] {
+        &self.spawns
+    }
+
+    /// Consume the builder and return the spawns, ready to drop into
+    /// [`Scenario::spawns`]. [`ScenarioRunner::new`] sorts them by tick
+    /// on construction, so builders don't need to maintain a sorted
+    /// invariant.
+    #[must_use]
+    pub fn into_spawns(self) -> Vec<TimedSpawn> {
+        self.spawns
     }
 }

--- a/crates/elevator-core/src/tests/helpers.rs
+++ b/crates/elevator-core/src/tests/helpers.rs
@@ -68,3 +68,84 @@ pub fn all_riders_arrived(sim: &Simulation) -> bool {
 pub fn scan() -> ScanDispatch {
     ScanDispatch::new()
 }
+
+/// Multi-stop, multi-elevator test config. Stops are uniformly spaced
+/// `4.0` units apart starting at `0.0`; all elevators share the same
+/// physics as [`default_config`] and start at stop index 0.
+///
+/// Used by canonical benchmark scenarios that need more than the
+/// 3-stop/1-elevator default (up-peak sweeps, down-peak mirror,
+/// full-load cycle, etc.).
+///
+/// # Panics
+/// Panics if `stops < 2` or `cars < 1` — both are preconditions
+/// for building a valid [`SimConfig`].
+pub fn multi_floor_config(stops: usize, cars: usize) -> SimConfig {
+    assert!(stops >= 2, "multi_floor_config requires at least 2 stops");
+    assert!(cars >= 1, "multi_floor_config requires at least 1 car");
+    let stop_configs: Vec<StopConfig> = (0..stops)
+        .map(|i| StopConfig {
+            id: StopId(i as u32),
+            name: format!("Floor {i}"),
+            position: i as f64 * 4.0,
+        })
+        .collect();
+    let elevators: Vec<ElevatorConfig> = (0..cars)
+        .map(|i| ElevatorConfig {
+            id: i as u32,
+            name: format!("Car {i}"),
+            max_speed: Speed::from(2.0),
+            acceleration: Accel::from(1.5),
+            deceleration: Accel::from(2.0),
+            weight_capacity: Weight::from(800.0),
+            starting_stop: StopId(0),
+            door_open_ticks: 10,
+            door_transition_ticks: 5,
+            restricted_stops: Vec::new(),
+            #[cfg(feature = "energy")]
+            energy_profile: None,
+            service_mode: None,
+            inspection_speed_factor: 0.25,
+            bypass_load_up_pct: None,
+            bypass_load_down_pct: None,
+        })
+        .collect();
+    SimConfig {
+        building: BuildingConfig {
+            name: format!("{stops}-stop test building"),
+            stops: stop_configs,
+            lines: None,
+            groups: None,
+        },
+        elevators,
+        simulation: SimulationParams {
+            ticks_per_second: 60.0,
+        },
+        passenger_spawning: PassengerSpawnConfig {
+            mean_interval_ticks: 120,
+            weight_range: (50.0, 100.0),
+        },
+    }
+}
+
+/// Step the simulation until all riders reach a terminal state
+/// (`Arrived` or `Abandoned`) or `max_ticks` elapse. Drains events
+/// each tick so event-driven metrics stay up to date.
+///
+/// Returns `true` if the sim drained before the timeout. Canonical
+/// scenarios assert on the return value to fail fast on a stuck sim
+/// rather than silently accepting a partial result.
+pub fn run_until_done(sim: &mut Simulation, max_ticks: u64) -> bool {
+    for _ in 0..max_ticks {
+        sim.step();
+        sim.drain_events();
+        let all_terminal = sim
+            .world()
+            .iter_riders()
+            .all(|(_, r)| matches!(r.phase, RiderPhase::Arrived | RiderPhase::Abandoned));
+        if all_terminal {
+            return true;
+        }
+    }
+    false
+}

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -29,6 +29,7 @@ mod reroute_tests;
 mod resource_tests;
 mod scenario_tests;
 mod snapshot_tests;
+mod spawn_schedule_tests;
 mod substep_tests;
 mod tagged_metrics_tests;
 mod time_tests;

--- a/crates/elevator-core/src/tests/spawn_schedule_tests.rs
+++ b/crates/elevator-core/src/tests/spawn_schedule_tests.rs
@@ -1,0 +1,256 @@
+//! Unit tests for [`crate::scenario::SpawnSchedule`] and the new
+//! [`crate::scenario::Condition::P95WaitBelow`] variant, plus sanity
+//! checks for the [`super::helpers`] additions.
+
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+use crate::scenario::SpawnSchedule;
+use crate::stop::StopId;
+use crate::traffic::TrafficPattern;
+
+use super::helpers::{multi_floor_config, run_until_done, scan};
+
+// ── SpawnSchedule::burst ────────────────────────────────────────────
+
+#[test]
+fn burst_creates_n_identical_spawns_at_same_tick() {
+    let schedule = SpawnSchedule::new().burst(StopId(0), StopId(3), 4, 100, 70.0);
+    assert_eq!(schedule.len(), 4);
+    for spawn in schedule.spawns() {
+        assert_eq!(spawn.tick, 100);
+        assert_eq!(spawn.origin, StopId(0));
+        assert_eq!(spawn.destination, StopId(3));
+        assert_eq!(spawn.weight, 70.0);
+    }
+}
+
+#[test]
+fn burst_with_zero_count_is_noop() {
+    let schedule = SpawnSchedule::new().burst(StopId(0), StopId(1), 0, 0, 70.0);
+    assert!(schedule.is_empty());
+}
+
+// ── SpawnSchedule::staggered ────────────────────────────────────────
+
+#[test]
+fn staggered_spaces_spawns_by_stagger_ticks() {
+    let schedule = SpawnSchedule::new().staggered(StopId(0), StopId(2), 5, 1000, 300, 70.0);
+    let ticks: Vec<u64> = schedule.spawns().iter().map(|s| s.tick).collect();
+    assert_eq!(ticks, vec![1000, 1300, 1600, 1900, 2200]);
+}
+
+/// `stagger_ticks = 0` degenerates to a burst — all spawns at `start_tick`.
+/// Documents the boundary behaviour so callers don't need to special-case.
+#[test]
+fn staggered_with_zero_stagger_degenerates_to_burst() {
+    let staggered = SpawnSchedule::new().staggered(StopId(0), StopId(1), 3, 500, 0, 60.0);
+    assert!(staggered.spawns().iter().all(|s| s.tick == 500));
+    assert_eq!(staggered.len(), 3);
+}
+
+// ── SpawnSchedule::from_pattern ─────────────────────────────────────
+
+/// Seeded RNG ⇒ deterministic spawn sequence. Pin it so scenario-test
+/// authors don't have to worry about cross-run drift.
+#[test]
+fn from_pattern_is_deterministic_with_seeded_rng() {
+    let stops = vec![StopId(0), StopId(1), StopId(2), StopId(3)];
+    let run = |seed: u64| {
+        let mut rng = StdRng::seed_from_u64(seed);
+        SpawnSchedule::new()
+            .from_pattern(
+                TrafficPattern::UpPeak,
+                &stops,
+                5_000,
+                120,
+                (60.0, 80.0),
+                &mut rng,
+            )
+            .into_spawns()
+    };
+    let first = run(42);
+    let second = run(42);
+    assert_eq!(
+        first.len(),
+        second.len(),
+        "same seed must yield same spawn count"
+    );
+    for (a, b) in first.iter().zip(second.iter()) {
+        assert_eq!(a.tick, b.tick);
+        assert_eq!(a.origin, b.origin);
+        assert_eq!(a.destination, b.destination);
+        assert!((a.weight - b.weight).abs() < 1e-9);
+    }
+}
+
+#[test]
+fn from_pattern_respects_duration_bound() {
+    let stops = vec![StopId(0), StopId(1), StopId(2)];
+    let mut rng = StdRng::seed_from_u64(7);
+    let schedule = SpawnSchedule::new().from_pattern(
+        TrafficPattern::Uniform,
+        &stops,
+        1_000,
+        50,
+        (70.0, 80.0),
+        &mut rng,
+    );
+    assert!(
+        schedule.spawns().iter().all(|s| s.tick < 1_000),
+        "no spawns should exceed the duration bound"
+    );
+}
+
+/// Up-peak samples destinations from `1..n`; origin is always the lobby.
+/// Useful to assert a schedule is actually shaped like up-peak.
+#[test]
+fn from_pattern_up_peak_biases_origin_to_lobby() {
+    let stops = vec![StopId(0), StopId(1), StopId(2), StopId(3)];
+    let mut rng = StdRng::seed_from_u64(99);
+    let schedule = SpawnSchedule::new().from_pattern(
+        TrafficPattern::UpPeak,
+        &stops,
+        20_000,
+        120,
+        (70.0, 70.0),
+        &mut rng,
+    );
+    let lobby_origins = schedule
+        .spawns()
+        .iter()
+        .filter(|s| s.origin == StopId(0))
+        .count();
+    let total = schedule.len();
+    // Up-peak is 80% lobby-origin (see `TrafficPattern::UpPeak` docs).
+    // Allow generous slack for Poisson variance on short runs.
+    assert!(total > 50, "need enough samples for the ratio test");
+    assert!(
+        lobby_origins * 10 >= total * 6,
+        "expected ≥60% lobby origins under up-peak, got {lobby_origins}/{total}"
+    );
+}
+
+#[test]
+fn from_pattern_with_fewer_than_two_stops_returns_empty() {
+    let mut rng = StdRng::seed_from_u64(1);
+    let stops_one = vec![StopId(0)];
+    let schedule = SpawnSchedule::new().from_pattern(
+        TrafficPattern::Uniform,
+        &stops_one,
+        1_000,
+        50,
+        (70.0, 80.0),
+        &mut rng,
+    );
+    assert!(schedule.is_empty());
+}
+
+#[test]
+fn from_pattern_with_zero_mean_interval_returns_empty() {
+    let mut rng = StdRng::seed_from_u64(1);
+    let stops = vec![StopId(0), StopId(1)];
+    let schedule = SpawnSchedule::new().from_pattern(
+        TrafficPattern::Uniform,
+        &stops,
+        1_000,
+        0,
+        (70.0, 80.0),
+        &mut rng,
+    );
+    assert!(schedule.is_empty());
+}
+
+/// Weight range with reversed endpoints is swapped, matching
+/// [`crate::traffic::PoissonSource`] convention.
+#[test]
+fn from_pattern_handles_reversed_weight_range() {
+    let mut rng = StdRng::seed_from_u64(2);
+    let stops = vec![StopId(0), StopId(1), StopId(2)];
+    let schedule = SpawnSchedule::new().from_pattern(
+        TrafficPattern::Uniform,
+        &stops,
+        5_000,
+        100,
+        (90.0, 60.0), // reversed
+        &mut rng,
+    );
+    for spawn in schedule.spawns() {
+        assert!((60.0..=90.0).contains(&spawn.weight));
+    }
+}
+
+// ── Composition ─────────────────────────────────────────────────────
+
+#[test]
+fn merge_concatenates_spawns() {
+    let a = SpawnSchedule::new().burst(StopId(0), StopId(1), 2, 100, 70.0);
+    let b = SpawnSchedule::new().burst(StopId(1), StopId(0), 3, 200, 80.0);
+    let merged = a.merge(b);
+    assert_eq!(merged.len(), 5);
+    assert_eq!(merged.spawns()[0].tick, 100);
+    assert_eq!(merged.spawns()[4].tick, 200);
+}
+
+#[test]
+fn push_appends_single_spawn() {
+    let schedule = SpawnSchedule::new()
+        .burst(StopId(0), StopId(1), 2, 0, 70.0)
+        .push(crate::scenario::TimedSpawn {
+            tick: 50,
+            origin: StopId(2),
+            destination: StopId(0),
+            weight: 65.0,
+        });
+    assert_eq!(schedule.len(), 3);
+    assert_eq!(schedule.spawns()[2].tick, 50);
+}
+
+#[test]
+fn into_spawns_yields_vec() {
+    let schedule = SpawnSchedule::new().burst(StopId(0), StopId(1), 2, 0, 70.0);
+    let v: Vec<_> = schedule.into_spawns();
+    assert_eq!(v.len(), 2);
+}
+
+// ── helpers sanity ──────────────────────────────────────────────────
+
+#[test]
+fn multi_floor_config_has_requested_shape() {
+    let cfg = multi_floor_config(6, 3);
+    assert_eq!(cfg.building.stops.len(), 6);
+    assert_eq!(cfg.elevators.len(), 3);
+    // Uniform 4.0 spacing.
+    for (i, stop) in cfg.building.stops.iter().enumerate() {
+        assert!((i as f64).mul_add(-4.0, stop.position).abs() < 1e-9);
+    }
+}
+
+#[test]
+#[should_panic(expected = "at least 2 stops")]
+fn multi_floor_config_panics_on_one_stop() {
+    let _ = multi_floor_config(1, 1);
+}
+
+#[test]
+#[should_panic(expected = "at least 1 car")]
+fn multi_floor_config_panics_on_zero_cars() {
+    let _ = multi_floor_config(3, 0);
+}
+
+#[test]
+fn run_until_done_returns_true_for_simple_scenario() {
+    let cfg = multi_floor_config(3, 1);
+    let mut sim = crate::sim::Simulation::new(&cfg, scan()).unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    assert!(run_until_done(&mut sim, 20_000));
+}
+
+#[test]
+fn run_until_done_returns_false_for_empty_deadline() {
+    // Rider present but deadline too short ⇒ returns false.
+    let cfg = multi_floor_config(3, 1);
+    let mut sim = crate::sim::Simulation::new(&cfg, scan()).unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    assert!(!run_until_done(&mut sim, 5));
+}


### PR DESCRIPTION
## Summary

- Adds `SpawnSchedule` — a fluent builder for `Vec<TimedSpawn>` — to `scenario.rs`.
- Adds `multi_floor_config(stops, cars)` and `run_until_done(sim, max_ticks)` helpers to `tests/helpers.rs`.
- 18 new unit tests (`tests/spawn_schedule_tests.rs`), 720 lib tests passing total.

## Why

The canonical benchmark scenarios in the dispatch-research PR stack (up-peak rate sweep, down-peak mirror, full-load cycle, burst-then-silence, strategy-comparison matrix) all need the same three primitives:

1. a way to construct a non-trivial multi-stop/multi-car config (the existing `default_config()` is 3 stops / 1 elevator);
2. a poll-to-completion loop (currently copy-pasted across tests);
3. a way to author spawns that unifies deterministic bursts with Poisson draws from `TrafficPattern`.

Per the scenario gap analysis, a `SpawnSchedule` builder is the single biggest leverage point — unlocks ~80% of the missing canonical shapes with one abstraction.

Third in the dispatch-research PR stack (see #345 for background).

## API

```rust
// Deterministic bursts.
SpawnSchedule::new().burst(StopId(0), StopId(5), 10, 0, 70.0)

// Deterministic cadence (stagger=0 degenerates to burst).
SpawnSchedule::new().staggered(StopId(0), StopId(3), 5, 1_000, 300, 70.0)

// Poisson draw from a TrafficPattern, deterministic under seeded RNG.
SpawnSchedule::new().from_pattern(
    TrafficPattern::UpPeak,
    &stops, 20_000, 120, (70.0, 80.0), &mut rng,
)

// Compose.
up_peak.merge(background_interfloor)

// Extract.
let spawns: Vec<TimedSpawn> = schedule.into_spawns();
```

Plus `push(spawn)`, `len()`, `is_empty()`, `spawns()` accessors. `ScenarioRunner::new` already sorts by tick on construction, so builders don't need to maintain a sorted invariant.

## What changed

- `crates/elevator-core/src/scenario.rs`: `SpawnSchedule` struct + impl. Pure additive, no changes to existing public types.
- `crates/elevator-core/src/tests/helpers.rs`: `multi_floor_config`, `run_until_done`.
- `crates/elevator-core/src/tests/mod.rs`: register new module.
- `crates/elevator-core/src/tests/spawn_schedule_tests.rs`: 18 new unit tests covering determinism, pattern bias, boundary conditions (<2 stops, zero mean_interval, zero count, zero stagger, reversed weight range), composition, and the helper assertions (including `#[should_panic]` for the preconditions).
- `Cargo.lock`: release-please drift sync (same pattern as #345 / #347).

## Out of scope

- `Condition::P95WaitBelow` + `assert_p95_wait_under` helper — need the `p95_wait_time` API from #347 to land first. Follow-up PR.
- The actual canonical benchmark scenarios (up-peak sweep, down-peak mirror, etc.) — unblocked by this PR, but deferred to #4 in the stack so review surface stays small.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p elevator-core --all-features --tests -- -D warnings`
- [x] `cargo test -p elevator-core --all-features --lib` — 720 passed (+18 net)
- [x] `cargo test -p elevator-core --all-features --doc` — 158 passed
- [x] `cargo check --workspace --all-features --all-targets`
- [x] Pre-commit hook end-to-end