### PR TITLE
fix(dispatch): set_dispatch prefers strategy.builtin_id() over arg

### DIFF
--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -962,13 +962,23 @@ impl Simulation {
     ///
     /// Also synchronises `HallCallMode`: `Destination` for DCS, `Classic`
     /// for other built-ins; `Custom` strategies leave the mode untouched.
+    ///
+    /// The stored snapshot identity is taken from the strategy's own
+    /// [`DispatchStrategy::builtin_id`] when it returns `Some(..)`, so
+    /// built-in strategies always round-trip as themselves even if the
+    /// `id` argument drifts out of sync with the actual impl. Custom
+    /// strategies that don't override `builtin_id` fall back to the
+    /// caller-supplied `id`, preserving the prior API for registered
+    /// custom factories. Mirrors the pattern applied to
+    /// [`set_reposition`](Self::set_reposition) in #414.
     pub fn set_dispatch(
         &mut self,
         group: GroupId,
         strategy: Box<dyn DispatchStrategy>,
         id: crate::dispatch::BuiltinStrategy,
     ) {
-        let mode = match &id {
+        let resolved_id = strategy.builtin_id().unwrap_or(id);
+        let mode = match &resolved_id {
             BuiltinStrategy::Destination => Some(crate::dispatch::HallCallMode::Destination),
             BuiltinStrategy::Custom(_) => None,
             BuiltinStrategy::Scan
@@ -983,7 +993,7 @@ impl Simulation {
             g.set_hall_call_mode(mode);
         }
         self.dispatchers.insert(group, strategy);
-        self.strategy_ids.insert(group, id);
+        self.strategy_ids.insert(group, resolved_id);
     }
 
     // ── Reposition management ─────────────────────────────────────────

--- a/crates/elevator-core/src/tests/access_tests.rs
+++ b/crates/elevator-core/src/tests/access_tests.rs
@@ -429,3 +429,44 @@ fn run_until_quiet_returns_err_on_budget_exhaustion() {
         "sim state must reflect the steps taken"
     );
 }
+
+// ── Simulation::set_dispatch identity resolution ──────────────────
+
+/// `set_dispatch` now consults the strategy's own `builtin_id()` to
+/// fill in the snapshot identity, so a caller passing a mismatched
+/// `id` argument (or a stale config value) can't silently record
+/// the wrong type. The strategy's runtime type always wins for
+/// built-ins — mirror of the fix #414 applied to `set_reposition`.
+#[test]
+fn set_dispatch_prefers_strategy_builtin_id_over_arg() {
+    use crate::dispatch::BuiltinStrategy;
+    use crate::dispatch::look::LookDispatch;
+    use crate::ids::GroupId;
+    use crate::sim::Simulation;
+    use crate::tests::helpers;
+
+    let mut sim = Simulation::new(&helpers::default_config(), helpers::scan()).unwrap();
+    // Caller claims Destination while actually passing LookDispatch.
+    // Pre-fix this silently recorded Destination as the snapshot id
+    // AND flipped the group's HallCallMode to Destination — the DCS
+    // path would then try to service a non-DCS strategy.
+    sim.set_dispatch(
+        GroupId(0),
+        Box::new(LookDispatch::new()),
+        BuiltinStrategy::Destination,
+    );
+    assert_eq!(
+        sim.strategy_id(GroupId(0)),
+        Some(&BuiltinStrategy::Look),
+        "strategy.builtin_id() must override the caller-supplied id \
+         when the strategy identifies as a known built-in",
+    );
+    // The HallCallMode sync keys off the resolved id — with the fix
+    // it stays Classic because Look (not Destination) is the real id.
+    assert_eq!(
+        sim.groups()[0].hall_call_mode(),
+        crate::dispatch::HallCallMode::Classic,
+        "HallCallMode must follow the resolved built-in, not the \
+         stale caller-supplied id",
+    );
+}


### PR DESCRIPTION
## Summary

Mirror of #414 (reposition identity fix) applied to the dispatch path. `Simulation::set_dispatch(group, strategy, id)` takes the strategy impl and the `BuiltinStrategy` id as separate params — the two could drift, and a caller passing `LookDispatch::new()` with `BuiltinStrategy::Destination` would:

- record the wrong snapshot identity (`Destination` instead of `Look`), so a snapshot round-trip would instantiate `DestinationDispatch` on restore;
- flip the group's `HallCallMode` to `Destination`, routing non-DCS strategies through a DCS-style hall-call surface.

## Fix

Prefer the strategy's own `builtin_id()` when it returns `Some(..)`, falling back to the caller-supplied id for custom strategies that don't override. The mode-sync logic now keys off the resolved id too, so mode and identity move together.

## Completes the identity-round-trip audit

Every entry point that records a strategy identity now consults `builtin_id()` first:

| Entry point | Fixed in |
|---|---|
| `Simulation::new` (legacy topology) | #410 |
| Builder override path (explicit topology) | #410 |
| `Simulation::set_reposition` | #414 |
| `Simulation::set_dispatch` | **this PR** |

## Test plan

- [x] New regression test `set_dispatch_prefers_strategy_builtin_id_over_arg` pins both the id override and the HallCallMode follow-through.
- [x] `cargo test -p elevator-core --all-features` — 824 lib tests (+1) + doctests green.
- [x] `cargo clippy -p elevator-core --all-features --all-targets -- -D warnings` clean.
- [x] `RUSTDOCFLAGS=-D warnings cargo doc -p elevator-core --all-features --no-deps` clean.