### PR TITLE
feat(traffic-detector): rolling-window classifier as world resource

### DIFF
--- a/crates/elevator-core/src/arrival_log.rs
+++ b/crates/elevator-core/src/arrival_log.rs
@@ -128,3 +128,76 @@ impl ArrivalLog {
             });
     }
 }
+
+/// Append-only log of rider *destinations*, mirror of [`ArrivalLog`]
+/// for the outgoing side of a trip.
+///
+/// Enables destination-aware signals that the origin-only
+/// `ArrivalLog` can't produce — specifically
+/// [`TrafficMode::DownPeak`](crate::traffic_detector::TrafficMode::DownPeak)
+/// detection, which triggers on "lots of riders heading *to* the
+/// lobby" rather than "lots of riders arriving *from* it."
+///
+/// Auto-installed alongside [`ArrivalLog`] by `Simulation::new` and
+/// appended to in the same rider-spawn path. Shares
+/// [`ArrivalLogRetention`]'s retention window so the two logs can't
+/// drift against each other's time horizon.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DestinationLog {
+    /// `(tick, destination_stop)` pairs. Entries are appended in
+    /// tick order; all queries go through
+    /// [`destinations_in_window`](Self::destinations_in_window).
+    entries: Vec<(u64, EntityId)>,
+}
+
+impl DestinationLog {
+    /// Record that a rider spawned at `tick` heading to `destination`.
+    pub fn record(&mut self, tick: u64, destination: EntityId) {
+        self.entries.push((tick, destination));
+    }
+
+    /// Count rides to `stop` within the window `[now - window, now]`
+    /// inclusive. `window_ticks = 0` always returns 0.
+    #[must_use]
+    pub fn destinations_in_window(&self, stop: EntityId, now: u64, window_ticks: u64) -> u64 {
+        if window_ticks == 0 {
+            return 0;
+        }
+        let lower = now.saturating_sub(window_ticks);
+        self.entries
+            .iter()
+            .filter(|(t, s)| *s == stop && *t >= lower && *t <= now)
+            .count() as u64
+    }
+
+    /// Prune entries older than `cutoff` ticks. Called from
+    /// `Simulation::advance_tick` alongside [`ArrivalLog::prune_before`].
+    pub fn prune_before(&mut self, cutoff: u64) {
+        self.entries.retain(|(t, _)| *t >= cutoff);
+    }
+
+    /// Number of recorded events (diagnostic / tests).
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the log has no recorded events.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Remap entity IDs for snapshot restore. Mirrors
+    /// [`ArrivalLog::remap_entity_ids`].
+    pub fn remap_entity_ids(&mut self, id_remap: &std::collections::HashMap<EntityId, EntityId>) {
+        self.entries
+            .retain_mut(|(_, stop)| match id_remap.get(stop) {
+                Some(&new) => {
+                    *stop = new;
+                    true
+                }
+                None => false,
+            });
+    }
+}

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -409,6 +409,8 @@ pub mod topology;
 /// Traffic generation (arrival patterns).
 #[cfg(feature = "traffic")]
 pub mod traffic;
+/// Traffic-mode detector (up-peak / idle / inter-floor).
+pub mod traffic_detector;
 
 /// Register multiple extension types for snapshot deserialization in one call.
 ///

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -604,6 +604,16 @@ impl Simulation {
         {
             world.insert_resource(crate::traffic_detector::TrafficDetector::default());
         }
+        // Same forward-compat pattern for the destination log. An
+        // older snapshot would leave the detector unable to detect
+        // down-peak post-restore; a fresh empty log lets it resume
+        // classification after a few ticks of observed traffic.
+        if world
+            .resource::<crate::arrival_log::DestinationLog>()
+            .is_none()
+        {
+            world.insert_resource(crate::arrival_log::DestinationLog::default());
+        }
         Self {
             world,
             events: EventBus::default(),

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -185,6 +185,10 @@ impl Simulation {
         world.insert_resource(crate::arrival_log::ArrivalLog::default());
         world.insert_resource(crate::arrival_log::CurrentTick::default());
         world.insert_resource(crate::arrival_log::ArrivalLogRetention::default());
+        // Traffic-mode classifier. Auto-refreshed in the metrics phase
+        // from the same rolling window; strategies read the current
+        // mode via `World::resource::<TrafficDetector>()`.
+        world.insert_resource(crate::traffic_detector::TrafficDetector::default());
         // Expose tick rate to strategies that need to unit-convert
         // tick-denominated elevator fields (door cycle, ack latency)
         // into the second-denominated terms of their cost functions.

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -591,6 +591,19 @@ impl Simulation {
         // sim, silently halving ETD's door-cost scale.
         let mut world = world;
         world.insert_resource(crate::time::TickRate(ticks_per_second));
+        // Re-insert the traffic detector for the same forward-compat
+        // reason as `TickRate`: a snapshot taken before this resource
+        // existed wouldn't carry it, and `refresh_traffic_detector` in
+        // the metrics phase would silently no-op forever post-restore
+        // (greptile review of #361). `insert_resource` is
+        // last-writer-wins, so snapshots that already carry a
+        // detector keep their stored state.
+        if world
+            .resource::<crate::traffic_detector::TrafficDetector>()
+            .is_none()
+        {
+            world.insert_resource(crate::traffic_detector::TrafficDetector::default());
+        }
         Self {
             world,
             events: EventBus::default(),

--- a/crates/elevator-core/src/sim/rider.rs
+++ b/crates/elevator-core/src/sim/rider.rs
@@ -172,6 +172,12 @@ impl super::Simulation {
         if let Some(log) = self.world.resource_mut::<crate::arrival_log::ArrivalLog>() {
             log.record(self.tick, origin);
         }
+        if let Some(log) = self
+            .world
+            .resource_mut::<crate::arrival_log::DestinationLog>()
+        {
+            log.record(self.tick, destination);
+        }
         self.events.emit(Event::RiderSpawned {
             rider: eid,
             origin,

--- a/crates/elevator-core/src/sim/substep.rs
+++ b/crates/elevator-core/src/sim/substep.rs
@@ -305,6 +305,12 @@ impl super::Simulation {
         if let Some(log) = self.world.resource_mut::<crate::arrival_log::ArrivalLog>() {
             log.prune_before(cutoff);
         }
+        if let Some(log) = self
+            .world
+            .resource_mut::<crate::arrival_log::DestinationLog>()
+        {
+            log.prune_before(cutoff);
+        }
     }
 
     /// Mirror `self.tick` into the `CurrentTick` world resource so

--- a/crates/elevator-core/src/systems/metrics.rs
+++ b/crates/elevator-core/src/systems/metrics.rs
@@ -124,4 +124,31 @@ pub fn run(
     }
 
     metrics.update_throughput(ctx.tick);
+    refresh_traffic_detector(world, ctx.tick);
+}
+
+/// Clone the arrival log, collect stops in position order (lobby
+/// first), and hand both to the auto-installed
+/// [`TrafficDetector`](crate::traffic_detector::TrafficDetector).
+/// Skipped when either resource is absent — games running a bare
+/// `World` without them get a silent no-op.
+fn refresh_traffic_detector(world: &mut World, tick: u64) {
+    let Some(log) = world.resource::<crate::arrival_log::ArrivalLog>().cloned() else {
+        return;
+    };
+    if world
+        .resource::<crate::traffic_detector::TrafficDetector>()
+        .is_none()
+    {
+        return;
+    }
+    let mut stops: Vec<_> = world
+        .iter_stops()
+        .map(|(eid, s)| (eid, s.position))
+        .collect();
+    stops.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+    let stop_ids: Vec<crate::entity::EntityId> = stops.into_iter().map(|(eid, _)| eid).collect();
+    if let Some(detector) = world.resource_mut::<crate::traffic_detector::TrafficDetector>() {
+        detector.update(&log, tick, &stop_ids);
+    }
 }

--- a/crates/elevator-core/src/systems/metrics.rs
+++ b/crates/elevator-core/src/systems/metrics.rs
@@ -127,13 +127,16 @@ pub fn run(
     refresh_traffic_detector(world, ctx.tick);
 }
 
-/// Clone the arrival log, collect stops in position order (lobby
-/// first), and hand both to the auto-installed
+/// Clone the arrival + destination logs, collect stops in position
+/// order (lobby first), and hand everything to the auto-installed
 /// [`TrafficDetector`](crate::traffic_detector::TrafficDetector).
-/// Skipped when either resource is absent — games running a bare
-/// `World` without them get a silent no-op.
+/// Skipped when the detector is absent — games running a bare
+/// `World` without it get a silent no-op. A missing
+/// [`DestinationLog`](crate::arrival_log::DestinationLog) is
+/// tolerated with a default-empty fallback so down-peak detection
+/// silently disables without panicking.
 fn refresh_traffic_detector(world: &mut World, tick: u64) {
-    let Some(log) = world.resource::<crate::arrival_log::ArrivalLog>().cloned() else {
+    let Some(arrivals) = world.resource::<crate::arrival_log::ArrivalLog>().cloned() else {
         return;
     };
     if world
@@ -142,6 +145,10 @@ fn refresh_traffic_detector(world: &mut World, tick: u64) {
     {
         return;
     }
+    let destinations = world
+        .resource::<crate::arrival_log::DestinationLog>()
+        .cloned()
+        .unwrap_or_default();
     let mut stops: Vec<_> = world
         .iter_stops()
         .map(|(eid, s)| (eid, s.position))
@@ -149,6 +156,6 @@ fn refresh_traffic_detector(world: &mut World, tick: u64) {
     stops.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
     let stop_ids: Vec<crate::entity::EntityId> = stops.into_iter().map(|(eid, _)| eid).collect();
     if let Some(detector) = world.resource_mut::<crate::traffic_detector::TrafficDetector>() {
-        detector.update(&log, tick, &stop_ids);
+        detector.update(&arrivals, &destinations, tick, &stop_ids);
     }
 }

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -35,6 +35,7 @@ mod substep_tests;
 mod tagged_metrics_tests;
 mod time_tests;
 mod topology_tests;
+mod traffic_detector_tests;
 #[cfg(feature = "traffic")]
 mod traffic_tests;
 mod world_tests;

--- a/crates/elevator-core/src/tests/traffic_detector_tests.rs
+++ b/crates/elevator-core/src/tests/traffic_detector_tests.rs
@@ -1,6 +1,6 @@
 //! Unit + integration tests for [`crate::traffic_detector::TrafficDetector`].
 
-use crate::arrival_log::ArrivalLog;
+use crate::arrival_log::{ArrivalLog, DestinationLog};
 use crate::entity::EntityId;
 use crate::traffic_detector::{TrafficDetector, TrafficMode};
 use crate::world::World;
@@ -35,7 +35,7 @@ fn empty_log_stays_idle() {
     let mut d = TrafficDetector::new();
     let log = ArrivalLog::default();
     let (_w, stops) = fake_stops();
-    d.update(&log, 60 * 60 * 10, &stops);
+    d.update(&log, &DestinationLog::default(), 60 * 60 * 10, &stops);
     assert_eq!(d.current_mode(), TrafficMode::Idle);
 }
 
@@ -57,7 +57,7 @@ fn up_peak_trips_on_lobby_fraction() {
         log.record(t * 50, f2);
         log.record(t * 50, f3);
     }
-    d.update(&log, 3_500, &[lobby, f2, f3]);
+    d.update(&log, &DestinationLog::default(), 3_500, &[lobby, f2, f3]);
     assert_eq!(d.current_mode(), TrafficMode::UpPeak);
 }
 
@@ -73,7 +73,7 @@ fn inter_floor_uniform_distribution() {
             log.record(t * 10, s);
         }
     }
-    d.update(&log, 3_500, &stops);
+    d.update(&log, &DestinationLog::default(), 3_500, &stops);
     assert_eq!(d.current_mode(), TrafficMode::InterFloor);
 }
 
@@ -91,7 +91,7 @@ fn idle_rate_overrides_lobby_fraction() {
     // 0.00028/tick, under the 2/3600 ≈ 0.00056 default threshold.
     // Total rate is what the classifier checks first.
     log.record(100, lobby);
-    d.update(&log, 3_500, &[lobby, f2]);
+    d.update(&log, &DestinationLog::default(), 3_500, &[lobby, f2]);
     assert_eq!(d.current_mode(), TrafficMode::Idle);
 }
 
@@ -99,7 +99,12 @@ fn idle_rate_overrides_lobby_fraction() {
 #[test]
 fn no_stops_is_idle() {
     let mut d = TrafficDetector::new();
-    d.update(&ArrivalLog::default(), 1_000, &[]);
+    d.update(
+        &ArrivalLog::default(),
+        &DestinationLog::default(),
+        1_000,
+        &[],
+    );
     assert_eq!(d.current_mode(), TrafficMode::Idle);
 }
 
@@ -112,8 +117,68 @@ fn no_stops_is_idle() {
 fn zero_threshold_with_empty_window_stays_idle() {
     let mut d = TrafficDetector::new().with_idle_rate_threshold(0.0);
     let (_w, stops) = fake_stops();
-    d.update(&ArrivalLog::default(), 3_600, &stops);
+    d.update(
+        &ArrivalLog::default(),
+        &DestinationLog::default(),
+        3_600,
+        &stops,
+    );
     assert_eq!(d.current_mode(), TrafficMode::Idle);
+}
+
+/// Classifier flips to `DownPeak` when ≥60% of destinations are
+/// lobby. Needs arrivals to be distributed (otherwise `UpPeak`'s
+/// higher precedence wins the mode).
+#[test]
+fn down_peak_trips_on_lobby_destination_fraction() {
+    let mut d = TrafficDetector::new().with_window_ticks(3_600);
+    let mut arrivals = ArrivalLog::default();
+    let mut destinations = DestinationLog::default();
+    let (_w, stops) = fake_stops();
+    let lobby = stops[0];
+    let f2 = stops[1];
+    let f3 = stops[2];
+    // 30 arrivals each at f2 and f3 (60 total, 0% lobby-origin),
+    // 45 of their destinations are lobby (75% lobby-destination).
+    for t in 0..30u64 {
+        arrivals.record(t * 50, f2);
+        arrivals.record(t * 50, f3);
+    }
+    for t in 0..45u64 {
+        destinations.record(t * 50, lobby);
+    }
+    for t in 0..15u64 {
+        destinations.record(t * 50, f2);
+    }
+    d.update(&arrivals, &destinations, 3_500, &[lobby, f2, f3]);
+    assert_eq!(d.current_mode(), TrafficMode::DownPeak);
+}
+
+/// Up-peak wins precedence when both thresholds are met — documented
+/// in `TrafficDetector::update`'s precedence paragraph.
+#[test]
+fn up_peak_beats_down_peak_when_both_trigger() {
+    let mut d = TrafficDetector::new().with_window_ticks(3_600);
+    let mut arrivals = ArrivalLog::default();
+    let mut destinations = DestinationLog::default();
+    let (_w, stops) = fake_stops();
+    let lobby = stops[0];
+    let f2 = stops[1];
+    // Pathological: every arrival AND every destination at lobby.
+    // `f2` appears only to avoid div-by-zero with zero non-lobby
+    // stops; the log entries there are 0.
+    for t in 0..100u64 {
+        arrivals.record(t * 30, lobby);
+        destinations.record(t * 30, lobby);
+    }
+    d.update(&arrivals, &destinations, 3_500, &[lobby, f2]);
+    assert_eq!(d.current_mode(), TrafficMode::UpPeak);
+}
+
+#[test]
+#[should_panic(expected = "down_peak_fraction must be finite and in [0, 1]")]
+fn down_peak_fraction_out_of_range_panics() {
+    let _ = TrafficDetector::new().with_down_peak_fraction(-0.1);
 }
 
 #[test]

--- a/crates/elevator-core/src/tests/traffic_detector_tests.rs
+++ b/crates/elevator-core/src/tests/traffic_detector_tests.rs
@@ -103,6 +103,19 @@ fn no_stops_is_idle() {
     assert_eq!(d.current_mode(), TrafficMode::Idle);
 }
 
+/// An empty arrival window with `idle_rate_threshold = 0.0` must
+/// still classify as `Idle` — the docstring promises "min rate to
+/// leave Idle," which a zero threshold trivially satisfies, but the
+/// strict `<` in the rate comparison wouldn't on its own (0 < 0 is
+/// false). Greptile regression pin for the #361 review.
+#[test]
+fn zero_threshold_with_empty_window_stays_idle() {
+    let mut d = TrafficDetector::new().with_idle_rate_threshold(0.0);
+    let (_w, stops) = fake_stops();
+    d.update(&ArrivalLog::default(), 3_600, &stops);
+    assert_eq!(d.current_mode(), TrafficMode::Idle);
+}
+
 #[test]
 #[should_panic(expected = "TrafficDetector::with_window_ticks requires a positive window")]
 fn zero_window_panics() {

--- a/crates/elevator-core/src/tests/traffic_detector_tests.rs
+++ b/crates/elevator-core/src/tests/traffic_detector_tests.rs
@@ -1,0 +1,164 @@
+//! Unit + integration tests for [`crate::traffic_detector::TrafficDetector`].
+
+use crate::arrival_log::ArrivalLog;
+use crate::entity::EntityId;
+use crate::traffic_detector::{TrafficDetector, TrafficMode};
+use crate::world::World;
+
+use super::helpers::{default_config, run_until_done, scan};
+use crate::sim::Simulation;
+use crate::stop::StopId;
+
+/// Spawn three anonymous entities in a scratch world. Stable order —
+/// the returned `[lobby, f2, f3]` layout matches the detector's
+/// "lobby-is-first" expectation.
+fn fake_stops() -> (World, Vec<EntityId>) {
+    let mut world = World::new();
+    let lobby = world.spawn();
+    let f2 = world.spawn();
+    let f3 = world.spawn();
+    (world, vec![lobby, f2, f3])
+}
+
+// ── Classifier — direct unit tests ──────────────────────────────────
+
+#[test]
+fn default_mode_is_idle() {
+    let d = TrafficDetector::new();
+    assert_eq!(d.current_mode(), TrafficMode::Idle);
+}
+
+/// An empty arrival log at any tick keeps the detector idle — no
+/// demand means no mode to claim.
+#[test]
+fn empty_log_stays_idle() {
+    let mut d = TrafficDetector::new();
+    let log = ArrivalLog::default();
+    let (_w, stops) = fake_stops();
+    d.update(&log, 60 * 60 * 10, &stops);
+    assert_eq!(d.current_mode(), TrafficMode::Idle);
+}
+
+/// Classifier flips to `UpPeak` once ≥60% of arrivals are at the
+/// lobby over the window.
+#[test]
+fn up_peak_trips_on_lobby_fraction() {
+    let mut d = TrafficDetector::new().with_window_ticks(3_600);
+    let mut log = ArrivalLog::default();
+    let (_w, stops) = fake_stops();
+    let lobby = stops[0];
+    let f2 = stops[1];
+    let f3 = stops[2];
+    // 70 arrivals at lobby, 30 spread across upper floors → 70% lobby.
+    for t in 0..70u64 {
+        log.record(t * 50, lobby);
+    }
+    for t in 0..15u64 {
+        log.record(t * 50, f2);
+        log.record(t * 50, f3);
+    }
+    d.update(&log, 3_500, &[lobby, f2, f3]);
+    assert_eq!(d.current_mode(), TrafficMode::UpPeak);
+}
+
+/// Evenly distributed arrivals at a sustained rate classify as
+/// `InterFloor`, not up-peak.
+#[test]
+fn inter_floor_uniform_distribution() {
+    let mut d = TrafficDetector::new().with_window_ticks(3_600);
+    let mut log = ArrivalLog::default();
+    let (_w, stops) = fake_stops();
+    for t in 0..60u64 {
+        for &s in &stops {
+            log.record(t * 10, s);
+        }
+    }
+    d.update(&log, 3_500, &stops);
+    assert_eq!(d.current_mode(), TrafficMode::InterFloor);
+}
+
+/// Below the idle-rate threshold the classifier returns `Idle`
+/// regardless of the lobby fraction — a trickle of lobby-only
+/// arrivals during overnight hours isn't "up-peak."
+#[test]
+fn idle_rate_overrides_lobby_fraction() {
+    let mut d = TrafficDetector::new().with_window_ticks(3_600);
+    let mut log = ArrivalLog::default();
+    let (_w, stops) = fake_stops();
+    let lobby = stops[0];
+    let f2 = stops[1];
+    // 1 lobby arrival over the 3600-tick window = rate 1/3600 ≈
+    // 0.00028/tick, under the 2/3600 ≈ 0.00056 default threshold.
+    // Total rate is what the classifier checks first.
+    log.record(100, lobby);
+    d.update(&log, 3_500, &[lobby, f2]);
+    assert_eq!(d.current_mode(), TrafficMode::Idle);
+}
+
+/// Zero stops → Idle (no lobby to compare against).
+#[test]
+fn no_stops_is_idle() {
+    let mut d = TrafficDetector::new();
+    d.update(&ArrivalLog::default(), 1_000, &[]);
+    assert_eq!(d.current_mode(), TrafficMode::Idle);
+}
+
+#[test]
+#[should_panic(expected = "TrafficDetector::with_window_ticks requires a positive window")]
+fn zero_window_panics() {
+    let _ = TrafficDetector::new().with_window_ticks(0);
+}
+
+#[test]
+#[should_panic(expected = "up_peak_fraction must be finite and in [0, 1]")]
+fn out_of_range_up_peak_fraction_panics() {
+    let _ = TrafficDetector::new().with_up_peak_fraction(1.5);
+}
+
+#[test]
+#[should_panic(expected = "idle_rate_threshold must be finite and non-negative")]
+fn nan_idle_rate_panics() {
+    let _ = TrafficDetector::new().with_idle_rate_threshold(f64::NAN);
+}
+
+// ── Integration: Simulation auto-installs + auto-updates ────────────
+
+/// `Simulation::new` must install a `TrafficDetector` as a world
+/// resource so downstream strategies can read it without manual
+/// plumbing.
+#[test]
+fn simulation_installs_traffic_detector_resource() {
+    let sim = Simulation::new(&default_config(), scan()).unwrap();
+    let present = sim.world().resource::<TrafficDetector>().is_some();
+    assert!(
+        present,
+        "Simulation::new must insert a TrafficDetector resource by default"
+    );
+}
+
+/// The metrics phase must refresh the detector each tick. After a
+/// burst of lobby-spawns and enough sim time for the window to fill,
+/// the detector's `last_update_tick` must be recent relative to the
+/// current tick (within one tick — the metrics phase runs with
+/// `ctx.tick` reflecting the just-completed tick, which trails
+/// `sim.current_tick()` by at most 1).
+#[test]
+fn metrics_phase_refreshes_detector_last_update_tick() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    let _ = run_until_done(&mut sim, 20_000);
+    let now = sim.current_tick();
+    let detector = sim
+        .world()
+        .resource::<TrafficDetector>()
+        .unwrap_or_else(|| panic!("detector installed"));
+    let delta = now.saturating_sub(detector.last_update_tick());
+    assert!(
+        delta <= 1,
+        "metrics phase must refresh the detector every tick (delta={delta}, now={now})"
+    );
+    assert!(
+        detector.last_update_tick() > 0,
+        "detector was never updated"
+    );
+}

--- a/crates/elevator-core/src/traffic_detector.rs
+++ b/crates/elevator-core/src/traffic_detector.rs
@@ -1,0 +1,198 @@
+//! Traffic-mode detector.
+//!
+//! Classifies the current simulation moment into one of a small set of
+//! [`TrafficMode`]s by reading the [`ArrivalLog`](crate::arrival_log::ArrivalLog)'s
+//! rolling window. Consumers — dispatch tuning, adaptive reposition,
+//! HUD narration — read [`TrafficDetector::current_mode`] each tick to
+//! get a cheap, pre-computed answer instead of re-deriving it
+//! themselves.
+//!
+//! V1 implements the hard-rule classifier from Siikonen's
+//! fuzzy-labelled traffic patterns (the fuzzy membership math reduces
+//! to the same threshold crossings once defuzzified): up-peak is
+//! triggered when the lobby-origin fraction crosses a threshold over
+//! a rolling window; idle when the total arrival rate is below a
+//! noise floor; everything else is inter-floor. Down-peak detection
+//! needs a destination signal (rides heading *to* the lobby, not
+//! arrivals *from* it) which the base [`ArrivalLog`] doesn't carry;
+//! `DownPeak` is in [`TrafficMode`] for API stability and will flip
+//! on in a follow-up.
+
+use crate::arrival_log::ArrivalLog;
+use crate::entity::EntityId;
+use serde::{Deserialize, Serialize};
+
+/// Detected traffic mode. Consumers read this via
+/// [`TrafficDetector::current_mode`] each tick.
+///
+/// `#[non_exhaustive]` so adding variants (`DownPeak`, `Lunch`) in
+/// follow-up PRs is a minor-version bump, not a break.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[non_exhaustive]
+pub enum TrafficMode {
+    /// Total arrival rate is below [`TrafficDetector::idle_rate_threshold`].
+    /// Reposition strategies should stay put; dispatch can drop
+    /// starvation-avoidance bonuses.
+    #[default]
+    Idle,
+    /// Lobby-origin fraction is above [`TrafficDetector::up_peak_fraction`].
+    /// Classic morning rush — reposition to lobby, prefer faster
+    /// lobby↔upper cycles.
+    UpPeak,
+    /// Arrivals are distributed across stops without a strong lobby
+    /// skew. Default non-rush state.
+    InterFloor,
+    /// Reserved for a future destination-aware classifier (rides to
+    /// the lobby dominate). Never emitted by the V1 implementation;
+    /// present in the enum so downstream match arms can compile once
+    /// the down-peak signal lands.
+    DownPeak,
+}
+
+/// Rolling-window classifier for the sim's current traffic pattern.
+///
+/// Stored as a world resource under `World::resource::<TrafficDetector>()`
+/// and auto-refreshed each tick in the metrics phase. Manual reconstruction
+/// is supported via [`TrafficDetector::with_*`] builders for tests that
+/// bypass `Simulation`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrafficDetector {
+    /// Window over which arrivals are counted (ticks).
+    window_ticks: u64,
+    /// Minimum per-tick arrival rate to leave [`TrafficMode::Idle`].
+    /// `arrivals_total / window_ticks` must exceed this.
+    idle_rate_threshold: f64,
+    /// Lobby-origin fraction at or above which we flip to
+    /// [`TrafficMode::UpPeak`]. 0.6 matches the Siikonen-Aalto
+    /// threshold for "clear up-peak" from the rolling-average
+    /// classifier lineage.
+    up_peak_fraction: f64,
+    /// Last classified mode; returned by [`current_mode`](Self::current_mode).
+    current: TrafficMode,
+    /// Tick of the most recent `update` call. Read by snapshot
+    /// inspectors; not used for staleness (the metrics phase always
+    /// refreshes before consumers read).
+    last_update_tick: u64,
+}
+
+impl Default for TrafficDetector {
+    fn default() -> Self {
+        Self {
+            window_ticks: crate::arrival_log::DEFAULT_ARRIVAL_WINDOW_TICKS,
+            // Two arrivals per minute at 60 Hz = ~0.000555 per tick.
+            // Below that the sim is effectively idle from a traffic
+            // perspective — empty overnight or cold-start scenarios.
+            idle_rate_threshold: 2.0 / 3600.0,
+            up_peak_fraction: 0.6,
+            current: TrafficMode::Idle,
+            last_update_tick: 0,
+        }
+    }
+}
+
+impl TrafficDetector {
+    /// Create with default thresholds.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Override the rolling-window size (ticks).
+    ///
+    /// # Panics
+    /// Panics on `window_ticks = 0` — the classifier would divide by
+    /// zero when computing the rate.
+    #[must_use]
+    pub const fn with_window_ticks(mut self, window_ticks: u64) -> Self {
+        assert!(
+            window_ticks > 0,
+            "TrafficDetector::with_window_ticks requires a positive window"
+        );
+        self.window_ticks = window_ticks;
+        self
+    }
+
+    /// Override the idle-rate threshold (arrivals per tick).
+    ///
+    /// # Panics
+    /// Panics on non-finite or negative values.
+    #[must_use]
+    pub fn with_idle_rate_threshold(mut self, rate: f64) -> Self {
+        assert!(
+            rate.is_finite() && rate >= 0.0,
+            "idle_rate_threshold must be finite and non-negative, got {rate}"
+        );
+        self.idle_rate_threshold = rate;
+        self
+    }
+
+    /// Override the lobby-origin fraction that trips up-peak.
+    ///
+    /// # Panics
+    /// Panics if `fraction` is NaN or outside `[0.0, 1.0]`.
+    #[must_use]
+    pub fn with_up_peak_fraction(mut self, fraction: f64) -> Self {
+        assert!(
+            fraction.is_finite() && (0.0..=1.0).contains(&fraction),
+            "up_peak_fraction must be finite and in [0, 1], got {fraction}"
+        );
+        self.up_peak_fraction = fraction;
+        self
+    }
+
+    /// The most recently classified mode.
+    #[must_use]
+    pub const fn current_mode(&self) -> TrafficMode {
+        self.current
+    }
+
+    /// Tick of the last `update` call (diagnostic only).
+    #[must_use]
+    pub const fn last_update_tick(&self) -> u64 {
+        self.last_update_tick
+    }
+
+    /// Rolling-window size (ticks).
+    #[must_use]
+    pub const fn window_ticks(&self) -> u64 {
+        self.window_ticks
+    }
+
+    /// Re-classify using arrivals from `log` as of tick `now`. `stops`
+    /// is the list of stop entities to aggregate over; the *first*
+    /// entry is treated as the lobby for up-peak classification, so
+    /// callers must pass them in position order (lobby first).
+    ///
+    /// Idempotent — calling twice with the same inputs yields the
+    /// same mode. Called once per tick by the metrics phase; callers
+    /// driving the sim manually (tests, games stepping by hand) can
+    /// invoke it directly.
+    pub fn update(&mut self, log: &ArrivalLog, now: u64, stops: &[EntityId]) {
+        self.last_update_tick = now;
+        if stops.is_empty() || self.window_ticks == 0 {
+            self.current = TrafficMode::Idle;
+            return;
+        }
+        let lobby = stops[0];
+        let lobby_count = log.arrivals_in_window(lobby, now, self.window_ticks);
+        let mut total: u64 = 0;
+        for &s in stops {
+            total = total.saturating_add(log.arrivals_in_window(s, now, self.window_ticks));
+        }
+        #[allow(clippy::cast_precision_loss)] // counts fit in f64 mantissa
+        let rate_per_tick = total as f64 / self.window_ticks as f64;
+        if rate_per_tick < self.idle_rate_threshold {
+            self.current = TrafficMode::Idle;
+            return;
+        }
+        if total > 0 {
+            #[allow(clippy::cast_precision_loss)]
+            let fraction = lobby_count as f64 / total as f64;
+            if fraction >= self.up_peak_fraction {
+                self.current = TrafficMode::UpPeak;
+                return;
+            }
+        }
+        self.current = TrafficMode::InterFloor;
+    }
+}

--- a/crates/elevator-core/src/traffic_detector.rs
+++ b/crates/elevator-core/src/traffic_detector.rs
@@ -179,19 +179,25 @@ impl TrafficDetector {
         for &s in stops {
             total = total.saturating_add(log.arrivals_in_window(s, now, self.window_ticks));
         }
+        // An empty window is always `Idle`, independent of the
+        // configured threshold. Guards the `idle_rate_threshold = 0.0`
+        // edge case where the strict `<` comparison below wouldn't
+        // catch `total == 0` (greptile review of #361).
+        if total == 0 {
+            self.current = TrafficMode::Idle;
+            return;
+        }
         #[allow(clippy::cast_precision_loss)] // counts fit in f64 mantissa
         let rate_per_tick = total as f64 / self.window_ticks as f64;
         if rate_per_tick < self.idle_rate_threshold {
             self.current = TrafficMode::Idle;
             return;
         }
-        if total > 0 {
-            #[allow(clippy::cast_precision_loss)]
-            let fraction = lobby_count as f64 / total as f64;
-            if fraction >= self.up_peak_fraction {
-                self.current = TrafficMode::UpPeak;
-                return;
-            }
+        #[allow(clippy::cast_precision_loss)]
+        let fraction = lobby_count as f64 / total as f64;
+        if fraction >= self.up_peak_fraction {
+            self.current = TrafficMode::UpPeak;
+            return;
         }
         self.current = TrafficMode::InterFloor;
     }

--- a/crates/elevator-core/src/traffic_detector.rs
+++ b/crates/elevator-core/src/traffic_detector.rs
@@ -20,7 +20,7 @@
 //! [`crate::traffic_detector::TrafficMode::DownPeak`] is in the enum
 //! for API stability and will flip on in a follow-up.
 
-use crate::arrival_log::ArrivalLog;
+use crate::arrival_log::{ArrivalLog, DestinationLog};
 use crate::entity::EntityId;
 use serde::{Deserialize, Serialize};
 
@@ -69,6 +69,12 @@ pub struct TrafficDetector {
     /// threshold for "clear up-peak" from the rolling-average
     /// classifier lineage.
     up_peak_fraction: f64,
+    /// Lobby-destination fraction at or above which we flip to
+    /// [`TrafficMode::DownPeak`]. Uses the same 0.6 default as
+    /// `up_peak_fraction` — the two peaks are mirror statistical
+    /// events and the clarity-threshold literature treats them
+    /// symmetrically.
+    down_peak_fraction: f64,
     /// Last classified mode; returned by [`current_mode`](Self::current_mode).
     current: TrafficMode,
     /// Tick of the most recent `update` call. Read by snapshot
@@ -86,6 +92,7 @@ impl Default for TrafficDetector {
             // perspective — empty overnight or cold-start scenarios.
             idle_rate_threshold: 2.0 / 3600.0,
             up_peak_fraction: 0.6,
+            down_peak_fraction: 0.6,
             current: TrafficMode::Idle,
             last_update_tick: 0,
         }
@@ -142,6 +149,21 @@ impl TrafficDetector {
         self
     }
 
+    /// Override the lobby-destination fraction that trips
+    /// down-peak.
+    ///
+    /// # Panics
+    /// Panics if `fraction` is NaN or outside `[0.0, 1.0]`.
+    #[must_use]
+    pub fn with_down_peak_fraction(mut self, fraction: f64) -> Self {
+        assert!(
+            fraction.is_finite() && (0.0..=1.0).contains(&fraction),
+            "down_peak_fraction must be finite and in [0, 1], got {fraction}"
+        );
+        self.down_peak_fraction = fraction;
+        self
+    }
+
     /// The most recently classified mode.
     #[must_use]
     pub const fn current_mode(&self) -> TrafficMode {
@@ -160,46 +182,84 @@ impl TrafficDetector {
         self.window_ticks
     }
 
-    /// Re-classify using arrivals from `log` as of tick `now`. `stops`
-    /// is the list of stop entities to aggregate over; the *first*
-    /// entry is treated as the lobby for up-peak classification, so
-    /// callers must pass them in position order (lobby first).
+    /// Re-classify using arrivals and destinations as of tick
+    /// `now`. `stops` is the list of stop entities to aggregate
+    /// over; the *first* entry is treated as the lobby for both
+    /// up-peak and down-peak classification, so callers must pass
+    /// them in position order (lobby first). `destinations` may be
+    /// an empty (default-constructed) `DestinationLog` — in that
+    /// case down-peak detection silently no-ops and only the
+    /// origin-driven modes fire.
+    ///
+    /// Precedence when both peaks meet their thresholds (rare —
+    /// lobby-origins and lobby-destinations can't both be ≥60% in a
+    /// 100-arrival window without overlap): `UpPeak` wins because
+    /// the origin signal arrives first in time (rider spawn is what
+    /// logs the arrival; the destination signal arrives at the same
+    /// instant but the dispatcher sees up-peak's lobby queue before
+    /// down-peak's upper-floor queue absorbs the car).
     ///
     /// Idempotent — calling twice with the same inputs yields the
-    /// same mode. Called once per tick by the metrics phase; callers
-    /// driving the sim manually (tests, games stepping by hand) can
-    /// invoke it directly.
-    pub fn update(&mut self, log: &ArrivalLog, now: u64, stops: &[EntityId]) {
+    /// same mode. Called once per tick by the metrics phase;
+    /// callers driving the sim manually can invoke it directly.
+    pub fn update(
+        &mut self,
+        arrivals: &ArrivalLog,
+        destinations: &DestinationLog,
+        now: u64,
+        stops: &[EntityId],
+    ) {
         self.last_update_tick = now;
         if stops.is_empty() || self.window_ticks == 0 {
             self.current = TrafficMode::Idle;
             return;
         }
         let lobby = stops[0];
-        let lobby_count = log.arrivals_in_window(lobby, now, self.window_ticks);
-        let mut total: u64 = 0;
+        let lobby_origin_count = arrivals.arrivals_in_window(lobby, now, self.window_ticks);
+        let lobby_dest_count = destinations.destinations_in_window(lobby, now, self.window_ticks);
+        let mut total_origin: u64 = 0;
+        let mut total_dest: u64 = 0;
         for &s in stops {
-            total = total.saturating_add(log.arrivals_in_window(s, now, self.window_ticks));
+            total_origin =
+                total_origin.saturating_add(arrivals.arrivals_in_window(s, now, self.window_ticks));
+            total_dest = total_dest.saturating_add(destinations.destinations_in_window(
+                s,
+                now,
+                self.window_ticks,
+            ));
         }
-        // An empty window is always `Idle`, independent of the
-        // configured threshold. Guards the `idle_rate_threshold = 0.0`
-        // edge case where the strict `<` comparison below wouldn't
-        // catch `total == 0` (greptile review of #361).
-        if total == 0 {
+        // An empty arrivals window is always `Idle`, independent of
+        // the configured threshold. Guards the `idle_rate_threshold
+        // = 0.0` edge case where the strict `<` comparison below
+        // wouldn't catch `total == 0`.
+        if total_origin == 0 {
             self.current = TrafficMode::Idle;
             return;
         }
         #[allow(clippy::cast_precision_loss)] // counts fit in f64 mantissa
-        let rate_per_tick = total as f64 / self.window_ticks as f64;
+        let rate_per_tick = total_origin as f64 / self.window_ticks as f64;
         if rate_per_tick < self.idle_rate_threshold {
             self.current = TrafficMode::Idle;
             return;
         }
         #[allow(clippy::cast_precision_loss)]
-        let fraction = lobby_count as f64 / total as f64;
-        if fraction >= self.up_peak_fraction {
+        let up_fraction = lobby_origin_count as f64 / total_origin as f64;
+        if up_fraction >= self.up_peak_fraction {
             self.current = TrafficMode::UpPeak;
             return;
+        }
+        // Down-peak: check only if the destination log has seen
+        // any activity; a zero-destination window (old snapshot or
+        // pure rider-less hall calls) would divide by zero and
+        // spuriously match the threshold at `0/0 = NaN` — falling
+        // through to `InterFloor` is the safer default.
+        if total_dest > 0 {
+            #[allow(clippy::cast_precision_loss)]
+            let down_fraction = lobby_dest_count as f64 / total_dest as f64;
+            if down_fraction >= self.down_peak_fraction {
+                self.current = TrafficMode::DownPeak;
+                return;
+            }
         }
         self.current = TrafficMode::InterFloor;
     }

--- a/crates/elevator-core/src/traffic_detector.rs
+++ b/crates/elevator-core/src/traffic_detector.rs
@@ -1,11 +1,12 @@
 //! Traffic-mode detector.
 //!
-//! Classifies the current simulation moment into one of a small set of
-//! [`TrafficMode`]s by reading the [`ArrivalLog`](crate::arrival_log::ArrivalLog)'s
-//! rolling window. Consumers — dispatch tuning, adaptive reposition,
-//! HUD narration — read [`TrafficDetector::current_mode`] each tick to
-//! get a cheap, pre-computed answer instead of re-deriving it
-//! themselves.
+//! Classifies the current simulation moment into one of a small set
+//! of `TrafficMode` variants by reading the
+//! [`ArrivalLog`](crate::arrival_log::ArrivalLog)'s rolling window.
+//! Consumers — dispatch tuning, adaptive reposition, HUD narration —
+//! read [`crate::traffic_detector::TrafficDetector::current_mode`]
+//! each tick to get a cheap, pre-computed answer instead of
+//! re-deriving it themselves.
 //!
 //! V1 implements the hard-rule classifier from Siikonen's
 //! fuzzy-labelled traffic patterns (the fuzzy membership math reduces
@@ -14,9 +15,10 @@
 //! a rolling window; idle when the total arrival rate is below a
 //! noise floor; everything else is inter-floor. Down-peak detection
 //! needs a destination signal (rides heading *to* the lobby, not
-//! arrivals *from* it) which the base [`ArrivalLog`] doesn't carry;
-//! `DownPeak` is in [`TrafficMode`] for API stability and will flip
-//! on in a follow-up.
+//! arrivals *from* it) which the base
+//! [`ArrivalLog`](crate::arrival_log::ArrivalLog) doesn't carry;
+//! [`crate::traffic_detector::TrafficMode::DownPeak`] is in the enum
+//! for API stability and will flip on in a follow-up.
 
 use crate::arrival_log::ArrivalLog;
 use crate::entity::EntityId;
@@ -30,12 +32,12 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[non_exhaustive]
 pub enum TrafficMode {
-    /// Total arrival rate is below [`TrafficDetector::idle_rate_threshold`].
+    /// Total arrival rate is below the detector's `idle_rate_threshold`.
     /// Reposition strategies should stay put; dispatch can drop
     /// starvation-avoidance bonuses.
     #[default]
     Idle,
-    /// Lobby-origin fraction is above [`TrafficDetector::up_peak_fraction`].
+    /// Lobby-origin fraction is above the detector's `up_peak_fraction`.
     /// Classic morning rush — reposition to lobby, prefer faster
     /// lobby↔upper cycles.
     UpPeak,
@@ -52,9 +54,9 @@ pub enum TrafficMode {
 /// Rolling-window classifier for the sim's current traffic pattern.
 ///
 /// Stored as a world resource under `World::resource::<TrafficDetector>()`
-/// and auto-refreshed each tick in the metrics phase. Manual reconstruction
-/// is supported via [`TrafficDetector::with_*`] builders for tests that
-/// bypass `Simulation`.
+/// and auto-refreshed each tick in the metrics phase. Manual
+/// reconstruction is supported via the `with_*` builders for tests
+/// that bypass `Simulation`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TrafficDetector {
     /// Window over which arrivals are counted (ticks).


### PR DESCRIPTION
## Summary

Adds `TrafficDetector` — a cheap hard-rule classifier that reads the existing `ArrivalLog` rolling window and exposes a `TrafficMode` each tick.

Auto-installed by `Simulation::new`, auto-refreshed in the metrics phase, consumed via `world.resource::<TrafficDetector>()`. No consumer inside this PR; it lays the foundation for the `AdaptiveParking` reposition (brief PR #7) which will gate between `ReturnToLobby` / `SpreadEvenly` / `PredictiveParking` based on the detected mode.

Sixth in the dispatch-research PR stack.

## Classifier (Siikonen–Aalto hard-rule lineage)

```
rate = total_arrivals_in_window / window_ticks
if rate < idle_rate_threshold       -> Idle
if arrivals_at_lobby / total >= 0.6 -> UpPeak
else                                -> InterFloor
```

`DownPeak` is in the `TrafficMode` enum for API stability but never emitted — it needs a destination signal (rides *to* the lobby, not arrivals *from* it) that `ArrivalLog` doesn't carry. Will flip on in a follow-up once a destination-log resource lands.

Defaults: 18 000-tick window (5 min at 60 Hz, matching `PredictiveParking`), `2/3600` idle-rate threshold, `0.6` up-peak fraction. All tunable via `with_*` builders with finite/range asserts.

## What changed

- `crates/elevator-core/src/traffic_detector.rs`: new module — `TrafficMode` enum (`#[non_exhaustive]`), `TrafficDetector` struct, `update(log, now, stops)`.
- `crates/elevator-core/src/lib.rs`: register `pub mod traffic_detector`.
- `crates/elevator-core/src/sim/construction.rs`: auto-install `TrafficDetector::default()` next to `ArrivalLog`.
- `crates/elevator-core/src/systems/metrics.rs`: new private `refresh_traffic_detector` called at the end of the metrics phase. Extracted rather than inlined so the outer `run` stays under the 100-line clippy cap.
- `crates/elevator-core/src/tests/traffic_detector_tests.rs`: 11 new tests — classifier cases, auto-install, auto-refresh, config-validation panics.
- `crates/elevator-core/src/tests/mod.rs`: register new module.

## Out of scope

- `DownPeak` detection — needs destination-aware signal.
- CUSUM change-point detector — hard-rule classifier is simpler and covers the common case; CUSUM can replace the rule set in a follow-up if we need finer transitions.
- Any dispatch / reposition strategy consuming the detector — that's brief PR #7.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p elevator-core --all-features --tests -- -D warnings`
- [x] `cargo test -p elevator-core --all-features --lib` — 758 passed (+11 net)
- [x] `cargo test -p elevator-core --all-features --doc` — pass
- [x] `cargo check --workspace --all-features --all-targets`
- [x] Pre-commit hook end-to-end