### PR TITLE
chore: gitignore proptest-regressions/ under crates/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@
 .cargo/config.toml
 mutants.out/
 mutants.out.old/
+# proptest writes shrunk failing seeds to this directory on failure.
+# Locally reproducing the same seed is useful during investigation,
+# but committing the file pins that specific workload into every
+# future CI run — one stale flake blocks every PR. Re-generate
+# locally with `PROPTEST_CASES=N` when a flake needs reproducing.
+crates/*/proptest-regressions/
 .claude/agent-memory-local/
 .claude/*.lock
 .claude/worktrees/


### PR DESCRIPTION
`proptest` saves shrunk failing seeds to `crates/elevator-core/proptest-regressions/…` on every failure. Each time that directory appeared during dev it had to be deleted manually before committing.

Reproducing a specific seed is useful during investigation — but committing the file pins that workload into every future CI run, so one stale flake would block every PR. Re-generate locally with `PROPTEST_CASES=N` when a flake needs deterministic reproduction.

## Test plan
- [x] `.gitignore`-only change, no test impact.