### PR TITLE
feat(traffic): TopFloorPeak pattern for stranded-penthouse scenarios

### DIFF
--- a/crates/elevator-core/src/tests/traffic_tests.rs
+++ b/crates/elevator-core/src/tests/traffic_tests.rs
@@ -80,6 +80,50 @@ fn down_peak_biases_dest_to_lobby() {
     );
 }
 
+/// `TopFloorPeak` biases origins to the topmost stop — mirror of
+/// `UpPeak` for the other end of the shaft. Catches the regression
+/// class "stranded top-floor rider never dispatched" that plain
+/// `Mixed` or `Uniform` patterns rarely exercise.
+#[test]
+fn top_floor_peak_biases_origin_to_top() {
+    let mut world = World::new();
+    let stops = make_stops(&mut world, 10);
+    let top = *stops.last().unwrap();
+    let mut rng = rand::rng();
+
+    let mut top_origins = 0;
+    let total = 1000;
+    for _ in 0..total {
+        let (o, _) = TrafficPattern::TopFloorPeak
+            .sample(&stops, &mut rng)
+            .unwrap();
+        if o == top {
+            top_origins += 1;
+        }
+    }
+    let ratio = top_origins as f64 / total as f64;
+    assert!(
+        ratio > 0.5,
+        "TopFloorPeak should have >50% origins from the top stop, got {ratio:.2}"
+    );
+}
+
+/// A `TopFloorPeak` rider's destination must never equal the origin;
+/// the rejection-sampling branch for inter-floor fallbacks handles
+/// the `< 1/n` tail where `uniform_pair_indices` collision-retries.
+#[test]
+fn top_floor_peak_origin_never_equals_destination() {
+    let mut world = World::new();
+    let stops = make_stops(&mut world, 6);
+    let mut rng = rand::rng();
+    for _ in 0..2_000 {
+        let (o, d) = TrafficPattern::TopFloorPeak
+            .sample(&stops, &mut rng)
+            .unwrap();
+        assert_ne!(o, d, "origin == destination leaks a zero-length trip");
+    }
+}
+
 #[test]
 fn too_few_stops_returns_none() {
     let mut world = World::new();

--- a/crates/elevator-core/src/tests/traffic_tests.rs
+++ b/crates/elevator-core/src/tests/traffic_tests.rs
@@ -124,6 +124,19 @@ fn top_floor_peak_origin_never_equals_destination() {
     }
 }
 
+/// `TopFloorPeak` must survive a serde round-trip so scenarios that
+/// reference it in RON (and snapshots capturing a
+/// [`crate::traffic::TrafficSchedule`] that uses it) restore to the
+/// same variant. Greptile P2 on #364.
+#[test]
+fn top_floor_peak_serde_roundtrip() {
+    let v = TrafficPattern::TopFloorPeak;
+    let s = ron::to_string(&v).unwrap();
+    assert_eq!(s, "TopFloorPeak");
+    let back: TrafficPattern = ron::from_str(&s).unwrap();
+    assert_eq!(v, back);
+}
+
 #[test]
 fn too_few_stops_returns_none() {
     let mut world = World::new();

--- a/crates/elevator-core/src/traffic.rs
+++ b/crates/elevator-core/src/traffic.rs
@@ -62,6 +62,13 @@ pub enum TrafficPattern {
     Lunchtime,
     /// Mixed: combination of up-peak, down-peak, and inter-floor traffic.
     Mixed,
+    /// Stranded top-floor: most riders originate at the **topmost** stop
+    /// (rather than the lobby) and head elsewhere. Models the canonical
+    /// community-benchmark shape where a penthouse or rooftop deck
+    /// drives isolated, low-rate demand that easily gets starved by
+    /// lobby-centric dispatchers. Unlike [`UpPeak`](Self::UpPeak),
+    /// origins are skewed *away* from the lobby.
+    TopFloorPeak,
 }
 
 /// Sample an (origin, destination) index pair from `n` stops.
@@ -129,6 +136,19 @@ fn sample_indices(
                 Some((lobby, rng.random_range(1..n)))
             } else if r < 0.6 {
                 Some((rng.random_range(1..n), lobby))
+            } else {
+                Some(uniform_pair_indices(n, rng))
+            }
+        }
+
+        TrafficPattern::TopFloorPeak => {
+            // 80% from the top stop, 20% inter-floor. Destination is
+            // drawn from `0..top` so origin ≠ destination without
+            // needing the rejection-sampling loop in
+            // `uniform_pair_indices`.
+            let top = n - 1;
+            if rng.random_range(0.0..1.0) < 0.8 {
+                Some((top, rng.random_range(0..top)))
             } else {
                 Some(uniform_pair_indices(n, rng))
             }


### PR DESCRIPTION
## Summary

Adds a sixth `TrafficPattern` variant — `TopFloorPeak` — that mirrors `UpPeak` for the other end of the shaft: 80% of riders originate at the topmost stop, 20% inter-floor fallback. Non-breaking via the enum's `#[non_exhaustive]`.

## Why

The canonical community-benchmark "stranded top-floor rider" scenario — a lightly-used penthouse or rooftop deck that's easy for lobby-centric dispatchers to starve under concurrent up-peak traffic. Without this variant, the existing patterns (Uniform, UpPeak, DownPeak, Lunchtime, Mixed) all either bias toward the lobby or cycle through uniformly; none reproduce the top-end bias needed to exercise that starvation path.

Eighth in the dispatch-research PR stack.

## What changed

- `crates/elevator-core/src/traffic.rs`: new enum variant + sampling branch in `sample_indices`. Uses `rng.random_range(0..top)` instead of `uniform_pair_indices` for the biased case so origin ≠ destination falls out of the index construction without rejection sampling.
- `crates/elevator-core/src/tests/traffic_tests.rs`: 2 new tests — `top_floor_peak_biases_origin_to_top` (ratio > 50%) and `top_floor_peak_origin_never_equals_destination`.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p elevator-core --all-features --tests -- -D warnings`
- [x] `cargo test -p elevator-core --all-features --lib` — 754 passed (+2 net)
- [x] Pre-commit hook end-to-end