### PR TITLE
fix(playground): bubble text clipping + mobile scenario-card density

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -55,7 +55,7 @@
     <section
       id="scenario-cards"
       aria-label="Scenario picker"
-      class="scenario-cards grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-2 px-5 py-2.5 border-b border-stroke-subtle max-md:flex max-md:flex-row max-md:gap-2 max-md:px-3.5 max-md:py-2.5 max-md:overflow-x-auto max-md:snap-x max-md:snap-mandatory max-md:[-webkit-overflow-scrolling:touch] max-md:[scrollbar-width:none] max-md:[&::-webkit-scrollbar]:hidden"
+      class="scenario-cards grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-2 px-5 py-2.5 border-b border-stroke-subtle max-md:flex max-md:flex-row max-md:gap-1.5 max-md:px-3 max-md:py-1.5 max-md:overflow-x-auto max-md:snap-x max-md:snap-mandatory max-md:[-webkit-overflow-scrolling:touch] max-md:[scrollbar-width:none] max-md:[&::-webkit-scrollbar]:hidden"
     ></section>
 
     <section class="controls flex flex-wrap gap-3.5 items-end px-5 py-3 bg-surface border-b border-stroke-subtle max-md:px-3.5 max-md:gap-2.5">

--- a/playground/src/canvas.ts
+++ b/playground/src/canvas.ts
@@ -360,7 +360,18 @@ export class CanvasRenderer {
         remaining > ttl * FADE_FRAC ? 1 : Math.max(0, remaining / (ttl * FADE_FRAC));
       if (alpha <= 0) continue;
 
-      const textW = ctx.measureText(bubble.text).width;
+      // Use the ink bounding box when it's wider than the advance width.
+      // Bubble text contains Unicode symbols (›●◌+↓) that aren't in
+      // system-ui on every platform — the font stack falls back to a
+      // symbol font with different metrics, so `measureText().width` (the
+      // advance in the primary font) under-reports the actual rendered
+      // width and the glyph tail clips outside the bubble. The
+      // `actualBoundingBox*` pair reports the real ink extent across the
+      // fallback chain. Ceil to avoid sub-pixel clipping on HiDPI.
+      const metrics = ctx.measureText(bubble.text);
+      const inkW =
+        (metrics.actualBoundingBoxLeft ?? 0) + (metrics.actualBoundingBoxRight ?? 0);
+      const textW = Math.ceil(Math.max(metrics.width, inkW));
       const bubbleW = textW + padX * 2;
       const bubbleH = s.fontSmall + padY * 2 + 2;
 

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -1402,7 +1402,10 @@ const SCENARIO_CARD_CLS =
   "aria-pressed:border-[color-mix(in_srgb,var(--accent)_55%,transparent)] " +
   "aria-pressed:from-accent-muted aria-pressed:to-surface-elevated " +
   "aria-pressed:shadow-[0_0_0_1px_color-mix(in_srgb,var(--accent)_25%,transparent),var(--shadow-md)] " +
-  "max-md:flex-none max-md:min-w-[140px] max-md:snap-start";
+  // Mobile pill form — description is hidden (SCENARIO_DESC_CLS) so the
+  // card collapses to a label+kbd row. Tighter padding + narrower min-w
+  // lets three cards fit on a 375px screen without horizontal scrolling.
+  "max-md:flex-none max-md:min-w-[120px] max-md:px-2.5 max-md:py-1 max-md:snap-start";
 const SCENARIO_LABEL_CLS =
   "flex items-center gap-2 text-[13px] font-semibold text-content tracking-[0.005em]";
 const SCENARIO_KBD_CLS =


### PR DESCRIPTION
## Summary

Follow-up polish to #383:

- **Bubble text clipping.** The speech-bubble width used \`ctx.measureText(text).width\` — the advance in the primary font. But the bubble content (\`› To Floor 3\`, \`● At Lobby\`, \`↓ Off at …\`) uses Unicode symbols (\`\u203a\u25cf\u25cc+\u2193\`) that aren't in \`system-ui\` on every platform, so \`fillText\` falls back to a symbol font with different metrics and the glyph tail overflowed the bubble frame. Now uses \`actualBoundingBoxLeft + actualBoundingBoxRight\` (the real ink extent across the fallback chain), ceiled to avoid sub-pixel HiDPI clipping.
- **Mobile scenario-card strip** was ~54 px tall and eating vertical space behind the drawer. Tighter pill form: container \`py-2.5 → py-1.5\`, card \`py-2 → py-1\`, \`min-w-[140px] → min-w-[120px]\`. Drops the strip to ~38 px (~30 % shorter) and fits three cards on a 375 px viewport without horizontal scrolling.

## Test plan

- [ ] Open playground on mobile, trigger a scenario run, confirm bubble text (\`\u203a To Keynote Hall\`, \`\u25cf At Lobby\`, etc.) stays inside the bubble frame
- [ ] Desktop check: \`\u00d7\` symbol in \`Speed 2\u00d7\` / \`Intensity 1.0\u00d7\` labels unaffected (they don't go through the bubble renderer)
- [ ] Mobile: scenario pill strip noticeably shorter; three scenario pills fit on a 375 px-wide screen
- [ ] \`pnpm typecheck\` + \`pnpm build\` (both pass locally)