### PR TITLE
feat(core): add OutOfService mode, recall_to API, fix Inspection dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.17.2"
+version = "15.17.3"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/components/service_mode.rs
+++ b/crates/elevator-core/src/components/service_mode.rs
@@ -60,11 +60,11 @@ impl ServiceMode {
     /// `true` if the loading phase should automatically board and exit
     /// riders at open doors.
     ///
-    /// Only [`Normal`](Self::Normal) allows auto-boarding. All other
+    /// Only [`Normal`](Self::Normal) allows auto-loading. All other
     /// modes hand rider management to the consumer or are operationally
     /// unsuitable for passenger service.
     #[must_use]
-    pub const fn allows_auto_boarding(self) -> bool {
+    pub const fn allows_auto_loading(self) -> bool {
         matches!(self, Self::Normal)
     }
 }

--- a/crates/elevator-core/src/components/service_mode.rs
+++ b/crates/elevator-core/src/components/service_mode.rs
@@ -29,18 +29,43 @@ pub enum ServiceMode {
     /// door-control API. Can stop at any position — the elevator is not
     /// required to align with a configured stop.
     Manual,
+    /// Out of service: the elevator is shut down. Excluded from dispatch
+    /// and repositioning; auto-boarding is disabled. In-flight trips
+    /// complete and doors cycle normally, but no riders board or exit.
+    /// Once idle the car is fully inert.
+    ///
+    /// Unlike [`Simulation::disable`](crate::sim::Simulation::disable),
+    /// the entity remains visible in queries and is not skipped by
+    /// iteration — games can render an "out of order" indicator.
+    OutOfService,
 }
 
 impl ServiceMode {
     /// `true` if elevators in this mode are skipped by the automatic
     /// dispatch and repositioning phases.
     ///
-    /// Returns `true` for [`Independent`](Self::Independent) and
-    /// [`Manual`](Self::Manual), which both hand elevator movement over
-    /// to the consumer.
+    /// Returns `true` for [`Independent`](Self::Independent),
+    /// [`Manual`](Self::Manual), [`Inspection`](Self::Inspection), and
+    /// [`OutOfService`](Self::OutOfService). Independent and Manual hand
+    /// movement over to the consumer; Inspection is technician-controlled;
+    /// `OutOfService` is fully inert.
     #[must_use]
     pub const fn is_dispatch_excluded(self) -> bool {
-        matches!(self, Self::Independent | Self::Manual)
+        matches!(
+            self,
+            Self::Independent | Self::Manual | Self::Inspection | Self::OutOfService
+        )
+    }
+
+    /// `true` if the loading phase should automatically board and exit
+    /// riders at open doors.
+    ///
+    /// Only [`Normal`](Self::Normal) allows auto-boarding. All other
+    /// modes hand rider management to the consumer or are operationally
+    /// unsuitable for passenger service.
+    #[must_use]
+    pub const fn allows_auto_boarding(self) -> bool {
+        matches!(self, Self::Normal)
     }
 }
 
@@ -51,6 +76,7 @@ impl std::fmt::Display for ServiceMode {
             Self::Independent => write!(f, "Independent"),
             Self::Inspection => write!(f, "Inspection"),
             Self::Manual => write!(f, "Manual"),
+            Self::OutOfService => write!(f, "OutOfService"),
         }
     }
 }

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -308,6 +308,22 @@ pub enum Event {
         tick: u64,
     },
 
+    /// An elevator was recalled to a specific stop via
+    /// [`Simulation::recall_to`](crate::sim::Simulation::recall_to).
+    ///
+    /// The car's destination queue has been replaced with the recall
+    /// target. If the car was mid-flight, it continues to its current
+    /// target, then proceeds to the recall stop. If idle, it departs
+    /// on the next tick.
+    ElevatorRecalled {
+        /// The elevator that was recalled.
+        elevator: EntityId,
+        /// The stop the elevator is being sent to.
+        to_stop: EntityId,
+        /// The tick when the recall was issued.
+        tick: u64,
+    },
+
     /// An elevator's service mode was changed.
     ServiceModeChanged {
         /// The elevator whose mode changed.
@@ -742,6 +758,7 @@ impl Event {
             Self::ElevatorRepositioning { .. } | Self::ElevatorRepositioned { .. } => {
                 EventCategory::Reposition
             }
+            Self::ElevatorRecalled { .. } => EventCategory::Elevator,
             Self::DirectionIndicatorChanged { .. } => EventCategory::Direction,
             Self::ServiceModeChanged { .. }
             | Self::CapacityChanged { .. }

--- a/crates/elevator-core/src/sim/destinations.rs
+++ b/crates/elevator-core/src/sim/destinations.rs
@@ -196,6 +196,14 @@ impl super::Simulation {
     /// Works in any service mode — even dispatch-excluded cars can be
     /// recalled. Emits [`Event::ElevatorRecalled`].
     ///
+    /// # Service mode interaction
+    ///
+    /// Non-Normal modes suppress the loading phase (both boarding and
+    /// exiting). If you set `OutOfService` *before* the car arrives at
+    /// the recall stop, riders aboard will not auto-exit. For the
+    /// fire-service pattern, switch to `OutOfService` only *after*
+    /// observing `ElevatorArrived` and letting the loading phase drain.
+    ///
     /// # Errors
     ///
     /// - [`SimError::NotAnElevator`] if `elev` is not an elevator.

--- a/crates/elevator-core/src/sim/destinations.rs
+++ b/crates/elevator-core/src/sim/destinations.rs
@@ -180,6 +180,49 @@ impl super::Simulation {
         Ok(())
     }
 
+    /// Recall an elevator to a specific stop.
+    ///
+    /// Clears the destination queue and replaces it with `stop` as the
+    /// sole target. Riders aboard stay aboard. The car proceeds to the
+    /// recall stop and opens doors on arrival (standard `MovingToStop`
+    /// semantics).
+    ///
+    /// If the car is already at the recall stop, doors open on the next
+    /// tick. If the car is mid-flight, it finishes its current leg's
+    /// deceleration (the movement system handles the redirect). If the
+    /// car is in a door cycle (opening/loading/closing), the cycle
+    /// completes, then the car departs.
+    ///
+    /// Works in any service mode — even dispatch-excluded cars can be
+    /// recalled. Emits [`Event::ElevatorRecalled`].
+    ///
+    /// # Errors
+    ///
+    /// - [`SimError::NotAnElevator`] if `elev` is not an elevator.
+    /// - [`SimError::NotAStop`] if `stop` is not a stop.
+    pub fn recall_to(
+        &mut self,
+        elev: ElevatorId,
+        stop: impl Into<StopRef>,
+    ) -> Result<(), SimError> {
+        let eid = elev.entity();
+        let stop = self.resolve_stop(stop.into())?;
+        self.validate_push_targets(eid, stop)?;
+
+        if let Some(q) = self.world.destination_queue_mut(eid) {
+            q.clear();
+            q.push_back(stop);
+        }
+
+        self.events.emit(Event::ElevatorRecalled {
+            elevator: eid,
+            to_stop: stop,
+            tick: self.tick,
+        });
+
+        Ok(())
+    }
+
     /// Validate that `elev` is an elevator and `stop` is a stop.
     fn validate_push_targets(&self, elev: EntityId, stop: EntityId) -> Result<(), SimError> {
         if self.world.elevator(elev).is_none() {

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -77,6 +77,14 @@ fn collect_actions(
         if world.is_disabled(eid) {
             continue;
         }
+        if !world
+            .service_mode(eid)
+            .copied()
+            .unwrap_or_default()
+            .allows_auto_boarding()
+        {
+            continue;
+        }
         let Some(car) = world.elevator(eid) else {
             continue;
         };

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -81,7 +81,7 @@ fn collect_actions(
             .service_mode(eid)
             .copied()
             .unwrap_or_default()
-            .allows_auto_boarding()
+            .allows_auto_loading()
         {
             continue;
         }

--- a/crates/elevator-core/src/tests/destination_queue_tests.rs
+++ b/crates/elevator-core/src/tests/destination_queue_tests.rs
@@ -322,3 +322,192 @@ fn redirect_via_push_front_updates_direction_indicators() {
     );
     assert_eq!(sim.elevator_going_down(elev.entity()), Some(true));
 }
+
+// ── recall_to ──────────────────────────────────────────────────────
+
+/// recall_to clears the queue and sets a single target.
+#[test]
+fn recall_to_clears_queue_and_sets_target() {
+    let mut sim = SimulationBuilder::demo().build().unwrap();
+    let elev = ElevatorId::from(sim.world().elevator_ids()[0]);
+
+    // Queue a destination, then recall to the other stop.
+    sim.push_destination(elev, StopId(1)).unwrap();
+    sim.recall_to(elev, StopId(0)).unwrap();
+
+    let q = sim.destination_queue(elev).unwrap();
+    assert_eq!(q.len(), 1, "queue should contain only the recall target");
+    assert_eq!(q[0], sim.stop_entity(StopId(0)).unwrap());
+}
+
+/// recall_to emits an ElevatorRecalled event.
+#[test]
+fn recall_to_emits_event() {
+    let mut sim = SimulationBuilder::demo().build().unwrap();
+    let elev = ElevatorId::from(sim.world().elevator_ids()[0]);
+    sim.drain_events();
+
+    sim.recall_to(elev, StopId(1)).unwrap();
+
+    let recall_events: Vec<_> = sim
+        .drain_events()
+        .into_iter()
+        .filter(|e| matches!(e, Event::ElevatorRecalled { .. }))
+        .collect();
+    assert_eq!(recall_events.len(), 1);
+    if let Event::ElevatorRecalled {
+        elevator, to_stop, ..
+    } = &recall_events[0]
+    {
+        assert_eq!(*elevator, elev.entity());
+        assert_eq!(*to_stop, sim.stop_entity(StopId(1)).unwrap());
+    }
+}
+
+/// recall_to on an idle car at a different stop causes it to depart.
+#[test]
+fn recall_idle_car_to_distant_stop() {
+    let mut sim = SimulationBuilder::demo().build().unwrap();
+    let elev = ElevatorId::from(sim.world().elevator_ids()[0]);
+
+    sim.recall_to(elev, StopId(1)).unwrap();
+
+    let target_pos = sim
+        .world()
+        .stop(sim.stop_entity(StopId(1)).unwrap())
+        .unwrap()
+        .position();
+    let mut arrived = false;
+    for _ in 0..2000 {
+        sim.step();
+        let pos = sim.world().position(elev.entity()).unwrap().value;
+        if (pos - target_pos).abs() < 0.01 {
+            arrived = true;
+            break;
+        }
+    }
+    assert!(arrived, "car should have arrived at the recall stop");
+}
+
+/// recall_to on a car already at the recall stop triggers a door cycle.
+#[test]
+fn recall_to_current_stop_opens_doors() {
+    let mut sim = SimulationBuilder::demo().build().unwrap();
+    let elev = ElevatorId::from(sim.world().elevator_ids()[0]);
+
+    // Car starts at stop 0 (default). Recall to stop 0.
+    sim.recall_to(elev, StopId(0)).unwrap();
+
+    // Track whether doors opened during the cycle.
+    let mut saw_open = false;
+    for _ in 0..30 {
+        sim.step();
+        let car = sim.world().elevator(elev.entity()).unwrap();
+        if car.door().is_open() {
+            saw_open = true;
+            break;
+        }
+    }
+    assert!(saw_open, "doors should open when recalled to current stop");
+}
+
+/// recall_to works on dispatch-excluded (Independent) cars.
+#[test]
+fn recall_works_on_independent_car() {
+    let mut sim = SimulationBuilder::demo().build().unwrap();
+    let elev = ElevatorId::from(sim.world().elevator_ids()[0]);
+
+    sim.set_service_mode(elev.entity(), crate::components::ServiceMode::Independent)
+        .unwrap();
+
+    sim.recall_to(elev, StopId(1)).unwrap();
+
+    let target_pos = sim
+        .world()
+        .stop(sim.stop_entity(StopId(1)).unwrap())
+        .unwrap()
+        .position();
+    let mut arrived = false;
+    for _ in 0..2000 {
+        sim.step();
+        let pos = sim.world().position(elev.entity()).unwrap().value;
+        if (pos - target_pos).abs() < 0.01 {
+            arrived = true;
+            break;
+        }
+    }
+    assert!(arrived, "Independent car should still respond to recall_to");
+}
+
+/// recall_to errors on invalid entities.
+#[test]
+fn recall_to_validates_entities() {
+    let mut sim = SimulationBuilder::demo().build().unwrap();
+    let elev = ElevatorId::from(sim.world().elevator_ids()[0]);
+    let stop_entity = sim.stop_entity(StopId(0)).unwrap();
+
+    // Not an elevator.
+    assert!(matches!(
+        sim.recall_to(ElevatorId::from(stop_entity), StopId(0)),
+        Err(SimError::NotAnElevator(_))
+    ));
+
+    // Not a stop.
+    assert!(sim.recall_to(elev, StopId(99)).is_err());
+}
+
+/// recall_to mid-flight redirects the car to the recall stop.
+#[test]
+fn recall_mid_flight_redirects() {
+    let mut sim = SimulationBuilder::demo().build().unwrap();
+    let elev = ElevatorId::from(sim.world().elevator_ids()[0]);
+
+    // Send car toward stop 1.
+    sim.push_destination(elev, StopId(1)).unwrap();
+
+    // Wait until car is actually moving.
+    for _ in 0..10 {
+        sim.step();
+        if sim
+            .world()
+            .elevator(elev.entity())
+            .unwrap()
+            .phase()
+            .is_moving()
+        {
+            break;
+        }
+    }
+    assert!(
+        sim.world()
+            .elevator(elev.entity())
+            .unwrap()
+            .phase()
+            .is_moving(),
+        "car should be in flight"
+    );
+
+    // Recall back to stop 0 mid-flight.
+    sim.recall_to(elev, StopId(0)).unwrap();
+
+    // Car should eventually return to stop 0.
+    let stop0_pos = sim
+        .world()
+        .stop(sim.stop_entity(StopId(0)).unwrap())
+        .unwrap()
+        .position();
+    let mut returned = false;
+    for _ in 0..2000 {
+        sim.step();
+        let pos = sim.world().position(elev.entity()).unwrap().value;
+        let phase = sim.world().elevator(elev.entity()).unwrap().phase();
+        if (pos - stop0_pos).abs() < 0.01 && !phase.is_moving() {
+            returned = true;
+            break;
+        }
+    }
+    assert!(
+        returned,
+        "car should return to stop 0 after mid-flight recall"
+    );
+}

--- a/crates/elevator-core/src/tests/destination_queue_tests.rs
+++ b/crates/elevator-core/src/tests/destination_queue_tests.rs
@@ -325,7 +325,7 @@ fn redirect_via_push_front_updates_direction_indicators() {
 
 // ── recall_to ──────────────────────────────────────────────────────
 
-/// recall_to clears the queue and sets a single target.
+/// `recall_to` clears the queue and sets a single target.
 #[test]
 fn recall_to_clears_queue_and_sets_target() {
     let mut sim = SimulationBuilder::demo().build().unwrap();
@@ -340,7 +340,7 @@ fn recall_to_clears_queue_and_sets_target() {
     assert_eq!(q[0], sim.stop_entity(StopId(0)).unwrap());
 }
 
-/// recall_to emits an ElevatorRecalled event.
+/// `recall_to` emits an `ElevatorRecalled` event.
 #[test]
 fn recall_to_emits_event() {
     let mut sim = SimulationBuilder::demo().build().unwrap();
@@ -364,7 +364,7 @@ fn recall_to_emits_event() {
     }
 }
 
-/// recall_to on an idle car at a different stop causes it to depart.
+/// `recall_to` on an idle car at a different stop causes it to depart.
 #[test]
 fn recall_idle_car_to_distant_stop() {
     let mut sim = SimulationBuilder::demo().build().unwrap();
@@ -389,7 +389,7 @@ fn recall_idle_car_to_distant_stop() {
     assert!(arrived, "car should have arrived at the recall stop");
 }
 
-/// recall_to on a car already at the recall stop triggers a door cycle.
+/// `recall_to` on a car already at the recall stop triggers a door cycle.
 #[test]
 fn recall_to_current_stop_opens_doors() {
     let mut sim = SimulationBuilder::demo().build().unwrap();
@@ -411,7 +411,7 @@ fn recall_to_current_stop_opens_doors() {
     assert!(saw_open, "doors should open when recalled to current stop");
 }
 
-/// recall_to works on dispatch-excluded (Independent) cars.
+/// `recall_to` works on dispatch-excluded (`Independent`) cars.
 #[test]
 fn recall_works_on_independent_car() {
     let mut sim = SimulationBuilder::demo().build().unwrap();
@@ -439,7 +439,7 @@ fn recall_works_on_independent_car() {
     assert!(arrived, "Independent car should still respond to recall_to");
 }
 
-/// recall_to errors on invalid entities.
+/// `recall_to` errors on invalid entities.
 #[test]
 fn recall_to_validates_entities() {
     let mut sim = SimulationBuilder::demo().build().unwrap();
@@ -456,7 +456,7 @@ fn recall_to_validates_entities() {
     assert!(sim.recall_to(elev, StopId(99)).is_err());
 }
 
-/// recall_to mid-flight redirects the car to the recall stop.
+/// `recall_to` mid-flight redirects the car to the recall stop.
 #[test]
 fn recall_mid_flight_redirects() {
     let mut sim = SimulationBuilder::demo().build().unwrap();

--- a/crates/elevator-core/src/tests/service_mode_tests.rs
+++ b/crates/elevator-core/src/tests/service_mode_tests.rs
@@ -298,17 +298,14 @@ fn non_normal_modes_skip_auto_boarding() {
         "rider should not be auto-boarded in Independent mode"
     );
     assert_eq!(
-        sim.world()
-            .elevator(elev)
-            .map(|c| c.riders().len())
-            .unwrap_or(0),
+        sim.world().elevator(elev).map_or(0, |c| c.riders().len()),
         0,
         "no riders should be aboard the Independent car"
     );
 }
 
-/// 9. OutOfService: excluded from dispatch, no auto-boarding, but entity
-/// stays visible and queries still work.
+/// 9. `OutOfService`: excluded from dispatch, no auto-boarding, but entity
+///    stays visible and queries still work.
 #[test]
 fn out_of_service_fully_inert() {
     let config = default_config();
@@ -345,7 +342,7 @@ fn out_of_service_fully_inert() {
     assert!(sim.metrics().total_delivered() > 0);
 }
 
-/// 10. OutOfService during motion: in-flight trip completes.
+/// 10. `OutOfService` during motion: in-flight trip completes.
 #[test]
 fn out_of_service_mid_flight_completes_trip() {
     use crate::entity::ElevatorId;

--- a/crates/elevator-core/src/tests/service_mode_tests.rs
+++ b/crates/elevator-core/src/tests/service_mode_tests.rs
@@ -105,19 +105,22 @@ fn inspection_reduced_speed() {
 }
 
 /// 4. Inspection mode -- doors hold open indefinitely.
+///
+/// Inspection is dispatch-excluded, so we open doors manually via
+/// `open_door` rather than relying on dispatch.
 #[test]
 fn inspection_doors_hold_open() {
+    use crate::entity::ElevatorId;
+
     let config = default_config();
     let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
 
     let elev = sim.world().elevator_ids()[0];
     sim.set_service_mode(elev, ServiceMode::Inspection).unwrap();
 
-    // Spawn a rider so the elevator gets dispatched and eventually opens doors.
-    sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
+    // Manually open doors (elevator starts at stop 0).
+    sim.open_door(ElevatorId::from(elev)).unwrap();
 
-    // The elevator starts at stop 0, so dispatch should open doors immediately.
-    // Run until doors are open.
     let mut doors_opened = false;
     for _ in 0..200 {
         sim.step();
@@ -260,5 +263,135 @@ fn independent_excluded_from_reposition() {
     assert!(
         (pos_before - pos_after).abs() < 1e-9,
         "independent elevator should not be repositioned: before={pos_before}, after={pos_after}, phase={phase}"
+    );
+}
+
+/// 8. Non-Normal modes skip auto-boarding even when doors are open.
+///
+/// An Independent car with manually opened doors at a stop with waiting
+/// riders should not auto-board them — only Normal does.
+#[test]
+fn non_normal_modes_skip_auto_boarding() {
+    use crate::entity::ElevatorId;
+
+    let config = default_config();
+    let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
+    let elev = sim.world().elevator_ids()[0];
+
+    sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
+
+    sim.set_service_mode(elev, ServiceMode::Independent)
+        .unwrap();
+
+    // Manually open doors at stop 0 (where the rider is waiting).
+    sim.open_door(ElevatorId::from(elev)).unwrap();
+
+    for _ in 0..200 {
+        sim.step();
+    }
+
+    // Rider should still be waiting — Independent mode skips auto-boarding.
+    assert!(
+        sim.world()
+            .iter_riders()
+            .any(|(_, r)| r.phase() == RiderPhase::Waiting),
+        "rider should not be auto-boarded in Independent mode"
+    );
+    assert_eq!(
+        sim.world()
+            .elevator(elev)
+            .map(|c| c.riders().len())
+            .unwrap_or(0),
+        0,
+        "no riders should be aboard the Independent car"
+    );
+}
+
+/// 9. OutOfService: excluded from dispatch, no auto-boarding, but entity
+/// stays visible and queries still work.
+#[test]
+fn out_of_service_fully_inert() {
+    let config = default_config();
+    let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
+    let elev = sim.world().elevator_ids()[0];
+
+    sim.set_service_mode(elev, ServiceMode::OutOfService)
+        .unwrap();
+
+    // Entity is still visible (not disabled).
+    assert!(!sim.is_disabled(elev));
+    assert!(sim.world().elevator(elev).is_some());
+
+    sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
+
+    for _ in 0..500 {
+        sim.step();
+    }
+
+    // Rider should still be waiting — OOS car doesn't serve dispatch.
+    assert!(
+        sim.world()
+            .iter_riders()
+            .any(|(_, r)| r.phase() == RiderPhase::Waiting),
+        "rider should not be served by an OutOfService car"
+    );
+    assert_eq!(sim.metrics().total_delivered(), 0);
+
+    // Restore normal service; rider gets delivered.
+    sim.set_service_mode(elev, ServiceMode::Normal).unwrap();
+    for _ in 0..2000 {
+        sim.step();
+    }
+    assert!(sim.metrics().total_delivered() > 0);
+}
+
+/// 10. OutOfService during motion: in-flight trip completes.
+#[test]
+fn out_of_service_mid_flight_completes_trip() {
+    use crate::entity::ElevatorId;
+
+    let config = default_config();
+    let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
+    let elev = sim.world().elevator_ids()[0];
+
+    // Send car to stop 2 via push_destination.
+    sim.push_destination(ElevatorId::from(elev), StopId(2))
+        .unwrap();
+
+    // Wait until it's moving.
+    for _ in 0..20 {
+        sim.step();
+        if sim.world().elevator(elev).unwrap().phase().is_moving() {
+            break;
+        }
+    }
+    assert!(
+        sim.world().elevator(elev).unwrap().phase().is_moving(),
+        "car should be in flight before switching to OutOfService"
+    );
+
+    // Switch to OutOfService mid-flight.
+    sim.set_service_mode(elev, ServiceMode::OutOfService)
+        .unwrap();
+
+    // Car should still arrive at stop 2.
+    let target_pos = sim
+        .world()
+        .stop(sim.stop_entity(StopId(2)).unwrap())
+        .unwrap()
+        .position();
+    let mut arrived = false;
+    for _ in 0..2000 {
+        sim.step();
+        let pos = sim.world().position(elev).unwrap().value;
+        let phase = sim.world().elevator(elev).unwrap().phase();
+        if (pos - target_pos).abs() < 0.01 && !phase.is_moving() {
+            arrived = true;
+            break;
+        }
+    }
+    assert!(
+        arrived,
+        "OutOfService car should complete in-flight trip to stop 2"
     );
 }


### PR DESCRIPTION
## Summary

- **`OutOfService` service mode**: dispatch-excluded, no auto-boarding, entity stays visible (unlike `disable()`). In-flight trips complete, then car goes inert. Games can render "out of order" indicators.
- **`recall_to()` API**: imperative recall to a specific stop — clears destination queue, re-targets the car, opens doors on arrival. Works in any service mode (even Independent/Manual). Emits `ElevatorRecalled` event.
- **Inspection dispatch fix**: Inspection mode is now dispatch-excluded. Technician-controlled cars shouldn't receive automatic assignments.
- **Loading phase guard**: new `allows_auto_boarding()` method — only `Normal` mode auto-boards riders. Independent/Inspection/Manual/OutOfService cars no longer get surprise passengers.

## Design

These are composable primitives, not prescriptive game mechanics. A game dev builds fire service by composing: `recall_to(lobby)` + `set_service_mode(OutOfService)` + their own trigger logic.

## Test plan

- [ ] 807 core tests pass (9 new: OutOfService inert, OOS mid-flight, auto-boarding guard, recall queue/event/idle/current-stop/independent/mid-flight/validation)
- [ ] All 5 scenario tests pass (including updated Inspection doors test)
- [ ] Clippy clean, workspace compiles (FFI/bevy/wasm/gdext)
- [ ] Pre-commit hook passes (fmt, clippy, tests, doctests, commitlint)