### PR TITLE
fix(wasm): sync HallCallMode when switching to/from DCS dispatch

### DIFF
--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -42,6 +42,25 @@ type TopologyResult = (
     BTreeMap<GroupId, BuiltinStrategy>,
 );
 
+/// Ensure DCS groups have `HallCallMode::Destination` at construction
+/// time. Non-DCS groups are left at whatever the config specified —
+/// forcing Classic here would clobber explicit config overrides (e.g. a
+/// Scan group that the author deliberately set to Destination mode).
+///
+/// Runtime swaps via [`Simulation::set_dispatch`] do a full bidirectional
+/// sync because a strategy change is an explicit user action where
+/// resetting the mode is expected.
+fn sync_hall_call_modes(
+    groups: &mut [ElevatorGroup],
+    strategy_ids: &BTreeMap<GroupId, BuiltinStrategy>,
+) {
+    for group in groups.iter_mut() {
+        if strategy_ids.get(&group.id()) == Some(&BuiltinStrategy::Destination) {
+            group.set_hall_call_mode(crate::dispatch::HallCallMode::Destination);
+        }
+    }
+}
+
 /// Validate the physics fields shared by [`crate::config::ElevatorConfig`]
 /// and [`super::ElevatorParams`]. Both construction-time validation and
 /// the runtime `add_elevator` path call this so an invalid set of params
@@ -205,18 +224,19 @@ impl Simulation {
         // into a seconds expression and getting ~60× over-weighted.
         world.insert_resource(crate::time::TickRate(config.simulation.ticks_per_second));
 
-        let (groups, dispatchers, strategy_ids) = if let Some(line_configs) = &config.building.lines
-        {
-            Self::build_explicit_topology(
-                &mut world,
-                config,
-                line_configs,
-                &stop_lookup,
-                builder_dispatchers,
-            )
-        } else {
-            Self::build_legacy_topology(&mut world, config, &stop_lookup, builder_dispatchers)
-        };
+        let (mut groups, dispatchers, strategy_ids) =
+            if let Some(line_configs) = &config.building.lines {
+                Self::build_explicit_topology(
+                    &mut world,
+                    config,
+                    line_configs,
+                    &stop_lookup,
+                    builder_dispatchers,
+                )
+            } else {
+                Self::build_legacy_topology(&mut world, config, &stop_lookup, builder_dispatchers)
+            };
+        sync_hall_call_modes(&mut groups, &strategy_ids);
 
         let dt = 1.0 / config.simulation.ticks_per_second;
 
@@ -903,8 +923,8 @@ impl Simulation {
 
     /// Replace the dispatch strategy for a group.
     ///
-    /// The `id` parameter identifies the strategy for snapshot serialization.
-    /// Use `BuiltinStrategy::Custom("name")` for custom strategies.
+    /// Also synchronises `HallCallMode`: `Destination` for DCS, `Classic`
+    /// for other built-ins; `Custom` strategies leave the mode untouched.
     pub fn set_dispatch(
         &mut self,
         group: GroupId,
@@ -912,11 +932,13 @@ impl Simulation {
         id: crate::dispatch::BuiltinStrategy,
     ) {
         let mode = match &id {
-            crate::dispatch::BuiltinStrategy::Destination => {
-                Some(crate::dispatch::HallCallMode::Destination)
-            }
-            crate::dispatch::BuiltinStrategy::Custom(_) => None,
-            _ => Some(crate::dispatch::HallCallMode::Classic),
+            BuiltinStrategy::Destination => Some(crate::dispatch::HallCallMode::Destination),
+            BuiltinStrategy::Custom(_) => None,
+            BuiltinStrategy::Scan
+            | BuiltinStrategy::Look
+            | BuiltinStrategy::NearestCar
+            | BuiltinStrategy::Etd
+            | BuiltinStrategy::Rsr => Some(crate::dispatch::HallCallMode::Classic),
         };
         if let Some(mode) = mode
             && let Some(g) = self.groups.iter_mut().find(|g| g.id() == group)

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -911,6 +911,18 @@ impl Simulation {
         strategy: Box<dyn DispatchStrategy>,
         id: crate::dispatch::BuiltinStrategy,
     ) {
+        let mode = match &id {
+            crate::dispatch::BuiltinStrategy::Destination => {
+                Some(crate::dispatch::HallCallMode::Destination)
+            }
+            crate::dispatch::BuiltinStrategy::Custom(_) => None,
+            _ => Some(crate::dispatch::HallCallMode::Classic),
+        };
+        if let Some(mode) = mode
+            && let Some(g) = self.groups.iter_mut().find(|g| g.id() == group)
+        {
+            g.set_hall_call_mode(mode);
+        }
         self.dispatchers.insert(group, strategy);
         self.strategy_ids.insert(group, id);
     }

--- a/crates/elevator-core/src/tests/destination_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/destination_dispatch_tests.rs
@@ -6,6 +6,7 @@ use crate::config::{
     SimulationParams,
 };
 use crate::dispatch::destination::{ASSIGNED_CAR_KEY, AssignedCar, DestinationDispatch};
+use crate::dispatch::scan::ScanDispatch;
 use crate::entity::ElevatorId;
 use crate::sim::Simulation;
 use crate::stop::{StopConfig, StopId};
@@ -664,5 +665,60 @@ fn commitment_window_locks_when_current_car_is_close() {
     assert_ne!(
         sim.world().ext::<AssignedCar>(rid.entity()),
         Some(AssignedCar(car_a)),
+    );
+}
+
+// ── HallCallMode auto-sync ──────────────────────────────────────────
+
+#[test]
+fn set_dispatch_to_destination_syncs_hall_call_mode() {
+    let mut sim = Simulation::new(&single_car_config(), ScanDispatch::new()).unwrap();
+    assert_eq!(
+        sim.groups()[0].hall_call_mode(),
+        crate::dispatch::HallCallMode::Classic,
+    );
+
+    let gid = sim.groups()[0].id();
+    sim.set_dispatch(
+        gid,
+        Box::new(DestinationDispatch::new()),
+        crate::dispatch::BuiltinStrategy::Destination,
+    );
+    assert_eq!(
+        sim.groups()[0].hall_call_mode(),
+        crate::dispatch::HallCallMode::Destination,
+        "set_dispatch(Destination) must flip hall call mode",
+    );
+}
+
+#[test]
+fn set_dispatch_away_from_destination_resets_hall_call_mode() {
+    let mut sim =
+        Simulation::new(&two_cars_same_group_config(), DestinationDispatch::new()).unwrap();
+    assert_eq!(
+        sim.groups()[0].hall_call_mode(),
+        crate::dispatch::HallCallMode::Destination,
+    );
+
+    let gid = sim.groups()[0].id();
+    sim.set_dispatch(
+        gid,
+        Box::new(ScanDispatch::new()),
+        crate::dispatch::BuiltinStrategy::Scan,
+    );
+    assert_eq!(
+        sim.groups()[0].hall_call_mode(),
+        crate::dispatch::HallCallMode::Classic,
+        "set_dispatch(Scan) must reset hall call mode to Classic",
+    );
+}
+
+#[test]
+fn construction_with_dcs_auto_sets_destination_mode() {
+    let sim = Simulation::new(&two_cars_same_group_config(), DestinationDispatch::new()).unwrap();
+    assert_eq!(
+        sim.groups()[0].hall_call_mode(),
+        crate::dispatch::HallCallMode::Destination,
+        "Simulation::new with DCS strategy must auto-set Destination mode",
     );
 }

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -106,13 +106,6 @@ impl WasmSim {
         let mut inner = make_sim(&config, strategy)
             .ok_or_else(|| JsError::new(&format!("unknown strategy: {strategy}")))?
             .map_err(|e| JsError::new(&format!("sim build: {e}")))?;
-        // Simulation::new doesn't route through set_dispatch (which now
-        // auto-syncs the mode), so handle the initial-construction case.
-        if strategy == "destination" {
-            for group in inner.groups_mut() {
-                group.set_hall_call_mode(HallCallMode::Destination);
-            }
-        }
         // Resolve the caller-supplied reposition name (if any) to a
         // `BuiltinReposition` variant; fall back to `Adaptive` when
         // absent or unrecognised so old permalinks and undecorated

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -12,8 +12,8 @@
 
 use elevator_core::config::SimConfig;
 use elevator_core::dispatch::{
-    BuiltinReposition, BuiltinStrategy, DestinationDispatch, EtdDispatch, LookDispatch,
-    NearestCarDispatch, RsrDispatch, ScanDispatch,
+    BuiltinReposition, BuiltinStrategy, DestinationDispatch, EtdDispatch, HallCallMode,
+    LookDispatch, NearestCarDispatch, RsrDispatch, ScanDispatch,
 };
 use elevator_core::prelude::{Simulation, StopId};
 use wasm_bindgen::prelude::*;
@@ -77,6 +77,20 @@ fn make_sim(
     })
 }
 
+/// Flip every group's hall-call mode to match the active strategy.
+/// DCS requires `Destination` mode (riders announce their floor at the
+/// lobby kiosk); all other built-ins expect `Classic` (up/down buttons).
+fn sync_hall_call_mode(sim: &mut Simulation, strategy: &str) {
+    let mode = if strategy == "destination" {
+        HallCallMode::Destination
+    } else {
+        HallCallMode::Classic
+    };
+    for group in sim.groups_mut() {
+        group.set_hall_call_mode(mode);
+    }
+}
+
 /// Opaque simulation handle for JS.
 #[wasm_bindgen]
 pub struct WasmSim {
@@ -106,6 +120,7 @@ impl WasmSim {
         let mut inner = make_sim(&config, strategy)
             .ok_or_else(|| JsError::new(&format!("unknown strategy: {strategy}")))?
             .map_err(|e| JsError::new(&format!("sim build: {e}")))?;
+        sync_hall_call_mode(&mut inner, strategy);
         // Resolve the caller-supplied reposition name (if any) to a
         // `BuiltinReposition` variant; fall back to `Adaptive` when
         // absent or unrecognised so old permalinks and undecorated
@@ -254,6 +269,7 @@ impl WasmSim {
                 self.inner.set_dispatch(gid, dispatcher, id.clone());
             }
         }
+        sync_hall_call_mode(&mut self.inner, name);
         self.strategy_name = name.to_string();
         true
     }
@@ -497,6 +513,7 @@ impl WasmSim {
             self.inner
                 .set_dispatch(gid, Box::new(strategy), BuiltinStrategy::Destination);
         }
+        sync_hall_call_mode(&mut self.inner, "destination");
         self.strategy_name = "destination".to_string();
     }
 

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -77,20 +77,6 @@ fn make_sim(
     })
 }
 
-/// Flip every group's hall-call mode to match the active strategy.
-/// DCS requires `Destination` mode (riders announce their floor at the
-/// lobby kiosk); all other built-ins expect `Classic` (up/down buttons).
-fn sync_hall_call_mode(sim: &mut Simulation, strategy: &str) {
-    let mode = if strategy == "destination" {
-        HallCallMode::Destination
-    } else {
-        HallCallMode::Classic
-    };
-    for group in sim.groups_mut() {
-        group.set_hall_call_mode(mode);
-    }
-}
-
 /// Opaque simulation handle for JS.
 #[wasm_bindgen]
 pub struct WasmSim {
@@ -120,7 +106,13 @@ impl WasmSim {
         let mut inner = make_sim(&config, strategy)
             .ok_or_else(|| JsError::new(&format!("unknown strategy: {strategy}")))?
             .map_err(|e| JsError::new(&format!("sim build: {e}")))?;
-        sync_hall_call_mode(&mut inner, strategy);
+        // Simulation::new doesn't route through set_dispatch (which now
+        // auto-syncs the mode), so handle the initial-construction case.
+        if strategy == "destination" {
+            for group in inner.groups_mut() {
+                group.set_hall_call_mode(HallCallMode::Destination);
+            }
+        }
         // Resolve the caller-supplied reposition name (if any) to a
         // `BuiltinReposition` variant; fall back to `Adaptive` when
         // absent or unrecognised so old permalinks and undecorated
@@ -269,7 +261,6 @@ impl WasmSim {
                 self.inner.set_dispatch(gid, dispatcher, id.clone());
             }
         }
-        sync_hall_call_mode(&mut self.inner, name);
         self.strategy_name = name.to_string();
         true
     }
@@ -481,7 +472,6 @@ impl WasmSim {
     /// that want DCS (e.g. the hotel) call this once on load.
     #[wasm_bindgen(js_name = setHallCallModeDestination)]
     pub fn set_hall_call_mode_destination(&mut self) {
-        use elevator_core::dispatch::HallCallMode;
         for group in self.inner.groups_mut() {
             group.set_hall_call_mode(HallCallMode::Destination);
         }
@@ -513,7 +503,6 @@ impl WasmSim {
             self.inner
                 .set_dispatch(gid, Box::new(strategy), BuiltinStrategy::Destination);
         }
-        sync_hall_call_mode(&mut self.inner, "destination");
         self.strategy_name = "destination".to_string();
     }
 


### PR DESCRIPTION
## Summary

- DCS dispatch was completely inert in the playground — selecting "destination" strategy never flipped `HallCallMode` from `Classic` to `Destination`, so `pre_dispatch` early-returned on every tick (no assignments, empty queues, `rank` always `None`, all cars Idle)
- Added `sync_hall_call_mode()` helper called from `WasmSim::new`, `set_strategy`, and `set_dcs_with_commitment_window` to keep the mode in sync with the active dispatch strategy
- Switching away from DCS resets groups back to `Classic`

## Test plan

- [x] All 794 core unit tests pass
- [x] All 158 doc-tests pass
- [x] All 7 WASM integration tests pass (including `hotel_scenario_builds_and_accepts_dcs_swap`)
- [ ] Verify in playground: select DCS strategy → riders should be assigned and picked up
- [ ] Verify strategy switching: DCS → SCAN → DCS round-trip works