### PR TITLE
feat(dispatch): AdaptiveParking reposition — gates by TrafficMode

### DIFF
--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -1118,6 +1118,9 @@ pub enum BuiltinReposition {
     NearestIdle,
     /// Pre-position cars near stops with the highest recent arrival rate.
     PredictiveParking,
+    /// Mode-gated: picks between `ReturnToLobby` / `PredictiveParking`
+    /// based on the current `TrafficDetector` mode.
+    Adaptive,
     /// Custom strategy identified by name.
     Custom(String),
 }
@@ -1130,6 +1133,7 @@ impl std::fmt::Display for BuiltinReposition {
             Self::DemandWeighted => write!(f, "DemandWeighted"),
             Self::NearestIdle => write!(f, "NearestIdle"),
             Self::PredictiveParking => write!(f, "PredictiveParking"),
+            Self::Adaptive => write!(f, "Adaptive"),
             Self::Custom(name) => write!(f, "Custom({name})"),
         }
     }
@@ -1148,6 +1152,7 @@ impl BuiltinReposition {
             Self::DemandWeighted => Some(Box::new(reposition::DemandWeighted)),
             Self::NearestIdle => Some(Box::new(reposition::NearestIdle)),
             Self::PredictiveParking => Some(Box::new(reposition::PredictiveParking::new())),
+            Self::Adaptive => Some(Box::new(reposition::AdaptiveParking::new())),
             Self::Custom(_) => None,
         }
     }

--- a/crates/elevator-core/src/dispatch/reposition.rs
+++ b/crates/elevator-core/src/dispatch/reposition.rs
@@ -269,6 +269,104 @@ impl RepositionStrategy for PredictiveParking {
     }
 }
 
+/// Mode-gated reposition: dispatches to an inner strategy chosen
+/// by the current [`TrafficMode`](crate::traffic_detector::TrafficMode).
+///
+/// Closes the playground-reported "chaotic repositioning" complaint:
+/// the single-strategy defaults either lock cars to the lobby
+/// ([`ReturnToLobby`]) or shuttle them toward the hottest stop
+/// ([`PredictiveParking`]) regardless of traffic shape. Adaptive
+/// picks per mode:
+///
+/// | Mode                                              | Inner                      |
+/// |---------------------------------------------------|----------------------------|
+/// | [`UpPeak`](crate::traffic_detector::TrafficMode::UpPeak)         | [`ReturnToLobby`]           |
+/// | [`InterFloor`](crate::traffic_detector::TrafficMode::InterFloor) | [`PredictiveParking`]       |
+/// | [`DownPeak`](crate::traffic_detector::TrafficMode::DownPeak)     | [`PredictiveParking`] (today) |
+/// | [`Idle`](crate::traffic_detector::TrafficMode::Idle)             | no-op (stay put)             |
+///
+/// The `DownPeak` row uses `PredictiveParking` for now — it'll
+/// become a dedicated upper-floor-biased variant once
+/// `TrafficDetector` emits `DownPeak` (needs the destination-log
+/// that today's [`ArrivalLog`] doesn't carry). Falls back to a
+/// `PredictiveParking`-like default if the detector is missing
+/// from `World` (e.g. hand-built tests bypassing `Simulation`).
+pub struct AdaptiveParking {
+    /// Inner strategy used in up-peak mode. Configurable so games
+    /// can pin a different home stop (sky-lobby buildings, e.g.).
+    return_to_lobby: ReturnToLobby,
+    /// Inner strategy used when demand is diffuse or heading down.
+    predictive: PredictiveParking,
+}
+
+impl AdaptiveParking {
+    /// Create with defaults: `ReturnToLobby::new()` (home = stop 0)
+    /// and `PredictiveParking::new()` (default rolling window).
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            return_to_lobby: ReturnToLobby::new(),
+            predictive: PredictiveParking::new(),
+        }
+    }
+
+    /// Override the home stop used during `UpPeak`. Same semantics as
+    /// [`ReturnToLobby::with_home`].
+    #[must_use]
+    pub const fn with_home(mut self, index: usize) -> Self {
+        self.return_to_lobby = ReturnToLobby::with_home(index);
+        self
+    }
+
+    /// Override the window used for `InterFloor` / `DownPeak`
+    /// predictive parking. Same semantics as
+    /// [`PredictiveParking::with_window_ticks`].
+    ///
+    /// # Panics
+    /// Panics on `window_ticks = 0`, matching `PredictiveParking`.
+    #[must_use]
+    pub const fn with_window_ticks(mut self, window_ticks: u64) -> Self {
+        self.predictive = PredictiveParking::with_window_ticks(window_ticks);
+        self
+    }
+}
+
+impl Default for AdaptiveParking {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RepositionStrategy for AdaptiveParking {
+    fn reposition(
+        &mut self,
+        idle_elevators: &[(EntityId, f64)],
+        stop_positions: &[(EntityId, f64)],
+        group: &ElevatorGroup,
+        world: &World,
+        out: &mut Vec<(EntityId, EntityId)>,
+    ) {
+        use crate::traffic_detector::{TrafficDetector, TrafficMode};
+        let mode = world
+            .resource::<TrafficDetector>()
+            .map_or(TrafficMode::InterFloor, TrafficDetector::current_mode);
+        match mode {
+            TrafficMode::Idle => {
+                // Stay put — no point commuting when there's no
+                // demand to pre-position for.
+            }
+            TrafficMode::UpPeak => {
+                self.return_to_lobby
+                    .reposition(idle_elevators, stop_positions, group, world, out);
+            }
+            TrafficMode::DownPeak | TrafficMode::InterFloor => {
+                self.predictive
+                    .reposition(idle_elevators, stop_positions, group, world, out);
+            }
+        }
+    }
+}
+
 /// No-op strategy: idle elevators stay where they stopped.
 ///
 /// Use this to disable repositioning for a group while keeping

--- a/crates/elevator-core/src/tests/adaptive_parking_tests.rs
+++ b/crates/elevator-core/src/tests/adaptive_parking_tests.rs
@@ -1,0 +1,212 @@
+//! Unit tests for [`crate::dispatch::reposition::AdaptiveParking`].
+//!
+//! The strategy's behaviour is a pure dispatch on the current
+//! [`TrafficMode`](crate::traffic_detector::TrafficMode); each test
+//! pins the detector to one mode and verifies the idle-car moves
+//! match the mode's inner strategy.
+
+use crate::arrival_log::{ArrivalLog, CurrentTick};
+use crate::dispatch::reposition::AdaptiveParking;
+use crate::dispatch::{BuiltinReposition, RepositionStrategy};
+use crate::entity::EntityId;
+use crate::traffic_detector::{TrafficDetector, TrafficMode};
+
+use super::helpers::{default_config, scan};
+use crate::sim::Simulation;
+
+/// Spawn a world via `Simulation::new`, then return the first group +
+/// a snapshot of `(stop_entity, position)` pairs sorted by position.
+/// Keeps the test boilerplate tight.
+fn sim_with_idle_cars(cars: usize) -> Simulation {
+    let mut cfg = default_config();
+    for i in 1..cars {
+        cfg.elevators.push(crate::config::ElevatorConfig {
+            id: i as u32,
+            name: format!("Car {i}"),
+            max_speed: cfg.elevators[0].max_speed,
+            acceleration: cfg.elevators[0].acceleration,
+            deceleration: cfg.elevators[0].deceleration,
+            weight_capacity: cfg.elevators[0].weight_capacity,
+            starting_stop: crate::stop::StopId(0),
+            door_open_ticks: cfg.elevators[0].door_open_ticks,
+            door_transition_ticks: cfg.elevators[0].door_transition_ticks,
+            restricted_stops: Vec::new(),
+            #[cfg(feature = "energy")]
+            energy_profile: None,
+            service_mode: None,
+            inspection_speed_factor: 0.25,
+            bypass_load_up_pct: None,
+            bypass_load_down_pct: None,
+        });
+    }
+    Simulation::new(&cfg, scan()).unwrap()
+}
+
+fn force_mode(sim: &mut Simulation, mode: TrafficMode) {
+    // Replace the auto-installed detector with a pre-classified one
+    // so the test doesn't depend on ArrivalLog seeding to reach the
+    // desired mode. The wrapper here matches what the metrics phase
+    // would produce for that mode.
+    let mut detector = TrafficDetector::new();
+    // SAFETY: the only way to set `current` from outside the module
+    // is via `update()`, which reads the log. Use the log path.
+    match mode {
+        TrafficMode::Idle => { /* default mode */ }
+        TrafficMode::UpPeak => {
+            let mut log = ArrivalLog::default();
+            // 70 arrivals at stop 0 over 18k-tick default window → up-peak.
+            let lobby = sim.stop_entity(crate::stop::StopId(0)).unwrap();
+            for t in 0..70u64 {
+                log.record(t * 50, lobby);
+            }
+            let stops: Vec<EntityId> = sim.world().iter_stops().map(|(eid, _)| eid).collect();
+            detector.update(&log, 3_500, &stops);
+        }
+        TrafficMode::InterFloor => {
+            let mut log = ArrivalLog::default();
+            let stops: Vec<EntityId> = sim.world().iter_stops().map(|(eid, _)| eid).collect();
+            for t in 0..60u64 {
+                for &s in &stops {
+                    log.record(t * 10, s);
+                }
+            }
+            detector.update(&log, 3_500, &stops);
+        }
+        TrafficMode::DownPeak => {
+            // Not yet emitted by V1 detector; test behaviour against
+            // an `InterFloor`-seeded detector since Adaptive handles
+            // them identically today. Real `DownPeak` validation
+            // waits for the destination-log follow-up.
+            let mut log = ArrivalLog::default();
+            let stops: Vec<EntityId> = sim.world().iter_stops().map(|(eid, _)| eid).collect();
+            for t in 0..60u64 {
+                for &s in &stops {
+                    log.record(t * 10, s);
+                }
+            }
+            detector.update(&log, 3_500, &stops);
+        }
+    }
+    // Ensure the detector's view is consistent with `CurrentTick` the
+    // PredictiveParking inner strategy reads.
+    sim.world_mut().insert_resource(detector);
+    sim.world_mut().insert_resource(CurrentTick(3_500));
+}
+
+fn run_reposition(sim: &Simulation, strat: &mut AdaptiveParking) -> Vec<(EntityId, EntityId)> {
+    let group = &sim.groups()[0];
+    let idle: Vec<(EntityId, f64)> = group
+        .elevator_entities()
+        .iter()
+        .filter_map(|&eid| sim.world().position(eid).map(|p| (eid, p.value)))
+        .collect();
+    let stops: Vec<(EntityId, f64)> = group
+        .stop_entities()
+        .iter()
+        .filter_map(|&s| sim.world().stop_position(s).map(|p| (s, p)))
+        .collect();
+    let mut out = Vec::new();
+    strat.reposition(&idle, &stops, group, sim.world(), &mut out);
+    out
+}
+
+// ── Mode → inner strategy wiring ────────────────────────────────────
+
+#[test]
+fn idle_mode_stays_put() {
+    let mut sim = sim_with_idle_cars(2);
+    force_mode(&mut sim, TrafficMode::Idle);
+    let mut strat = AdaptiveParking::new();
+    let moves = run_reposition(&sim, &mut strat);
+    assert!(
+        moves.is_empty(),
+        "Idle mode must not move cars, got {moves:?}"
+    );
+}
+
+/// Up-peak should delegate to `ReturnToLobby` — cars not already at
+/// the home stop get sent there.
+#[test]
+fn up_peak_returns_cars_to_lobby() {
+    let mut sim = sim_with_idle_cars(2);
+    // Move one car off the lobby so we can see it get called back.
+    let elev = sim.world().elevator_ids()[1];
+    let floor2 = sim.stop_entity(crate::stop::StopId(2)).unwrap();
+    sim.world_mut()
+        .set_position(elev, crate::components::Position { value: 8.0 });
+    force_mode(&mut sim, TrafficMode::UpPeak);
+    let mut strat = AdaptiveParking::new();
+    let moves = run_reposition(&sim, &mut strat);
+    assert!(
+        moves
+            .iter()
+            .any(|(e, s)| *e == elev && *s == sim.stop_entity(crate::stop::StopId(0)).unwrap()),
+        "up-peak must call idle cars back to lobby; moves={moves:?} (off-lobby car at stop entity {floor2:?})"
+    );
+}
+
+/// `InterFloor` delegates to `PredictiveParking` — without any
+/// arrivals at a specific hot stop, it's a no-op. Here we seed
+/// arrivals via `force_mode`'s `InterFloor` branch (even spread),
+/// so `PredictiveParking` will score every stop equally; the
+/// greedy assignment then either moves nothing or moves each car
+/// to a distinct stop. Either way it shouldn't send every car to
+/// one stop.
+#[test]
+fn inter_floor_uses_predictive_not_return_to_lobby() {
+    let mut sim = sim_with_idle_cars(3);
+    // Move cars 1 and 2 off the lobby.
+    let ids = sim.world().elevator_ids();
+    sim.world_mut()
+        .set_position(ids[1], crate::components::Position { value: 8.0 });
+    sim.world_mut()
+        .set_position(ids[2], crate::components::Position { value: 4.0 });
+    force_mode(&mut sim, TrafficMode::InterFloor);
+    let mut strat = AdaptiveParking::new();
+    let moves = run_reposition(&sim, &mut strat);
+    // Negation test: inter-floor must NOT behave like ReturnToLobby,
+    // which would send every off-lobby car to stop 0.
+    let lobby = sim.stop_entity(crate::stop::StopId(0)).unwrap();
+    let all_going_to_lobby = !moves.is_empty() && moves.iter().all(|(_, s)| *s == lobby);
+    assert!(
+        !all_going_to_lobby,
+        "inter-floor must not converge every car on the lobby; moves={moves:?}"
+    );
+}
+
+/// Missing `TrafficDetector` resource (e.g. hand-built `World`) falls
+/// back to `PredictiveParking` behaviour — treated as `InterFloor`.
+#[test]
+fn missing_detector_falls_back_to_predictive() {
+    let mut sim = sim_with_idle_cars(2);
+    // Forcibly remove the detector. The strategy should still
+    // produce no-panic output (PredictiveParking reads the arrival
+    // log and returns empty when the log is empty).
+    sim.world_mut().remove_resource::<TrafficDetector>();
+    let mut strat = AdaptiveParking::new();
+    let moves = run_reposition(&sim, &mut strat);
+    // No arrivals logged → PredictiveParking is a no-op. We don't
+    // care about specific decisions, only that the missing-detector
+    // path doesn't panic or crash.
+    assert!(moves.is_empty() || moves.iter().all(|(_, _)| true));
+}
+
+// ── BuiltinReposition round-trip ────────────────────────────────────
+
+#[test]
+fn builtin_adaptive_instantiates() {
+    assert!(BuiltinReposition::Adaptive.instantiate().is_some());
+}
+
+#[test]
+fn builtin_adaptive_display() {
+    assert_eq!(BuiltinReposition::Adaptive.to_string(), "Adaptive");
+}
+
+#[test]
+fn builtin_adaptive_serde_roundtrip() {
+    let v = BuiltinReposition::Adaptive;
+    let s = ron::to_string(&v).unwrap();
+    let back: BuiltinReposition = ron::from_str(&s).unwrap();
+    assert_eq!(v, back);
+}

--- a/crates/elevator-core/src/tests/adaptive_parking_tests.rs
+++ b/crates/elevator-core/src/tests/adaptive_parking_tests.rs
@@ -5,7 +5,7 @@
 //! pins the detector to one mode and verifies the idle-car moves
 //! match the mode's inner strategy.
 
-use crate::arrival_log::{ArrivalLog, CurrentTick};
+use crate::arrival_log::{ArrivalLog, CurrentTick, DestinationLog};
 use crate::dispatch::reposition::AdaptiveParking;
 use crate::dispatch::{BuiltinReposition, RepositionStrategy};
 use crate::entity::EntityId;
@@ -60,7 +60,7 @@ fn force_mode(sim: &mut Simulation, mode: TrafficMode) {
                 log.record(t * 50, lobby);
             }
             let stops: Vec<EntityId> = sim.world().iter_stops().map(|(eid, _)| eid).collect();
-            detector.update(&log, 3_500, &stops);
+            detector.update(&log, &DestinationLog::default(), 3_500, &stops);
         }
         TrafficMode::InterFloor => {
             let mut log = ArrivalLog::default();
@@ -70,21 +70,31 @@ fn force_mode(sim: &mut Simulation, mode: TrafficMode) {
                     log.record(t * 10, s);
                 }
             }
-            detector.update(&log, 3_500, &stops);
+            detector.update(&log, &DestinationLog::default(), 3_500, &stops);
         }
         TrafficMode::DownPeak => {
-            // Not yet emitted by V1 detector; test behaviour against
-            // an `InterFloor`-seeded detector since Adaptive handles
-            // them identically today. Real `DownPeak` validation
-            // waits for the destination-log follow-up.
-            let mut log = ArrivalLog::default();
+            // Seed a destination-heavy window: origins spread across
+            // upper floors, destinations dominated by the lobby.
+            let mut arrivals = ArrivalLog::default();
+            let mut destinations = DestinationLog::default();
             let stops: Vec<EntityId> = sim.world().iter_stops().map(|(eid, _)| eid).collect();
-            for t in 0..60u64 {
-                for &s in &stops {
-                    log.record(t * 10, s);
+            let lobby = stops[0];
+            // 30 arrivals each at every non-lobby stop.
+            for t in 0..30u64 {
+                for &s in &stops[1..] {
+                    arrivals.record(t * 50, s);
                 }
             }
-            detector.update(&log, 3_500, &stops);
+            // 75% of destinations at the lobby → down-peak.
+            for t in 0..60u64 {
+                destinations.record(t * 25, lobby);
+            }
+            for t in 0..20u64 {
+                for &s in &stops[1..] {
+                    destinations.record(t * 25, s);
+                }
+            }
+            detector.update(&arrivals, &destinations, 3_500, &stops);
         }
     }
     // Ensure the detector's view is consistent with `CurrentTick` the

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -13,6 +13,7 @@
 mod helpers;
 
 mod access_tests;
+mod adaptive_parking_tests;
 mod builder_tests;
 mod config_tests;
 mod dispatch_tests;

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -81,16 +81,19 @@ impl WasmSim {
         let mut inner = make_sim(&config, strategy)
             .ok_or_else(|| JsError::new(&format!("unknown strategy: {strategy}")))?
             .map_err(|e| JsError::new(&format!("sim build: {e}")))?;
-        // Default to PredictiveParking reposition *only* when the config
-        // didn't pick one. SpreadEvenly used to be the default, but it's
-        // position-only — during morning up-peak (lobby-heavy) or evening
-        // down-peak it actively pushes idle cars *away* from demand, so
-        // two of three cars end up shuttling to the sky lobby and the
-        // penthouse while the first car handles every lobby call alone.
-        // PredictiveParking reads the arrival log's rolling window and
-        // greedily seats idle cars at the hottest stops, which is what
-        // most observers expect from a multi-car playground. An explicit
-        // RON choice still wins so downstream consumers can opt out.
+        // Default to AdaptiveParking reposition *only* when the config
+        // didn't pick one. The history:
+        //   SpreadEvenly (pre-#358) — position-only, pushed cars away
+        //     from demand during up-peak.
+        //   PredictiveParking (#358) — demand-aware, great under up-peak
+        //     but can still churn under mixed traffic where every
+        //     delivery triggers a "go back to the hottest stop" move.
+        //   AdaptiveParking (this PR) — mode-gated: ReturnToLobby in
+        //     up-peak, PredictiveParking when demand is diffuse, no-op
+        //     when the building is idle. Reads TrafficDetector, which
+        //     is auto-installed.
+        // An explicit RON choice still wins so downstream consumers
+        // can opt out.
         let groups_needing_default: Vec<_> = inner
             .groups()
             .iter()
@@ -98,8 +101,8 @@ impl WasmSim {
             .filter(|gid| inner.reposition_id(*gid).is_none())
             .collect();
         for gid in groups_needing_default {
-            if let Some(strategy) = BuiltinReposition::PredictiveParking.instantiate() {
-                inner.set_reposition(gid, strategy, BuiltinReposition::PredictiveParking);
+            if let Some(strategy) = BuiltinReposition::Adaptive.instantiate() {
+                inner.set_reposition(gid, strategy, BuiltinReposition::Adaptive);
             }
         }
         Ok(Self {


### PR DESCRIPTION
## Summary

Seventh and final piece of the dispatch-research PR stack. `AdaptiveParking` reads the auto-installed `TrafficDetector` each reposition pass and delegates to a mode-appropriate inner strategy:

| Mode | Inner |
|---|---|
| `UpPeak` | `ReturnToLobby` (home = stop 0, overridable) |
| `InterFloor` | `PredictiveParking` |
| `DownPeak` | `PredictiveParking` (provisional — a dedicated upper-floor-biased variant waits for the destination-log follow-up that'll let `TrafficDetector` actually emit `DownPeak`) |
| `Idle` | no-op (stay put) |

Missing detector (hand-built World bypassing `Simulation::new`) also delegates to `PredictiveParking` — safe degradation, not a panic.

## Why

Closes the "smart repositioning seems chaotic" complaint the user reported on the playground. Single-mode strategies either:

- lock cars to lobby (`ReturnToLobby`) — starves upper floors during inter-floor periods
- chase the highest-rate stop every tick (`PredictiveParking`) — churns under diffuse traffic
- ignore demand entirely (`SpreadEvenly`) — the original default, known to shuttle cars away from demand during up-peak

`AdaptiveParking` picks the right tool for what's actually happening, with `TrafficDetector` as the signal source.

## What changed

- `crates/elevator-core/src/dispatch/reposition.rs`: new `AdaptiveParking` struct + `RepositionStrategy` impl.
- `crates/elevator-core/src/dispatch/mod.rs`: `BuiltinReposition::Adaptive` variant (non-breaking via `#[non_exhaustive]`) + Display + `instantiate`.
- `crates/elevator-core/src/tests/adaptive_parking_tests.rs`: 7 new tests covering per-mode wiring, missing-detector fallback, `BuiltinReposition` round-trip.
- `crates/elevator-wasm/src/lib.rs`: swap the playground default from `PredictiveParking` → `Adaptive` so the mode-gating is user-visible without an opt-in.

## Dependencies + rebase

Branched off `feat/traffic-detector` (PR #361) since `TrafficDetector`/`TrafficMode` live there pending merge. Will rebase on main once #361 lands.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p elevator-core --all-features --tests -- -D warnings`
- [x] `cargo test -p elevator-core --all-features --lib` — 771 passed (+7 net)
- [x] `cargo check -p elevator-wasm --target wasm32-unknown-unknown --no-default-features`
- [x] Pre-commit hook end-to-end