### PR TITLE
fix(dispatch): route RSR through pair_is_useful to guard aboard riders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.20.2"
+version = "15.20.3"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -127,6 +127,71 @@ pub fn pair_can_do_work(ctx: &RankContext<'_>) -> bool {
         .is_some_and(|calls| calls.iter().any(|c| c.pending_riders.is_empty()))
 }
 
+/// Stronger servability predicate: [`pair_can_do_work`] *plus* a path
+/// check guaranteeing the pickup doesn't strand aboard riders.
+///
+/// A car carrying riders with committed destinations refuses pickups
+/// that would pull it off the path to every aboard rider's destination.
+/// Without this guard, a stream of closer-destination hall calls can
+/// indefinitely preempt a farther aboard rider's delivery — the
+/// "never reaches the passenger's desired stop" loop. `NearestCar` and
+/// `Rsr` both call this at the top of `rank`; strategies with their
+/// own direction discipline (SCAN/LOOK/ETD) use [`pair_can_do_work`]
+/// because their sweep/direction terms already rule out backtracks.
+///
+/// Aboard riders without a published route (game-managed manual
+/// riders) don't constrain the path — any pickup is trivially
+/// on-the-way for them, so the predicate falls back to the base
+/// [`pair_can_do_work`] check.
+#[must_use]
+pub fn pair_is_useful(ctx: &RankContext<'_>) -> bool {
+    if !pair_can_do_work(ctx) {
+        return false;
+    }
+
+    let Some(car) = ctx.world.elevator(ctx.car) else {
+        return false;
+    };
+    // Exiting an aboard rider is always on-the-way for that rider.
+    let can_exit_here = car
+        .riders()
+        .iter()
+        .any(|&rid| ctx.world.route(rid).and_then(Route::current_destination) == Some(ctx.stop));
+    if can_exit_here || car.riders().is_empty() {
+        return true;
+    }
+
+    // Route-less aboard riders (game-managed manual riders) don't
+    // publish a destination, so there's no committed path to protect.
+    // Any pickup is trivially on-the-way — fall back to the raw
+    // servability check. Otherwise we'd refuse every pickup the moment
+    // the car carried its first manually-managed passenger.
+    let has_routed_rider = car.riders().iter().any(|&rid| {
+        ctx.world
+            .route(rid)
+            .and_then(Route::current_destination)
+            .is_some()
+    });
+    if !has_routed_rider {
+        return true;
+    }
+
+    // Pickups allowed only on the path to an aboard rider's destination.
+    // Candidate at the car's position (to_cand = 0) trivially qualifies —
+    // useful for same-floor boards.
+    let to_cand = ctx.stop_position - ctx.car_position;
+    car.riders().iter().any(|&rid| {
+        let Some(dest) = ctx.world.route(rid).and_then(Route::current_destination) else {
+            return false;
+        };
+        let Some(dest_pos) = ctx.world.stop_position(dest) else {
+            return false;
+        };
+        let to_dest = dest_pos - ctx.car_position;
+        to_dest * to_cand >= 0.0 && to_cand.abs() <= to_dest.abs()
+    })
+}
+
 /// Whether a waiting rider could actually board this car, matching the
 /// same filters the loading phase applies. Prevents `pair_can_do_work`
 /// from approving a pickup whose only demand is direction-filtered or

--- a/crates/elevator-core/src/dispatch/nearest_car.rs
+++ b/crates/elevator-core/src/dispatch/nearest_car.rs
@@ -9,7 +9,7 @@ use super::{DispatchStrategy, RankContext, pair_is_useful};
 /// — no two cars can be sent to the same hall call.
 ///
 /// Two guards are applied on top of the raw distance, both via the
-/// shared [`pair_is_useful`](super::pair_is_useful) predicate:
+/// shared [`pair_is_useful`] predicate:
 ///
 /// 1. The `(car, stop)` pair must be serviceable — at least one aboard
 ///    rider can exit, or at least one waiting rider can fit. A full car

--- a/crates/elevator-core/src/dispatch/nearest_car.rs
+++ b/crates/elevator-core/src/dispatch/nearest_car.rs
@@ -1,8 +1,6 @@
 //! Nearest-car dispatch — assigns each call to the closest idle elevator.
 
-use crate::components::Route;
-
-use super::{DispatchStrategy, RankContext, pair_can_do_work};
+use super::{DispatchStrategy, RankContext, pair_is_useful};
 
 /// Scores `(car, stop)` by absolute distance between the car and the stop.
 ///
@@ -10,7 +8,8 @@ use super::{DispatchStrategy, RankContext, pair_can_do_work};
 /// yields the globally minimum-total-distance matching across the group
 /// — no two cars can be sent to the same hall call.
 ///
-/// Two guards are applied on top of the raw distance:
+/// Two guards are applied on top of the raw distance, both via the
+/// shared [`pair_is_useful`](super::pair_is_useful) predicate:
 ///
 /// 1. The `(car, stop)` pair must be serviceable — at least one aboard
 ///    rider can exit, or at least one waiting rider can fit. A full car
@@ -48,56 +47,4 @@ impl DispatchStrategy for NearestCarDispatch {
     fn builtin_id(&self) -> Option<super::BuiltinStrategy> {
         Some(super::BuiltinStrategy::NearestCar)
     }
-}
-
-/// Decide whether assigning `ctx.car` to `ctx.stop` is on the path to
-/// any aboard rider's destination. Combined with
-/// [`pair_can_do_work`](super::pair_can_do_work), this keeps a car
-/// carrying riders from being pulled backward by closer pickups.
-fn pair_is_useful(ctx: &RankContext<'_>) -> bool {
-    if !pair_can_do_work(ctx) {
-        return false;
-    }
-
-    let Some(car) = ctx.world.elevator(ctx.car) else {
-        return false;
-    };
-    // Exiting an aboard rider is always on-the-way for that rider.
-    let can_exit_here = car
-        .riders()
-        .iter()
-        .any(|&rid| ctx.world.route(rid).and_then(Route::current_destination) == Some(ctx.stop));
-    if can_exit_here || car.riders().is_empty() {
-        return true;
-    }
-
-    // Route-less aboard riders (game-managed manual riders) don't
-    // publish a destination, so there's no committed path to protect.
-    // Any pickup is trivially on-the-way — fall back to the raw
-    // servability check. Otherwise we'd refuse every pickup the moment
-    // the car carried its first manually-managed passenger.
-    let has_routed_rider = car.riders().iter().any(|&rid| {
-        ctx.world
-            .route(rid)
-            .and_then(Route::current_destination)
-            .is_some()
-    });
-    if !has_routed_rider {
-        return true;
-    }
-
-    // Pickups allowed only on the path to an aboard rider's destination.
-    // Candidate at the car's position (to_cand = 0) trivially qualifies —
-    // useful for same-floor boards.
-    let to_cand = ctx.stop_position - ctx.car_position;
-    car.riders().iter().any(|&rid| {
-        let Some(dest) = ctx.world.route(rid).and_then(Route::current_destination) else {
-            return false;
-        };
-        let Some(dest_pos) = ctx.world.stop_position(dest) else {
-            return false;
-        };
-        let to_dest = dest_pos - ctx.car_position;
-        to_dest * to_cand >= 0.0 && to_cand.abs() <= to_dest.abs()
-    })
 }

--- a/crates/elevator-core/src/dispatch/rsr.rs
+++ b/crates/elevator-core/src/dispatch/rsr.rs
@@ -77,8 +77,8 @@ pub struct RsrDispatch {
     /// (`load_penalty_coeff · load_ratio`).
     ///
     /// Fires for partially loaded cars below the `bypass_load_*_pct`
-    /// threshold enforced by [`pair_can_do_work`]; lets you prefer
-    /// emptier cars for new pickups without an on/off cliff.
+    /// threshold enforced by [`pair_can_do_work`](super::pair_can_do_work);
+    /// lets you prefer emptier cars for new pickups without an on/off cliff.
     /// Default `0.0`.
     pub load_penalty_coeff: f64,
     /// Multiplier applied to `wrong_direction_penalty` when the

--- a/crates/elevator-core/src/dispatch/rsr.rs
+++ b/crates/elevator-core/src/dispatch/rsr.rs
@@ -18,7 +18,7 @@
 use crate::components::{CarCall, ElevatorPhase};
 use crate::traffic_detector::{TrafficDetector, TrafficMode};
 
-use super::{DispatchStrategy, RankContext, pair_can_do_work};
+use super::{DispatchStrategy, RankContext, pair_is_useful};
 
 /// Look up the current [`TrafficMode`] from `ctx.world` and return the
 /// scaling factor to apply to the wrong-direction penalty.
@@ -198,7 +198,14 @@ impl Default for RsrDispatch {
 
 impl DispatchStrategy for RsrDispatch {
     fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
-        if !pair_can_do_work(ctx) {
+        // `pair_is_useful` subsumes `pair_can_do_work` and adds the
+        // aboard-rider path guard. Without it, a loaded RSR car gets
+        // pulled off the path to its aboard riders' destinations by
+        // closer pickups — the same "never reaches the passenger's
+        // desired stop" loop that NearestCar specifically fixes. RSR's
+        // `wrong_direction_penalty` can mitigate this when configured,
+        // but the guard is a correctness floor independent of tuning.
+        if !pair_is_useful(ctx) {
             return None;
         }
         let car = ctx.world.elevator(ctx.car)?;

--- a/crates/elevator-core/src/tests/rsr_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/rsr_dispatch_tests.rs
@@ -7,10 +7,11 @@
 use super::dispatch_tests::{
     add_demand, decide_all, decide_one, spawn_elevator, test_group, test_world,
 };
-use crate::components::{CarCall, ElevatorPhase};
+use crate::components::{CarCall, ElevatorPhase, Route, Weight};
 use crate::dispatch::rsr::RsrDispatch;
-use crate::dispatch::{BuiltinStrategy, DispatchDecision, DispatchManifest};
+use crate::dispatch::{BuiltinStrategy, DispatchDecision, DispatchManifest, RiderInfo};
 use crate::entity::EntityId;
+use crate::ids::GroupId;
 
 // ── Defaults ────────────────────────────────────────────────────────
 
@@ -446,6 +447,92 @@ fn peak_direction_multiplier_tolerates_missing_detector() {
     );
     let committed_dec = decisions.iter().find(|(e, _)| *e == committed_up).unwrap();
     assert_eq!(committed_dec.1, DispatchDecision::GoToStop(stops[0]));
+}
+
+// ── Aboard-rider path guard ─────────────────────────────────────────
+//
+// These two tests lock in the correctness fix routing RSR through
+// `pair_is_useful` (the shared NearestCar path guard). With only
+// `pair_can_do_work`, an unconfigured RSR (all weights at their
+// `new()` defaults — i.e. effectively NearestCar) would be pulled off
+// its aboard riders' path by closer pickups, indefinitely deferring
+// delivery. Tests mirror `nearest_car_*` regression tests so any
+// future drift shows up on both strategies simultaneously.
+
+/// Full-car self-pair: a saturated RSR car parked at a pickup stop
+/// whose only waiter it cannot board must still be dispatched to its
+/// aboard rider's destination, not re-selected to its own stop.
+#[test]
+fn rsr_full_car_at_pickup_stop_prefers_rider_destination() {
+    let (mut world, stops) = test_world();
+    let elev = spawn_elevator(&mut world, 4.0); // at stops[1]
+    {
+        let car = world.elevator_mut(elev).unwrap();
+        car.current_load = car.weight_capacity;
+    }
+    let aboard = world.spawn();
+    world.elevator_mut(elev).unwrap().riders.push(aboard);
+    world.set_route(aboard, Route::direct(stops[0], stops[3], GroupId(0)));
+
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    add_demand(&mut manifest, &mut world, stops[1], 70.0);
+    manifest
+        .riding_to_stop
+        .entry(stops[3])
+        .or_default()
+        .push(RiderInfo {
+            id: aboard,
+            destination: Some(stops[3]),
+            weight: Weight::from(70.0),
+            wait_ticks: 0,
+        });
+
+    let mut rsr = RsrDispatch::new();
+    let decision = decide_one(&mut rsr, elev, 4.0, &group, &manifest, &mut world);
+    assert_eq!(
+        decision,
+        DispatchDecision::GoToStop(stops[3]),
+        "full car must be routed to its aboard rider's destination, not \
+         the un-serveable pickup at its current position"
+    );
+}
+
+/// Backward pickup with rider aboard: a car carrying a rider bound
+/// *up* must reject a closer-but-below pickup even on default RSR
+/// weights (where `wrong_direction_penalty = 0.0` means direction
+/// cost alone can't deflect the assignment).
+#[test]
+fn rsr_skips_backward_pickup_when_rider_aboard() {
+    let (mut world, stops) = test_world();
+    // Car at stops[2] (pos 8), rider aboard going *up* to stops[3] (pos 12).
+    let elev = spawn_elevator(&mut world, 8.0);
+    let aboard = world.spawn();
+    world.elevator_mut(elev).unwrap().riders.push(aboard);
+    world.set_route(aboard, Route::direct(stops[0], stops[3], GroupId(0)));
+
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    // Pickup below the car — closer in raw distance but opposite direction.
+    add_demand(&mut manifest, &mut world, stops[1], 70.0);
+    manifest
+        .riding_to_stop
+        .entry(stops[3])
+        .or_default()
+        .push(RiderInfo {
+            id: aboard,
+            destination: Some(stops[3]),
+            weight: Weight::from(70.0),
+            wait_ticks: 0,
+        });
+
+    let mut rsr = RsrDispatch::new();
+    let decision = decide_one(&mut rsr, elev, 8.0, &group, &manifest, &mut world);
+    assert_eq!(
+        decision,
+        DispatchDecision::GoToStop(stops[3]),
+        "backward pickup must not preempt an aboard rider's forward destination"
+    );
 }
 
 // ── Sanity: _elev unused suppresses dead-code warning ──────────────


### PR DESCRIPTION
## Summary

- Hoist `pair_is_useful` from `nearest_car.rs` to `dispatch/mod.rs` as a shared `pub fn` alongside `pair_can_do_work`, and route `RsrDispatch::rank` through it.
- Without the path guard, an unconfigured RSR — every weight at its `new()` zero default, which collapses to `NearestCarDispatch` — could be pulled off the path to its aboard riders' destinations by closer pickups, indefinitely deferring delivery (the "never reaches the passenger's desired stop" loop).
- Strategies with their own direction discipline (SCAN/LOOK/ETD) stay on the weaker `pair_can_do_work` floor: their sweep/direction terms already reject backtracks, and the stronger predicate would spuriously filter legitimate same-direction stops that aren't strictly on-path to a specific aboard rider's destination.

## Why now

Diagnosed while investigating why SCAN beats RSR on the Skyscraper playground scenario. The headline finding is tuning-driven (RSR's penalty stack is disabled by default and will be addressed separately), but the path guard is a correctness prereq: without it, RSR's pickup-loading behaviour is strictly worse than NearestCar regardless of weight tuning. Landing this first so subsequent tuning work doesn't amplify a latent bug.

## Test plan

- [x] `cargo test -p elevator-core --all-features` — 827 unit tests, all scenarios, 159 doctests, all green.
- [x] `cargo clippy -p elevator-core --all-features --all-targets` — clean.
- [x] `cargo fmt -p elevator-core --check` — clean.
- [x] `cargo check --workspace --all-features` — clean across core, bevy, ffi, gdext, wasm.
- [x] New regression tests added and verified against both the fix and a temporary revert:
  - `rsr_full_car_at_pickup_stop_prefers_rider_destination` — mirrors the NearestCar test; asserts a saturated RSR car at a waiter it can't board routes to its aboard rider's dest instead of its own stop.
  - `rsr_skips_backward_pickup_when_rider_aboard` — mirrors the NearestCar test; asserts a loaded RSR car going up rejects a closer-but-below pickup.
  - Both fail without the `pair_is_useful` wiring and pass with it — confirmed locally by toggling back to `pair_can_do_work` before finalising the commit.

## Notes

- Public API change is purely additive: `pair_is_useful` is a new `pub fn` in `elevator_core::dispatch`. Existing strategies using `pair_can_do_work` are unaffected.
- Separate follow-ups tracked for the rest of the RSR cleanup (tuned `Default::default()` weights, proportional `wrong_direction_penalty`, age-linear fairness term) and for the ETD door-overhead normalisation that explains the cross-strategy Skyscraper gap.