### PR TITLE
fix(scenario): gate merge doc test body behind traffic feature

### DIFF
--- a/crates/elevator-core/src/scenario.rs
+++ b/crates/elevator-core/src/scenario.rs
@@ -421,10 +421,14 @@ impl SpawnSchedule {
     /// plus a uniform inter-floor background:
     ///
     /// ```
-    /// # use elevator_core::scenario::SpawnSchedule;
-    /// # use elevator_core::stop::StopId;
-    /// # use elevator_core::traffic::TrafficPattern;
-    /// # use rand::SeedableRng;
+    /// # #[cfg(not(feature = "traffic"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "traffic")]
+    /// # fn main() {
+    /// use elevator_core::scenario::SpawnSchedule;
+    /// use elevator_core::stop::StopId;
+    /// use elevator_core::traffic::TrafficPattern;
+    /// use rand::SeedableRng;
     /// let mut rng = rand::rngs::StdRng::seed_from_u64(7);
     /// let stops = vec![StopId(0), StopId(1), StopId(2)];
     /// let background = SpawnSchedule::new().from_pattern(
@@ -433,6 +437,7 @@ impl SpawnSchedule {
     /// let up_peak = SpawnSchedule::new().burst(StopId(0), StopId(2), 20, 0, 70.0);
     /// let combined = up_peak.merge(background);
     /// assert!(combined.len() >= 20);
+    /// # }
     /// ```
     #[must_use]
     pub fn merge(mut self, other: Self) -> Self {


### PR DESCRIPTION
## Summary

Follow-up to #351. Wraps the `SpawnSchedule::merge` doc-test body in `cfg` main-fn gates so `cargo test --no-default-features --doc` doesn't fail with E0432 on the `use crate::traffic::TrafficPattern` / `use rand::SeedableRng` lines.

## Why

Greptile P1 on #351 flagged that after gating `from_pattern` behind `#[cfg(feature = "traffic")]`, the `merge` doc test still imports those feature-gated symbols unconditionally. The comment arrived after #351 had already satisfied its check requirements and auto-merged, so this lands as a follow-up.

`cargo test --no-default-features --doc` isn't currently run in CI — the wasm32 gate job only does `cargo check`, not `cargo test --doc`. So this fix is about latent correctness rather than unblocking CI.

## What changed

Wrap the body of `merge`'s doc test in:

```
# #[cfg(not(feature = "traffic"))]
# fn main() {}
# #[cfg(feature = "traffic")]
# fn main() {
  ...
# }
```

When `traffic` is off, the doctest compiles to an empty `main` and exits 0. When on, it runs the original example.

## Verification

- [x] `cargo test -p elevator-core --all-features --doc merge` — pass
- [x] `cargo test -p elevator-core --no-default-features --doc` — merge doctest passes (11 pre-existing failures in `traffic-generation.md` are unrelated)
- [x] Pre-commit hook end-to-end