### PR TITLE
feat(traffic-detector): DestinationLog enables DownPeak detection

### DIFF
--- a/crates/elevator-core/src/arrival_log.rs
+++ b/crates/elevator-core/src/arrival_log.rs
@@ -128,3 +128,76 @@ impl ArrivalLog {
             });
     }
 }
+
+/// Append-only log of rider *destinations*, mirror of [`ArrivalLog`]
+/// for the outgoing side of a trip.
+///
+/// Enables destination-aware signals that the origin-only
+/// `ArrivalLog` can't produce — specifically
+/// [`TrafficMode::DownPeak`](crate::traffic_detector::TrafficMode::DownPeak)
+/// detection, which triggers on "lots of riders heading *to* the
+/// lobby" rather than "lots of riders arriving *from* it."
+///
+/// Auto-installed alongside [`ArrivalLog`] by `Simulation::new` and
+/// appended to in the same rider-spawn path. Shares
+/// [`ArrivalLogRetention`]'s retention window so the two logs can't
+/// drift against each other's time horizon.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DestinationLog {
+    /// `(tick, destination_stop)` pairs. Entries are appended in
+    /// tick order; all queries go through
+    /// [`destinations_in_window`](Self::destinations_in_window).
+    entries: Vec<(u64, EntityId)>,
+}
+
+impl DestinationLog {
+    /// Record that a rider spawned at `tick` heading to `destination`.
+    pub fn record(&mut self, tick: u64, destination: EntityId) {
+        self.entries.push((tick, destination));
+    }
+
+    /// Count rides to `stop` within the window `[now - window, now]`
+    /// inclusive. `window_ticks = 0` always returns 0.
+    #[must_use]
+    pub fn destinations_in_window(&self, stop: EntityId, now: u64, window_ticks: u64) -> u64 {
+        if window_ticks == 0 {
+            return 0;
+        }
+        let lower = now.saturating_sub(window_ticks);
+        self.entries
+            .iter()
+            .filter(|(t, s)| *s == stop && *t >= lower && *t <= now)
+            .count() as u64
+    }
+
+    /// Prune entries older than `cutoff` ticks. Called from
+    /// `Simulation::advance_tick` alongside [`ArrivalLog::prune_before`].
+    pub fn prune_before(&mut self, cutoff: u64) {
+        self.entries.retain(|(t, _)| *t >= cutoff);
+    }
+
+    /// Number of recorded events (diagnostic / tests).
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the log has no recorded events.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Remap entity IDs for snapshot restore. Mirrors
+    /// [`ArrivalLog::remap_entity_ids`].
+    pub fn remap_entity_ids(&mut self, id_remap: &std::collections::HashMap<EntityId, EntityId>) {
+        self.entries
+            .retain_mut(|(_, stop)| match id_remap.get(stop) {
+                Some(&new) => {
+                    *stop = new;
+                    true
+                }
+                None => false,
+            });
+    }
+}

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -604,6 +604,16 @@ impl Simulation {
         {
             world.insert_resource(crate::traffic_detector::TrafficDetector::default());
         }
+        // Same forward-compat pattern for the destination log. An
+        // older snapshot would leave the detector unable to detect
+        // down-peak post-restore; a fresh empty log lets it resume
+        // classification after a few ticks of observed traffic.
+        if world
+            .resource::<crate::arrival_log::DestinationLog>()
+            .is_none()
+        {
+            world.insert_resource(crate::arrival_log::DestinationLog::default());
+        }
         Self {
             world,
             events: EventBus::default(),

--- a/crates/elevator-core/src/sim/rider.rs
+++ b/crates/elevator-core/src/sim/rider.rs
@@ -172,6 +172,12 @@ impl super::Simulation {
         if let Some(log) = self.world.resource_mut::<crate::arrival_log::ArrivalLog>() {
             log.record(self.tick, origin);
         }
+        if let Some(log) = self
+            .world
+            .resource_mut::<crate::arrival_log::DestinationLog>()
+        {
+            log.record(self.tick, destination);
+        }
         self.events.emit(Event::RiderSpawned {
             rider: eid,
             origin,

--- a/crates/elevator-core/src/sim/substep.rs
+++ b/crates/elevator-core/src/sim/substep.rs
@@ -305,6 +305,12 @@ impl super::Simulation {
         if let Some(log) = self.world.resource_mut::<crate::arrival_log::ArrivalLog>() {
             log.prune_before(cutoff);
         }
+        if let Some(log) = self
+            .world
+            .resource_mut::<crate::arrival_log::DestinationLog>()
+        {
+            log.prune_before(cutoff);
+        }
     }
 
     /// Mirror `self.tick` into the `CurrentTick` world resource so

--- a/crates/elevator-core/src/systems/metrics.rs
+++ b/crates/elevator-core/src/systems/metrics.rs
@@ -127,13 +127,16 @@ pub fn run(
     refresh_traffic_detector(world, ctx.tick);
 }
 
-/// Clone the arrival log, collect stops in position order (lobby
-/// first), and hand both to the auto-installed
+/// Clone the arrival + destination logs, collect stops in position
+/// order (lobby first), and hand everything to the auto-installed
 /// [`TrafficDetector`](crate::traffic_detector::TrafficDetector).
-/// Skipped when either resource is absent — games running a bare
-/// `World` without them get a silent no-op.
+/// Skipped when the detector is absent — games running a bare
+/// `World` without it get a silent no-op. A missing
+/// [`DestinationLog`](crate::arrival_log::DestinationLog) is
+/// tolerated with a default-empty fallback so down-peak detection
+/// silently disables without panicking.
 fn refresh_traffic_detector(world: &mut World, tick: u64) {
-    let Some(log) = world.resource::<crate::arrival_log::ArrivalLog>().cloned() else {
+    let Some(arrivals) = world.resource::<crate::arrival_log::ArrivalLog>().cloned() else {
         return;
     };
     if world
@@ -142,6 +145,10 @@ fn refresh_traffic_detector(world: &mut World, tick: u64) {
     {
         return;
     }
+    let destinations = world
+        .resource::<crate::arrival_log::DestinationLog>()
+        .cloned()
+        .unwrap_or_default();
     let mut stops: Vec<_> = world
         .iter_stops()
         .map(|(eid, s)| (eid, s.position))
@@ -149,6 +156,6 @@ fn refresh_traffic_detector(world: &mut World, tick: u64) {
     stops.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
     let stop_ids: Vec<crate::entity::EntityId> = stops.into_iter().map(|(eid, _)| eid).collect();
     if let Some(detector) = world.resource_mut::<crate::traffic_detector::TrafficDetector>() {
-        detector.update(&log, tick, &stop_ids);
+        detector.update(&arrivals, &destinations, tick, &stop_ids);
     }
 }

--- a/crates/elevator-core/src/tests/traffic_detector_tests.rs
+++ b/crates/elevator-core/src/tests/traffic_detector_tests.rs
@@ -1,6 +1,6 @@
 //! Unit + integration tests for [`crate::traffic_detector::TrafficDetector`].
 
-use crate::arrival_log::ArrivalLog;
+use crate::arrival_log::{ArrivalLog, DestinationLog};
 use crate::entity::EntityId;
 use crate::traffic_detector::{TrafficDetector, TrafficMode};
 use crate::world::World;
@@ -35,7 +35,7 @@ fn empty_log_stays_idle() {
     let mut d = TrafficDetector::new();
     let log = ArrivalLog::default();
     let (_w, stops) = fake_stops();
-    d.update(&log, 60 * 60 * 10, &stops);
+    d.update(&log, &DestinationLog::default(), 60 * 60 * 10, &stops);
     assert_eq!(d.current_mode(), TrafficMode::Idle);
 }
 
@@ -57,7 +57,7 @@ fn up_peak_trips_on_lobby_fraction() {
         log.record(t * 50, f2);
         log.record(t * 50, f3);
     }
-    d.update(&log, 3_500, &[lobby, f2, f3]);
+    d.update(&log, &DestinationLog::default(), 3_500, &[lobby, f2, f3]);
     assert_eq!(d.current_mode(), TrafficMode::UpPeak);
 }
 
@@ -73,7 +73,7 @@ fn inter_floor_uniform_distribution() {
             log.record(t * 10, s);
         }
     }
-    d.update(&log, 3_500, &stops);
+    d.update(&log, &DestinationLog::default(), 3_500, &stops);
     assert_eq!(d.current_mode(), TrafficMode::InterFloor);
 }
 
@@ -91,7 +91,7 @@ fn idle_rate_overrides_lobby_fraction() {
     // 0.00028/tick, under the 2/3600 ≈ 0.00056 default threshold.
     // Total rate is what the classifier checks first.
     log.record(100, lobby);
-    d.update(&log, 3_500, &[lobby, f2]);
+    d.update(&log, &DestinationLog::default(), 3_500, &[lobby, f2]);
     assert_eq!(d.current_mode(), TrafficMode::Idle);
 }
 
@@ -99,7 +99,12 @@ fn idle_rate_overrides_lobby_fraction() {
 #[test]
 fn no_stops_is_idle() {
     let mut d = TrafficDetector::new();
-    d.update(&ArrivalLog::default(), 1_000, &[]);
+    d.update(
+        &ArrivalLog::default(),
+        &DestinationLog::default(),
+        1_000,
+        &[],
+    );
     assert_eq!(d.current_mode(), TrafficMode::Idle);
 }
 
@@ -112,8 +117,68 @@ fn no_stops_is_idle() {
 fn zero_threshold_with_empty_window_stays_idle() {
     let mut d = TrafficDetector::new().with_idle_rate_threshold(0.0);
     let (_w, stops) = fake_stops();
-    d.update(&ArrivalLog::default(), 3_600, &stops);
+    d.update(
+        &ArrivalLog::default(),
+        &DestinationLog::default(),
+        3_600,
+        &stops,
+    );
     assert_eq!(d.current_mode(), TrafficMode::Idle);
+}
+
+/// Classifier flips to `DownPeak` when ≥60% of destinations are
+/// lobby. Needs arrivals to be distributed (otherwise `UpPeak`'s
+/// higher precedence wins the mode).
+#[test]
+fn down_peak_trips_on_lobby_destination_fraction() {
+    let mut d = TrafficDetector::new().with_window_ticks(3_600);
+    let mut arrivals = ArrivalLog::default();
+    let mut destinations = DestinationLog::default();
+    let (_w, stops) = fake_stops();
+    let lobby = stops[0];
+    let f2 = stops[1];
+    let f3 = stops[2];
+    // 30 arrivals each at f2 and f3 (60 total, 0% lobby-origin),
+    // 45 of their destinations are lobby (75% lobby-destination).
+    for t in 0..30u64 {
+        arrivals.record(t * 50, f2);
+        arrivals.record(t * 50, f3);
+    }
+    for t in 0..45u64 {
+        destinations.record(t * 50, lobby);
+    }
+    for t in 0..15u64 {
+        destinations.record(t * 50, f2);
+    }
+    d.update(&arrivals, &destinations, 3_500, &[lobby, f2, f3]);
+    assert_eq!(d.current_mode(), TrafficMode::DownPeak);
+}
+
+/// Up-peak wins precedence when both thresholds are met — documented
+/// in `TrafficDetector::update`'s precedence paragraph.
+#[test]
+fn up_peak_beats_down_peak_when_both_trigger() {
+    let mut d = TrafficDetector::new().with_window_ticks(3_600);
+    let mut arrivals = ArrivalLog::default();
+    let mut destinations = DestinationLog::default();
+    let (_w, stops) = fake_stops();
+    let lobby = stops[0];
+    let f2 = stops[1];
+    // Pathological: every arrival AND every destination at lobby.
+    // `f2` appears only to avoid div-by-zero with zero non-lobby
+    // stops; the log entries there are 0.
+    for t in 0..100u64 {
+        arrivals.record(t * 30, lobby);
+        destinations.record(t * 30, lobby);
+    }
+    d.update(&arrivals, &destinations, 3_500, &[lobby, f2]);
+    assert_eq!(d.current_mode(), TrafficMode::UpPeak);
+}
+
+#[test]
+#[should_panic(expected = "down_peak_fraction must be finite and in [0, 1]")]
+fn down_peak_fraction_out_of_range_panics() {
+    let _ = TrafficDetector::new().with_down_peak_fraction(-0.1);
 }
 
 #[test]

--- a/crates/elevator-core/src/traffic_detector.rs
+++ b/crates/elevator-core/src/traffic_detector.rs
@@ -20,7 +20,7 @@
 //! [`crate::traffic_detector::TrafficMode::DownPeak`] is in the enum
 //! for API stability and will flip on in a follow-up.
 
-use crate::arrival_log::ArrivalLog;
+use crate::arrival_log::{ArrivalLog, DestinationLog};
 use crate::entity::EntityId;
 use serde::{Deserialize, Serialize};
 
@@ -69,6 +69,12 @@ pub struct TrafficDetector {
     /// threshold for "clear up-peak" from the rolling-average
     /// classifier lineage.
     up_peak_fraction: f64,
+    /// Lobby-destination fraction at or above which we flip to
+    /// [`TrafficMode::DownPeak`]. Uses the same 0.6 default as
+    /// `up_peak_fraction` — the two peaks are mirror statistical
+    /// events and the clarity-threshold literature treats them
+    /// symmetrically.
+    down_peak_fraction: f64,
     /// Last classified mode; returned by [`current_mode`](Self::current_mode).
     current: TrafficMode,
     /// Tick of the most recent `update` call. Read by snapshot
@@ -86,6 +92,7 @@ impl Default for TrafficDetector {
             // perspective — empty overnight or cold-start scenarios.
             idle_rate_threshold: 2.0 / 3600.0,
             up_peak_fraction: 0.6,
+            down_peak_fraction: 0.6,
             current: TrafficMode::Idle,
             last_update_tick: 0,
         }
@@ -142,6 +149,21 @@ impl TrafficDetector {
         self
     }
 
+    /// Override the lobby-destination fraction that trips
+    /// down-peak.
+    ///
+    /// # Panics
+    /// Panics if `fraction` is NaN or outside `[0.0, 1.0]`.
+    #[must_use]
+    pub fn with_down_peak_fraction(mut self, fraction: f64) -> Self {
+        assert!(
+            fraction.is_finite() && (0.0..=1.0).contains(&fraction),
+            "down_peak_fraction must be finite and in [0, 1], got {fraction}"
+        );
+        self.down_peak_fraction = fraction;
+        self
+    }
+
     /// The most recently classified mode.
     #[must_use]
     pub const fn current_mode(&self) -> TrafficMode {
@@ -160,46 +182,84 @@ impl TrafficDetector {
         self.window_ticks
     }
 
-    /// Re-classify using arrivals from `log` as of tick `now`. `stops`
-    /// is the list of stop entities to aggregate over; the *first*
-    /// entry is treated as the lobby for up-peak classification, so
-    /// callers must pass them in position order (lobby first).
+    /// Re-classify using arrivals and destinations as of tick
+    /// `now`. `stops` is the list of stop entities to aggregate
+    /// over; the *first* entry is treated as the lobby for both
+    /// up-peak and down-peak classification, so callers must pass
+    /// them in position order (lobby first). `destinations` may be
+    /// an empty (default-constructed) `DestinationLog` — in that
+    /// case down-peak detection silently no-ops and only the
+    /// origin-driven modes fire.
+    ///
+    /// Precedence when both peaks meet their thresholds (rare —
+    /// lobby-origins and lobby-destinations can't both be ≥60% in a
+    /// 100-arrival window without overlap): `UpPeak` wins because
+    /// the origin signal arrives first in time (rider spawn is what
+    /// logs the arrival; the destination signal arrives at the same
+    /// instant but the dispatcher sees up-peak's lobby queue before
+    /// down-peak's upper-floor queue absorbs the car).
     ///
     /// Idempotent — calling twice with the same inputs yields the
-    /// same mode. Called once per tick by the metrics phase; callers
-    /// driving the sim manually (tests, games stepping by hand) can
-    /// invoke it directly.
-    pub fn update(&mut self, log: &ArrivalLog, now: u64, stops: &[EntityId]) {
+    /// same mode. Called once per tick by the metrics phase;
+    /// callers driving the sim manually can invoke it directly.
+    pub fn update(
+        &mut self,
+        arrivals: &ArrivalLog,
+        destinations: &DestinationLog,
+        now: u64,
+        stops: &[EntityId],
+    ) {
         self.last_update_tick = now;
         if stops.is_empty() || self.window_ticks == 0 {
             self.current = TrafficMode::Idle;
             return;
         }
         let lobby = stops[0];
-        let lobby_count = log.arrivals_in_window(lobby, now, self.window_ticks);
-        let mut total: u64 = 0;
+        let lobby_origin_count = arrivals.arrivals_in_window(lobby, now, self.window_ticks);
+        let lobby_dest_count = destinations.destinations_in_window(lobby, now, self.window_ticks);
+        let mut total_origin: u64 = 0;
+        let mut total_dest: u64 = 0;
         for &s in stops {
-            total = total.saturating_add(log.arrivals_in_window(s, now, self.window_ticks));
+            total_origin =
+                total_origin.saturating_add(arrivals.arrivals_in_window(s, now, self.window_ticks));
+            total_dest = total_dest.saturating_add(destinations.destinations_in_window(
+                s,
+                now,
+                self.window_ticks,
+            ));
         }
-        // An empty window is always `Idle`, independent of the
-        // configured threshold. Guards the `idle_rate_threshold = 0.0`
-        // edge case where the strict `<` comparison below wouldn't
-        // catch `total == 0` (greptile review of #361).
-        if total == 0 {
+        // An empty arrivals window is always `Idle`, independent of
+        // the configured threshold. Guards the `idle_rate_threshold
+        // = 0.0` edge case where the strict `<` comparison below
+        // wouldn't catch `total == 0`.
+        if total_origin == 0 {
             self.current = TrafficMode::Idle;
             return;
         }
         #[allow(clippy::cast_precision_loss)] // counts fit in f64 mantissa
-        let rate_per_tick = total as f64 / self.window_ticks as f64;
+        let rate_per_tick = total_origin as f64 / self.window_ticks as f64;
         if rate_per_tick < self.idle_rate_threshold {
             self.current = TrafficMode::Idle;
             return;
         }
         #[allow(clippy::cast_precision_loss)]
-        let fraction = lobby_count as f64 / total as f64;
-        if fraction >= self.up_peak_fraction {
+        let up_fraction = lobby_origin_count as f64 / total_origin as f64;
+        if up_fraction >= self.up_peak_fraction {
             self.current = TrafficMode::UpPeak;
             return;
+        }
+        // Down-peak: check only if the destination log has seen
+        // any activity; a zero-destination window (old snapshot or
+        // pure rider-less hall calls) would divide by zero and
+        // spuriously match the threshold at `0/0 = NaN` — falling
+        // through to `InterFloor` is the safer default.
+        if total_dest > 0 {
+            #[allow(clippy::cast_precision_loss)]
+            let down_fraction = lobby_dest_count as f64 / total_dest as f64;
+            if down_fraction >= self.down_peak_fraction {
+                self.current = TrafficMode::DownPeak;
+                return;
+            }
         }
         self.current = TrafficMode::InterFloor;
     }


### PR DESCRIPTION
## Summary

- Adds `DestinationLog` — mirror of `ArrivalLog` but keyed on rider destination (rather than origin). Auto-installed alongside `ArrivalLog`, pruned in lockstep by `advance_tick`.
- Extends `TrafficDetector::update` to take both logs. When the lobby-destination fraction crosses `down_peak_fraction` (default 0.6) over the rolling window, the classifier flips to `TrafficMode::DownPeak` — previously an enum variant that was never emitted by V1.
- `UpPeak` takes precedence when both thresholds trigger, because rider spawns log the origin first and the dispatcher sees the lobby queue before upper-floor queues absorb cars. Pinned by `up_peak_beats_down_peak_when_both_trigger`.
- Threshold mirrors `up_peak_fraction` at 0.6 — the two peaks are mirror statistical events and clarity-threshold literature treats them symmetrically. New `with_down_peak_fraction` builder for overrides.

## Why this matters

Downstream consumers — `AdaptiveParking`, dispatch tuning, HUD narration — can now branch on evening-rush patterns instead of silently degrading to `InterFloor` during downpeak.

## Test plan

- [x] 3 new unit tests: `down_peak_trips_on_lobby_destination_fraction`, `up_peak_beats_down_peak_when_both_trigger`, `down_peak_fraction_out_of_range_panics`.
- [x] Existing 11 detector tests updated to new `update()` signature — all still pass.
- [x] Full suite: 767 lib tests + 158 doc tests pass.
- [x] `cargo clippy -p elevator-core --all-features --tests -- -D warnings` clean.
- [x] `cargo check --workspace` clean.

## Dependency

Stacked on #361 (feat/traffic-detector). Rebase onto main once #361 merges.