### PR TITLE
fix(scenario): gate SpawnSchedule::from_pattern behind traffic feature

### DIFF
--- a/crates/elevator-core/src/scenario.rs
+++ b/crates/elevator-core/src/scenario.rs
@@ -6,7 +6,9 @@ use crate::error::SimError;
 use crate::metrics::Metrics;
 use crate::sim::Simulation;
 use crate::stop::StopId;
+#[cfg(feature = "traffic")]
 use crate::traffic::TrafficPattern;
+#[cfg(feature = "traffic")]
 use rand::RngExt;
 use serde::{Deserialize, Serialize};
 
@@ -358,6 +360,11 @@ impl SpawnSchedule {
     /// Returns the schedule with generated spawns appended. If `stops`
     /// has fewer than 2 entries, no spawns are generated (pattern
     /// sampling requires at least two stops).
+    ///
+    /// Requires the `traffic` feature — gated so no-default-features
+    /// builds (notably the wasm32 gate CI job) don't pull in `rand`
+    /// and the `traffic` module transitively.
+    #[cfg(feature = "traffic")]
     #[must_use]
     pub fn from_pattern(
         mut self,


### PR DESCRIPTION
## Summary

Gates `SpawnSchedule::from_pattern` (and its `use crate::traffic::TrafficPattern;` + `use rand::RngExt;` imports) behind `#[cfg(feature = \"traffic\")]`. Fixes the `wasm32 gate` CI regression introduced by #348.

## Why

#348 added `from_pattern` with unconditional imports. But both `crate::traffic` (whole module) and `rand` (whole crate) are only pulled in when the `traffic` feature is on. The wasm32 gate CI job runs `cargo check -p elevator-core --no-default-features` and failed with E0432 on both imports, blocking auto-merge on #347 and #350.

## What changed

- `crates/elevator-core/src/scenario.rs`: add `#[cfg(feature = "traffic")]` to the two imports and to the `from_pattern` method. No other methods touched — `burst`, `staggered`, `merge`, `push`, and all accessors still compile without the feature.

## Verification

- [x] `cargo check -p elevator-core --no-default-features` — clean (was failing pre-fix)
- [x] `cargo test -p elevator-core --all-features --lib` — all green
- [x] `cargo test -p elevator-core --all-features --doc` — 158/158
- [x] `cargo check --workspace --no-default-features` — clean
- [x] Pre-commit hook end-to-end