### PR TITLE
fix(session-review): snapshot + reroute destination-log + perf + wasm registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.14.1"
+version = "15.15.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/dispatch/reposition.rs
+++ b/crates/elevator-core/src/dispatch/reposition.rs
@@ -278,19 +278,20 @@ impl RepositionStrategy for PredictiveParking {
 /// ([`PredictiveParking`]) regardless of traffic shape. Adaptive
 /// picks per mode:
 ///
-/// | Mode                                              | Inner                      |
-/// |---------------------------------------------------|----------------------------|
-/// | [`UpPeak`](crate::traffic_detector::TrafficMode::UpPeak)         | [`ReturnToLobby`]           |
-/// | [`InterFloor`](crate::traffic_detector::TrafficMode::InterFloor) | [`PredictiveParking`]       |
-/// | [`DownPeak`](crate::traffic_detector::TrafficMode::DownPeak)     | [`PredictiveParking`] (today) |
-/// | [`Idle`](crate::traffic_detector::TrafficMode::Idle)             | no-op (stay put)             |
+/// | Mode                                                             | Inner                |
+/// |------------------------------------------------------------------|----------------------|
+/// | [`UpPeak`](crate::traffic_detector::TrafficMode::UpPeak)         | [`ReturnToLobby`]    |
+/// | [`InterFloor`](crate::traffic_detector::TrafficMode::InterFloor) | [`PredictiveParking`]|
+/// | [`DownPeak`](crate::traffic_detector::TrafficMode::DownPeak)     | [`PredictiveParking`]|
+/// | [`Idle`](crate::traffic_detector::TrafficMode::Idle)             | no-op (stay put)     |
 ///
-/// The `DownPeak` row uses `PredictiveParking` for now — it'll
-/// become a dedicated upper-floor-biased variant once
-/// `TrafficDetector` emits `DownPeak` (needs the destination-log
-/// that today's [`ArrivalLog`] doesn't carry). Falls back to a
-/// `PredictiveParking`-like default if the detector is missing
-/// from `World` (e.g. hand-built tests bypassing `Simulation`).
+/// `DownPeak` reuses `PredictiveParking` intentionally: during a down
+/// peak, upper floors are the high-arrival stops (riders spawn there
+/// heading to the lobby), and `PredictiveParking` scores stops by
+/// [`ArrivalLog`] counts — so it correctly biases idle cars upward
+/// without needing a destination-aware variant. Falls back to
+/// `InterFloor` routing if the detector is missing from `World`
+/// (e.g. hand-built tests bypassing `Simulation`).
 pub struct AdaptiveParking {
     /// Inner strategy used in up-peak mode. Configurable so games
     /// can pin a different home stop (sky-lobby buildings, e.g.).

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -278,8 +278,16 @@ impl Simulation {
 
         // A rerouted resident is indistinguishable from a fresh arrival —
         // record it so predictive parking and `arrivals_at` see the demand.
+        // Mirror into the destination log so down-peak classification stays
+        // coherent for multi-leg riders.
         if let Some(log) = self.world.resource_mut::<crate::arrival_log::ArrivalLog>() {
             log.record(self.tick, stop);
+        }
+        if let Some(log) = self
+            .world
+            .resource_mut::<crate::arrival_log::DestinationLog>()
+        {
+            log.record(self.tick, new_destination);
         }
 
         self.metrics.record_reroute();

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -132,6 +132,19 @@ pub struct WorldSnapshot {
     /// [`DEFAULT_ARRIVAL_WINDOW_TICKS`](crate::arrival_log::DEFAULT_ARRIVAL_WINDOW_TICKS).
     #[serde(default)]
     pub arrival_log_retention: crate::arrival_log::ArrivalLogRetention,
+    /// Mirror of [`arrival_log`] keyed on rider *destination* — what
+    /// powers the `DownPeak` classifier branch. Same remap semantics
+    /// as [`arrival_log`] on restore. Empty in legacy snapshots; the
+    /// detector silently under-classifies `DownPeak` until the post-
+    /// restore log refills.
+    #[serde(default)]
+    pub destination_log: crate::arrival_log::DestinationLog,
+    /// Traffic-mode classifier state. Carries the current mode,
+    /// thresholds, and last-update tick across snapshot round-trip
+    /// so a restored sim doesn't momentarily reset to `Idle` when
+    /// the metrics phase hasn't run yet.
+    #[serde(default)]
+    pub traffic_detector: crate::traffic_detector::TrafficDetector,
 }
 
 /// Per-line snapshot info within a group.
@@ -299,6 +312,19 @@ impl WorldSnapshot {
         world.insert_resource(log);
         world.insert_resource(crate::arrival_log::CurrentTick(self.tick));
         world.insert_resource(self.arrival_log_retention);
+        // Destination log mirrors the same remap — entries reference
+        // rider destinations, which are stop entities that were just
+        // reallocated. Without the remap every entry would reference
+        // a dead ID and the classifier's down-peak branch would
+        // silently see zero.
+        let mut dest_log = self.destination_log;
+        dest_log.remap_entity_ids(&id_remap);
+        world.insert_resource(dest_log);
+        // The detector carries classified-mode state plus thresholds.
+        // Re-inserting it last-writer-wins means the restore carries
+        // the *classified* state forward — refresh_traffic_detector
+        // will update on the next metrics phase with fresh counts.
+        world.insert_resource(self.traffic_detector);
 
         let mut sim = crate::sim::Simulation::from_parts(
             world,
@@ -885,6 +911,14 @@ impl crate::sim::Simulation {
             arrival_log_retention: world
                 .resource::<crate::arrival_log::ArrivalLogRetention>()
                 .copied()
+                .unwrap_or_default(),
+            destination_log: world
+                .resource::<crate::arrival_log::DestinationLog>()
+                .cloned()
+                .unwrap_or_default(),
+            traffic_detector: world
+                .resource::<crate::traffic_detector::TrafficDetector>()
+                .cloned()
                 .unwrap_or_default(),
         }
     }

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -132,9 +132,9 @@ pub struct WorldSnapshot {
     /// [`DEFAULT_ARRIVAL_WINDOW_TICKS`](crate::arrival_log::DEFAULT_ARRIVAL_WINDOW_TICKS).
     #[serde(default)]
     pub arrival_log_retention: crate::arrival_log::ArrivalLogRetention,
-    /// Mirror of [`arrival_log`] keyed on rider *destination* — what
+    /// Mirror of `arrival_log` keyed on rider *destination* — what
     /// powers the `DownPeak` classifier branch. Same remap semantics
-    /// as [`arrival_log`] on restore. Empty in legacy snapshots; the
+    /// as `arrival_log` on restore. Empty in legacy snapshots; the
     /// detector silently under-classifies `DownPeak` until the post-
     /// restore log refills.
     #[serde(default)]

--- a/crates/elevator-core/src/systems/advance_transient.rs
+++ b/crates/elevator-core/src/systems/advance_transient.rs
@@ -77,8 +77,18 @@ fn handle_exit(
             }
             if let Some(stop) = world.rider(id).and_then(|r| r.current_stop) {
                 rider_index.insert_waiting(stop, id);
+                // Capture the next leg's destination before we take mutable
+                // borrows of the arrival log — the destination log pairs
+                // with the arrival log on every append so down-peak stays
+                // coherent through multi-leg trips.
+                let next_destination = world.route(id).and_then(Route::current_destination);
                 if let Some(log) = world.resource_mut::<crate::arrival_log::ArrivalLog>() {
                     log.record(ctx.tick, stop);
+                }
+                if let Some(dest) = next_destination
+                    && let Some(log) = world.resource_mut::<crate::arrival_log::DestinationLog>()
+                {
+                    log.record(ctx.tick, dest);
                 }
                 if let Some(p) = world.patience_mut(id) {
                     p.waited_ticks = 0;

--- a/crates/elevator-core/src/systems/metrics.rs
+++ b/crates/elevator-core/src/systems/metrics.rs
@@ -127,35 +127,40 @@ pub fn run(
     refresh_traffic_detector(world, ctx.tick);
 }
 
-/// Clone the arrival + destination logs, collect stops in position
-/// order (lobby first), and hand everything to the auto-installed
-/// [`TrafficDetector`](crate::traffic_detector::TrafficDetector).
-/// Skipped when the detector is absent — games running a bare
-/// `World` without it get a silent no-op. A missing
-/// [`DestinationLog`](crate::arrival_log::DestinationLog) is
+/// Refresh the auto-installed
+/// [`TrafficDetector`](crate::traffic_detector::TrafficDetector) with
+/// the latest rolling window. Skipped when the detector is absent —
+/// games running a bare `World` without it get a silent no-op. A
+/// missing [`DestinationLog`](crate::arrival_log::DestinationLog) is
 /// tolerated with a default-empty fallback so down-peak detection
 /// silently disables without panicking.
+///
+/// Temporarily removes the detector (a few f64/u64 fields) so we can
+/// hold immutable references to the logs without cloning them — a
+/// naive `resource()` read + `resource_mut()` write conflicts with
+/// the borrow checker, and cloning the logs every tick was an
+/// 18 000-entry heap copy at default retention.
 fn refresh_traffic_detector(world: &mut World, tick: u64) {
-    let Some(arrivals) = world.resource::<crate::arrival_log::ArrivalLog>().cloned() else {
+    let Some(mut detector) = world.remove_resource::<crate::traffic_detector::TrafficDetector>()
+    else {
         return;
     };
-    if world
-        .resource::<crate::traffic_detector::TrafficDetector>()
-        .is_none()
-    {
+    let Some(arrivals) = world.resource::<crate::arrival_log::ArrivalLog>() else {
+        // No arrivals resource — nothing to classify. Re-insert the
+        // detector so the next tick can try again.
+        world.insert_resource(detector);
         return;
-    }
+    };
+    let destinations_fallback = crate::arrival_log::DestinationLog::default();
     let destinations = world
         .resource::<crate::arrival_log::DestinationLog>()
-        .cloned()
-        .unwrap_or_default();
+        .unwrap_or(&destinations_fallback);
     let mut stops: Vec<_> = world
         .iter_stops()
         .map(|(eid, s)| (eid, s.position))
         .collect();
     stops.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
     let stop_ids: Vec<crate::entity::EntityId> = stops.into_iter().map(|(eid, _)| eid).collect();
-    if let Some(detector) = world.resource_mut::<crate::traffic_detector::TrafficDetector>() {
-        detector.update(&arrivals, &destinations, tick, &stop_ids);
-    }
+    detector.update(arrivals, destinations, tick, &stop_ids);
+    world.insert_resource(detector);
 }

--- a/crates/elevator-core/src/tests/arrival_log_tests.rs
+++ b/crates/elevator-core/src/tests/arrival_log_tests.rs
@@ -195,6 +195,20 @@ fn reroute_records_arrival_and_resets_spawn_tick() {
     // boundary as their reference, not the original spawn.
     let r = sim.world().rider(rider.entity()).unwrap();
     assert_eq!(r.spawn_tick(), sim.current_tick());
+
+    // The new destination (stop0 — the lobby) must be logged so down-peak
+    // classification counts the rerouted rider. Before this fix the reroute
+    // path only touched ArrivalLog, silently undercounting lobby-bound
+    // multi-leg traffic.
+    let dest_count = sim
+        .world()
+        .resource::<crate::arrival_log::DestinationLog>()
+        .unwrap()
+        .destinations_in_window(stop0, sim.current_tick(), 10);
+    assert_eq!(
+        dest_count, 1,
+        "reroute must record the new destination in the destination log"
+    );
 }
 
 #[test]

--- a/crates/elevator-core/tests/scenarios/snapshot_roundtrip.rs
+++ b/crates/elevator-core/tests/scenarios/snapshot_roundtrip.rs
@@ -2,10 +2,13 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
+use elevator_core::arrival_log::{ArrivalLog, DestinationLog};
 use elevator_core::dispatch::BuiltinReposition;
-use elevator_core::dispatch::reposition::ReturnToLobby;
+use elevator_core::dispatch::reposition::{AdaptiveParking, ReturnToLobby};
+use elevator_core::ids::GroupId;
 use elevator_core::prelude::*;
 use elevator_core::snapshot::WorldSnapshot;
+use elevator_core::traffic_detector::TrafficDetector;
 
 #[test]
 fn snapshot_roundtrip_preserves_state() {
@@ -85,4 +88,115 @@ fn snapshot_roundtrip_remaps_repositioning_phase() {
         }
         other => panic!("expected Repositioning after restore, got {other:?}"),
     }
+}
+
+/// Snapshot restore must carry the reposition *strategy discriminant*
+/// forward — `Simulation::from_parts` initialises with empty
+/// repositioners and relies on the snapshot restore to re-install
+/// them from the serialised `BuiltinReposition` ids. Without this
+/// pin, a silent regression in that restore loop (snapshot.rs
+/// `set_reposition` calls) would leave the restored sim with no
+/// reposition strategy despite the snapshot carrying one.
+#[test]
+fn snapshot_roundtrip_preserves_adaptive_repositioner() {
+    let sim = SimulationBuilder::demo()
+        .reposition(AdaptiveParking::new(), BuiltinReposition::Adaptive)
+        .build()
+        .unwrap();
+    assert_eq!(
+        sim.reposition_id(GroupId(0)),
+        Some(&BuiltinReposition::Adaptive),
+        "fixture must start with Adaptive — guards against a test that \
+         passes vacuously"
+    );
+
+    let snap = sim.snapshot();
+    let ron_str = ron::to_string(&snap).unwrap();
+    let snap2: WorldSnapshot = ron::from_str(&ron_str).unwrap();
+    let restored = snap2.restore(None).unwrap();
+
+    assert_eq!(
+        restored.reposition_id(GroupId(0)),
+        Some(&BuiltinReposition::Adaptive),
+        "restored sim must carry the same reposition id as the snapshot"
+    );
+}
+
+/// Snapshot must carry both logs forward. Before this pin,
+/// `DestinationLog` was written to the snapshot write path but never
+/// listed in the payload — round-trip silently reset it to empty,
+/// blanking the down-peak signal until enough new arrivals refilled
+/// the window.
+#[test]
+fn snapshot_roundtrip_preserves_arrival_and_destination_logs() {
+    let mut sim = SimulationBuilder::demo().build().unwrap();
+    for _ in 0..5 {
+        sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
+    }
+    // Tick once to let the metrics phase process the spawns, but the
+    // logs themselves are populated synchronously in spawn.
+    sim.step();
+
+    let orig_arrivals = sim.world().resource::<ArrivalLog>().unwrap().len();
+    let orig_destinations = sim.world().resource::<DestinationLog>().unwrap().len();
+    assert!(
+        orig_arrivals > 0,
+        "fixture must have arrivals to be meaningful"
+    );
+    assert!(
+        orig_destinations > 0,
+        "fixture must have destinations to be meaningful"
+    );
+
+    let snap = sim.snapshot();
+    let ron_str = ron::to_string(&snap).unwrap();
+    let snap2: WorldSnapshot = ron::from_str(&ron_str).unwrap();
+    let restored = snap2.restore(None).unwrap();
+
+    assert_eq!(
+        restored.world().resource::<ArrivalLog>().unwrap().len(),
+        orig_arrivals,
+        "arrival log size must survive round-trip"
+    );
+    assert_eq!(
+        restored.world().resource::<DestinationLog>().unwrap().len(),
+        orig_destinations,
+        "destination log size must survive round-trip"
+    );
+}
+
+/// The classified `TrafficMode` and thresholds must survive a
+/// snapshot. Otherwise a sim snapshotted mid-peak restores into
+/// `Idle` (the default) and immediately branches into the wrong
+/// reposition path until the metrics phase reclassifies.
+#[test]
+fn snapshot_roundtrip_preserves_traffic_detector_state() {
+    let mut sim = SimulationBuilder::demo().build().unwrap();
+    for _ in 0..8 {
+        sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
+    }
+    // Run long enough for the detector to classify at least once.
+    for _ in 0..200 {
+        sim.step();
+    }
+    let orig_detector = sim.world().resource::<TrafficDetector>().unwrap();
+    let orig_mode = orig_detector.current_mode();
+    let orig_last_update = orig_detector.last_update_tick();
+
+    let snap = sim.snapshot();
+    let ron_str = ron::to_string(&snap).unwrap();
+    let snap2: WorldSnapshot = ron::from_str(&ron_str).unwrap();
+    let restored = snap2.restore(None).unwrap();
+
+    let restored_detector = restored.world().resource::<TrafficDetector>().unwrap();
+    assert_eq!(
+        restored_detector.current_mode(),
+        orig_mode,
+        "classified mode must carry across snapshot"
+    );
+    assert_eq!(
+        restored_detector.last_update_tick(),
+        orig_last_update,
+        "last_update_tick must carry across snapshot"
+    );
 }

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -455,7 +455,7 @@ impl WasmSim {
 #[wasm_bindgen(js_name = builtinStrategies)]
 #[must_use]
 pub fn builtin_strategies() -> Vec<JsValue> {
-    ["scan", "look", "nearest", "etd", "destination"]
+    ["scan", "look", "nearest", "etd", "destination", "rsr"]
         .iter()
         .map(|s| JsValue::from_str(s))
         .collect()


### PR DESCRIPTION
## Summary

Fixes surfaced by auditing the dispatch-research PR arc (#361, #364, #366, #371, #373, #374, #375) with three parallel review agents (gap-finder, code-reviewer, security).

### 1. Snapshot now preserves `DestinationLog` + `TrafficDetector` state
Both resources were written in `from_parts`'s backward-compat backfill but missing from the payload itself. Round-trip silently reset the destination log to empty and the detector to `Idle`, blanking DownPeak classification until the rolling window refilled from fresh arrivals.

### 2. `reroute_rider` + transit-rewait paths log `DestinationLog`
`sim/lifecycle.rs::reroute_rider` and `systems/advance_transient.rs::handle_exit` were asymmetric — they wrote to `ArrivalLog` but not `DestinationLog`. Down-peak classification silently undercounted any multi-leg or rerouted trip (sky-lobby transfers, reroute-to-lobby scenarios).

### 3. `refresh_traffic_detector`: drop per-tick log clones
Was cloning both logs (up to 18 000 entries each at default retention) every tick to satisfy the borrow checker. Now temporarily removes the small `TrafficDetector` struct, holds both logs by immutable reference, re-inserts. Eliminates the steady-state per-tick heap allocation.

### 4. `builtinStrategies()` wasm export now includes `"rsr"`
`strategy_id` and `make_sim` already handled it; the registry used for JS dropdowns was stale.

### 5. `AdaptiveParking` docstring: drop stale DownPeak note
The "will become a dedicated variant once DownPeak fires" note is obsolete — DownPeak fires now, and `PredictiveParking` already biases upward during down-peak (upper floors are where the origin signal is).

## Tests

Added:
- `snapshot_roundtrip_preserves_adaptive_repositioner`
- `snapshot_roundtrip_preserves_arrival_and_destination_logs`
- `snapshot_roundtrip_preserves_traffic_detector_state`

Extended `reroute_records_arrival_and_resets_spawn_tick` to also assert `DestinationLog` is written.

## Test plan

- [x] `cargo test -p elevator-core --all-features` — 782 lib tests pass, 5 snapshot scenarios pass
- [x] `cargo clippy -p elevator-core --all-features --tests -- -D warnings` clean
- [x] `cargo check --workspace` clean