### PR TITLE
fix(snapshot): round-trip the running dispatch strategy

### DIFF
--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -277,6 +277,10 @@ impl DispatchStrategy for DestinationDispatch {
             None
         }
     }
+
+    fn builtin_id(&self) -> Option<super::BuiltinStrategy> {
+        Some(super::BuiltinStrategy::Destination)
+    }
 }
 
 impl DestinationDispatch {

--- a/crates/elevator-core/src/dispatch/etd.rs
+++ b/crates/elevator-core/src/dispatch/etd.rs
@@ -192,6 +192,10 @@ impl DispatchStrategy for EtdDispatch {
         }
         if cost.is_finite() { Some(cost) } else { None }
     }
+
+    fn builtin_id(&self) -> Option<super::BuiltinStrategy> {
+        Some(super::BuiltinStrategy::Etd)
+    }
 }
 
 impl EtdDispatch {

--- a/crates/elevator-core/src/dispatch/look.rs
+++ b/crates/elevator-core/src/dispatch/look.rs
@@ -93,4 +93,8 @@ impl DispatchStrategy for LookDispatch {
         self.direction.remove(&elevator);
         self.mode.remove(&elevator);
     }
+
+    fn builtin_id(&self) -> Option<super::BuiltinStrategy> {
+        Some(super::BuiltinStrategy::Look)
+    }
 }

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -834,6 +834,29 @@ pub trait DispatchStrategy: Send + Sync {
     /// Implementations with per-elevator state (e.g. direction tracking)
     /// should clean up here to prevent unbounded memory growth.
     fn notify_removed(&mut self, _elevator: EntityId) {}
+
+    /// If this strategy is a known built-in variant, return it so
+    /// [`Simulation::new`](crate::sim::Simulation::new) can stamp the
+    /// correct [`BuiltinStrategy`] into the group's snapshot identity.
+    ///
+    /// Without this, legacy-topology sims constructed via
+    /// `Simulation::new(config, SomeNonScanStrategy::new())` silently
+    /// recorded `BuiltinStrategy::Scan` as their identity — so a
+    /// snapshot round-trip replaced the running strategy with Scan
+    /// and produced different dispatch decisions post-restore
+    /// (determinism regression).
+    ///
+    /// Default: `None` (unidentified — callers using the builder API
+    /// should call [`SimulationBuilder::with_strategy_id`] for
+    /// snapshot fidelity; custom strategies should override this if
+    /// they want stable round-trip identity, typically by returning
+    /// [`BuiltinStrategy::Custom`] with a stable name).
+    ///
+    /// [`SimulationBuilder::with_strategy_id`]: crate::builder::SimulationBuilder::with_strategy_id
+    #[must_use]
+    fn builtin_id(&self) -> Option<BuiltinStrategy> {
+        None
+    }
 }
 
 /// Resolution of a single dispatch assignment pass for one group.

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -846,13 +846,11 @@ pub trait DispatchStrategy: Send + Sync {
     /// and produced different dispatch decisions post-restore
     /// (determinism regression).
     ///
-    /// Default: `None` (unidentified — callers using the builder API
-    /// should call [`SimulationBuilder::with_strategy_id`] for
-    /// snapshot fidelity; custom strategies should override this if
-    /// they want stable round-trip identity, typically by returning
-    /// [`BuiltinStrategy::Custom`] with a stable name).
-    ///
-    /// [`SimulationBuilder::with_strategy_id`]: crate::builder::SimulationBuilder::with_strategy_id
+    /// Default: `None` (unidentified — the constructor falls back to
+    /// recording [`BuiltinStrategy::Scan`], matching pre-fix behaviour
+    /// for callers that never cared about round-trip identity). Custom
+    /// strategies that DO care should override this to return
+    /// [`BuiltinStrategy::Custom`] with a stable name.
     #[must_use]
     fn builtin_id(&self) -> Option<BuiltinStrategy> {
         None

--- a/crates/elevator-core/src/dispatch/nearest_car.rs
+++ b/crates/elevator-core/src/dispatch/nearest_car.rs
@@ -44,6 +44,10 @@ impl DispatchStrategy for NearestCarDispatch {
         }
         Some((ctx.car_position - ctx.stop_position).abs())
     }
+
+    fn builtin_id(&self) -> Option<super::BuiltinStrategy> {
+        Some(super::BuiltinStrategy::NearestCar)
+    }
 }
 
 /// Decide whether assigning `ctx.car` to `ctx.stop` is on the path to

--- a/crates/elevator-core/src/dispatch/rsr.rs
+++ b/crates/elevator-core/src/dispatch/rsr.rs
@@ -261,4 +261,8 @@ impl DispatchStrategy for RsrDispatch {
         let cost = cost.max(0.0);
         if cost.is_finite() { Some(cost) } else { None }
     }
+
+    fn builtin_id(&self) -> Option<super::BuiltinStrategy> {
+        Some(super::BuiltinStrategy::Rsr)
+    }
 }

--- a/crates/elevator-core/src/dispatch/scan.rs
+++ b/crates/elevator-core/src/dispatch/scan.rs
@@ -98,4 +98,8 @@ impl DispatchStrategy for ScanDispatch {
         self.direction.remove(&elevator);
         self.mode.remove(&elevator);
     }
+
+    fn builtin_id(&self) -> Option<super::BuiltinStrategy> {
+        Some(super::BuiltinStrategy::Scan)
+    }
 }

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -423,6 +423,22 @@ impl Simulation {
         let user_dispatcher = builder_dispatchers
             .into_iter()
             .find_map(|(gid, d)| if gid == GroupId(0) { Some(d) } else { None });
+        // Infer the snapshot identity from the dispatcher itself via
+        // `DispatchStrategy::builtin_id`. Pre-fix this was hard-coded to
+        // `BuiltinStrategy::Scan` regardless of the impl actually passed,
+        // so `Simulation::new(config, NearestCarDispatch::new())` would
+        // record `Scan` as the group's identity — and a snapshot round-
+        // trip would silently swap the running strategy back to Scan,
+        // breaking determinism. Built-ins override `builtin_id` to
+        // return their own variant; custom strategies can override it
+        // to return `BuiltinStrategy::Custom(name)` for snapshot fidelity.
+        // Strategies that don't override (returning `None`) still fall
+        // back to Scan, matching the previous behaviour for callers that
+        // never cared about round-trip identity.
+        let inferred_id = user_dispatcher
+            .as_ref()
+            .and_then(|d| d.builtin_id())
+            .unwrap_or(BuiltinStrategy::Scan);
         if let Some(d) = user_dispatcher {
             dispatchers.insert(GroupId(0), d);
         } else {
@@ -431,12 +447,7 @@ impl Simulation {
                 Box::new(crate::dispatch::scan::ScanDispatch::new()) as Box<dyn DispatchStrategy>,
             );
         }
-        // strategy_ids defaults to Scan (the legacy-topology default and
-        // the type passed by every Simulation::new caller in practice).
-        // Builder users who install a non-Scan dispatcher should also
-        // call `.with_strategy_id(...)` if they need snapshot fidelity —
-        // we can't infer the BuiltinStrategy class from `Box<dyn>`.
-        strategy_ids.insert(GroupId(0), BuiltinStrategy::Scan);
+        strategy_ids.insert(GroupId(0), inferred_id);
 
         (vec![group], dispatchers, strategy_ids)
     }
@@ -580,19 +591,24 @@ impl Simulation {
         // Pre-fix this could mismatch `strategy_ids` against `dispatchers`
         // when both config and builder specified a strategy for the same
         // group (#287). The new precedence: builder wins for the dispatcher
-        // and we keep the config's strategy_id only when no builder
-        // override touched the group.
+        // and, for snapshot fidelity, we prefer the dispatcher's own
+        // `builtin_id()` over any stale config-supplied id. Falling back
+        // to the config id when the dispatcher is unidentified matches
+        // the pre-fix behaviour for custom strategies that don't override
+        // `builtin_id`.
         for (gid, d) in builder_dispatchers {
+            let inferred_id = d.builtin_id();
             dispatchers.insert(gid, d);
-            // Builder dispatchers don't carry a `BuiltinStrategy` discriminant.
-            // If there's no config strategy_id for this group, leave it absent
-            // (snapshot will fail to instantiate; caller must register a
-            // factory). If there IS one, keep it: in practice, the
-            // `Simulation::new(cfg, X)` direct path always passes an X that
-            // matches the config's declared strategy.
-            strategy_ids
-                .entry(gid)
-                .or_insert_with(|| BuiltinStrategy::Custom("user-supplied".into()));
+            match inferred_id {
+                Some(id) => {
+                    strategy_ids.insert(gid, id);
+                }
+                None => {
+                    strategy_ids
+                        .entry(gid)
+                        .or_insert_with(|| BuiltinStrategy::Custom("user-supplied".into()));
+                }
+            }
         }
 
         (groups, dispatchers, strategy_ids)
@@ -642,6 +658,27 @@ impl Simulation {
             .is_none()
         {
             world.insert_resource(crate::arrival_log::DestinationLog::default());
+        }
+        // Auto-register dispatch-internal extension types the sim itself
+        // owns, and immediately load their data from the pending
+        // resource. Without this, DCS sticky assignments
+        // (`AssignedCar`) evaporate across snapshot round-trip and
+        // `DestinationDispatch` re-computes every commitment from
+        // scratch — producing different decisions than the original
+        // sim and breaking tick-for-tick determinism.
+        //
+        // `deserialize_extensions` takes a `&` of the pending map and
+        // silently skips types that aren't registered, so the call is
+        // safe to make with user-owned extensions still in the map.
+        // The `PendingExtensions` resource stays in place for a later
+        // `load_extensions_with` call to materialize the caller's own
+        // types.
+        world.register_ext::<crate::dispatch::destination::AssignedCar>(
+            crate::dispatch::destination::ASSIGNED_CAR_KEY,
+        );
+        if let Some(pending) = world.resource::<crate::snapshot::PendingExtensions>() {
+            let data = pending.0.clone();
+            world.deserialize_extensions(&data);
         }
         Self {
             world,

--- a/crates/elevator-core/src/tests/builder_tests.rs
+++ b/crates/elevator-core/src/tests/builder_tests.rs
@@ -333,11 +333,12 @@ fn from_config_dispatch_override_marks_strategy_as_custom() {
         .dispatch(LookDispatch::new())
         .build()
         .unwrap();
-    // strategy_id is preserved as the config's Scan because builder
-    // overrides only mark Custom when the group had no prior id; here
-    // the builder default applies via Simulation::new path which keeps
-    // the config's existing entry. The dispatcher itself is Look — but
-    // verifying that requires running the sim; the strategy_id check
-    // demonstrates the snapshot identifier did not get clobbered.
-    assert_eq!(sim.strategy_id(GroupId(0)), Some(&BuiltinStrategy::Scan));
+    // The builder override installs `LookDispatch` and, via the
+    // `DispatchStrategy::builtin_id` hook, stamps the matching
+    // `BuiltinStrategy::Look` into `strategy_ids` — which is exactly
+    // what a snapshot needs to instantiate the right strategy on
+    // restore. Pre-fix this kept the stale config-supplied `Scan`
+    // identifier, producing sims whose snapshot round-trip silently
+    // swapped the running strategy back to Scan.
+    assert_eq!(sim.strategy_id(GroupId(0)), Some(&BuiltinStrategy::Look));
 }

--- a/crates/elevator-core/src/tests/builder_tests.rs
+++ b/crates/elevator-core/src/tests/builder_tests.rs
@@ -253,12 +253,16 @@ fn from_config_honours_config_group_dispatch() {
     );
 }
 
-/// `SimulationBuilder::from_config(...).dispatch(custom)` actually
-/// installs the custom dispatcher AND records the override in
-/// `strategy_ids` (so peek-and-restore consumers see Custom rather
-/// than the stale config strategy). Companion test for #287.
+/// `SimulationBuilder::from_config(...).dispatch(custom)` installs
+/// the override dispatcher AND records the matching identity in
+/// `strategy_ids` (so peek-and-restore consumers see the override's
+/// true `BuiltinStrategy` rather than the stale config value).
+/// Originally a companion test for #287 asserting a `Custom` marker;
+/// now asserts the exact built-in the dispatcher's `builtin_id`
+/// returns — which is the stronger snapshot-fidelity guarantee the
+/// identity is there for.
 #[test]
-fn from_config_dispatch_override_marks_strategy_as_custom() {
+fn from_config_dispatch_override_records_dispatcher_identity() {
     use crate::config::{GroupConfig, LineConfig};
     use crate::dispatch::BuiltinStrategy;
     use crate::ids::GroupId;

--- a/crates/elevator-core/src/tests/destination_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/destination_dispatch_tests.rs
@@ -399,11 +399,17 @@ fn up_peak_scenario_delivers_all_riders() {
 #[test]
 fn dcs_gated_to_destination_mode() {
     let mut sim = Simulation::new(&single_car_config(), DestinationDispatch::new()).unwrap();
-    // Leave the group in its default Classic mode — DCS should skip.
+    // `Simulation::new` infers the strategy_id from the dispatcher's
+    // `builtin_id()` and `sync_hall_call_modes` then flips the group
+    // to Destination — which would enable DCS. Force the group back
+    // to Classic so we can assert the gate does skip in that mode.
+    for g in sim.groups_mut() {
+        g.set_hall_call_mode(crate::dispatch::HallCallMode::Classic);
+    }
     assert_eq!(
         sim.groups()[0].hall_call_mode(),
         crate::dispatch::HallCallMode::Classic,
-        "default group mode should still be Classic for this test",
+        "test harness should have forced Classic before stepping",
     );
     sim.world_mut()
         .register_ext::<AssignedCar>(ASSIGNED_CAR_KEY);

--- a/crates/elevator-core/src/tests/invariants_tests.rs
+++ b/crates/elevator-core/src/tests/invariants_tests.rs
@@ -45,10 +45,34 @@
 //!    and reroute loops — classes of bug the per-tick invariants
 //!    don't see because they only assert *consistency*, not
 //!    *progress*.
+//! 6. **Snapshot round-trip determinism.** After `WARMUP_TICKS` ticks
+//!    on a sim, `(snapshot, restore)` yields a sim that follows the
+//!    original's future trajectory tick-for-tick: after both step
+//!    another `COMPARE_TICKS`, their integer `Metrics` counters and
+//!    per-phase rider histograms match exactly. Originally surfaced
+//!    the strategy-identity bug where legacy-topology construction
+//!    hard-coded `BuiltinStrategy::Scan` as the snapshot id — the
+//!    fix adds [`DispatchStrategy::builtin_id`] and routes it
+//!    through the constructor so every built-in dispatcher round-
+//!    trips as itself.
+//!
+//!    Covers `NearestCar`, `Etd`, `Rsr`, `Destination`. `Scan` and
+//!    `Look` are excluded because they carry per-elevator sweep-
+//!    direction state in the dispatcher struct (`direction` /
+//!    `mode` HashMaps) that isn't part of `WorldSnapshot`. Restore
+//!    instantiates them fresh with default-`Up` directions, so
+//!    their trajectories legitimately diverge from a running sim
+//!    whose elevators are mid-sweep. Round-tripping that state
+//!    needs a `serialize_state`/`restore_state` hook on the
+//!    `DispatchStrategy` trait — separate change, separate PR.
+//!    Floating-point accumulators (`total_distance`,
+//!    `reposition_distance`) are also omitted: summation-order
+//!    sensitivity means they can diverge by ULPs without
+//!    indicating a state-capture bug.
 
 use proptest::prelude::*;
 
-use crate::components::{Accel, RiderPhase, Speed, Weight};
+use crate::components::{Accel, RiderPhase, RiderPhaseKind, Speed, Weight};
 use crate::config::{
     BuildingConfig, ElevatorConfig, PassengerSpawnConfig, SimConfig, SimulationParams,
 };
@@ -524,6 +548,124 @@ proptest! {
                 terminal,
                 "[{}] rider {:?} stuck in non-terminal phase {:?} after {} ticks",
                 label, id, rider.phase, TICK_BUDGET,
+            );
+        }
+    }
+}
+
+// Snapshot round-trip determinism: snapshot mid-run, restore into a
+// fresh sim, step both the original and the restore for the same
+// number of additional ticks, assert that the discrete observable
+// state (integer metrics counters and per-phase rider histogram)
+// matches tick-for-tick. `WARMUP_TICKS` is deliberately short enough
+// that many riders are still mid-lifecycle at snapshot time —
+// snapshotting a drained sim would make the comparison trivial.
+// Floating-point accumulators are excluded intentionally (summation-
+// order ULP drift isn't a state-capture bug).
+const WARMUP_TICKS: u64 = 400;
+const COMPARE_TICKS: u64 = 1_200;
+
+/// Fixed-shape histogram of riders by phase kind. Used to compare two
+/// sims without depending on `EntityId` stability across
+/// snapshot/restore (`WorldSnapshot::restore` renumbers ids). A
+/// struct beats a `HashMap`/`BTreeMap` because `RiderPhaseKind`
+/// derives neither `Hash` nor `Ord`, and the variant set is closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct PhaseHistogram {
+    waiting: usize,
+    boarding: usize,
+    riding: usize,
+    exiting: usize,
+    walking: usize,
+    arrived: usize,
+    abandoned: usize,
+    resident: usize,
+}
+
+fn phase_histogram(sim: &Simulation) -> PhaseHistogram {
+    let mut h = PhaseHistogram::default();
+    for (_, rider) in sim.world().iter_riders() {
+        match rider.phase.kind() {
+            RiderPhaseKind::Waiting => h.waiting += 1,
+            RiderPhaseKind::Boarding => h.boarding += 1,
+            RiderPhaseKind::Riding => h.riding += 1,
+            RiderPhaseKind::Exiting => h.exiting += 1,
+            RiderPhaseKind::Walking => h.walking += 1,
+            RiderPhaseKind::Arrived => h.arrived += 1,
+            RiderPhaseKind::Abandoned => h.abandoned += 1,
+            RiderPhaseKind::Resident => h.resident += 1,
+        }
+    }
+    h
+}
+
+/// Proptest generator for the strategies whose in-memory state is
+/// entirely captured by `WorldSnapshot`. Excludes `Scan` and `Look`,
+/// which hold per-elevator sweep direction on the dispatcher struct.
+/// See the top-of-file doc comment for invariant #6.
+fn any_snapshottable_strategy() -> impl Strategy<Value = StrategyKind> {
+    prop_oneof![
+        Just(StrategyKind::NearestCar),
+        Just(StrategyKind::Etd),
+        Just(StrategyKind::Rsr),
+        Just(StrategyKind::Destination),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(8))]
+
+    #[test]
+    fn snapshot_restore_preserves_trajectory_across_strategies(
+        kind in any_snapshottable_strategy(),
+        workload in any_workload(),
+    ) {
+        let (mut sim_a, _stops) = build_sim(kind, &workload);
+        let label = kind.label();
+
+        for _ in 0..WARMUP_TICKS {
+            sim_a.step();
+            let _ = sim_a.drain_events();
+        }
+
+        let snap = sim_a.snapshot();
+        let mut sim_b = snap.restore(None).expect("restore");
+
+        for tick in 0..COMPARE_TICKS {
+            sim_a.step();
+            let _ = sim_a.drain_events();
+            sim_b.step();
+            let _ = sim_b.drain_events();
+
+            let ma = sim_a.metrics();
+            let mb = sim_b.metrics();
+            prop_assert_eq!(
+                ma.total_delivered(), mb.total_delivered(),
+                "[{}] compare tick {}: total_delivered drift", label, tick,
+            );
+            prop_assert_eq!(
+                ma.total_abandoned(), mb.total_abandoned(),
+                "[{}] compare tick {}: total_abandoned drift", label, tick,
+            );
+            prop_assert_eq!(
+                ma.total_spawned(), mb.total_spawned(),
+                "[{}] compare tick {}: total_spawned drift", label, tick,
+            );
+            prop_assert_eq!(
+                ma.max_wait_time(), mb.max_wait_time(),
+                "[{}] compare tick {}: max_wait_time drift", label, tick,
+            );
+            prop_assert_eq!(
+                ma.total_moves(), mb.total_moves(),
+                "[{}] compare tick {}: total_moves drift", label, tick,
+            );
+
+            let ha = phase_histogram(&sim_a);
+            let hb = phase_histogram(&sim_b);
+            prop_assert_eq!(
+                &ha, &hb,
+                "[{}] compare tick {}: phase histogram drift\nlive: {:?}\nrestored: {:?}",
+                label, tick, ha, hb,
             );
         }
     }

--- a/crates/elevator-core/src/tests/invariants_tests.rs
+++ b/crates/elevator-core/src/tests/invariants_tests.rs
@@ -59,7 +59,7 @@
 //!    Covers `NearestCar`, `Etd`, `Rsr`, `Destination`. `Scan` and
 //!    `Look` are excluded because they carry per-elevator sweep-
 //!    direction state in the dispatcher struct (`direction` /
-//!    `mode` HashMaps) that isn't part of `WorldSnapshot`. Restore
+//!    `mode` `HashMap`s) that isn't part of `WorldSnapshot`. Restore
 //!    instantiates them fresh with default-`Up` directions, so
 //!    their trajectories legitimately diverge from a running sim
 //!    whose elevators are mid-sweep. Round-tripping that state


### PR DESCRIPTION
## Summary

`Simulation::new(cfg, NonScanStrategy::new())` silently recorded `BuiltinStrategy::Scan` as the group's snapshot identity regardless of the strategy impl actually passed in. So `snapshot → restore` instantiated a fresh `ScanDispatch` for every non-Scan sim built via the direct API, swapping the running strategy and producing different dispatch decisions tick-for-tick post-restore.

This regression predates the invariant harness — surfaced by writing the determinism property as invariant #6.

## Root cause

`sim/construction.rs:439` (legacy topology):
```rust
strategy_ids.insert(GroupId(0), BuiltinStrategy::Scan); // always Scan, regardless of impl
```

Equivalent bug in the builder-override path of explicit topology.

## Fix

**Primary:** Add `DispatchStrategy::builtin_id() -> Option<BuiltinStrategy>` (default `None`), override on every built-in:

| Strategy | `builtin_id()` |
|---|---|
| `ScanDispatch` | `Some(Scan)` |
| `LookDispatch` | `Some(Look)` |
| `NearestCarDispatch` | `Some(NearestCar)` |
| `EtdDispatch` | `Some(Etd)` |
| `RsrDispatch` | `Some(Rsr)` |
| `DestinationDispatch` | `Some(Destination)` |
| Custom | `None` (unchanged) |

`Simulation::new` and the builder override path now prefer the dispatcher's own `builtin_id()` over any stale config-supplied id; they fall back to the prior hard-coded Scan only when the impl is unidentified.

**Secondary:** DCS sticky `AssignedCar` extensions were also lost on restore because users had to register the type manually. `Simulation::from_parts` now auto-registers and deserializes `AssignedCar`, so `snapshot → restore` preserves DCS commitments without the caller knowing the internal extension exists. User-owned extensions still flow through `load_extensions_with`.

## Proof

New sixth invariant in the cross-strategy harness: **snapshot round-trip determinism.** After 400 warmup ticks, `snapshot + restore` the sim, step both original and restore for 1200 more ticks, assert integer metrics counters and per-phase rider histograms match every tick. Covers `NearestCar`/`Etd`/`Rsr`/`Destination`.

`Scan` and `Look` are excluded — they carry per-elevator sweep-direction state on the dispatcher struct (`direction` / `mode` HashMaps) that isn't part of `WorldSnapshot`. Round-tripping that state needs a `serialize_state`/`restore_state` hook on the `DispatchStrategy` trait (separate change, separate PR). Documented in the module doc.

## Test plan

- [x] `cargo test -p elevator-core --all-features` — 816 lib tests (+1 determinism invariant), all green
- [x] `cargo clippy -p elevator-core --all-features --all-targets -- -D warnings` clean
- [x] `cargo check --workspace` clean (no FFI/bevy/gdext/wasm drift)
- [x] Two existing tests drifted with the corrected behaviour and were updated; neither exercised a real invariant, just the prior buggy defaults

## Drift in updated tests

- `builder_tests::from_config_dispatch_override_marks_strategy_as_custom` — previously asserted the builder override KEPT the config's `Scan` even when the dispatcher was `Look`. Now asserts it records `Look`, which is what snapshot fidelity requires.
- `destination_dispatch_tests::dcs_gated_to_destination_mode` — previously constructed `Simulation::new(cfg, DestinationDispatch::new())` and relied on the group staying in `Classic` mode (because `strategy_ids` was incorrectly `Scan`, so `sync_hall_call_modes` didn't trigger). Updated to force Classic post-construction so the gate-behavior invariant still holds.