### PR TITLE
fix(reposition): round-trip strategy identity via builtin_id

### DIFF
--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -1177,6 +1177,23 @@ pub trait RepositionStrategy: Send + Sync {
         world: &World,
         out: &mut Vec<(EntityId, EntityId)>,
     );
+
+    /// If this strategy is a known built-in variant, return it so
+    /// [`Simulation::set_reposition`](crate::sim::Simulation::set_reposition)
+    /// callers don't have to pass a separate [`BuiltinReposition`] id
+    /// that might drift from the dispatcher's actual type.
+    ///
+    /// Mirrors the pattern introduced for [`DispatchStrategy::builtin_id`]
+    /// in #410: the runtime impl identifies itself so the snapshot
+    /// identity always matches the executing behaviour, instead of
+    /// depending on the caller to keep two parameters consistent.
+    /// Default `None` — custom strategies should override to return
+    /// [`BuiltinReposition::Custom`] with a stable name for snapshot
+    /// fidelity.
+    #[must_use]
+    fn builtin_id(&self) -> Option<BuiltinReposition> {
+        None
+    }
 }
 
 /// Serializable identifier for built-in repositioning strategies.

--- a/crates/elevator-core/src/dispatch/reposition.rs
+++ b/crates/elevator-core/src/dispatch/reposition.rs
@@ -143,6 +143,10 @@ impl RepositionStrategy for SpreadEvenly {
             }
         }
     }
+
+    fn builtin_id(&self) -> Option<super::BuiltinReposition> {
+        Some(super::BuiltinReposition::SpreadEvenly)
+    }
 }
 
 /// Return idle elevators to a configured home stop (default: first stop).
@@ -197,6 +201,10 @@ impl RepositionStrategy for ReturnToLobby {
                 .map(|&(eid, _)| (eid, home_eid)),
         );
     }
+
+    fn builtin_id(&self) -> Option<super::BuiltinReposition> {
+        Some(super::BuiltinReposition::ReturnToLobby)
+    }
 }
 
 /// Position idle elevators near stops with historically high demand.
@@ -240,6 +248,10 @@ impl RepositionStrategy for DemandWeighted {
         scored.sort_by(|a, b| b.2.total_cmp(&a.2));
 
         assign_greedy_by_score(&scored, idle_elevators, group, world, out);
+    }
+
+    fn builtin_id(&self) -> Option<super::BuiltinReposition> {
+        Some(super::BuiltinReposition::DemandWeighted)
     }
 }
 
@@ -330,6 +342,10 @@ impl RepositionStrategy for PredictiveParking {
         scored.sort_by_key(|(_, _, count)| std::cmp::Reverse(*count));
 
         assign_greedy_by_score(&scored, idle_elevators, group, world, out);
+    }
+
+    fn builtin_id(&self) -> Option<super::BuiltinReposition> {
+        Some(super::BuiltinReposition::PredictiveParking)
     }
 }
 
@@ -430,6 +446,10 @@ impl RepositionStrategy for AdaptiveParking {
             }
         }
     }
+
+    fn builtin_id(&self) -> Option<super::BuiltinReposition> {
+        Some(super::BuiltinReposition::Adaptive)
+    }
 }
 
 /// No-op strategy: idle elevators stay where they stopped.
@@ -447,6 +467,10 @@ impl RepositionStrategy for NearestIdle {
         _world: &World,
         _out: &mut Vec<(EntityId, EntityId)>,
     ) {
+    }
+
+    fn builtin_id(&self) -> Option<super::BuiltinReposition> {
+        Some(super::BuiltinReposition::NearestIdle)
     }
 }
 

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -992,14 +992,23 @@ impl Simulation {
     ///
     /// Enables the reposition phase for this group. Idle elevators will
     /// be repositioned according to the strategy after each dispatch phase.
+    ///
+    /// The stored snapshot identity is taken from the strategy's own
+    /// [`RepositionStrategy::builtin_id`] when it returns `Some(..)`,
+    /// so built-in strategies always round-trip as themselves even if
+    /// the `id` argument drifts out of sync with the actual impl.
+    /// Custom strategies that don't override `builtin_id` fall back
+    /// to the caller-supplied `id`, preserving the prior API for
+    /// registered custom factories.
     pub fn set_reposition(
         &mut self,
         group: GroupId,
         strategy: Box<dyn RepositionStrategy>,
         id: BuiltinReposition,
     ) {
+        let resolved_id = strategy.builtin_id().unwrap_or(id);
         self.repositioners.insert(group, strategy);
-        self.reposition_ids.insert(group, id);
+        self.reposition_ids.insert(group, resolved_id);
     }
 
     /// Remove the reposition strategy for a group, disabling repositioning.

--- a/crates/elevator-core/src/tests/reposition_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_tests.rs
@@ -1130,3 +1130,34 @@ fn etd_zero_max_speed_infinite_cost() {
     let b_dec = decisions.iter().find(|(e, _)| *e == elev_b).unwrap();
     assert_eq!(b_dec.1, DispatchDecision::GoToStop(stops[1]));
 }
+
+// ── builtin_id round-trip identity (regression for #411-style drift) ──
+
+/// `set_reposition` now consults the strategy's own `builtin_id()` to
+/// fill in the snapshot identity, so a caller passing a mismatched
+/// `id` argument (or a stale config value) can't silently record the
+/// wrong type. The strategy's runtime type always wins for built-ins.
+#[test]
+fn set_reposition_prefers_strategy_builtin_id_over_arg() {
+    use crate::dispatch::BuiltinReposition;
+    use crate::dispatch::reposition::SpreadEvenly;
+    use crate::ids::GroupId;
+    use crate::sim::Simulation;
+    use crate::tests::helpers;
+
+    let mut sim = Simulation::new(&helpers::default_config(), helpers::scan()).unwrap();
+    // Caller claims ReturnToLobby while actually passing SpreadEvenly —
+    // pre-fix this silently recorded ReturnToLobby, so a snapshot
+    // round-trip would instantiate the wrong strategy on restore.
+    sim.set_reposition(
+        GroupId(0),
+        Box::new(SpreadEvenly),
+        BuiltinReposition::ReturnToLobby,
+    );
+    assert_eq!(
+        sim.reposition_id(GroupId(0)),
+        Some(&BuiltinReposition::SpreadEvenly),
+        "strategy.builtin_id() must override the caller-supplied id \
+         when the strategy identifies as a known built-in",
+    );
+}


### PR DESCRIPTION
## Summary

Mirror of #410 for the `RepositionStrategy` trait. `Simulation::set_reposition` took an explicit `BuiltinReposition` id alongside the strategy impl, and the two could drift silently: a caller passing `SpreadEvenly` with `BuiltinReposition::ReturnToLobby` would record the wrong identity and, on snapshot round-trip, `BuiltinReposition::ReturnToLobby.instantiate()` would produce a ReturnToLobby strategy instead of the SpreadEvenly that was actually running.

## Fix

Additive, non-breaking trait method:

```rust
fn builtin_id(&self) -> Option<BuiltinReposition> { None }
```

Overridden on every built-in (`SpreadEvenly`, `ReturnToLobby`, `DemandWeighted`, `PredictiveParking`, `AdaptiveParking`, `NearestIdle`). `Simulation::set_reposition` now prefers the strategy's own id when it returns `Some(..)`; custom strategies that don't override fall back to the caller-supplied id, preserving the prior API for registered factories.

Regression test in `reposition_tests` pins the override-priority contract.

## Test plan

- [x] `cargo test -p elevator-core --all-features` — 820 lib tests (+1) + doctests green
- [x] `cargo clippy -p elevator-core --all-features --all-targets -- -D warnings` clean
- [x] `RUSTDOCFLAGS=-D warnings cargo doc -p elevator-core --all-features --no-deps` clean
- [x] `cargo check --workspace` clean