### PR TITLE
perf(dispatch): borrow restricted_stops in cost-matrix build + add RSR to bench

### DIFF
--- a/crates/elevator-core/benches/dispatch_bench.rs
+++ b/crates/elevator-core/benches/dispatch_bench.rs
@@ -18,6 +18,7 @@ use elevator_core::dispatch::destination::DestinationDispatch;
 use elevator_core::dispatch::etd::EtdDispatch;
 use elevator_core::dispatch::look::LookDispatch;
 use elevator_core::dispatch::nearest_car::NearestCarDispatch;
+use elevator_core::dispatch::rsr::RsrDispatch;
 use elevator_core::dispatch::scan::ScanDispatch;
 use elevator_core::sim::Simulation;
 use elevator_core::stop::{StopConfig, StopId};
@@ -116,6 +117,7 @@ fn bench_dispatch_comparison(c: &mut Criterion) {
             NearestCarDispatch::new()
         );
         bench_strategy!(group, "etd", elevators, stops, riders, EtdDispatch::new());
+        bench_strategy!(group, "rsr", elevators, stops, riders, RsrDispatch::new());
         bench_strategy!(
             group,
             "destination",

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -1098,17 +1098,21 @@ pub(crate) fn assign(
     let mut data: Vec<i64> = vec![ASSIGNMENT_SENTINEL; n * cols];
     for (i, &(car_eid, car_pos)) in idle_cars.iter().enumerate() {
         strategy.prepare_car(car_eid, car_pos, group, manifest, world);
-        // Cache the car's restricted-stops set for this row so each
+        // Borrow the car's restricted-stops set for this row so each
         // (car, stop) pair can short-circuit before calling rank().
         // Pre-fix only DCS consulted restricted_stops; SCAN/LOOK/NC/ETD
         // happily ranked restricted pairs and `commit_go_to_stop` later
         // silently dropped the assignment, starving the call. (#256)
+        //
+        // The row only reads through `world` (via `prepare_car` and
+        // `rank`), so holding an immutable borrow of the set instead
+        // of cloning it drops one HashSet allocation per car per
+        // dispatch pass — a win that scales with elevator count.
         let restricted = world
             .elevator(car_eid)
-            .map(|c| c.restricted_stops().clone())
-            .unwrap_or_default();
+            .map(crate::components::Elevator::restricted_stops);
         for (j, &(stop_eid, stop_pos)) in pending_stops.iter().enumerate() {
-            if restricted.contains(&stop_eid) {
+            if restricted.is_some_and(|r| r.contains(&stop_eid)) {
                 continue; // leave SENTINEL — this pair is unavailable
             }
             let ctx = RankContext {


### PR DESCRIPTION
## Summary

The assignment phase cloned each car's `restricted_stops` HashSet on every row of the cost matrix so the inner `(car, stop)` loop could call `.contains()`. The clone was wasted work — the row only reads through `world` (via `prepare_car` and `rank`), so an immutable borrow lives long enough.

Also adds `RsrDispatch` to the dispatch_comparison matrix. It was the only built-in missing from the head-to-head bench — a coverage hole after #411 wired RSR through `builtin_id` / `snapshot_config`.

## Results

Head-to-head `dispatch_bench` at 20 elevators × 50 stops (release, `--sample-size 15`, `--measurement-time 4`, p<0.05 for all):

| Strategy | Before | After | Change |
|---|---:|---:|---:|
| scan        | baseline | 1.10 ms | **-3.6 %** |
| look        | baseline | 1.14 ms | **-4.2 %** |
| nearest_car | baseline | 1.09 ms | **-4.9 %** |
| etd         | baseline | 1.17 ms | **-4.7 %** |

`sim_bench / dispatch / 10e_50s` also dropped **-4.3 %** (p<0.05).

## Why this is a win without trade-offs

- The change is literally `.clone() + .contains()` → `.contains()`. No behaviour diff, no allocation diff in the common case (empty set), pure work elimination when the set is non-empty.
- Borrow lifetime is the row loop, which doesn't mutate `world` anywhere — verified by `prepare_car(&World)` and `RankContext { world: &World }` signatures.
- The exploration that almost landed here — pre-building a `HashSet` for `pinned + committed` car exclusion to drop the O(E²) filter — was reverted after bench showed scan/look regressing; the HashSet construction overhead beats the linear scan at these elevator counts. Left as a targeted follow-up for buildings with hundreds of elevators per group.

## Test plan

- [x] `cargo test -p elevator-core --all-features` — 825 tests + doctests + integration green
- [x] `cargo clippy -p elevator-core --all-features --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo bench -p elevator-core --bench dispatch_bench "20e_50s"` — wins above
- [x] `cargo bench -p elevator-core --bench sim_bench dispatch` — wins above