### PR TITLE
fix(playground): default reposition to PredictiveParking, not SpreadEvenly

### DIFF
--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -75,10 +75,16 @@ impl WasmSim {
         let mut inner = make_sim(&config, strategy)
             .ok_or_else(|| JsError::new(&format!("unknown strategy: {strategy}")))?
             .map_err(|e| JsError::new(&format!("sim build: {e}")))?;
-        // Default to SpreadEvenly reposition *only* when the config didn't
-        // pick one — scenarios with several cars on one line visibly benefit
-        // from active repositioning, but an explicit RON choice must win so
-        // downstream consumers (and future tests) aren't silently overridden.
+        // Default to PredictiveParking reposition *only* when the config
+        // didn't pick one. SpreadEvenly used to be the default, but it's
+        // position-only — during morning up-peak (lobby-heavy) or evening
+        // down-peak it actively pushes idle cars *away* from demand, so
+        // two of three cars end up shuttling to the sky lobby and the
+        // penthouse while the first car handles every lobby call alone.
+        // PredictiveParking reads the arrival log's rolling window and
+        // greedily seats idle cars at the hottest stops, which is what
+        // most observers expect from a multi-car playground. An explicit
+        // RON choice still wins so downstream consumers can opt out.
         let groups_needing_default: Vec<_> = inner
             .groups()
             .iter()
@@ -86,8 +92,8 @@ impl WasmSim {
             .filter(|gid| inner.reposition_id(*gid).is_none())
             .collect();
         for gid in groups_needing_default {
-            if let Some(strategy) = BuiltinReposition::SpreadEvenly.instantiate() {
-                inner.set_reposition(gid, strategy, BuiltinReposition::SpreadEvenly);
+            if let Some(strategy) = BuiltinReposition::PredictiveParking.instantiate() {
+                inner.set_reposition(gid, strategy, BuiltinReposition::PredictiveParking);
             }
         }
         Ok(Self {


### PR DESCRIPTION
## Summary

Changes the playground's auto-wired reposition default from `BuiltinReposition::SpreadEvenly` to `BuiltinReposition::PredictiveParking`. Scenarios that explicitly pick a reposition in their RON still win.

## User report

> In the playground demos, whenever there are 3 elevator cars, it looks like the first one is doing the most work and the other two are just moving together to floors that have already been serviced.

## Root cause

`SpreadEvenly` is **position-only** — it greedily assigns each idle car to the stop that maximises the minimum distance from every other occupied car, with no awareness of demand. In the skyscraper scenario (3 cars, lobby-heavy morning rush):

- The closest car to the lobby wins every dispatch.
- The other two cars fall to `fallback` → become idle.
- Reposition then shuttles them to the sky lobby (middle) and penthouse (top) — the two stops furthest from the first car — even though no one is arriving there.
- By the time those shuttled cars return to lobby-adjacent floors, the first car has handled the next 5–10 calls alone.

## Fix

Swap the default to `PredictiveParking`, which reads `ArrivalLog`'s rolling window and seats idle cars at the highest-rate stops. During up-peak the lobby dominates, so 2 of 3 cars park there and are immediately dispatched to the next pickups instead of commuting to the roof. It degrades gracefully during sparse / cold-start periods (no arrivals → no moves), so the "cars travel to the top at sim start" regression that SpreadEvenly's tiebreaker was added for does not return.

## What changed

- `crates/elevator-wasm/src/lib.rs`: single line, `SpreadEvenly → PredictiveParking` in the `reposition_id(gid).is_none()` fallback path. Updated the comment to document why.

No core behaviour change — both strategies are already in `BuiltinReposition`; this just picks a different default for the playground.

## Verification

- [x] `cargo check -p elevator-wasm --target wasm32-unknown-unknown --no-default-features` — clean
- [x] Pre-commit hook end-to-end
- [ ] Manual verification in the live playground after `wasm-pack` rebuild — left for the reviewer / reproducer