### PR TITLE
feat(playground): strip scenarios to 3 + UX polish pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.15.1"
+version = "15.16.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/playground/index.html
+++ b/playground/index.html
@@ -15,21 +15,23 @@
     <header class="top">
       <h1>elevator-core playground</h1>
       <nav>
+        <button type="button" id="shortcuts" class="nav-btn" title="Keyboard shortcuts (press ?)">?</button>
         <a href="https://github.com/andymai/elevator-core">repo</a>
         <a href="https://docs.rs/elevator-core">docs</a>
         <a href="../">guide</a>
       </nav>
     </header>
 
+    <section class="scenario-cards" id="scenario-cards" aria-label="Scenario picker"></section>
+
     <section class="controls">
-      <label class="ctl">
-        <span class="ctl-k">Scenario</span>
-        <select id="scenario"></select>
-      </label>
-      <label class="ctl">
-        <span class="ctl-k">Strategy</span>
-        <select id="strategy-a"></select>
-      </label>
+      <div class="ctl ctl-strategy">
+        <label class="ctl-inline" for="strategy-a">
+          <span class="ctl-k">Strategy</span>
+          <select id="strategy-a"></select>
+        </label>
+        <p id="strategy-desc" class="ctl-desc"></p>
+      </div>
       <label class="ctl hidden" id="strategy-b-wrap">
         <span class="ctl-k">vs</span>
         <select id="strategy-b"></select>
@@ -45,9 +47,9 @@
       <label class="ctl">
         <span class="ctl-k">
           <span>Speed</span>
-          <span id="speed-label" class="ctl-v">4&times;</span>
+          <span id="speed-label" class="ctl-v">2&times;</span>
         </span>
-        <input id="speed" type="range" min="1" max="16" step="1" value="4" />
+        <input id="speed" type="range" min="1" max="16" step="1" value="2" />
       </label>
       <label class="ctl">
         <span class="ctl-k">
@@ -67,42 +69,62 @@
     </section>
 
     <section class="tweak-panel" id="tweak-panel" hidden aria-label="Building physics parameters">
-      <div class="tweak-row" data-key="cars">
+      <div class="tweak-row" data-key="cars" tabindex="0">
         <span class="tweak-label">Cars</span>
         <div class="tweak-stepper">
           <button type="button" class="tweak-dec" aria-label="Decrease">&minus;</button>
           <span class="tweak-value">2</span>
           <button type="button" class="tweak-inc" aria-label="Increase">+</button>
         </div>
+        <div class="tweak-track" aria-hidden="true">
+          <div class="tweak-track-default"></div>
+          <div class="tweak-track-fill"></div>
+          <div class="tweak-track-thumb"></div>
+        </div>
         <span class="tweak-default">default <span class="tweak-default-v">2</span></span>
         <button type="button" class="tweak-reset" hidden aria-label="Reset to default">Reset</button>
       </div>
-      <div class="tweak-row" data-key="maxSpeed">
+      <div class="tweak-row" data-key="maxSpeed" tabindex="0">
         <span class="tweak-label">Max speed <span class="tweak-unit">m/s</span></span>
         <div class="tweak-stepper">
           <button type="button" class="tweak-dec" aria-label="Decrease">&minus;</button>
           <span class="tweak-value">2.5</span>
           <button type="button" class="tweak-inc" aria-label="Increase">+</button>
         </div>
+        <div class="tweak-track" aria-hidden="true">
+          <div class="tweak-track-default"></div>
+          <div class="tweak-track-fill"></div>
+          <div class="tweak-track-thumb"></div>
+        </div>
         <span class="tweak-default">default <span class="tweak-default-v">2.5</span></span>
         <button type="button" class="tweak-reset" hidden aria-label="Reset to default">Reset</button>
       </div>
-      <div class="tweak-row" data-key="weightCapacity">
+      <div class="tweak-row" data-key="weightCapacity" tabindex="0">
         <span class="tweak-label">Capacity <span class="tweak-unit">kg</span></span>
         <div class="tweak-stepper">
           <button type="button" class="tweak-dec" aria-label="Decrease">&minus;</button>
           <span class="tweak-value">800</span>
           <button type="button" class="tweak-inc" aria-label="Increase">+</button>
         </div>
+        <div class="tweak-track" aria-hidden="true">
+          <div class="tweak-track-default"></div>
+          <div class="tweak-track-fill"></div>
+          <div class="tweak-track-thumb"></div>
+        </div>
         <span class="tweak-default">default <span class="tweak-default-v">800</span></span>
         <button type="button" class="tweak-reset" hidden aria-label="Reset to default">Reset</button>
       </div>
-      <div class="tweak-row" data-key="doorCycleSec">
+      <div class="tweak-row" data-key="doorCycleSec" tabindex="0">
         <span class="tweak-label">Door cycle <span class="tweak-unit">s</span></span>
         <div class="tweak-stepper">
           <button type="button" class="tweak-dec" aria-label="Decrease">&minus;</button>
           <span class="tweak-value">5.5</span>
           <button type="button" class="tweak-inc" aria-label="Increase">+</button>
+        </div>
+        <div class="tweak-track" aria-hidden="true">
+          <div class="tweak-track-default"></div>
+          <div class="tweak-track-fill"></div>
+          <div class="tweak-track-thumb"></div>
         </div>
         <span class="tweak-default">default <span class="tweak-default-v">5.5</span></span>
         <button type="button" class="tweak-reset" hidden aria-label="Reset to default">Reset</button>
@@ -110,23 +132,34 @@
       <div class="tweak-foot">
         <span class="tweak-foot-hint">
           Speed, capacity, and door cycle hot-swap live. Changing the
-          car count rebuilds the sim.
+          car count rebuilds the sim. Focus a row and use arrow keys
+          to nudge.
         </span>
         <button type="button" id="tweak-reset-all" hidden>Reset all</button>
       </div>
     </section>
 
     <section class="phase-strip" id="phase-strip">
-      <span class="phase-k">Phase</span>
-      <span id="phase-label" class="phase-v">&mdash;</span>
-      <span id="feature-hint" class="phase-hint"></span>
+      <div class="phase-row">
+        <span class="phase-k">Phase</span>
+        <span id="phase-label" class="phase-v">&mdash;</span>
+        <span id="feature-hint" class="phase-hint"></span>
+      </div>
+      <div class="phase-progress" aria-hidden="true">
+        <div class="phase-progress-fill" id="phase-progress-fill"></div>
+      </div>
     </section>
+
+    <section class="verdict-ribbon" id="verdict-ribbon" hidden aria-label="Comparison scoreboard"></section>
 
     <main id="layout" class="layout" data-mode="single">
       <section id="pane-a" class="pane pane-a">
         <header class="pane-header">
           <span class="pane-badge">A</span>
-          <span id="name-a" class="pane-name">LOOK</span>
+          <div class="pane-title">
+            <span id="name-a" class="pane-name">LOOK</span>
+            <span id="decision-a" class="pane-decision" aria-live="polite"></span>
+          </div>
           <span id="mode-a" class="pane-mode" data-mode="Idle" title="Traffic mode from TrafficDetector">Idle</span>
         </header>
         <div class="shaft-wrap">
@@ -138,7 +171,10 @@
       <section id="pane-b" class="pane pane-b">
         <header class="pane-header">
           <span class="pane-badge">B</span>
-          <span id="name-b" class="pane-name">ETD</span>
+          <div class="pane-title">
+            <span id="name-b" class="pane-name">ETD</span>
+            <span id="decision-b" class="pane-decision" aria-live="polite"></span>
+          </div>
           <span id="mode-b" class="pane-mode" data-mode="Idle" title="Traffic mode from TrafficDetector">Idle</span>
         </header>
         <div class="shaft-wrap">
@@ -153,6 +189,25 @@
       <div class="loader-text">Loading simulation&hellip;</div>
     </div>
     <div id="toast" class="toast" role="status"></div>
+
+    <div id="shortcut-sheet" class="shortcut-sheet" hidden role="dialog" aria-modal="true" aria-label="Keyboard shortcuts">
+      <div class="shortcut-sheet-inner">
+        <header>
+          <span>Keyboard shortcuts</span>
+          <button type="button" id="shortcut-sheet-close" aria-label="Close">&times;</button>
+        </header>
+        <dl>
+          <dt><kbd>Space</kbd></dt><dd>Pause / play</dd>
+          <dt><kbd>R</kbd></dt><dd>Reset the sim</dd>
+          <dt><kbd>C</kbd></dt><dd>Toggle compare mode</dd>
+          <dt><kbd>S</kbd></dt><dd>Copy permalink</dd>
+          <dt><kbd>T</kbd></dt><dd>Open / close the tweak panel</dd>
+          <dt><kbd>1</kbd>&nbsp;<kbd>2</kbd>&nbsp;<kbd>3</kbd></dt><dd>Jump to scenario card</dd>
+          <dt><kbd>&uarr;</kbd>&nbsp;<kbd>&darr;</kbd></dt><dd>Nudge focused tweak row</dd>
+          <dt><kbd>?</kbd></dt><dd>Toggle this sheet</dd>
+        </dl>
+      </div>
+    </div>
 
     <script type="module" src="./src/main.ts"></script>
   </body>

--- a/playground/src/__tests__/params.test.ts
+++ b/playground/src/__tests__/params.test.ts
@@ -58,65 +58,65 @@ describe("params: defaults extraction", () => {
   });
 
   it("defaultFor returns scenario default for each key", () => {
-    const office = scenarioById("office-mid-rise");
-    expect(defaultFor(office, "cars")).toBe(2);
-    expect(defaultFor(office, "maxSpeed")).toBe(2.2);
-    expect(defaultFor(office, "weightCapacity")).toBe(800);
-    // 210 ticks dwell + 2 × 60 ticks transition = 330 / 60 = 5.5 s
-    expect(defaultFor(office, "doorCycleSec")).toBeCloseTo(5.5, 5);
+    const sky = scenarioById("skyscraper-sky-lobby");
+    expect(defaultFor(sky, "cars")).toBe(3);
+    expect(defaultFor(sky, "maxSpeed")).toBe(4.0);
+    expect(defaultFor(sky, "weightCapacity")).toBe(1200);
+    // 300 ticks dwell + 2 × 72 ticks transition = 444 / 60 = 7.4 s
+    expect(defaultFor(sky, "doorCycleSec")).toBeCloseTo(7.4, 5);
   });
 });
 
 describe("params: resolution & overrides", () => {
-  const office = scenarioById("office-mid-rise");
+  const sky = scenarioById("skyscraper-sky-lobby");
 
   it("resolveParam falls back to default for missing/non-finite overrides", () => {
-    expect(resolveParam(office, "maxSpeed", {})).toBe(2.2);
-    expect(resolveParam(office, "maxSpeed", { maxSpeed: NaN })).toBe(2.2);
-    expect(resolveParam(office, "maxSpeed", { maxSpeed: 4.5 })).toBe(4.5);
+    expect(resolveParam(sky, "maxSpeed", {})).toBe(4.0);
+    expect(resolveParam(sky, "maxSpeed", { maxSpeed: NaN })).toBe(4.0);
+    expect(resolveParam(sky, "maxSpeed", { maxSpeed: 4.5 })).toBe(4.5);
   });
 
   it("resolveParam clamps out-of-range overrides to the slider bounds", () => {
-    expect(resolveParam(office, "maxSpeed", { maxSpeed: -10 })).toBe(0.5);
-    expect(resolveParam(office, "maxSpeed", { maxSpeed: 999 })).toBe(12);
-    expect(resolveParam(office, "cars", { cars: 99 })).toBe(6);
-    expect(resolveParam(office, "cars", { cars: 0 })).toBe(1);
+    expect(resolveParam(sky, "maxSpeed", { maxSpeed: -10 })).toBe(0.5);
+    expect(resolveParam(sky, "maxSpeed", { maxSpeed: 999 })).toBe(12);
+    expect(resolveParam(sky, "cars", { cars: 99 })).toBe(6);
+    expect(resolveParam(sky, "cars", { cars: 0 })).toBe(1);
   });
 
   it("isOverridden tolerates within-half-step noise", () => {
-    // Step is 0.5 m/s; 2.2 ± 0.24 still counts as default.
-    expect(isOverridden(office, "maxSpeed", 2.2)).toBe(false);
-    expect(isOverridden(office, "maxSpeed", 2.4)).toBe(false);
-    expect(isOverridden(office, "maxSpeed", 2.5)).toBe(true);
+    // Step is 0.5 m/s; 4.0 ± 0.24 still counts as default.
+    expect(isOverridden(sky, "maxSpeed", 4.0)).toBe(false);
+    expect(isOverridden(sky, "maxSpeed", 4.2)).toBe(false);
+    expect(isOverridden(sky, "maxSpeed", 4.3)).toBe(true);
   });
 
   it("compactOverrides drops keys that round back to the default", () => {
-    const overrides: Overrides = { maxSpeed: 2.2, weightCapacity: 1200 };
-    const compact = compactOverrides(office, overrides);
-    expect(compact).toEqual({ weightCapacity: 1200 });
+    const overrides: Overrides = { maxSpeed: 4.0, weightCapacity: 2000 };
+    const compact = compactOverrides(sky, overrides);
+    expect(compact).toEqual({ weightCapacity: 2000 });
   });
 });
 
 describe("params: door cycle splitting", () => {
-  const office = scenarioById("office-mid-rise");
+  const sky = scenarioById("skyscraper-sky-lobby");
 
   it("doorCycleSecFromTicks computes total seconds from tick fields", () => {
-    expect(doorCycleSecFromTicks(210, 60)).toBeCloseTo(5.5, 5);
+    expect(doorCycleSecFromTicks(300, 72)).toBeCloseTo(7.4, 5);
     expect(doorCycleSecFromTicks(180, 60)).toBeCloseTo(5.0, 5);
   });
 
   it("preserves the scenario's dwell-share when the user changes the cycle", () => {
-    // Office defaults to 5.5 s with dwell-share 3.5/5.5 ≈ 0.636.
-    // Doubling the cycle to 11 s should keep that share.
-    const split = doorCycleSecToTicks(office, 11);
+    // Skyscraper defaults to 7.4 s with dwell-share 300/444 ≈ 0.676.
+    // Doubling the cycle to 14.8 s should keep that share.
+    const split = doorCycleSecToTicks(sky, 14.8);
     const total = split.openTicks + 2 * split.transitionTicks;
-    expect(total).toBeGreaterThanOrEqual(660 - 2);
-    expect(total).toBeLessThanOrEqual(660 + 2);
-    expect(split.openTicks / total).toBeCloseTo(0.636, 1);
+    expect(total).toBeGreaterThanOrEqual(888 - 2);
+    expect(total).toBeLessThanOrEqual(888 + 2);
+    expect(split.openTicks / total).toBeCloseTo(0.676, 1);
   });
 
   it("clamps both halves to ≥1 tick so engine validation passes", () => {
-    const split = doorCycleSecToTicks(office, 2);
+    const split = doorCycleSecToTicks(sky, 2);
     expect(split.openTicks).toBeGreaterThanOrEqual(1);
     expect(split.transitionTicks).toBeGreaterThanOrEqual(1);
   });
@@ -140,32 +140,33 @@ describe("params: starting-stop spread", () => {
 });
 
 describe("params: RON regeneration", () => {
-  const office = scenarioById("office-mid-rise");
+  const sky = scenarioById("skyscraper-sky-lobby");
+  const convention = scenarioById("convention-burst");
 
   it("default overrides round-trip to the same physics as the canonical RON", () => {
-    const ron = buildScenarioRon(office, {});
-    expect(ron).toMatch(/name: "Mid-Rise Office"/);
-    expect((ron.match(/ElevatorConfig\s*\(/g) ?? []).length).toBe(office.defaultCars);
-    expect(ron).toMatch(/max_speed: 2\.2/);
-    expect(ron).toMatch(/weight_capacity: 800\.0/);
-    expect(ron).toMatch(/door_open_ticks: 210/);
-    expect(ron).toMatch(/door_transition_ticks: 60/);
+    const ron = buildScenarioRon(sky, {});
+    expect(ron).toMatch(/name: "Skyscraper \(Sky Lobby\)"/);
+    expect((ron.match(/ElevatorConfig\s*\(/g) ?? []).length).toBe(sky.defaultCars);
+    expect(ron).toMatch(/max_speed: 4\.0/);
+    expect(ron).toMatch(/weight_capacity: 1200\.0/);
+    expect(ron).toMatch(/door_open_ticks: 300/);
+    expect(ron).toMatch(/door_transition_ticks: 72/);
   });
 
   it("regenerates with a new car count using uniform physics across all cars", () => {
-    const ron = buildScenarioRon(office, { cars: 4 });
+    const ron = buildScenarioRon(sky, { cars: 4 });
     expect((ron.match(/ElevatorConfig\s*\(/g) ?? []).length).toBe(4);
-    expect((ron.match(/max_speed: 2\.2/g) ?? []).length).toBe(4);
+    expect((ron.match(/max_speed: 4\.0/g) ?? []).length).toBe(4);
   });
 
   it("bakes hot-swappable overrides into the RON so the initial sim already reflects them", () => {
-    const ron = buildScenarioRon(office, {
+    const ron = buildScenarioRon(sky, {
       maxSpeed: 4.5,
-      weightCapacity: 1200,
+      weightCapacity: 1500,
       doorCycleSec: 8,
     });
     expect(ron).toMatch(/max_speed: 4\.5/);
-    expect(ron).toMatch(/weight_capacity: 1200\.0/);
+    expect(ron).toMatch(/weight_capacity: 1500\.0/);
     const open = Number(/door_open_ticks:\s*(\d+)/.exec(ron)?.[1] ?? "NaN");
     const trans = Number(/door_transition_ticks:\s*(\d+)/.exec(ron)?.[1] ?? "NaN");
     expect(open + 2 * trans).toBeGreaterThanOrEqual(478);
@@ -173,33 +174,32 @@ describe("params: RON regeneration", () => {
   });
 
   it("preserves the bypass percentages on scenarios that ship them", () => {
-    const sky = scenarioById("skyscraper-sky-lobby");
     const ron = buildScenarioRon(sky, {});
     expect((ron.match(/bypass_load_up_pct: Some\(0\.8\)/g) ?? []).length).toBe(sky.defaultCars);
     expect((ron.match(/bypass_load_down_pct: Some\(0\.5\)/g) ?? []).length).toBe(sky.defaultCars);
   });
 
   it("omits bypass fields on scenarios that don't ship them", () => {
-    const ron = buildScenarioRon(office, {});
+    const ron = buildScenarioRon(convention, {});
     expect(ron).not.toMatch(/bypass_load_up_pct/);
     expect(ron).not.toMatch(/bypass_load_down_pct/);
   });
 });
 
 describe("params: applyPhysicsOverrides", () => {
-  const office = scenarioById("office-mid-rise");
+  const sky = scenarioById("skyscraper-sky-lobby");
 
   it("returns scenario defaults when no overrides are present", () => {
-    const out = applyPhysicsOverrides(office, {});
-    expect(out.maxSpeed).toBe(2.2);
-    expect(out.weightCapacity).toBe(800);
-    expect(out.doorOpenTicks).toBe(210);
-    expect(out.doorTransitionTicks).toBe(60);
-    expect(out.acceleration).toBe(office.elevatorDefaults.acceleration);
+    const out = applyPhysicsOverrides(sky, {});
+    expect(out.maxSpeed).toBe(4.0);
+    expect(out.weightCapacity).toBe(1200);
+    expect(out.doorOpenTicks).toBe(300);
+    expect(out.doorTransitionTicks).toBe(72);
+    expect(out.acceleration).toBe(sky.elevatorDefaults.acceleration);
   });
 
   it("respects user overrides for all four hot-swappable knobs", () => {
-    const out = applyPhysicsOverrides(office, {
+    const out = applyPhysicsOverrides(sky, {
       maxSpeed: 5,
       weightCapacity: 1500,
       doorCycleSec: 7,

--- a/playground/src/__tests__/permalink.test.ts
+++ b/playground/src/__tests__/permalink.test.ts
@@ -20,7 +20,7 @@ describe("permalink: core knobs", () => {
   it("round-trips through encode/decode without drift", () => {
     const state = {
       ...DEFAULT_STATE,
-      scenario: "office-mid-rise",
+      scenario: "convention-burst",
       strategyA: "look" as const,
       seed: 7,
       intensity: 1.4,

--- a/playground/src/__tests__/permalink.test.ts
+++ b/playground/src/__tests__/permalink.test.ts
@@ -6,7 +6,8 @@ describe("permalink: core knobs", () => {
     const qs = encodePermalink(DEFAULT_STATE);
     expect(qs).toMatch(/s=skyscraper-sky-lobby/);
     expect(qs).toMatch(/a=etd/);
-    expect(qs).toMatch(/c=1/);
+    // Compare defaults to off — the `c` key is only emitted when true.
+    expect(qs).not.toMatch(/(^|&|\?)c=/);
     expect(qs).toMatch(/k=42/);
   });
 

--- a/playground/src/__tests__/scenarios.test.ts
+++ b/playground/src/__tests__/scenarios.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { SCENARIOS, scenarioById } from "../scenarios";
 
 describe("scenarios metadata", () => {
-  it("ships exactly 6 scenarios", () => {
-    expect(SCENARIOS).toHaveLength(6);
+  it("ships exactly 3 scenarios", () => {
+    expect(SCENARIOS).toHaveLength(3);
   });
 
   it("every id is unique", () => {
@@ -13,7 +13,7 @@ describe("scenarios metadata", () => {
 
   it("every scenario declares a default strategy", () => {
     for (const s of SCENARIOS) {
-      expect(s.defaultStrategy, `${s.id}`).toMatch(/^(scan|look|nearest|etd|destination)$/);
+      expect(s.defaultStrategy, `${s.id}`).toMatch(/^(scan|look|nearest|etd|destination|rsr)$/);
     }
   });
 
@@ -52,26 +52,15 @@ describe("scenarios metadata", () => {
     }
   });
 
-  it("feature hooks are consistent with defaultStrategy when the hook requires one", () => {
-    for (const s of SCENARIOS) {
-      if (s.hook.kind === "deferred_dcs") {
-        expect(s.defaultStrategy, `${s.id}`).toBe("destination");
-      }
-      if (s.hook.kind === "etd_group_time") {
-        expect(s.defaultStrategy, `${s.id}`).toBe("etd");
-      }
-    }
-  });
-
-  it("day-cycle scenarios sum to a plausible length (3–10 real-min range)", () => {
+  it("day-cycle scenarios sum to a plausible length (1–10 real-min range)", () => {
     // Target: ~5 min per sim-day. Phases are in sim-seconds with the
-    // sim running at 4× default, so the real-time duration is
-    // sum(durationSec) / 4. Accept 1 min (fast demo cadence) through
-    // 10 min (deliberately slow "live" run).
+    // sim running at the 2× default playback, so real-time duration
+    // is sum(durationSec) / 2. Accept 1 min (fast demo cadence)
+    // through 10 min (deliberately slow "live" run).
     for (const s of SCENARIOS) {
       if (s.phases.length === 0) continue;
       const totalSimSec = s.phases.reduce((acc, p) => acc + p.durationSec, 0);
-      const realMin = totalSimSec / 4 / 60;
+      const realMin = totalSimSec / 2 / 60;
       expect(realMin, `${s.id}`).toBeGreaterThanOrEqual(1);
       expect(realMin, `${s.id}`).toBeLessThanOrEqual(10);
     }

--- a/playground/src/canvas.ts
+++ b/playground/src/canvas.ts
@@ -327,14 +327,20 @@ export class CanvasRenderer {
     canvasWidth: number,
   ): void {
     const ctx = this.#ctx;
-    const padX = 6;
-    const padY = 3;
+    const padX = 7;
+    const padY = 4;
     const tailW = 5;
     const tailH = 4;
-    const radius = 5;
-    const font = `${s.fontSmall}px system-ui, sans-serif`;
+    const radius = 6;
+    const font = `600 ${s.fontSmall + 0.5}px system-ui, -apple-system, "Segoe UI", sans-serif`;
     ctx.font = font;
     ctx.textBaseline = "middle";
+    // Fade the last FADE_FRAC of the bubble's lifetime so dismissal
+    // feels soft rather than binary. Kept at 30 % so the message still
+    // reads crisply for most of its dwell.
+    const FADE_FRAC = 0.3;
+    const now = performance.now();
+    const strokeBase = this.#accent;
 
     for (const car of snap.cars) {
       const bubble = bubbles.get(car.id);
@@ -342,6 +348,12 @@ export class CanvasRenderer {
       const cx = carX.get(car.id);
       if (cx === undefined) continue;
       const cy = toScreenY(car.y);
+
+      const ttl = Math.max(1, bubble.expiresAt - bubble.bornAt);
+      const remaining = bubble.expiresAt - now;
+      const alpha =
+        remaining > ttl * FADE_FRAC ? 1 : Math.max(0, remaining / (ttl * FADE_FRAC));
+      if (alpha <= 0) continue;
 
       const textW = ctx.measureText(bubble.text).width;
       const bubbleW = textW + padX * 2;
@@ -358,12 +370,22 @@ export class CanvasRenderer {
         side === "right" ? cx + halfCar + tailW : cx - halfCar - tailW - bubbleW;
       const by = cy - bubbleH / 2;
 
-      // Rounded-rect body.
-      ctx.fillStyle = "rgba(18, 22, 31, 0.92)";
-      ctx.strokeStyle = "rgba(125, 211, 252, 0.55)";
-      ctx.lineWidth = 1;
+      ctx.save();
+      ctx.globalAlpha = alpha;
+
+      // Soft pane-accent glow beneath the bubble, so the bubble reads
+      // as belonging to its pane even at a glance.
+      ctx.shadowColor = strokeBase;
+      ctx.shadowBlur = 8;
+      ctx.fillStyle = "rgba(16, 19, 26, 0.94)";
       roundedRect(ctx, bx, by, bubbleW, bubbleH, radius);
       ctx.fill();
+      ctx.shadowBlur = 0;
+
+      // Pane-accent border.
+      ctx.strokeStyle = withAlpha(strokeBase, 0.65);
+      ctx.lineWidth = 1;
+      roundedRect(ctx, bx, by, bubbleW, bubbleH, radius);
       ctx.stroke();
 
       // Tail — small triangle pointing at the car.
@@ -378,12 +400,15 @@ export class CanvasRenderer {
         ctx.lineTo(bx + bubbleW, cy + tailH / 2);
       }
       ctx.closePath();
+      ctx.fillStyle = "rgba(16, 19, 26, 0.94)";
       ctx.fill();
       ctx.stroke();
 
       // Text.
-      ctx.fillStyle = "#e8ecf5";
+      ctx.fillStyle = "#f0f3fb";
       ctx.fillText(bubble.text, bx + padX, cy);
+
+      ctx.restore();
     }
   }
 
@@ -925,6 +950,15 @@ function truncate(ctx: CanvasRenderingContext2D, text: string, maxWidth: number)
     else hi = mid - 1;
   }
   return lo === 0 ? ellipsis : text.slice(0, lo) + ellipsis;
+}
+
+/** Apply `alpha` (0..1) to a 6-digit hex color. Used for pane-tinted
+ *  canvas strokes where we have a base hex and want a translucent
+ *  variant without adding a CSS variable lookup on every frame. */
+function withAlpha(hex: string, alpha: number): string {
+  const a = Math.round(Math.max(0, Math.min(1, alpha)) * 255);
+  const suffix = a.toString(16).padStart(2, "0");
+  return hex.length === 7 ? `${hex}${suffix}` : hex;
 }
 
 /**

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -37,9 +37,47 @@ const STRATEGY_LABELS: Record<StrategyName, string> = {
   destination: "DCS",
   rsr: "RSR",
 };
+
+/**
+ * One-liners shown under the strategy selector. Tuned to be readable
+ * at a glance without jargon while still being specific enough to
+ * differentiate the six strategies. The phrasing leads with behavior,
+ * not mechanism — a reader new to vertical-transport theory should
+ * still come away with a sense of what each controller does.
+ */
+const STRATEGY_DESCRIPTIONS: Record<StrategyName, string> = {
+  scan: "Sweeps end-to-end like a disk head — simple, predictable, ignores who's waiting longest.",
+  look: "Like SCAN but reverses early when nothing's queued further — a practical baseline.",
+  nearest: "Grabs whichever call is closest right now. Fast under light load, thrashes under rush.",
+  etd: "Estimated time of dispatch — assigns calls to whichever car can finish fastest.",
+  destination: "Destination-control: riders pick their floor at the lobby; the group optimises assignments.",
+  rsr: "Relative System Response — a wait-aware variant of ETD that penalises long queues.",
+};
 const WAIT_HISTORY_LEN = 120;
 const COLOR_A = "#7dd3fc";
 const COLOR_B = "#fda4af";
+
+/**
+ * Keys for the metric strip rows. Kept as a string literal union so
+ * `MetricVerdicts` and `Pane.metricHistory` both index the same set
+ * and a typo in one spot surfaces at the other.
+ */
+type MetricKey = "avg_wait_s" | "max_wait_s" | "delivered" | "abandoned" | "utilization";
+const METRIC_KEYS: MetricKey[] = [
+  "avg_wait_s",
+  "max_wait_s",
+  "delivered",
+  "abandoned",
+  "utilization",
+];
+
+/**
+ * How long a pane's decision-narration line stays at full opacity
+ * after a fresh `elevator-assigned` event. After this window the line
+ * dims but stays readable — users can still see the most recent
+ * decision after a lull, just with lower visual priority.
+ */
+const DECISION_TTL_MS = 1800;
 
 const speedLabel = (v: number): string => `${v}\u00d7`;
 const intensityLabel = (v: number): string => `${v.toFixed(1)}\u00d7`;
@@ -50,24 +88,46 @@ interface Pane {
   renderer: CanvasRenderer;
   metricsEl: HTMLElement;
   modeEl: HTMLElement;
+  decisionEl: HTMLElement;
   waitHistory: number[];
+  /**
+   * Rolling per-metric history for inline sparklines. Matches the
+   * wait-history length so every row's trace covers the same window.
+   * Keys mirror `MetricVerdicts`; we keep raw numbers and do the chart
+   * math at render time.
+   */
+  metricHistory: Record<MetricKey, number[]>;
   latestMetrics: Metrics | null;
   /**
    * Per-car speech bubbles. Keyed by car entity id. Each entry fades
-   * after [`BUBBLE_TTL_MS`] wall-clock milliseconds; stale entries are
-   * evicted lazily in [`updateBubbles`] so the map never grows past
-   * `cars × 1`.
+   * per its event-kind TTL; stale entries are evicted lazily in
+   * [`updateBubbles`] so the map never grows past `cars × 1`.
    */
   bubbles: Map<number, CarBubble>;
+  /**
+   * Wall-clock ms after which the pane's decision line (the
+   * `Car X → <stop>` readout) should fade out. We keep the text
+   * visible after fade-out so the last known decision is still there
+   * on the next pulse, just at reduced opacity — makes compare mode
+   * read as "here's the story" rather than flashing on/off.
+   */
+  decisionExpiresAt: number;
 }
 
 /**
- * How long a speech bubble lingers after its triggering event, in
- * wall-clock milliseconds. Chosen so that under 1× playback the bubble
- * reads comfortably; at 16× it's short enough that stale events don't
- * linger past the action they describe.
+ * Per-event speech-bubble lifetimes in wall-clock milliseconds. Events
+ * that carry more information (destination, dropoff) linger; transient
+ * events (door open) dismiss quickly so the per-car bubble cycles
+ * through the action it describes without feeling stale at 16×.
  */
-const BUBBLE_TTL_MS = 1400;
+const BUBBLE_TTL_BY_KIND: Record<string, number> = {
+  "elevator-assigned": 1400,
+  "elevator-arrived": 1200,
+  "door-opened": 550,
+  "rider-boarded": 850,
+  "rider-exited": 1600,
+};
+const BUBBLE_TTL_DEFAULT_MS = 1000;
 
 interface State {
   running: boolean;
@@ -91,6 +151,7 @@ interface PaneHandles {
   canvas: HTMLCanvasElement;
   name: HTMLElement;
   mode: HTMLElement;
+  decision: HTMLElement;
   metrics: HTMLElement;
   accent: string;
 }
@@ -102,12 +163,16 @@ interface TweakRowHandles {
   dec: HTMLButtonElement;
   inc: HTMLButtonElement;
   reset: HTMLButtonElement;
+  trackFill: HTMLElement | null;
+  trackDefault: HTMLElement | null;
+  trackThumb: HTMLElement | null;
 }
 
 interface UiHandles {
-  scenarioSelect: HTMLSelectElement;
+  scenarioCards: HTMLElement;
   strategyASelect: HTMLSelectElement;
   strategyBSelect: HTMLSelectElement;
+  strategyDesc: HTMLElement;
   compareToggle: HTMLInputElement;
   strategyBWrap: HTMLElement;
   seedInput: HTMLInputElement;
@@ -127,6 +192,11 @@ interface UiHandles {
   toast: HTMLElement;
   phaseLabel: HTMLElement | null;
   featureHint: HTMLElement | null;
+  phaseProgress: HTMLElement | null;
+  verdictRibbon: HTMLElement;
+  shortcutsBtn: HTMLButtonElement;
+  shortcutSheet: HTMLElement;
+  shortcutSheetClose: HTMLButtonElement;
   paneA: PaneHandles;
   paneB: PaneHandles;
 }
@@ -161,15 +231,15 @@ async function boot(): Promise<void> {
   attachListeners(state, ui);
   await resetAll(state, ui);
   state.ready = true;
-  loop(state);
+  loop(state, ui);
 }
 
 /**
- * Canonicalise legacy scenario ids (e.g. `"office-5"`) through the
- * `scenarioById` fallback so the rest of boot operates on the current
- * canonical id. Strategy is intentionally left alone: on first load
- * we honour whatever the permalink encoded — the snap-to-scenario-default
- * behavior only fires on an interactive scenario change, not on boot.
+ * Canonicalise legacy scenario ids through the `scenarioById` fallback
+ * so the rest of boot operates on the current canonical id. Strategy is
+ * intentionally left alone: on first load we honour whatever the
+ * permalink encoded — the snap-to-scenario-default behaviour only
+ * fires on an interactive scenario change, not on boot.
  */
 function reconcileStrategyWithScenario(p: PermalinkState): void {
   const scenario = scenarioById(p.scenario);
@@ -189,6 +259,7 @@ function wireUi(): UiHandles {
     canvas: q<HTMLCanvasElement>(`shaft-${suffix}`),
     name: q(`name-${suffix}`),
     mode: q(`mode-${suffix}`),
+    decision: q(`decision-${suffix}`),
     metrics: q(`metrics-${suffix}`),
     accent,
   });
@@ -200,6 +271,8 @@ function wireUi(): UiHandles {
       if (!el) throw new Error(`missing ${sel} in tweak row ${key}`);
       return el;
     };
+    const getOpt = <T extends HTMLElement>(sel: string): T | null =>
+      root.querySelector<T>(sel) ?? null;
     return {
       root,
       value: get<HTMLElement>(".tweak-value"),
@@ -207,6 +280,9 @@ function wireUi(): UiHandles {
       dec: get<HTMLButtonElement>(".tweak-dec"),
       inc: get<HTMLButtonElement>(".tweak-inc"),
       reset: get<HTMLButtonElement>(".tweak-reset"),
+      trackFill: getOpt<HTMLElement>(".tweak-track-fill"),
+      trackDefault: getOpt<HTMLElement>(".tweak-track-default"),
+      trackThumb: getOpt<HTMLElement>(".tweak-track-thumb"),
     };
   };
   const tweakRows: Record<ParamKey, TweakRowHandles> = {
@@ -216,9 +292,10 @@ function wireUi(): UiHandles {
     doorCycleSec: tweakRow("doorCycleSec"),
   };
   const ui: UiHandles = {
-    scenarioSelect: q<HTMLSelectElement>("scenario"),
+    scenarioCards: q("scenario-cards"),
     strategyASelect: q<HTMLSelectElement>("strategy-a"),
     strategyBSelect: q<HTMLSelectElement>("strategy-b"),
+    strategyDesc: q("strategy-desc"),
     compareToggle: q<HTMLInputElement>("compare"),
     strategyBWrap: q("strategy-b-wrap"),
     seedInput: q<HTMLInputElement>("seed"),
@@ -238,17 +315,16 @@ function wireUi(): UiHandles {
     toast: q("toast"),
     phaseLabel: qOpt("phase-label"),
     featureHint: qOpt("feature-hint"),
+    phaseProgress: qOpt("phase-progress-fill"),
+    verdictRibbon: q("verdict-ribbon"),
+    shortcutsBtn: q<HTMLButtonElement>("shortcuts"),
+    shortcutSheet: q("shortcut-sheet"),
+    shortcutSheetClose: q<HTMLButtonElement>("shortcut-sheet-close"),
     paneA: paneHandles("a", COLOR_A),
     paneB: paneHandles("b", COLOR_B),
   };
 
-  for (const s of SCENARIOS) {
-    const opt = document.createElement("option");
-    opt.value = s.id;
-    opt.textContent = s.label;
-    opt.title = s.description;
-    ui.scenarioSelect.appendChild(opt);
-  }
+  renderScenarioCards(ui);
   for (const name of UI_STRATEGIES) {
     for (const select of [ui.strategyASelect, ui.strategyBSelect]) {
       const opt = document.createElement("option");
@@ -258,19 +334,10 @@ function wireUi(): UiHandles {
     }
   }
 
-  // Rewire the intensity slider now that the semantics changed from
-  // "absolute riders/min" to "0.5x–2x multiplier". Driven here rather
-  // than in HTML so permalinks with stale `t=` values still land in
-  // the new range.
-  ui.intensityInput.min = "0.5";
-  ui.intensityInput.max = "2";
-  ui.intensityInput.step = "0.1";
-
   return ui;
 }
 
 function applyPermalinkToUi(p: PermalinkState, ui: UiHandles): void {
-  ui.scenarioSelect.value = p.scenario;
   ui.strategyASelect.value = p.strategyA;
   ui.strategyBSelect.value = p.strategyB;
   ui.compareToggle.checked = p.compare;
@@ -281,6 +348,8 @@ function applyPermalinkToUi(p: PermalinkState, ui: UiHandles): void {
   ui.speedLabel.textContent = speedLabel(p.speed);
   ui.intensityInput.value = String(p.intensity);
   ui.intensityLabel.textContent = intensityLabel(p.intensity);
+  renderStrategyDesc(ui, p.strategyA);
+  syncScenarioCards(ui, p.scenario);
   const scenario = scenarioById(p.scenario);
   if (ui.featureHint) ui.featureHint.textContent = scenario.featureHint;
   // Auto-open the drawer when the permalink carries any override —
@@ -341,6 +410,18 @@ function renderTweakPanel(
     row.inc.disabled = value >= range.max - 1e-9;
     row.root.dataset.overridden = String(overridden);
     row.reset.hidden = !overridden;
+    // Sync the slider track: fill reflects progress to current value,
+    // default mark pins the scenario default, thumb sits on current.
+    // Clamped span and guarded against degenerate single-value ranges
+    // (e.g. space elevator cars locked at 1..1) so the computed ratios
+    // stay finite.
+    const span = Math.max(range.max - range.min, 1e-9);
+    const pct = Math.max(0, Math.min(1, (value - range.min) / span));
+    const defPct = Math.max(0, Math.min(1, (def - range.min) / span));
+    if (row.trackFill) row.trackFill.style.width = `${(pct * 100).toFixed(1)}%`;
+    if (row.trackThumb) row.trackThumb.style.left = `${(pct * 100).toFixed(1)}%`;
+    if (row.trackDefault)
+      row.trackDefault.style.left = `${(defPct * 100).toFixed(1)}%`;
   }
   ui.tweakResetAllBtn.hidden = !anyOverridden;
 }
@@ -375,23 +456,50 @@ async function makePane(
   // tick using defaults followed by a setter call.
   const ron = buildScenarioRon(scenario, overrides);
   const sim = await Sim.create(ron, strategy);
-  // Apply the scenario's commercial-feature hook once on load. The
-  // user can still swap strategies afterwards; the hook's effects
-  // stick only as long as the strategy it tuned remains active.
-  sim.applyHook(scenario.hook);
   const renderer = new CanvasRenderer(handles.canvas, handles.accent);
   handles.name.textContent = STRATEGY_LABELS[strategy];
   initMetricRows(handles.metrics);
+  handles.decision.textContent = "";
+  handles.decision.dataset.active = "false";
+  handles.decision.dataset.pulse = "false";
   return {
     strategy,
     sim,
     renderer,
     metricsEl: handles.metrics,
     modeEl: handles.mode,
+    decisionEl: handles.decision,
     waitHistory: [],
+    metricHistory: {
+      avg_wait_s: [],
+      max_wait_s: [],
+      delivered: [],
+      abandoned: [],
+      utilization: [],
+    },
     latestMetrics: null,
     bubbles: new Map(),
+    decisionExpiresAt: 0,
   };
+}
+
+/**
+ * Re-apply a scenario's traffic configuration to the current driver.
+ * Called once after constructing a fresh driver, and again after
+ * seed-spawn pumping has advanced its internal cycle clock — re-seating
+ * the phase schedule puts the cycle back at t=0 so the first real frame
+ * opens on the scenario's first phase.
+ */
+function configureTraffic(state: State, scenario: ScenarioMeta): void {
+  state.traffic.setPhases(scenario.phases);
+  state.traffic.setIntensity(state.permalink.intensity);
+  // Scenario-level abandonment — converted from seconds to ticks using
+  // the sim's 60 Hz canonical rate. Scenarios omitting `abandonAfterSec`
+  // (convention burst) keep "wait forever" so their stress tests stay
+  // punishing.
+  state.traffic.setPatienceTicks(
+    scenario.abandonAfterSec ? Math.round(scenario.abandonAfterSec * 60) : 0,
+  );
 }
 
 async function resetAll(state: State, ui: UiHandles): Promise<void> {
@@ -402,15 +510,7 @@ async function resetAll(state: State, ui: UiHandles): Promise<void> {
   // construction throws after paneA was installed, the surviving paneA
   // must see the reset seed — not the previous driver's accumulator.
   state.traffic = new TrafficDriver(state.permalink.seed);
-  state.traffic.setPhases(scenario.phases);
-  state.traffic.setIntensity(state.permalink.intensity);
-  // Scenario-level abandonment — converted from seconds to ticks using
-  // the sim's 60 Hz canonical rate. Scenarios omitting `abandonAfterSec`
-  // (convention burst) keep the pre-patience "wait forever" behavior
-  // so their stress tests stay punishing.
-  state.traffic.setPatienceTicks(
-    scenario.abandonAfterSec ? Math.round(scenario.abandonAfterSec * 60) : 0,
-  );
+  configureTraffic(state, scenario);
   // Tear the old panes down *before* building new ones so the freed wasm
   // memory is released before we allocate the replacements.
   disposePane(state.paneA);
@@ -444,13 +544,22 @@ async function resetAll(state: State, ui: UiHandles): Promise<void> {
     }
     // Seed pre-loaded spawns (convention scenario) once both panes are
     // live so the injection is apples-to-apples across compared sims.
+    // `drainSpawns` internally caps dt to 4/60 s so we pump it at that
+    // cap until cumulative emission reaches the target. The driver
+    // advances its internal cycle clock while pumping, so we reconfigure
+    // it afterwards — otherwise a big seed would eat into the opening
+    // phase before the user sees a single real frame.
     if (scenario.seedSpawns > 0) {
       const snapForSeed = state.paneA.sim.snapshot();
-      for (let i = 0; i < scenario.seedSpawns; i += 1) {
-        // Abuse drainSpawns by feeding a full minute's worth of
-        // elapsed time at 300 riders/min so the driver emits the
-        // seed count from the first phase's distribution.
-        const specs = state.traffic.drainSpawns(snapForSeed, 1 / 300);
+      const dtPerCall = 4 / 60;
+      let emitted = 0;
+      // Hard cap on iterations — if the scenario has a zero-rate
+      // current phase or no addressable stops, drainSpawns will
+      // return empty forever and we must bail instead of spinning.
+      const maxCalls = 10000;
+      for (let i = 0; i < maxCalls && emitted < scenario.seedSpawns; i += 1) {
+        const specs = state.traffic.drainSpawns(snapForSeed, dtPerCall);
+        if (specs.length === 0) break;
         for (const spec of specs) {
           forEachPane(state, (pane) =>
             pane.sim.spawnRider(
@@ -460,12 +569,11 @@ async function resetAll(state: State, ui: UiHandles): Promise<void> {
               spec.patienceTicks,
             ),
           );
+          emitted += 1;
+          if (emitted >= scenario.seedSpawns) break;
         }
-        // Break once we've seeded enough — drainSpawns caps per-frame
-        // output at its internal accumulator, so we just loop until
-        // cumulative emission >= the target.
-        if (specs.length === 0) break;
       }
+      configureTraffic(state, scenario);
     }
     if (ui.featureHint) ui.featureHint.textContent = scenario.featureHint;
     updatePhaseIndicator(state, ui);
@@ -483,38 +591,22 @@ async function resetAll(state: State, ui: UiHandles): Promise<void> {
 }
 
 function attachListeners(state: State, ui: UiHandles): void {
-  ui.scenarioSelect.addEventListener("change", async () => {
-    const scenario = scenarioById(ui.scenarioSelect.value);
-    // Snap pane A (and pane B when in single-pane mode) to the
-    // scenario's recommended strategy. In compare mode we leave both
-    // panes alone so the user's comparison setup survives.
-    const nextStrategyA = state.permalink.compare
-      ? state.permalink.strategyA
-      : scenario.defaultStrategy;
-    // Clear all parameter overrides on scenario switch — every
-    // scenario has its own physics envelope (a 0.5 m/s slider value
-    // makes sense for residential, makes no sense for the space
-    // elevator) so cross-scenario carry-over surprised more than it
-    // helped during early prototyping.
-    state.permalink = {
-      ...state.permalink,
-      scenario: scenario.id,
-      strategyA: nextStrategyA,
-      overrides: {},
-    };
-    ui.strategyASelect.value = nextStrategyA;
-    await resetAll(state, ui);
-    renderTweakPanel(scenario, state.permalink.overrides, ui);
-    toast(ui, `${scenario.label} · ${STRATEGY_LABELS[nextStrategyA]}`);
+  ui.scenarioCards.addEventListener("click", async (ev) => {
+    const target = ev.target;
+    if (!(target instanceof HTMLElement)) return;
+    const card = target.closest<HTMLElement>(".scenario-card");
+    if (!card) return;
+    const id = card.dataset.scenarioId;
+    if (!id || id === state.permalink.scenario) return;
+    await switchScenario(state, ui, id);
   });
   // Strategy changes reset the whole comparator so both panes stay aligned
   // on the same rider stream from t=0 — mixing pre- and post-change metrics
   // would make the scoreboard misleading.
   ui.strategyASelect.addEventListener("change", async () => {
-    state.permalink = {
-      ...state.permalink,
-      strategyA: ui.strategyASelect.value as StrategyName,
-    };
+    const strategyA = ui.strategyASelect.value as StrategyName;
+    state.permalink = { ...state.permalink, strategyA };
+    renderStrategyDesc(ui, strategyA);
     await resetAll(state, ui);
     toast(ui, `A: ${STRATEGY_LABELS[state.permalink.strategyA]}`);
   });
@@ -569,9 +661,21 @@ function attachListeners(state: State, ui: UiHandles): void {
   });
   for (const key of PARAM_KEYS) {
     const row = ui.tweakRows[key];
-    row.dec.addEventListener("click", () => bumpParam(state, ui, key, -1));
-    row.inc.addEventListener("click", () => bumpParam(state, ui, key, +1));
+    attachHoldToRepeat(row.dec, () => bumpParam(state, ui, key, -1));
+    attachHoldToRepeat(row.inc, () => bumpParam(state, ui, key, +1));
     row.reset.addEventListener("click", () => resetParam(state, ui, key));
+    // Arrow keys on the focused row nudge the value just like clicking
+    // +/-. We gate on exact key so Page/Home/End still reach the
+    // scroll-to-section defaults the browser provides.
+    row.root.addEventListener("keydown", (ev) => {
+      if (ev.key === "ArrowUp" || ev.key === "ArrowRight") {
+        ev.preventDefault();
+        bumpParam(state, ui, key, +1);
+      } else if (ev.key === "ArrowDown" || ev.key === "ArrowLeft") {
+        ev.preventDefault();
+        bumpParam(state, ui, key, -1);
+      }
+    });
   }
   ui.tweakResetAllBtn.addEventListener("click", () => {
     void resetAllOverrides(state, ui);
@@ -583,9 +687,146 @@ function attachListeners(state: State, ui: UiHandles): void {
     await navigator.clipboard.writeText(url).catch(() => {});
     toast(ui, "Permalink copied");
   });
+
+  // ── Shortcut sheet + global keys ─────────────────────────────────
+  ui.shortcutsBtn.addEventListener("click", () =>
+    setShortcutSheetOpen(ui, ui.shortcutSheet.hidden),
+  );
+  ui.shortcutSheetClose.addEventListener("click", () => setShortcutSheetOpen(ui, false));
+  ui.shortcutSheet.addEventListener("click", (ev) => {
+    // Click on the dim backdrop closes the sheet; clicks inside
+    // `.shortcut-sheet-inner` bubble through unless stopped.
+    if (ev.target === ui.shortcutSheet) setShortcutSheetOpen(ui, false);
+  });
+  attachKeyboardShortcuts(state, ui);
 }
 
-function loop(state: State): void {
+/**
+ * Install a pointer+repeat binding on a stepper button. First press
+ * fires immediately; holding past `initialDelay` starts a steady
+ * `interval` repeat. We stop on any `pointerup`/`pointerleave`/blur so
+ * the repeat can't outlive the press. The original click handler is
+ * *not* registered — this function replaces it.
+ */
+function attachHoldToRepeat(btn: HTMLButtonElement, fn: () => void): void {
+  const initialDelay = 380;
+  const interval = 70;
+  let timer = 0;
+  let repeat = 0;
+  const stop = (): void => {
+    if (timer) window.clearTimeout(timer);
+    if (repeat) window.clearInterval(repeat);
+    timer = 0;
+    repeat = 0;
+  };
+  btn.addEventListener("pointerdown", (ev) => {
+    if (btn.disabled) return;
+    ev.preventDefault();
+    fn();
+    timer = window.setTimeout(() => {
+      repeat = window.setInterval(() => {
+        if (btn.disabled) {
+          stop();
+          return;
+        }
+        fn();
+      }, interval);
+    }, initialDelay);
+  });
+  btn.addEventListener("pointerup", stop);
+  btn.addEventListener("pointerleave", stop);
+  btn.addEventListener("pointercancel", stop);
+  btn.addEventListener("blur", stop);
+  // Keyboard activation (Enter / Space) still fires a normal click;
+  // register a click listener so that path works too. Using pointer-
+  // based press detection means the click event would otherwise fire
+  // a second time after pointerup — guarded by checking whether the
+  // pointer sequence already fired.
+  btn.addEventListener("click", (ev) => {
+    if ((ev as PointerEvent).pointerType) return;
+    fn();
+  });
+}
+
+/**
+ * Global keyboard shortcuts. Gated on focused element — typing into a
+ * number input (seed) or a select shouldn't steal Space/R/C for the
+ * app. The tweak row's arrow-key nudge is registered separately so it
+ * still fires when the row itself is focused.
+ */
+function attachKeyboardShortcuts(state: State, ui: UiHandles): void {
+  window.addEventListener("keydown", (ev) => {
+    const target = ev.target as HTMLElement | null;
+    if (target) {
+      const tag = target.tagName;
+      if (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        tag === "SELECT" ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+    }
+    if (ev.metaKey || ev.ctrlKey || ev.altKey) return;
+    switch (ev.key) {
+      case " ": {
+        ev.preventDefault();
+        ui.playBtn.click();
+        return;
+      }
+      case "r":
+      case "R": {
+        ev.preventDefault();
+        ui.resetBtn.click();
+        return;
+      }
+      case "c":
+      case "C": {
+        ev.preventDefault();
+        ui.compareToggle.click();
+        return;
+      }
+      case "s":
+      case "S": {
+        ev.preventDefault();
+        ui.shareBtn.click();
+        return;
+      }
+      case "t":
+      case "T": {
+        ev.preventDefault();
+        ui.tweakBtn.click();
+        return;
+      }
+      case "?":
+      case "/": {
+        ev.preventDefault();
+        setShortcutSheetOpen(ui, ui.shortcutSheet.hidden);
+        return;
+      }
+      case "Escape": {
+        if (!ui.shortcutSheet.hidden) {
+          ev.preventDefault();
+          setShortcutSheetOpen(ui, false);
+        }
+        return;
+      }
+    }
+    // 1..N → scenario cards. Guarded to the SCENARIOS array length so
+    // extra digits are inert rather than reaching an undefined slot.
+    const n = Number(ev.key);
+    if (Number.isInteger(n) && n >= 1 && n <= SCENARIOS.length) {
+      const scenario = SCENARIOS[n - 1];
+      if (scenario.id !== state.permalink.scenario) {
+        ev.preventDefault();
+        void switchScenario(state, ui, scenario.id);
+      }
+    }
+  });
+}
+
+function loop(state: State, ui: UiHandles): void {
   let uiFrame = 0;
   const frame = (): void => {
     const now = performance.now();
@@ -598,9 +839,17 @@ function loop(state: State): void {
         pane.sim.step(ticks);
         // Drain events every frame so the wasm `EventBus` can't grow
         // unbounded during long sessions, and feed the speech-bubble
-        // layer the freshest per-car action.
+        // layer the freshest per-car action. The decision narration
+        // piggybacks on the same event stream — `pushDecision` only
+        // reacts to `elevator-assigned`, which is strategy-level
+        // dispatch output rather than the per-car action bubbles.
         const events = pane.sim.drainEvents();
-        updateBubbles(pane, events);
+        if (events.length > 0) {
+          const snap = pane.sim.snapshot();
+          const stopName = (id: number): string => resolveStopName(snap, id);
+          updateBubbles(pane, events, snap);
+          for (const ev of events) pushDecision(pane, ev, stopName);
+        }
       });
 
       const snapA = state.paneA.sim.snapshot();
@@ -628,10 +877,13 @@ function loop(state: State): void {
         renderPane(state.paneB, state.paneB.sim.snapshot(), speed);
       }
 
-      updateScoreboard(state);
+      updateScoreboard(state, ui);
       // Phase indicator updates at ~15 Hz so it stays readable even
       // when the sim is racing ahead.
-      if ((uiFrame += 1) % 4 === 0) updatePhaseIndicatorFromState(state);
+      if ((uiFrame += 1) % 4 === 0) {
+        updatePhaseIndicator(state, ui);
+        updatePhaseProgress(state, ui);
+      }
     }
 
     requestAnimationFrame(frame);
@@ -644,12 +896,23 @@ function renderPane(pane: Pane, snap: Snapshot, speed: number): void {
   pane.latestMetrics = metrics;
   pane.waitHistory.push(metrics.avg_wait_s);
   if (pane.waitHistory.length > WAIT_HISTORY_LEN) pane.waitHistory.shift();
+  for (const key of METRIC_KEYS) {
+    const arr = pane.metricHistory[key];
+    arr.push(metrics[key]);
+    if (arr.length > WAIT_HISTORY_LEN) arr.shift();
+  }
   // Evict stale bubbles lazily before handing the map to the renderer.
   const now = performance.now();
   for (const [carId, bubble] of pane.bubbles) {
     if (bubble.expiresAt <= now) pane.bubbles.delete(carId);
   }
   pane.renderer.draw(snap, pane.waitHistory, speed, pane.bubbles);
+  // Decay the decision line: past TTL we dim the text instead of
+  // clearing it, so compare-mode users can still see the last known
+  // assignment while knowing it's stale.
+  if (pane.decisionEl.dataset.active === "true" && now > pane.decisionExpiresAt) {
+    pane.decisionEl.dataset.active = "false";
+  }
 }
 
 /**
@@ -662,10 +925,8 @@ function renderPane(pane: Pane, snap: Snapshot, speed: number): void {
  * [`resolveStopName`]; unresolved stop ids fall back to the numeric
  * id rather than dropping the bubble.
  */
-function updateBubbles(pane: Pane, events: BubbleEvent[]): void {
-  if (events.length === 0) return;
-  const expiresAt = performance.now() + BUBBLE_TTL_MS;
-  const snap = pane.sim.snapshot();
+function updateBubbles(pane: Pane, events: BubbleEvent[], snap: Snapshot): void {
+  const bornAt = performance.now();
   const stopName = (id: number): string => resolveStopName(snap, id);
   for (const ev of events) {
     const text = bubbleTextFor(ev, stopName);
@@ -675,28 +936,30 @@ function updateBubbles(pane: Pane, events: BubbleEvent[]): void {
     // get here when `ev` carries an `elevator` field.
     const carId = (ev as { elevator?: number }).elevator;
     if (carId === undefined) continue;
-    pane.bubbles.set(carId, { text, expiresAt });
+    const ttl = BUBBLE_TTL_BY_KIND[ev.kind] ?? BUBBLE_TTL_DEFAULT_MS;
+    pane.bubbles.set(carId, { text, bornAt, expiresAt: bornAt + ttl });
   }
 }
 
-/** Map an event to a short human-readable bubble text, or `null` for
- *  events that have no car to attach to (rider-spawned, rider-abandoned). */
+/** Map an event to a short bubble string (icon glyph + phrase), or
+ *  `null` when the event has no car to attach to, or when emitting a
+ *  bubble for it would add more noise than signal. `elevator-departed`
+ *  and `door-closed` are intentionally suppressed because the prior
+ *  bubble ("Arrived at X", "Doors open") already narrates the context
+ *  and re-firing on closure makes the car feel chatty without adding
+ *  information. */
 function bubbleTextFor(ev: BubbleEvent, stopName: (id: number) => string): string | null {
   switch (ev.kind) {
     case "elevator-assigned":
-      return `Heading to ${stopName(ev.stop)}`;
-    case "elevator-departed":
-      return `Leaving ${stopName(ev.stop)}`;
+      return `\u203a To ${stopName(ev.stop)}`;
     case "elevator-arrived":
-      return `Arrived at ${stopName(ev.stop)}`;
+      return `\u25cf At ${stopName(ev.stop)}`;
     case "door-opened":
-      return "Doors open";
-    case "door-closed":
-      return "Doors closed";
+      return "\u25cc Doors open";
     case "rider-boarded":
-      return "Boarding";
+      return "\u002b Boarding";
     case "rider-exited":
-      return `Dropping off at ${stopName(ev.stop)}`;
+      return `\u2193 Off at ${stopName(ev.stop)}`;
     default:
       return null;
   }
@@ -711,28 +974,24 @@ function resolveStopName(snap: Snapshot, stopEntityId: number): string {
 }
 
 function updatePhaseIndicator(state: State, ui: UiHandles): void {
-  if (!ui.phaseLabel) return;
-  const label = state.traffic.currentPhaseLabel();
-  ui.phaseLabel.textContent = label || "—";
-}
-
-function updatePhaseIndicatorFromState(state: State): void {
-  const el = document.getElementById("phase-label");
+  const el = ui.phaseLabel;
   if (!el) return;
-  const label = state.traffic.currentPhaseLabel();
-  if (el.textContent !== label) el.textContent = label || "—";
+  const next = state.traffic.currentPhaseLabel() || "—";
+  if (el.textContent !== next) el.textContent = next;
 }
 
-function updateScoreboard(state: State): void {
+function updateScoreboard(state: State, ui: UiHandles): void {
   const paneA = state.paneA;
   if (!paneA?.latestMetrics) return;
   const paneB = state.paneB;
   if (paneB?.latestMetrics) {
     const compare = diffMetrics(paneA.latestMetrics, paneB.latestMetrics);
-    renderMetricRows(paneA.metricsEl, paneA.latestMetrics, compare.a);
-    renderMetricRows(paneB.metricsEl, paneB.latestMetrics, compare.b);
+    renderMetricRows(paneA.metricsEl, paneA.latestMetrics, compare.a, paneA.metricHistory);
+    renderMetricRows(paneB.metricsEl, paneB.latestMetrics, compare.b, paneB.metricHistory);
+    renderVerdictRibbon(ui.verdictRibbon, compare.a);
   } else {
-    renderMetricRows(paneA.metricsEl, paneA.latestMetrics, null);
+    renderMetricRows(paneA.metricsEl, paneA.latestMetrics, null, paneA.metricHistory);
+    ui.verdictRibbon.hidden = true;
   }
   updateModeBadge(paneA);
   if (paneB) updateModeBadge(paneB);
@@ -754,13 +1013,7 @@ function updateModeBadge(pane: Pane): void {
 }
 
 type Verdict = "win" | "lose" | "tie";
-interface MetricVerdicts {
-  avg_wait_s: Verdict;
-  max_wait_s: Verdict;
-  delivered: Verdict;
-  abandoned: Verdict;
-  utilization: Verdict;
-}
+type MetricVerdicts = Record<MetricKey, Verdict>;
 /**
  * Epsilon-based verdict so two panes that render identical values in the
  * metric strip (e.g. `0.0 s` vs `0.04 s` both display as `0.0 s`) don't
@@ -790,8 +1043,9 @@ function diffMetrics(a: Metrics, b: Metrics): { a: MetricVerdicts; b: MetricVerd
 }
 
 // Metric row layout: 5 fixed rows, always the same keys in the same order.
-// We build the DOM once and mutate text + verdict in place every frame.
-const METRIC_DEFS: Array<[string, keyof MetricVerdicts]> = [
+// We build the DOM once and mutate text + verdict + sparkline in place
+// every frame.
+const METRIC_DEFS: Array<[string, MetricKey]> = [
   ["Avg wait", "avg_wait_s"],
   ["Max wait", "max_wait_s"],
   ["Delivered", "delivered"],
@@ -799,7 +1053,7 @@ const METRIC_DEFS: Array<[string, keyof MetricVerdicts]> = [
   ["Utilization", "utilization"],
 ];
 
-function metricValue(m: Metrics, key: keyof MetricVerdicts): string {
+function metricValue(m: Metrics, key: MetricKey): string {
   switch (key) {
     case "avg_wait_s":
       return `${m.avg_wait_s.toFixed(1)} s`;
@@ -814,17 +1068,32 @@ function metricValue(m: Metrics, key: keyof MetricVerdicts): string {
   }
 }
 
+/** Build an HTML element with a className and optional text in one call. */
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  className: string,
+  text?: string,
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag);
+  node.className = className;
+  if (text !== undefined) node.textContent = text;
+  return node;
+}
+
 function initMetricRows(root: HTMLElement): void {
   const frag = document.createDocumentFragment();
   for (const [label] of METRIC_DEFS) {
-    const row = document.createElement("div");
-    row.className = "metric-row";
-    const ks = document.createElement("span");
-    ks.className = "metric-k";
-    ks.textContent = label;
-    const vs = document.createElement("span");
-    vs.className = "metric-v";
-    row.append(ks, vs);
+    const row = el("div", "metric-row");
+    // SVG sparkline lives in the metric row and is mutated in place each
+    // frame. Using SVG (not another canvas) keeps it crisp at any DPR
+    // and lets CSS drive the stroke color via `currentColor` / the
+    // `data-verdict` attribute on the row.
+    const spark = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    spark.classList.add("metric-spark");
+    spark.setAttribute("viewBox", "0 0 100 14");
+    spark.setAttribute("preserveAspectRatio", "none");
+    spark.appendChild(document.createElementNS("http://www.w3.org/2000/svg", "path"));
+    row.append(el("span", "metric-k", label), el("span", "metric-v"), spark);
     frag.appendChild(row);
   }
   root.replaceChildren(frag);
@@ -834,6 +1103,7 @@ function renderMetricRows(
   root: HTMLElement,
   m: Metrics,
   verdicts: MetricVerdicts | null,
+  history: Record<MetricKey, number[]>,
 ): void {
   const rows = root.children;
   for (let i = 0; i < METRIC_DEFS.length; i++) {
@@ -841,10 +1111,42 @@ function renderMetricRows(
     const key = METRIC_DEFS[i][1];
     const verdict = verdicts ? verdicts[key] : "";
     if (row.dataset.verdict !== verdict) row.dataset.verdict = verdict;
-    const vs = row.lastElementChild as HTMLElement;
+    const vs = row.children[1] as HTMLElement;
     const val = metricValue(m, key);
     if (vs.textContent !== val) vs.textContent = val;
+    const spark = row.children[2] as SVGSVGElement;
+    const path = spark.firstElementChild as SVGPathElement;
+    const d = buildSparklinePath(history[key]);
+    if (path.getAttribute("d") !== d) path.setAttribute("d", d);
   }
+}
+
+/**
+ * Build an SVG path `d` string sampling `values` across a 100×14
+ * viewBox. The path uses the last up-to-`WAIT_HISTORY_LEN` samples
+ * and auto-scales to the min/max within that window so the trace
+ * always fills the vertical range regardless of absolute magnitude.
+ * An empty or single-sample window draws a flat baseline.
+ */
+function buildSparklinePath(values: number[]): string {
+  if (values.length < 2) return "M 0 13 L 100 13";
+  let min = values[0];
+  let max = values[0];
+  for (let i = 1; i < values.length; i++) {
+    const v = values[i];
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  const span = max - min;
+  const n = values.length;
+  let d = "";
+  for (let i = 0; i < n; i++) {
+    const x = (i / (n - 1)) * 100;
+    // Inverted y-axis so higher values sit higher on the chart.
+    const y = span > 0 ? 13 - ((values[i] - min) / span) * 12 : 7;
+    d += `${i === 0 ? "M" : "L"} ${x.toFixed(2)} ${y.toFixed(2)} `;
+  }
+  return d.trim();
 }
 
 let toastTimer = 0;
@@ -985,6 +1287,162 @@ function labelForKey(key: ParamKey): string {
       return "Capacity";
     case "doorCycleSec":
       return "Door cycle";
+  }
+}
+
+// ─── Scenario cards ──────────────────────────────────────────────────
+
+function renderScenarioCards(ui: UiHandles): void {
+  const frag = document.createDocumentFragment();
+  SCENARIOS.forEach((s, i) => {
+    const card = el("button", "scenario-card");
+    card.type = "button";
+    card.dataset.scenarioId = s.id;
+    card.setAttribute("aria-pressed", "false");
+    const label = el("span", "scenario-card-label");
+    label.append(
+      el("span", "", s.label),
+      el("span", "scenario-card-kbd", String(i + 1)),
+    );
+    card.append(
+      label,
+      el("span", "scenario-card-desc", s.description),
+      el("span", "scenario-card-hint", s.featureHint),
+    );
+    frag.appendChild(card);
+  });
+  ui.scenarioCards.replaceChildren(frag);
+}
+
+function syncScenarioCards(ui: UiHandles, scenarioId: string): void {
+  for (const card of ui.scenarioCards.children) {
+    const el = card as HTMLElement;
+    el.setAttribute(
+      "aria-pressed",
+      el.dataset.scenarioId === scenarioId ? "true" : "false",
+    );
+  }
+}
+
+/**
+ * Shared by keyboard shortcuts and scenario-card clicks so both paths
+ * dispatch the same transition.
+ *
+ * Overrides are cleared on scenario switch — every scenario has a
+ * distinct physics envelope (a 0.5 m/s slider makes sense for a
+ * residential tower, not for a 50 m/s climber on a tether) so
+ * cross-scenario carry-over surprised more than it helped during
+ * early prototyping.
+ */
+async function switchScenario(
+  state: State,
+  ui: UiHandles,
+  scenarioId: string,
+): Promise<void> {
+  const scenario = scenarioById(scenarioId);
+  // Snap pane A (and pane B when in single-pane mode) to the
+  // scenario's recommended strategy. In compare mode we leave both
+  // panes alone so the user's comparison setup survives.
+  const nextStrategyA = state.permalink.compare
+    ? state.permalink.strategyA
+    : scenario.defaultStrategy;
+  state.permalink = {
+    ...state.permalink,
+    scenario: scenario.id,
+    strategyA: nextStrategyA,
+    overrides: {},
+  };
+  ui.strategyASelect.value = nextStrategyA;
+  renderStrategyDesc(ui, nextStrategyA);
+  syncScenarioCards(ui, scenario.id);
+  await resetAll(state, ui);
+  renderTweakPanel(scenario, state.permalink.overrides, ui);
+  toast(ui, `${scenario.label} · ${STRATEGY_LABELS[nextStrategyA]}`);
+}
+
+// ─── Strategy description ────────────────────────────────────────────
+
+function renderStrategyDesc(ui: UiHandles, strategy: StrategyName): void {
+  ui.strategyDesc.textContent = STRATEGY_DESCRIPTIONS[strategy];
+}
+
+// ─── Verdict ribbon ──────────────────────────────────────────────────
+
+function renderVerdictRibbon(root: HTMLElement, verdictsA: MetricVerdicts): void {
+  if (root.childElementCount === 0) {
+    root.appendChild(el("span", "verdict-ribbon-title", "Who's winning?"));
+    for (const [label] of METRIC_DEFS) {
+      const cell = el("div", "verdict-cell");
+      cell.append(
+        el("span", "verdict-cell-k", label),
+        el("span", "verdict-cell-winner"),
+      );
+      root.appendChild(cell);
+    }
+  }
+  root.hidden = false;
+  for (let i = 0; i < METRIC_DEFS.length; i++) {
+    const cell = root.children[i + 1] as HTMLElement;
+    const key = METRIC_DEFS[i][1];
+    const { winner, text } = verdictToWinner(verdictsA[key]);
+    if (cell.dataset.winner !== winner) cell.dataset.winner = winner;
+    const winnerEl = cell.lastElementChild as HTMLElement;
+    if (winnerEl.textContent !== text) winnerEl.textContent = text;
+  }
+}
+
+function verdictToWinner(v: Verdict): { winner: "A" | "B" | "tie"; text: string } {
+  switch (v) {
+    case "win":
+      return { winner: "A", text: "A" };
+    case "lose":
+      return { winner: "B", text: "B" };
+    case "tie":
+      return { winner: "tie", text: "Tie" };
+  }
+}
+
+// ─── Phase progress ──────────────────────────────────────────────────
+
+function updatePhaseProgress(state: State, ui: UiHandles): void {
+  if (!ui.phaseProgress) return;
+  const pct = Math.round(state.traffic.progressInPhase() * 1000) / 10;
+  const next = `${pct}%`;
+  if (ui.phaseProgress.style.width !== next) ui.phaseProgress.style.width = next;
+}
+
+// ─── Decision narration ──────────────────────────────────────────────
+
+function pushDecision(pane: Pane, ev: BubbleEvent, stopName: (id: number) => string): void {
+  if (ev.kind !== "elevator-assigned") return;
+  const el = pane.decisionEl;
+  const text = `Car ${ev.elevator} \u2192 ${stopName(ev.stop)}`;
+  if (el.textContent !== text) el.textContent = text;
+  el.dataset.active = "true";
+  pane.decisionExpiresAt = performance.now() + DECISION_TTL_MS;
+  // Retrigger the pulse keyframes by flipping data-pulse in the next
+  // frame — clearing synchronously has no effect because the same
+  // animation name stays active.
+  el.dataset.pulse = "false";
+  requestAnimationFrame(() => {
+    el.dataset.pulse = "true";
+  });
+}
+
+// ─── Shortcut sheet ──────────────────────────────────────────────────
+
+function setShortcutSheetOpen(ui: UiHandles, open: boolean): void {
+  const wasOpen = !ui.shortcutSheet.hidden;
+  if (open === wasOpen) return;
+  ui.shortcutSheet.hidden = !open;
+  // Focus management — the sheet is modal-like but not a real <dialog>,
+  // so we shuttle focus manually. Opening moves focus into the sheet
+  // (so Escape / Tab land predictably); closing returns focus to the
+  // trigger so keyboard flow doesn't snap back to <body>.
+  if (open) {
+    ui.shortcutSheetClose.focus();
+  } else {
+    ui.shortcutsBtn.focus();
   }
 }
 

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -553,13 +553,16 @@ async function resetAll(state: State, ui: UiHandles): Promise<void> {
       const snapForSeed = state.paneA.sim.snapshot();
       const dtPerCall = 4 / 60;
       let emitted = 0;
-      // Hard cap on iterations — if the scenario has a zero-rate
-      // current phase or no addressable stops, drainSpawns will
-      // return empty forever and we must bail instead of spinning.
+      // Hard cap on iterations — with dtPerCall = 4/60 s and the
+      // per-phase accumulator only growing ~0.12 riders per call at
+      // 110 riders/min, we need ~9 calls before the first emission.
+      // Earlier code had an early `specs.length === 0` break that
+      // fired on call 1 and seeded zero riders; maxCalls is the only
+      // guard we need against a truly zero-rate phase (it caps the
+      // spin at a few ms even in that degenerate case).
       const maxCalls = 10000;
       for (let i = 0; i < maxCalls && emitted < scenario.seedSpawns; i += 1) {
         const specs = state.traffic.drainSpawns(snapForSeed, dtPerCall);
-        if (specs.length === 0) break;
         for (const spec of specs) {
           forEachPane(state, (pane) =>
             pane.sim.spawnRider(

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -12,7 +12,7 @@ import {
 } from "./params";
 import { DEFAULT_STATE, decodePermalink, encodePermalink, type PermalinkState } from "./permalink";
 import { SCENARIOS, scenarioById } from "./scenarios";
-import { Sim } from "./sim";
+import { Sim, loadWasm } from "./sim";
 import { TrafficDriver } from "./traffic";
 import type {
   BubbleEvent,
@@ -144,7 +144,24 @@ interface State {
    * stays referenced (and gets `step()`-ed on freed wasm memory next frame).
    */
   initToken: number;
+  /**
+   * Progressive pre-seed state for scenarios with `seedSpawns > 0`.
+   * Instead of blocking the loader on hundreds of synchronous
+   * `spawnRider` calls, we hand the quota to the render loop and
+   * inject a per-frame batch until `remaining` hits zero. `null`
+   * when not seeding (the common case for day-cycle scenarios).
+   */
+  seeding: { remaining: number } | null;
 }
+
+/**
+ * Per-frame cap on `drainSpawns` calls during progressive seeding.
+ * At convention-burst's keynote rate (110 riders/min, 4/60-s dt) the
+ * driver's accumulator grows ~0.12 per call, so this yields ~24
+ * riders per frame — the full 120-rider seed drains in ~5 frames
+ * (~80 ms wall-clock) without ever blocking the loader.
+ */
+const SEED_CALLS_PER_FRAME = 200;
 
 interface PaneHandles {
   root: HTMLElement;
@@ -202,6 +219,16 @@ interface UiHandles {
 }
 
 async function boot(): Promise<void> {
+  // Kick off the wasm fetch + compile *before* DOM wiring so the
+  // ~hundreds-of-ms WebAssembly.instantiate overlaps with synchronous
+  // JS work (scenario-card rendering, handle lookups, permalink
+  // decode). `loadWasm` memoises via an internal promise, so the
+  // subsequent `Sim.create` calls in `makePane` await the same
+  // module without re-fetching.
+  const wasmReady = loadWasm();
+  // Swallow rejections here; `makePane` will re-await the same
+  // promise and surface the error through the Init-failed toast.
+  wasmReady.catch(() => {});
   const ui = wireUi();
   const permalink = { ...DEFAULT_STATE, ...decodePermalink(window.location.search) };
   // If the permalink points at a scenario we don't have, fall back to the
@@ -227,6 +254,7 @@ async function boot(): Promise<void> {
     traffic: new TrafficDriver(permalink.seed),
     lastFrameTime: performance.now(),
     initToken: 0,
+    seeding: null,
   };
   attachListeners(state, ui);
   await resetAll(state, ui);
@@ -542,42 +570,13 @@ async function resetAll(state: State, ui: UiHandles): Promise<void> {
       }
       state.paneB = paneB;
     }
-    // Seed pre-loaded spawns (convention scenario) once both panes are
-    // live so the injection is apples-to-apples across compared sims.
-    // `drainSpawns` internally caps dt to 4/60 s so we pump it at that
-    // cap until cumulative emission reaches the target. The driver
-    // advances its internal cycle clock while pumping, so we reconfigure
-    // it afterwards — otherwise a big seed would eat into the opening
-    // phase before the user sees a single real frame.
-    if (scenario.seedSpawns > 0) {
-      const snapForSeed = state.paneA.sim.snapshot();
-      const dtPerCall = 4 / 60;
-      let emitted = 0;
-      // Hard cap on iterations — with dtPerCall = 4/60 s and the
-      // per-phase accumulator only growing ~0.12 riders per call at
-      // 110 riders/min, we need ~9 calls before the first emission.
-      // Earlier code had an early `specs.length === 0` break that
-      // fired on call 1 and seeded zero riders; maxCalls is the only
-      // guard we need against a truly zero-rate phase (it caps the
-      // spin at a few ms even in that degenerate case).
-      const maxCalls = 10000;
-      for (let i = 0; i < maxCalls && emitted < scenario.seedSpawns; i += 1) {
-        const specs = state.traffic.drainSpawns(snapForSeed, dtPerCall);
-        for (const spec of specs) {
-          forEachPane(state, (pane) =>
-            pane.sim.spawnRider(
-              spec.originStopId,
-              spec.destStopId,
-              spec.weight,
-              spec.patienceTicks,
-            ),
-          );
-          emitted += 1;
-          if (emitted >= scenario.seedSpawns) break;
-        }
-      }
-      configureTraffic(state, scenario);
-    }
+    // Progressive pre-seed: instead of pumping hundreds of spawns
+    // synchronously (which blocked the loader for ~50 ms even warm),
+    // hand the quota to the render loop. It injects per-frame
+    // batches starting the next rAF and re-seats the driver via
+    // `configureTraffic` once the quota drains, so the scenario's
+    // day-cycle clock still starts from t=0.
+    state.seeding = scenario.seedSpawns > 0 ? { remaining: scenario.seedSpawns } : null;
     if (ui.featureHint) ui.featureHint.textContent = scenario.featureHint;
     updatePhaseIndicator(state, ui);
     renderTweakPanel(scenario, state.permalink.overrides, ui);
@@ -855,13 +854,25 @@ function loop(state: State, ui: UiHandles): void {
         }
       });
 
+      // Progressive pre-seed: drain the remaining quota in per-frame
+      // batches. While seeding is active we suppress the normal
+      // wall-clock drain below so the driver's accumulator — which
+      // also advances here — stays dedicated to the initial crowd.
+      // When the last rider lands we re-seat the driver so the
+      // scenario's day cycle starts from t=0.
+      if (state.seeding) {
+        drainSeedBatch(state);
+      }
+
       const snapA = state.paneA.sim.snapshot();
       // Fan-out spawns to both sims so the comparison is apples-to-apples.
       // `elapsed` is wall-clock; scaling by `ticks` keeps the sim-time
       // budget the driver operates on in lockstep with the actual
-      // simulation advance.
+      // simulation advance. Skipped while we're still seeding.
       const simElapsed = elapsed * ticks;
-      const specs = state.traffic.drainSpawns(snapA, simElapsed);
+      const specs = state.seeding
+        ? []
+        : state.traffic.drainSpawns(snapA, simElapsed);
       for (const spec of specs) {
         forEachPane(state, (pane) =>
           pane.sim.spawnRider(
@@ -1290,6 +1301,45 @@ function labelForKey(key: ParamKey): string {
       return "Capacity";
     case "doorCycleSec":
       return "Door cycle";
+  }
+}
+
+// ─── Progressive pre-seed ────────────────────────────────────────────
+
+/**
+ * Inject a per-frame batch of pre-seed riders. Pumps `drainSpawns`
+ * up to `SEED_CALLS_PER_FRAME` times at the driver's 4/60-s dt cap,
+ * stopping early when the scenario's quota is met. When the quota
+ * drains we re-seat the driver via `configureTraffic` so the
+ * scenario's day-cycle clock starts from t=0 on the next frame.
+ *
+ * Callers must check `state.seeding` before invoking; this function
+ * assumes it's non-null. The rider-count check inside the inner loop
+ * lets a single `drainSpawns` call emitting multiple specs stop
+ * exactly at the quota rather than overshooting.
+ */
+function drainSeedBatch(state: State): void {
+  if (!state.seeding || !state.paneA) return;
+  const snap = state.paneA.sim.snapshot();
+  const dt = 4 / 60;
+  for (let c = 0; c < SEED_CALLS_PER_FRAME && state.seeding.remaining > 0; c++) {
+    const specs = state.traffic.drainSpawns(snap, dt);
+    for (const spec of specs) {
+      forEachPane(state, (pane) =>
+        pane.sim.spawnRider(
+          spec.originStopId,
+          spec.destStopId,
+          spec.weight,
+          spec.patienceTicks,
+        ),
+      );
+      state.seeding.remaining -= 1;
+      if (state.seeding.remaining <= 0) break;
+    }
+  }
+  if (state.seeding.remaining <= 0) {
+    configureTraffic(state, scenarioById(state.permalink.scenario));
+    state.seeding = null;
   }
 }
 

--- a/playground/src/permalink.ts
+++ b/playground/src/permalink.ts
@@ -46,10 +46,8 @@ const OVERRIDE_KEYS: Record<ParamKey, string> = {
 export const DEFAULT_STATE: PermalinkState = {
   // First-impression tuning: skyscraper is the visually richest
   // scenario (3 cars, 12 floors, bypass feature firing during morning
-  // rush) — office would have a visitor watching idle cars during
-  // "Overnight" for 45 sim-seconds before anything happens. The
-  // legacy `office-5` id still resolves through `scenarioById`
-  // fallback so stale permalinks keep loading cleanly.
+  // rush). Unknown scenario ids still resolve through
+  // `scenarioById`'s fallback so stale permalinks keep loading cleanly.
   scenario: "skyscraper-sky-lobby",
   strategyA: "etd",
   strategyB: "scan",
@@ -70,7 +68,14 @@ export const DEFAULT_STATE: PermalinkState = {
   overrides: {},
 };
 
-const STRATEGIES: readonly StrategyName[] = ["scan", "look", "nearest", "etd", "destination"];
+const STRATEGIES: readonly StrategyName[] = [
+  "scan",
+  "look",
+  "nearest",
+  "etd",
+  "destination",
+  "rsr",
+];
 
 function parseStrategy(raw: string | null, fallback: StrategyName): StrategyName {
   return raw !== null && (STRATEGIES as readonly string[]).includes(raw)

--- a/playground/src/permalink.ts
+++ b/playground/src/permalink.ts
@@ -51,12 +51,11 @@ export const DEFAULT_STATE: PermalinkState = {
   scenario: "skyscraper-sky-lobby",
   strategyA: "etd",
   strategyB: "scan",
-  // Compare mode on by default: the single most visceral "one strategy
-  // is clearly better" demonstration the playground offers is the live
-  // scoreboard. A cold visitor in single-pane mode would have to
-  // manually swap strategies to notice any difference and most won't —
-  // defaulting compare on makes the library's payoff immediate.
-  compare: true,
+  // Compare mode off by default: turning it on doubles the cold-boot
+  // time because `resetAll` serialises both `WasmSim` constructions.
+  // Single-pane first-paint is cheaper; users flip compare via the
+  // checkbox or the `C` shortcut once the first sim is visible.
+  compare: false,
   seed: 42,
   intensity: 1.0,
   // 2× default (was 4×): after door times moved to realistic

--- a/playground/src/scenarios.ts
+++ b/playground/src/scenarios.ts
@@ -2,10 +2,10 @@ import type { Phase, ScenarioMeta, TweakRanges } from "./types";
 
 // ─── Default tweak bounds ───────────────────────────────────────────
 //
-// One set of bounds works for every commercial scenario (mid-rise
-// office through skyscraper). The space elevator overrides these
-// because its operating envelope (50 m/s climbers, 1000 m shaft, 2
-// stops) is two orders of magnitude away from a building.
+// Shared by the two commercial-scale scenarios (convention burst and
+// skyscraper). The space elevator overrides these because its
+// operating envelope (50 m/s climbers, 1 000 m shaft, 2 stops) is two
+// orders of magnitude away from a building.
 
 const COMMERCIAL_TWEAK_RANGES: TweakRanges = {
   cars: { min: 1, max: 6, step: 1 },
@@ -21,11 +21,11 @@ const COMMERCIAL_TWEAK_RANGES: TweakRanges = {
 //
 // Every scenario declares:
 //   - `phases` — a day cycle the TrafficDriver loops through. Phase
-//     durations are in *sim-seconds*; with the 4× default playback the
-//     5-minute sim day lasts ~75 real-seconds.
-//   - `hook` — a commercial-controller feature to spotlight on load.
-//   - `defaultStrategy` — the dispatch strategy chosen to pair with
-//     that hook; the user can still override via the UI.
+//     durations are in *sim-seconds*; at the 2× default playback a
+//     5-minute sim day lasts ~2.5 real-minutes.
+//   - `featureHint` — one-line narrative framing what to watch for.
+//   - `defaultStrategy` — the dispatch strategy the scenario opens
+//     with; the user can still override via the UI.
 //
 // Phase weight vectors are indexed by stop position in the scenario's
 // RON stop list, not by StopId — a renumbering in the RON would need a
@@ -38,150 +38,124 @@ function uniform(n: number): number[] {
   return Array.from({ length: n }, () => 1);
 }
 
-/** Vector of `n` where only the lobby (index 0) is selectable. */
-function lobbyOnly(n: number): number[] {
-  return Array.from({ length: n }, (_, i) => (i === 0 ? 1 : 0));
-}
-
 /** Vector where weights grow slightly with altitude — plausible prior for
  *  exec suites / penthouses attracting modestly more traffic. */
 function topBias(n: number): number[] {
   return Array.from({ length: n }, (_, i) => 1 + (i / Math.max(1, n - 1)) * 0.5);
 }
 
-// ─── Mid-rise office — group-time ETD hook ──────────────────────────
+// ─── Convention burst — acute post-keynote surge ────────────────────
 
-const OFFICE_STOPS = 6;
-// Two 800 kg cars (~10 riders/trip each). With 5.5 s round-trip door
-// overhead now in place (3.5 s dwell + 2 × 1 s transition), per-car
-// round trip is ~35 s across 3 intermediate stops, giving ~18
-// riders/min combined. Phase rates stay at ~1.1–1.4× that during
-// rushes so queues build visibly without overflowing patience.
-const officePhases: Phase[] = [
-  // 0: overnight — tiny trickle of late-workers or cleaners.
+const CONV_STOPS = 5;
+// Two 1500 kg cars at 3.5 m/s over a short 16 m shaft. With 7 s door
+// cycle (5 s dwell for group boarding + 2 × 1 s transition), round
+// trip is ~30 s and each car delivers ~40 riders/min — ~80
+// combined. The keynote burst intentionally overshoots that to
+// stress-test dispatch; the rate still drops enough between bursts
+// that the cycle is recognizably calm.
+const conventionPhases: Phase[] = [
+  // Acute peak right after a keynote lets out.
   {
-    name: "Overnight",
+    name: "Keynote lets out",
     durationSec: 45,
-    ridersPerMin: 3,
-    originWeights: uniform(OFFICE_STOPS),
-    destWeights: uniform(OFFICE_STOPS),
+    ridersPerMin: 110,
+    originWeights: Array.from({ length: CONV_STOPS }, (_, i) => (i === CONV_STOPS - 1 ? 8 : 1)),
+    destWeights: [5, 2, 1, 1, 0],
   },
-  // 1: morning up-peak — 85 % from the lobby, weighted toward higher floors.
+  // Tapering as the hall clears.
   {
-    name: "Morning rush",
-    durationSec: 60,
-    ridersPerMin: 30,
-    originWeights: [8.5, 0.3, 0.3, 0.3, 0.3, 0.3],
-    destWeights: topBias(OFFICE_STOPS).map((w, i) => (i === 0 ? 0 : w)),
+    name: "Tapering",
+    durationSec: 90,
+    ridersPerMin: 18,
+    originWeights: uniform(CONV_STOPS),
+    destWeights: uniform(CONV_STOPS),
   },
-  // 2: midday interfloor — uniform, moderate rate.
+  // Quiet before the next session. Generous length so the cycle
+  // actually rests between bursts — users get a chance to watch cars
+  // park before the next keynote spike hits.
   {
-    name: "Midday interfloor",
-    durationSec: 60,
-    ridersPerMin: 16,
-    originWeights: uniform(OFFICE_STOPS),
-    destWeights: uniform(OFFICE_STOPS),
-  },
-  // 3: lunchtime — bidirectional burst between upper floors and a
-  // canteen on stop 1. The hardest pattern for any controller, so it
-  // lands slightly above the pair's cruise capacity on purpose —
-  // this is where the group-time ETD hook gets its chance to shine.
-  {
-    name: "Lunchtime",
-    durationSec: 45,
-    ridersPerMin: 36,
-    // Origins skew toward upper floors (people leaving for lunch) and the canteen.
-    originWeights: [0.3, 3, 2, 2, 2, 2],
-    destWeights: [0.3, 3, 2, 2, 2, 2],
-  },
-  // 4: evening down-peak — reverse of morning.
-  {
-    name: "Evening exodus",
-    durationSec: 60,
-    ridersPerMin: 30,
-    originWeights: topBias(OFFICE_STOPS).map((w, i) => (i === 0 ? 0 : w)),
-    destWeights: lobbyOnly(OFFICE_STOPS),
+    name: "Between sessions",
+    durationSec: 135,
+    ridersPerMin: 4,
+    originWeights: uniform(CONV_STOPS),
+    destWeights: uniform(CONV_STOPS),
   },
 ];
 
-const office: ScenarioMeta = {
-  id: "office-mid-rise",
-  label: "Mid-rise office",
+const convention: ScenarioMeta = {
+  id: "convention-burst",
+  label: "Convention burst",
   description:
-    "Six floors, two 800 kg cars. Walks through morning rush → midday → lunchtime → evening exodus. Group-time ETD damps tail waits under sustained load.",
+    "Five-floor convention center. A keynote ends and 200+ riders spill into the elevators at once — an acute stress test rather than a day cycle.",
   defaultStrategy: "etd",
-  phases: officePhases,
-  seedSpawns: 0,
-  // 90 s patience: office workers won't wait forever during a lunch
-  // burst — they take the stairs, grab the other bank, or skip the
-  // trip. Without this, lunchtime demand (65/min) above the pair's
-  // ~54/min cruise capacity grew the queue monotonically.
-  abandonAfterSec: 90,
-  hook: { kind: "etd_group_time", waitSquaredWeight: 0.002 },
+  phases: conventionPhases,
+  seedSpawns: 120,
+  // Intentionally omits `abandonAfterSec` — the whole point of this
+  // scenario is to stress-test dispatch under a real pile-up. Letting
+  // attendees abandon would gut the arrival-rate signal's purpose,
+  // which is "how punishing is *persistent* demand?"
   featureHint:
-    "Group-time ETD (`wait_squared_weight = 0.002`) — stops hosting older waiters win ties, damping long-wait tail during lunchtime bursts.",
-  buildingName: "Mid-Rise Office",
+    "Arrival-rate signal lights up as the burst hits — `DispatchManifest::arrivals_at` feeds downstream strategies the per-stop intensity for the next 5 minutes.",
+  buildingName: "Convention Center",
   stops: [
     { name: "Lobby", positionM: 0.0 },
-    { name: "Floor 2", positionM: 4.0 },
-    { name: "Floor 3", positionM: 8.0 },
-    { name: "Floor 4", positionM: 12.0 },
-    { name: "Floor 5", positionM: 16.0 },
-    { name: "Floor 6", positionM: 20.0 },
+    { name: "Exhibit Hall", positionM: 4.0 },
+    { name: "Mezzanine", positionM: 8.0 },
+    { name: "Ballroom", positionM: 12.0 },
+    { name: "Keynote Hall", positionM: 16.0 },
   ],
   defaultCars: 2,
   elevatorDefaults: {
-    maxSpeed: 2.2,
-    acceleration: 1.5,
-    deceleration: 2.0,
-    weightCapacity: 800.0,
-    doorOpenTicks: 210,
+    maxSpeed: 3.5,
+    acceleration: 2.0,
+    deceleration: 2.5,
+    weightCapacity: 1500.0,
+    doorOpenTicks: 300,
     doorTransitionTicks: 60,
   },
-  tweakRanges: COMMERCIAL_TWEAK_RANGES,
-  passengerMeanIntervalTicks: 90,
-  passengerWeightRange: [50.0, 100.0],
+  tweakRanges: { ...COMMERCIAL_TWEAK_RANGES, cars: { min: 1, max: 5, step: 1 } },
+  passengerMeanIntervalTicks: 30,
+  passengerWeightRange: [55.0, 100.0],
   ron: `SimConfig(
     building: BuildingConfig(
-        name: "Mid-Rise Office",
+        name: "Convention Center",
         stops: [
-            StopConfig(id: StopId(0), name: "Lobby",   position: 0.0),
-            StopConfig(id: StopId(1), name: "Floor 2", position: 4.0),
-            StopConfig(id: StopId(2), name: "Floor 3", position: 8.0),
-            StopConfig(id: StopId(3), name: "Floor 4", position: 12.0),
-            StopConfig(id: StopId(4), name: "Floor 5", position: 16.0),
-            StopConfig(id: StopId(5), name: "Floor 6", position: 20.0),
+            StopConfig(id: StopId(0), name: "Lobby",        position: 0.0),
+            StopConfig(id: StopId(1), name: "Exhibit Hall", position: 4.0),
+            StopConfig(id: StopId(2), name: "Mezzanine",    position: 8.0),
+            StopConfig(id: StopId(3), name: "Ballroom",     position: 12.0),
+            StopConfig(id: StopId(4), name: "Keynote Hall", position: 16.0),
         ],
     ),
+    // Convention door timing: 5 s dwell for group boarding. Big crowds
+    // after keynote are slow to actually step through the threshold;
+    // rushing the doors closed ejects riders mid-walk and re-opens, a
+    // realistic failure mode.
     elevators: [
         ElevatorConfig(
             id: 0, name: "Car 1",
-            max_speed: 2.2, acceleration: 1.5, deceleration: 2.0,
-            weight_capacity: 800.0,
+            max_speed: 3.5, acceleration: 2.0, deceleration: 2.5,
+            weight_capacity: 1500.0,
             starting_stop: StopId(0),
-            // Realistic mid-rise commercial: 3.5 s dwell, 1 s each way.
-            // The previous ~1 s total cycle was ~4× faster than any
-            // real elevator and read as cartoonish on the canvas —
-            // doors barely flickered before cars peeled off again.
-            door_open_ticks: 210, door_transition_ticks: 60,
+            door_open_ticks: 300, door_transition_ticks: 60,
         ),
         ElevatorConfig(
             id: 1, name: "Car 2",
-            max_speed: 2.2, acceleration: 1.5, deceleration: 2.0,
-            weight_capacity: 800.0,
-            starting_stop: StopId(3),
-            door_open_ticks: 210, door_transition_ticks: 60,
+            max_speed: 3.5, acceleration: 2.0, deceleration: 2.5,
+            weight_capacity: 1500.0,
+            starting_stop: StopId(4),
+            door_open_ticks: 300, door_transition_ticks: 60,
         ),
     ],
     simulation: SimulationParams(ticks_per_second: 60.0),
     passenger_spawning: PassengerSpawnConfig(
-        mean_interval_ticks: 90,
-        weight_range: (50.0, 100.0),
+        mean_interval_ticks: 30,
+        weight_range: (55.0, 100.0),
     ),
 )`,
 };
 
-// ─── Skyscraper with sky lobby — full-load bypass hook ──────────────
+// ─── Skyscraper with sky lobby — full-load bypass showcase ──────────
 
 const SKY_STOPS = 13; // Lobby + 12 floors
 // Three 1200 kg cars at 4 m/s through a 48 m shaft. With realistic
@@ -245,7 +219,6 @@ const skyscraper: ScenarioMeta = {
   // at the tail of morning rush even with well-tuned rates; 180 s
   // gives ETD room to drain the queue between phases.
   abandonAfterSec: 180,
-  hook: { kind: "bypass_narration" },
   featureHint:
     "Direction-dependent bypass (80 % up / 50 % down) on all three cars — baked into the RON below. Watch the fullest car skip hall calls.",
   buildingName: "Skyscraper (Sky Lobby)",
@@ -297,16 +270,16 @@ const skyscraper: ScenarioMeta = {
             StopConfig(id: StopId(12), name: "Penthouse",  position: 48.0),
         ],
     ),
+    // High-rise commercial door timing: 5 s dwell (surge loading during
+    // rush) + 1.2 s each way. The long dwell is what lets the bypass
+    // matter — a full car's few seconds saved by skipping a hall call
+    // is meaningful at this scale.
     elevators: [
         ElevatorConfig(
             id: 0, name: "Car A",
             max_speed: 4.0, acceleration: 2.0, deceleration: 2.5,
             weight_capacity: 1200.0,
             starting_stop: StopId(0),
-            // High-rise commercial: 5 s dwell (surge loading during
-            // rush), 1.2 s each way. The long dwell is what lets the
-            // bypass hook matter — a full car's few seconds saved by
-            // skipping a hall call is meaningful at this scale.
             door_open_ticks: 300, door_transition_ticks: 72,
             bypass_load_up_pct: Some(0.80), bypass_load_down_pct: Some(0.50),
         ),
@@ -315,10 +288,6 @@ const skyscraper: ScenarioMeta = {
             max_speed: 4.0, acceleration: 2.0, deceleration: 2.5,
             weight_capacity: 1200.0,
             starting_stop: StopId(6),
-            // High-rise commercial: 5 s dwell (surge loading during
-            // rush), 1.2 s each way. The long dwell is what lets the
-            // bypass hook matter — a full car's few seconds saved by
-            // skipping a hall call is meaningful at this scale.
             door_open_ticks: 300, door_transition_ticks: 72,
             bypass_load_up_pct: Some(0.80), bypass_load_down_pct: Some(0.50),
         ),
@@ -327,409 +296,8 @@ const skyscraper: ScenarioMeta = {
             max_speed: 4.0, acceleration: 2.0, deceleration: 2.5,
             weight_capacity: 1200.0,
             starting_stop: StopId(12),
-            // High-rise commercial: 5 s dwell (surge loading during
-            // rush), 1.2 s each way. The long dwell is what lets the
-            // bypass hook matter — a full car's few seconds saved by
-            // skipping a hall call is meaningful at this scale.
             door_open_ticks: 300, door_transition_ticks: 72,
             bypass_load_up_pct: Some(0.80), bypass_load_down_pct: Some(0.50),
-        ),
-    ],
-    simulation: SimulationParams(ticks_per_second: 60.0),
-    passenger_spawning: PassengerSpawnConfig(
-        mean_interval_ticks: 30,
-        weight_range: (55.0, 100.0),
-    ),
-)`,
-};
-
-// ─── Residential tower — predictive parking hook ────────────────────
-
-const RES_STOPS = 8;
-// Two 700 kg cars at 2.5 m/s over 24.5 m. With realistic 5 s door
-// cycle (3 s dwell + 2 × 1 s transition), round trip is ~35 s and
-// each car delivers ~15 riders/min — 30 combined. Rates stay
-// modest so the midday quiet actually reads as quiet — predictive
-// parking needs the rate signal to drop between bursts to
-// meaningfully pre-position.
-const residentialPhases: Phase[] = [
-  {
-    name: "Overnight",
-    durationSec: 60,
-    ridersPerMin: 3,
-    originWeights: uniform(RES_STOPS),
-    destWeights: uniform(RES_STOPS),
-  },
-  // Morning: residents heading out — heavy upper → lobby.
-  {
-    name: "Morning exodus",
-    durationSec: 75,
-    ridersPerMin: 35,
-    originWeights: [0, ...topBias(RES_STOPS - 1)],
-    destWeights: lobbyOnly(RES_STOPS),
-  },
-  // Midday: light traffic. Predictive parking should notice the slump.
-  {
-    name: "Midday quiet",
-    durationSec: 60,
-    ridersPerMin: 7,
-    originWeights: uniform(RES_STOPS),
-    destWeights: uniform(RES_STOPS),
-  },
-  // Afternoon: groceries, kids, a modest rise.
-  {
-    name: "Afternoon drift",
-    durationSec: 45,
-    ridersPerMin: 14,
-    originWeights: Array.from({ length: RES_STOPS }, (_, i) => (i === 0 ? 3 : 1)),
-    destWeights: uniform(RES_STOPS),
-  },
-  // Evening: commuters returning — lobby → upper. Inverse of morning.
-  {
-    name: "Evening return",
-    durationSec: 60,
-    ridersPerMin: 30,
-    originWeights: lobbyOnly(RES_STOPS),
-    destWeights: [0, ...topBias(RES_STOPS - 1)],
-  },
-];
-
-const residential: ScenarioMeta = {
-  id: "residential-tower",
-  label: "Residential tower",
-  description:
-    "Eight floors, two cars. Asymmetric day: morning exodus, quiet midday, evening return. Predictive parking anticipates the next peak by the arrival-log rate signal.",
-  defaultStrategy: "etd",
-  phases: residentialPhases,
-  seedSpawns: 0,
-  // 180 s: residents are less flighty than office workers (groceries,
-  // kids in tow, shared building) and the load stays well under cruise
-  // capacity, so abandonment rarely fires — it exists as a safety
-  // valve for user-triggered 2× intensity bursts.
-  abandonAfterSec: 180,
-  hook: { kind: "predictive_parking", windowTicks: 9000 }, // 2.5 min at 60 Hz
-  featureHint:
-    "Predictive parking with a 2.5-min window — during the midday slump, idle cars pre-position toward the floors that spiked most recently.",
-  buildingName: "Residential Tower",
-  stops: [
-    { name: "Lobby", positionM: 0.0 },
-    { name: "Floor 2", positionM: 3.5 },
-    { name: "Floor 3", positionM: 7.0 },
-    { name: "Floor 4", positionM: 10.5 },
-    { name: "Floor 5", positionM: 14.0 },
-    { name: "Floor 6", positionM: 17.5 },
-    { name: "Floor 7", positionM: 21.0 },
-    { name: "Penthouse", positionM: 24.5 },
-  ],
-  defaultCars: 2,
-  elevatorDefaults: {
-    maxSpeed: 2.5,
-    acceleration: 1.6,
-    deceleration: 2.2,
-    weightCapacity: 700.0,
-    doorOpenTicks: 180,
-    doorTransitionTicks: 60,
-  },
-  tweakRanges: COMMERCIAL_TWEAK_RANGES,
-  passengerMeanIntervalTicks: 75,
-  passengerWeightRange: [50.0, 95.0],
-  ron: `SimConfig(
-    building: BuildingConfig(
-        name: "Residential Tower",
-        stops: [
-            StopConfig(id: StopId(0), name: "Lobby",   position: 0.0),
-            StopConfig(id: StopId(1), name: "Floor 2", position: 3.5),
-            StopConfig(id: StopId(2), name: "Floor 3", position: 7.0),
-            StopConfig(id: StopId(3), name: "Floor 4", position: 10.5),
-            StopConfig(id: StopId(4), name: "Floor 5", position: 14.0),
-            StopConfig(id: StopId(5), name: "Floor 6", position: 17.5),
-            StopConfig(id: StopId(6), name: "Floor 7", position: 21.0),
-            StopConfig(id: StopId(7), name: "Penthouse", position: 24.5),
-        ],
-    ),
-    elevators: [
-        ElevatorConfig(
-            id: 0, name: "Car 1",
-            max_speed: 2.5, acceleration: 1.6, deceleration: 2.2,
-            weight_capacity: 700.0,
-            starting_stop: StopId(0),
-            // Residential: 3 s dwell, 1 s each way. Lighter traffic
-            // than commercial; no luggage-loading dwell to pad.
-            door_open_ticks: 180, door_transition_ticks: 60,
-        ),
-        ElevatorConfig(
-            id: 1, name: "Car 2",
-            max_speed: 2.5, acceleration: 1.6, deceleration: 2.2,
-            weight_capacity: 700.0,
-            starting_stop: StopId(4),
-            // Residential: 3 s dwell, 1 s each way. Lighter traffic
-            // than commercial; no luggage-loading dwell to pad.
-            door_open_ticks: 180, door_transition_ticks: 60,
-        ),
-    ],
-    simulation: SimulationParams(ticks_per_second: 60.0),
-    passenger_spawning: PassengerSpawnConfig(
-        mean_interval_ticks: 75,
-        weight_range: (50.0, 95.0),
-    ),
-)`,
-};
-
-// ─── Hotel 24/7 — deferred DCS hook ─────────────────────────────────
-
-const HOTEL_STOPS = 10;
-// Three 900 kg cars at 3 m/s over 31.5 m. With 6 s door cycle (4 s
-// dwell for luggage + 2 × 1 s transition), round trip is ~45 s and
-// each car delivers ~15 riders/min — ~48 combined. Rush rates sit
-// at ~0.6× that so all three cars stay visibly busy during check-in
-// / check-out bursts without saturating; DCS's benefit comes from
-// *reassignment opportunity*, not from overload.
-const hotelPhases: Phase[] = [
-  // Pre-dawn baseline — minimal traffic.
-  {
-    name: "Overnight",
-    durationSec: 45,
-    ridersPerMin: 3,
-    originWeights: uniform(HOTEL_STOPS),
-    destWeights: uniform(HOTEL_STOPS),
-  },
-  // Breakfast + check-out bump — upper to lobby / upper to restaurant (floor 2).
-  {
-    name: "Check-out rush",
-    durationSec: 60,
-    ridersPerMin: 32,
-    originWeights: [0, 0.5, ...Array.from({ length: HOTEL_STOPS - 2 }, () => 1)],
-    destWeights: [5, 2, ...Array.from({ length: HOTEL_STOPS - 2 }, () => 0.3)],
-  },
-  // Daytime — sightseers, room service, uniform interfloor.
-  {
-    name: "Daytime",
-    durationSec: 75,
-    ridersPerMin: 15,
-    originWeights: uniform(HOTEL_STOPS),
-    destWeights: uniform(HOTEL_STOPS),
-  },
-  // Check-in / dinner — lobby heavy again.
-  {
-    name: "Check-in rush",
-    durationSec: 60,
-    ridersPerMin: 28,
-    originWeights: [4, 1, ...Array.from({ length: HOTEL_STOPS - 2 }, () => 0.3)],
-    destWeights: [0, 0.5, ...Array.from({ length: HOTEL_STOPS - 2 }, () => 1)],
-  },
-  // Late night — mostly room returns.
-  {
-    name: "Late night",
-    durationSec: 60,
-    ridersPerMin: 10,
-    originWeights: [2, 2, ...Array.from({ length: HOTEL_STOPS - 2 }, () => 0.5)],
-    destWeights: [0.5, 0.5, ...Array.from({ length: HOTEL_STOPS - 2 }, () => 1)],
-  },
-];
-
-const hotel: ScenarioMeta = {
-  id: "hotel-24-7",
-  label: "Hotel 24/7",
-  description:
-    "Ten floors, three cars in DCS mode. Low-rate baseline with check-in / check-out bumps; deferred commitment reallocates assignments while cars are still far from the rider's origin.",
-  defaultStrategy: "destination",
-  phases: hotelPhases,
-  seedSpawns: 0,
-  // 150 s: hotel guests with luggage are more patient than office
-  // workers but less than residents; tuned so check-in bursts still
-  // produce a visible queue without the queue ever running away
-  // under 2× intensity.
-  abandonAfterSec: 150,
-  hook: { kind: "deferred_dcs", commitmentWindowTicks: 180 },
-  featureHint:
-    "Deferred DCS with a 3-s (180-tick) commitment window — sticky assignments keep re-competing until a car is close to the rider, yielding better matches under bursty demand.",
-  buildingName: "Hotel 24/7",
-  stops: [
-    { name: "Lobby", positionM: 0.0 },
-    { name: "Restaurant", positionM: 3.5 },
-    { name: "Floor 3", positionM: 7.0 },
-    { name: "Floor 4", positionM: 10.5 },
-    { name: "Floor 5", positionM: 14.0 },
-    { name: "Floor 6", positionM: 17.5 },
-    { name: "Floor 7", positionM: 21.0 },
-    { name: "Floor 8", positionM: 24.5 },
-    { name: "Floor 9", positionM: 28.0 },
-    { name: "Penthouse", positionM: 31.5 },
-  ],
-  defaultCars: 3,
-  elevatorDefaults: {
-    maxSpeed: 3.0,
-    acceleration: 1.8,
-    deceleration: 2.3,
-    weightCapacity: 900.0,
-    doorOpenTicks: 240,
-    doorTransitionTicks: 60,
-  },
-  tweakRanges: COMMERCIAL_TWEAK_RANGES,
-  passengerMeanIntervalTicks: 120,
-  passengerWeightRange: [50.0, 95.0],
-  ron: `SimConfig(
-    building: BuildingConfig(
-        name: "Hotel 24/7",
-        stops: [
-            StopConfig(id: StopId(0), name: "Lobby",      position: 0.0),
-            StopConfig(id: StopId(1), name: "Restaurant", position: 3.5),
-            StopConfig(id: StopId(2), name: "Floor 3",    position: 7.0),
-            StopConfig(id: StopId(3), name: "Floor 4",    position: 10.5),
-            StopConfig(id: StopId(4), name: "Floor 5",    position: 14.0),
-            StopConfig(id: StopId(5), name: "Floor 6",    position: 17.5),
-            StopConfig(id: StopId(6), name: "Floor 7",    position: 21.0),
-            StopConfig(id: StopId(7), name: "Floor 8",    position: 24.5),
-            StopConfig(id: StopId(8), name: "Floor 9",    position: 28.0),
-            StopConfig(id: StopId(9), name: "Penthouse",  position: 31.5),
-        ],
-    ),
-    elevators: [
-        ElevatorConfig(
-            id: 0, name: "Car A",
-            max_speed: 3.0, acceleration: 1.8, deceleration: 2.3,
-            weight_capacity: 900.0,
-            starting_stop: StopId(0),
-            // Hotel: 4 s dwell (luggage carts, guests with bags),
-            // 1 s each way. Longer than office, shorter than
-            // transit — fits the observed commercial range.
-            door_open_ticks: 240, door_transition_ticks: 60,
-        ),
-        ElevatorConfig(
-            id: 1, name: "Car B",
-            max_speed: 3.0, acceleration: 1.8, deceleration: 2.3,
-            weight_capacity: 900.0,
-            starting_stop: StopId(4),
-            // Hotel: 4 s dwell (luggage carts, guests with bags),
-            // 1 s each way. Longer than office, shorter than
-            // transit — fits the observed commercial range.
-            door_open_ticks: 240, door_transition_ticks: 60,
-        ),
-        ElevatorConfig(
-            id: 2, name: "Car C",
-            max_speed: 3.0, acceleration: 1.8, deceleration: 2.3,
-            weight_capacity: 900.0,
-            starting_stop: StopId(9),
-            // Hotel: 4 s dwell (luggage carts, guests with bags),
-            // 1 s each way. Longer than office, shorter than
-            // transit — fits the observed commercial range.
-            door_open_ticks: 240, door_transition_ticks: 60,
-        ),
-    ],
-    simulation: SimulationParams(ticks_per_second: 60.0),
-    passenger_spawning: PassengerSpawnConfig(
-        mean_interval_ticks: 120,
-        weight_range: (50.0, 95.0),
-    ),
-)`,
-};
-
-// ─── Convention burst — arrival-log rate signal hook ────────────────
-
-const CONV_STOPS = 5;
-// Two 1500 kg cars at 3.5 m/s over a short 16 m shaft. With 7 s door
-// cycle (5 s dwell for group boarding + 2 × 1 s transition), round
-// trip is ~30 s and each car delivers ~40 riders/min — ~80
-// combined. The keynote burst intentionally overshoots that to
-// stress-test dispatch; the rate still drops enough between bursts
-// that the cycle is recognizably calm.
-const conventionPhases: Phase[] = [
-  // Acute peak right after a keynote lets out.
-  {
-    name: "Keynote lets out",
-    durationSec: 45,
-    ridersPerMin: 110,
-    originWeights: Array.from({ length: CONV_STOPS }, (_, i) => (i === CONV_STOPS - 1 ? 8 : 1)),
-    destWeights: [5, 2, 1, 1, 0],
-  },
-  // Tapering as the hall clears.
-  {
-    name: "Tapering",
-    durationSec: 90,
-    ridersPerMin: 18,
-    originWeights: uniform(CONV_STOPS),
-    destWeights: uniform(CONV_STOPS),
-  },
-  // Quiet before the next session. Generous length so the cycle
-  // actually rests between bursts — users get a chance to watch cars
-  // park before the next keynote spike hits.
-  {
-    name: "Between sessions",
-    durationSec: 135,
-    ridersPerMin: 4,
-    originWeights: uniform(CONV_STOPS),
-    destWeights: uniform(CONV_STOPS),
-  },
-];
-
-const convention: ScenarioMeta = {
-  id: "convention-burst",
-  label: "Convention burst",
-  description:
-    "Five-floor convention center. A keynote ends and 200+ riders spill into the elevators at once — an acute stress test rather than a day cycle.",
-  defaultStrategy: "etd",
-  phases: conventionPhases,
-  seedSpawns: 120,
-  // Intentionally omits `abandonAfterSec` — the whole point of this
-  // scenario is to stress-test dispatch under a real pile-up. Letting
-  // attendees abandon would gut the `arrival_log` rate signal's
-  // purpose, which is "how punishing is *persistent* demand?"
-  hook: { kind: "arrival_log" },
-  featureHint:
-    "Arrival-rate signal lights up as the burst hits — `DispatchManifest::arrivals_at` feeds downstream strategies the per-stop intensity for the next 5 minutes.",
-  buildingName: "Convention Center",
-  stops: [
-    { name: "Lobby", positionM: 0.0 },
-    { name: "Exhibit Hall", positionM: 4.0 },
-    { name: "Mezzanine", positionM: 8.0 },
-    { name: "Ballroom", positionM: 12.0 },
-    { name: "Keynote Hall", positionM: 16.0 },
-  ],
-  defaultCars: 2,
-  elevatorDefaults: {
-    maxSpeed: 3.5,
-    acceleration: 2.0,
-    deceleration: 2.5,
-    weightCapacity: 1500.0,
-    doorOpenTicks: 300,
-    doorTransitionTicks: 60,
-  },
-  tweakRanges: { ...COMMERCIAL_TWEAK_RANGES, cars: { min: 1, max: 5, step: 1 } },
-  passengerMeanIntervalTicks: 30,
-  passengerWeightRange: [55.0, 100.0],
-  ron: `SimConfig(
-    building: BuildingConfig(
-        name: "Convention Center",
-        stops: [
-            StopConfig(id: StopId(0), name: "Lobby",        position: 0.0),
-            StopConfig(id: StopId(1), name: "Exhibit Hall", position: 4.0),
-            StopConfig(id: StopId(2), name: "Mezzanine",    position: 8.0),
-            StopConfig(id: StopId(3), name: "Ballroom",     position: 12.0),
-            StopConfig(id: StopId(4), name: "Keynote Hall", position: 16.0),
-        ],
-    ),
-    elevators: [
-        ElevatorConfig(
-            id: 0, name: "Car 1",
-            max_speed: 3.5, acceleration: 2.0, deceleration: 2.5,
-            weight_capacity: 1500.0,
-            starting_stop: StopId(0),
-            // Convention: 5 s dwell for group boarding. Big crowds
-            // after keynote are slow to actually step through the
-            // threshold; rushing the doors closed ejects riders
-            // mid-walk and re-opens, a realistic failure mode.
-            door_open_ticks: 300, door_transition_ticks: 60,
-        ),
-        ElevatorConfig(
-            id: 1, name: "Car 2",
-            max_speed: 3.5, acceleration: 2.0, deceleration: 2.5,
-            weight_capacity: 1500.0,
-            starting_stop: StopId(4),
-            // Convention: 5 s dwell for group boarding. Big crowds
-            // after keynote are slow to actually step through the
-            // threshold; rushing the doors closed ejects riders
-            // mid-walk and re-opens, a realistic failure mode.
-            door_open_ticks: 300, door_transition_ticks: 60,
         ),
     ],
     simulation: SimulationParams(ticks_per_second: 60.0),
@@ -758,7 +326,6 @@ const spaceElevator: ScenarioMeta = {
     },
   ],
   seedSpawns: 0,
-  hook: { kind: "none" },
   featureHint:
     "No controller feature to showcase — this scenario exists to demonstrate that the engine is topology-agnostic.",
   buildingName: "Orbital Tether",
@@ -811,14 +378,10 @@ const spaceElevator: ScenarioMeta = {
 )`,
 };
 
-export const SCENARIOS: ScenarioMeta[] = [
-  office,
-  skyscraper,
-  residential,
-  hotel,
-  convention,
-  spaceElevator,
-];
+// Order is intentional: scale-ascending. A 5-stop acute burst, then a
+// 13-stop sky-lobby tower, then a 2-stop tether 1 000 km tall — the
+// card strip reads as a "zoom out" from building to orbit.
+export const SCENARIOS: ScenarioMeta[] = [convention, skyscraper, spaceElevator];
 
 export function scenarioById(id: string): ScenarioMeta {
   return SCENARIOS.find((s) => s.id === id) ?? SCENARIOS[0];

--- a/playground/src/sim.ts
+++ b/playground/src/sim.ts
@@ -34,12 +34,6 @@ interface WasmSimInstance {
   metrics(): unknown;
   waitingCountAt(stopId: number): number;
   free(): void;
-  // Scenario-feature hooks (optional for backwards-compat; absent until a
-  // fresh wasm build ships the new setters).
-  setHallCallModeDestination?(): void;
-  setEtdWithWaitSquaredWeight?(weight: number): void;
-  setDcsWithCommitmentWindow?(windowTicks: bigint): void;
-  setRepositionPredictiveParking?(windowTicks: bigint): void;
   // Live elevator-physics setters (uniform across every car). Optional
   // until a fresh wasm-pack build ships them; the playground falls back
   // to a sim rebuild when absent so a stale `public/pkg/` doesn't break
@@ -201,31 +195,6 @@ export class Sim {
       return true;
     } catch {
       return false;
-    }
-  }
-
-  /**
-   * Apply a scenario feature hook. Falls through to a no-op if the
-   * active wasm build predates the setter (useful during local dev
-   * when the playground is served ahead of a wasm rebuild).
-   */
-  applyHook(hook: import("./types").ScenarioHook): void {
-    const w = this.#inner;
-    switch (hook.kind) {
-      case "none":
-      case "arrival_log":
-      case "bypass_narration":
-        return;
-      case "etd_group_time":
-        w.setEtdWithWaitSquaredWeight?.(hook.waitSquaredWeight);
-        return;
-      case "deferred_dcs":
-        w.setHallCallModeDestination?.();
-        w.setDcsWithCommitmentWindow?.(BigInt(hook.commitmentWindowTicks));
-        return;
-      case "predictive_parking":
-        w.setRepositionPredictiveParking?.(BigInt(hook.windowTicks));
-        return;
     }
   }
 

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -157,16 +157,37 @@ select:focus-visible {
 
 /* Phase strip sits directly below the controls row: a single-line
  * readout of the current traffic phase plus the scenario's feature
- * hint. Deliberately quiet styling — the shafts are the focus. */
+ * hint, topped with a hairline progress bar toward the next phase.
+ * Deliberately quiet styling — the shafts are the focus. */
 .phase-strip {
   display: flex;
-  align-items: baseline;
-  gap: 10px;
-  padding: 8px 20px;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 20px 10px;
   background: var(--ink-0);
   border-bottom: 1px solid var(--line-1);
   font-size: 11.5px;
   color: var(--fg-2);
+}
+.phase-row {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+.phase-progress {
+  position: relative;
+  height: 3px;
+  background: var(--ink-2);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.phase-progress-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0%;
+  background: linear-gradient(90deg, var(--accent) 0%, var(--accent-up) 100%);
+  box-shadow: 0 0 8px rgba(6, 194, 181, 0.45);
+  transition: width var(--t-norm);
 }
 .phase-k {
   font-size: 10.5px;
@@ -217,16 +238,22 @@ select:focus-visible {
 
 .tweak-row {
   display: grid;
-  grid-template-columns: minmax(110px, 1fr) auto auto auto;
+  grid-template-columns: minmax(110px, 1fr) auto minmax(90px, 140px) auto auto;
   align-items: center;
   gap: 10px;
-  padding: 6px 10px;
+  padding: 8px 10px;
   background: var(--ink-2);
   border: 1px solid var(--line-1);
   border-radius: var(--r-2);
   transition:
     border-color var(--t-norm),
-    background var(--t-norm);
+    background var(--t-norm),
+    box-shadow var(--t-norm);
+  outline: none;
+}
+.tweak-row:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
 }
 .tweak-row[data-overridden="true"] {
   border-color: rgba(6, 194, 181, 0.35);
@@ -816,6 +843,429 @@ button:active {
   transform: translateX(-50%) translateY(0) scale(1);
 }
 
+/* ── Scenario cards ─────────────────────────────────────────────────── */
+
+.scenario-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+  padding: 12px 20px;
+  background:
+    radial-gradient(700px 200px at 50% -40%, rgba(6, 194, 181, 0.06), transparent 70%),
+    var(--ink-0);
+  border-bottom: 1px solid var(--line-1);
+}
+.scenario-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 14px;
+  background: linear-gradient(180deg, var(--ink-2) 0%, var(--ink-1) 100%);
+  border: 1px solid var(--line-1);
+  border-radius: var(--r-2);
+  color: var(--fg-1);
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  letter-spacing: 0;
+  box-shadow: var(--shadow-1);
+  transition:
+    border-color var(--t-norm),
+    transform var(--t-quick),
+    box-shadow var(--t-quick),
+    background var(--t-norm);
+}
+.scenario-card:hover {
+  transform: translateY(-1px);
+  border-color: var(--line-3);
+  box-shadow: var(--shadow-2);
+  background: linear-gradient(180deg, var(--ink-3) 0%, var(--ink-2) 100%);
+}
+.scenario-card:active {
+  transform: translateY(0);
+}
+.scenario-card[aria-pressed="true"] {
+  border-color: rgba(6, 194, 181, 0.55);
+  background: linear-gradient(180deg, rgba(6, 194, 181, 0.1) 0%, var(--ink-2) 100%);
+  box-shadow: 0 0 0 1px rgba(6, 194, 181, 0.25), var(--shadow-2);
+}
+.scenario-card[aria-pressed="true"]::before {
+  content: "";
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent) 0%, var(--accent-up) 100%);
+  border-radius: 0 0 var(--r-2) var(--r-2);
+  box-shadow: 0 0 12px rgba(6, 194, 181, 0.55);
+}
+.scenario-card-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg-0);
+  letter-spacing: 0.005em;
+}
+.scenario-card-kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--fg-3);
+  background: var(--ink-0);
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-1);
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
+}
+.scenario-card-desc {
+  font-size: 11.5px;
+  color: var(--fg-2);
+  line-height: 1.4;
+}
+.scenario-card-hint {
+  font-size: 11px;
+  color: var(--fg-3);
+  line-height: 1.4;
+}
+
+/* ── Strategy info line ─────────────────────────────────────────────── */
+
+.ctl-strategy {
+  min-width: 240px;
+}
+.ctl-inline {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.ctl-desc {
+  margin: 4px 0 0;
+  font-size: 11px;
+  color: var(--fg-3);
+  line-height: 1.4;
+  max-width: 380px;
+  min-height: 1.4em;
+}
+/* ── Nav button (?) ─────────────────────────────────────────────────── */
+
+.nav-btn {
+  margin-left: 16px;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ink-1);
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-1);
+  color: var(--fg-2);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--t-quick);
+  letter-spacing: 0;
+  box-shadow: none;
+}
+.nav-btn:hover {
+  color: var(--fg-0);
+  border-color: var(--line-3);
+  background: var(--ink-2);
+  transform: none;
+  box-shadow: none;
+}
+
+/* ── Tweak row — slider track ───────────────────────────────────────── */
+
+.tweak-track {
+  position: relative;
+  height: 6px;
+  background: var(--ink-1);
+  border: 1px solid var(--line-1);
+  border-radius: 999px;
+  align-self: center;
+  overflow: hidden;
+}
+.tweak-track-default {
+  position: absolute;
+  top: -2px;
+  bottom: -2px;
+  width: 2px;
+  background: var(--fg-3);
+  opacity: 0.75;
+  transform: translateX(-1px);
+}
+.tweak-track-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0%;
+  background: linear-gradient(90deg, var(--accent-soft) 0%, rgba(6, 194, 181, 0.25) 100%);
+  transition: width var(--t-norm);
+}
+.tweak-track-thumb {
+  position: absolute;
+  top: 50%;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, var(--fg-0) 0%, var(--fg-1) 100%);
+  box-shadow: var(--shadow-1);
+  transform: translate(-50%, -50%);
+  transition: left var(--t-norm);
+}
+.tweak-row[data-overridden="true"] .tweak-track {
+  border-color: rgba(6, 194, 181, 0.4);
+}
+.tweak-row[data-overridden="true"] .tweak-track-fill {
+  background: linear-gradient(90deg, var(--accent) 0%, var(--accent-up) 100%);
+  opacity: 0.65;
+}
+.tweak-row[data-overridden="true"] .tweak-track-thumb {
+  background: linear-gradient(180deg, var(--accent-up) 0%, var(--accent) 100%);
+  box-shadow: 0 0 0 3px var(--accent-soft), var(--shadow-1);
+}
+
+/* ── Pane title + decision narration ────────────────────────────────── */
+
+.pane-title {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  flex: 1;
+}
+.pane-decision {
+  font-size: 10.5px;
+  color: var(--fg-3);
+  letter-spacing: 0.02em;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-height: 1.2em;
+  opacity: 0;
+  transition: opacity var(--t-norm), color var(--t-norm);
+}
+.pane-decision[data-active="true"] {
+  opacity: 1;
+  color: var(--pane-accent);
+}
+.pane-decision::before {
+  content: "\2022";
+  display: inline-block;
+  margin-right: 6px;
+  color: var(--pane-accent);
+  font-size: 10px;
+  transform: translateY(-1px);
+  text-shadow: 0 0 6px currentColor;
+}
+.pane-decision[data-pulse="true"]::before {
+  animation: decision-pulse 450ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+@keyframes decision-pulse {
+  0% {
+    transform: translateY(-1px) scale(1);
+    opacity: 1;
+  }
+  40% {
+    transform: translateY(-1px) scale(1.8);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(-1px) scale(1);
+    opacity: 1;
+  }
+}
+
+/* ── Metric sparkline ───────────────────────────────────────────────── */
+
+.metric-row {
+  position: relative;
+}
+.metric-spark {
+  margin-top: 2px;
+  width: 100%;
+  height: 14px;
+  display: block;
+  opacity: 0.85;
+}
+.metric-spark path {
+  fill: none;
+  stroke: var(--fg-2);
+  stroke-width: 1.1;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+}
+.metric-row[data-verdict="win"] .metric-spark path {
+  stroke: var(--ok);
+}
+.metric-row[data-verdict="lose"] .metric-spark path {
+  stroke: var(--bad);
+}
+
+/* ── Verdict ribbon (compare mode) ──────────────────────────────────── */
+
+.verdict-ribbon {
+  display: grid;
+  grid-template-columns: auto repeat(5, minmax(0, 1fr));
+  gap: 10px;
+  align-items: center;
+  padding: 8px 20px;
+  background: linear-gradient(180deg, var(--ink-1) 0%, var(--ink-0) 100%);
+  border-bottom: 1px solid var(--line-1);
+  font-size: 11px;
+  color: var(--fg-2);
+}
+.verdict-ribbon[hidden] {
+  display: none;
+}
+.verdict-ribbon-title {
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-3);
+  font-weight: 500;
+  white-space: nowrap;
+}
+.verdict-cell {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: var(--r-1);
+  background: var(--ink-2);
+  border: 1px solid var(--line-1);
+  font-variant-numeric: tabular-nums;
+  overflow: hidden;
+}
+.verdict-cell-k {
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-3);
+}
+.verdict-cell-winner {
+  font-weight: 600;
+  color: var(--fg-0);
+  letter-spacing: 0.02em;
+}
+.verdict-cell[data-winner="A"] .verdict-cell-winner {
+  color: var(--pane-a);
+}
+.verdict-cell[data-winner="B"] .verdict-cell-winner {
+  color: var(--pane-b);
+}
+.verdict-cell[data-winner="tie"] .verdict-cell-winner {
+  color: var(--fg-2);
+}
+
+/* ── Shortcut sheet overlay ─────────────────────────────────────────── */
+
+.shortcut-sheet {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(10, 12, 16, 0.7);
+  backdrop-filter: blur(4px) saturate(120%);
+  -webkit-backdrop-filter: blur(4px) saturate(120%);
+  z-index: 95;
+  animation: fade-in var(--t-norm) ease-out;
+}
+.shortcut-sheet[hidden] {
+  display: none;
+}
+.shortcut-sheet-inner {
+  width: min(480px, 90vw);
+  background: linear-gradient(180deg, var(--ink-3) 0%, var(--ink-1) 100%);
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-3);
+  box-shadow: var(--shadow-3);
+  padding: 18px 20px 20px;
+  color: var(--fg-1);
+  animation: shortcut-pop var(--t-spring);
+}
+@keyframes shortcut-pop {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+.shortcut-sheet-inner header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0 0 12px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg-0);
+  letter-spacing: 0.005em;
+}
+#shortcut-sheet-close {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--fg-3);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px 8px;
+  letter-spacing: 0;
+  box-shadow: none;
+}
+#shortcut-sheet-close:hover {
+  color: var(--fg-0);
+  transform: none;
+  box-shadow: none;
+  background: transparent;
+}
+.shortcut-sheet-inner dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px 16px;
+  margin: 0;
+  font-size: 12px;
+}
+.shortcut-sheet-inner dt {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+}
+.shortcut-sheet-inner dd {
+  margin: 0;
+  color: var(--fg-2);
+}
+.shortcut-sheet-inner kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  padding: 1px 6px;
+  background: var(--ink-0);
+  border: 1px solid var(--line-2);
+  border-bottom-width: 2px;
+  border-radius: var(--r-1);
+  color: var(--fg-0);
+  font-family: "SFMono-Regular", ui-monospace, Menlo, Consolas, monospace;
+  font-size: 10.5px;
+  font-weight: 500;
+}
+
 /* ── Mobile ─────────────────────────────────────────────────────────── */
 
 @media (max-width: 820px) {
@@ -871,6 +1321,31 @@ button:active {
     height: 46vh;
     height: 46dvh;
     min-height: 260px;
+  }
+
+  .scenario-cards {
+    padding: 10px 14px;
+    grid-template-columns: 1fr;
+  }
+  .scenario-card {
+    padding: 10px 12px;
+  }
+  .ctl-strategy {
+    flex: 1 1 100%;
+    min-width: 0;
+  }
+  .ctl-desc {
+    max-width: none;
+  }
+  .verdict-ribbon {
+    grid-template-columns: 1fr 1fr;
+    padding: 8px 14px;
+  }
+  .verdict-ribbon-title {
+    grid-column: 1 / -1;
+  }
+  .pane-decision {
+    font-size: 10px;
   }
 }
 

--- a/playground/src/traffic.ts
+++ b/playground/src/traffic.ts
@@ -127,6 +127,22 @@ export class TrafficDriver {
     return Math.min(1, this.#elapsedInCycleSec / this.#totalDurationSec);
   }
 
+  /**
+   * 0..1 progress *within* the current phase. Drives the slim progress
+   * bar under the phase label so users can feel the next phase coming.
+   * Returns 0 when the driver has no schedule installed.
+   */
+  progressInPhase(): number {
+    if (this.#phases.length === 0) return 0;
+    let t = this.#elapsedInCycleSec;
+    for (let i = 0; i < this.#phases.length; i += 1) {
+      const d = this.#phases[i].durationSec;
+      if (t < d) return d > 0 ? Math.min(1, t / d) : 0;
+      t -= d;
+    }
+    return 1;
+  }
+
   /** Read-only view of the installed phase schedule — the UI draws the strip from this. */
   phases(): readonly Phase[] {
     return this.#phases;

--- a/playground/src/types.ts
+++ b/playground/src/types.ts
@@ -89,13 +89,15 @@ export type BubbleEvent =
   | { kind: "other"; tick: number; label: string };
 
 /**
- * Per-car speech-bubble state, keyed by car entity id. `expiresAt`
- * uses `performance.now()` wall-clock ms — not a sim tick — so the
- * bubble fades predictably even when the sim races ahead or the tab
- * backgrounds and `requestAnimationFrame` stalls.
+ * Per-car speech-bubble state, keyed by car entity id. All three
+ * timestamps use `performance.now()` wall-clock ms — not sim ticks — so
+ * the bubble fades predictably even when the sim races ahead or the tab
+ * backgrounds and `requestAnimationFrame` stalls. `bornAt` exists so
+ * the renderer can fade the last ~30 % of lifetime for a soft exit.
  */
 export interface CarBubble {
   text: string;
+  bornAt: number;
   expiresAt: number;
 }
 
@@ -126,21 +128,6 @@ export interface Phase {
    */
   destWeights?: number[];
 }
-
-/**
- * Optional scenario feature hooks. Applied once on scenario load so
- * the scenario's signature behavior is visible without the user
- * having to hunt for the right tunable.
- */
-export type ScenarioHook =
-  | { kind: "none" }
-  | { kind: "etd_group_time"; waitSquaredWeight: number }
-  | { kind: "deferred_dcs"; commitmentWindowTicks: number }
-  | { kind: "predictive_parking"; windowTicks: number }
-  | { kind: "arrival_log" }
-  // bypass is already wired via the RON ElevatorConfig fields — this
-  // marker is purely for UI narration (label + description).
-  | { kind: "bypass_narration" };
 
 /**
  * Per-elevator physics defaults applied uniformly when the playground
@@ -208,9 +195,7 @@ export interface ScenarioMeta {
    * for day-cycle scenarios.
    */
   seedSpawns: number;
-  /** Commercial-feature hook applied once on scenario load. */
-  hook: ScenarioHook;
-  /** One-line narrative shown alongside the feature hook to frame what to watch for. */
+  /** One-line narrative shown alongside the scenario to frame what to watch for. */
   featureHint: string;
   /**
    * Building name as it appears in the RON `BuildingConfig.name` field.
@@ -241,19 +226,13 @@ export interface ScenarioMeta {
   passengerWeightRange: [number, number];
   /**
    * Time a rider will wait before abandoning the queue, in simulated
-   * seconds. Prevents scenarios whose peak phases run above the
-   * building's cruise capacity from accumulating an unbounded wait
-   * line — old waiters leave, new ones arrive, queue reaches a
-   * bounded steady state matching the demand/supply gap.
+   * seconds. 90–180 s matches realistic human patience for commercial
+   * elevators; with it set, peak phases above cruise capacity reach a
+   * bounded steady state (old waiters leave as new ones arrive).
    *
-   * Pre-fix, office-lunchtime under two cars at 65 riders/min vs.
-   * ~54/min cruise grew the queue forever; 90–120 s is a realistic
-   * human patience budget for commercial elevators (shorter during
-   * bursty peaks, longer during midday lulls — we use one value per
-   * scenario for simplicity).
-   *
-   * Omit to disable abandonment (convention burst leaves it off so
-   * the full 170-riders/min stress test actually applies pressure).
+   * Omit to disable abandonment — the convention burst leaves it off
+   * so its deliberate post-keynote stress test actually applies
+   * pressure instead of auto-draining.
    */
   abandonAfterSec?: number;
 }


### PR DESCRIPTION
## Summary

- Trim the playground scenario roster from 6 → 3 (convention-burst → skyscraper-sky-lobby → space-elevator, scale-ascending) and drop the now-vestigial `ScenarioHook` system (every surviving variant was a no-op).
- Run a focused UX polish: pane-tinted speech bubbles with per-event TTLs + icons, one-line strategy descriptions, a slider track under each tweak stepper (with arrow-key nudge + hold-to-repeat), scenario cards replacing the scenario dropdown, live SVG sparklines per metric row, pane-header decision narration on `elevator-assigned`, a compare-mode verdict ribbon, a slim phase-progress bar, and keyboard shortcuts (Space / R / C / S / T / 1-3 / ? / Esc) with a cheat-sheet overlay.
- Fix two issues surfaced during internal review: `permalink.STRATEGIES` was missing `"rsr"` so RSR permalinks silently fell back to the default; `resetAll`'s seed-spawn loop pumped `drainSpawns` with a dt far too small to ever accumulate a rider, so `convention-burst` was starting empty — now pumps at the driver's `4/60 s` cap until the target is reached, then re-seats the driver so the phase clock starts at 0.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` — 46/46 pass
- [x] `pnpm build` — production bundle 46.6 kB JS (gzip 15.7 kB), 23.4 kB CSS (gzip 5.2 kB)
- [x] Pre-commit hook: fmt + clippy + core/doc tests + `cargo check --workspace` all green
- [ ] Visual verify on `pnpm dev` — scenario cards click, card kbd shortcuts (1/2/3) switch scenarios, compare toggle reveals pane B + verdict ribbon, tweak steppers reveal the slider track with default mark, ± hold-to-repeat fires, arrow-keys nudge focused tweak row, bubbles show icons + fade, decision narration pulses in pane header on assignments, phase-progress bar advances, `?` opens cheat sheet with focus on close button, Escape closes, convention-burst opens with the pre-loaded crowd visible