### PR TITLE
feat(scenario): canonical benchmark suite + Condition::P95WaitBelow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.8.0"
+version = "15.9.1"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/scenario.rs
+++ b/crates/elevator-core/src/scenario.rs
@@ -33,6 +33,11 @@ pub enum Condition {
     AvgWaitBelow(f64),
     /// Maximum wait time must be below this value (ticks).
     MaxWaitBelow(u64),
+    /// 95th-percentile wait time must be below this value (ticks).
+    /// Uses [`Metrics::p95_wait_time`](crate::metrics::Metrics::p95_wait_time);
+    /// returns 0 (vacuously passing) when the wait-sample buffer is
+    /// empty or disabled.
+    P95WaitBelow(u64),
     /// Throughput must be above this value (riders per window).
     ThroughputAbove(u64),
     /// All spawned riders must reach a terminal state (delivered or abandoned)
@@ -239,6 +244,11 @@ fn evaluate_condition(
             condition: condition.clone(),
             passed: metrics.max_wait_time() < *threshold,
             actual_value: metrics.max_wait_time() as f64,
+        },
+        Condition::P95WaitBelow(threshold) => ConditionResult {
+            condition: condition.clone(),
+            passed: metrics.p95_wait_time() < *threshold,
+            actual_value: metrics.p95_wait_time() as f64,
         },
         Condition::ThroughputAbove(threshold) => ConditionResult {
             condition: condition.clone(),

--- a/crates/elevator-core/src/tests/canonical_benchmarks.rs
+++ b/crates/elevator-core/src/tests/canonical_benchmarks.rs
@@ -1,0 +1,278 @@
+//! Canonical benchmark scenarios drawn from the dispatch research brief.
+//!
+//! Each test assembles a [`crate::scenario::Scenario`] with a fixed
+//! [`SpawnSchedule`](crate::scenario::SpawnSchedule) and runs it
+//! through [`ScenarioRunner`](crate::scenario::ScenarioRunner). The
+//! four base patterns (up-peak, down-peak, full-load cycle, burst-
+//! then-silence) exercise distinct parts of the dispatch + reposition
+//! surface. The matrix test then runs the up-peak shape across every
+//! non-DCS built-in strategy so any regression that cripples one
+//! strategy is caught by a targeted name — not by a scenario-wide
+//! timeout in a single-strategy test.
+
+use crate::components::Weight;
+use crate::dispatch::DispatchStrategy;
+use crate::dispatch::etd::EtdDispatch;
+use crate::dispatch::look::LookDispatch;
+use crate::dispatch::nearest_car::NearestCarDispatch;
+use crate::dispatch::scan::ScanDispatch;
+use crate::scenario::{Condition, Scenario, ScenarioRunner, SpawnSchedule};
+use crate::stop::StopId;
+
+use super::helpers::{assert_p95_wait_under, multi_floor_config};
+
+/// Factory returning a boxed dispatch strategy. Keeps the matrix test's
+/// strategy list readable — clippy flagged the inline
+/// `Vec<(&str, Box<dyn Fn() -> Box<dyn …>>)>` type as too complex.
+type StrategyFactory = Box<dyn Fn() -> Box<dyn DispatchStrategy>>;
+
+// ── Up-peak rate sweep ──────────────────────────────────────────────
+
+/// Classic morning-rush benchmark: 20 riders enter the lobby staggered
+/// over 20 seconds, each bound for a distinct upper floor. Asserts the
+/// max wait stays bounded and every rider is delivered before the
+/// timeout. Catches sweep-inefficiency regressions on up-sweep and
+/// reposition-to-lobby churn.
+#[test]
+fn up_peak_8_floor_2_car_delivers_within_budget() {
+    let config = multi_floor_config(8, 2);
+    let stops = (0..8).map(StopId).collect::<Vec<_>>();
+    // 20 riders, lobby -> floors 1..=7 (round-robin), 60-tick stagger.
+    let mut schedule = SpawnSchedule::new();
+    for i in 0..20u64 {
+        let dest = stops[1 + (i as usize % 7)];
+        schedule = schedule.staggered(stops[0], dest, 1, i * 60, 60, 70.0);
+    }
+    let scenario = Scenario {
+        name: "up-peak 8-floor 2-car".into(),
+        config,
+        spawns: schedule.into_spawns(),
+        conditions: vec![
+            Condition::AllDeliveredByTick(12_000),
+            Condition::MaxWaitBelow(6_000),
+        ],
+        max_ticks: 15_000,
+    };
+    let mut runner = ScenarioRunner::new(scenario, EtdDispatch::new()).unwrap();
+    let result = runner.run_to_completion();
+    assert!(
+        result.passed,
+        "up-peak must satisfy timeout + max-wait: {:#?}",
+        result.conditions
+    );
+    assert_eq!(runner.skipped_spawns(), 0);
+}
+
+// ── Down-peak mirror ────────────────────────────────────────────────
+
+/// Evening-rush mirror of up-peak: 20 riders from upper floors back
+/// to the lobby. Exercises the down-sweep path and `bypass_load_down_pct`
+/// branch; a regression in either surfaces here but not in up-peak.
+#[test]
+fn down_peak_8_floor_2_car_delivers_within_budget() {
+    let config = multi_floor_config(8, 2);
+    let stops = (0..8).map(StopId).collect::<Vec<_>>();
+    let mut schedule = SpawnSchedule::new();
+    for i in 0..20u64 {
+        let origin = stops[1 + (i as usize % 7)];
+        schedule = schedule.staggered(origin, stops[0], 1, i * 60, 60, 70.0);
+    }
+    let scenario = Scenario {
+        name: "down-peak 8-floor 2-car".into(),
+        config,
+        spawns: schedule.into_spawns(),
+        conditions: vec![
+            Condition::AllDeliveredByTick(12_000),
+            Condition::MaxWaitBelow(6_000),
+        ],
+        max_ticks: 15_000,
+    };
+    let mut runner = ScenarioRunner::new(scenario, EtdDispatch::new()).unwrap();
+    let result = runner.run_to_completion();
+    assert!(
+        result.passed,
+        "down-peak must satisfy timeout + max-wait: {:#?}",
+        result.conditions
+    );
+    assert_eq!(runner.skipped_spawns(), 0);
+}
+
+// ── Full-load cycle ─────────────────────────────────────────────────
+
+/// 20 riders at the lobby, all heading to the top floor, with a
+/// single under-capacity car. Forces at least three round-trips.
+/// Exercises the full-load self-assign guard (see
+/// [`crate::dispatch::pair_can_do_work`]); regression here was
+/// previously a doors-cycle-forever bug (#317).
+#[test]
+fn full_load_cycle_delivers_all_in_bounded_trips() {
+    let mut config = multi_floor_config(6, 1);
+    // 6 riders × 70kg = 420kg; set capacity to 400kg so each trip
+    // carries 5 riders. 20 riders / 5-per-trip = 4 trips minimum.
+    config.elevators[0].weight_capacity = Weight::from(400.0);
+    let stops = (0..6).map(StopId).collect::<Vec<_>>();
+    let schedule = SpawnSchedule::new().burst(stops[0], stops[5], 20, 0, 70.0);
+    let scenario = Scenario {
+        name: "full-load cycle".into(),
+        config,
+        spawns: schedule.into_spawns(),
+        conditions: vec![
+            Condition::AllDeliveredByTick(20_000),
+            Condition::AbandonmentRateBelow(0.01),
+        ],
+        max_ticks: 25_000,
+    };
+    let mut runner = ScenarioRunner::new(scenario, ScanDispatch::new()).unwrap();
+    let result = runner.run_to_completion();
+    assert!(
+        result.passed,
+        "full-load cycle must deliver all 20 riders without abandonment: {:#?}",
+        result.conditions
+    );
+    assert_eq!(
+        result.metrics.total_delivered(),
+        20,
+        "exactly 20 riders must reach their destination"
+    );
+}
+
+// ── Burst-then-silence ──────────────────────────────────────────────
+
+/// 15 riders in a 10-tick burst, then 5 000 ticks of silence, then 1
+/// latecomer. Exercises idle→dispatch transitions, reposition kick-
+/// in, and the rolling-window arrival-log computation crossing an
+/// empty region.
+#[test]
+fn burst_then_silence_handles_latecomer() {
+    let config = multi_floor_config(5, 2);
+    let stops = (0..5).map(StopId).collect::<Vec<_>>();
+    let schedule = SpawnSchedule::new()
+        .staggered(stops[0], stops[3], 15, 0, 1, 70.0) // 15 riders, 1 tick apart
+        .push(crate::scenario::TimedSpawn {
+            tick: 5_000,
+            origin: stops[4],
+            destination: stops[1],
+            weight: 70.0,
+        });
+    let scenario = Scenario {
+        name: "burst then silence".into(),
+        config,
+        spawns: schedule.into_spawns(),
+        conditions: vec![Condition::AllDeliveredByTick(10_000)],
+        max_ticks: 12_000,
+    };
+    let mut runner = ScenarioRunner::new(scenario, EtdDispatch::new()).unwrap();
+    let result = runner.run_to_completion();
+    assert!(
+        result.passed,
+        "burst-then-silence must deliver all 16 riders: {:#?}",
+        result.conditions
+    );
+    assert_eq!(result.metrics.total_delivered(), 16);
+    // p95 is the fraction most sensitive to the latecomer; a blow-up
+    // means reposition didn't recover during the silence.
+    assert_p95_wait_under(runner.sim(), 3_000);
+}
+
+// ── Strategy-comparison matrix ──────────────────────────────────────
+
+/// Up-peak pattern replayed across every non-DCS built-in strategy.
+/// Each strategy must at minimum deliver every rider before the
+/// matrix's generous deadline; the per-strategy metrics (avg wait,
+/// max wait, p95) are read back but not bounded — this test exists
+/// to catch strategies that *fail to deliver*, not to rank them.
+///
+/// Destination-dispatch is excluded because it requires the group
+/// to be in [`crate::dispatch::HallCallMode::Destination`] and a
+/// riders' route to carry destinations at press time, which changes
+/// the scenario shape.
+#[test]
+fn strategy_matrix_all_builtins_deliver_up_peak() {
+    let stops = (0..6).map(StopId).collect::<Vec<_>>();
+    let make_schedule = || {
+        let mut s = SpawnSchedule::new();
+        for i in 0..12u64 {
+            let dest = stops[1 + (i as usize % 5)];
+            s = s.staggered(stops[0], dest, 1, i * 80, 80, 70.0);
+        }
+        s
+    };
+
+    let strategies: Vec<(&str, StrategyFactory)> = vec![
+        ("Scan", Box::new(|| Box::new(ScanDispatch::new()))),
+        ("Look", Box::new(|| Box::new(LookDispatch::new()))),
+        (
+            "NearestCar",
+            Box::new(|| Box::new(NearestCarDispatch::new())),
+        ),
+        ("Etd", Box::new(|| Box::new(EtdDispatch::new()))),
+    ];
+
+    for (name, factory) in strategies {
+        let scenario = Scenario {
+            name: format!("up-peak via {name}"),
+            config: multi_floor_config(6, 2),
+            spawns: make_schedule().into_spawns(),
+            conditions: vec![Condition::AllDeliveredByTick(15_000)],
+            max_ticks: 20_000,
+        };
+        let mut runner = ScenarioRunner::new(scenario, BoxedStrategy(factory())).unwrap();
+        let result = runner.run_to_completion();
+        assert!(
+            result.passed,
+            "strategy {name} must deliver all 12 riders: {:#?}",
+            result.conditions
+        );
+        assert_eq!(
+            result.metrics.total_delivered(),
+            12,
+            "{name} must deliver exactly 12 riders"
+        );
+    }
+}
+
+/// Adapter so a boxed trait object can be fed into
+/// [`ScenarioRunner::new`], which requires
+/// `impl DispatchStrategy + 'static` (not directly `Box<dyn …>`).
+struct BoxedStrategy(Box<dyn DispatchStrategy>);
+
+impl DispatchStrategy for BoxedStrategy {
+    fn pre_dispatch(
+        &mut self,
+        group: &crate::dispatch::ElevatorGroup,
+        manifest: &crate::dispatch::DispatchManifest,
+        world: &mut crate::world::World,
+    ) {
+        self.0.pre_dispatch(group, manifest, world);
+    }
+
+    fn prepare_car(
+        &mut self,
+        car: crate::entity::EntityId,
+        pos: f64,
+        group: &crate::dispatch::ElevatorGroup,
+        manifest: &crate::dispatch::DispatchManifest,
+        world: &crate::world::World,
+    ) {
+        self.0.prepare_car(car, pos, group, manifest, world);
+    }
+
+    fn rank(&mut self, ctx: &crate::dispatch::RankContext<'_>) -> Option<f64> {
+        self.0.rank(ctx)
+    }
+
+    fn fallback(
+        &mut self,
+        car: crate::entity::EntityId,
+        pos: f64,
+        group: &crate::dispatch::ElevatorGroup,
+        manifest: &crate::dispatch::DispatchManifest,
+        world: &crate::world::World,
+    ) -> crate::dispatch::DispatchDecision {
+        self.0.fallback(car, pos, group, manifest, world)
+    }
+
+    fn notify_removed(&mut self, elevator: crate::entity::EntityId) {
+        self.0.notify_removed(elevator);
+    }
+}

--- a/crates/elevator-core/src/tests/helpers.rs
+++ b/crates/elevator-core/src/tests/helpers.rs
@@ -149,3 +149,21 @@ pub fn run_until_done(sim: &mut Simulation, max_ticks: u64) -> bool {
     }
     false
 }
+
+/// Assert the sim's p95 wait time is strictly below `ticks`, with a
+/// failure message that surfaces the observed p95 and sample count.
+/// Scenario tests use this instead of inlining `assert!` so the
+/// message shape is uniform across the canonical benchmark suite.
+///
+/// # Panics
+/// Panics if [`Metrics::p95_wait_time`](crate::metrics::Metrics::p95_wait_time)
+/// is at or above `ticks`.
+pub fn assert_p95_wait_under(sim: &Simulation, ticks: u64) {
+    let m = sim.metrics();
+    let observed = m.p95_wait_time();
+    assert!(
+        observed < ticks,
+        "expected p95 wait < {ticks} ticks, observed {observed} (samples: {})",
+        m.wait_sample_count(),
+    );
+}

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -45,6 +45,7 @@ mod arrival_log_tests;
 mod boundary_tests;
 mod braking_tests;
 mod bypass_tests;
+mod canonical_benchmarks;
 mod destination_dispatch_tests;
 mod destination_queue_tests;
 mod direction_indicator_tests;


### PR DESCRIPTION
## Summary

- Adds five canonical benchmark tests in `crates/elevator-core/src/tests/canonical_benchmarks.rs`.
- Adds `Condition::P95WaitBelow(u64)` and `assert_p95_wait_under` helper.
- Tests 733 → 738 (+5 net).

## Why

Fifth in the dispatch-research PR stack. With #347 (`p95_wait_time`), #348 (`SpawnSchedule` + `multi_floor_config` / `run_until_done`), and #351 (wasm32 gate) all landed, the primitives for running CIBSE-style benchmarks are now in place.

The five scenarios:

1. **Up-peak rate sweep** — 20 riders lobby → distinct uppers, 60-tick stagger, 8-floor / 2-car.
2. **Down-peak mirror** — reversed direction of (1), exercises down-sweep + `bypass_load_down_pct`.
3. **Full-load cycle** — 20 riders at lobby, capacity-400kg car (5 riders/trip). Exercises full-load self-assign guard (regression #317).
4. **Burst-then-silence** — 15 riders in 15-tick burst, 5000-tick silence, 1 latecomer. Exercises idle→dispatch transitions and reposition kick-in. Asserts `p95 < 3_000 ticks`.
5. **Strategy-comparison matrix** — up-peak shape across `Scan`, `Look`, `NearestCar`, `Etd`. Catches dispatch regressions that cripple a single strategy.

## What changed

- `crates/elevator-core/src/tests/canonical_benchmarks.rs`: new file, 5 tests + `BoxedStrategy` adapter for iterating `Box<dyn DispatchStrategy>` factories.
- `crates/elevator-core/src/scenario.rs`: `Condition::P95WaitBelow(u64)` + evaluator.
- `crates/elevator-core/src/tests/helpers.rs`: `assert_p95_wait_under` helper with uniform failure-message shape.
- `crates/elevator-core/src/tests/mod.rs`: register new module.
- `Cargo.lock`: release-please drift sync.

## Out of scope

- `RsrDispatch` is excluded from the matrix because #350 hasn't merged yet. Once it does, a one-line follow-up adds it to the strategy list.
- `DestinationDispatch` excluded because it requires `HallCallMode::Destination` and per-call destinations at press time — different scenario shape.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p elevator-core --all-features --tests -- -D warnings`
- [x] `cargo test -p elevator-core --all-features --lib` — 738 passed (+5 net)
- [x] `cargo test -p elevator-core --all-features --doc` — 158 passed
- [x] `cargo check --workspace --all-features --all-targets`
- [x] Pre-commit hook end-to-end