### PR TITLE
fix(core): scrub disabled stops from queues, clear Manual door commands

### DIFF
--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -595,16 +595,10 @@ impl Simulation {
             vel.value = 0.0;
         }
 
-        // If this is a stop, scrub it from elevator destination queues,
+        // If this is a stop, scrub it from elevator targets/queues,
         // abandon resident riders, and invalidate routes.
         if self.world.stop(id).is_some() {
-            let elevator_ids: Vec<EntityId> =
-                self.world.iter_elevators().map(|(eid, _, _)| eid).collect();
-            for eid in elevator_ids {
-                if let Some(q) = self.world.destination_queue_mut(eid) {
-                    q.retain(|s| s != id);
-                }
-            }
+            self.scrub_stop_from_elevators(id);
             let resident_ids: Vec<EntityId> =
                 self.rider_index.residents_at(id).iter().copied().collect();
             for rid in resident_ids {
@@ -744,6 +738,23 @@ impl Simulation {
                     stop: abandon_stop,
                     tick: self.tick,
                 });
+            }
+        }
+    }
+
+    /// Remove a disabled stop from all elevator targets and queues.
+    fn scrub_stop_from_elevators(&mut self, stop: EntityId) {
+        let elevator_ids: Vec<EntityId> =
+            self.world.iter_elevators().map(|(eid, _, _)| eid).collect();
+        for eid in elevator_ids {
+            if let Some(car) = self.world.elevator_mut(eid)
+                && car.target_stop == Some(stop)
+            {
+                car.target_stop = None;
+                car.phase = ElevatorPhase::Idle;
+            }
+            if let Some(q) = self.world.destination_queue_mut(eid) {
+                q.retain(|s| s != stop);
             }
         }
     }

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -595,8 +595,16 @@ impl Simulation {
             vel.value = 0.0;
         }
 
-        // If this is a stop, abandon resident riders and invalidate routes.
+        // If this is a stop, scrub it from elevator destination queues,
+        // abandon resident riders, and invalidate routes.
         if self.world.stop(id).is_some() {
+            let elevator_ids: Vec<EntityId> =
+                self.world.iter_elevators().map(|(eid, _, _)| eid).collect();
+            for eid in elevator_ids {
+                if let Some(q) = self.world.destination_queue_mut(eid) {
+                    q.retain(|s| s != id);
+                }
+            }
             let resident_ids: Vec<EntityId> =
                 self.rider_index.residents_at(id).iter().copied().collect();
             for rid in resident_ids {
@@ -928,6 +936,7 @@ impl Simulation {
         if old == crate::components::ServiceMode::Manual {
             if let Some(car) = self.world.elevator_mut(elevator) {
                 car.manual_target_velocity = None;
+                car.door_command_queue.clear();
             }
             if let Some(v) = self.world.velocity_mut(elevator) {
                 v.value = 0.0;

--- a/crates/elevator-core/src/tests/destination_queue_tests.rs
+++ b/crates/elevator-core/src/tests/destination_queue_tests.rs
@@ -511,3 +511,23 @@ fn recall_mid_flight_redirects() {
         "car should return to stop 0 after mid-flight recall"
     );
 }
+
+/// Disabling a stop scrubs it from all elevator destination queues.
+#[test]
+fn disable_stop_scrubs_destination_queues() {
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+
+    sim.push_destination(elev, StopId(1)).unwrap();
+    sim.push_destination(elev, StopId(2)).unwrap();
+
+    let stop1_entity = sim.stop_entity(StopId(1)).unwrap();
+    sim.disable(stop1_entity).unwrap();
+
+    let q = sim.destination_queue(elev).unwrap();
+    assert!(
+        !q.contains(&stop1_entity),
+        "disabled stop should be scrubbed from destination queue"
+    );
+    assert_eq!(q.len(), 1, "only the non-disabled stop should remain");
+}

--- a/crates/elevator-core/src/tests/destination_queue_tests.rs
+++ b/crates/elevator-core/src/tests/destination_queue_tests.rs
@@ -531,3 +531,52 @@ fn disable_stop_scrubs_destination_queues() {
     );
     assert_eq!(q.len(), 1, "only the non-disabled stop should remain");
 }
+
+/// Disabling a stop that a car is actively targeting resets the car to `Idle`.
+#[test]
+fn disable_stop_resets_inflight_car() {
+    let mut sim = build_sim();
+    let elev = first_elevator(&sim);
+
+    // Send car toward stop 2.
+    sim.push_destination(elev, StopId(2)).unwrap();
+
+    // Advance until the car is in flight (target popped from queue).
+    for _ in 0..10 {
+        sim.step();
+        if sim
+            .world()
+            .elevator(elev.entity())
+            .unwrap()
+            .phase()
+            .is_moving()
+        {
+            break;
+        }
+    }
+    assert!(
+        sim.world()
+            .elevator(elev.entity())
+            .unwrap()
+            .phase()
+            .is_moving(),
+        "car should be in flight"
+    );
+
+    // Disable the target stop while car is en route.
+    let stop2_entity = sim.stop_entity(StopId(2)).unwrap();
+    sim.disable(stop2_entity).unwrap();
+
+    // Car should be reset to Idle — no longer targeting the disabled stop.
+    let car = sim.world().elevator(elev.entity()).unwrap();
+    assert_eq!(
+        car.phase(),
+        ElevatorPhase::Idle,
+        "car targeting a disabled stop should be reset to Idle"
+    );
+    assert_eq!(
+        car.target_stop(),
+        None,
+        "target_stop should be cleared for the disabled stop"
+    );
+}

--- a/crates/elevator-core/src/tests/service_mode_tests.rs
+++ b/crates/elevator-core/src/tests/service_mode_tests.rs
@@ -392,3 +392,39 @@ fn out_of_service_mid_flight_completes_trip() {
         "OutOfService car should complete in-flight trip to stop 2"
     );
 }
+
+/// 11. Leaving Manual mode clears queued door commands.
+#[test]
+fn leaving_manual_clears_door_command_queue() {
+    use crate::entity::ElevatorId;
+
+    let config = default_config();
+    let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
+    let elev = sim.world().elevator_ids()[0];
+
+    sim.set_service_mode(elev, ServiceMode::Manual).unwrap();
+
+    // Queue a hold-open command while in Manual.
+    sim.hold_door(ElevatorId::from(elev), 999).unwrap();
+
+    assert!(
+        !sim.world()
+            .elevator(elev)
+            .unwrap()
+            .door_command_queue()
+            .is_empty(),
+        "door command queue should have a pending command"
+    );
+
+    // Switch back to Normal — queued commands should be cleared.
+    sim.set_service_mode(elev, ServiceMode::Normal).unwrap();
+
+    assert!(
+        sim.world()
+            .elevator(elev)
+            .unwrap()
+            .door_command_queue()
+            .is_empty(),
+        "door command queue should be cleared after leaving Manual"
+    );
+}


### PR DESCRIPTION
## Summary

Two bugs found during code audit:

- **Disabled stop lingers in destination queues**: When a stop is disabled via `sim.disable(stop)`, it was left in elevator destination queues. Cars would navigate to the ghost floor, open doors, find no riders, and idle — wasting a trip. Now `disable()` scrubs the stop from all queues, mirroring `remove_stop()` which already did this.
- **Manual mode door commands persist after mode switch**: Leaving `ServiceMode::Manual` cleared `manual_target_velocity` and velocity, but not the `door_command_queue`. A `HoldOpen` command queued during Manual would survive into Normal mode, holding doors indefinitely. Now cleared alongside the other Manual state.

## Test plan

- [ ] `disable_stop_scrubs_destination_queues` — push stop to queue, disable it, verify it's gone
- [ ] `leaving_manual_clears_door_command_queue` — queue HoldOpen in Manual, switch to Normal, verify queue empty
- [ ] 809 existing tests still pass
- [ ] Clippy clean with `-D warnings` on all targets