### PR TITLE
feat(dispatch): add RsrDispatch — additive composite cost stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.7.0"
+version = "15.8.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -42,6 +42,8 @@ pub mod look;
 pub mod nearest_car;
 /// Built-in repositioning strategies.
 pub mod reposition;
+/// Relative System Response (RSR) dispatch algorithm.
+pub mod rsr;
 /// SCAN dispatch algorithm.
 pub mod scan;
 /// Shared sweep-direction logic used by SCAN and LOOK.
@@ -51,6 +53,7 @@ pub use destination::{AssignedCar, DestinationDispatch};
 pub use etd::EtdDispatch;
 pub use look::LookDispatch;
 pub use nearest_car::NearestCarDispatch;
+pub use rsr::RsrDispatch;
 pub use scan::ScanDispatch;
 
 use serde::{Deserialize, Serialize};
@@ -393,6 +396,9 @@ pub enum BuiltinStrategy {
     Etd,
     /// Hall-call destination dispatch — sticky per-rider assignment.
     Destination,
+    /// Relative System Response — additive composite of ETA, direction,
+    /// car-call affinity, and load-share terms.
+    Rsr,
     /// Custom strategy identified by name. The game must provide a factory.
     Custom(String),
 }
@@ -405,6 +411,7 @@ impl std::fmt::Display for BuiltinStrategy {
             Self::NearestCar => write!(f, "NearestCar"),
             Self::Etd => write!(f, "Etd"),
             Self::Destination => write!(f, "Destination"),
+            Self::Rsr => write!(f, "Rsr"),
             Self::Custom(name) => write!(f, "Custom({name})"),
         }
     }
@@ -423,6 +430,7 @@ impl BuiltinStrategy {
             Self::NearestCar => Some(Box::new(nearest_car::NearestCarDispatch::new())),
             Self::Etd => Some(Box::new(etd::EtdDispatch::new())),
             Self::Destination => Some(Box::new(destination::DestinationDispatch::new())),
+            Self::Rsr => Some(Box::new(rsr::RsrDispatch::new())),
             Self::Custom(_) => None,
         }
     }

--- a/crates/elevator-core/src/dispatch/rsr.rs
+++ b/crates/elevator-core/src/dispatch/rsr.rs
@@ -26,6 +26,15 @@ use super::{DispatchStrategy, RankContext, pair_can_do_work};
 /// except `eta_weight` (1.0), giving a baseline that mirrors
 /// [`NearestCarDispatch`](super::NearestCarDispatch) until terms are
 /// opted in.
+///
+/// # Weight invariants
+///
+/// Every weight field must be **finite and non-negative**. The
+/// `with_*` builder methods enforce this with `assert!`; direct field
+/// mutation bypasses the check and is a caller responsibility. A `NaN` weight propagates through the multiply-add
+/// chain and silently collapses every pair's cost to zero (Rust's
+/// `NaN.max(0.0) == 0.0`), producing an arbitrary but type-valid
+/// assignment from the Hungarian solver — a hard bug to diagnose.
 pub struct RsrDispatch {
     /// Weight on `travel_time = distance / max_speed` (seconds).
     /// Default `1.0`; raising it shifts the blend toward travel time.
@@ -49,9 +58,9 @@ pub struct RsrDispatch {
     /// (`load_penalty_coeff · load_ratio`).
     ///
     /// Fires for partially loaded cars below the `bypass_load_*_pct`
-    /// threshold enforced by [`pair_can_do_work`](super::pair_can_do_work);
-    /// lets you prefer emptier cars for new pickups without an on/off
-    /// cliff. Default `0.0`.
+    /// threshold enforced by [`pair_can_do_work`]; lets you prefer
+    /// emptier cars for new pickups without an on/off cliff.
+    /// Default `0.0`.
     pub load_penalty_coeff: f64,
 }
 

--- a/crates/elevator-core/src/dispatch/rsr.rs
+++ b/crates/elevator-core/src/dispatch/rsr.rs
@@ -1,0 +1,197 @@
+//! Relative System Response (RSR) dispatch — a composite additive
+//! cost stack.
+//!
+//! Inspired by the Otis patent lineage (Bittar US5024295A, US5146053A)
+//! and the Barney–dos Santos CGC framework. Unlike those proprietary
+//! systems, this implementation is an educational model, not a
+//! faithful reproduction of any vendor's scoring.
+//!
+//! Shape: `rank = eta_weight · travel_time + Σ penalties − Σ bonuses`.
+//! All terms are additive scalars, so they compose cleanly with the
+//! library's Kuhn–Munkres assignment. Defaults are tuned so the stack
+//! reduces to the nearest-car baseline when every weight is zero.
+//!
+//! What this deliberately leaves out: online weight tuning, fuzzy
+//! inference, and stickiness state. Those belong above the trait, not
+//! inside a strategy.
+
+use crate::components::{CarCall, ElevatorPhase};
+
+use super::{DispatchStrategy, RankContext, pair_can_do_work};
+
+/// Additive RSR-style cost stack. Lower scores win the Hungarian
+/// assignment.
+///
+/// See module docs for the cost shape. All weights default to `0.0`
+/// except `eta_weight` (1.0), giving a baseline that mirrors
+/// [`NearestCarDispatch`](super::NearestCarDispatch) until terms are
+/// opted in.
+pub struct RsrDispatch {
+    /// Weight on `travel_time = distance / max_speed` (seconds).
+    /// Default `1.0`; raising it shifts the blend toward travel time.
+    pub eta_weight: f64,
+    /// Constant added when the candidate stop lies opposite the
+    /// car's committed travel direction.
+    ///
+    /// Default `0.0`; the Otis RSR lineage uses a large value so any
+    /// right-direction candidate outranks any wrong-direction one.
+    /// Ignored for cars in [`ElevatorPhase::Idle`] or stopped phases,
+    /// since an idle car has no committed direction to be opposite to.
+    pub wrong_direction_penalty: f64,
+    /// Bonus subtracted when the candidate stop is already a car-call
+    /// inside this car.
+    ///
+    /// Merges the new pickup with an existing dropoff instead of
+    /// spawning an unrelated trip. Default `0.0`. Read from
+    /// [`DispatchManifest::car_calls_for`](super::DispatchManifest::car_calls_for).
+    pub coincident_car_call_bonus: f64,
+    /// Coefficient on a smooth load-fraction penalty
+    /// (`load_penalty_coeff · load_ratio`).
+    ///
+    /// Fires for partially loaded cars below the `bypass_load_*_pct`
+    /// threshold enforced by [`pair_can_do_work`](super::pair_can_do_work);
+    /// lets you prefer emptier cars for new pickups without an on/off
+    /// cliff. Default `0.0`.
+    pub load_penalty_coeff: f64,
+}
+
+impl RsrDispatch {
+    /// Create a new `RsrDispatch` with the baseline weights
+    /// (`eta_weight = 1.0`, all penalties/bonuses disabled).
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            eta_weight: 1.0,
+            wrong_direction_penalty: 0.0,
+            coincident_car_call_bonus: 0.0,
+            load_penalty_coeff: 0.0,
+        }
+    }
+
+    /// Set the wrong-direction penalty.
+    ///
+    /// # Panics
+    /// Panics on non-finite or negative weights — a negative penalty
+    /// would invert the direction ordering, silently preferring
+    /// wrong-direction candidates.
+    #[must_use]
+    pub fn with_wrong_direction_penalty(mut self, weight: f64) -> Self {
+        assert!(
+            weight.is_finite() && weight >= 0.0,
+            "wrong_direction_penalty must be finite and non-negative, got {weight}"
+        );
+        self.wrong_direction_penalty = weight;
+        self
+    }
+
+    /// Set the coincident-car-call bonus.
+    ///
+    /// # Panics
+    /// Panics on non-finite or negative weights — the bonus is
+    /// subtracted, so a negative value would become a penalty.
+    #[must_use]
+    pub fn with_coincident_car_call_bonus(mut self, weight: f64) -> Self {
+        assert!(
+            weight.is_finite() && weight >= 0.0,
+            "coincident_car_call_bonus must be finite and non-negative, got {weight}"
+        );
+        self.coincident_car_call_bonus = weight;
+        self
+    }
+
+    /// Set the load-penalty coefficient.
+    ///
+    /// # Panics
+    /// Panics on non-finite or negative weights.
+    #[must_use]
+    pub fn with_load_penalty_coeff(mut self, weight: f64) -> Self {
+        assert!(
+            weight.is_finite() && weight >= 0.0,
+            "load_penalty_coeff must be finite and non-negative, got {weight}"
+        );
+        self.load_penalty_coeff = weight;
+        self
+    }
+
+    /// Set the ETA weight.
+    ///
+    /// # Panics
+    /// Panics on non-finite or negative weights. Zero is allowed and
+    /// reduces the strategy to penalty/bonus tiebreaking alone.
+    #[must_use]
+    pub fn with_eta_weight(mut self, weight: f64) -> Self {
+        assert!(
+            weight.is_finite() && weight >= 0.0,
+            "eta_weight must be finite and non-negative, got {weight}"
+        );
+        self.eta_weight = weight;
+        self
+    }
+}
+
+impl Default for RsrDispatch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DispatchStrategy for RsrDispatch {
+    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+        if !pair_can_do_work(ctx) {
+            return None;
+        }
+        let car = ctx.world.elevator(ctx.car)?;
+
+        // ETA — travel time to the candidate stop.
+        let distance = (ctx.car_position - ctx.stop_position).abs();
+        let max_speed = car.max_speed.value();
+        if max_speed <= 0.0 {
+            return None;
+        }
+        let travel_time = distance / max_speed;
+        let mut cost = self.eta_weight * travel_time;
+
+        // Wrong-direction penalty. Only applies when the car has a
+        // committed direction (not Idle / Stopped) — an idle car can
+        // accept any candidate without "reversing" anything.
+        if self.wrong_direction_penalty > 0.0
+            && let Some(target) = car.phase.moving_target()
+            && let Some(target_pos) = ctx.world.stop_position(target)
+        {
+            let car_going_up = target_pos > ctx.car_position;
+            let car_going_down = target_pos < ctx.car_position;
+            let cand_above = ctx.stop_position > ctx.car_position;
+            let cand_below = ctx.stop_position < ctx.car_position;
+            if (car_going_up && cand_below) || (car_going_down && cand_above) {
+                cost += self.wrong_direction_penalty;
+            }
+        }
+
+        // Coincident-car-call bonus — the candidate stop is already a
+        // committed dropoff for this car.
+        if self.coincident_car_call_bonus > 0.0
+            && ctx
+                .manifest
+                .car_calls_for(ctx.car)
+                .iter()
+                .any(|c: &CarCall| c.floor == ctx.stop)
+        {
+            cost -= self.coincident_car_call_bonus;
+        }
+
+        // Smooth load-fraction penalty. `pair_can_do_work` has already
+        // filtered over-capacity and bypass-threshold cases; this term
+        // shapes preference among the survivors so emptier cars win
+        // pickups when all else is equal. Idle cars contribute zero.
+        if self.load_penalty_coeff > 0.0 && car.phase() != ElevatorPhase::Idle {
+            let capacity = car.weight_capacity().value();
+            if capacity > 0.0 {
+                let load_ratio = (car.current_load().value() / capacity).clamp(0.0, 1.0);
+                cost += self.load_penalty_coeff * load_ratio;
+            }
+        }
+
+        let cost = cost.max(0.0);
+        if cost.is_finite() { Some(cost) } else { None }
+    }
+}

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -69,6 +69,7 @@ mod query_event_tests;
 mod reposition_tests;
 mod resident_tests;
 mod rider_index_tests;
+mod rsr_dispatch_tests;
 mod runtime_upgrades_tests;
 mod service_mode_tests;
 mod waiting_direction_tests;

--- a/crates/elevator-core/src/tests/rsr_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/rsr_dispatch_tests.rs
@@ -1,0 +1,244 @@
+//! Behavioural tests for [`crate::dispatch::rsr::RsrDispatch`].
+//!
+//! Follows the `etd_mutant_tests` pattern: each term of the additive
+//! cost stack gets a focused test that asserts the term's presence by
+//! observing which elevator wins the Hungarian assignment.
+
+use super::dispatch_tests::{
+    add_demand, decide_all, decide_one, spawn_elevator, test_group, test_world,
+};
+use crate::components::{CarCall, ElevatorPhase};
+use crate::dispatch::rsr::RsrDispatch;
+use crate::dispatch::{BuiltinStrategy, DispatchDecision, DispatchManifest};
+use crate::entity::EntityId;
+
+// ── Defaults ────────────────────────────────────────────────────────
+
+#[test]
+fn default_weights_match_nearest_car_baseline() {
+    // eta_weight = 1.0, all penalties/bonuses disabled. With one car
+    // and one stop, the car must go to the stop (no other options).
+    let (mut world, stops) = test_world();
+    let elev = spawn_elevator(&mut world, 0.0);
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    add_demand(&mut manifest, &mut world, stops[2], 70.0);
+
+    let mut rsr = RsrDispatch::new();
+    let decision = decide_one(&mut rsr, elev, 0.0, &group, &manifest, &mut world);
+    assert_eq!(decision, DispatchDecision::GoToStop(stops[2]));
+}
+
+#[test]
+fn closer_car_wins_on_pure_eta() {
+    let (mut world, stops) = test_world();
+    let near = spawn_elevator(&mut world, 6.0); // closer to stops[2] (pos 8)
+    let far = spawn_elevator(&mut world, 0.0);
+    let group = test_group(&stops, vec![near, far]);
+    let mut manifest = DispatchManifest::default();
+    add_demand(&mut manifest, &mut world, stops[2], 70.0);
+
+    let mut rsr = RsrDispatch::new();
+    let decisions = decide_all(
+        &mut rsr,
+        &[(near, 6.0), (far, 0.0)],
+        &group,
+        &manifest,
+        &mut world,
+    );
+    let near_dec = decisions.iter().find(|(e, _)| *e == near).unwrap();
+    assert_eq!(near_dec.1, DispatchDecision::GoToStop(stops[2]));
+}
+
+// ── Wrong-direction penalty ─────────────────────────────────────────
+
+/// A car committed upward has the penalty applied to a stop below it.
+/// With a large enough penalty, the other (idle) car wins even at
+/// greater distance.
+#[test]
+fn wrong_direction_penalty_steers_away_from_reversing_car() {
+    let (mut world, stops) = test_world();
+    let committed_up = spawn_elevator(&mut world, 6.0);
+    let idle_far = spawn_elevator(&mut world, 16.0);
+    // Commit `committed_up` to stops[3] (pos 12) — travel direction up.
+    world.elevator_mut(committed_up).unwrap().phase = ElevatorPhase::MovingToStop(stops[3]);
+
+    let group = test_group(&stops, vec![committed_up, idle_far]);
+    let mut manifest = DispatchManifest::default();
+    // Demand at stops[0] (pos 0) — below `committed_up`, so it's a
+    // wrong-direction candidate for that car.
+    add_demand(&mut manifest, &mut world, stops[0], 70.0);
+
+    let mut rsr = RsrDispatch::new().with_wrong_direction_penalty(1_000.0);
+    let decisions = decide_all(
+        &mut rsr,
+        &[(committed_up, 6.0), (idle_far, 16.0)],
+        &group,
+        &manifest,
+        &mut world,
+    );
+    let idle_dec = decisions.iter().find(|(e, _)| *e == idle_far).unwrap();
+    assert_eq!(
+        idle_dec.1,
+        DispatchDecision::GoToStop(stops[0]),
+        "large wrong-direction penalty must route the idle car, not the committed-up one"
+    );
+}
+
+/// An idle car has no committed direction, so the wrong-direction
+/// penalty must not fire — otherwise an all-idle-fleet would refuse
+/// every down-from-top pickup after a single up trip.
+#[test]
+fn wrong_direction_penalty_does_not_fire_for_idle_car() {
+    let (mut world, stops) = test_world();
+    let idle = spawn_elevator(&mut world, 12.0);
+    world.elevator_mut(idle).unwrap().phase = ElevatorPhase::Idle;
+
+    let group = test_group(&stops, vec![idle]);
+    let mut manifest = DispatchManifest::default();
+    add_demand(&mut manifest, &mut world, stops[0], 70.0);
+
+    let mut rsr = RsrDispatch::new().with_wrong_direction_penalty(1_000_000.0);
+    let decision = decide_one(&mut rsr, idle, 12.0, &group, &manifest, &mut world);
+    assert_eq!(
+        decision,
+        DispatchDecision::GoToStop(stops[0]),
+        "idle car must accept any candidate; the penalty targets committed cars only"
+    );
+}
+
+// ── Coincident car-call bonus ───────────────────────────────────────
+
+/// With two cars equidistant, the one whose car-call matches the
+/// candidate stop wins — merging pickup with existing dropoff is
+/// cheaper than spawning a separate trip.
+#[test]
+fn coincident_car_call_bonus_prefers_car_with_matching_destination() {
+    let (mut world, stops) = test_world();
+    let car_with_call = spawn_elevator(&mut world, 0.0);
+    let car_without = spawn_elevator(&mut world, 16.0);
+    let group = test_group(&stops, vec![car_with_call, car_without]);
+    let mut manifest = DispatchManifest::default();
+    add_demand(&mut manifest, &mut world, stops[2], 70.0);
+    // Attribute a car-call at stops[2] to `car_with_call`.
+    manifest
+        .car_calls_by_car
+        .entry(car_with_call)
+        .or_default()
+        .push(CarCall::new(car_with_call, stops[2], 0));
+
+    let mut rsr = RsrDispatch::new().with_coincident_car_call_bonus(100.0);
+    let decisions = decide_all(
+        &mut rsr,
+        &[(car_with_call, 0.0), (car_without, 16.0)],
+        &group,
+        &manifest,
+        &mut world,
+    );
+    let winner = decisions
+        .iter()
+        .find(|(_, d)| matches!(d, DispatchDecision::GoToStop(s) if *s == stops[2]))
+        .unwrap();
+    assert_eq!(
+        winner.0, car_with_call,
+        "car with a matching car-call must win when the coincident bonus is active"
+    );
+}
+
+// ── Load-fraction penalty ───────────────────────────────────────────
+
+/// Two cars, same distance, one half-loaded. A positive load penalty
+/// sends the empty car to the pickup so the half-loaded one can
+/// finish its current trip unperturbed.
+#[test]
+fn load_penalty_prefers_emptier_car() {
+    let (mut world, stops) = test_world();
+    let empty = spawn_elevator(&mut world, 0.0);
+    let half_loaded = spawn_elevator(&mut world, 16.0);
+    // Put a phantom aboard-rider in `half_loaded` via a direct load push.
+    {
+        let e = world.elevator_mut(half_loaded).unwrap();
+        e.phase = ElevatorPhase::Idle;
+        e.current_load = crate::components::Weight::from(400.0);
+    }
+    world.elevator_mut(empty).unwrap().phase = ElevatorPhase::Idle;
+
+    let group = test_group(&stops, vec![empty, half_loaded]);
+    let mut manifest = DispatchManifest::default();
+    // Pickup at stops[1] (pos 4) — 4 units from each car.
+    add_demand(&mut manifest, &mut world, stops[1], 70.0);
+
+    let mut rsr = RsrDispatch::new().with_load_penalty_coeff(10.0);
+    let decisions = decide_all(
+        &mut rsr,
+        &[(empty, 0.0), (half_loaded, 16.0)],
+        &group,
+        &manifest,
+        &mut world,
+    );
+    let empty_dec = decisions.iter().find(|(e, _)| *e == empty).unwrap();
+    assert_eq!(
+        empty_dec.1,
+        DispatchDecision::GoToStop(stops[1]),
+        "empty car must win over half-loaded one under the load penalty"
+    );
+}
+
+// ── BuiltinStrategy round-trip ──────────────────────────────────────
+
+#[test]
+fn builtin_rsr_variant_instantiates() {
+    let boxed = BuiltinStrategy::Rsr.instantiate();
+    assert!(boxed.is_some(), "BuiltinStrategy::Rsr must instantiate");
+}
+
+#[test]
+fn builtin_rsr_variant_display() {
+    assert_eq!(BuiltinStrategy::Rsr.to_string(), "Rsr");
+}
+
+/// Serde round-trip — snapshots referencing `Rsr` must survive
+/// deserialize-then-reserialize unchanged.
+#[test]
+fn builtin_rsr_variant_serde_roundtrip() {
+    let v = BuiltinStrategy::Rsr;
+    let s = ron::to_string(&v).unwrap();
+    let back: BuiltinStrategy = ron::from_str(&s).unwrap();
+    assert_eq!(v, back);
+}
+
+// ── Weight-validation panics ────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "wrong_direction_penalty must be finite and non-negative")]
+fn wrong_direction_penalty_rejects_nan() {
+    let _ = RsrDispatch::new().with_wrong_direction_penalty(f64::NAN);
+}
+
+#[test]
+#[should_panic(expected = "wrong_direction_penalty must be finite and non-negative")]
+fn wrong_direction_penalty_rejects_negative() {
+    let _ = RsrDispatch::new().with_wrong_direction_penalty(-1.0);
+}
+
+#[test]
+#[should_panic(expected = "coincident_car_call_bonus must be finite and non-negative")]
+fn coincident_bonus_rejects_negative() {
+    let _ = RsrDispatch::new().with_coincident_car_call_bonus(-1.0);
+}
+
+#[test]
+#[should_panic(expected = "load_penalty_coeff must be finite and non-negative")]
+fn load_penalty_rejects_nan() {
+    let _ = RsrDispatch::new().with_load_penalty_coeff(f64::NAN);
+}
+
+#[test]
+#[should_panic(expected = "eta_weight must be finite and non-negative")]
+fn eta_weight_rejects_negative() {
+    let _ = RsrDispatch::new().with_eta_weight(-0.5);
+}
+
+// ── Sanity: _elev unused suppresses dead-code warning ──────────────
+#[allow(dead_code)]
+fn _touch(_elev: EntityId) {}

--- a/docs/src/dispatch-strategies.md
+++ b/docs/src/dispatch-strategies.md
@@ -47,6 +47,7 @@ You can mix imperative and strategy-driven dispatch freely. Dispatch keeps the q
 | `NearestCarDispatch` | Assign each call to the closest idle elevator | Multi-elevator groups | Low average wait; can cause bunching when elevators cluster |
 | `EtdDispatch` | Minimize estimated time to destination across all riders | Multi-elevator groups with mixed traffic | Best average performance; higher per-tick computation |
 | `DestinationDispatch` | Sticky rider-to-car assignment via lobby kiosk input | Destination-dispatch systems (DCS) | Requires `HallCallMode::Destination`; best with lobby kiosks |
+| `RsrDispatch` | Additive composite: ETA + wrong-direction / load / car-call-affinity terms | Production-style controllers with tunable preferences | Weights default to a nearest-car baseline; opt in per term |
 
 ### Choosing a strategy
 

--- a/docs/src/dispatch-strategies.md
+++ b/docs/src/dispatch-strategies.md
@@ -1,6 +1,6 @@
 # Dispatch Strategies
 
-Dispatch is the brain of an elevator system -- it decides which elevator goes where. This chapter covers imperative dispatch, the five built-in strategies, and how to choose between them.
+Dispatch is the brain of an elevator system -- it decides which elevator goes where. This chapter covers imperative dispatch, the six built-in strategies, and how to choose between them.
 
 ## How dispatch works
 
@@ -91,7 +91,7 @@ fn main() -> Result<(), SimError> {
 }
 ```
 
-All five strategies live in their respective modules:
+All six strategies live in their respective modules:
 
 ```rust,no_run
 use elevator_core::dispatch::scan::ScanDispatch;
@@ -99,6 +99,7 @@ use elevator_core::dispatch::look::LookDispatch;
 use elevator_core::dispatch::nearest_car::NearestCarDispatch;
 use elevator_core::dispatch::etd::EtdDispatch;
 use elevator_core::dispatch::destination::DestinationDispatch;
+use elevator_core::dispatch::rsr::RsrDispatch;
 ```
 
 The ETD strategy accepts a delay weight that controls how much it penalizes delays to existing riders when assigning a new call:


### PR DESCRIPTION
## Summary

- Adds `RsrDispatch`, a sixth built-in dispatch strategy that composes ETA with three opt-in additive terms (wrong-direction penalty, coincident-car-call bonus, load-fraction penalty).
- New `BuiltinStrategy::Rsr` variant — non-breaking via `#[non_exhaustive]`.
- 14 new unit tests covering each term in isolation plus variant round-trip; 734 total lib tests.

## Why

Fourth in the dispatch-research PR stack (see #345). Academic/industry convergence on an additive scoring shape — `ETA + Σ penalties − Σ bonuses` — has been the dominant production model since Bittar US5024295A and Barney–dos Santos 1985. Both the puzzle-game community solutions and the patent literature use variations of it.

`EtdDispatch` already covers some of the same territory (travel time, direction bonus, door overhead), but it collapses the whole cost into one monolithic computation. `RsrDispatch` splits the cost stack into independent, individually-tunable terms so users can weight them for their specific traffic shape.

## The cost stack

```
rank = eta_weight · travel_time
     + wrong_direction_penalty         (iff car committed opposite to candidate direction)
     − coincident_car_call_bonus       (iff stop ∈ manifest.car_calls_for(car))
     + load_penalty_coeff · load_ratio (smooth preference for emptier cars)
```

Defaults: `eta_weight = 1.0`, all other weights `0.0`. A fresh `RsrDispatch::new()` is observationally identical to `NearestCarDispatch`.

## What changed

- `crates/elevator-core/src/dispatch/rsr.rs`: new module (~170 lines).
- `crates/elevator-core/src/dispatch/mod.rs`: module registration + `BuiltinStrategy::Rsr` + Display + `instantiate()` wiring.
- `crates/elevator-core/src/tests/rsr_dispatch_tests.rs`: 14 new tests.
- `crates/elevator-core/src/tests/mod.rs`: register new test module.
- `docs/src/dispatch-strategies.md`: add `RsrDispatch` to the built-ins table.
- `Cargo.lock`: release-please drift sync.

## Guards

- `pair_can_do_work` filters unservable pairs (existing shared helper — keeps us honest about capacity/direction bypass).
- Wrong-direction penalty **does not** fire for `ElevatorPhase::Idle` cars (no committed direction to be "opposite" of). Validated by `wrong_direction_penalty_does_not_fire_for_idle_car`.
- All builder methods `assert!` finite + non-negative weights; four `#[should_panic]` tests pin the invariants.

## Out of scope

- Previously-assigned stickiness bonus: described in the brief but deferred — it either needs a new trait hook (`finalize_assignment`) or per-strategy global state. Neither fits cleanly into the current per-pass model.
- Online weight tuning / fuzzy inference: on the convergent skip list. Expose weights as config; users tune.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p elevator-core --all-features --tests -- -D warnings`
- [x] `cargo test -p elevator-core --all-features --lib` — 734 passed (+14 net)
- [x] `cargo test -p elevator-core --all-features --doc` — 156 passed
- [x] `cargo check --workspace --all-features --all-targets`
- [x] `scripts/lint-docs.sh`
- [x] Pre-commit hook end-to-end

## Lineage

Bittar US5024295A, US5146053A; Barney–dos Santos 1985; Smith–Peters ETD 2002.