### PR TITLE
fix(snapshot): round-trip Scan and Look sweep direction

### DIFF
--- a/crates/elevator-core/src/dispatch/look.rs
+++ b/crates/elevator-core/src/dispatch/look.rs
@@ -19,10 +19,18 @@ use super::sweep::{self, SweepDirection, SweepMode};
 use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext, pair_can_do_work};
 
 /// Elevator dispatch using the LOOK algorithm. See module docs.
+#[derive(serde::Serialize, serde::Deserialize)]
 pub struct LookDispatch {
-    /// Per-elevator sweep direction.
+    /// Per-elevator sweep direction. Persisted across dispatch passes
+    /// (reversed once a sweep exhausts demand ahead) and round-tripped
+    /// through [`DispatchStrategy::snapshot_config`] so a restored sim
+    /// continues the current sweep instead of defaulting to `Up` for
+    /// every car.
     direction: HashMap<EntityId, SweepDirection>,
     /// Per-elevator accept mode for the current dispatch pass.
+    /// Overwritten in full by `prepare_car` every pass, so no round-
+    /// trip is needed.
+    #[serde(skip)]
     mode: HashMap<EntityId, SweepMode>,
 }
 
@@ -96,5 +104,15 @@ impl DispatchStrategy for LookDispatch {
 
     fn builtin_id(&self) -> Option<super::BuiltinStrategy> {
         Some(super::BuiltinStrategy::Look)
+    }
+
+    fn snapshot_config(&self) -> Option<String> {
+        ron::to_string(self).ok()
+    }
+
+    fn restore_config(&mut self, serialized: &str) -> Result<(), String> {
+        let restored: Self = ron::from_str(serialized).map_err(|e| e.to_string())?;
+        *self = restored;
+        Ok(())
     }
 }

--- a/crates/elevator-core/src/dispatch/scan.rs
+++ b/crates/elevator-core/src/dispatch/scan.rs
@@ -21,10 +21,19 @@ use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext, pair
 /// reverse side. Direction and mode are resolved once per pass in
 /// [`DispatchStrategy::prepare_car`] so ranking is independent of the
 /// iteration order over stops.
+#[derive(serde::Serialize, serde::Deserialize)]
 pub struct ScanDispatch {
-    /// Per-elevator sweep direction.
+    /// Per-elevator sweep direction. Persisted across dispatch passes
+    /// (reversed once a sweep exhausts demand ahead) and round-tripped
+    /// through [`DispatchStrategy::snapshot_config`] so a restored sim
+    /// continues the current sweep instead of defaulting to `Up` for
+    /// every car.
     direction: HashMap<EntityId, SweepDirection>,
     /// Per-elevator accept mode for the current dispatch pass.
+    /// Overwritten in full by `prepare_car` every pass, so no round-
+    /// trip is needed; `#[serde(skip)]` keeps snapshot bytes compact
+    /// and deterministic across process runs.
+    #[serde(skip)]
     mode: HashMap<EntityId, SweepMode>,
 }
 
@@ -101,5 +110,15 @@ impl DispatchStrategy for ScanDispatch {
 
     fn builtin_id(&self) -> Option<super::BuiltinStrategy> {
         Some(super::BuiltinStrategy::Scan)
+    }
+
+    fn snapshot_config(&self) -> Option<String> {
+        ron::to_string(self).ok()
+    }
+
+    fn restore_config(&mut self, serialized: &str) -> Result<(), String> {
+        let restored: Self = ron::from_str(serialized).map_err(|e| e.to_string())?;
+        *self = restored;
+        Ok(())
     }
 }

--- a/crates/elevator-core/src/dispatch/sweep.rs
+++ b/crates/elevator-core/src/dispatch/sweep.rs
@@ -12,7 +12,7 @@ use super::{DispatchManifest, ElevatorGroup};
 pub const EPSILON: f64 = 1e-9;
 
 /// Sweep direction for a single car.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum SweepDirection {
     /// Traveling upward (increasing position).
     Up,
@@ -31,7 +31,7 @@ impl SweepDirection {
 }
 
 /// Per-car accept mode for one dispatch pass.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum SweepMode {
     /// Demand exists strictly ahead — accept only strictly-ahead stops.
     Strict,

--- a/crates/elevator-core/src/tests/invariants_tests.rs
+++ b/crates/elevator-core/src/tests/invariants_tests.rs
@@ -59,19 +59,16 @@
 //!    through the constructor so every built-in dispatcher round-
 //!    trips as itself.
 //!
-//!    Covers `NearestCar`, `Etd`, `Rsr`, `Destination`. `Scan` and
-//!    `Look` are excluded because they carry per-elevator sweep-
-//!    direction state in the dispatcher struct (`direction` /
-//!    `mode` `HashMap`s) that isn't part of `WorldSnapshot`. Restore
-//!    instantiates them fresh with default-`Up` directions, so
-//!    their trajectories legitimately diverge from a running sim
-//!    whose elevators are mid-sweep. Round-tripping that state
-//!    needs a `serialize_state`/`restore_state` hook on the
-//!    `DispatchStrategy` trait — separate change, separate PR.
-//!    Floating-point accumulators (`total_distance`,
-//!    `reposition_distance`) are also omitted: summation-order
-//!    sensitivity means they can diverge by ULPs without
-//!    indicating a state-capture bug.
+//!    Covers all six built-ins: `Scan`, `Look`, `NearestCar`, `Etd`,
+//!    `Rsr`, `Destination`. `Scan` and `Look` were historically
+//!    excluded — their per-elevator sweep-direction `HashMap` lived
+//!    on the dispatcher with no snapshot pathway — but after the
+//!    fix in this area they round-trip via
+//!    [`DispatchStrategy::snapshot_config`], same mechanism as the
+//!    tunable-weight strategies. Floating-point accumulators
+//!    (`total_distance`, `reposition_distance`) are omitted:
+//!    summation-order sensitivity means they can diverge by ULPs
+//!    without indicating a state-capture bug.
 
 use proptest::prelude::*;
 
@@ -624,16 +621,14 @@ fn phase_histogram(sim: &Simulation) -> PhaseHistogram {
 }
 
 /// Proptest generator for the strategies whose in-memory state is
-/// entirely captured by `WorldSnapshot`. Excludes `Scan` and `Look`,
-/// which hold per-elevator sweep direction on the dispatcher struct.
-/// See the top-of-file doc comment for invariant #6.
+/// entirely captured by `WorldSnapshot`. All six built-ins are now
+/// eligible: `Scan` and `Look` were historically excluded because
+/// their per-elevator sweep-direction state sat on the dispatcher
+/// struct with no snapshot pathway, but after moving them onto the
+/// `snapshot_config` round-trip introduced by #411 they round-trip
+/// as faithfully as the other four.
 fn any_snapshottable_strategy() -> impl Strategy<Value = StrategyKind> {
-    prop_oneof![
-        Just(StrategyKind::NearestCar),
-        Just(StrategyKind::Etd),
-        Just(StrategyKind::Rsr),
-        Just(StrategyKind::Destination),
-    ]
+    any_strategy()
 }
 
 proptest! {


### PR DESCRIPTION
## Summary

Completes the snapshot-determinism story started in #410 / #411. `ScanDispatch` and `LookDispatch` carried per-elevator `direction: HashMap<EntityId, SweepDirection>` on the dispatcher struct, which `BuiltinStrategy::instantiate()` couldn't reconstruct. On restore, every elevator defaulted to `SweepDirection::Up` — a running sim whose cars were mid-down-sweep would diverge tick-for-tick from the restored copy. Invariant #6 (snapshot-determinism, #410) flagged this by excluding `Scan`/`Look` from its coverage with a follow-up note.

## Fix

Stacks on #414 (mergeable first). Reuses the `snapshot_config`/`restore_config` mechanism from #411:

- Derive `Serialize`/`Deserialize` on `SweepDirection` and `SweepMode`.
- Derive `Serialize`/`Deserialize` on `ScanDispatch` and `LookDispatch`.
- `mode` is per-pass scratch, fully rewritten by `prepare_car` every pass — `#[serde(skip)]` keeps snapshot bytes compact and the post-restore map is benign (any stale entry is overwritten before it's read).
- Override `snapshot_config`/`restore_config` on both strategies via RON round-trip of self.
- Re-include `Scan` and `Look` in `any_snapshottable_strategy()`. **The determinism invariant now covers all six built-ins.**

Works because `EntityId` keys in the dispatcher state survive snapshot restore: `spawn_entities` replays the snapshot in the original spawn order into a fresh slotmap, producing identical key sequences. Confirmed by the determinism invariant holding tick-for-tick.

## Test plan

- [x] `cargo test -p elevator-core --all-features` — 820 lib tests, all 6 invariants green including determinism with `Scan`/`Look`
- [x] `cargo clippy -p elevator-core --all-features --all-targets -- -D warnings` clean
- [x] `cargo check --workspace` clean