### PR TITLE
fix(wasm): use tsify instead of unmaintained tsify-next

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2511,7 +2511,7 @@ dependencies = [
  "ron",
  "serde",
  "slotmap",
- "tsify-next",
+ "tsify",
  "wasm-bindgen",
 ]
 
@@ -5434,22 +5434,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "tsify-next"
+name = "tsify"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0f2208feeb5f7a6edb15a2389c14cd42480ef6417318316bb866da5806a61d"
+checksum = "8ec5505497c87f1c050b4392d3f11b49a04537fcb9dc0da57bc0af168a6331f2"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",
- "tsify-next-macros",
+ "tsify-macros",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "tsify-next-macros"
+name = "tsify-macros"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81253930d0d388a3ab8fa4ae56da9973ab171ef833d1be2e9080fc3ce502bd6"
+checksum = "9fc2c44dc9fe4baf55b88e032621b7a11b215a1f0a7de8d0aa04367207d915bc"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/elevator-wasm/Cargo.toml
+++ b/crates/elevator-wasm/Cargo.toml
@@ -32,7 +32,7 @@ missing_const_for_fn = "allow"
 [dependencies]
 elevator-core = { path = "../elevator-core", features = ["traffic"] }
 wasm-bindgen = "0.2"
-tsify-next = { version = "0.5", default-features = false, features = ["js"] }
+tsify = { version = "0.5", default-features = false, features = ["js"] }
 serde = { workspace = true }
 ron = { workspace = true }
 slotmap = { workspace = true }

--- a/crates/elevator-wasm/src/dto.rs
+++ b/crates/elevator-wasm/src/dto.rs
@@ -11,7 +11,7 @@ use elevator_core::events::Event;
 use elevator_core::prelude::{ElevatorPhase, Simulation};
 use serde::Serialize;
 use slotmap::Key;
-use tsify_next::Tsify;
+use tsify::Tsify;
 
 /// Per-elevator rendering snapshot.
 #[derive(Serialize, Tsify)]


### PR DESCRIPTION
## Summary

- Swap `tsify-next` → `tsify` (same version 0.5, same API)
- `tsify-next` has RUSTSEC-2025-0048 advisory marking it unmaintained

## Test plan

- [x] `cargo check -p elevator-wasm --target wasm32-unknown-unknown`
- [x] Pre-commit hook (all 1010 tests, clippy, fmt, workspace check)