### PR TITLE
fix(snapshot): round-trip tunable dispatcher configuration

### DIFF
--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -55,6 +55,7 @@ pub const ASSIGNED_CAR_KEY: ExtKey<AssignedCar> = ExtKey::new("assigned_car");
 /// routes each car to its own queue front and returns `None` for every
 /// other stop, so the group-wide Hungarian assignment trivially pairs
 /// each car with the stop it has already committed to.
+#[derive(serde::Serialize, serde::Deserialize)]
 pub struct DestinationDispatch {
     /// Weight for per-stop door overhead in the cost function. A positive
     /// value biases assignments toward cars whose route change adds no
@@ -280,6 +281,16 @@ impl DispatchStrategy for DestinationDispatch {
 
     fn builtin_id(&self) -> Option<super::BuiltinStrategy> {
         Some(super::BuiltinStrategy::Destination)
+    }
+
+    fn snapshot_config(&self) -> Option<String> {
+        ron::to_string(self).ok()
+    }
+
+    fn restore_config(&mut self, serialized: &str) -> Result<(), String> {
+        let restored: Self = ron::from_str(serialized).map_err(|e| e.to_string())?;
+        *self = restored;
+        Ok(())
     }
 }
 

--- a/crates/elevator-core/src/dispatch/etd.rs
+++ b/crates/elevator-core/src/dispatch/etd.rs
@@ -21,6 +21,7 @@ use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext, pair
 /// for intervening stops, and a small bonus for cars already heading
 /// toward the stop. The dispatch system runs an optimal assignment
 /// across all pairs so the globally best matching is chosen.
+#[derive(serde::Serialize, serde::Deserialize)]
 pub struct EtdDispatch {
     /// Weight for travel time to reach the calling stop.
     pub wait_weight: f64,
@@ -49,7 +50,10 @@ pub struct EtdDispatch {
     pub age_linear_weight: f64,
     /// Positions of every demanded stop in the group, cached by
     /// [`DispatchStrategy::pre_dispatch`] so `rank` avoids rebuilding the
-    /// list for every `(car, stop)` pair.
+    /// list for every `(car, stop)` pair. Per-pass scratch — excluded
+    /// from [`snapshot_config`](DispatchStrategy::snapshot_config) since
+    /// `pre_dispatch` rebuilds it on every pass.
+    #[serde(skip)]
     pending_positions: SmallVec<[f64; 16]>,
 }
 
@@ -195,6 +199,16 @@ impl DispatchStrategy for EtdDispatch {
 
     fn builtin_id(&self) -> Option<super::BuiltinStrategy> {
         Some(super::BuiltinStrategy::Etd)
+    }
+
+    fn snapshot_config(&self) -> Option<String> {
+        ron::to_string(self).ok()
+    }
+
+    fn restore_config(&mut self, serialized: &str) -> Result<(), String> {
+        let restored: Self = ron::from_str(serialized).map_err(|e| e.to_string())?;
+        *self = restored;
+        Ok(())
     }
 }
 

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -855,6 +855,46 @@ pub trait DispatchStrategy: Send + Sync {
     fn builtin_id(&self) -> Option<BuiltinStrategy> {
         None
     }
+
+    /// Serialize this strategy's tunable configuration to a string
+    /// that [`restore_config`](Self::restore_config) can apply to a
+    /// freshly-instantiated instance.
+    ///
+    /// Returning `Some(..)` makes the configuration survive snapshot
+    /// round-trip: without it, [`crate::snapshot::WorldSnapshot::restore`]
+    /// instantiates each built-in via [`BuiltinStrategy::instantiate`],
+    /// which calls `::new()` with default weights — silently dropping
+    /// any tuning applied via `with_*` builder methods (e.g.
+    /// `EtdDispatch::with_delay_weight(2.5)` degrades to the default
+    /// `1.0` on the restored sim).
+    ///
+    /// Default: `None` (no configuration to save). Built-ins with
+    /// tunable weights override to return a RON-serialized copy of
+    /// themselves; strategies with transient per-pass scratch should
+    /// use `#[serde(skip)]` on those fields so the snapshot stays
+    /// compact and deterministic.
+    #[must_use]
+    fn snapshot_config(&self) -> Option<String> {
+        None
+    }
+
+    /// Restore tunable configuration from a string previously produced
+    /// by [`snapshot_config`](Self::snapshot_config) on the same
+    /// strategy variant. Called by
+    /// [`crate::snapshot::WorldSnapshot::restore`] immediately after
+    /// [`BuiltinStrategy::instantiate`] builds the default instance,
+    /// so the restore writes over the defaults.
+    ///
+    /// # Errors
+    /// Returns the underlying parse error as a `String` when the
+    /// serialized form doesn't round-trip. Default implementation
+    /// ignores the argument and returns `Ok(())` — paired with the
+    /// `None` default of `snapshot_config`, this means strategies that
+    /// don't override either method skip configuration round-trip,
+    /// matching pre-fix behaviour.
+    fn restore_config(&mut self, _serialized: &str) -> Result<(), String> {
+        Ok(())
+    }
 }
 
 /// Resolution of a single dispatch assignment pass for one group.

--- a/crates/elevator-core/src/dispatch/rsr.rs
+++ b/crates/elevator-core/src/dispatch/rsr.rs
@@ -53,6 +53,7 @@ fn peak_scaling(ctx: &RankContext<'_>, multiplier: f64) -> f64 {
 /// chain and silently collapses every pair's cost to zero (Rust's
 /// `NaN.max(0.0) == 0.0`), producing an arbitrary but type-valid
 /// assignment from the Hungarian solver — a hard bug to diagnose.
+#[derive(serde::Serialize, serde::Deserialize)]
 pub struct RsrDispatch {
     /// Weight on `travel_time = distance / max_speed` (seconds).
     /// Default `1.0`; raising it shifts the blend toward travel time.
@@ -264,5 +265,15 @@ impl DispatchStrategy for RsrDispatch {
 
     fn builtin_id(&self) -> Option<super::BuiltinStrategy> {
         Some(super::BuiltinStrategy::Rsr)
+    }
+
+    fn snapshot_config(&self) -> Option<String> {
+        ron::to_string(self).ok()
+    }
+
+    fn restore_config(&mut self, serialized: &str) -> Result<(), String> {
+        let restored: Self = ron::from_str(serialized).map_err(|e| e.to_string())?;
+        *self = restored;
+        Ok(())
     }
 }

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -601,6 +601,18 @@ pub enum Event {
         /// The group whose strategy was lost.
         group: GroupId,
     },
+    /// A snapshot restore instantiated the dispatch strategy for a
+    /// group but couldn't replay its tunable configuration (the
+    /// serialized form in the snapshot didn't parse). The strategy
+    /// runs with its default weights — identical to a legacy snapshot
+    /// that never carried dispatch config at all.
+    DispatchConfigNotRestored {
+        /// The group whose dispatcher ran with defaults.
+        group: GroupId,
+        /// The parse error from
+        /// [`DispatchStrategy::restore_config`](crate::dispatch::DispatchStrategy::restore_config).
+        reason: String,
+    },
     /// A stop was removed while resident riders were present.
     /// The game must relocate or despawn these riders.
     ResidentsAtRemovedStop {
@@ -771,9 +783,9 @@ impl Event {
             | Self::HallCallCleared { .. }
             | Self::CarButtonPressed { .. } => EventCategory::Dispatch,
             Self::RiderSkipped { .. } => EventCategory::Rider,
-            Self::SnapshotDanglingReference { .. } | Self::RepositionStrategyNotRestored { .. } => {
-                EventCategory::Observability
-            }
+            Self::SnapshotDanglingReference { .. }
+            | Self::RepositionStrategyNotRestored { .. }
+            | Self::DispatchConfigNotRestored { .. } => EventCategory::Observability,
             Self::ResidentsAtRemovedStop { .. } => EventCategory::Topology,
         }
     }

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -151,6 +151,18 @@ pub struct WorldSnapshot {
     /// `id_remap` to match newly-allocated entity IDs.
     #[serde(default)]
     pub reposition_cooldowns: crate::dispatch::reposition::RepositionCooldowns,
+    /// Per-group serialized dispatcher configuration produced by
+    /// [`crate::dispatch::DispatchStrategy::snapshot_config`] and
+    /// replayed via
+    /// [`crate::dispatch::DispatchStrategy::restore_config`] on
+    /// restore. Round-trips the tunable weights configured via
+    /// `with_*` builder methods (e.g. `EtdDispatch::with_delay_weight`)
+    /// that [`BuiltinStrategy::instantiate`](crate::dispatch::BuiltinStrategy::instantiate)
+    /// can't reconstruct because it always calls `::new()`. Absent /
+    /// empty in legacy snapshots — they restore to default weights,
+    /// matching pre-fix behaviour.
+    #[serde(default)]
+    pub dispatch_config: BTreeMap<GroupId, String>,
 }
 
 /// Per-line snapshot info within a group.
@@ -349,6 +361,26 @@ impl WorldSnapshot {
             self.metrics,
             self.ticks_per_second,
         );
+
+        // Replay any per-group dispatcher tuning captured in the
+        // snapshot. Each built-in with `with_*` builder methods
+        // overrides `snapshot_config`/`restore_config` to round-trip
+        // its weights; strategies that don't override silently skip
+        // (default `restore_config` is `Ok(())`), preserving pre-fix
+        // behaviour. A deserialization failure (e.g. snapshot from a
+        // future version with new fields) surfaces as an event rather
+        // than a hard error — the restored sim runs with defaults,
+        // same as a legacy snapshot with no dispatch_config at all.
+        for (gid, serialized) in &self.dispatch_config {
+            if let Some(dispatcher) = sim.dispatchers_mut().get_mut(gid)
+                && let Err(err) = dispatcher.restore_config(serialized)
+            {
+                sim.push_event(crate::events::Event::DispatchConfigNotRestored {
+                    group: *gid,
+                    reason: err,
+                });
+            }
+        }
 
         // Restore reposition strategies from group snapshots.
         for gs in &self.groups {
@@ -936,6 +968,15 @@ impl crate::sim::Simulation {
                 .resource::<crate::dispatch::reposition::RepositionCooldowns>()
                 .cloned()
                 .unwrap_or_default(),
+            // Per-group dispatcher configuration. Only strategies that
+            // override `snapshot_config` emit non-None here; the rest
+            // default to empty and restore to built-in defaults,
+            // preserving pre-fix behaviour for stateless strategies.
+            dispatch_config: self
+                .dispatchers()
+                .iter()
+                .filter_map(|(gid, d)| d.snapshot_config().map(|s| (*gid, s)))
+                .collect(),
         }
     }
 

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -681,3 +681,112 @@ fn snapshot_bytes_are_stable_in_process() {
         "two snapshots of the same sim must be byte-identical"
     );
 }
+
+// ── Dispatch-config round-trip (regression for silent weight reset) ──
+
+/// Pre-fix, `BuiltinStrategy::instantiate()` always called `::new()`
+/// with default weights, so any `with_*` tuning on a built-in
+/// dispatcher vanished silently through snapshot round-trip. With
+/// `snapshot_config`/`restore_config` wired up, the weights
+/// round-trip exactly.
+#[test]
+fn etd_tuned_weights_survive_snapshot_round_trip() {
+    use crate::dispatch::etd::EtdDispatch;
+
+    let tuned = EtdDispatch::new()
+        .with_wait_squared_weight(0.25)
+        .with_age_linear_weight(0.10);
+    let mut sim =
+        crate::sim::Simulation::new(&helpers::default_config(), tuned).expect("build sim");
+
+    // Walk the sim for a few ticks so any lazy scratch is primed.
+    for _ in 0..10 {
+        sim.step();
+    }
+
+    let snap = sim.snapshot();
+    let restored = snap.restore(None).expect("restore");
+
+    // Peek at the restored dispatcher's snapshot_config — if the
+    // weights round-tripped, a freshly-serialized copy equals the
+    // original's serialized form. This also confirms we didn't
+    // silently fall back to `EtdDispatch::new()` defaults.
+    let dispatcher = restored
+        .dispatchers()
+        .values()
+        .next()
+        .expect("one dispatcher after restore");
+    let restored_config = dispatcher
+        .snapshot_config()
+        .expect("EtdDispatch overrides snapshot_config");
+    assert!(
+        restored_config.contains("wait_squared_weight:0.25"),
+        "expected tuned wait_squared_weight=0.25 in restored config, got {restored_config}"
+    );
+    assert!(
+        restored_config.contains("age_linear_weight:0.1"),
+        "expected tuned age_linear_weight=0.1 in restored config, got {restored_config}"
+    );
+}
+
+/// Same regression, `RsrDispatch` flavour.
+#[test]
+fn rsr_tuned_weights_survive_snapshot_round_trip() {
+    use crate::dispatch::rsr::RsrDispatch;
+
+    let tuned = RsrDispatch::new()
+        .with_wrong_direction_penalty(15.0)
+        .with_load_penalty_coeff(2.5)
+        .with_peak_direction_multiplier(3.0);
+    let mut sim =
+        crate::sim::Simulation::new(&helpers::default_config(), tuned).expect("build sim");
+    for _ in 0..10 {
+        sim.step();
+    }
+
+    let snap = sim.snapshot();
+    let restored = snap.restore(None).expect("restore");
+    let dispatcher = restored.dispatchers().values().next().unwrap();
+    let restored_config = dispatcher.snapshot_config().unwrap();
+    assert!(
+        restored_config.contains("wrong_direction_penalty:15"),
+        "{restored_config}",
+    );
+    assert!(
+        restored_config.contains("load_penalty_coeff:2.5"),
+        "{restored_config}",
+    );
+    assert!(
+        restored_config.contains("peak_direction_multiplier:3"),
+        "{restored_config}",
+    );
+}
+
+/// `DestinationDispatch` config survives too; `with_stop_penalty`
+/// drives the fresh-stop cost term.
+#[test]
+fn destination_tuned_config_survives_snapshot_round_trip() {
+    use crate::dispatch::destination::DestinationDispatch;
+
+    let tuned = DestinationDispatch::new()
+        .with_stop_penalty(12.5)
+        .with_commitment_window_ticks(240);
+    let mut sim =
+        crate::sim::Simulation::new(&helpers::default_config(), tuned).expect("build sim");
+    for _ in 0..10 {
+        sim.step();
+    }
+
+    let snap = sim.snapshot();
+    let restored = snap.restore(None).expect("restore");
+    let dispatcher = restored.dispatchers().values().next().unwrap();
+    let restored_config = dispatcher.snapshot_config().unwrap();
+    assert!(
+        restored_config.contains("Some(12.5)"),
+        "expected stop_penalty=Some(12.5) in restored config, got {restored_config}"
+    );
+    assert!(
+        restored_config.contains("Some(240)"),
+        "expected commitment_window_ticks=Some(240) in restored config, got {restored_config}"
+    );
+}

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -1,4 +1,5 @@
 use crate::components::RiderPhase;
+use crate::dispatch::DispatchStrategy;
 use crate::entity::ElevatorId;
 use crate::stop::StopId;
 use crate::tests::helpers;
@@ -688,7 +689,11 @@ fn snapshot_bytes_are_stable_in_process() {
 /// with default weights, so any `with_*` tuning on a built-in
 /// dispatcher vanished silently through snapshot round-trip. With
 /// `snapshot_config`/`restore_config` wired up, the weights
-/// round-trip exactly.
+/// round-trip exactly. These tests parse the restored
+/// `snapshot_config` output back into the concrete strategy type
+/// and assert on typed fields — fragile-by-substring checks would
+/// break the moment RON's float formatting changes (`0.25` vs
+/// `0.2500`).
 #[test]
 fn etd_tuned_weights_survive_snapshot_round_trip() {
     use crate::dispatch::etd::EtdDispatch;
@@ -707,25 +712,24 @@ fn etd_tuned_weights_survive_snapshot_round_trip() {
     let snap = sim.snapshot();
     let restored = snap.restore(None).expect("restore");
 
-    // Peek at the restored dispatcher's snapshot_config — if the
-    // weights round-tripped, a freshly-serialized copy equals the
-    // original's serialized form. This also confirms we didn't
-    // silently fall back to `EtdDispatch::new()` defaults.
     let dispatcher = restored
         .dispatchers()
         .values()
         .next()
         .expect("one dispatcher after restore");
-    let restored_config = dispatcher
+    let serialized = dispatcher
         .snapshot_config()
         .expect("EtdDispatch overrides snapshot_config");
+    let parsed: EtdDispatch = ron::from_str(&serialized).expect("round-trip parse");
     assert!(
-        restored_config.contains("wait_squared_weight:0.25"),
-        "expected tuned wait_squared_weight=0.25 in restored config, got {restored_config}"
+        (parsed.wait_squared_weight - 0.25).abs() < f64::EPSILON,
+        "wait_squared_weight drift: {}",
+        parsed.wait_squared_weight,
     );
     assert!(
-        restored_config.contains("age_linear_weight:0.1"),
-        "expected tuned age_linear_weight=0.1 in restored config, got {restored_config}"
+        (parsed.age_linear_weight - 0.10).abs() < f64::EPSILON,
+        "age_linear_weight drift: {}",
+        parsed.age_linear_weight,
     );
 }
 
@@ -747,18 +751,22 @@ fn rsr_tuned_weights_survive_snapshot_round_trip() {
     let snap = sim.snapshot();
     let restored = snap.restore(None).expect("restore");
     let dispatcher = restored.dispatchers().values().next().unwrap();
-    let restored_config = dispatcher.snapshot_config().unwrap();
+    let serialized = dispatcher.snapshot_config().unwrap();
+    let parsed: RsrDispatch = ron::from_str(&serialized).expect("round-trip parse");
     assert!(
-        restored_config.contains("wrong_direction_penalty:15"),
-        "{restored_config}",
+        (parsed.wrong_direction_penalty - 15.0).abs() < f64::EPSILON,
+        "wrong_direction_penalty drift: {}",
+        parsed.wrong_direction_penalty,
     );
     assert!(
-        restored_config.contains("load_penalty_coeff:2.5"),
-        "{restored_config}",
+        (parsed.load_penalty_coeff - 2.5).abs() < f64::EPSILON,
+        "load_penalty_coeff drift: {}",
+        parsed.load_penalty_coeff,
     );
     assert!(
-        restored_config.contains("peak_direction_multiplier:3"),
-        "{restored_config}",
+        (parsed.peak_direction_multiplier - 3.0).abs() < f64::EPSILON,
+        "peak_direction_multiplier drift: {}",
+        parsed.peak_direction_multiplier,
     );
 }
 
@@ -780,13 +788,29 @@ fn destination_tuned_config_survives_snapshot_round_trip() {
     let snap = sim.snapshot();
     let restored = snap.restore(None).expect("restore");
     let dispatcher = restored.dispatchers().values().next().unwrap();
-    let restored_config = dispatcher.snapshot_config().unwrap();
-    assert!(
-        restored_config.contains("Some(12.5)"),
-        "expected stop_penalty=Some(12.5) in restored config, got {restored_config}"
+    let serialized = dispatcher.snapshot_config().unwrap();
+    // DestinationDispatch's config fields are `pub(crate)`, so
+    // parsing back through its serde shape and reading via
+    // `snapshot_config` on the parsed instance gives us a stable
+    // typed round-trip assertion without exposing internal fields
+    // just for tests. If parsing the restored config and
+    // re-serializing produces the same string as the original's
+    // snapshot_config, every config field round-tripped.
+    let parsed: DestinationDispatch = ron::from_str(&serialized).expect("round-trip parse");
+    let re_serialized = parsed
+        .snapshot_config()
+        .expect("DestinationDispatch overrides snapshot_config");
+    assert_eq!(
+        serialized, re_serialized,
+        "DestinationDispatch config should parse-then-serialize to the same bytes",
     );
-    assert!(
-        restored_config.contains("Some(240)"),
-        "expected commitment_window_ticks=Some(240) in restored config, got {restored_config}"
+    // And the re-serialized form must differ from defaults — prove
+    // we didn't silently fall back to `DestinationDispatch::new()`.
+    let defaults = DestinationDispatch::new()
+        .snapshot_config()
+        .expect("defaults also serialize");
+    assert_ne!(
+        serialized, defaults,
+        "restored config matched defaults — tuning was lost: {serialized}",
     );
 }


### PR DESCRIPTION
## Summary

Follow-up to #410 — same class of bug, different silent data loss.

`BuiltinStrategy::instantiate()` always calls `::new()` with default weights on restore, so any tuning applied via `with_*` builder methods vanishes silently through snapshot round-trip:

| Strategy | Silently reset fields |
|---|---|
| `EtdDispatch` | `wait_weight`, `delay_weight`, `door_weight`, `wait_squared_weight`, `age_linear_weight` |
| `RsrDispatch` | `eta_weight`, `wrong_direction_penalty`, `coincident_car_call_bonus`, `load_penalty_coeff`, `peak_direction_multiplier` |
| `DestinationDispatch` | `stop_penalty`, `commitment_window_ticks` |

Concrete example: `EtdDispatch::new().with_delay_weight(2.5)` becomes the default `1.0` on the restored sim. This is worse than the Scan/Look sweep-direction gap documented in #410 — weights shape long-run dispatch behaviour, not just short-term state.

## Fix

Two non-breaking additive trait methods on `DispatchStrategy`:

```rust
fn snapshot_config(&self) -> Option<String> { None }
fn restore_config(&mut self, _serialized: &str) -> Result<(), String> { Ok(()) }
```

Each of the three config-carrying built-ins derives `Serialize`/`Deserialize` and overrides with a RON round-trip. `EtdDispatch::pending_positions` is `#[serde(skip)]` per-pass scratch.

`WorldSnapshot` gains `dispatch_config: BTreeMap<GroupId, String>`, `#[serde(default)]` so legacy snapshots keep restoring cleanly — they just land on built-in defaults, same as pre-fix.

Parse failures surface as a new `Event::DispatchConfigNotRestored` observability event; the restored sim runs with defaults rather than erroring out, matching the legacy-snapshot code path.

## Tests

Three regression tests in `snapshot_tests` pin the round-trip for each tunable built-in. The cross-strategy invariant harness from #406–#410 stays unchanged — it already validates determinism with default weights; these new tests cover the tuning-specific regression.

- [x] `cargo test -p elevator-core --all-features` — 819 lib tests (+3), all green
- [x] `cargo clippy -p elevator-core --all-features --all-targets -- -D warnings` clean
- [x] `RUSTDOCFLAGS=-D warnings cargo doc -p elevator-core --all-features --no-deps` clean
- [x] `cargo check --workspace` clean (no FFI/bevy/gdext/wasm drift)