### PR TITLE
feat(playground): expose RsrDispatch in the strategy picker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.10.0"
+version = "15.11.1"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -13,7 +13,7 @@
 use elevator_core::config::SimConfig;
 use elevator_core::dispatch::{
     BuiltinReposition, BuiltinStrategy, DestinationDispatch, EtdDispatch, LookDispatch,
-    NearestCarDispatch, ScanDispatch,
+    NearestCarDispatch, RsrDispatch, ScanDispatch,
 };
 use elevator_core::prelude::{Simulation, StopId};
 use wasm_bindgen::prelude::*;
@@ -29,6 +29,7 @@ fn strategy_id(name: &str) -> Option<BuiltinStrategy> {
         "nearest" => Some(BuiltinStrategy::NearestCar),
         "etd" => Some(BuiltinStrategy::Etd),
         "destination" => Some(BuiltinStrategy::Destination),
+        "rsr" => Some(BuiltinStrategy::Rsr),
         _ => None,
     }
 }
@@ -47,6 +48,11 @@ fn make_sim(
         "nearest" => Simulation::new(config, NearestCarDispatch::new()),
         "etd" => Simulation::new(config, EtdDispatch::new()),
         "destination" => Simulation::new(config, DestinationDispatch::new()),
+        // RSR is the composite cost-stack strategy (ETA + wrong-
+        // direction / car-call-affinity / load-fraction terms). The
+        // playground exposes it with the stock weights — callers
+        // seeking non-default tunings must drop to the Rust API.
+        "rsr" => Simulation::new(config, RsrDispatch::new()),
         _ => return None,
     })
 }

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -28,13 +28,14 @@ import type {
 // pane A is visible. A lightweight scoreboard highlights which strategy is
 // winning on each live metric.
 
-const UI_STRATEGIES: StrategyName[] = ["scan", "look", "nearest", "etd", "destination"];
+const UI_STRATEGIES: StrategyName[] = ["scan", "look", "nearest", "etd", "destination", "rsr"];
 const STRATEGY_LABELS: Record<StrategyName, string> = {
   scan: "SCAN",
   look: "LOOK",
   nearest: "NEAREST",
   etd: "ETD",
   destination: "DCS",
+  rsr: "RSR",
 };
 const WAIT_HISTORY_LEN = 120;
 const COLOR_A = "#7dd3fc";

--- a/playground/src/types.ts
+++ b/playground/src/types.ts
@@ -57,7 +57,7 @@ export interface Metrics {
   total_moves: number;
 }
 
-export type StrategyName = "scan" | "look" | "nearest" | "etd" | "destination";
+export type StrategyName = "scan" | "look" | "nearest" | "etd" | "destination" | "rsr";
 
 /**
  * Decoded event DTOs surfaced by `Sim.drainEvents`. Kind-tagged to


### PR DESCRIPTION
## Summary

`RsrDispatch` landed in #350 but the playground's strategy selector still only exposes the original five built-ins. Adding \"rsr\" across the three coupled surfaces makes it user-selectable alongside SCAN / LOOK / NEAREST / ETD / DCS.

## What changed

- `crates/elevator-wasm/src/lib.rs`: add \`\"rsr\"\` branch to `strategy_id` and `make_sim`, import `RsrDispatch`.
- `playground/src/types.ts`: extend the `StrategyName` union with \`\"rsr\"\`.
- `playground/src/main.ts`: add to `UI_STRATEGIES` + `STRATEGY_LABELS`.

Uses the stock weights (`eta_weight = 1.0`, penalties/bonuses at `0.0`) so out-of-the-box behaviour mirrors `NearestCar`; callers wanting non-default tunings still need the Rust API.

## Test plan

- [x] `cargo check -p elevator-wasm --target wasm32-unknown-unknown --no-default-features`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm test` — 47/47 pass
- [x] Pre-commit hook end-to-end

The wasm bundle in `playground/public/pkg/` is regenerated by the docs deploy workflow — no manual rebuild required.