### PR TITLE
fix(dispatch): hoist idle-rider destination lookup out of per-stop loop

### DIFF
--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -64,7 +64,7 @@ use crate::components::{
 use crate::entity::EntityId;
 use crate::ids::GroupId;
 use crate::world::World;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 /// Whether assigning `ctx.car` to `ctx.stop` can perform useful work.
 ///
@@ -973,6 +973,13 @@ fn pending_stops_minus_covered(
         total_weight <= capacity_here
     };
 
+    let idle_rider_destinations: HashSet<EntityId> = idle_cars
+        .iter()
+        .filter_map(|&(car_eid, _)| world.elevator(car_eid))
+        .flat_map(|car| car.riders().iter().copied())
+        .filter_map(|rid| world.route(rid).and_then(Route::current_destination))
+        .collect();
+
     group
         .stop_entities()
         .iter()
@@ -980,18 +987,7 @@ fn pending_stops_minus_covered(
             if !manifest.has_demand(**s) {
                 return false;
             }
-            // A stop must not be filtered if an idle-pool car has
-            // riders needing to exit there. Only check cars in the idle
-            // pool — riders on committed `MovingToStop` cars are already
-            // en route and don't need a redundant dispatch.
-            let idle_car_needs_stop = idle_cars.iter().any(|&(car_eid, _)| {
-                world.elevator(car_eid).is_some_and(|car| {
-                    car.riders().iter().any(|&rid| {
-                        world.route(rid).and_then(Route::current_destination) == Some(**s)
-                    })
-                })
-            });
-            if idle_car_needs_stop {
+            if idle_rider_destinations.contains(*s) {
                 return true;
             }
             !is_covered(**s)


### PR DESCRIPTION
## Summary

- Fixes the benchmark regression flagged by nightly CI in #340
- Root cause: the idle-car rider check added in #390 iterated `idle_cars × riders` inside the per-stop filter in `pending_stops_minus_covered`, creating O(stops × idle_cars × riders) work per dispatch tick
- At the `scaling_extreme` benchmark scale (500e/5000s/50000r), this more than doubled step time (+106%)
- Fix: precompute idle-rider destinations into a `HashSet` once before the loop, then do O(1) membership tests per stop

## Benchmark recovery (local, vs regressed values from #340)

| Benchmark | Regressed | After fix |
|---|---|---|
| `step/1_riders` | 5.53 µs | 3.99 µs |
| `scaling_realistic/50e_200s_2000r` | 82.9 ms | 45.2 ms |
| `scaling_extreme/500e_5000s_50000r` | 3.0 s | 2.25 s |
| `dispatch/10e_50s` | 31.3 µs | 22.7 µs |
| `spawn_pressure/10k_spawns` | 7.59 ms | 5.77 ms |

## Test plan

- [x] Full test suite (794 lib + 158 doc tests) passes
- [x] Clippy clean
- [x] Pre-commit hook passes
- [x] Local benchmarks confirm regression recovery across all flagged benchmarks

Closes #340