### PR TITLE
feat(playground): mobile-first UI overhaul + Tailwind v4 migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Plug it into Bevy, Unity, your own renderer, or run headless.
 [![CI](https://img.shields.io/github/actions/workflow/status/andymai/elevator-core/ci.yml?label=CI)](https://github.com/andymai/elevator-core/actions)
 [![License](https://img.shields.io/crates/l/elevator-core.svg)](LICENSE-MIT)
 
-[Guide](https://andymai.github.io/elevator-core/) · [API Reference](https://docs.rs/elevator-core) · [Examples](crates/elevator-core/examples/) · [Changelog](CHANGELOG.md) · [Stability](STABILITY.md) · [Bench history](https://andymai.github.io/elevator-core/bench/)
+[Guide](https://andymai.github.io/elevator-core/) · [API Reference](https://docs.rs/elevator-core) · [Examples](crates/elevator-core/examples/)
 
-**[▶ Try the live playground](https://andymai.github.io/elevator-core/playground/)** — swap dispatch strategies, tune traffic, and share seeds right in your browser.
+**[▶ Try the live playground](https://andymai.github.io/elevator-core/playground/)** — race two dispatch strategies on the same traffic, side-by-side in your browser.
 
 </div>
 
@@ -99,6 +99,10 @@ cargo run -- assets/config/space_elevator.ron    # 1,000 km orbital tether
 |------|---------|------|
 | `traffic` | yes | Poisson arrivals, daily traffic patterns. Pulls in `rand`. |
 | `energy` | no | Per-elevator energy/regen modeling. |
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md).
 
 ## License
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-> **Try it live:** the [in-browser playground](./playground/index.html) runs the full simulation — swap dispatch strategies, tune traffic, and share seeds without installing anything.
+> **Try it live:** the [in-browser playground](./playground/index.html) runs the full simulation — race two dispatch strategies on the same traffic, side-by-side, without installing anything.
 
 **elevator-core** is an engine-agnostic elevator simulation library written in pure Rust. It gives you a tick-based simulation with realistic trapezoidal motion profiles, pluggable dispatch algorithms, and a typed event bus -- everything you need to build elevator games, building management tools, or algorithm testbeds without coupling to any particular game engine or rendering framework.
 

--- a/playground/index.html
+++ b/playground/index.html
@@ -202,7 +202,7 @@
     <main
       id="layout"
       data-mode="single"
-      class="layout grid gap-3.5 px-5 pt-3.5 pb-5 h-[calc(100dvh-130px)] data-[mode=single]:grid-cols-1 data-[mode=compare]:grid-cols-2 max-md:gap-2.5 max-md:px-[calc(14px+env(safe-area-inset-left))] max-md:pr-[calc(14px+env(safe-area-inset-right))] max-md:pt-2.5 max-md:pb-[calc(var(--sheet-peek,64px)+10px+env(safe-area-inset-bottom))] max-md:h-[calc(100dvh-44px)] max-md:data-[mode=compare]:grid-cols-1 max-md:landscape:data-[mode=compare]:grid-cols-2"
+      class="layout grid gap-3.5 px-5 pt-3.5 pb-5 flex-1 min-h-0 data-[mode=single]:grid-cols-1 data-[mode=compare]:grid-cols-2 max-md:gap-2.5 max-md:px-[calc(14px+env(safe-area-inset-left))] max-md:pr-[calc(14px+env(safe-area-inset-right))] max-md:pt-2.5 max-md:pb-[calc(var(--sheet-peek,64px)+10px+env(safe-area-inset-bottom))] max-md:data-[mode=compare]:grid-cols-1 max-md:landscape:data-[mode=compare]:grid-cols-2"
     >
       <section
         id="pane-a"

--- a/playground/index.html
+++ b/playground/index.html
@@ -8,63 +8,97 @@
       name="description"
       content="Live in-browser demo of the elevator-core Rust simulation library. Compare dispatch strategies side-by-side on identical rider traffic."
     />
-    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='4' y='2' width='16' height='20' rx='3' fill='%2306c2b5'/%3E%3Crect x='8' y='6' width='8' height='4' rx='0.5' fill='%230a0c10'/%3E%3Crect x='8' y='14' width='8' height='4' rx='0.5' fill='%230a0c10'/%3E%3C/svg%3E" />
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='4' y='2' width='16' height='20' rx='3' fill='%23f59e0b'/%3E%3Crect x='8' y='6' width='8' height='4' rx='0.5' fill='%230f0f12'/%3E%3Crect x='8' y='14' width='8' height='4' rx='0.5' fill='%230f0f12'/%3E%3C/svg%3E" />
     <link rel="stylesheet" href="./src/style.css" />
   </head>
   <body>
-    <header class="top">
-      <h1>elevator-core playground</h1>
-      <nav>
+    <header class="top flex items-center justify-between px-5 py-3 bg-gradient-to-b from-surface-secondary to-surface border-b border-stroke-subtle relative">
+      <h1 class="m-0 text-[14px] font-semibold tracking-[-0.005em] text-content inline-flex items-center gap-2.5 before:content-[''] before:inline-block before:w-2 before:h-2 before:rounded-[2px] before:bg-accent before:shadow-[0_0_10px_color-mix(in_srgb,var(--accent)_50%,transparent)]">elevator-core playground</h1>
+      <nav class="flex items-center">
         <button type="button" id="shortcuts" class="nav-btn" title="Keyboard shortcuts (press ?)">?</button>
-        <a href="https://github.com/andymai/elevator-core">repo</a>
-        <a href="https://docs.rs/elevator-core">docs</a>
-        <a href="../">guide</a>
+        <a class="ml-4 text-content-tertiary no-underline text-xs transition-colors hover:text-content" href="https://github.com/andymai/elevator-core">repo</a>
+        <a class="ml-4 text-content-tertiary no-underline text-xs transition-colors hover:text-content" href="https://docs.rs/elevator-core">docs</a>
+        <a class="ml-4 text-content-tertiary no-underline text-xs transition-colors hover:text-content" href="../">guide</a>
       </nav>
     </header>
 
-    <section class="scenario-cards" id="scenario-cards" aria-label="Scenario picker"></section>
+    <aside
+      class="group md:contents max-md:fixed max-md:bottom-0 max-md:inset-x-0 max-md:z-40 max-md:bg-surface-secondary max-md:border-t max-md:border-stroke max-md:rounded-t-lg max-md:shadow-sheet max-md:max-h-[85dvh] max-md:translate-y-[calc(100%-64px)] max-md:transition-transform max-md:duration-slow max-md:ease-spring max-md:will-change-transform max-md:pb-[env(safe-area-inset-bottom)] max-md:data-[open=true]:translate-y-0"
+      id="controls-sheet"
+      data-open="false"
+    >
+      <button
+        class="hidden max-md:flex max-md:items-center max-md:gap-3 max-md:w-full max-md:h-16 max-md:px-4 max-md:pt-3.5 max-md:pb-2.5 max-md:bg-transparent max-md:border-0 max-md:shadow-none max-md:text-content max-md:text-left max-md:relative max-md:cursor-pointer"
+        id="sheet-toggle"
+        type="button"
+        aria-label="Controls"
+        aria-expanded="false"
+        aria-controls="sheet-body"
+      >
+        <span
+          class="max-md:absolute max-md:top-1.5 max-md:left-1/2 max-md:-translate-x-1/2 max-md:w-9 max-md:h-1 max-md:rounded-[2px] max-md:bg-stroke-strong max-md:transition-colors max-md:duration-fast group-data-[open=true]:bg-accent group-data-[open=true]:opacity-60"
+          aria-hidden="true"
+        ></span>
+        <div class="max-md:flex max-md:flex-1 max-md:items-baseline max-md:gap-2 max-md:min-w-0 max-md:overflow-hidden max-md:whitespace-nowrap">
+          <span id="sheet-scenario" class="text-[13px] font-semibold text-content overflow-hidden text-ellipsis">Convention burst</span>
+          <span class="text-content-disabled" aria-hidden="true">&middot;</span>
+          <span id="sheet-strategy" class="text-xs text-content-tertiary tabular-nums tracking-[0.02em]">ETD</span>
+        </div>
+        <span
+          class="max-md:inline-flex max-md:items-center max-md:justify-center max-md:flex-none max-md:w-10 max-md:h-10 max-md:rounded-full max-md:bg-accent-muted max-md:text-accent-hover max-md:border max-md:border-[color-mix(in_srgb,var(--accent)_35%,transparent)] max-md:text-sm max-md:leading-none max-md:shadow-sm max-md:transition-[transform,background] max-md:duration-fast max-md:active:scale-95 max-md:cursor-pointer"
+          id="sheet-play"
+          aria-hidden="true"
+        >&#9654;</span>
+      </button>
+      <div class="max-md:overflow-y-auto max-md:max-h-[calc(85dvh-64px)] max-md:pb-3 max-md:[-webkit-overflow-scrolling:touch]" id="sheet-body">
 
-    <section class="controls">
-      <div class="ctl ctl-strategy">
-        <label class="ctl-inline" for="strategy-a">
+    <section
+      id="scenario-cards"
+      aria-label="Scenario picker"
+      class="scenario-cards grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-2 px-5 py-2.5 border-b border-stroke-subtle max-md:flex max-md:flex-row max-md:gap-2 max-md:px-3.5 max-md:py-2.5 max-md:overflow-x-auto max-md:snap-x max-md:snap-mandatory max-md:[-webkit-overflow-scrolling:touch] max-md:[scrollbar-width:none] max-md:[&::-webkit-scrollbar]:hidden"
+    ></section>
+
+    <section class="controls flex flex-wrap gap-3.5 items-end px-5 py-3 bg-surface border-b border-stroke-subtle max-md:px-3.5 max-md:gap-2.5">
+      <div class="ctl-strategy flex flex-col gap-1 min-w-0 max-md:basis-full">
+        <label for="strategy-a">
           <span class="ctl-k">Strategy</span>
           <select id="strategy-a"></select>
         </label>
         <p id="strategy-desc" class="ctl-desc"></p>
       </div>
-      <label class="ctl hidden" id="strategy-b-wrap">
+      <label class="hidden flex flex-col gap-1 min-w-0 ctl-half" id="strategy-b-wrap">
         <span class="ctl-k">vs</span>
         <select id="strategy-b"></select>
       </label>
-      <label class="ctl ctl-check">
+      <label class="ctl-check flex flex-row items-center gap-2 px-2.5 py-2 bg-surface-elevated border border-stroke-subtle rounded-md cursor-pointer transition-colors duration-fast select-none hover:bg-surface-hover hover:border-stroke max-md:basis-full">
         <input id="compare" type="checkbox" />
-        <span class="ctl-k">Compare</span>
+        <span class="text-[11px] text-content-secondary font-medium tracking-[0.08em] uppercase">Compare</span>
       </label>
-      <label class="ctl">
+      <label class="flex flex-col gap-1 min-w-0 ctl-half">
         <span class="ctl-k">Seed</span>
-        <input id="seed" type="number" value="42" min="0" />
+        <input id="seed" type="number" value="42" min="0" class="max-md:min-h-10 max-md:w-full" />
       </label>
-      <label class="ctl">
+      <label class="flex flex-col gap-1 min-w-0 ctl-half">
         <span class="ctl-k">
           <span>Speed</span>
-          <span id="speed-label" class="ctl-v">2&times;</span>
+          <span id="speed-label" class="normal-case tracking-normal text-content-secondary text-[11.5px] tabular-nums">2&times;</span>
         </span>
-        <input id="speed" type="range" min="1" max="16" step="1" value="2" />
+        <input id="speed" type="range" min="1" max="16" step="1" value="2" class="max-md:w-full" />
       </label>
-      <label class="ctl">
+      <label class="flex flex-col gap-1 min-w-0 ctl-half">
         <span class="ctl-k">
           <span>Intensity</span>
-          <span id="traffic-label" class="ctl-v">1.0&times;</span>
+          <span id="traffic-label" class="normal-case tracking-normal text-content-secondary text-[11.5px] tabular-nums">1.0&times;</span>
         </span>
-        <input id="traffic" type="range" min="0.5" max="2" step="0.1" value="1" />
+        <input id="traffic" type="range" min="0.5" max="2" step="0.1" value="1" class="max-md:w-full" />
       </label>
-      <div class="actions">
-        <button id="tweak" type="button" aria-expanded="false" aria-controls="tweak-panel">
+      <div class="actions flex gap-2 ml-auto max-md:basis-full max-md:ml-0 max-md:flex-wrap">
+        <button id="tweak" type="button" aria-expanded="false" aria-controls="tweak-panel" class="max-md:flex-1 max-md:basis-[calc(50%-4px)] max-md:min-h-10">
           Tweak parameters
         </button>
-        <button id="play" type="button">Pause</button>
-        <button id="reset" type="button">Reset</button>
-        <button id="share" type="button">Share</button>
+        <button id="play" type="button" class="max-md:flex-1 max-md:basis-[calc(50%-4px)] max-md:min-h-10">Pause</button>
+        <button id="reset" type="button" class="max-md:flex-1 max-md:basis-[calc(50%-4px)] max-md:min-h-10">Reset</button>
+        <button id="share" type="button" class="max-md:flex-1 max-md:basis-[calc(50%-4px)] max-md:min-h-10">Share</button>
       </div>
     </section>
 
@@ -138,73 +172,124 @@
         <button type="button" id="tweak-reset-all" hidden>Reset all</button>
       </div>
     </section>
-
-    <section class="phase-strip" id="phase-strip">
-      <div class="phase-row">
-        <span class="phase-k">Phase</span>
-        <span id="phase-label" class="phase-v">&mdash;</span>
-        <span id="feature-hint" class="phase-hint"></span>
       </div>
-      <div class="phase-progress" aria-hidden="true">
-        <div class="phase-progress-fill" id="phase-progress-fill"></div>
+    </aside>
+
+    <section
+      id="phase-strip"
+      class="phase-strip flex flex-col gap-1.5 px-5 pt-2 pb-2.5 bg-surface border-b border-stroke-subtle text-[11.5px] text-content-tertiary max-md:px-3.5 max-md:py-1.5 max-md:pb-2 max-md:text-[11px]"
+    >
+      <div class="flex items-baseline gap-2.5">
+        <span class="ctl-k">Phase</span>
+        <span id="phase-label" class="text-content-secondary tabular-nums font-medium">&mdash;</span>
+        <span id="feature-hint" class="text-content-disabled text-[11px] flex-1 overflow-hidden text-ellipsis whitespace-nowrap"></span>
+      </div>
+      <div class="relative h-[3px] bg-surface-elevated rounded-[2px] overflow-hidden" aria-hidden="true">
+        <div
+          id="phase-progress-fill"
+          class="absolute inset-y-0 left-0 w-0 bg-gradient-to-r from-accent to-accent-hover shadow-[0_0_8px_color-mix(in_srgb,var(--accent)_45%,transparent)] transition-[width] duration-normal ease-normal"
+        ></div>
       </div>
     </section>
 
-    <section class="verdict-ribbon" id="verdict-ribbon" hidden aria-label="Comparison scoreboard"></section>
+    <section
+      id="verdict-ribbon"
+      hidden
+      aria-label="Comparison scoreboard"
+      class="verdict-ribbon grid grid-cols-[auto_repeat(5,1fr)] gap-3 px-5 py-2.5 bg-surface-secondary border-b border-stroke-subtle text-[11px] tabular-nums max-md:grid-cols-2 max-md:px-3.5"
+    ></section>
 
-    <main id="layout" class="layout" data-mode="single">
-      <section id="pane-a" class="pane pane-a">
-        <header class="pane-header">
-          <span class="pane-badge">A</span>
-          <div class="pane-title">
-            <span id="name-a" class="pane-name">LOOK</span>
-            <span id="decision-a" class="pane-decision" aria-live="polite"></span>
+    <main
+      id="layout"
+      data-mode="single"
+      class="layout grid gap-3.5 px-5 pt-3.5 pb-5 h-[calc(100dvh-130px)] data-[mode=single]:grid-cols-1 data-[mode=compare]:grid-cols-2 max-md:gap-2.5 max-md:px-[calc(14px+env(safe-area-inset-left))] max-md:pr-[calc(14px+env(safe-area-inset-right))] max-md:pt-2.5 max-md:pb-[calc(var(--sheet-peek,64px)+10px+env(safe-area-inset-bottom))] max-md:h-[calc(100dvh-44px)] max-md:data-[mode=compare]:grid-cols-1 max-md:landscape:data-[mode=compare]:grid-cols-2"
+    >
+      <section
+        id="pane-a"
+        class="pane pane-a grid grid-rows-[auto_1fr_auto] gap-2.5 min-w-0 min-h-0 p-3 bg-gradient-to-b from-surface-elevated to-surface-secondary border border-stroke-subtle border-t-2 border-t-pane-a rounded-lg shadow-md relative max-md:p-2.5 max-md:gap-2"
+        style="--pane-accent: var(--pane-a)"
+      >
+        <header class="pane-header flex items-center gap-2.5 px-0 py-0.5">
+          <span class="pane-badge inline-flex items-center justify-center w-[22px] h-[22px] rounded-sm bg-pane-a text-surface font-bold text-[11px] tracking-[0.04em] shadow-sm">A</span>
+          <div class="pane-title flex flex-col gap-px min-w-0 flex-1">
+            <span id="name-a" class="pane-name text-[13.5px] font-semibold tracking-[0.01em] text-content">LOOK</span>
+            <span id="decision-a" class="pane-decision max-md:text-[10px]" aria-live="polite"></span>
           </div>
-          <span id="mode-a" class="pane-mode" data-mode="Idle" title="Traffic mode from TrafficDetector">Idle</span>
+          <span
+            id="mode-a"
+            class="pane-mode ml-auto text-[10.5px] font-semibold tracking-[0.06em] uppercase px-2 py-0.5 rounded-sm border border-stroke-subtle bg-surface-elevated text-content-tertiary tabular-nums transition-colors data-[mode=Idle]:opacity-55"
+            data-mode="Idle"
+            title="Traffic mode from TrafficDetector"
+          >Idle</span>
         </header>
-        <div class="shaft-wrap">
-          <canvas id="shaft-a"></canvas>
+        <div class="shaft-wrap bg-[radial-gradient(ellipse_at_50%_0%,var(--bg-hover)_0%,var(--bg-secondary)_80%)] border border-stroke-subtle rounded-md overflow-hidden min-h-0 shadow-[inset_0_1px_0_rgba(255,255,255,0.02)] max-md:min-h-[200px]">
+          <canvas id="shaft-a" class="w-full h-full block"></canvas>
         </div>
-        <div id="metrics-a" class="metric-strip"></div>
+        <div id="metrics-a" class="metric-strip grid grid-cols-5 gap-1.5 p-0.5 tabular-nums max-md:grid-cols-3"></div>
       </section>
 
-      <section id="pane-b" class="pane pane-b">
-        <header class="pane-header">
-          <span class="pane-badge">B</span>
-          <div class="pane-title">
-            <span id="name-b" class="pane-name">ETD</span>
-            <span id="decision-b" class="pane-decision" aria-live="polite"></span>
+      <section
+        id="pane-b"
+        class="pane pane-b grid grid-rows-[auto_1fr_auto] gap-2.5 min-w-0 min-h-0 p-3 bg-gradient-to-b from-surface-elevated to-surface-secondary border border-stroke-subtle border-t-2 border-t-pane-b rounded-lg shadow-md relative max-md:p-2.5 max-md:gap-2"
+        style="--pane-accent: var(--pane-b)"
+      >
+        <header class="pane-header flex items-center gap-2.5 px-0 py-0.5">
+          <span class="pane-badge inline-flex items-center justify-center w-[22px] h-[22px] rounded-sm bg-pane-b text-surface font-bold text-[11px] tracking-[0.04em] shadow-sm">B</span>
+          <div class="pane-title flex flex-col gap-px min-w-0 flex-1">
+            <span id="name-b" class="pane-name text-[13.5px] font-semibold tracking-[0.01em] text-content">ETD</span>
+            <span id="decision-b" class="pane-decision max-md:text-[10px]" aria-live="polite"></span>
           </div>
-          <span id="mode-b" class="pane-mode" data-mode="Idle" title="Traffic mode from TrafficDetector">Idle</span>
+          <span
+            id="mode-b"
+            class="pane-mode ml-auto text-[10.5px] font-semibold tracking-[0.06em] uppercase px-2 py-0.5 rounded-sm border border-stroke-subtle bg-surface-elevated text-content-tertiary tabular-nums transition-colors data-[mode=Idle]:opacity-55"
+            data-mode="Idle"
+            title="Traffic mode from TrafficDetector"
+          >Idle</span>
         </header>
-        <div class="shaft-wrap">
-          <canvas id="shaft-b"></canvas>
+        <div class="shaft-wrap bg-[radial-gradient(ellipse_at_50%_0%,var(--bg-hover)_0%,var(--bg-secondary)_80%)] border border-stroke-subtle rounded-md overflow-hidden min-h-0 shadow-[inset_0_1px_0_rgba(255,255,255,0.02)] max-md:min-h-[200px]">
+          <canvas id="shaft-b" class="w-full h-full block"></canvas>
         </div>
-        <div id="metrics-b" class="metric-strip"></div>
+        <div id="metrics-b" class="metric-strip grid grid-cols-5 gap-1.5 p-0.5 tabular-nums max-md:grid-cols-3"></div>
       </section>
     </main>
 
-    <div id="loader" class="loader show" role="status" aria-live="polite">
-      <div class="loader-spinner" aria-hidden="true"></div>
-      <div class="loader-text">Loading simulation&hellip;</div>
+    <div
+      id="loader"
+      class="loader show fixed inset-0 grid place-items-center gap-3 bg-[color-mix(in_srgb,var(--bg-primary)_85%,transparent)] backdrop-blur-[2px] z-[60] opacity-0 pointer-events-none transition-opacity duration-slow [&.show]:opacity-100 [&.show]:pointer-events-auto"
+      role="status"
+      aria-live="polite"
+    >
+      <div class="w-[34px] h-[34px] rounded-full border-[3px] border-stroke-subtle border-t-accent animate-[spin_720ms_linear_infinite]" aria-hidden="true"></div>
+      <div class="text-content-tertiary text-xs tracking-[0.02em]">Loading simulation&hellip;</div>
     </div>
-    <div id="toast" class="toast" role="status"></div>
+    <div
+      id="toast"
+      class="toast fixed bottom-7 left-1/2 -translate-x-1/2 translate-y-2.5 scale-95 px-3.5 py-2 bg-surface-elevated border border-stroke rounded-lg shadow-lg text-content text-[12.5px] font-medium tracking-[0.01em] pointer-events-none z-[55] opacity-0 transition-all duration-normal ease-spring [&.show]:opacity-100 [&.show]:translate-y-0 [&.show]:scale-100"
+      role="status"
+    ></div>
 
-    <div id="shortcut-sheet" class="shortcut-sheet" hidden role="dialog" aria-modal="true" aria-label="Keyboard shortcuts">
-      <div class="shortcut-sheet-inner">
-        <header>
+    <div
+      id="shortcut-sheet"
+      hidden
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+      class="shortcut-sheet fixed inset-0 flex items-center justify-center bg-[color-mix(in_srgb,var(--bg-primary)_70%,transparent)] backdrop-blur-[4px] backdrop-saturate-[120%] z-[95]"
+    >
+      <div class="shortcut-sheet-inner w-[min(480px,90vw)] bg-gradient-to-b from-surface-hover to-surface-secondary border border-stroke rounded-lg shadow-lg p-[18px_20px_20px] text-content-secondary">
+        <header class="flex items-center justify-between mb-4 pb-3 border-b border-stroke-subtle text-content font-semibold text-sm tracking-[0.01em]">
           <span>Keyboard shortcuts</span>
-          <button type="button" id="shortcut-sheet-close" aria-label="Close">&times;</button>
+          <button type="button" id="shortcut-sheet-close" aria-label="Close" class="w-6 h-6 p-0 flex items-center justify-center bg-transparent border-0 text-content-tertiary text-base leading-none hover:text-content hover:bg-surface-hover rounded-sm">&times;</button>
         </header>
-        <dl>
-          <dt><kbd>Space</kbd></dt><dd>Pause / play</dd>
-          <dt><kbd>R</kbd></dt><dd>Reset the sim</dd>
-          <dt><kbd>C</kbd></dt><dd>Toggle compare mode</dd>
-          <dt><kbd>S</kbd></dt><dd>Copy permalink</dd>
-          <dt><kbd>T</kbd></dt><dd>Open / close the tweak panel</dd>
-          <dt><kbd>1</kbd>&nbsp;<kbd>2</kbd>&nbsp;<kbd>3</kbd></dt><dd>Jump to scenario card</dd>
-          <dt><kbd>&uarr;</kbd>&nbsp;<kbd>&darr;</kbd></dt><dd>Nudge focused tweak row</dd>
-          <dt><kbd>?</kbd></dt><dd>Toggle this sheet</dd>
+        <dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2.5 m-0">
+          <dt class="flex items-center gap-1 whitespace-nowrap"><kbd>Space</kbd></dt><dd class="m-0 text-content-tertiary">Pause / play</dd>
+          <dt class="flex items-center gap-1 whitespace-nowrap"><kbd>R</kbd></dt><dd class="m-0 text-content-tertiary">Reset the sim</dd>
+          <dt class="flex items-center gap-1 whitespace-nowrap"><kbd>C</kbd></dt><dd class="m-0 text-content-tertiary">Toggle compare mode</dd>
+          <dt class="flex items-center gap-1 whitespace-nowrap"><kbd>S</kbd></dt><dd class="m-0 text-content-tertiary">Copy permalink</dd>
+          <dt class="flex items-center gap-1 whitespace-nowrap"><kbd>T</kbd></dt><dd class="m-0 text-content-tertiary">Open / close the tweak panel</dd>
+          <dt class="flex items-center gap-1 whitespace-nowrap"><kbd>1</kbd>&nbsp;<kbd>2</kbd>&nbsp;<kbd>3</kbd></dt><dd class="m-0 text-content-tertiary">Jump to scenario card</dd>
+          <dt class="flex items-center gap-1 whitespace-nowrap"><kbd>&uarr;</kbd>&nbsp;<kbd>&darr;</kbd></dt><dd class="m-0 text-content-tertiary">Nudge focused tweak row</dd>
+          <dt class="flex items-center gap-1 whitespace-nowrap"><kbd>?</kbd></dt><dd class="m-0 text-content-tertiary">Toggle this sheet</dd>
         </dl>
       </div>
     </div>

--- a/playground/package.json
+++ b/playground/package.json
@@ -12,7 +12,9 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.2.2",
     "@types/node": "^22.0.0",
+    "tailwindcss": "^4.2.2",
     "typescript": "^5.6.0",
     "vite": "^6.4.2",
     "vitest": "^4.1.4"

--- a/playground/pnpm-lock.yaml
+++ b/playground/pnpm-lock.yaml
@@ -8,18 +8,24 @@ importers:
 
   .:
     devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.2.2
+        version: 4.2.2(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
+      tailwindcss:
+        specifier: ^4.2.2
+        version: 4.2.2
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(@types/node@22.19.17)
+        version: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@22.19.17)(vite@6.4.2(@types/node@22.19.17))
+        version: 4.1.4(@types/node@22.19.17)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))
 
 packages:
 
@@ -179,8 +185,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
@@ -323,6 +342,100 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@tailwindcss/node@4.2.2':
+    resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
+
+  '@tailwindcss/oxide-android-arm64@4.2.2':
+    resolution: {integrity: sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.2':
+    resolution: {integrity: sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.2.2':
+    resolution: {integrity: sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.2':
+    resolution: {integrity: sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
+    resolution: {integrity: sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
+    resolution: {integrity: sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
+    resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
+    resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
+    resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
+    resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
+    resolution: {integrity: sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
+    resolution: {integrity: sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.2.2':
+    resolution: {integrity: sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.2.2':
+    resolution: {integrity: sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -375,6 +488,14 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  enhanced-resolve@5.20.1:
+    resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
+    engines: {node: '>=10.13.0'}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
@@ -403,6 +524,87 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -446,6 +648,13 @@ packages:
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  tailwindcss@4.2.2:
+    resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
+
+  tapable@2.3.2:
+    resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
+    engines: {node: '>=6'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -636,7 +845,24 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     optional: true
@@ -715,6 +941,74 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@tailwindcss/node@4.2.2':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.20.1
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.2.2
+
+  '@tailwindcss/oxide-android-arm64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide@4.2.2':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.2.2
+      '@tailwindcss/oxide-darwin-arm64': 4.2.2
+      '@tailwindcss/oxide-darwin-x64': 4.2.2
+      '@tailwindcss/oxide-freebsd-x64': 4.2.2
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.2
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.2
+      '@tailwindcss/oxide-linux-arm64-musl': 4.2.2
+      '@tailwindcss/oxide-linux-x64-gnu': 4.2.2
+      '@tailwindcss/oxide-linux-x64-musl': 4.2.2
+      '@tailwindcss/oxide-wasm32-wasi': 4.2.2
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
+      '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
+
+  '@tailwindcss/vite@4.2.2(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))':
+    dependencies:
+      '@tailwindcss/node': 4.2.2
+      '@tailwindcss/oxide': 4.2.2
+      tailwindcss: 4.2.2
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -737,13 +1031,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@6.4.2(@types/node@22.19.17))':
+  '@vitest/mocker@4.1.4(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.2(@types/node@22.19.17)
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -774,6 +1068,13 @@ snapshots:
   chai@6.2.2: {}
 
   convert-source-map@2.0.0: {}
+
+  detect-libc@2.1.2: {}
+
+  enhanced-resolve@5.20.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.2
 
   es-module-lexer@2.0.0: {}
 
@@ -818,6 +1119,59 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  graceful-fs@4.2.11: {}
+
+  jiti@2.6.1: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   magic-string@0.30.21:
     dependencies:
@@ -878,6 +1232,10 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  tailwindcss@4.2.2: {}
+
+  tapable@2.3.2: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.1.1: {}
@@ -893,7 +1251,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  vite@6.4.2(@types/node@22.19.17):
+  vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -904,11 +1262,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.17
       fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
 
-  vitest@4.1.4(@types/node@22.19.17)(vite@6.4.2(@types/node@22.19.17)):
+  vitest@4.1.4(@types/node@22.19.17)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@6.4.2(@types/node@22.19.17))
+      '@vitest/mocker': 4.1.4(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -925,7 +1285,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 6.4.2(@types/node@22.19.17)
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17

--- a/playground/src/canvas.ts
+++ b/playground/src/canvas.ts
@@ -54,30 +54,33 @@ function scaleFor(width: number): Scale {
   };
 }
 
+// Palette mirrors style.css primitives. Canvas rendering can't read CSS
+// custom properties cheaply in a hot loop, so these are JS constants that
+// track the CSS tokens. Keep in sync with `:root` in src/style.css.
 const PHASE_COLORS: Record<Car["phase"], string> = {
-  idle: "#5d6271",
-  moving: "#06c2b5",
-  repositioning: "#a78bfa",
-  "door-opening": "#fbbf24",
-  loading: "#7dd3fc",
-  "door-closing": "#fbbf24",
-  stopped: "#8b90a0",
-  unknown: "#5d6271",
+  idle: "#6b6b75",          // --text-disabled
+  moving: "#f59e0b",        // --accent
+  repositioning: "#a78bfa", // violet — no CSS token; phase-specific hue
+  "door-opening": "#fbbf24", // --accent-up
+  loading: "#7dd3fc",       // --pane-a
+  "door-closing": "#fbbf24", // --accent-up
+  stopped: "#8b8c92",       // --text-tertiary
+  unknown: "#6b6b75",       // --text-disabled
 };
 
-const STOP_LINE = "#1f2431";
-const STOP_LABEL = "#c8ccd6";
-// Up and down use distinct hue families so the direction is legible at
-// small dot sizes. Cool blue reads as "up" (sky), warm amber as "down"
-// (gravity / descent).
-const UP_COLOR = "#7dd3fc";
-const DOWN_COLOR = "#fbbf24";
-const CAR_DOT_COLOR = "#f5f6f9";
-const OVERFLOW_COLOR = "#8b90a0";
-const SPARK_LINE = "#2e3445";
-const SPARK_TEXT = "#8b90a0";
-const TARGET_RING = "rgba(6, 194, 181, 0.85)";
-const TARGET_FILL = "rgba(6, 194, 181, 0.95)";
+const STOP_LINE = "#2a2a35";   // --border-subtle
+const STOP_LABEL = "#a1a1aa";  // --text-secondary
+// Up and down use distinct hue families so direction is legible at small
+// dot sizes. Cool blue reads as "up" (sky / lift), rose as "down" (gravity).
+// Rose chosen over amber since amber now owns the brand accent.
+const UP_COLOR = "#7dd3fc";    // --pane-a
+const DOWN_COLOR = "#fda4af";  // --pane-b
+const CAR_DOT_COLOR = "#fafafa"; // --text-primary
+const OVERFLOW_COLOR = "#8b8c92"; // --text-tertiary
+const SPARK_LINE = "#3a3a45";   // --border-default
+const SPARK_TEXT = "#8b8c92";   // --text-tertiary
+const TARGET_RING = "rgba(245, 158, 11, 0.85)"; // --accent at α
+const TARGET_FILL = "rgba(245, 158, 11, 0.95)"; // --accent at α
 
 // Board/alight animation baseline. Effective duration is divided by the sim
 // speed multiplier so fast-forwarded runs don't queue stale tweens.
@@ -516,7 +519,7 @@ export class CanvasRenderer {
       // Outer pulsing ring + inner dot. The ring reads "this car is
       // committed to going there"; the inner dot anchors the mark on
       // the rung even when the ring is subtle.
-      ctx.strokeStyle = `rgba(6, 194, 181, ${pulse})`;
+      ctx.strokeStyle = `rgba(245, 158, 11, ${pulse})`;
       ctx.lineWidth = 2;
       ctx.beginPath();
       ctx.arc(cx, cy, outerR, 0, Math.PI * 2);
@@ -558,7 +561,7 @@ export class CanvasRenderer {
     const cy = toScreenY(car.y);
     const halfW = s.carW / 2;
     const halfH = s.carH / 2;
-    const base = PHASE_COLORS[car.phase] ?? "#5d6271";
+    const base = PHASE_COLORS[car.phase] ?? "#6b6b75";
 
     const grad = ctx.createLinearGradient(cx, cy - halfH, cx, cy + halfH);
     grad.addColorStop(0, shade(base, 0.14));

--- a/playground/src/canvas.ts
+++ b/playground/src/canvas.ts
@@ -171,7 +171,7 @@ function easeOutNorm(tx: number): number {
 export class CanvasRenderer {
   #canvas: HTMLCanvasElement;
   #ctx: CanvasRenderingContext2D;
-  #dpr: number;
+  #dpr: number = window.devicePixelRatio || 1;
   #onResize: () => void;
   #cachedScale: Scale | null = null;
   #cachedScaleWidth = -1;
@@ -188,7 +188,6 @@ export class CanvasRenderer {
     const ctx = canvas.getContext("2d");
     if (!ctx) throw new Error("2D context unavailable");
     this.#ctx = ctx;
-    this.#dpr = window.devicePixelRatio || 1;
     this.#accent = accent;
     this.#sparkLabel = sparkLabel;
     this.#resize();
@@ -201,6 +200,9 @@ export class CanvasRenderer {
   }
 
   #resize(): void {
+    // Re-read DPR each resize so browser zoom / moving to a different-density
+    // display updates the backing-store scale. `resize` fires on both.
+    this.#dpr = window.devicePixelRatio || 1;
     const { clientWidth, clientHeight } = this.#canvas;
     if (clientWidth === 0 || clientHeight === 0) return;
     const targetW = clientWidth * this.#dpr;
@@ -955,13 +957,19 @@ function truncate(ctx: CanvasRenderingContext2D, text: string, maxWidth: number)
   return lo === 0 ? ellipsis : text.slice(0, lo) + ellipsis;
 }
 
-/** Apply `alpha` (0..1) to a 6-digit hex color. Used for pane-tinted
+/** Apply `alpha` (0..1) to a `#RRGGBB` hex color. Used for pane-tinted
  *  canvas strokes where we have a base hex and want a translucent
- *  variant without adding a CSS variable lookup on every frame. */
+ *  variant without adding a CSS variable lookup on every frame.
+ *
+ *  Falls back to `hexWithAlpha` (rgba() form) for anything that isn't
+ *  strictly `#RRGGBB` — cheap safety net so a future caller passing
+ *  shorthand or a CSS variable doesn't silently drop alpha. */
 function withAlpha(hex: string, alpha: number): string {
-  const a = Math.round(Math.max(0, Math.min(1, alpha)) * 255);
-  const suffix = a.toString(16).padStart(2, "0");
-  return hex.length === 7 ? `${hex}${suffix}` : hex;
+  if (/^#[0-9a-f]{6}$/i.test(hex)) {
+    const a = Math.round(Math.max(0, Math.min(1, alpha)) * 255);
+    return `${hex}${a.toString(16).padStart(2, "0")}`;
+  }
+  return hexWithAlpha(hex, alpha);
 }
 
 /**

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -214,6 +214,11 @@ interface UiHandles {
   shortcutsBtn: HTMLButtonElement;
   shortcutSheet: HTMLElement;
   shortcutSheetClose: HTMLButtonElement;
+  sheet: HTMLElement;
+  sheetToggle: HTMLButtonElement;
+  sheetScenario: HTMLElement;
+  sheetStrategy: HTMLElement;
+  sheetPlay: HTMLElement;
   paneA: PaneHandles;
   paneB: PaneHandles;
 }
@@ -348,6 +353,11 @@ function wireUi(): UiHandles {
     shortcutsBtn: q<HTMLButtonElement>("shortcuts"),
     shortcutSheet: q("shortcut-sheet"),
     shortcutSheetClose: q<HTMLButtonElement>("shortcut-sheet-close"),
+    sheet: q("controls-sheet"),
+    sheetToggle: q<HTMLButtonElement>("sheet-toggle"),
+    sheetScenario: q("sheet-scenario"),
+    sheetStrategy: q("sheet-strategy"),
+    sheetPlay: q("sheet-play"),
     paneA: paneHandles("a", COLOR_A),
     paneB: paneHandles("b", COLOR_B),
   };
@@ -380,6 +390,7 @@ function applyPermalinkToUi(p: PermalinkState, ui: UiHandles): void {
   syncScenarioCards(ui, p.scenario);
   const scenario = scenarioById(p.scenario);
   if (ui.featureHint) ui.featureHint.textContent = scenario.featureHint;
+  syncSheetCompact(ui, scenario.label, p.strategyA);
   // Auto-open the drawer when the permalink carries any override —
   // the recipient sees what the sender customized without an extra
   // click. A clean URL leaves the drawer closed so first-time
@@ -609,6 +620,7 @@ function attachListeners(state: State, ui: UiHandles): void {
     const strategyA = ui.strategyASelect.value as StrategyName;
     state.permalink = { ...state.permalink, strategyA };
     renderStrategyDesc(ui, strategyA);
+    syncSheetCompact(ui, scenarioById(state.permalink.scenario).label, strategyA);
     await resetAll(state, ui);
     toast(ui, `A: ${STRATEGY_LABELS[state.permalink.strategyA]}`);
   });
@@ -650,6 +662,21 @@ function attachListeners(state: State, ui: UiHandles): void {
   ui.playBtn.addEventListener("click", () => {
     state.running = !state.running;
     ui.playBtn.textContent = state.running ? "Pause" : "Play";
+    // Pause glyph when running (offering "pause"), play glyph when paused.
+    ui.sheetPlay.textContent = state.running ? "\u23F8" : "\u25B6";
+  });
+
+  // ── Bottom sheet (mobile drawer) ─────────────────────────────────
+  ui.sheetToggle.addEventListener("click", () => {
+    const open = ui.sheet.dataset.open !== "true";
+    ui.sheet.dataset.open = String(open);
+    ui.sheetToggle.setAttribute("aria-expanded", String(open));
+  });
+  // The play glyph lives inside the sheet handle; stop propagation so
+  // tapping it doesn't also open/close the sheet.
+  ui.sheetPlay.addEventListener("click", (ev) => {
+    ev.stopPropagation();
+    ui.playBtn.click();
   });
   ui.resetBtn.addEventListener("click", () => {
     void resetAll(state, ui);
@@ -1097,7 +1124,10 @@ function el<K extends keyof HTMLElementTagNameMap>(
 function initMetricRows(root: HTMLElement): void {
   const frag = document.createDocumentFragment();
   for (const [label] of METRIC_DEFS) {
-    const row = el("div", "metric-row");
+    const row = el(
+      "div",
+      "metric-row flex flex-col gap-[3px] px-2.5 py-[7px] bg-surface-elevated border border-stroke-subtle rounded-md transition-colors duration-normal",
+    );
     // SVG sparkline lives in the metric row and is mutated in place each
     // frame. Using SVG (not another canvas) keeps it crisp at any DPR
     // and lets CSS drive the stroke color via `currentColor` / the
@@ -1107,7 +1137,18 @@ function initMetricRows(root: HTMLElement): void {
     spark.setAttribute("viewBox", "0 0 100 14");
     spark.setAttribute("preserveAspectRatio", "none");
     spark.appendChild(document.createElementNS("http://www.w3.org/2000/svg", "path"));
-    row.append(el("span", "metric-k", label), el("span", "metric-v"), spark);
+    row.append(
+      el(
+        "span",
+        "text-[9.5px] uppercase tracking-[0.08em] text-content-disabled font-medium",
+        label,
+      ),
+      el(
+        "span",
+        "metric-v text-[15px] text-content font-medium [font-feature-settings:'tnum'_1]",
+      ),
+      spark,
+    );
     frag.appendChild(row);
   }
   root.replaceChildren(frag);
@@ -1345,23 +1386,45 @@ function drainSeedBatch(state: State): void {
 
 // ─── Scenario cards ──────────────────────────────────────────────────
 
+// Hoisted so the utility chain isn't reassembled on every render, and so a
+// designer scanning the card markup sees one source of truth per subpart.
+// The `.scenario-card` marker stays live — the CSS `::before` accent
+// indicator (style.css) keys off `[aria-pressed="true"]` on this class.
+const SCENARIO_CARD_CLS =
+  "scenario-card relative flex flex-col gap-[3px] px-3 py-2 " +
+  "bg-gradient-to-b from-surface-elevated to-surface-secondary " +
+  "border border-stroke-subtle rounded-md text-content-secondary text-left " +
+  "shadow-sm cursor-pointer " +
+  "transition-[border-color,transform,box-shadow,background] duration-normal " +
+  "hover:-translate-y-px hover:border-stroke-strong hover:shadow-md " +
+  "hover:from-surface-hover hover:to-surface-elevated " +
+  "active:translate-y-0 " +
+  "aria-pressed:border-[color-mix(in_srgb,var(--accent)_55%,transparent)] " +
+  "aria-pressed:from-accent-muted aria-pressed:to-surface-elevated " +
+  "aria-pressed:shadow-[0_0_0_1px_color-mix(in_srgb,var(--accent)_25%,transparent),var(--shadow-md)] " +
+  "max-md:flex-none max-md:min-w-[140px] max-md:snap-start";
+const SCENARIO_LABEL_CLS =
+  "flex items-center gap-2 text-[13px] font-semibold text-content tracking-[0.005em]";
+const SCENARIO_KBD_CLS =
+  "inline-flex items-center justify-center min-w-[18px] h-[18px] px-[5px] " +
+  "text-[10px] font-semibold text-content-disabled bg-surface border border-stroke " +
+  "rounded-sm ml-auto tabular-nums";
+const SCENARIO_DESC_CLS =
+  "text-[11.5px] text-content-tertiary leading-[1.35] max-md:hidden";
+
 function renderScenarioCards(ui: UiHandles): void {
   const frag = document.createDocumentFragment();
   SCENARIOS.forEach((s, i) => {
-    const card = el("button", "scenario-card");
+    const card = el("button", SCENARIO_CARD_CLS);
     card.type = "button";
     card.dataset.scenarioId = s.id;
     card.setAttribute("aria-pressed", "false");
-    const label = el("span", "scenario-card-label");
+    const label = el("span", SCENARIO_LABEL_CLS);
     label.append(
       el("span", "", s.label),
-      el("span", "scenario-card-kbd", String(i + 1)),
+      el("span", SCENARIO_KBD_CLS, String(i + 1)),
     );
-    card.append(
-      label,
-      el("span", "scenario-card-desc", s.description),
-      el("span", "scenario-card-hint", s.featureHint),
-    );
+    card.append(label, el("span", SCENARIO_DESC_CLS, s.description));
     frag.appendChild(card);
   });
   ui.scenarioCards.replaceChildren(frag);
@@ -1387,6 +1450,15 @@ function syncScenarioCards(ui: UiHandles, scenarioId: string): void {
  * cross-scenario carry-over surprised more than it helped during
  * early prototyping.
  */
+function syncSheetCompact(
+  ui: UiHandles,
+  scenarioLabel: string,
+  strategyA: StrategyName,
+): void {
+  ui.sheetScenario.textContent = scenarioLabel;
+  ui.sheetStrategy.textContent = STRATEGY_LABELS[strategyA];
+}
+
 async function switchScenario(
   state: State,
   ui: UiHandles,
@@ -1408,6 +1480,7 @@ async function switchScenario(
   ui.strategyASelect.value = nextStrategyA;
   renderStrategyDesc(ui, nextStrategyA);
   syncScenarioCards(ui, scenario.id);
+  syncSheetCompact(ui, scenario.label, nextStrategyA);
   await resetAll(state, ui);
   renderTweakPanel(scenario, state.permalink.overrides, ui);
   toast(ui, `${scenario.label} · ${STRATEGY_LABELS[nextStrategyA]}`);
@@ -1423,12 +1496,31 @@ function renderStrategyDesc(ui: UiHandles, strategy: StrategyName): void {
 
 function renderVerdictRibbon(root: HTMLElement, verdictsA: MetricVerdicts): void {
   if (root.childElementCount === 0) {
-    root.appendChild(el("span", "verdict-ribbon-title", "Who's winning?"));
+    root.appendChild(
+      el(
+        "span",
+        "text-[10.5px] uppercase tracking-[0.08em] text-content-disabled font-medium whitespace-nowrap max-md:col-span-full",
+        "Who's winning?",
+      ),
+    );
     for (const [label] of METRIC_DEFS) {
-      const cell = el("div", "verdict-cell");
+      // `.verdict-cell` stays — CSS keys the winner-color cascade off its
+      // `[data-winner]` attribute. `.verdict-cell-winner` also stays — it's
+      // the child that cascade colors.
+      const cell = el(
+        "div",
+        "verdict-cell flex items-center gap-1.5 px-2 py-1 rounded-sm bg-surface-elevated border border-stroke-subtle tabular-nums overflow-hidden",
+      );
       cell.append(
-        el("span", "verdict-cell-k", label),
-        el("span", "verdict-cell-winner"),
+        el(
+          "span",
+          "text-[10.5px] uppercase tracking-[0.06em] text-content-disabled",
+          label,
+        ),
+        el(
+          "span",
+          "verdict-cell-winner font-semibold text-content tracking-[0.02em]",
+        ),
       );
       root.appendChild(cell);
     }

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -1,102 +1,211 @@
+@import "tailwindcss";
+
+/* Exclude build outputs from Tailwind's class detection. */
+@source not "../dist";
+@source not "../public";
+
+/* Tailwind v4 semantic design tokens. Follows the gridfinity-layout-tool
+ * convention: primitive palette lives in `:root`, and `@theme` aliases it
+ * into Tailwind's `--color-*`, `--radius-*`, `--shadow-*`, `--ease-*`,
+ * `--breakpoint-*` namespaces so utilities like `bg-surface`, `text-content`,
+ * `border-stroke-subtle`, `rounded-md`, `shadow-md`, `md:grid-cols-2`
+ * resolve to the playground's values.
+ *
+ * Change a primitive (`--bg-primary`, `--accent`) once in `:root` and every
+ * utility + legacy custom class updates in lockstep. */
+@theme {
+  /* Surfaces */
+  --color-surface: var(--bg-primary);
+  --color-surface-secondary: var(--bg-secondary);
+  --color-surface-elevated: var(--bg-elevated);
+  --color-surface-hover: var(--bg-hover);
+  --color-surface-active: var(--bg-active);
+
+  /* Text / content */
+  --color-content: var(--text-primary);
+  --color-content-secondary: var(--text-secondary);
+  --color-content-tertiary: var(--text-tertiary);
+  --color-content-disabled: var(--text-disabled);
+
+  /* Strokes / borders */
+  --color-stroke-subtle: var(--border-subtle);
+  --color-stroke: var(--border-default);
+  --color-stroke-strong: var(--border-strong);
+
+  /* Semantic */
+  --color-accent: var(--accent);
+  --color-accent-hover: var(--accent-up);
+  --color-accent-muted: var(--accent-soft);
+  --color-success: var(--ok);
+  --color-success-muted: var(--ok-soft);
+  --color-error: var(--bad);
+  --color-error-muted: var(--bad-soft);
+
+  /* Pane identities — used by compare mode */
+  --color-pane-a: var(--pane-a);
+  --color-pane-b: var(--pane-b);
+  --color-pane-a-muted: var(--pane-a-soft);
+  --color-pane-b-muted: var(--pane-b-soft);
+
+  /* Radii */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 14px;
+
+  /* Shadows (with gridfinity's inset-highlight elevation treatment) */
+  --shadow-sm: 0 1px 0 rgba(255, 255, 255, 0.02) inset, 0 1px 2px rgba(0, 0, 0, 0.35);
+  --shadow-md: 0 1px 0 rgba(255, 255, 255, 0.02) inset, 0 6px 14px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 1px 0 rgba(255, 255, 255, 0.03) inset, 0 14px 34px rgba(0, 0, 0, 0.45);
+  --shadow-sheet: 0 -8px 28px rgba(0, 0, 0, 0.5);
+
+  /* Motion — durations + curves split so Tailwind's `duration-*` and
+   * `ease-*` utilities both resolve, and custom CSS can use `--transition-*`
+   * shorthand from :root below. */
+  --duration-fast: 90ms;
+  --duration-normal: 160ms;
+  --duration-slow: 240ms;
+  --ease-fast: cubic-bezier(0, 0, 0.2, 1);
+  --ease-normal: cubic-bezier(0.2, 0.6, 0.2, 1);
+  --ease-slow: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* Breakpoints — match gridfinity's scale so `sm:`, `md:`, `lg:`, `xl:`
+   * utilities work consistently across both codebases. */
+  --breakpoint-sm: 640px;
+  --breakpoint-md: 768px;
+  --breakpoint-lg: 900px;
+  --breakpoint-xl: 1280px;
+
+  /* Typography scale — gridfinity-aligned. `text-base` is 14px so UI
+   * density matches gridfinity-layout-tool. `text-xxs` is new for tiny
+   * metric-strip labels; `text-sm` at 13px is the tight-label standard. */
+  --text-xxs: 0.625rem;  /* 10px */
+  --text-xs: 0.75rem;    /* 12px */
+  --text-sm: 0.8125rem;  /* 13px */
+  --text-base: 0.875rem; /* 14px */
+  --text-lg: 1rem;       /* 16px */
+  --text-xl: 1.125rem;   /* 18px */
+  --text-2xl: 1.5rem;    /* 24px */
+}
+
 :root {
-  /* Surfaces — cool-neutral near-black, layered in small steps. */
-  --ink-0: #0a0c10;
-  --ink-1: #10131a;
-  --ink-2: #161a23;
-  --ink-3: #1e232e;
-  --ink-4: #272d3a;
+  /* ============================================
+     PRIMITIVE PALETTE — warm-dark, amber accent.
+     Matches gridfinity-layout-tool token names.
+     ============================================ */
 
-  /* Strokes — quiet at rest, strong on emphasis. */
-  --line-1: #1f2431;
-  --line-2: #2e3445;
-  --line-3: #3d4458;
+  /* Backgrounds — warm-dark, layered in small steps. */
+  --bg-primary: #0f0f12;
+  --bg-secondary: #1a1a1f;
+  --bg-elevated: #252530;
+  --bg-hover: #2a2a35;
+  --bg-active: #323240;
 
-  /* Text — wide tonal range so hierarchy reads without color. */
-  --fg-0: #f5f6f9;
-  --fg-1: #c8ccd6;
-  --fg-2: #8b90a0;
-  --fg-3: #5d6271;
+  /* Borders — quiet at rest, strong on emphasis. */
+  --border-subtle: #2a2a35;
+  --border-default: #3a3a45;
+  --border-strong: #4a4a55;
 
-  /* One accent — used only for focus, active states, primary CTA. */
-  --accent: #06c2b5;
-  --accent-up: #0ad4c6;
-  --accent-soft: rgba(6, 194, 181, 0.14);
+  /* Text — wide tonal range so hierarchy reads without colour. */
+  --text-primary: #fafafa;
+  --text-secondary: #a1a1aa;
+  --text-tertiary: #8b8c92;
+  --text-disabled: #6b6b75;
 
-  /* Pane identities — distinct hues for A vs B comparison. */
+  /* Accent — amber, matches gridfinity-layout-tool. */
+  --accent: #f59e0b;
+  --accent-up: #fbbf24;
+  --accent-soft: color-mix(in srgb, var(--accent) 15%, transparent);
+
+  /* Pane identities — functional A/B distinction. */
   --pane-a: #7dd3fc;
   --pane-b: #fda4af;
-  --pane-a-soft: rgba(125, 211, 252, 0.1);
-  --pane-b-soft: rgba(253, 164, 175, 0.1);
+  --pane-a-soft: color-mix(in srgb, var(--pane-a) 10%, transparent);
+  --pane-b-soft: color-mix(in srgb, var(--pane-b) 10%, transparent);
 
   /* Verdict semantics. */
-  --ok: #5dd99a;
-  --bad: #f07a7a;
-  --ok-soft: rgba(93, 217, 154, 0.1);
-  --bad-soft: rgba(240, 122, 122, 0.1);
+  --ok: #22c55e;
+  --ok-soft: color-mix(in srgb, var(--ok) 10%, transparent);
+  --bad: #ef4444;
+  --bad-soft: color-mix(in srgb, var(--bad) 10%, transparent);
 
-  /* Elevation. */
-  --shadow-1: 0 1px 0 rgba(255, 255, 255, 0.02) inset, 0 1px 2px rgba(0, 0, 0, 0.35);
-  --shadow-2: 0 1px 0 rgba(255, 255, 255, 0.02) inset, 0 6px 14px rgba(0, 0, 0, 0.4);
-  --shadow-3: 0 1px 0 rgba(255, 255, 255, 0.03) inset, 0 14px 34px rgba(0, 0, 0, 0.45);
+  /* Focus ring */
+  --focus-ring: var(--accent);
 
-  /* Motion. */
-  --t-quick: 90ms ease-out;
-  --t-norm: 160ms cubic-bezier(0.2, 0.6, 0.2, 1);
-  --t-spring: 240ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  /* Mobile touch target (matches Apple HIG) */
+  --touch-target: 44px;
 
-  /* Shape. */
-  --r-1: 4px;
-  --r-2: 8px;
-  --r-3: 14px;
+  /* Transition shorthand — combined duration + curve for custom CSS
+   * convenience. Tailwind utilities consume the split tokens from @theme. */
+  --transition-fast: var(--duration-fast) var(--ease-fast);
+  --transition-normal: var(--duration-normal) var(--ease-normal);
+  --transition-slow: var(--duration-slow) var(--ease-slow);
+  --transition-spring: var(--duration-slow) var(--ease-spring);
 }
 
-* {
-  box-sizing: border-box;
+/* Custom CSS is layered so Tailwind utilities (utilities layer) cleanly
+ * override any component-level rules below. Without this the unlayered
+ * custom CSS would always win over utility classes. */
+@layer base {
+  * {
+    box-sizing: border-box;
+  }
+
+  html,
+  body {
+    margin: 0;
+    padding: 0;
+    min-height: 100%;
+    background:
+      radial-gradient(1200px 600px at 80% -10%, color-mix(in srgb, var(--accent) 6%, transparent), transparent 60%),
+      radial-gradient(1000px 500px at -10% 100%, color-mix(in srgb, var(--pane-a) 5%, transparent), transparent 55%),
+      var(--bg-primary);
+    color: var(--text-primary);
+    font: 13.5px / 1.45 system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-variant-numeric: tabular-nums;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  :focus-visible {
+    outline: 2px solid var(--focus-ring);
+    outline-offset: -2px;
+    border-radius: var(--radius-sm);
+  }
+  button:focus-visible,
+  input:focus-visible,
+  select:focus-visible {
+    outline: 2px solid var(--focus-ring);
+    outline-offset: -2px;
+  }
 }
 
-html,
-body {
-  margin: 0;
-  padding: 0;
-  min-height: 100%;
-  background:
-    radial-gradient(1200px 600px at 80% -10%, rgba(6, 194, 181, 0.06), transparent 60%),
-    radial-gradient(1000px 500px at -10% 100%, rgba(125, 211, 252, 0.05), transparent 55%),
-    var(--ink-0);
-  color: var(--fg-0);
-  font: 13.5px / 1.45 system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
-  font-variant-numeric: tabular-nums;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
+@layer components {
+  .hidden {
+    display: none !important;
+  }
 
-.hidden {
-  display: none !important;
-}
+  /* Sheet handle desktop hide + mobile show is now inlined via
+   * `hidden max-md:flex` on the `<button id="sheet-toggle">`. */
 
-:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
-  border-radius: var(--r-1);
-}
-button:focus-visible,
-input:focus-visible,
-select:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
-}
+  /* Shared label pattern for the controls strip — used on Strategy, vs,
+   * Seed, Speed, Intensity. Kept as a component class (vs inline utilities)
+   * because the exact 7-utility chain repeats 5 times in the same region. */
+  .ctl-k {
+    @apply inline-flex items-baseline gap-1.5 text-[10.5px] uppercase tracking-[0.08em] text-content-disabled font-medium;
+  }
+
+  /* Two-up mobile field width — halves minus the 20px row gap. Repeats on
+   * every non-strategy field in the controls strip. */
+  .ctl-half {
+    @apply max-md:basis-[calc(50%-10px)];
+  }
 
 /* ── Header ─────────────────────────────────────────────────────────── */
 
-.top {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 14px 20px;
-  background: linear-gradient(180deg, var(--ink-1) 0%, var(--ink-0) 100%);
-  border-bottom: 1px solid var(--line-1);
-  position: relative;
-}
+/* The top bar's accent underglow isn't expressible as a Tailwind utility
+ * (complex 90deg transparent→accent→transparent gradient) so the pseudo-
+ * element stays here. Box-model + color properties moved to utilities. */
 .top::after {
   content: "";
   position: absolute;
@@ -107,108 +216,16 @@ select:focus-visible {
   background: linear-gradient(
     90deg,
     transparent,
-    rgba(6, 194, 181, 0.3) 20%,
-    rgba(6, 194, 181, 0.3) 80%,
+    color-mix(in srgb, var(--accent) 30%, transparent) 20%,
+    color-mix(in srgb, var(--accent) 30%, transparent) 80%,
     transparent
   );
   opacity: 0.4;
 }
-.top h1 {
-  margin: 0;
-  font-size: 14px;
-  font-weight: 600;
-  letter-spacing: -0.005em;
-  color: var(--fg-0);
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-}
-.top h1::before {
-  content: "";
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 2px;
-  background: var(--accent);
-  box-shadow: 0 0 10px rgba(6, 194, 181, 0.5);
-}
-.top nav a {
-  margin-left: 16px;
-  color: var(--fg-2);
-  text-decoration: none;
-  font-size: 12px;
-  transition: color var(--t-quick);
-}
-.top nav a:hover {
-  color: var(--fg-0);
-}
 
-/* ── Controls ───────────────────────────────────────────────────────── */
-
-.controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 14px;
-  align-items: flex-end;
-  padding: 12px 20px;
-  background: var(--ink-0);
-  border-bottom: 1px solid var(--line-1);
-}
-
-/* Phase strip sits directly below the controls row: a single-line
- * readout of the current traffic phase plus the scenario's feature
- * hint, topped with a hairline progress bar toward the next phase.
- * Deliberately quiet styling — the shafts are the focus. */
-.phase-strip {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 8px 20px 10px;
-  background: var(--ink-0);
-  border-bottom: 1px solid var(--line-1);
-  font-size: 11.5px;
-  color: var(--fg-2);
-}
-.phase-row {
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
-}
-.phase-progress {
-  position: relative;
-  height: 3px;
-  background: var(--ink-2);
-  border-radius: 2px;
-  overflow: hidden;
-}
-.phase-progress-fill {
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: 0%;
-  background: linear-gradient(90deg, var(--accent) 0%, var(--accent-up) 100%);
-  box-shadow: 0 0 8px rgba(6, 194, 181, 0.45);
-  transition: width var(--t-norm);
-}
-.phase-k {
-  font-size: 10.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--fg-3);
-  font-weight: 500;
-}
-.phase-v {
-  color: var(--fg-1);
-  font-variant-numeric: tabular-nums;
-  font-weight: 500;
-}
-.phase-hint {
-  color: var(--fg-3);
-  font-size: 11px;
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
+/* Controls and phase strip base styling moved to Tailwind utilities on the
+ * respective HTML elements. See index.html `<section class="controls ...">`
+ * and `<section class="phase-strip ...">`. */
 
 /* ── Tweak panel ───────────────────────────────────────────────────── */
 
@@ -217,10 +234,10 @@ select:focus-visible {
   grid-template-columns: repeat(auto-fit, minmax(290px, 1fr));
   gap: 10px 18px;
   padding: 12px 20px 14px;
-  background: linear-gradient(180deg, var(--ink-1) 0%, var(--ink-0) 100%);
-  border-bottom: 1px solid var(--line-1);
+  background: linear-gradient(180deg, var(--bg-secondary) 0%, var(--bg-primary) 100%);
+  border-bottom: 1px solid var(--border-subtle);
   font-variant-numeric: tabular-nums;
-  animation: tweak-slide var(--t-norm) ease-out;
+  animation: tweak-slide var(--transition-normal) ease-out;
 }
 .tweak-panel[hidden] {
   display: none;
@@ -242,13 +259,13 @@ select:focus-visible {
   align-items: center;
   gap: 10px;
   padding: 8px 10px;
-  background: var(--ink-2);
-  border: 1px solid var(--line-1);
-  border-radius: var(--r-2);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
   transition:
-    border-color var(--t-norm),
-    background var(--t-norm),
-    box-shadow var(--t-norm);
+    border-color var(--transition-normal),
+    background var(--transition-normal),
+    box-shadow var(--transition-normal);
   outline: none;
 }
 .tweak-row:focus-visible {
@@ -256,18 +273,18 @@ select:focus-visible {
   box-shadow: 0 0 0 2px var(--accent-soft);
 }
 .tweak-row[data-overridden="true"] {
-  border-color: rgba(6, 194, 181, 0.35);
-  background: linear-gradient(180deg, var(--accent-soft) 0%, var(--ink-2) 100%);
+  border-color: color-mix(in srgb, var(--accent) 35%, transparent);
+  background: linear-gradient(180deg, var(--accent-soft) 0%, var(--bg-elevated) 100%);
 }
 
 .tweak-label {
   font-size: 11.5px;
-  color: var(--fg-1);
+  color: var(--text-secondary);
   font-weight: 500;
   letter-spacing: 0.005em;
 }
 .tweak-unit {
-  color: var(--fg-3);
+  color: var(--text-disabled);
   font-size: 10.5px;
   margin-left: 4px;
 }
@@ -276,16 +293,16 @@ select:focus-visible {
   display: inline-flex;
   align-items: center;
   gap: 0;
-  background: var(--ink-1);
-  border: 1px solid var(--line-2);
-  border-radius: var(--r-2);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 .tweak-stepper button {
   appearance: none;
   background: transparent;
   border: 0;
-  color: var(--fg-1);
+  color: var(--text-secondary);
   width: 26px;
   height: 28px;
   padding: 0;
@@ -293,23 +310,23 @@ select:focus-visible {
   font-weight: 600;
   cursor: pointer;
   transition:
-    background var(--t-quick),
-    color var(--t-quick);
+    background var(--transition-fast),
+    color var(--transition-fast);
   box-shadow: none;
   border-radius: 0;
   letter-spacing: 0;
 }
 .tweak-stepper button:hover {
-  background: var(--ink-3);
-  color: var(--fg-0);
+  background: var(--bg-hover);
+  color: var(--text-primary);
   transform: none;
   box-shadow: none;
 }
 .tweak-stepper button:active {
-  background: var(--ink-4);
+  background: var(--bg-active);
 }
 .tweak-stepper button:disabled {
-  color: var(--fg-3);
+  color: var(--text-disabled);
   cursor: not-allowed;
   background: transparent;
 }
@@ -320,12 +337,12 @@ select:focus-visible {
   min-width: 56px;
   height: 28px;
   padding: 0 8px;
-  color: var(--fg-0);
+  color: var(--text-primary);
   font-size: 12.5px;
   font-weight: 500;
-  border-left: 1px solid var(--line-2);
-  border-right: 1px solid var(--line-2);
-  background: var(--ink-2);
+  border-left: 1px solid var(--border-default);
+  border-right: 1px solid var(--border-default);
+  background: var(--bg-elevated);
   font-variant-numeric: tabular-nums;
 }
 .tweak-row[data-overridden="true"] .tweak-value {
@@ -334,36 +351,36 @@ select:focus-visible {
 
 .tweak-default {
   font-size: 10.5px;
-  color: var(--fg-3);
+  color: var(--text-disabled);
   letter-spacing: 0.02em;
   white-space: nowrap;
 }
 .tweak-default-v {
-  color: var(--fg-2);
+  color: var(--text-tertiary);
   font-variant-numeric: tabular-nums;
 }
 
 .tweak-reset {
   appearance: none;
   background: transparent;
-  border: 1px solid var(--line-2);
-  color: var(--fg-2);
+  border: 1px solid var(--border-default);
+  color: var(--text-tertiary);
   font-size: 10.5px;
   font-weight: 500;
   letter-spacing: 0.02em;
   padding: 4px 8px;
-  border-radius: var(--r-1);
+  border-radius: var(--radius-sm);
   cursor: pointer;
   transition:
-    color var(--t-quick),
-    border-color var(--t-quick),
-    background var(--t-quick);
+    color var(--transition-fast),
+    border-color var(--transition-fast),
+    background var(--transition-fast);
   box-shadow: none;
 }
 .tweak-reset:hover {
-  color: var(--fg-0);
-  border-color: var(--line-3);
-  background: var(--ink-3);
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
   transform: none;
   box-shadow: none;
 }
@@ -376,7 +393,7 @@ select:focus-visible {
   gap: 12px;
   padding-top: 4px;
   font-size: 11px;
-  color: var(--fg-3);
+  color: var(--text-disabled);
 }
 .tweak-foot-hint {
   flex: 1;
@@ -385,14 +402,14 @@ select:focus-visible {
   font-size: 11px;
   padding: 5px 10px;
   background: transparent;
-  border: 1px solid var(--line-2);
-  color: var(--fg-2);
+  border: 1px solid var(--border-default);
+  color: var(--text-tertiary);
   letter-spacing: 0.01em;
 }
 #tweak-reset-all:hover {
-  background: var(--ink-3);
-  color: var(--fg-0);
-  border-color: var(--line-3);
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--border-strong);
   box-shadow: none;
   transform: none;
 }
@@ -402,65 +419,22 @@ select:focus-visible {
  * is the active surface. */
 #tweak[aria-expanded="true"] {
   color: var(--accent);
-  border-color: rgba(6, 194, 181, 0.35);
-  background: linear-gradient(180deg, rgba(6, 194, 181, 0.12) 0%, rgba(6, 194, 181, 0.04) 100%);
+  border-color: color-mix(in srgb, var(--accent) 35%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 12%, transparent) 0%, color-mix(in srgb, var(--accent) 4%, transparent) 100%);
 }
 
-.ctl {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 0;
-}
-.ctl-k {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 6px;
-  font-size: 10.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--fg-3);
-  font-weight: 500;
-}
-.ctl-v {
-  text-transform: none;
-  letter-spacing: 0;
-  color: var(--fg-1);
-  font-size: 11.5px;
-  font-variant-numeric: tabular-nums;
-}
-.ctl-check {
-  flex-direction: row;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 10px;
-  background: var(--ink-2);
-  border: 1px solid var(--line-1);
-  border-radius: var(--r-2);
-  cursor: pointer;
-  transition:
-    background var(--t-quick),
-    border-color var(--t-quick);
-  user-select: none;
-}
-.ctl-check:hover {
-  background: var(--ink-3);
-  border-color: var(--line-2);
-}
-.ctl-check .ctl-k {
-  color: var(--fg-1);
-  font-size: 11px;
-}
+/* .ctl, .ctl-k, .ctl-v, .ctl-check base layout moved to Tailwind utilities
+ * on the HTML labels. Only the custom checkbox rendering below remains. */
 .ctl-check input[type="checkbox"] {
   appearance: none;
   width: 16px;
   height: 16px;
   border-radius: 3px;
-  border: 1px solid var(--line-3);
-  background: var(--ink-1);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-secondary);
   cursor: pointer;
   position: relative;
-  transition: all var(--t-quick);
+  transition: all var(--transition-fast);
   flex-shrink: 0;
   margin: 0;
 }
@@ -475,7 +449,7 @@ select:focus-visible {
   top: 1.5px;
   width: 4px;
   height: 8px;
-  border: 2px solid var(--ink-0);
+  border: 2px solid var(--bg-primary);
   border-top: 0;
   border-left: 0;
   transform: rotate(45deg);
@@ -483,21 +457,21 @@ select:focus-visible {
 
 select,
 input[type="number"] {
-  background: var(--ink-1);
-  color: var(--fg-0);
-  border: 1px solid var(--line-1);
-  border-radius: var(--r-2);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
   padding: 7px 10px;
   font: inherit;
   font-size: 12.5px;
   transition:
-    border-color var(--t-quick),
-    background var(--t-quick);
+    border-color var(--transition-fast),
+    background var(--transition-fast);
 }
 select:hover,
 input[type="number"]:hover {
-  border-color: var(--line-2);
-  background: var(--ink-2);
+  border-color: var(--border-default);
+  background: var(--bg-elevated);
 }
 select {
   appearance: none;
@@ -512,7 +486,7 @@ input[type="range"] {
   -webkit-appearance: none;
   width: 150px;
   height: 4px;
-  background: var(--ink-3);
+  background: var(--bg-hover);
   border-radius: 2px;
   cursor: pointer;
   padding: 0;
@@ -524,432 +498,119 @@ input[type="range"]::-webkit-slider-thumb {
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  background: linear-gradient(180deg, var(--fg-0) 0%, var(--fg-1) 100%);
+  background: linear-gradient(180deg, var(--text-primary) 0%, var(--text-secondary) 100%);
   border: 0;
   cursor: grab;
-  box-shadow: var(--shadow-1);
+  box-shadow: var(--shadow-sm);
   transition:
-    transform var(--t-quick),
-    box-shadow var(--t-quick);
+    transform var(--transition-fast),
+    box-shadow var(--transition-fast);
 }
 input[type="range"]::-webkit-slider-thumb:hover {
   transform: scale(1.12);
   background: linear-gradient(180deg, var(--accent-up) 0%, var(--accent) 100%);
-  box-shadow: 0 0 0 4px var(--accent-soft), var(--shadow-1);
+  box-shadow: 0 0 0 4px var(--accent-soft), var(--shadow-sm);
 }
 input[type="range"]::-moz-range-thumb {
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  background: var(--fg-0);
+  background: var(--text-primary);
   border: 0;
   cursor: grab;
 }
 
-.actions {
-  display: flex;
-  gap: 8px;
-  margin-left: auto;
-}
+/* .actions flex moved to Tailwind utilities on the wrapping div. */
 
 button {
-  background: linear-gradient(180deg, var(--ink-3) 0%, var(--ink-2) 100%);
-  color: var(--fg-0);
-  border: 1px solid var(--line-2);
-  border-radius: var(--r-2);
+  background: linear-gradient(180deg, var(--bg-hover) 0%, var(--bg-elevated) 100%);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
   padding: 7px 14px;
   cursor: pointer;
   font: inherit;
   font-size: 12.5px;
   font-weight: 500;
   letter-spacing: 0.005em;
-  box-shadow: var(--shadow-1);
+  box-shadow: var(--shadow-sm);
   transition:
-    transform var(--t-quick),
-    background var(--t-quick),
-    border-color var(--t-quick),
-    box-shadow var(--t-quick);
+    transform var(--transition-fast),
+    background var(--transition-fast),
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
 }
 button:hover {
-  background: linear-gradient(180deg, var(--ink-4) 0%, var(--ink-3) 100%);
-  border-color: var(--line-3);
+  background: linear-gradient(180deg, var(--bg-active) 0%, var(--bg-hover) 100%);
+  border-color: var(--border-strong);
   transform: translateY(-1px);
-  box-shadow: var(--shadow-2);
+  box-shadow: var(--shadow-md);
 }
 button:active {
   transform: translateY(0);
-  box-shadow: var(--shadow-1);
+  box-shadow: var(--shadow-sm);
 }
 #play {
   color: var(--accent);
-  border-color: rgba(6, 194, 181, 0.35);
-  background: linear-gradient(180deg, rgba(6, 194, 181, 0.12) 0%, rgba(6, 194, 181, 0.04) 100%);
+  border-color: color-mix(in srgb, var(--accent) 35%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 12%, transparent) 0%, color-mix(in srgb, var(--accent) 4%, transparent) 100%);
 }
 #play:hover {
-  background: linear-gradient(180deg, rgba(6, 194, 181, 0.2) 0%, rgba(6, 194, 181, 0.08) 100%);
-  border-color: rgba(6, 194, 181, 0.5);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 20%, transparent) 0%, color-mix(in srgb, var(--accent) 8%, transparent) 100%);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
 }
 
 /* ── Layout ─────────────────────────────────────────────────────────── */
 
-.layout {
-  display: grid;
-  gap: 14px;
-  padding: 14px 20px 20px;
-  height: calc(100vh - 130px);
-  height: calc(100dvh - 130px);
-}
-.layout[data-mode="single"] {
-  grid-template-columns: 1fr;
-}
+/* .layout, .pane, .pane-header, .pane-badge, .pane-name, .pane-mode (base)
+ * moved to Tailwind utilities on the HTML elements. Pane-mode state
+ * variants below remain as custom CSS — the 3-way color-mix across
+ * success/accent/error hues is awkward as utility chains. */
 .layout[data-mode="single"] #pane-b {
   display: none;
 }
-.layout[data-mode="compare"] {
-  grid-template-columns: 1fr 1fr;
-}
 
-.pane {
-  display: grid;
-  grid-template-rows: auto 1fr auto;
-  gap: 10px;
-  min-width: 0;
-  min-height: 0;
-  padding: 12px;
-  background: linear-gradient(180deg, var(--ink-2) 0%, var(--ink-1) 100%);
-  border: 1px solid var(--line-1);
-  border-top: 2px solid var(--pane-accent);
-  border-radius: var(--r-3);
-  box-shadow: var(--shadow-2);
-  position: relative;
-}
-.pane-a {
-  --pane-accent: var(--pane-a);
-}
-.pane-b {
-  --pane-accent: var(--pane-b);
-}
+/* .shaft-wrap, .metric-strip, .metric-row (base), .metric-k, .metric-v (base)
+ * moved to Tailwind utilities. State variants (pane-mode[data-mode=X],
+ * metric-row[data-verdict=X]) live in @layer utilities at the end of this
+ * file so they override the utility base classes on these elements. */
 
-.pane-header {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 2px 0;
-}
-.pane-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  border-radius: var(--r-1);
-  background: var(--pane-accent);
-  color: var(--ink-0);
-  font-weight: 700;
-  font-size: 11px;
-  letter-spacing: 0.04em;
-  box-shadow: var(--shadow-1);
-}
-.pane-name {
-  font-size: 13.5px;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  color: var(--fg-0);
-}
-.pane-mode {
-  margin-left: auto;
-  font-size: 10.5px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  padding: 2px 8px;
-  border-radius: var(--r-1);
-  border: 1px solid var(--line-1);
-  background: var(--ink-2);
-  color: var(--fg-2);
-  font-variant-numeric: tabular-nums;
-  transition: background 0.15s, color 0.15s, border-color 0.15s;
-}
-.pane-mode[data-mode="Idle"] {
-  opacity: 0.55;
-}
-.pane-mode[data-mode="UpPeak"] {
-  background: color-mix(in oklab, var(--ok) 22%, var(--ink-2));
-  color: var(--ok);
-  border-color: color-mix(in oklab, var(--ok) 35%, var(--line-1));
-}
-.pane-mode[data-mode="InterFloor"] {
-  background: color-mix(in oklab, var(--accent) 18%, var(--ink-2));
-  color: var(--accent-up);
-  border-color: color-mix(in oklab, var(--accent) 30%, var(--line-1));
-}
-.pane-mode[data-mode="DownPeak"] {
-  background: color-mix(in oklab, var(--bad) 22%, var(--ink-2));
-  color: var(--bad);
-  border-color: color-mix(in oklab, var(--bad) 35%, var(--line-1));
-}
-
-.shaft-wrap {
-  background: radial-gradient(ellipse at 50% 0%, var(--ink-3) 0%, var(--ink-1) 80%);
-  border: 1px solid var(--line-1);
-  border-radius: var(--r-2);
-  overflow: hidden;
-  min-height: 0;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
-}
-.shaft-wrap canvas {
-  width: 100%;
-  height: 100%;
-  display: block;
-}
-
-/* ── Metric strip ───────────────────────────────────────────────────── */
-
-.metric-strip {
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 6px;
-  padding: 2px;
-  font-variant-numeric: tabular-nums;
-}
-.metric-row {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  padding: 7px 9px;
-  background: var(--ink-2);
-  border: 1px solid var(--line-1);
-  border-radius: var(--r-2);
-  transition:
-    background var(--t-norm),
-    border-color var(--t-norm);
-}
-.metric-row[data-verdict="win"] {
-  background: linear-gradient(180deg, var(--ok-soft) 0%, var(--ink-2) 100%);
-  border-color: rgba(93, 217, 154, 0.3);
-}
-.metric-row[data-verdict="lose"] {
-  background: linear-gradient(180deg, var(--bad-soft) 0%, var(--ink-2) 100%);
-  border-color: rgba(240, 122, 122, 0.25);
-}
-.metric-k {
-  font-size: 9.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--fg-3);
-  font-weight: 500;
-}
-.metric-v {
-  font-size: 15px;
-  color: var(--fg-0);
-  font-weight: 500;
-  font-feature-settings: "tnum" 1;
-}
-.metric-row[data-verdict="win"] .metric-v {
-  color: var(--ok);
-}
-.metric-row[data-verdict="lose"] .metric-v {
-  color: var(--bad);
-}
-
-/* ── Loader ─────────────────────────────────────────────────────────── */
-
-.loader {
-  position: fixed;
-  inset: 0;
-  display: none;
-  align-items: center;
-  justify-content: center;
-  flex-direction: column;
-  gap: 16px;
-  background: rgba(10, 12, 16, 0.88);
-  color: var(--fg-2);
-  z-index: 100;
-  backdrop-filter: blur(6px) saturate(120%);
-  -webkit-backdrop-filter: blur(6px) saturate(120%);
-  animation: fade-in var(--t-norm) ease-out;
-}
-.loader.show {
-  display: flex;
-}
-.loader-spinner {
-  position: relative;
-  width: 44px;
-  height: 44px;
-}
-.loader-spinner::before,
-.loader-spinner::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: 50%;
-  border: 2px solid transparent;
-}
-.loader-spinner::before {
-  border-top-color: var(--accent);
-  border-right-color: var(--accent);
-  animation: spin 900ms cubic-bezier(0.5, 0.1, 0.5, 0.9) infinite;
-}
-.loader-spinner::after {
-  border-top-color: var(--pane-a);
-  opacity: 0.35;
-  animation: spin 1800ms linear infinite reverse;
-}
-.loader-text {
-  font-size: 12px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--fg-2);
-}
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-@keyframes fade-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-/* ── Toast ──────────────────────────────────────────────────────────── */
-
-.toast {
-  position: fixed;
-  bottom: 24px;
-  left: 50%;
-  padding: 10px 16px;
-  background: linear-gradient(180deg, var(--ink-3) 0%, var(--ink-2) 100%);
-  color: var(--fg-0);
-  border: 1px solid var(--line-2);
-  border-radius: var(--r-2);
-  font-size: 12px;
-  font-weight: 500;
-  letter-spacing: 0.01em;
-  opacity: 0;
-  pointer-events: none;
-  transform: translateX(-50%) translateY(16px) scale(0.96);
-  transition:
-    opacity var(--t-norm),
-    transform var(--t-spring);
-  box-shadow: var(--shadow-3);
-  z-index: 90;
-}
-.toast.show {
-  opacity: 1;
-  transform: translateX(-50%) translateY(0) scale(1);
-}
+/* Loader, toast styling moved to Tailwind utilities on the HTML elements.
+ * Tailwind provides `animate-spin` as a default so no custom spin
+ * keyframe is needed. */
 
 /* ── Scenario cards ─────────────────────────────────────────────────── */
 
+/* .scenario-cards container background is a two-layer radial+solid
+ * gradient that's awkward as a Tailwind arbitrary value; keep it here.
+ * Layout (grid + mobile pill strip) moved to utilities on the HTML. */
 .scenario-cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 10px;
-  padding: 12px 20px;
   background:
-    radial-gradient(700px 200px at 50% -40%, rgba(6, 194, 181, 0.06), transparent 70%),
-    var(--ink-0);
-  border-bottom: 1px solid var(--line-1);
+    radial-gradient(700px 200px at 50% -40%, color-mix(in srgb, var(--accent) 6%, transparent), transparent 70%),
+    var(--bg-primary);
 }
-.scenario-card {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 12px 14px;
-  background: linear-gradient(180deg, var(--ink-2) 0%, var(--ink-1) 100%);
-  border: 1px solid var(--line-1);
-  border-radius: var(--r-2);
-  color: var(--fg-1);
-  cursor: pointer;
-  text-align: left;
-  font: inherit;
-  letter-spacing: 0;
-  box-shadow: var(--shadow-1);
-  transition:
-    border-color var(--t-norm),
-    transform var(--t-quick),
-    box-shadow var(--t-quick),
-    background var(--t-norm);
-}
-.scenario-card:hover {
-  transform: translateY(-1px);
-  border-color: var(--line-3);
-  box-shadow: var(--shadow-2);
-  background: linear-gradient(180deg, var(--ink-3) 0%, var(--ink-2) 100%);
-}
-.scenario-card:active {
-  transform: translateY(0);
-}
-.scenario-card[aria-pressed="true"] {
-  border-color: rgba(6, 194, 181, 0.55);
-  background: linear-gradient(180deg, rgba(6, 194, 181, 0.1) 0%, var(--ink-2) 100%);
-  box-shadow: 0 0 0 1px rgba(6, 194, 181, 0.25), var(--shadow-2);
-}
+/* Scenario card hover/active/pressed base moved to Tailwind utilities in
+ * `renderScenarioCards()` (src/main.ts). The ::before accent indicator
+ * below is kept as a pseudo since utilities can't inline a pseudo
+ * directly with a complex gradient + glow. */
 .scenario-card[aria-pressed="true"]::before {
   content: "";
   position: absolute;
   inset: auto 0 0 0;
   height: 2px;
   background: linear-gradient(90deg, var(--accent) 0%, var(--accent-up) 100%);
-  border-radius: 0 0 var(--r-2) var(--r-2);
-  box-shadow: 0 0 12px rgba(6, 194, 181, 0.55);
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--accent) 55%, transparent);
 }
-.scenario-card-label {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--fg-0);
-  letter-spacing: 0.005em;
-}
-.scenario-card-kbd {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 18px;
-  height: 18px;
-  padding: 0 5px;
-  font-size: 10px;
-  font-weight: 600;
-  color: var(--fg-3);
-  background: var(--ink-0);
-  border: 1px solid var(--line-2);
-  border-radius: var(--r-1);
-  margin-left: auto;
-  font-variant-numeric: tabular-nums;
-  letter-spacing: 0;
-}
-.scenario-card-desc {
-  font-size: 11.5px;
-  color: var(--fg-2);
-  line-height: 1.4;
-}
-.scenario-card-hint {
-  font-size: 11px;
-  color: var(--fg-3);
-  line-height: 1.4;
-}
-
-/* ── Strategy info line ─────────────────────────────────────────────── */
-
-.ctl-strategy {
-  min-width: 240px;
-}
-.ctl-inline {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
+/* Description line under the strategy select — constrained width and
+ * min-height that are awkward as utility variants. The `.ctl-strategy`
+ * marker is kept on its parent for CSS query scope but carries no rule:
+ * `min-w-0` inline on that element would have overridden any
+ * `.ctl-strategy { min-width: ... }` rule anyway. */
 .ctl-desc {
   margin: 4px 0 0;
   font-size: 11px;
-  color: var(--fg-3);
+  color: var(--text-disabled);
   line-height: 1.4;
   max-width: 380px;
   min-height: 1.4em;
@@ -964,21 +625,21 @@ button:active {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: var(--ink-1);
-  border: 1px solid var(--line-2);
-  border-radius: var(--r-1);
-  color: var(--fg-2);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  color: var(--text-tertiary);
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
-  transition: all var(--t-quick);
+  transition: all var(--transition-fast);
   letter-spacing: 0;
   box-shadow: none;
 }
 .nav-btn:hover {
-  color: var(--fg-0);
-  border-color: var(--line-3);
-  background: var(--ink-2);
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+  background: var(--bg-elevated);
   transform: none;
   box-shadow: none;
 }
@@ -988,8 +649,8 @@ button:active {
 .tweak-track {
   position: relative;
   height: 6px;
-  background: var(--ink-1);
-  border: 1px solid var(--line-1);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
   border-radius: 999px;
   align-self: center;
   overflow: hidden;
@@ -999,7 +660,7 @@ button:active {
   top: -2px;
   bottom: -2px;
   width: 2px;
-  background: var(--fg-3);
+  background: var(--text-disabled);
   opacity: 0.75;
   transform: translateX(-1px);
 }
@@ -1007,8 +668,8 @@ button:active {
   position: absolute;
   inset: 0 auto 0 0;
   width: 0%;
-  background: linear-gradient(90deg, var(--accent-soft) 0%, rgba(6, 194, 181, 0.25) 100%);
-  transition: width var(--t-norm);
+  background: linear-gradient(90deg, var(--accent-soft) 0%, color-mix(in srgb, var(--accent) 25%, transparent) 100%);
+  transition: width var(--transition-normal);
 }
 .tweak-track-thumb {
   position: absolute;
@@ -1016,13 +677,13 @@ button:active {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: linear-gradient(180deg, var(--fg-0) 0%, var(--fg-1) 100%);
-  box-shadow: var(--shadow-1);
+  background: linear-gradient(180deg, var(--text-primary) 0%, var(--text-secondary) 100%);
+  box-shadow: var(--shadow-sm);
   transform: translate(-50%, -50%);
-  transition: left var(--t-norm);
+  transition: left var(--transition-normal);
 }
 .tweak-row[data-overridden="true"] .tweak-track {
-  border-color: rgba(6, 194, 181, 0.4);
+  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
 }
 .tweak-row[data-overridden="true"] .tweak-track-fill {
   background: linear-gradient(90deg, var(--accent) 0%, var(--accent-up) 100%);
@@ -1030,21 +691,17 @@ button:active {
 }
 .tweak-row[data-overridden="true"] .tweak-track-thumb {
   background: linear-gradient(180deg, var(--accent-up) 0%, var(--accent) 100%);
-  box-shadow: 0 0 0 3px var(--accent-soft), var(--shadow-1);
+  box-shadow: 0 0 0 3px var(--accent-soft), var(--shadow-sm);
 }
 
 /* ── Pane title + decision narration ────────────────────────────────── */
 
-.pane-title {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  min-width: 0;
-  flex: 1;
-}
+/* .pane-title layout (flex / min-w-0 / flex-1) moved to utilities inline on
+ * the `<div class="pane-title ...">` — only the state-driven .pane-decision
+ * color cascade below remains. */
 .pane-decision {
   font-size: 10.5px;
-  color: var(--fg-3);
+  color: var(--text-disabled);
   letter-spacing: 0.02em;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
@@ -1052,7 +709,7 @@ button:active {
   text-overflow: ellipsis;
   min-height: 1.2em;
   opacity: 0;
-  transition: opacity var(--t-norm), color var(--t-norm);
+  transition: opacity var(--transition-normal), color var(--transition-normal);
 }
 .pane-decision[data-active="true"] {
   opacity: 1;
@@ -1099,7 +756,7 @@ button:active {
 }
 .metric-spark path {
   fill: none;
-  stroke: var(--fg-2);
+  stroke: var(--text-tertiary);
   stroke-width: 1.1;
   stroke-linecap: round;
   stroke-linejoin: round;
@@ -1114,153 +771,28 @@ button:active {
 
 /* ── Verdict ribbon (compare mode) ──────────────────────────────────── */
 
-.verdict-ribbon {
-  display: grid;
-  grid-template-columns: auto repeat(5, minmax(0, 1fr));
-  gap: 10px;
-  align-items: center;
-  padding: 8px 20px;
-  background: linear-gradient(180deg, var(--ink-1) 0%, var(--ink-0) 100%);
-  border-bottom: 1px solid var(--line-1);
-  font-size: 11px;
-  color: var(--fg-2);
-}
-.verdict-ribbon[hidden] {
-  display: none;
-}
-.verdict-ribbon-title {
-  font-size: 10.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--fg-3);
-  font-weight: 500;
-  white-space: nowrap;
-}
-.verdict-cell {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 8px;
-  border-radius: var(--r-1);
-  background: var(--ink-2);
-  border: 1px solid var(--line-1);
-  font-variant-numeric: tabular-nums;
-  overflow: hidden;
-}
-.verdict-cell-k {
-  font-size: 10.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--fg-3);
-}
-.verdict-cell-winner {
-  font-weight: 600;
-  color: var(--fg-0);
-  letter-spacing: 0.02em;
-}
-.verdict-cell[data-winner="A"] .verdict-cell-winner {
-  color: var(--pane-a);
-}
-.verdict-cell[data-winner="B"] .verdict-cell-winner {
-  color: var(--pane-b);
-}
-.verdict-cell[data-winner="tie"] .verdict-cell-winner {
-  color: var(--fg-2);
-}
+/* Verdict ribbon container + title + cell base moved to Tailwind utilities
+ * on the HTML `<section id="verdict-ribbon">` and in `renderVerdictRibbon()`
+ * (src/main.ts). The data-winner cascade that colors .verdict-cell-winner
+ * through its .verdict-cell parent remains here since utilities can't
+ * easily express a parent-attribute→child-color pattern cleanly. */
+/* Verdict-cell data-winner→child color cascade moved to @layer utilities. */
 
 /* ── Shortcut sheet overlay ─────────────────────────────────────────── */
 
-.shortcut-sheet {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(10, 12, 16, 0.7);
-  backdrop-filter: blur(4px) saturate(120%);
-  -webkit-backdrop-filter: blur(4px) saturate(120%);
-  z-index: 95;
-  animation: fade-in var(--t-norm) ease-out;
-}
-.shortcut-sheet[hidden] {
-  display: none;
-}
-.shortcut-sheet-inner {
-  width: min(480px, 90vw);
-  background: linear-gradient(180deg, var(--ink-3) 0%, var(--ink-1) 100%);
-  border: 1px solid var(--line-2);
-  border-radius: var(--r-3);
-  box-shadow: var(--shadow-3);
-  padding: 18px 20px 20px;
-  color: var(--fg-1);
-  animation: shortcut-pop var(--t-spring);
-}
-@keyframes shortcut-pop {
-  from {
-    opacity: 0;
-    transform: translateY(8px) scale(0.96);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-.shortcut-sheet-inner header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin: 0 0 12px;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--fg-0);
-  letter-spacing: 0.005em;
-}
-#shortcut-sheet-close {
-  appearance: none;
-  background: transparent;
-  border: 0;
-  color: var(--fg-3);
-  font-size: 16px;
-  line-height: 1;
-  cursor: pointer;
-  padding: 4px 8px;
-  letter-spacing: 0;
-  box-shadow: none;
-}
-#shortcut-sheet-close:hover {
-  color: var(--fg-0);
-  transform: none;
-  box-shadow: none;
-  background: transparent;
-}
-.shortcut-sheet-inner dl {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 8px 16px;
-  margin: 0;
-  font-size: 12px;
-}
-.shortcut-sheet-inner dt {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  white-space: nowrap;
-}
-.shortcut-sheet-inner dd {
-  margin: 0;
-  color: var(--fg-2);
-}
+/* Modal backdrop, panel layout, and dl grid moved to Tailwind utilities on
+ * the HTML elements. Only the custom <kbd> rendering (below) remains. */
 .shortcut-sheet-inner kbd {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   min-width: 22px;
   padding: 1px 6px;
-  background: var(--ink-0);
-  border: 1px solid var(--line-2);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-default);
   border-bottom-width: 2px;
-  border-radius: var(--r-1);
-  color: var(--fg-0);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
   font-family: "SFMono-Regular", ui-monospace, Menlo, Consolas, monospace;
   font-size: 10.5px;
   font-weight: 500;
@@ -1268,90 +800,85 @@ button:active {
 
 /* ── Mobile ─────────────────────────────────────────────────────────── */
 
-@media (max-width: 820px) {
-  .top {
-    padding: calc(12px + env(safe-area-inset-top)) 16px 12px;
+/* Mobile-specific styling was previously concentrated here in a
+ * `@media (max-width: 767px)` block. Every rule has migrated to Tailwind
+ * `max-md:` variants on the HTML elements (or in `renderScenarioCards()`
+ * for generated content). See `index.html` — the sheet drawer, sticky
+ * top, pill-scroll scenario cards, 2-col control grid, stacked
+ * compare-mode panes, and landscape-flip `@media (orientation: landscape)`
+ * compare layout are all expressed as utility variants. */
+
+} /* end @layer components */
+
+/* Utilities layer: safe-area helpers plus the state-variant overrides
+ * (pane-mode, metric-row, verdict-cell) that must beat the base utility
+ * classes applied to those elements. Putting them here (not in
+ * @layer components) guarantees the correct cascade regardless of which
+ * Tailwind utilities the element also carries. */
+@layer utilities {
+  .safe-top {
+    padding-top: env(safe-area-inset-top);
   }
-  .top h1 {
-    font-size: 13px;
+  .safe-right {
+    padding-right: env(safe-area-inset-right);
   }
-  .top nav a {
-    margin-left: 12px;
-    font-size: 11px;
+  .safe-bottom {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+  .safe-left {
+    padding-left: env(safe-area-inset-left);
+  }
+  .safe-inset {
+    padding:
+      env(safe-area-inset-top)
+      env(safe-area-inset-right)
+      env(safe-area-inset-bottom)
+      env(safe-area-inset-left);
   }
 
-  .controls {
-    padding: 12px 14px;
-    gap: 10px;
+  /* Pane mode: traffic-mode indicator states. 3-way color-mix hue swap. */
+  .pane-mode[data-mode="UpPeak"] {
+    background: color-mix(in oklab, var(--ok) 22%, var(--bg-elevated));
+    color: var(--ok);
+    border-color: color-mix(in oklab, var(--ok) 35%, var(--border-subtle));
   }
-  .ctl {
-    flex: 1 1 calc(50% - 10px);
-    min-width: 0;
+  .pane-mode[data-mode="InterFloor"] {
+    background: color-mix(in oklab, var(--accent) 18%, var(--bg-elevated));
+    color: var(--accent-up);
+    border-color: color-mix(in oklab, var(--accent) 30%, var(--border-subtle));
   }
-  .ctl-check {
-    flex: 1 1 100%;
-  }
-  .ctl select,
-  .ctl input[type="number"] {
-    min-height: 40px;
-    width: 100%;
-  }
-  input[type="range"] {
-    width: 100%;
-  }
-  .actions {
-    flex: 1 1 100%;
-    margin-left: 0;
-  }
-  .actions button {
-    flex: 1;
-    min-height: 40px;
+  .pane-mode[data-mode="DownPeak"] {
+    background: color-mix(in oklab, var(--bad) 22%, var(--bg-elevated));
+    color: var(--bad);
+    border-color: color-mix(in oklab, var(--bad) 35%, var(--border-subtle));
   }
 
-  .layout {
-    padding: 12px;
-    gap: 12px;
-    height: auto;
+  /* Metric row: win/lose verdict colors the bg/border AND the nested
+   * .metric-v value. Uses a parent→child cascade. */
+  .metric-row[data-verdict="win"] {
+    background: linear-gradient(180deg, var(--ok-soft) 0%, var(--bg-elevated) 100%);
+    border-color: color-mix(in srgb, var(--ok) 30%, transparent);
   }
-  .layout[data-mode="compare"] {
-    grid-template-columns: 1fr;
+  .metric-row[data-verdict="lose"] {
+    background: linear-gradient(180deg, var(--bad-soft) 0%, var(--bg-elevated) 100%);
+    border-color: color-mix(in srgb, var(--bad) 25%, transparent);
+  }
+  .metric-row[data-verdict="win"] .metric-v {
+    color: var(--ok);
+  }
+  .metric-row[data-verdict="lose"] .metric-v {
+    color: var(--bad);
   }
 
-  .shaft-wrap {
-    height: 46vh;
-    height: 46dvh;
-    min-height: 260px;
+  /* Verdict cell: winner label takes the winning pane's accent. */
+  .verdict-cell[data-winner="A"] .verdict-cell-winner {
+    color: var(--pane-a);
   }
-
-  .scenario-cards {
-    padding: 10px 14px;
-    grid-template-columns: 1fr;
+  .verdict-cell[data-winner="B"] .verdict-cell-winner {
+    color: var(--pane-b);
   }
-  .scenario-card {
-    padding: 10px 12px;
-  }
-  .ctl-strategy {
-    flex: 1 1 100%;
-    min-width: 0;
-  }
-  .ctl-desc {
-    max-width: none;
-  }
-  .verdict-ribbon {
-    grid-template-columns: 1fr 1fr;
-    padding: 8px 14px;
-  }
-  .verdict-ribbon-title {
-    grid-column: 1 / -1;
-  }
-  .pane-decision {
-    font-size: 10px;
-  }
-}
-
-@media (max-width: 440px) {
-  .metric-strip {
-    grid-template-columns: repeat(3, 1fr);
+  .verdict-cell[data-winner="tie"] .verdict-cell-winner {
+    color: var(--text-tertiary);
   }
 }
 

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -155,7 +155,6 @@
   body {
     margin: 0;
     padding: 0;
-    min-height: 100%;
     background:
       radial-gradient(1200px 600px at 80% -10%, color-mix(in srgb, var(--accent) 6%, transparent), transparent 60%),
       radial-gradient(1000px 500px at -10% 100%, color-mix(in srgb, var(--pane-a) 5%, transparent), transparent 55%),
@@ -165,6 +164,16 @@
     font-variant-numeric: tabular-nums;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+  }
+  /* Body is a flex column so `<main id="layout">` can `flex-1` to fill
+   * whatever space is left after header + scenario strip + controls +
+   * phase strip + (optional) verdict ribbon + (optional) tweak panel.
+   * Avoids a hardcoded `calc(100dvh - 130px)` that would clip once
+   * any optional section opens. */
+  body {
+    display: flex;
+    flex-direction: column;
+    min-height: 100dvh;
   }
 
   :focus-visible {

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vite";
+import tailwindcss from "@tailwindcss/vite";
 
 // The playground loads the wasm-pack bundle from `public/pkg/` at runtime.
 // That directory is populated by CI (`wasm-pack build --target web --out-dir
@@ -9,6 +10,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   base: "./",
+  plugins: [tailwindcss()],
   build: {
     outDir: "dist",
     emptyOutDir: true,


### PR DESCRIPTION
## Summary

- **Mobile-first redesign.** Bottom-sheet drawer replaces the stacked controls band; scenario cards become a horizontal-scroll pill strip; compare mode stacks in portrait and auto-flips side-by-side in landscape.
- **Tailwind v4 migration.** Adopts the gridfinity-layout-tool design system — semantic tokens (\`bg-surface\`, \`text-content\`, \`border-stroke-*\`), warm-dark palette, amber accent (\`#f59e0b\` replaces teal \`#06c2b5\`), \`@layer base/components/utilities\`.
- **CSS shrank ~45%** (component layer: 1625 → 695 lines). Most layout/typography now inline as Tailwind utilities on HTML and in TS-generated elements (scenario cards, metric rows, verdict cells). State-variant cascades live in \`@layer utilities\` to beat utility base classes.
- **Docs tidy.** README header trimmed from 6 nav links to 3 + footer Changelog; removed broken Bench link + unused Stability link. Playground CTA rewritten across README + mdBook intro (\"race two dispatch strategies on the same traffic\").

## Test plan

- [ ] \`pnpm typecheck\` + \`pnpm build\` in \`playground/\` (both pass locally)
- [ ] Mobile viewport (iPhone 12 / 390×844): shaft dominates, sheet handle always visible, drag-up opens controls
- [ ] Mobile landscape: compare mode flips to 1fr 1fr
- [ ] Desktop ≥ 768 px: sheet renders as pass-through (children flow normally, handle hidden)
- [ ] Scenario switch via pill tap + keyboard (1/2/3 shortcuts)
- [ ] Compare toggle + both panes render, verdict ribbon updates
- [ ] Tweak panel (unchanged, custom CSS) still opens via \`T\` and the button
- [ ] Keyboard shortcut overlay (\`?\`)
- [ ] No visual regressions on main simulation canvas (amber \`moving\` phase, rose \`down\` direction markers)
- [ ] \`cargo test -p elevator-core\` (workspace-wide pre-commit hook already passed)