### PR TITLE
fix(dispatch): break self-reinforcing sweep loop in DCS queue rebuild

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.18.0"
+version = "15.20.1"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -474,9 +474,39 @@ fn rebuild_car_queue(world: &mut crate::world::World, car_eid: EntityId) {
         return;
     };
     let car_pos = world.position(car_eid).map_or(0.0, |p| p.value);
-    let sweep_up = match car.direction() {
-        Direction::Up | Direction::Either => true,
-        Direction::Down => false,
+    // Derive the sweep direction primarily from aboard-rider destinations,
+    // not the car's indicator lamps. Under heavy load on a single-car group
+    // the lamp state is itself a consequence of the previous rebuild, so
+    // lamp-driven `sweep_up` creates a self-reinforcing loop: a rebuild
+    // ordered around "current direction" keeps fresh pickups ahead of
+    // deliveries, which keeps the direction pointed at the pickups, which
+    // keeps the rebuild ordering them first. Letting aboard riders' dests
+    // pick the sweep breaks the loop — the car finishes delivering before
+    // it chases new pickups. Falls back to lamp direction when the car is
+    // empty (no aboard demand to break the tie).
+    let sweep_up = {
+        let mut aboard_up = 0u32;
+        let mut aboard_down = 0u32;
+        for &rid in car.riders() {
+            if let Some(dest) = world
+                .route(rid)
+                .and_then(crate::components::Route::current_destination)
+                && let Some(dp) = world.stop_position(dest)
+            {
+                if dp > car_pos + 1e-9 {
+                    aboard_up += 1;
+                } else if dp < car_pos - 1e-9 {
+                    aboard_down += 1;
+                }
+            }
+        }
+        match aboard_up.cmp(&aboard_down) {
+            std::cmp::Ordering::Greater => true,
+            std::cmp::Ordering::Less => false,
+            std::cmp::Ordering::Equal => {
+                matches!(car.direction(), Direction::Up | Direction::Either)
+            }
+        }
     };
 
     // Skip inserting a stop the car is currently parked at and loading.

--- a/crates/elevator-core/src/tests/destination_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/destination_dispatch_tests.rs
@@ -728,3 +728,111 @@ fn construction_with_dcs_auto_sets_destination_mode() {
         "Simulation::new with DCS strategy must auto-set Destination mode",
     );
 }
+
+/// Regression: a single-car DCS group under heavy cross-line demand
+/// (20 riders, 4 stops, 600 kg car) used to oscillate indefinitely
+/// between two pickup stops without ever delivering the aboard riders.
+/// The queue rebuild derived `sweep_up` from the car's direction lamps,
+/// which were themselves an output of the previous rebuild — a
+/// self-reinforcing loop that kept fresh pickups ranked ahead of
+/// aboard destinations. The fix derives the sweep from aboard-rider
+/// destinations, so the car finishes delivering before chasing new
+/// pickups. This specific 20-rider workload is the one that kept
+/// re-tripping the cross-strategy liveness invariant on main CI.
+#[test]
+fn single_car_heavy_load_drains_within_tick_budget() {
+    // Seed-1 xorshift workload that stalled on main: 4 stops, 1 car,
+    // 600 kg cap, 20 riders with mixed cross-line destinations. Spawned
+    // up-front so the dispatcher sees the full workload at tick 0.
+    const TICK_BUDGET: u64 = 8_000;
+    let config = SimConfig {
+        building: BuildingConfig {
+            name: "DCS Heavy Load".into(),
+            stops: (0..4)
+                .map(|i| StopConfig {
+                    id: StopId(i),
+                    name: format!("Floor {i}"),
+                    position: f64::from(i) * 4.0,
+                })
+                .collect(),
+            lines: None,
+            groups: None,
+        },
+        elevators: vec![ElevatorConfig {
+            id: 0,
+            name: "Car 0".into(),
+            max_speed: Speed::from(3.0),
+            acceleration: Accel::from(1.5),
+            deceleration: Accel::from(2.0),
+            weight_capacity: Weight::from(600.0),
+            starting_stop: StopId(0),
+            door_open_ticks: 8,
+            door_transition_ticks: 4,
+            restricted_stops: Vec::new(),
+            #[cfg(feature = "energy")]
+            energy_profile: None,
+            service_mode: None,
+            inspection_speed_factor: 0.25,
+            bypass_load_up_pct: None,
+            bypass_load_down_pct: None,
+        }],
+        simulation: SimulationParams {
+            ticks_per_second: 60.0,
+        },
+        passenger_spawning: PassengerSpawnConfig {
+            mean_interval_ticks: 120,
+            weight_range: (50.0, 100.0),
+        },
+    };
+    // (origin, destination, weight) — verbatim from the xorshift(1) stall
+    // reproducer. Any tweak here invalidates the regression seed.
+    let spawns: [(u32, u32, f64); 20] = [
+        (1, 0, 61.0),
+        (1, 0, 78.0),
+        (1, 2, 100.0),
+        (2, 0, 62.0),
+        (2, 0, 95.0),
+        (3, 2, 66.0),
+        (3, 0, 70.0),
+        (1, 0, 79.0),
+        (2, 3, 80.0),
+        (3, 2, 72.0),
+        (0, 2, 77.0),
+        (0, 3, 79.0),
+        (2, 3, 72.0),
+        (3, 0, 86.0),
+        (3, 1, 62.0),
+        (2, 3, 89.0),
+        (3, 0, 79.0),
+        (2, 0, 81.0),
+        (0, 2, 83.0),
+        (1, 3, 95.0),
+    ];
+
+    let mut sim = Simulation::new(&config, DestinationDispatch::new()).unwrap();
+    for group in sim.groups_mut() {
+        group.set_hall_call_mode(crate::dispatch::HallCallMode::Destination);
+    }
+    for &(o, d, w) in &spawns {
+        sim.spawn_rider(StopId(o), StopId(d), w).unwrap();
+    }
+    for _ in 0..TICK_BUDGET {
+        sim.step();
+        let _ = sim.drain_events();
+    }
+    let stuck: Vec<_> = sim
+        .world()
+        .iter_riders()
+        .filter(|(_, r)| {
+            !matches!(
+                r.phase,
+                RiderPhase::Arrived | RiderPhase::Abandoned | RiderPhase::Resident,
+            )
+        })
+        .map(|(id, r)| (id, r.phase))
+        .collect();
+    assert!(
+        stuck.is_empty(),
+        "DCS single-car heavy load stalled within {TICK_BUDGET} ticks: {stuck:?}",
+    );
+}

--- a/crates/elevator-core/src/tests/invariants_tests.rs
+++ b/crates/elevator-core/src/tests/invariants_tests.rs
@@ -44,10 +44,12 @@
 //!    or `Walking`. Catches stuck dispatchers, unserviceable demand,
 //!    and reroute loops — classes of bug the per-tick invariants
 //!    don't see because they only assert *consistency*, not
-//!    *progress*. Excludes `Destination` pending a follow-up
-//!    investigation into intermittent single-car heavy-load
-//!    stalls under DCS sticky assignment (see the comment above
-//!    `any_live_strategy`).
+//!    *progress*. Covers all six built-ins: Destination was
+//!    historically excluded after an intermittent single-car
+//!    heavy-load stall, but the root cause — a self-reinforcing
+//!    sweep-direction loop in the DCS queue rebuild — has since
+//!    been fixed (aboard-rider destinations now drive the sweep
+//!    instead of the lamp state that was itself a rebuild output).
 //! 6. **Snapshot round-trip determinism.** After `WARMUP_TICKS` ticks
 //!    on a sim, `(snapshot, restore)` yields a sim that follows the
 //!    original's future trajectory tick-for-tick: after both step
@@ -524,24 +526,14 @@ proptest! {
 // completed. All are stuck-dispatch signatures that the per-tick
 // invariants (consistency-only) would miss.
 //
-// `Destination` is excluded from this invariant pending a separate
-// investigation: proptest-generated workloads with one car plus
-// many riders crossing the whole line (e.g. 14 spawns, 4 stops,
-// 1 car) intermittently leave a rider stuck Waiting or Riding past
-// the 8 000-tick budget — reproducible in CI but not deterministic
-// across seeds. It is a real liveness gap in DCS sticky-assignment
-// logic under heavy single-car load, not a symptom of
-// determinism/state-capture like the bugs fixed in #410, so it
-// deserves its own diagnosis and fix. Keeping it in `any_strategy`
-// was making CI flaky on main (see CI runs on d4a4714 / 1d01ccb).
+// All six built-ins are now in scope. Destination was temporarily
+// excluded while the single-car heavy-load stall was diagnosed; the
+// rebuild now derives its sweep direction from aboard-rider
+// destinations instead of the car's own indicator lamps, which
+// broke the self-reinforcing loop that kept the car oscillating
+// between pickups while aboard riders waited indefinitely.
 fn any_live_strategy() -> impl Strategy<Value = StrategyKind> {
-    prop_oneof![
-        Just(StrategyKind::Scan),
-        Just(StrategyKind::Look),
-        Just(StrategyKind::NearestCar),
-        Just(StrategyKind::Etd),
-        Just(StrategyKind::Rsr),
-    ]
+    any_strategy()
 }
 
 proptest! {


### PR DESCRIPTION
## Summary

Fixes the DCS single-car liveness stall that forced Destination out of the cross-strategy liveness invariant in #412.

Under heavy demand on a one-car DCS group, aboard riders could end up permanently stuck in `Riding` phase — the car would oscillate between two pickup stops without ever delivering them.

## Root cause

`rebuild_car_queue` derived its sweep direction from the car's own indicator lamps:

```rust
let sweep_up = match car.direction() {
    Direction::Up | Direction::Either => true,
    Direction::Down => false,
};
```

But the lamps are themselves a consequence of the **previous** rebuild's queue order. A rebuild that placed a fresh pickup ahead of aboard deliveries pointed the lamp at the pickup; the next rebuild saw that lamp state and again ordered the pickup first. A perfect self-reinforcing loop — every tick the car recommitted to the pickup that was blocking its own deliveries.

## Fix

Sweep direction is now derived from **aboard-rider destinations** when the car has anyone aboard. The lamp state is only consulted as a tiebreak (balanced aboard counts, or empty car). A loaded car is now guaranteed to finish delivering before chasing new pickups.

## Re-including Destination in the liveness invariant

`any_live_strategy` in `invariants_tests.rs` now returns `any_strategy()` — the full 6-strategy matrix. `Destination` was excluded in #412 solely because of this bug; with the loop broken, 300-case proptest stress passes locally with no flakes.

## Regression pinning

The specific seed-1 xorshift workload that repeatedly tripped the main-CI flake (20 riders, 4 stops, 1 × 600 kg car) is now pinned as a deterministic unit test in `destination_dispatch_tests.rs` — `single_car_heavy_load_drains_within_tick_budget`. Future regressions in this class surface as a hard failure rather than proptest jitter.

## Test plan

- [x] `cargo test -p elevator-core --all-features` — 825 lib tests + doctests + integration green
- [x] `cargo clippy -p elevator-core --all-features --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo check --workspace --all-features` clean (no FFI/bevy drift)
- [x] `PROPTEST_CASES=300 cargo test all_riders_reach_terminal_phase_across_strategies` passes with all 6 strategies in scope
- [x] Brute-force stall sweep (50 seeds × 3 stop counts × 4 rider counts × 3 capacities = 1800 workloads) finds zero stalls post-fix (was finding stalls in single digits of seeds pre-fix)