### PR TITLE
bench: add Shanghai Tower canonical scale case

### DIFF
--- a/crates/elevator-core/benches/scaling_bench.rs
+++ b/crates/elevator-core/benches/scaling_bench.rs
@@ -138,6 +138,64 @@ fn bench_spawn_pressure(c: &mut Criterion) {
 }
 
 // ---------------------------------------------------------------------------
+// D) World-record scale: Shanghai Tower
+//
+// Shanghai Tower (上海中心大厦) holds the working world record for
+// most elevators in a single skyscraper: **149 lifts** (Mitsubishi
+// Electric package) across **133 stops** (128 above ground + 5
+// below). The real building zones these into an observation
+// shuttle, a sky-lobby shuttle bank, and five local zones, but this
+// bench keeps a single group so the numbers are directly comparable
+// with the other `scaling_*` cases.
+//
+// Traffic grounding — Shanghai Tower has ~16 000 concurrent
+// occupants at peak (CTBUH), and commercial elevator-planning
+// practice sizes morning up-peak to handle 11–15 % of population in
+// a 5-minute window. That's ~6–8 lobby arrivals per second; in a
+// 100-tick (≈1.67 s at 60 Hz) slice, realistic queue depth is a
+// few hundred riders, not a few thousand. The two bench cases below
+// anchor both ends:
+//
+// - `realistic_up_peak_300r` — mid-peak queue depth (~300 riders
+//   waiting for service). Matches the arrival rate published
+//   traffic models predict for this building class.
+// - `stress_2000r` — worst-case queue (evacuation, major event let
+//   out). Not a typical operating state; included as a "don't
+//   regress under extreme load" ceiling.
+// ---------------------------------------------------------------------------
+
+fn bench_shanghai_tower(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scaling_shanghai_tower");
+    group.sample_size(10);
+
+    group.bench_function("realistic_up_peak_300r_100ticks", |b| {
+        b.iter_batched(
+            || make_sim(133, 149, 300),
+            |mut sim| {
+                for _ in 0..100 {
+                    sim.step();
+                }
+            },
+            criterion::BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("stress_2000r_100ticks", |b| {
+        b.iter_batched(
+            || make_sim(133, 149, 2_000),
+            |mut sim| {
+                for _ in 0..100 {
+                    sim.step();
+                }
+            },
+            criterion::BatchSize::LargeInput,
+        );
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
 // Criterion harness
 // ---------------------------------------------------------------------------
 
@@ -145,6 +203,7 @@ criterion_group!(
     benches,
     bench_realistic,
     bench_extreme,
-    bench_spawn_pressure
+    bench_spawn_pressure,
+    bench_shanghai_tower
 );
 criterion_main!(benches);


### PR DESCRIPTION
## Summary

Adds a benchmark case modeled on **Shanghai Tower** — the world-record holder for elevators in a single skyscraper, with **149 lifts (Mitsubishi Electric)** across **133 stops** (128 above ground + 5 below).

## Traffic grounding

Earlier draft of this PR used a single 2 000-rider case, which was called out as unrealistic. Shanghai Tower carries **~16 000 concurrent occupants** at peak (CTBUH), and commercial elevator-planning practice sizes up-peak to handle **11–15 % of population per 5 minutes**:

- ~6–8 lobby arrivals per second
- In a 100-tick slice (≈1.67 s at 60 Hz), realistic queue depth is a few hundred riders, not a few thousand.

The PR now ships **two** Shanghai Tower cases so we anchor both ends:

| Case | Riders | Meaning | Baseline |
|---|---:|---|---:|
| `realistic_up_peak_300r_100ticks` | 300 | Mid-peak waiting queue — the number a real controller actually sees during morning rush | **~11.3 ms / 100 ticks** (~113 µs/tick) |
| `stress_2000r_100ticks` | 2 000 | Evacuation / major-event let-out — "don't regress under extreme load" ceiling | **~36.8 ms / 100 ticks** (~370 µs/tick) |

## Modeling choice

Single-group 149-car topology. The real building zones these into an observation shuttle + a sky-lobby shuttle bank + five local zones, which would exercise multi-group routing — valuable but orthogonal to raw dispatch cost. Keeping a single group makes the numbers directly comparable to the other `scaling_*` cases.

## Sources

- [Shanghai Tower — Wikipedia](https://en.wikipedia.org/wiki/Shanghai_Tower) — 149 Mitsubishi elevators, 128 above-ground floors + 5 below.
- [Shanghai Tower: sustainable and earthquake-resistant skyscraper — Tomorrow.City](https://www.tomorrow.city/shanghai-tower-sustainable-earthquake-resistant-skyscraper/) — ~30 000 daily throughput, ~16 000 concurrent occupants.
- [Shanghai Tower nabs three world records for its elevators — BD+C](https://www.bdcnetwork.com/home/news/55160731/shanghai-tower-nabs-three-world-records-for-its-elevators)

For comparison, distant seconds: **Pentagon — 70 elevators**, **Burj Khalifa — 57**.

## Test plan

- [x] `cargo bench -p elevator-core --bench scaling_bench -- shanghai` — both cases run cleanly, baselines captured above.
- [x] `cargo test -p elevator-core --all-features` — 825 tests + doctests green.
- [x] `cargo clippy -p elevator-core --all-features --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.