### PR TITLE
fix(core-wiring): install DestinationLog in Simulation::new; expand prelude

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.11.1"
+version = "15.14.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -503,12 +503,22 @@ macro_rules! register_extensions {
 ///   [`LookDispatch`](crate::dispatch::LookDispatch),
 ///   [`NearestCarDispatch`](crate::dispatch::NearestCarDispatch),
 ///   [`EtdDispatch`](crate::dispatch::EtdDispatch),
+///   [`RsrDispatch`](crate::dispatch::RsrDispatch),
+///   [`BuiltinStrategy`](crate::dispatch::BuiltinStrategy),
+///   [`BuiltinReposition`](crate::dispatch::BuiltinReposition),
 ///   plus the built-in reposition strategies
 ///   [`NearestIdle`](crate::dispatch::reposition::NearestIdle),
 ///   [`ReturnToLobby`](crate::dispatch::reposition::ReturnToLobby),
 ///   [`SpreadEvenly`](crate::dispatch::reposition::SpreadEvenly),
 ///   [`DemandWeighted`](crate::dispatch::reposition::DemandWeighted),
-///   [`PredictiveParking`](crate::dispatch::reposition::PredictiveParking)
+///   [`PredictiveParking`](crate::dispatch::reposition::PredictiveParking),
+///   [`AdaptiveParking`](crate::dispatch::reposition::AdaptiveParking)
+/// - **Traffic observation:** [`TrafficDetector`](crate::traffic_detector::TrafficDetector),
+///   [`TrafficMode`](crate::traffic_detector::TrafficMode),
+///   [`ArrivalLog`](crate::arrival_log::ArrivalLog),
+///   [`DestinationLog`](crate::arrival_log::DestinationLog),
+///   [`CurrentTick`](crate::arrival_log::CurrentTick),
+///   [`ArrivalLogRetention`](crate::arrival_log::ArrivalLogRetention)
 /// - **Identity:** [`EntityId`](crate::entity::EntityId),
 ///   [`StopId`](crate::stop::StopId), [`StopRef`](crate::stop::StopRef),
 ///   [`GroupId`](crate::ids::GroupId)
@@ -529,6 +539,7 @@ macro_rules! register_extensions {
 /// - Traffic generation types from [`crate::traffic`] (feature-gated)
 /// - Snapshot types from [`crate::snapshot`]
 pub mod prelude {
+    pub use crate::arrival_log::{ArrivalLog, ArrivalLogRetention, CurrentTick, DestinationLog};
     pub use crate::builder::SimulationBuilder;
     pub use crate::components::{
         Accel, AccessControl, DestinationQueue, Direction, Elevator, ElevatorPhase, Line,
@@ -537,12 +548,13 @@ pub mod prelude {
     };
     pub use crate::config::{ElevatorConfig, GroupConfig, LineConfig, SimConfig};
     pub use crate::dispatch::reposition::{
-        DemandWeighted, NearestIdle, PredictiveParking, ReturnToLobby, SpreadEvenly,
+        AdaptiveParking, DemandWeighted, NearestIdle, PredictiveParking, ReturnToLobby,
+        SpreadEvenly,
     };
     pub use crate::dispatch::{
-        AssignedCar, DestinationDispatch, DispatchDecision, DispatchManifest, DispatchStrategy,
-        ElevatorGroup, EtdDispatch, LookDispatch, NearestCarDispatch, RankContext,
-        RepositionStrategy, ScanDispatch,
+        AssignedCar, BuiltinReposition, BuiltinStrategy, DestinationDispatch, DispatchDecision,
+        DispatchManifest, DispatchStrategy, ElevatorGroup, EtdDispatch, LookDispatch,
+        NearestCarDispatch, RankContext, RepositionStrategy, RsrDispatch, ScanDispatch,
     };
     pub use crate::entity::{ElevatorId, EntityId, RiderId};
     pub use crate::error::{EtaError, RejectionContext, RejectionReason, SimError};
@@ -552,6 +564,7 @@ pub mod prelude {
     pub use crate::sim::{RiderBuilder, Simulation};
     pub use crate::stop::{StopConfig, StopId, StopRef};
     pub use crate::time::TimeAdapter;
+    pub use crate::traffic_detector::{TrafficDetector, TrafficMode};
     pub use crate::world::{ExtKey, World};
 }
 

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -181,8 +181,11 @@ impl Simulation {
 
         // Per-stop arrival signal, appended on rider spawn and queried
         // by dispatch/reposition strategies to drive traffic-mode
-        // switches and predictive parking.
+        // switches and predictive parking. The destination mirror is
+        // what powers down-peak detection — without it the classifier
+        // sees `total_dest = 0` and silently never emits `DownPeak`.
         world.insert_resource(crate::arrival_log::ArrivalLog::default());
+        world.insert_resource(crate::arrival_log::DestinationLog::default());
         world.insert_resource(crate::arrival_log::CurrentTick::default());
         world.insert_resource(crate::arrival_log::ArrivalLogRetention::default());
         // Traffic-mode classifier. Auto-refreshed in the metrics phase

--- a/crates/elevator-core/src/tests/traffic_detector_tests.rs
+++ b/crates/elevator-core/src/tests/traffic_detector_tests.rs
@@ -214,6 +214,36 @@ fn simulation_installs_traffic_detector_resource() {
     );
 }
 
+/// `Simulation::new` must install both logs — missing `DestinationLog`
+/// silently disables `DownPeak` detection because rider-spawn's
+/// `resource_mut` call no-ops when the resource isn't present.
+#[test]
+fn simulation_installs_both_arrival_and_destination_logs() {
+    let sim = Simulation::new(&default_config(), scan()).unwrap();
+    assert!(
+        sim.world().resource::<ArrivalLog>().is_some(),
+        "Simulation::new must insert an ArrivalLog resource"
+    );
+    assert!(
+        sim.world().resource::<DestinationLog>().is_some(),
+        "Simulation::new must insert a DestinationLog resource — \
+         missing it silently disables DownPeak detection"
+    );
+}
+
+/// End-to-end: spawning a rider must append to both logs. Catches the
+/// regression where only `ArrivalLog` was installed in `new()` and
+/// `DestinationLog` writes silently no-op'd.
+#[test]
+fn rider_spawn_appends_to_both_logs() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    let arrivals_len = sim.world().resource::<ArrivalLog>().unwrap().len();
+    let destinations_len = sim.world().resource::<DestinationLog>().unwrap().len();
+    assert_eq!(arrivals_len, 1, "arrival log must carry 1 entry");
+    assert_eq!(destinations_len, 1, "destination log must carry 1 entry");
+}
+
 /// The metrics phase must refresh the detector each tick. After a
 /// burst of lobby-spawns and enough sim time for the window to fill,
 /// the detector's `last_update_tick` must be recent relative to the


### PR DESCRIPTION
## Summary

Two wiring gaps surfaced during a post-merge audit of the dispatch-research stack:

1. **`DestinationLog` wasn't installed in `Simulation::new`** — only in `from_parts` (as a backward-compat shim for old snapshots). Since rider-spawn uses `world.resource_mut::<DestinationLog>().map(…)`, a missing resource silently no-op'd. Fresh simulations never logged destinations, and `TrafficMode::DownPeak` could never fire regardless of traffic pattern.
2. **Prelude drift** — `AdaptiveParking`, `RsrDispatch`, `BuiltinStrategy`, `BuiltinReposition`, `TrafficDetector`, `TrafficMode`, `ArrivalLog`, `DestinationLog`, `CurrentTick`, `ArrivalLogRetention` were all reachable only by full path.

## Tests

- `simulation_installs_both_arrival_and_destination_logs` — both resources present after `Simulation::new`
- `rider_spawn_appends_to_both_logs` — end-to-end smoke that spawn writes hit both logs

## Test plan

- [x] 782 lib tests + 158 doc tests pass
- [x] `cargo clippy -p elevator-core --all-features --tests -- -D warnings` clean
- [x] `cargo check --workspace` clean