### PR TITLE
fix(dispatch): prevent cars from idling with riders aboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.16.0"
+version = "15.17.1"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -975,7 +975,23 @@ fn pending_stops_minus_covered(
     group
         .stop_entities()
         .iter()
-        .filter(|s| manifest.has_demand(**s) && !is_covered(**s))
+        .filter(|s| {
+            if !manifest.has_demand(**s) {
+                return false;
+            }
+            // A stop with aboard-rider demand (`riding_to_stop`) must
+            // never be filtered out: those riders are on idle-pool cars
+            // that need to deliver them. Another car heading to the same
+            // stop cannot absorb demand that consists of passengers on a
+            // *different* car. Without this guard, a burst scenario
+            // (multiple cars heading to the same popular floor) causes
+            // `is_covered` to suppress the destination, `fallback()`
+            // returns Idle, and riders are stranded.
+            if manifest.riding_count_to(**s) > 0 {
+                return true;
+            }
+            !is_covered(**s)
+        })
         .filter_map(|s| world.stop_position(*s).map(|p| (*s, p)))
         .collect()
 }

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -904,6 +904,7 @@ fn pending_stops_minus_covered(
     group: &ElevatorGroup,
     manifest: &DispatchManifest,
     world: &World,
+    idle_cars: &[(EntityId, f64)],
 ) -> Vec<(EntityId, f64)> {
     // Vec + linear scan is fine: groups have O(few) elevators and
     // this runs once per dispatch tick.
@@ -979,15 +980,18 @@ fn pending_stops_minus_covered(
             if !manifest.has_demand(**s) {
                 return false;
             }
-            // A stop with aboard-rider demand (`riding_to_stop`) must
-            // never be filtered out: those riders are on idle-pool cars
-            // that need to deliver them. Another car heading to the same
-            // stop cannot absorb demand that consists of passengers on a
-            // *different* car. Without this guard, a burst scenario
-            // (multiple cars heading to the same popular floor) causes
-            // `is_covered` to suppress the destination, `fallback()`
-            // returns Idle, and riders are stranded.
-            if manifest.riding_count_to(**s) > 0 {
+            // A stop must not be filtered if an idle-pool car has
+            // riders needing to exit there. Only check cars in the idle
+            // pool — riders on committed `MovingToStop` cars are already
+            // en route and don't need a redundant dispatch.
+            let idle_car_needs_stop = idle_cars.iter().any(|&(car_eid, _)| {
+                world.elevator(car_eid).is_some_and(|car| {
+                    car.riders().iter().any(|&rid| {
+                        world.route(rid).and_then(Route::current_destination) == Some(**s)
+                    })
+                })
+            });
+            if idle_car_needs_stop {
                 return true;
             }
             !is_covered(**s)
@@ -1011,7 +1015,7 @@ pub(crate) fn assign(
     // Collect stops with active demand and known positions, excluding
     // any whose demand is already being absorbed by a car mid door
     // cycle (see `pending_stops_minus_covered` for the why).
-    let pending_stops = pending_stops_minus_covered(group, manifest, world);
+    let pending_stops = pending_stops_minus_covered(group, manifest, world, idle_cars);
 
     let n = idle_cars.len();
     let m = pending_stops.len();

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -176,10 +176,22 @@ pub fn run(
                     if let Some(car) = world.elevator(eid)
                         && !car.riders.is_empty()
                     {
+                        let car_pos = world.position(eid).map_or(0.0, |p| p.value);
                         let dest = car
                             .riders()
                             .iter()
-                            .find_map(|&rid| world.route(rid).and_then(Route::current_destination));
+                            .filter_map(|&rid| {
+                                world.route(rid).and_then(Route::current_destination)
+                            })
+                            .min_by(|&a, &b| {
+                                let da = world
+                                    .stop_position(a)
+                                    .map_or(f64::MAX, |p| (p - car_pos).abs());
+                                let db = world
+                                    .stop_position(b)
+                                    .map_or(f64::MAX, |p| (p - car_pos).abs());
+                                da.total_cmp(&db)
+                            });
                         if let Some(stop) = dest {
                             commit_go_to_stop(world, events, ctx, eid, stop);
                             continue;

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -171,6 +171,20 @@ pub fn run(
                     record_hall_assignment(world, stop_eid, eid);
                 }
                 DispatchDecision::Idle => {
+                    // Safety: never idle a car with riders aboard — route
+                    // it to the nearest aboard rider's destination instead.
+                    if let Some(car) = world.elevator(eid)
+                        && !car.riders.is_empty()
+                    {
+                        let dest = car
+                            .riders()
+                            .iter()
+                            .find_map(|&rid| world.route(rid).and_then(Route::current_destination));
+                        if let Some(stop) = dest {
+                            commit_go_to_stop(world, events, ctx, eid, stop);
+                            continue;
+                        }
+                    }
                     // Check if elevator was already idle before setting phase.
                     let was_idle = world
                         .elevator(eid)

--- a/crates/elevator-core/src/tests/idle_with_riders_tests.rs
+++ b/crates/elevator-core/src/tests/idle_with_riders_tests.rs
@@ -19,7 +19,7 @@ use super::helpers::{default_config, multi_floor_config};
 fn assert_no_idle_with_riders(sim: &Simulation, tick: u64) {
     for (eid, _pos, car) in sim.world().iter_elevators() {
         assert!(
-            !(car.phase() == ElevatorPhase::Idle && !car.riders().is_empty()),
+            car.phase() != ElevatorPhase::Idle || car.riders().is_empty(),
             "BUG: car {eid:?} went Idle with {} riders aboard at tick {tick}",
             car.riders().len()
         );

--- a/crates/elevator-core/src/tests/idle_with_riders_tests.rs
+++ b/crates/elevator-core/src/tests/idle_with_riders_tests.rs
@@ -15,6 +15,17 @@ use crate::stop::StopId;
 
 use super::helpers::{default_config, multi_floor_config};
 
+/// Assert no elevator in the sim is idle with riders aboard.
+fn assert_no_idle_with_riders(sim: &Simulation, tick: u64) {
+    for (eid, _pos, car) in sim.world().iter_elevators() {
+        assert!(
+            !(car.phase() == ElevatorPhase::Idle && !car.riders().is_empty()),
+            "BUG: car {eid:?} went Idle with {} riders aboard at tick {tick}",
+            car.riders().len()
+        );
+    }
+}
+
 /// Two cars, both with riders heading to the same destination. When one
 /// car is en route (`MovingToStop`), the other car (just finished
 /// loading, now `Stopped`) must NOT go idle — its aboard riders still
@@ -24,45 +35,25 @@ fn stopped_car_with_riders_not_idled_when_destination_covered() {
     let cfg = multi_floor_config(3, 2);
     let mut sim = Simulation::new(&cfg, EtdDispatch::new()).unwrap();
 
-    let car_ids = sim.world().elevator_ids();
-    let [car_a, car_b] = [car_ids[0], car_ids[1]];
-
     // Spawn two riders at stop 0 heading to stop 2.
     sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
     sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
-    // Let the sim run until at least one rider is aboard and one car
-    // is en route. With both cars starting at stop 0, they'll both
-    // open doors and start loading.
-    let mut ticks = 0;
     let max_setup = 500;
-    loop {
+    for tick in 0..max_setup {
         sim.step();
         sim.drain_events();
-        ticks += 1;
-        if ticks > max_setup {
-            panic!("setup failed: couldn't get riders aboard within {max_setup} ticks");
-        }
         // Check if both riders have been delivered (fast path — no bug).
         let all_arrived = sim
             .world()
             .iter_riders()
             .all(|(_, r)| r.phase == RiderPhase::Arrived);
         if all_arrived {
-            return; // Delivered without incident — pass.
+            return;
         }
-        // Check for the bug: any elevator is Idle with riders aboard.
-        for &car in &[car_a, car_b] {
-            if let Some(elev) = sim.world().elevator(car) {
-                if elev.phase() == ElevatorPhase::Idle && !elev.riders().is_empty() {
-                    panic!(
-                        "BUG: car {car:?} went Idle with {} riders aboard at tick {ticks}",
-                        elev.riders().len()
-                    );
-                }
-            }
-        }
+        assert_no_idle_with_riders(&sim, tick);
     }
+    panic!("riders not delivered within {max_setup} ticks");
 }
 
 /// Single car: after picking up a rider and closing doors, the car
@@ -73,23 +64,13 @@ fn single_car_with_rider_not_idled_after_doors_close() {
     let cfg = default_config();
     let mut sim = Simulation::new(&cfg, EtdDispatch::new()).unwrap();
 
-    let car_ids = sim.world().elevator_ids();
-    let car = car_ids[0];
-
     // Spawn a rider at stop 0 heading to stop 2.
     sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     for tick in 0..2000 {
         sim.step();
         sim.drain_events();
-        if let Some(elev) = sim.world().elevator(car) {
-            if elev.phase() == ElevatorPhase::Idle && !elev.riders().is_empty() {
-                panic!(
-                    "BUG: single car went Idle with {} riders aboard at tick {tick}",
-                    elev.riders().len()
-                );
-            }
-        }
+        assert_no_idle_with_riders(&sim, tick);
         let all_arrived = sim
             .world()
             .iter_riders()
@@ -108,8 +89,6 @@ fn burst_scenario_no_idle_with_riders() {
     let cfg = multi_floor_config(5, 4);
     let mut sim = Simulation::new(&cfg, EtdDispatch::new()).unwrap();
 
-    let car_ids = sim.world().elevator_ids();
-
     // Burst: 20 riders from stop 4 to stop 0.
     for _ in 0..20 {
         sim.spawn_rider(StopId(4), StopId(0), 75.0).unwrap();
@@ -118,16 +97,7 @@ fn burst_scenario_no_idle_with_riders() {
     for tick in 0..10_000 {
         sim.step();
         sim.drain_events();
-        for &car in &car_ids {
-            if let Some(elev) = sim.world().elevator(car) {
-                if elev.phase() == ElevatorPhase::Idle && !elev.riders().is_empty() {
-                    panic!(
-                        "BUG: car {car:?} went Idle with {} riders aboard at tick {tick}",
-                        elev.riders().len()
-                    );
-                }
-            }
-        }
+        assert_no_idle_with_riders(&sim, tick);
         let all_arrived = sim
             .world()
             .iter_riders()

--- a/crates/elevator-core/src/tests/idle_with_riders_tests.rs
+++ b/crates/elevator-core/src/tests/idle_with_riders_tests.rs
@@ -1,0 +1,140 @@
+//! Regression tests: elevators must never go idle with riders aboard.
+//!
+//! Root cause: `pending_stops_minus_covered` filters out a stop when
+//! another car in a door-cycle or `MovingToStop` phase targets it —
+//! but "covered" only checks *waiting* demand. If the stop's sole
+//! demand comes from aboard riders (`riding_to_stop`) needing to exit
+//! there, the filter erroneously removes it from the candidate set.
+//! With no pending stops, `fallback()` returns `Idle`, stranding
+//! passengers.
+
+use crate::components::{ElevatorPhase, RiderPhase};
+use crate::dispatch::etd::EtdDispatch;
+use crate::sim::Simulation;
+use crate::stop::StopId;
+
+use super::helpers::{default_config, multi_floor_config};
+
+/// Two cars, both with riders heading to the same destination. When one
+/// car is en route (`MovingToStop`), the other car (just finished
+/// loading, now `Stopped`) must NOT go idle — its aboard riders still
+/// need delivery.
+#[test]
+fn stopped_car_with_riders_not_idled_when_destination_covered() {
+    let cfg = multi_floor_config(3, 2);
+    let mut sim = Simulation::new(&cfg, EtdDispatch::new()).unwrap();
+
+    let car_ids = sim.world().elevator_ids();
+    let [car_a, car_b] = [car_ids[0], car_ids[1]];
+
+    // Spawn two riders at stop 0 heading to stop 2.
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+
+    // Let the sim run until at least one rider is aboard and one car
+    // is en route. With both cars starting at stop 0, they'll both
+    // open doors and start loading.
+    let mut ticks = 0;
+    let max_setup = 500;
+    loop {
+        sim.step();
+        sim.drain_events();
+        ticks += 1;
+        if ticks > max_setup {
+            panic!("setup failed: couldn't get riders aboard within {max_setup} ticks");
+        }
+        // Check if both riders have been delivered (fast path — no bug).
+        let all_arrived = sim
+            .world()
+            .iter_riders()
+            .all(|(_, r)| r.phase == RiderPhase::Arrived);
+        if all_arrived {
+            return; // Delivered without incident — pass.
+        }
+        // Check for the bug: any elevator is Idle with riders aboard.
+        for &car in &[car_a, car_b] {
+            if let Some(elev) = sim.world().elevator(car) {
+                if elev.phase() == ElevatorPhase::Idle && !elev.riders().is_empty() {
+                    panic!(
+                        "BUG: car {car:?} went Idle with {} riders aboard at tick {ticks}",
+                        elev.riders().len()
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Single car: after picking up a rider and closing doors, the car
+/// must not go idle — it should proceed to the rider's destination.
+/// This tests the eligibility path independent of `is_covered`.
+#[test]
+fn single_car_with_rider_not_idled_after_doors_close() {
+    let cfg = default_config();
+    let mut sim = Simulation::new(&cfg, EtdDispatch::new()).unwrap();
+
+    let car_ids = sim.world().elevator_ids();
+    let car = car_ids[0];
+
+    // Spawn a rider at stop 0 heading to stop 2.
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+
+    for tick in 0..2000 {
+        sim.step();
+        sim.drain_events();
+        if let Some(elev) = sim.world().elevator(car) {
+            if elev.phase() == ElevatorPhase::Idle && !elev.riders().is_empty() {
+                panic!(
+                    "BUG: single car went Idle with {} riders aboard at tick {tick}",
+                    elev.riders().len()
+                );
+            }
+        }
+        let all_arrived = sim
+            .world()
+            .iter_riders()
+            .all(|(_, r)| r.phase == RiderPhase::Arrived);
+        if all_arrived {
+            return;
+        }
+    }
+    panic!("rider never arrived within 2000 ticks");
+}
+
+/// Convention-center-like scenario: burst of riders from one floor
+/// to another, multiple cars. No car should ever idle with riders.
+#[test]
+fn burst_scenario_no_idle_with_riders() {
+    let cfg = multi_floor_config(5, 4);
+    let mut sim = Simulation::new(&cfg, EtdDispatch::new()).unwrap();
+
+    let car_ids = sim.world().elevator_ids();
+
+    // Burst: 20 riders from stop 4 to stop 0.
+    for _ in 0..20 {
+        sim.spawn_rider(StopId(4), StopId(0), 75.0).unwrap();
+    }
+
+    for tick in 0..10_000 {
+        sim.step();
+        sim.drain_events();
+        for &car in &car_ids {
+            if let Some(elev) = sim.world().elevator(car) {
+                if elev.phase() == ElevatorPhase::Idle && !elev.riders().is_empty() {
+                    panic!(
+                        "BUG: car {car:?} went Idle with {} riders aboard at tick {tick}",
+                        elev.riders().len()
+                    );
+                }
+            }
+        }
+        let all_arrived = sim
+            .world()
+            .iter_riders()
+            .all(|(_, r)| matches!(r.phase, RiderPhase::Arrived | RiderPhase::Abandoned));
+        if all_arrived {
+            return;
+        }
+    }
+    panic!("not all riders delivered within 10000 ticks");
+}

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -61,6 +61,7 @@ mod etd_age_weight_tests;
 mod etd_mutant_tests;
 mod event_payload_tests;
 mod hall_call_tests;
+mod idle_with_riders_tests;
 mod manual_mode_tests;
 mod move_count_tests;
 mod movement_boundary_tests;


### PR DESCRIPTION
## Summary

- Fixes a bug where elevators go idle with passengers still inside during burst scenarios (convention center keynote)
- Root cause: `pending_stops_minus_covered` incorrectly filtered stops whose only demand came from aboard riders (`riding_to_stop`), because `is_covered` only checked *waiting* rider weight — `0 ≤ capacity` is trivially true when no one is waiting
- Adds a guardrail in the `Idle` handler: if assignment somehow returns Idle for a car with riders, redirect it to the nearest aboard rider's destination

## Test plan

- [x] New regression test `burst_scenario_no_idle_with_riders` (4 cars, 20 riders from stop 4 → stop 0) — reproduces the bug on `main`, passes with fix
- [x] New test `stopped_car_with_riders_not_idled_when_destination_covered` (2-car minimal case)
- [x] New test `single_car_with_rider_not_idled_after_doors_close` (single-car control)
- [x] Full test suite (794 lib + 158 doc + integration tests) passes
- [x] Clippy clean