### PR TITLE
feat(sim): add Simulation::run_until_quiet helper

### DIFF
--- a/crates/elevator-core/src/sim/substep.rs
+++ b/crates/elevator-core/src/sim/substep.rs
@@ -352,4 +352,58 @@ impl super::Simulation {
         self.run_metrics();
         self.advance_tick();
     }
+
+    /// Step the simulation until every rider reaches a terminal phase
+    /// (`Arrived`, `Abandoned`, or `Resident`), draining events each
+    /// tick so event-driven metrics stay up to date.
+    ///
+    /// Returns the number of ticks actually stepped, or `Err(max_ticks)`
+    /// if the budget was exhausted before the sim drained. The cap is a
+    /// safety net against a stuck dispatch or an unserviceable rider
+    /// holding the tick loop open forever — right-size it for your
+    /// workload and fail fast rather than spinning silently.
+    ///
+    /// A sim with zero riders returns `Ok(0)` immediately.
+    ///
+    /// ```
+    /// use elevator_core::prelude::*;
+    /// use elevator_core::stop::StopId;
+    ///
+    /// let mut sim = SimulationBuilder::demo().build().unwrap();
+    /// sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
+    /// let ticks = sim.run_until_quiet(2_000).expect("sim drained in time");
+    /// assert!(sim.metrics().total_delivered() >= 1);
+    /// assert!(ticks <= 2_000);
+    /// ```
+    ///
+    /// # Errors
+    /// Returns `Err(max_ticks)` when `max_ticks` elapse without every
+    /// rider reaching a terminal phase. Inspect `sim.world()`
+    /// iteration or `sim.metrics()` to diagnose stuck riders; the
+    /// sim is left in its partially-advanced state so you can
+    /// snapshot it for post-mortem.
+    pub fn run_until_quiet(&mut self, max_ticks: u64) -> Result<u64, u64> {
+        use crate::components::RiderPhase;
+
+        fn all_quiet(sim: &super::Simulation) -> bool {
+            sim.world().iter_riders().all(|(_, r)| {
+                matches!(
+                    r.phase(),
+                    RiderPhase::Arrived | RiderPhase::Abandoned | RiderPhase::Resident
+                )
+            })
+        }
+
+        if all_quiet(self) {
+            return Ok(0);
+        }
+        for tick in 1..=max_ticks {
+            self.step();
+            let _ = self.drain_events();
+            if all_quiet(self) {
+                return Ok(tick);
+            }
+        }
+        Err(max_ticks)
+    }
 }

--- a/crates/elevator-core/src/tests/access_tests.rs
+++ b/crates/elevator-core/src/tests/access_tests.rs
@@ -374,3 +374,58 @@ fn access_control_non_empty_is_an_allowlist() {
     // Negative case (a different EntityId rejected) is covered by the
     // existing `rider_rejected_by_rider_access_control` integration test.
 }
+
+// ── Simulation::run_until_quiet ────────────────────────────────────
+
+/// Returns 0 immediately when the sim has no riders — a fresh sim
+/// or one whose riders have all reached a terminal phase is already
+/// "quiet" and shouldn't burn ticks waiting.
+#[test]
+fn run_until_quiet_returns_zero_for_empty_sim() {
+    use crate::tests::helpers;
+
+    let mut sim = crate::sim::Simulation::new(&helpers::default_config(), helpers::scan()).unwrap();
+    let ticks = sim
+        .run_until_quiet(1_000)
+        .expect("empty sim is already quiet");
+    assert_eq!(ticks, 0);
+    assert_eq!(sim.current_tick(), 0);
+}
+
+/// Delivers a normal rider and reports how many ticks it took —
+/// less than the budget, and positive.
+#[test]
+fn run_until_quiet_delivers_rider_within_budget() {
+    use crate::stop::StopId;
+    use crate::tests::helpers;
+
+    let mut sim = crate::sim::Simulation::new(&helpers::default_config(), helpers::scan()).unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+
+    let ticks = sim.run_until_quiet(5_000).expect("rider must deliver");
+    assert!(ticks > 0, "delivery took zero ticks?");
+    assert!(ticks <= 5_000);
+    assert_eq!(sim.metrics().total_delivered(), 1);
+}
+
+/// Returns `Err(max_ticks)` when the budget is exhausted before every
+/// rider reaches a terminal phase — guards against silent infinite
+/// loops when a dispatch stalls. The sim is left in its advanced
+/// state so the caller can snapshot it for diagnosis.
+#[test]
+fn run_until_quiet_returns_err_on_budget_exhaustion() {
+    use crate::stop::StopId;
+    use crate::tests::helpers;
+
+    let mut sim = crate::sim::Simulation::new(&helpers::default_config(), helpers::scan()).unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+
+    // Two ticks isn't enough to cover a three-stop delivery.
+    let err = sim.run_until_quiet(2).unwrap_err();
+    assert_eq!(err, 2, "error should carry the exhausted budget");
+    assert_eq!(
+        sim.current_tick(),
+        2,
+        "sim state must reflect the steps taken"
+    );
+}


### PR DESCRIPTION
## Summary

Users commonly want "step until every rider reaches a terminal phase, bounded by a tick budget". The pattern already existed in `tests::helpers::run_until_done` but was `pub(crate)` — downstream crates (games, benchmarks, scenario runners) had to duplicate the loop. Promoting it to the public `Simulation` surface saves that boilerplate.

## API

```rust
/// Returns `Ok(ticks_stepped)` on drain, `Err(max_ticks)` on budget exhaustion.
/// A zero-rider sim returns `Ok(0)` without stepping.
pub fn run_until_quiet(&mut self, max_ticks: u64) -> Result<u64, u64>
```

Example:

```rust
let ticks = sim.run_until_quiet(5_000).expect("sim drained in time");
assert!(sim.metrics().total_delivered() >= 1);
```

On `Err(max_ticks)` the sim is left in its partially-advanced state — callers can snapshot and diagnose the stall rather than starting from scratch.

## Tests

Three unit tests in `access_tests` cover:
- Empty sim short-circuit (returns `Ok(0)`, no ticks burned)
- Within-budget delivery (positive tick count, `total_delivered >= 1`)
- Budget exhaustion (`Err(max_ticks)`, sim state preserved at the cutoff)

Plus a crate-level doctest on the method.

## Test plan
- [x] `cargo test -p elevator-core --all-features` — 823 lib tests (+3) + doctests green
- [x] `cargo clippy -p elevator-core --all-features --all-targets -- -D warnings` clean
- [x] `RUSTDOCFLAGS=-D warnings cargo doc -p elevator-core --all-features --no-deps` clean