### PR TITLE
feat(rsr): peak_direction_multiplier — TrafficMode-aware wrong-direction scaling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.15.0"
+version = "15.15.1"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/dispatch/rsr.rs
+++ b/crates/elevator-core/src/dispatch/rsr.rs
@@ -16,8 +16,26 @@
 //! inside a strategy.
 
 use crate::components::{CarCall, ElevatorPhase};
+use crate::traffic_detector::{TrafficDetector, TrafficMode};
 
 use super::{DispatchStrategy, RankContext, pair_can_do_work};
+
+/// Look up the current [`TrafficMode`] from `ctx.world` and return the
+/// scaling factor to apply to the wrong-direction penalty.
+///
+/// Returns `multiplier` when the mode is `UpPeak` or `DownPeak`, else
+/// `1.0`. Also returns `1.0` when the detector resource is missing —
+/// keeping the strategy functional in tests that skip `Simulation::new`.
+fn peak_scaling(ctx: &RankContext<'_>, multiplier: f64) -> f64 {
+    let mode = ctx
+        .world
+        .resource::<TrafficDetector>()
+        .map_or(TrafficMode::Idle, TrafficDetector::current_mode);
+    match mode {
+        TrafficMode::UpPeak | TrafficMode::DownPeak => multiplier,
+        _ => 1.0,
+    }
+}
 
 /// Additive RSR-style cost stack. Lower scores win the Hungarian
 /// assignment.
@@ -62,6 +80,23 @@ pub struct RsrDispatch {
     /// emptier cars for new pickups without an on/off cliff.
     /// Default `0.0`.
     pub load_penalty_coeff: f64,
+    /// Multiplier applied to `wrong_direction_penalty` when the
+    /// [`TrafficDetector`](crate::traffic_detector::TrafficDetector)
+    /// classifies the current tick as
+    /// [`UpPeak`](crate::traffic_detector::TrafficMode::UpPeak) or
+    /// [`DownPeak`](crate::traffic_detector::TrafficMode::DownPeak).
+    ///
+    /// Default `1.0` (mode-agnostic — behaviour identical to pre-peak
+    /// tuning). Raising it strengthens directional commitment during
+    /// peaks where a car carrying a lobby-bound load shouldn't be
+    /// pulled backwards to grab a new pickup. Off-peak periods keep
+    /// the unscaled penalty, leaving inter-floor assignments free
+    /// to reverse cheaply.
+    ///
+    /// Silently reduces to `1.0` when no `TrafficDetector` resource
+    /// is installed — tests and custom sims that bypass the auto-install
+    /// stay unaffected.
+    pub peak_direction_multiplier: f64,
 }
 
 impl RsrDispatch {
@@ -74,6 +109,7 @@ impl RsrDispatch {
             wrong_direction_penalty: 0.0,
             coincident_car_call_bonus: 0.0,
             load_penalty_coeff: 0.0,
+            peak_direction_multiplier: 1.0,
         }
     }
 
@@ -136,6 +172,23 @@ impl RsrDispatch {
         self.eta_weight = weight;
         self
     }
+
+    /// Set the peak-direction multiplier.
+    ///
+    /// # Panics
+    /// Panics on non-finite or sub-1.0 values. A multiplier below `1.0`
+    /// would *weaken* the direction penalty during peaks (the opposite
+    /// of the intent) — explicitly disallowed so a typo doesn't silently
+    /// invert the tuning.
+    #[must_use]
+    pub fn with_peak_direction_multiplier(mut self, factor: f64) -> Self {
+        assert!(
+            factor.is_finite() && factor >= 1.0,
+            "peak_direction_multiplier must be finite and ≥ 1.0, got {factor}"
+        );
+        self.peak_direction_multiplier = factor;
+        self
+    }
 }
 
 impl Default for RsrDispatch {
@@ -172,7 +225,14 @@ impl DispatchStrategy for RsrDispatch {
             let cand_above = ctx.stop_position > ctx.car_position;
             let cand_below = ctx.stop_position < ctx.car_position;
             if (car_going_up && cand_below) || (car_going_down && cand_above) {
-                cost += self.wrong_direction_penalty;
+                // During up-peak/down-peak the directional invariant
+                // is load-bearing (a committed car shouldn't reverse
+                // to grab a new pickup), so scale the penalty up.
+                // Off-peak, the base value still rules — inter-floor
+                // traffic wants cheap reversals.
+                let scaled = self.wrong_direction_penalty
+                    * peak_scaling(ctx, self.peak_direction_multiplier);
+                cost += scaled;
             }
         }
 

--- a/crates/elevator-core/src/dispatch/rsr.rs
+++ b/crates/elevator-core/src/dispatch/rsr.rs
@@ -81,10 +81,8 @@ pub struct RsrDispatch {
     /// Default `0.0`.
     pub load_penalty_coeff: f64,
     /// Multiplier applied to `wrong_direction_penalty` when the
-    /// [`TrafficDetector`](crate::traffic_detector::TrafficDetector)
-    /// classifies the current tick as
-    /// [`UpPeak`](crate::traffic_detector::TrafficMode::UpPeak) or
-    /// [`DownPeak`](crate::traffic_detector::TrafficMode::DownPeak).
+    /// [`TrafficDetector`] classifies the current tick as
+    /// [`TrafficMode::UpPeak`] or [`TrafficMode::DownPeak`].
     ///
     /// Default `1.0` (mode-agnostic — behaviour identical to pre-peak
     /// tuning). Raising it strengthens directional commitment during

--- a/crates/elevator-core/src/tests/rsr_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/rsr_dispatch_tests.rs
@@ -239,6 +239,162 @@ fn eta_weight_rejects_negative() {
     let _ = RsrDispatch::new().with_eta_weight(-0.5);
 }
 
+#[test]
+#[should_panic(expected = "peak_direction_multiplier must be finite and ≥ 1.0")]
+fn peak_direction_multiplier_rejects_below_one() {
+    let _ = RsrDispatch::new().with_peak_direction_multiplier(0.5);
+}
+
+#[test]
+#[should_panic(expected = "peak_direction_multiplier must be finite and ≥ 1.0")]
+fn peak_direction_multiplier_rejects_nan() {
+    let _ = RsrDispatch::new().with_peak_direction_multiplier(f64::NAN);
+}
+
+// ── Peak-direction multiplier ───────────────────────────────────────
+
+/// During `UpPeak` the multiplier amplifies the wrong-direction
+/// penalty. A base penalty that's small enough to lose on distance
+/// alone wins with the peak multiplier applied.
+#[test]
+fn peak_direction_multiplier_strengthens_penalty_in_up_peak() {
+    use crate::arrival_log::ArrivalLog;
+    use crate::traffic_detector::{TrafficDetector, TrafficMode};
+
+    let (mut world, stops) = test_world();
+    let committed_up = spawn_elevator(&mut world, 6.0);
+    let idle_far = spawn_elevator(&mut world, 16.0);
+    world.elevator_mut(committed_up).unwrap().phase =
+        crate::components::ElevatorPhase::MovingToStop(stops[3]);
+
+    // Seed a detector that classifies as UpPeak. Using the classifier's
+    // own path here instead of reaching into private fields keeps the
+    // test coupled to the public invariant, not the storage shape.
+    let mut detector = TrafficDetector::new().with_window_ticks(3_600);
+    let mut log = ArrivalLog::default();
+    let lobby = stops[0];
+    for t in 0..70u64 {
+        log.record(t * 50, lobby);
+    }
+    detector.update(
+        &log,
+        &crate::arrival_log::DestinationLog::default(),
+        3_500,
+        &stops,
+    );
+    assert_eq!(detector.current_mode(), TrafficMode::UpPeak);
+    world.insert_resource(detector);
+
+    let group = test_group(&stops, vec![committed_up, idle_far]);
+    let mut manifest = DispatchManifest::default();
+    // Demand at stops[0] (below committed_up, above idle_far's dist).
+    add_demand(&mut manifest, &mut world, stops[0], 70.0);
+
+    // Base penalty too small to swing the assignment on its own (car
+    // at pos 6 vs pos 16; ETAs ~6 and ~16 for stops[0] at pos 0). Peak
+    // multiplier of 3× turns 5.0 into 15.0, enough to dominate the
+    // 10-unit ETA advantage.
+    let mut rsr = RsrDispatch::new()
+        .with_wrong_direction_penalty(5.0)
+        .with_peak_direction_multiplier(3.0);
+    let decisions = decide_all(
+        &mut rsr,
+        &[(committed_up, 6.0), (idle_far, 16.0)],
+        &group,
+        &manifest,
+        &mut world,
+    );
+    let idle_dec = decisions.iter().find(|(e, _)| *e == idle_far).unwrap();
+    assert_eq!(
+        idle_dec.1,
+        DispatchDecision::GoToStop(stops[0]),
+        "peak multiplier must strengthen direction penalty enough to reroute"
+    );
+}
+
+/// Off-peak (`InterFloor`) the multiplier is a no-op: the same 5.0 base
+/// penalty that flipped the decision under `UpPeak` stays too small, so
+/// distance wins and the committed-up car takes the job.
+#[test]
+fn peak_direction_multiplier_is_noop_off_peak() {
+    use crate::arrival_log::ArrivalLog;
+    use crate::traffic_detector::{TrafficDetector, TrafficMode};
+
+    let (mut world, stops) = test_world();
+    let committed_up = spawn_elevator(&mut world, 6.0);
+    let idle_far = spawn_elevator(&mut world, 16.0);
+    world.elevator_mut(committed_up).unwrap().phase =
+        crate::components::ElevatorPhase::MovingToStop(stops[3]);
+
+    // Uniform arrivals → InterFloor, not UpPeak.
+    let mut detector = TrafficDetector::new().with_window_ticks(3_600);
+    let mut log = ArrivalLog::default();
+    for t in 0..60u64 {
+        for &s in &stops {
+            log.record(t * 10, s);
+        }
+    }
+    detector.update(
+        &log,
+        &crate::arrival_log::DestinationLog::default(),
+        3_500,
+        &stops,
+    );
+    assert_eq!(detector.current_mode(), TrafficMode::InterFloor);
+    world.insert_resource(detector);
+
+    let group = test_group(&stops, vec![committed_up, idle_far]);
+    let mut manifest = DispatchManifest::default();
+    add_demand(&mut manifest, &mut world, stops[0], 70.0);
+
+    let mut rsr = RsrDispatch::new()
+        .with_wrong_direction_penalty(5.0)
+        .with_peak_direction_multiplier(3.0);
+    let decisions = decide_all(
+        &mut rsr,
+        &[(committed_up, 6.0), (idle_far, 16.0)],
+        &group,
+        &manifest,
+        &mut world,
+    );
+    let committed_dec = decisions.iter().find(|(e, _)| *e == committed_up).unwrap();
+    assert_eq!(
+        committed_dec.1,
+        DispatchDecision::GoToStop(stops[0]),
+        "off-peak must leave the base penalty unscaled — closer car wins"
+    );
+}
+
+/// Missing `TrafficDetector` resource (e.g. a test that bypasses
+/// `Simulation::new`) silently reduces to the base penalty — strategies
+/// must not panic on absent detector.
+#[test]
+fn peak_direction_multiplier_tolerates_missing_detector() {
+    let (mut world, stops) = test_world();
+    let committed_up = spawn_elevator(&mut world, 6.0);
+    let idle_far = spawn_elevator(&mut world, 16.0);
+    world.elevator_mut(committed_up).unwrap().phase =
+        crate::components::ElevatorPhase::MovingToStop(stops[3]);
+
+    let group = test_group(&stops, vec![committed_up, idle_far]);
+    let mut manifest = DispatchManifest::default();
+    add_demand(&mut manifest, &mut world, stops[0], 70.0);
+
+    let mut rsr = RsrDispatch::new()
+        .with_wrong_direction_penalty(5.0)
+        .with_peak_direction_multiplier(3.0);
+    // Same assertion as off-peak: without detector, no scaling applies.
+    let decisions = decide_all(
+        &mut rsr,
+        &[(committed_up, 6.0), (idle_far, 16.0)],
+        &group,
+        &manifest,
+        &mut world,
+    );
+    let committed_dec = decisions.iter().find(|(e, _)| *e == committed_up).unwrap();
+    assert_eq!(committed_dec.1, DispatchDecision::GoToStop(stops[0]));
+}
+
 // ── Sanity: _elev unused suppresses dead-code warning ──────────────
 #[allow(dead_code)]
 fn _touch(_elev: EntityId) {}

--- a/crates/elevator-core/src/tests/rsr_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/rsr_dispatch_tests.rs
@@ -312,6 +312,59 @@ fn peak_direction_multiplier_strengthens_penalty_in_up_peak() {
     );
 }
 
+/// Mirror of `peak_direction_multiplier_strengthens_penalty_in_up_peak`
+/// for `DownPeak`. The `match` arm treats both peaks symmetrically;
+/// this test guards against a future split that might scale only one.
+#[test]
+fn peak_direction_multiplier_strengthens_penalty_in_down_peak() {
+    use crate::arrival_log::{ArrivalLog, DestinationLog};
+    use crate::traffic_detector::{TrafficDetector, TrafficMode};
+
+    let (mut world, stops) = test_world();
+    let committed_up = spawn_elevator(&mut world, 6.0);
+    let idle_far = spawn_elevator(&mut world, 16.0);
+    world.elevator_mut(committed_up).unwrap().phase = ElevatorPhase::MovingToStop(stops[3]);
+
+    // Seed a DownPeak classification: sparse origins across upper
+    // floors, dominant destination at the lobby.
+    let mut detector = TrafficDetector::new().with_window_ticks(3_600);
+    let mut arrivals = ArrivalLog::default();
+    let mut destinations = DestinationLog::default();
+    let lobby = stops[0];
+    for t in 0..30u64 {
+        for &s in &stops[1..] {
+            arrivals.record(t * 50, s);
+        }
+    }
+    for t in 0..60u64 {
+        destinations.record(t * 25, lobby);
+    }
+    detector.update(&arrivals, &destinations, 3_500, &stops);
+    assert_eq!(detector.current_mode(), TrafficMode::DownPeak);
+    world.insert_resource(detector);
+
+    let group = test_group(&stops, vec![committed_up, idle_far]);
+    let mut manifest = DispatchManifest::default();
+    add_demand(&mut manifest, &mut world, stops[0], 70.0);
+
+    let mut rsr = RsrDispatch::new()
+        .with_wrong_direction_penalty(5.0)
+        .with_peak_direction_multiplier(3.0);
+    let decisions = decide_all(
+        &mut rsr,
+        &[(committed_up, 6.0), (idle_far, 16.0)],
+        &group,
+        &manifest,
+        &mut world,
+    );
+    let idle_dec = decisions.iter().find(|(e, _)| *e == idle_far).unwrap();
+    assert_eq!(
+        idle_dec.1,
+        DispatchDecision::GoToStop(stops[0]),
+        "DownPeak multiplier must strengthen direction penalty symmetrically with UpPeak"
+    );
+}
+
 /// Off-peak (`InterFloor`) the multiplier is a no-op: the same 5.0 base
 /// penalty that flipped the decision under `UpPeak` stays too small, so
 /// distance wins and the committed-up car takes the job.


### PR DESCRIPTION
## Summary

The wrong-direction penalty in `RsrDispatch` is currently mode-agnostic: a car committed upward pays the same penalty for diverting down during midday as it does during morning rush. That's backwards — peaks care about directional commitment far more than inter-floor traffic does.

This PR adds `peak_direction_multiplier: f64` (default `1.0`, no behaviour change). When the resident `TrafficDetector` classifies the tick as `UpPeak` or `DownPeak`, `wrong_direction_penalty` gets multiplied by the configured factor. Off-peak (`Idle` / `InterFloor`) and missing-detector cases reduce to the no-op multiplier.

Why stop at RSR? It's the cleanest vehicle:
- Already an additive cost stack, so one more scalar multiplier fits the existing shape.
- `ctx.world` already carries `TrafficDetector`, so no trait-surface change needed.
- Other strategies can adopt the same pattern (`peak_scaling` helper is reusable) if/when they gain similar tunables.

## Tests

- `peak_direction_multiplier_strengthens_penalty_in_up_peak` — seeds an `UpPeak` classification, shows a 5.0 base penalty that wasn't enough alone becomes decisive at 3× multiplier
- `peak_direction_multiplier_is_noop_off_peak` — same setup but `InterFloor` classification; closer car still wins (no scaling applied)
- `peak_direction_multiplier_tolerates_missing_detector` — no detector resource → multiplier reduces to 1.0 (same outcome as off-peak)
- `peak_direction_multiplier_rejects_below_one` / `_rejects_nan` — builder panics protect against typo-inversions

## Test plan

- [x] 785 lib tests pass
- [x] `cargo clippy -p elevator-core --all-features --tests -- -D warnings` clean
- [x] `cargo check --workspace` clean