### PR TITLE
feat(playground): per-car speech bubbles driven by sim events

### DIFF
--- a/playground/src/canvas.ts
+++ b/playground/src/canvas.ts
@@ -1,4 +1,4 @@
-import type { Car, Snapshot, Stop } from "./types";
+import type { Car, CarBubble, Snapshot, Stop } from "./types";
 
 // 2-D renderer. Each stop is a horizontal rung with two direction columns
 // (▲ up / ▼ down) showing waiting riders partitioned by route direction.
@@ -209,7 +209,12 @@ export class CanvasRenderer {
     this.#ctx.setTransform(this.#dpr, 0, 0, this.#dpr, 0, 0);
   }
 
-  draw(snap: Snapshot, waitHistory: number[], speedMultiplier: number): void {
+  draw(
+    snap: Snapshot,
+    waitHistory: number[],
+    speedMultiplier: number,
+    bubbles?: Map<number, CarBubble>,
+  ): void {
     this.#resize();
     const { clientWidth: w, clientHeight: h } = this.#canvas;
     this.#ctx.clearRect(0, 0, w, h);
@@ -295,7 +300,91 @@ export class CanvasRenderer {
     this.#computeTweens(snap, carX, toScreenY, s, speedMultiplier);
     this.#drawTweens(s);
 
+    if (bubbles && bubbles.size > 0) {
+      this.#drawBubbles(snap, carX, toScreenY, s, bubbles, w);
+    }
+
     this.#drawSparkline(waitHistory, w, h, s);
+  }
+
+  /**
+   * Draw a small rounded speech-bubble with a tail pointing to each
+   * car that has a fresh action. Bubbles render on top of cars and
+   * tweens so narration stays legible.
+   *
+   * Placement rules:
+   * - Prefer the right side of the car; flip to the left when the
+   *   bubble would clip the canvas edge (common in compare mode).
+   * - Vertically center on the car; no jitter even when the car
+   *   moves, so the bubble reads steadily during motion.
+   */
+  #drawBubbles(
+    snap: Snapshot,
+    carX: Map<number, number>,
+    toScreenY: (y: number) => number,
+    s: Scale,
+    bubbles: Map<number, CarBubble>,
+    canvasWidth: number,
+  ): void {
+    const ctx = this.#ctx;
+    const padX = 6;
+    const padY = 3;
+    const tailW = 5;
+    const tailH = 4;
+    const radius = 5;
+    const font = `${s.fontSmall}px system-ui, sans-serif`;
+    ctx.font = font;
+    ctx.textBaseline = "middle";
+
+    for (const car of snap.cars) {
+      const bubble = bubbles.get(car.id);
+      if (!bubble) continue;
+      const cx = carX.get(car.id);
+      if (cx === undefined) continue;
+      const cy = toScreenY(car.y);
+
+      const textW = ctx.measureText(bubble.text).width;
+      const bubbleW = textW + padX * 2;
+      const bubbleH = s.fontSmall + padY * 2 + 2;
+
+      // Tail side: prefer right; flip when the bubble would overflow
+      // the canvas. In compare mode the right pane's canvas is
+      // narrow enough that the right-side default would clip.
+      const halfCar = s.carW / 2;
+      const rightEdge = cx + halfCar + tailW + bubbleW + 2;
+      const side: "left" | "right" = rightEdge > canvasWidth - 2 ? "left" : "right";
+
+      const bx =
+        side === "right" ? cx + halfCar + tailW : cx - halfCar - tailW - bubbleW;
+      const by = cy - bubbleH / 2;
+
+      // Rounded-rect body.
+      ctx.fillStyle = "rgba(18, 22, 31, 0.92)";
+      ctx.strokeStyle = "rgba(125, 211, 252, 0.55)";
+      ctx.lineWidth = 1;
+      roundedRect(ctx, bx, by, bubbleW, bubbleH, radius);
+      ctx.fill();
+      ctx.stroke();
+
+      // Tail — small triangle pointing at the car.
+      ctx.beginPath();
+      if (side === "right") {
+        ctx.moveTo(bx, cy - tailH / 2);
+        ctx.lineTo(bx - tailW, cy);
+        ctx.lineTo(bx, cy + tailH / 2);
+      } else {
+        ctx.moveTo(bx + bubbleW, cy - tailH / 2);
+        ctx.lineTo(bx + bubbleW + tailW, cy);
+        ctx.lineTo(bx + bubbleW, cy + tailH / 2);
+      }
+      ctx.closePath();
+      ctx.fill();
+      ctx.stroke();
+
+      // Text.
+      ctx.fillStyle = "#e8ecf5";
+      ctx.fillText(bubble.text, bx + padX, cy);
+    }
   }
 
   // ── Stops, labels, direction queues ───────────────────────────────
@@ -836,6 +925,40 @@ function truncate(ctx: CanvasRenderingContext2D, text: string, maxWidth: number)
     else hi = mid - 1;
   }
   return lo === 0 ? ellipsis : text.slice(0, lo) + ellipsis;
+}
+
+/**
+ * Build a rounded-rectangle path on `ctx`. Caller fills/strokes.
+ * Uses `CanvasRenderingContext2D.roundRect` when available
+ * (Chrome/Edge 99+, Safari 16+, Firefox 113+) and falls back to a
+ * manual path for older engines. The playground's Vite + esbuild
+ * target is modern browsers; the fallback keeps a local dev build on
+ * an older headless Chromium (e.g. CI screenshotters) working.
+ */
+function roundedRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+): void {
+  const rr = Math.min(r, w / 2, h / 2);
+  ctx.beginPath();
+  if (typeof ctx.roundRect === "function") {
+    ctx.roundRect(x, y, w, h, rr);
+    return;
+  }
+  ctx.moveTo(x + rr, y);
+  ctx.lineTo(x + w - rr, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + rr);
+  ctx.lineTo(x + w, y + h - rr);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - rr, y + h);
+  ctx.lineTo(x + rr, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - rr);
+  ctx.lineTo(x, y + rr);
+  ctx.quadraticCurveTo(x, y, x + rr, y);
+  ctx.closePath();
 }
 
 // Internal re-export so TS doesn't mark `Stop` as unused if the module is

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -14,7 +14,14 @@ import { DEFAULT_STATE, decodePermalink, encodePermalink, type PermalinkState } 
 import { SCENARIOS, scenarioById } from "./scenarios";
 import { Sim } from "./sim";
 import { TrafficDriver } from "./traffic";
-import type { Metrics, ScenarioMeta, Snapshot, StrategyName } from "./types";
+import type {
+  BubbleEvent,
+  CarBubble,
+  Metrics,
+  ScenarioMeta,
+  Snapshot,
+  StrategyName,
+} from "./types";
 
 // The playground is a side-by-side comparator: up to two sims run the same
 // rider stream under different dispatch strategies. In single mode only
@@ -43,7 +50,22 @@ interface Pane {
   metricsEl: HTMLElement;
   waitHistory: number[];
   latestMetrics: Metrics | null;
+  /**
+   * Per-car speech bubbles. Keyed by car entity id. Each entry fades
+   * after [`BUBBLE_TTL_MS`] wall-clock milliseconds; stale entries are
+   * evicted lazily in [`updateBubbles`] so the map never grows past
+   * `cars × 1`.
+   */
+  bubbles: Map<number, CarBubble>;
 }
+
+/**
+ * How long a speech bubble lingers after its triggering event, in
+ * wall-clock milliseconds. Chosen so that under 1× playback the bubble
+ * reads comfortably; at 16× it's short enough that stale events don't
+ * linger past the action they describe.
+ */
+const BUBBLE_TTL_MS = 1400;
 
 interface State {
   running: boolean;
@@ -363,6 +385,7 @@ async function makePane(
     metricsEl: handles.metrics,
     waitHistory: [],
     latestMetrics: null,
+    bubbles: new Map(),
   };
 }
 
@@ -566,7 +589,14 @@ function loop(state: State): void {
 
     if (state.running && state.ready && state.paneA) {
       const ticks = state.permalink.speed;
-      forEachPane(state, (pane) => pane.sim.step(ticks));
+      forEachPane(state, (pane) => {
+        pane.sim.step(ticks);
+        // Drain events every frame so the wasm `EventBus` can't grow
+        // unbounded during long sessions, and feed the speech-bubble
+        // layer the freshest per-car action.
+        const events = pane.sim.drainEvents();
+        updateBubbles(pane, events);
+      });
 
       const snapA = state.paneA.sim.snapshot();
       // Fan-out spawns to both sims so the comparison is apples-to-apples.
@@ -609,7 +639,70 @@ function renderPane(pane: Pane, snap: Snapshot, speed: number): void {
   pane.latestMetrics = metrics;
   pane.waitHistory.push(metrics.avg_wait_s);
   if (pane.waitHistory.length > WAIT_HISTORY_LEN) pane.waitHistory.shift();
-  pane.renderer.draw(snap, pane.waitHistory, speed);
+  // Evict stale bubbles lazily before handing the map to the renderer.
+  const now = performance.now();
+  for (const [carId, bubble] of pane.bubbles) {
+    if (bubble.expiresAt <= now) pane.bubbles.delete(carId);
+  }
+  pane.renderer.draw(snap, pane.waitHistory, speed, pane.bubbles);
+}
+
+/**
+ * Translate this frame's raw events into per-car speech-bubble state.
+ * Latest event wins — at high speed multipliers a single frame can
+ * contain many events per car, and keeping just the last keeps the
+ * UI readable without pathologically long message queues.
+ *
+ * Uses stop name/id lookups from the pane's latest snapshot via
+ * [`resolveStopName`]; unresolved stop ids fall back to the numeric
+ * id rather than dropping the bubble.
+ */
+function updateBubbles(pane: Pane, events: BubbleEvent[]): void {
+  if (events.length === 0) return;
+  const expiresAt = performance.now() + BUBBLE_TTL_MS;
+  const snap = pane.sim.snapshot();
+  const stopName = (id: number): string => resolveStopName(snap, id);
+  for (const ev of events) {
+    const text = bubbleTextFor(ev, stopName);
+    if (text === null) continue;
+    // Some events are rider-scoped rather than car-scoped (spawn,
+    // abandon). bubbleTextFor returns `null` for those, so we only
+    // get here when `ev` carries an `elevator` field.
+    const carId = (ev as { elevator?: number }).elevator;
+    if (carId === undefined) continue;
+    pane.bubbles.set(carId, { text, expiresAt });
+  }
+}
+
+/** Map an event to a short human-readable bubble text, or `null` for
+ *  events that have no car to attach to (rider-spawned, rider-abandoned). */
+function bubbleTextFor(ev: BubbleEvent, stopName: (id: number) => string): string | null {
+  switch (ev.kind) {
+    case "elevator-assigned":
+      return `Heading to ${stopName(ev.stop)}`;
+    case "elevator-departed":
+      return `Leaving ${stopName(ev.stop)}`;
+    case "elevator-arrived":
+      return `Arrived at ${stopName(ev.stop)}`;
+    case "door-opened":
+      return "Doors open";
+    case "door-closed":
+      return "Doors closed";
+    case "rider-boarded":
+      return "Boarding";
+    case "rider-exited":
+      return `Dropping off at ${stopName(ev.stop)}`;
+    default:
+      return null;
+  }
+}
+
+/** Look up a stop's human-readable name by `entity_id` from a snapshot,
+ *  falling back to the numeric id when the stop isn't in this frame's
+ *  snapshot (can happen briefly after a config reset). */
+function resolveStopName(snap: Snapshot, stopEntityId: number): string {
+  const stop = snap.stops.find((s) => s.entity_id === stopEntityId);
+  return stop?.name ?? `stop #${stopEntityId}`;
 }
 
 function updatePhaseIndicator(state: State, ui: UiHandles): void {

--- a/playground/src/sim.ts
+++ b/playground/src/sim.ts
@@ -1,4 +1,4 @@
-import type { Metrics, Snapshot, StrategyName } from "./types";
+import type { BubbleEvent, Metrics, Snapshot, StrategyName } from "./types";
 
 // Thin TS wrapper around `WasmSim` that narrows JS values returned by
 // serde-wasm-bindgen to our typed DTOs. Kept deliberately small — we don't
@@ -89,11 +89,23 @@ export class Sim {
 
   step(n: number): void {
     this.#inner.stepMany(n);
-    // The wasm `EventBus` buffers every RiderSpawned / DoorOpened / ... event
-    // into `pending_output` until something drains it. The playground no
-    // longer consumes events (the event log was cut), so drop them here to
-    // keep the wasm heap from growing without bound during long sessions.
-    this.#inner.drainEvents();
+  }
+
+  /**
+   * Drain queued sim events into a typed array. Called once per frame
+   * by the playground's render pipeline to update per-car speech
+   * bubbles; also keeps the wasm `EventBus` from growing without bound
+   * during long sessions (previously the bus was drained-and-discarded
+   * inside `step` for exactly that reason).
+   */
+  drainEvents(): BubbleEvent[] {
+    const raw = this.#inner.drainEvents();
+    // The wasm bindgen surface returns `unknown` because the Rust side
+    // serialises via `serde-wasm-bindgen`. The DTO shape is authored in
+    // `crates/elevator-wasm/src/dto.rs` and mirrored by `BubbleEvent`;
+    // the tagged-union `kind: string` fallback absorbs any future variant
+    // the UI doesn't special-case.
+    return (raw as BubbleEvent[] | null | undefined) ?? [];
   }
 
   get dt(): number {

--- a/playground/src/types.ts
+++ b/playground/src/types.ts
@@ -60,6 +60,36 @@ export interface Metrics {
 export type StrategyName = "scan" | "look" | "nearest" | "etd" | "destination";
 
 /**
+ * Decoded event DTOs surfaced by `Sim.drainEvents`. Kind-tagged to
+ * mirror the Rust `EventDto` shape (`#[serde(tag = "kind", rename_all =
+ * "kebab-case")]`). Only the cases the speech-bubble layer consumes are
+ * enumerated; unknown variants fall through to the `string`-kind branch
+ * so a future DTO addition doesn't crash the UI.
+ */
+export type BubbleEvent =
+  | { kind: "rider-spawned"; tick: number; rider: number; origin: number; destination: number }
+  | { kind: "rider-boarded"; tick: number; rider: number; elevator: number }
+  | { kind: "rider-exited"; tick: number; rider: number; elevator: number; stop: number }
+  | { kind: "rider-abandoned"; tick: number; rider: number; stop: number }
+  | { kind: "elevator-arrived"; tick: number; elevator: number; stop: number }
+  | { kind: "elevator-departed"; tick: number; elevator: number; stop: number }
+  | { kind: "door-opened"; tick: number; elevator: number }
+  | { kind: "door-closed"; tick: number; elevator: number }
+  | { kind: "elevator-assigned"; tick: number; elevator: number; stop: number }
+  | { kind: "other"; tick: number; label: string };
+
+/**
+ * Per-car speech-bubble state, keyed by car entity id. `expiresAt`
+ * uses `performance.now()` wall-clock ms — not a sim tick — so the
+ * bubble fades predictably even when the sim races ahead or the tab
+ * backgrounds and `requestAnimationFrame` stalls.
+ */
+export interface CarBubble {
+  text: string;
+  expiresAt: number;
+}
+
+/**
  * One phase of a scenario's day cycle. The `TrafficDriver` linearly
  * interpolates spawn volume between adjacent phases so transitions
  * feel continuous rather than stepwise.


### PR DESCRIPTION
## Summary

Every elevator car now carries a small rounded speech bubble that renders the most recent event-driven action — "Arrived at Floor 5", "Boarding", "Doors open", "Heading to Sky Lobby" — and fades after ~1.4 s. Makes dispatch decisions visible without the user having to infer them from subtle phase-colour transitions.

## Why

User request: "in the playground demos, … update the playground so it shows little human-friendly speech bubbles next to each elevator car showing what's it's doing via events."

The sim already emits a rich event stream (`ElevatorArrived`, `DoorOpened`, `RiderBoarded`, …) exposed via `WasmSim::drainEvents`, but the playground was silently discarding them inside `step()` to keep the wasm `EventBus` from growing unbounded. This PR hooks that stream into a per-car UI overlay.

## What changed

- `playground/src/sim.ts` — `step(n)` no longer drains-and-discards events. A new `drainEvents(): BubbleEvent[]` surfaces the typed queue to callers; drain-per-frame is now the caller's responsibility.
- `playground/src/main.ts` — new `updateBubbles(pane, events)` maps each event to a short phrase via `bubbleTextFor`. Latest event per car wins; expired bubbles are evicted lazily in `renderPane`.
- `playground/src/canvas.ts` — new `#drawBubbles` renders a rounded-rect pill with a tail pointing at the car. Prefers the right side; flips left when it would overflow (compare-mode right pane is narrow). Adds a `roundedRect` helper with a manual-path fallback for engines lacking `CanvasRenderingContext2D.roundRect`.
- `playground/src/types.ts` — new `BubbleEvent` tagged union mirroring `crates/elevator-wasm/src/dto.rs::EventDto`, plus a `CarBubble` shape.

## Event → text mapping

| Event | Bubble text |
|---|---|
| `elevator-assigned` | "Heading to {stop}" |
| `elevator-departed` | "Leaving {stop}" |
| `elevator-arrived` | "Arrived at {stop}" |
| `door-opened` | "Doors open" |
| `door-closed` | "Doors closed" |
| `rider-boarded` | "Boarding" |
| `rider-exited` | "Dropping off at {stop}" |

Rider-scoped events (`rider-spawned`, `rider-abandoned`) have no car to attach to and return `null`.

## Verification

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test` — 47/47 pass
- [x] Pre-commit hook end-to-end

## Out of scope

- Speech bubbles for waiting riders / stops — different UX concern.
- Animating the bubble's fade — an opacity ramp would be nicer but costs a per-frame alpha computation; keeping the binary show/hide for now.