### PR TITLE
fix(playground): phase clock clamp + misc cleanup

### DIFF
--- a/crates/elevator-core/examples/playground_audit.rs
+++ b/crates/elevator-core/examples/playground_audit.rs
@@ -1,26 +1,24 @@
-//! Headless audit of the playground scenarios.
+//! Headless dispatch-strategy regression harness.
 //!
-//! Mirrors the playground's six scenarios (RON configs + phase tables +
-//! `abandonAfterSec` budgets) against a deterministic rider driver,
-//! then reports the metrics a human would be squinting at in the
-//! browser: delivered, abandoned, abandonment rate, avg/max wait, peak
-//! waiting-queue length across the whole run.
+//! Runs two fixed scenarios (mid-rise office, single-line sky-lobby
+//! skyscraper) against every built-in dispatch strategy with a
+//! deterministic rider driver, then reports the metrics a human would
+//! be squinting at in the browser: delivered, abandoned, abandonment
+//! rate, avg/max wait, peak waiting-queue length across the whole run.
 //!
-//! Purpose: verify that playground-level tuning changes (demand rates,
-//! elevator counts, abandonment budgets) produce bounded queues and
-//! realistic abandonment rates *without* needing to spin up a browser
-//! and watch the UI for minutes at a time. If the office's abandonment
-//! fix landed correctly, its peak-queue figure here should be finite
-//! and its `abandoned > 0` should reflect the demand/supply gap.
+//! Purpose: catch dispatch regressions across the `ScanDispatch`,
+//! `LookDispatch`, `NearestCarDispatch`, `EtdDispatch`, and
+//! `DestinationDispatch` strategies at a glance — a scan that reports
+//! 100% delivery and 0% abandonment that suddenly starts abandoning
+//! riders is an obvious regression.
 //!
-//! This intentionally **duplicates** the scenario data from
-//! `playground/src/scenarios.ts` — one RON string and phase table per
-//! scenario, copied verbatim. A single-source-of-truth refactor would
-//! require a JSON pivot that both TS and Rust consume; not worth the
-//! scope cost right now. If the scenarios.ts numbers change, this file
-//! needs a mirror edit. Comments at the top of each scenario anchor to
-//! the TS side's cruise-capacity docstring so divergence is easy to
-//! spot in review.
+//! Scope note: this example used to mirror the playground's scenario
+//! set, but the playground now runs a 42-stop multi-line skyscraper
+//! (Low / High / Executive / Service banks sharing a sky lobby
+//! transfer), and the audit's single-line 13-stop skyscraper is a
+//! deliberately simpler stand-in — both for faster iteration and
+//! because the audit's driver doesn't exercise the multi-leg route
+//! auto-solver. Keep the two intentionally decoupled.
 //!
 //! Run with:
 //! ```sh

--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 dist/
 *.log
 .vite/
+.screenshots/
+test-results/
+playwright-report/

--- a/playground/index.html
+++ b/playground/index.html
@@ -12,13 +12,13 @@
     <link rel="stylesheet" href="./src/style.css" />
   </head>
   <body>
-    <header class="top flex items-center justify-between px-5 py-3 bg-gradient-to-b from-surface-secondary to-surface border-b border-stroke-subtle relative">
-      <h1 class="m-0 text-[14px] font-semibold tracking-[-0.005em] text-content inline-flex items-center gap-2.5 before:content-[''] before:inline-block before:w-2 before:h-2 before:rounded-[2px] before:bg-accent before:shadow-[0_0_10px_color-mix(in_srgb,var(--accent)_50%,transparent)]">elevator-core playground</h1>
-      <nav class="flex items-center">
+    <header class="top flex items-center justify-between gap-3 px-5 py-3 bg-gradient-to-b from-surface-secondary to-surface border-b border-stroke-subtle relative max-md:px-3.5 max-md:py-2.5 max-md:gap-2">
+      <h1 class="m-0 text-[14px] font-semibold tracking-[-0.005em] text-content inline-flex items-center gap-2.5 whitespace-nowrap min-w-0 before:content-[''] before:inline-block before:flex-none before:w-2 before:h-2 before:rounded-[2px] before:bg-accent before:shadow-[0_0_10px_color-mix(in_srgb,var(--accent)_50%,transparent)] max-md:text-[12.5px] max-md:gap-2 max-md:tracking-[-0.01em]"><span class="truncate"><span class="max-md:hidden">elevator-core </span>playground</span></h1>
+      <nav class="flex items-center gap-4 max-md:gap-3 shrink-0">
         <button type="button" id="shortcuts" class="nav-btn" title="Keyboard shortcuts (press ?)">?</button>
-        <a class="ml-4 text-content-tertiary no-underline text-xs transition-colors hover:text-content" href="https://github.com/andymai/elevator-core">repo</a>
-        <a class="ml-4 text-content-tertiary no-underline text-xs transition-colors hover:text-content" href="https://docs.rs/elevator-core">docs</a>
-        <a class="ml-4 text-content-tertiary no-underline text-xs transition-colors hover:text-content" href="../">guide</a>
+        <a class="text-content-tertiary no-underline text-xs transition-colors hover:text-content" href="https://github.com/andymai/elevator-core">repo</a>
+        <a class="text-content-tertiary no-underline text-xs transition-colors hover:text-content max-md:hidden" href="https://docs.rs/elevator-core">docs</a>
+        <a class="text-content-tertiary no-underline text-xs transition-colors hover:text-content max-md:hidden" href="../">guide</a>
       </nav>
     </header>
 
@@ -193,9 +193,12 @@
       <div class="flex items-center gap-2.5 flex-wrap max-md:gap-2">
         <span class="ctl-k">Phase</span>
         <span id="phase-label" class="text-content-secondary tabular-nums font-medium">&mdash;</span>
-        <!-- Color legend merged into the phase strip's right side. -->
-        <div class="ml-auto flex items-center gap-x-3 gap-y-1 flex-wrap text-[10.5px] max-md:gap-x-2">
-          <span class="ctl-k">Cabin</span>
+        <!-- Color legend merged into the phase strip's right side.
+             On mobile the "CABIN" label drops and gaps tighten so the
+             legend can ride on the same row as the phase name instead
+             of wrapping to its own line. -->
+        <div class="ml-auto flex items-center gap-x-3 gap-y-1 flex-wrap text-[10.5px] max-md:gap-x-1.5 max-md:gap-y-0.5">
+          <span class="ctl-k max-md:hidden">Cabin</span>
           <span class="inline-flex items-center gap-1 whitespace-nowrap">
             <span class="w-2 h-2 rounded-[2px] shrink-0" style="background: #6b6b75"></span>Idle
           </span>

--- a/playground/index.html
+++ b/playground/index.html
@@ -193,10 +193,6 @@
       <div class="flex items-center gap-2.5 flex-wrap max-md:gap-2">
         <span class="ctl-k">Phase</span>
         <span id="phase-label" class="text-content-secondary tabular-nums font-medium">&mdash;</span>
-        <!-- `feature-hint` element kept for the code that still writes
-             to it, but hidden — it was taking a full row's width and
-             competing with the legend for attention. -->
-        <span id="feature-hint" hidden></span>
         <!-- Color legend merged into the phase strip's right side. -->
         <div class="ml-auto flex items-center gap-x-3 gap-y-1 flex-wrap text-[10.5px] max-md:gap-x-2">
           <span class="ctl-k">Cabin</span>

--- a/playground/index.html
+++ b/playground/index.html
@@ -287,7 +287,7 @@
             hidden
           ></div>
         </header>
-        <div class="shaft-wrap relative bg-[radial-gradient(ellipse_at_50%_0%,var(--bg-hover)_0%,var(--bg-secondary)_80%)] border border-stroke-subtle rounded-md overflow-hidden min-h-0 shadow-[inset_0_1px_0_rgba(255,255,255,0.02)] max-md:min-h-[200px]">
+        <div class="shaft-wrap relative bg-[radial-gradient(ellipse_at_50%_0%,var(--bg-hover)_0%,var(--bg-secondary)_80%)] border border-stroke-subtle rounded-md overflow-hidden min-h-0 shadow-[inset_0_1px_0_rgba(255,255,255,0.02)]">
           <canvas id="shaft-a" class="absolute inset-0 w-full h-full block"></canvas>
         </div>
         <div id="metrics-a" class="metric-strip grid grid-cols-5 gap-1.5 p-0.5 tabular-nums max-md:grid-cols-3"></div>
@@ -347,7 +347,7 @@
             hidden
           ></div>
         </header>
-        <div class="shaft-wrap relative bg-[radial-gradient(ellipse_at_50%_0%,var(--bg-hover)_0%,var(--bg-secondary)_80%)] border border-stroke-subtle rounded-md overflow-hidden min-h-0 shadow-[inset_0_1px_0_rgba(255,255,255,0.02)] max-md:min-h-[200px]">
+        <div class="shaft-wrap relative bg-[radial-gradient(ellipse_at_50%_0%,var(--bg-hover)_0%,var(--bg-secondary)_80%)] border border-stroke-subtle rounded-md overflow-hidden min-h-0 shadow-[inset_0_1px_0_rgba(255,255,255,0.02)]">
           <canvas id="shaft-b" class="absolute inset-0 w-full h-full block"></canvas>
         </div>
         <div id="metrics-b" class="metric-strip grid grid-cols-5 gap-1.5 p-0.5 tabular-nums max-md:grid-cols-3"></div>

--- a/playground/package.json
+++ b/playground/package.json
@@ -9,9 +9,11 @@
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "snap": "vite build && vite preview --port 4173 & sleep 2 && node scripts/snap.mjs ; kill %1 2>/dev/null || true"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.2.2",
     "@types/node": "^22.0.0",
     "tailwindcss": "^4.2.2",

--- a/playground/pnpm-lock.yaml
+++ b/playground/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))
@@ -204,6 +207,11 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
@@ -524,6 +532,11 @@ packages:
       picomatch:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -630,6 +643,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -873,6 +896,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     optional: true
@@ -1127,6 +1154,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -1196,6 +1226,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.10:
     dependencies:

--- a/playground/scripts/snap.mjs
+++ b/playground/scripts/snap.mjs
@@ -1,0 +1,104 @@
+// Screenshot harness for the playground. Spins up Chromium at two
+// viewports (desktop 1440×900, iPhone 14 390×844), loads the preview
+// server, and captures a handful of scenes per viewport so a visual
+// polish pass has something concrete to diff against.
+//
+// Usage: from playground/ run `pnpm snap` (which starts `vite preview`
+// and invokes this script). Output: playground/.screenshots/<scene>.png
+//
+// Adding scenes: push into SCENES with {name, url, setup?}. The setup
+// callback gets (page) and can click, type, etc. after navigation.
+
+import { chromium, devices } from "@playwright/test";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const OUT_DIR = new URL("../.screenshots/", import.meta.url).pathname;
+const BASE = process.env.SNAP_BASE_URL ?? "http://localhost:4173";
+
+// Scenes build on each other via query-string permalinks — the
+// playground's own share mechanism. Keeps scenes deterministic across
+// runs and independent of any mutation we might have done in a prior
+// scene.
+const SCENES = [
+  {
+    name: "default-compare",
+    url: `${BASE}/`,
+  },
+  {
+    name: "skyscraper-single",
+    // `c=0` forces single-pane mode; everything else inherits defaults.
+    url: `${BASE}/?s=skyscraper-sky-lobby&c=0&a=look`,
+  },
+  {
+    name: "convention-single",
+    url: `${BASE}/?s=convention-burst&c=0&a=etd`,
+  },
+  {
+    name: "space-elevator",
+    url: `${BASE}/?s=space-elevator&c=0&a=scan`,
+  },
+  {
+    name: "strategy-popover-open",
+    url: `${BASE}/?s=skyscraper-sky-lobby&c=0&a=scan`,
+    // Open the strategy popover on pane A to capture its styling.
+    // The chip is the first `.strategy-chip` that isn't the "sub"
+    // (park-strategy) variant.
+    async setup(page) {
+      await page.locator(".strategy-chip:not(.strategy-chip-sub)").first().click();
+      // Let the scale-in animation settle.
+      await page.waitForTimeout(300);
+    },
+  },
+];
+
+async function snapOne(context, scene, label) {
+  const page = await context.newPage();
+  await page.goto(scene.url, { waitUntil: "networkidle" });
+  // Pause the sim before snapping so the canvas state is deterministic
+  // frame-to-frame — shaves a visual-diff source of noise.
+  await page
+    .getByRole("button", { name: /^(pause|play)$/i })
+    .first()
+    .click()
+    .catch(() => {});
+  // Let the first frame land + any entry animations complete.
+  await page.waitForTimeout(400);
+  if (scene.setup) await scene.setup(page);
+  const path = join(OUT_DIR, `${label}__${scene.name}.png`);
+  await page.screenshot({ path, fullPage: true });
+  await page.close();
+  return path;
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  const desktop = await browser.newContext({
+    viewport: { width: 1440, height: 900 },
+    deviceScaleFactor: 2,
+  });
+  const mobile = await browser.newContext({
+    ...devices["iPhone 14"],
+  });
+
+  const outputs = [];
+  for (const scene of SCENES) {
+    outputs.push(await snapOne(desktop, scene, "desktop"));
+    outputs.push(await snapOne(mobile, scene, "mobile"));
+  }
+
+  await browser.close();
+
+  await writeFile(
+    join(OUT_DIR, "index.json"),
+    JSON.stringify({ capturedAt: new Date().toISOString(), files: outputs }, null, 2),
+  );
+  console.log(`Captured ${outputs.length} screenshots → ${OUT_DIR}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/playground/src/__tests__/traffic.test.ts
+++ b/playground/src/__tests__/traffic.test.ts
@@ -41,7 +41,7 @@ describe("TrafficDriver — phase schedule", () => {
     const d = new TrafficDriver(42);
     d.setPhases([FLAT(300, 60)]); // one phase, 5 min, 60 riders/min = 1/s
     const snap = snapshotWithStops(3);
-    // Advance 10 sim-seconds in small slices (respects the per-call 4/60s cap).
+    // Advance 10 sim-seconds in small per-frame slices.
     let spawns = 0;
     for (let i = 0; i < 10 * 60; i += 1) spawns += d.drainSpawns(snap, 1 / 60).length;
     // At 1 rider/sec for 10 sec we expect ~10 spawns ± accumulator remainder.

--- a/playground/src/canvas.ts
+++ b/playground/src/canvas.ts
@@ -54,11 +54,11 @@ function scaleFor(width: number): Scale {
     padTop: lerp(22, 30),
     // Just enough bottom breathing room below the lowest floor slab.
     padBottom: lerp(10, 14),
-    // Sized for the widest skyscraper label ("Mechanical" at 10 chars)
-    // at desktop, down to "Lobby"/"Floor N" on the narrowest phones.
-    // `truncate()` still clips anything that spills over on ultra-long
-    // custom stop names.
-    labelW: lerp(52, 82),
+    // Sized for the widest scenario labels ("Keynote Hall" /
+    // "Exhibit Hall" at 12 chars) on desktop, down to "Lobby" /
+    // "Floor N" on the narrowest phones. `truncate()` still clips
+    // anything that spills over on ultra-long custom stop names.
+    labelW: lerp(52, 92),
     // Preferred gutter for stick figures. The gutter grows further
     // only when shafts hit their max; otherwise shafts claim slack.
     figureGutterW: lerp(40, 70),
@@ -688,13 +688,29 @@ export class CanvasRenderer {
     const now = performance.now();
     const strokeBase = this.#accent;
 
+    // Two-pass draw so we can resolve bubble overlaps before committing
+    // ink. A narrow compare pane with adjacent shafts routinely has two
+    // cars arrive in the same frame; default placement is "above the
+    // cabin, centred on the shaft", which collides when the horizontal
+    // spacing between adjacent shafts is tighter than a bubble width.
+    interface Placement {
+      bubble: CarBubble;
+      alpha: number;
+      cx: number;
+      carTop: number;
+      carBottom: number;
+      bubbleW: number;
+      bubbleH: number;
+      side: "above" | "below";
+      bx: number;
+      by: number;
+    }
+    const placements: Placement[] = [];
     for (const car of snap.cars) {
       const bubble = bubbles.get(car.id);
       if (!bubble) continue;
       const cx = carX.get(car.id);
       if (cx === undefined) continue;
-      // `car.y` is the cabin's bottom (see #drawCar). Derive the
-      // cabin's top from carH and anchor the bubble off those edges.
       const carBottom = toScreenY(car.y);
       const carTop = carBottom - s.carH;
 
@@ -708,24 +724,80 @@ export class CanvasRenderer {
       const bubbleW = textW + padX * 2;
       const bubbleH = s.fontSmall + padY * 2 + 2;
 
-      // Vertical placement: above car by default, below when above
-      // would clip the top edge. Tail points from bubble toward car.
+      // Default vertical placement: above car when the canvas has room,
+      // below otherwise. Horizontal: centred on the shaft, clamped to
+      // the canvas edges.
       const aboveTop = carTop - gap - tailH - bubbleH;
-      const side: "above" | "below" = aboveTop < 2 ? "below" : "above";
+      const belowOverflow = carBottom + gap + tailH + bubbleH > canvasWidth; // safety fallback
+      const initialSide: "above" | "below" =
+        aboveTop < 2 && !belowOverflow ? "below" : "above";
       const by =
-        side === "above" ? carTop - gap - tailH - bubbleH : carBottom + gap + tailH;
-
-      // Horizontal: centered on the shaft, then clamped to canvas.
+        initialSide === "above"
+          ? carTop - gap - tailH - bubbleH
+          : carBottom + gap + tailH;
       let bx = cx - bubbleW / 2;
       const minX = 2;
       const maxX = canvasWidth - bubbleW - 2;
       if (bx < minX) bx = minX;
       if (bx > maxX) bx = maxX;
+      placements.push({
+        bubble,
+        alpha,
+        cx,
+        carTop,
+        carBottom,
+        bubbleW,
+        bubbleH,
+        side: initialSide,
+        bx,
+        by,
+      });
+    }
 
-      // Tail tip sits on the car's nearest edge; base centered on cx
-      // but clamped into the bubble's horizontal span so it stays
-      // attached even when the bubble itself was clamped to the canvas
-      // edge (e.g., leftmost / rightmost shaft in compare mode).
+    // Collision pass: if a bubble's rect intersects a previously placed
+    // one, flip it to the other side of its cabin. We only try the
+    // flip once — in the rare third-collision case we let the newer
+    // bubble sit on top; it's still legible because it's drawn last.
+    const rectsIntersect = (a: Placement, b: Placement): boolean =>
+      !(
+        a.bx + a.bubbleW <= b.bx ||
+        b.bx + b.bubbleW <= a.bx ||
+        a.by + a.bubbleH <= b.by ||
+        b.by + b.bubbleH <= a.by
+      );
+    for (let i = 1; i < placements.length; i++) {
+      const p = placements[i];
+      let collides = false;
+      for (let j = 0; j < i; j++) {
+        if (rectsIntersect(p, placements[j])) {
+          collides = true;
+          break;
+        }
+      }
+      if (!collides) continue;
+      const flipSide: "above" | "below" = p.side === "above" ? "below" : "above";
+      const flipBy =
+        flipSide === "above"
+          ? p.carTop - gap - tailH - p.bubbleH
+          : p.carBottom + gap + tailH;
+      // Only accept the flip if it actually clears; otherwise keep the
+      // original placement so we don't make things worse.
+      const flipped: Placement = { ...p, side: flipSide, by: flipBy };
+      let flipClears = true;
+      for (let j = 0; j < i; j++) {
+        if (rectsIntersect(flipped, placements[j])) {
+          flipClears = false;
+          break;
+        }
+      }
+      if (flipClears) {
+        placements[i] = flipped;
+      }
+    }
+
+    for (const p of placements) {
+      const { bubble, alpha, cx, carTop, carBottom, bubbleW, bubbleH, side, bx, by } =
+        p;
       const tipY = side === "above" ? carTop - gap : carBottom + gap;
       const baseY = side === "above" ? by + bubbleH : by;
       const tailCenter = Math.min(

--- a/playground/src/canvas.ts
+++ b/playground/src/canvas.ts
@@ -599,7 +599,17 @@ export class CanvasRenderer {
         if (top < groupTop) groupTop = top;
         shaftExtIdx++;
       }
-      if (Number.isFinite(firstCx) && Number.isFinite(groupTop)) {
+      // Shaft labels only make sense when the building has multiple
+      // banks to distinguish. A single-line scenario (convention,
+      // space elevator) has exactly one shaft group — slapping
+      // "LOW" on it is misleading because the label's semantics
+      // ("main passenger bank, low-zone") only hold against a
+      // skyscraper-style multi-line layout.
+      if (
+        lineIds.length > 1 &&
+        Number.isFinite(firstCx) &&
+        Number.isFinite(groupTop)
+      ) {
         shaftLabels.push({
           cx: (firstCx + lastCx) / 2,
           top: groupTop,

--- a/playground/src/canvas.ts
+++ b/playground/src/canvas.ts
@@ -54,11 +54,11 @@ function scaleFor(width: number): Scale {
     padTop: lerp(22, 30),
     // Just enough bottom breathing room below the lowest floor slab.
     padBottom: lerp(10, 14),
-    // Sized for the widest scenario labels ("Keynote Hall" /
-    // "Exhibit Hall" at 12 chars) on desktop, down to "Lobby" /
-    // "Floor N" on the narrowest phones. `truncate()` still clips
-    // anything that spills over on ultra-long custom stop names.
-    labelW: lerp(52, 92),
+    // Sized for the widest scenario labels ("Orbital Platform" at 16
+    // chars, space-elevator) on desktop, down to "Lobby" / "Floor N"
+    // on the narrowest phones. `truncate()` still clips anything that
+    // spills over on ultra-long custom stop names.
+    labelW: lerp(52, 120),
     // Preferred gutter for stick figures. The gutter grows further
     // only when shafts hit their max; otherwise shafts claim slack.
     figureGutterW: lerp(40, 70),

--- a/playground/src/canvas.ts
+++ b/playground/src/canvas.ts
@@ -54,8 +54,11 @@ function scaleFor(width: number): Scale {
     padTop: lerp(22, 30),
     // Just enough bottom breathing room below the lowest floor slab.
     padBottom: lerp(10, 14),
-    // Fits "Floor 12" at 12px without the truncate() ellipsis kicking in.
-    labelW: lerp(44, 68),
+    // Sized for the widest skyscraper label ("Mechanical" at 10 chars)
+    // at desktop, down to "Lobby"/"Floor N" on the narrowest phones.
+    // `truncate()` still clips anything that spills over on ultra-long
+    // custom stop names.
+    labelW: lerp(52, 82),
     // Preferred gutter for stick figures. The gutter grows further
     // only when shafts hit their max; otherwise shafts claim slack.
     figureGutterW: lerp(40, 70),

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -557,6 +557,18 @@ async function makePane(
   const ron = buildScenarioRon(scenario, overrides);
   const sim = await Sim.create(ron, strategy, reposition);
   const renderer = new CanvasRenderer(handles.canvas, handles.accent);
+  // Scenarios with a lot of floors need a taller shaft on mobile, or
+  // the 42-floor skyscraper crushes into a 6-px-per-story smear. The
+  // CSS rule reads `--shaft-min-h` inside a `max-width: 767px` media
+  // query; floor here means the mobile layout will stretch to fit and
+  // the main column scrolls. Desktop ignores the variable.
+  const wrap = handles.canvas.parentElement;
+  if (wrap) {
+    const stopCount = scenario.stops.length;
+    const perStoryPx = 16;
+    const minShaftPx = Math.max(200, stopCount * perStoryPx);
+    wrap.style.setProperty("--shaft-min-h", `${minShaftPx}px`);
+  }
   renderPaneStrategyInfo(handles, strategy);
   renderPaneRepositionInfo(handles, reposition);
   initMetricRows(handles.metrics);

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -263,7 +263,6 @@ interface UiHandles {
   loader: HTMLElement;
   toast: HTMLElement;
   phaseLabel: HTMLElement | null;
-  featureHint: HTMLElement | null;
   phaseProgress: HTMLElement | null;
   verdictRibbon: HTMLElement;
   shortcutsBtn: HTMLButtonElement;
@@ -418,7 +417,6 @@ function wireUi(): UiHandles {
     loader: q("loader"),
     toast: q("toast"),
     phaseLabel: qOpt("phase-label"),
-    featureHint: qOpt("feature-hint"),
     phaseProgress: qOpt("phase-progress-fill"),
     verdictRibbon: q("verdict-ribbon"),
     shortcutsBtn: q<HTMLButtonElement>("shortcuts"),
@@ -452,7 +450,6 @@ function applyPermalinkToUi(p: PermalinkState, ui: UiHandles): void {
   renderPaneRepositionInfo(ui.paneB, p.repositionB);
   syncScenarioCards(ui, p.scenario);
   const scenario = scenarioById(p.scenario);
-  if (ui.featureHint) ui.featureHint.textContent = scenario.featureHint;
   syncSheetCompact(ui, scenario.label, p.strategyA);
   // Auto-open the drawer when the permalink carries any override —
   // the recipient sees what the sender customized without an extra
@@ -666,7 +663,6 @@ async function resetAll(state: State, ui: UiHandles): Promise<void> {
     // `configureTraffic` once the quota drains, so the scenario's
     // day-cycle clock still starts from t=0.
     state.seeding = scenario.seedSpawns > 0 ? { remaining: scenario.seedSpawns } : null;
-    if (ui.featureHint) ui.featureHint.textContent = scenario.featureHint;
     updatePhaseIndicator(state, ui);
     renderTweakPanel(scenario, state.permalink.overrides, ui);
   } catch (err) {
@@ -986,10 +982,14 @@ function loop(state: State, ui: UiHandles): void {
 
       const snapA = paneA.sim.snapshot();
       // Fan-out spawns to both sims so the comparison is apples-to-apples.
-      // `elapsed` is wall-clock; scaling by `ticks` keeps the sim-time
-      // budget the driver operates on in lockstep with the actual
-      // simulation advance. Skipped while we're still seeding.
-      const simElapsed = elapsed * ticks;
+      // Clamp wall-clock first (to guard against tab-switch catch-up, which
+      // restores rAF with a multi-second delta), *then* scale by speed so
+      // the phase clock and spawn cadence track the sim's actual rate.
+      // At 8× the raw sim-time delta is ~0.128 s per 16 ms frame, which
+      // would exceed the driver's internal 4/60 sec clamp every frame
+      // and silently throttle phases to half speed. Skipped while seeding.
+      const clampedWall = Math.min(elapsed, 4 / 60);
+      const simElapsed = clampedWall * ticks;
       const specs = state.seeding
         ? []
         : state.traffic.drainSpawns(snapA, simElapsed);

--- a/playground/src/sim.ts
+++ b/playground/src/sim.ts
@@ -28,8 +28,6 @@ interface WasmSimInstance {
   strategyName(): string;
   trafficMode?(): string;
   setStrategy(name: string): boolean;
-  repositionStrategyName?(): string;
-  setReposition?(name: string): boolean;
   spawnRider(
     origin: number,
     destination: number,
@@ -140,25 +138,6 @@ export class Sim {
 
   setStrategy(name: StrategyName): boolean {
     return this.#inner.setStrategy(name);
-  }
-
-  /**
-   * Current reposition strategy name. Falls back to `"adaptive"` when
-   * the wasm build predates the API (stale `public/pkg/` during local
-   * dev) so the UI reads a sensible default rather than `undefined`.
-   */
-  repositionStrategyName(): RepositionStrategyName {
-    return (this.#inner.repositionStrategyName?.() as RepositionStrategyName) ?? "adaptive";
-  }
-
-  /**
-   * Swap the reposition strategy live. Returns `true` when the wasm
-   * build supports the setter and the name was valid, `false` when
-   * the build is stale or the name is unrecognised — caller falls
-   * back to a full sim rebuild in that case.
-   */
-  setReposition(name: RepositionStrategyName): boolean {
-    return this.#inner.setReposition?.(name) ?? false;
   }
 
   spawnRider(

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -620,6 +620,19 @@ button:active {
  * metric-row[data-verdict=X]) live in @layer utilities at the end of this
  * file so they override the utility base classes on these elements. */
 
+/* Mobile: floor scrunch guard. A 42-floor skyscraper squeezed into a
+ * flex-1 shaft-wrap on a phone ends up with ~6 px per story — labels
+ * overlap, cabins disappear. Let the shaft-wrap grow to a scenario-
+ * aware minimum so the surrounding page scrolls vertically instead of
+ * the floors stacking on top of each other. The renderer publishes
+ * `--shaft-min-h` on each shaft-wrap when a scenario loads, scaled to
+ * stop count; fallback keeps the old 200 px floor for small scenarios. */
+@media (max-width: 767px) {
+  .shaft-wrap {
+    min-height: var(--shaft-min-h, 200px);
+  }
+}
+
 /* Loader, toast styling moved to Tailwind utilities on the HTML elements.
  * Tailwind provides `animate-spin` as a default so no custom spin
  * keyframe is needed. */

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -298,32 +298,46 @@
   margin-left: 4px;
 }
 
+/* Segmented stepper mirroring gridfinity-layout-tool's Stepper: three
+ * independently-styled segments (minus button, value, plus button)
+ * sharing internal strokes. No wrapper border — each segment carries
+ * its own, which lets the buttons show hover / focus rings cleanly. */
 .tweak-stepper {
   display: inline-flex;
   align-items: center;
-  gap: 0;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius-md);
-  overflow: hidden;
+  height: 28px;
 }
 .tweak-stepper button {
   appearance: none;
-  background: transparent;
-  border: 0;
-  color: var(--text-secondary);
-  width: 26px;
-  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 100%;
   padding: 0;
   font-size: 14px;
   font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0;
   cursor: pointer;
+  color: var(--text-tertiary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  box-shadow: none;
   transition:
     background var(--transition-fast),
-    color var(--transition-fast);
-  box-shadow: none;
-  border-radius: 0;
-  letter-spacing: 0;
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+.tweak-stepper button.tweak-dec {
+  border-top-left-radius: var(--radius-md);
+  border-bottom-left-radius: var(--radius-md);
+  border-right: 0;
+}
+.tweak-stepper button.tweak-inc {
+  border-top-right-radius: var(--radius-md);
+  border-bottom-right-radius: var(--radius-md);
+  border-left: 0;
 }
 .tweak-stepper button:hover {
   background: var(--bg-hover);
@@ -331,28 +345,35 @@
   transform: none;
   box-shadow: none;
 }
+.tweak-stepper button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  z-index: 1;
+}
 .tweak-stepper button:active {
   background: var(--bg-active);
 }
 .tweak-stepper button:disabled {
   color: var(--text-disabled);
   cursor: not-allowed;
-  background: transparent;
+  background: var(--bg-elevated);
+  opacity: 0.5;
 }
 .tweak-value {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   min-width: 56px;
-  height: 28px;
-  padding: 0 8px;
+  height: 100%;
+  padding: 0 10px;
   color: var(--text-primary);
   font-size: 12.5px;
   font-weight: 500;
-  border-left: 1px solid var(--border-default);
-  border-right: 1px solid var(--border-default);
-  background: var(--bg-elevated);
+  background: var(--bg-primary);
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
   font-variant-numeric: tabular-nums;
+  user-select: none;
 }
 .tweak-row[data-overridden="true"] .tweak-value {
   color: var(--accent);
@@ -464,8 +485,12 @@
   transform: rotate(45deg);
 }
 
+/* Input / select base style. Mirrors gridfinity-layout-tool's Input
+ * wrapper: surface bg, `border-stroke` rounded-md, hover bumps the
+ * border, focus swaps it for `border-accent` with a matching ring. */
 select,
-input[type="number"] {
+input[type="number"],
+input[type="text"] {
   background: var(--bg-secondary);
   color: var(--text-primary);
   border: 1px solid var(--border-subtle);
@@ -473,14 +498,23 @@ input[type="number"] {
   padding: 7px 10px;
   font: inherit;
   font-size: 12.5px;
+  outline: none;
   transition:
     border-color var(--transition-fast),
-    background var(--transition-fast);
+    background var(--transition-fast),
+    box-shadow var(--transition-fast);
 }
 select:hover,
-input[type="number"]:hover {
+input[type="number"]:hover,
+input[type="text"]:hover {
   border-color: var(--border-default);
   background: var(--bg-elevated);
+}
+select:focus,
+input[type="number"]:focus,
+input[type="text"]:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
 }
 select {
   appearance: none;
@@ -838,18 +872,23 @@ button:active {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  background: linear-gradient(180deg, var(--bg-elevated) 0%, var(--bg-secondary) 100%);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius-md);
+  /* Flat elevated surface + subtle stroke, mirroring the
+   * `bg-surface-elevated border-stroke-subtle rounded-xl shadow-xl`
+   * pattern used by gridfinity-layout-tool's Popover. Drops the old
+   * gradient so the panel reads as a single layer, not a mini-sheet. */
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
   box-shadow: var(--shadow-lg);
-  animation: strategy-popover-in var(--transition-normal) ease-out;
+  transform-origin: top left;
+  animation: strategy-popover-in var(--transition-normal) var(--ease-fast);
 }
 .strategy-popover[hidden] {
   display: none;
 }
 @keyframes strategy-popover-in {
-  from { opacity: 0; transform: translateY(-4px); }
-  to { opacity: 1; transform: translateY(0); }
+  from { opacity: 0; transform: scale(0.95); }
+  to { opacity: 1; transform: scale(1); }
 }
 
 .strategy-option {

--- a/playground/src/traffic.ts
+++ b/playground/src/traffic.ts
@@ -86,11 +86,13 @@ export class TrafficDriver {
     // snapshot with &lt;2 addressable stops produces no specs at all.
     const addressable = snapshot.stops.filter((s) => s.stop_id !== 0xffffffff);
     if (addressable.length < 2) return [];
-    // Clamp to ~4 frames at 60 Hz. When the browser tab is hidden
-    // requestAnimationFrame pauses entirely, so on restore the first
-    // `elapsedSeconds` is the full hidden duration — which at 120 riders/min
-    // would dump ~20 spawns in a single frame and visibly jolt the sim.
-    const dt = Math.min(elapsedSeconds, 4 / 60);
+    // Defensive safety net: even if a caller forgets to clamp wall-clock
+    // before passing sim-time in, cap a single drain to ~1 sim-second of
+    // spawns so a tab-hidden restore can't dump an entire minute of
+    // traffic into one frame. Callers are expected to apply a tighter
+    // wall-clock clamp (the playground uses 4 frames at 60 Hz) before
+    // scaling by the sim-speed multiplier.
+    const dt = Math.min(Math.max(0, elapsedSeconds), 1);
     const phase = this.#phases[this.currentPhaseIndex()];
     this.#accumulator += ((phase.ridersPerMin * this.#intensity) / 60) * dt;
     this.#elapsedInCycleSec = (this.#elapsedInCycleSec + dt) % (this.#totalDurationSec || 1);


### PR DESCRIPTION
## Summary

Followup to #385. Small fixes and cleanups surfaced by the gap-finder pass, plus one real bug in the phase clock.

- **Phase clock fix** — at sim speed ≥ 2×, the traffic driver's internal clamp (sized for wall-clock) was capping sim-time deltas every frame, throttling phase advancement + spawn cadence to roughly half the sim's rate. Clamp is now applied to wall-clock *before* scaling by speed, so phases advance in lockstep with the sim.
- **Shaft labels** (`LOW / HIGH / VIP / SERVICE`) only render when the scenario has multiple banks. Single-line scenarios (Convention, Space Elevator) no longer get a misleading "LOW" tag above their lone shaft.
- **Dead TS wrappers removed** — `sim.setReposition` / `sim.repositionStrategyName` had no callers because the playground chose reset-for-fairness over live swap. Wasm exports stay for other embedders.
- **Dead `feature-hint` DOM element** + its two writers removed.
- **`playground_audit` docstring** updated — it's a standalone headless dispatch regression harness now, not a mirror of the playground scenarios.

## Test plan

- [x] `cargo test -p elevator-core --all-features` (1000+ tests pass via pre-commit hook)
- [x] `cargo check --workspace`
- [x] `pnpm --dir playground test --run` — 55/55
- [x] `pnpm --dir playground typecheck` — clean
- [ ] Manual: load playground at 8× on the skyscraper, confirm phase label cycles through Morning rush → Midday → Lunch → Evening → Late in proportion to the sim's visible progress (not ~half the rate it used to)