### PR TITLE
feat(dispatch): ship tuned RSR defaults so the dropdown entry actually does RSR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.20.2"
+version = "15.20.3"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/examples/playground_audit.rs
+++ b/crates/elevator-core/examples/playground_audit.rs
@@ -7,10 +7,15 @@
 //! rate, avg/max wait, peak waiting-queue length across the whole run.
 //!
 //! Purpose: catch dispatch regressions across the `ScanDispatch`,
-//! `LookDispatch`, `NearestCarDispatch`, `EtdDispatch`, and
-//! `DestinationDispatch` strategies at a glance — a scan that reports
-//! 100% delivery and 0% abandonment that suddenly starts abandoning
-//! riders is an obvious regression.
+//! `LookDispatch`, `NearestCarDispatch`, `EtdDispatch`, `RsrDispatch`,
+//! and `DestinationDispatch` strategies at a glance — a scan that
+//! reports 100% delivery and 0% abandonment that suddenly starts
+//! abandoning riders is an obvious regression.
+//!
+//! RSR runs under its tuned [`RsrDispatch::default`] weights (not the
+//! zero-baseline `new()`), matching what consumers get when they pick
+//! "RSR" from a dropdown. Running `new()` here would silently duplicate
+//! the `nearest` row.
 //!
 //! Scope note: this example used to mirror the playground's scenario
 //! set, but the playground now runs a 42-stop multi-line skyscraper
@@ -44,7 +49,7 @@
 
 use elevator_core::config::SimConfig;
 use elevator_core::dispatch::{
-    DestinationDispatch, EtdDispatch, LookDispatch, NearestCarDispatch, ScanDispatch,
+    DestinationDispatch, EtdDispatch, LookDispatch, NearestCarDispatch, RsrDispatch, ScanDispatch,
 };
 use elevator_core::sim::Simulation;
 use elevator_core::stop::StopId;
@@ -109,7 +114,7 @@ fn main() {
             "  {:<12} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10}",
             "strategy", "delivered", "abandoned", "aband%", "avg_wait", "max_wait", "peak_q"
         );
-        for strategy in ["scan", "look", "nearest", "etd", "destination"] {
+        for strategy in ["scan", "look", "nearest", "etd", "rsr", "destination"] {
             let report = run_once(scenario, strategy, effective_budget);
             println!(
                 "  {:<12} {:>10} {:>10} {:>9.1}% {:>9.1}s {:>9.1}s {:>10}",
@@ -150,6 +155,10 @@ fn run_once(scenario: &Scenario, strategy_name: &str, abandon_override: Option<u
         "look" => Simulation::new(&config, LookDispatch::new()),
         "nearest" => Simulation::new(&config, NearestCarDispatch::new()),
         "etd" => Simulation::new(&config, EtdDispatch::new()),
+        // Use `Default` (tuned stack), not `new()` (zero baseline) —
+        // `new()` would reduce RSR to `NearestCarDispatch` and give
+        // the audit a misleadingly duplicated row.
+        "rsr" => Simulation::new(&config, RsrDispatch::default()),
         "destination" => Simulation::new(&config, DestinationDispatch::new()),
         _ => panic!("unknown strategy: {strategy_name}"),
     }

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -430,7 +430,12 @@ impl BuiltinStrategy {
             Self::NearestCar => Some(Box::new(nearest_car::NearestCarDispatch::new())),
             Self::Etd => Some(Box::new(etd::EtdDispatch::new())),
             Self::Destination => Some(Box::new(destination::DestinationDispatch::new())),
-            Self::Rsr => Some(Box::new(rsr::RsrDispatch::new())),
+            // `Default` ships with the tuned penalty stack; `new()` is
+            // the zero baseline for additive-composition tests. The
+            // playground's "RSR" dropdown entry should map to the
+            // actual strategy, not to NearestCar-in-disguise, so use
+            // `Default` here.
+            Self::Rsr => Some(Box::new(rsr::RsrDispatch::default())),
             Self::Custom(_) => None,
         }
     }

--- a/crates/elevator-core/src/dispatch/rsr.rs
+++ b/crates/elevator-core/src/dispatch/rsr.rs
@@ -101,6 +101,18 @@ pub struct RsrDispatch {
 impl RsrDispatch {
     /// Create a new `RsrDispatch` with the baseline weights
     /// (`eta_weight = 1.0`, all penalties/bonuses disabled).
+    ///
+    /// This is the **additive-composition baseline** — every penalty
+    /// and bonus is zero, so the rank reduces to
+    /// [`NearestCarDispatch`](super::NearestCarDispatch) on distance
+    /// alone. Useful for tests that want to measure a single term in
+    /// isolation (`RsrDispatch::new().with_wrong_direction_penalty(…)`).
+    ///
+    /// For the opinionated "out-of-the-box RSR" configuration used by
+    /// [`BuiltinStrategy::Rsr`](super::BuiltinStrategy::Rsr) and the
+    /// playground, use [`RsrDispatch::default`] instead. `Default` ships
+    /// with the full penalty stack turned on; `new()` is the empty
+    /// canvas you build on top of.
     #[must_use]
     pub const fn new() -> Self {
         Self {
@@ -109,6 +121,38 @@ impl RsrDispatch {
             coincident_car_call_bonus: 0.0,
             load_penalty_coeff: 0.0,
             peak_direction_multiplier: 1.0,
+        }
+    }
+
+    /// Return the opinionated tuned configuration — equivalent to
+    /// [`Default::default`] but usable in `const` contexts.
+    ///
+    /// See [`RsrDispatch::default`] for the rationale behind each
+    /// weight. The tuned stack ships with every penalty/bonus turned
+    /// on so picking RSR out of the box is strictly richer than
+    /// `NearestCar`, not identical to it.
+    #[must_use]
+    pub const fn tuned() -> Self {
+        Self {
+            eta_weight: 1.0,
+            // Chosen ≈ one shaft-length travel time on a typical 20-stop
+            // commercial bank (≈15s), so a backward pickup costs as much
+            // as the trip to serve it. Large enough to dominate the ETA
+            // term for a close-but-wrong-direction candidate; small
+            // enough that off-peak inter-floor reversals still flip when
+            // the demand strongly favours them.
+            wrong_direction_penalty: 15.0,
+            // Small merge bonus — prefer a car with a matching car-call
+            // over spawning a new trip, but not so large it overrides a
+            // much closer empty car.
+            coincident_car_call_bonus: 5.0,
+            // Light load-balancing — prefer empty cars for new work
+            // when cars are otherwise tied.
+            load_penalty_coeff: 3.0,
+            // Strong directional commitment during up-peak / down-peak
+            // (lobby-bound loads shouldn't reverse for new pickups).
+            // Off-peak stays unscaled for cheap inter-floor reversals.
+            peak_direction_multiplier: 2.0,
         }
     }
 
@@ -191,8 +235,20 @@ impl RsrDispatch {
 }
 
 impl Default for RsrDispatch {
+    /// The opinionated "pick RSR from the dropdown" configuration.
+    ///
+    /// Defaults to [`RsrDispatch::tuned`] — every penalty and bonus
+    /// turned on with values calibrated to a 20-stop commercial bank.
+    /// Before this default was tuned, `RsrDispatch::default()`
+    /// reduced to the raw [`NearestCarDispatch`](super::NearestCarDispatch)
+    /// baseline: picking "RSR" in the playground produced worse
+    /// behaviour than picking "Nearest Car" (no direction discipline,
+    /// no load balancing, no car-call merging). The tuned default
+    /// fixes that without making any term mandatory — consumers
+    /// wanting the zero baseline can still call
+    /// [`RsrDispatch::new`].
     fn default() -> Self {
-        Self::new()
+        Self::tuned()
     }
 }
 

--- a/crates/elevator-core/src/tests/rsr_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/rsr_dispatch_tests.rs
@@ -15,9 +15,12 @@ use crate::entity::EntityId;
 // ── Defaults ────────────────────────────────────────────────────────
 
 #[test]
-fn default_weights_match_nearest_car_baseline() {
+fn new_is_nearest_car_zero_baseline() {
     // eta_weight = 1.0, all penalties/bonuses disabled. With one car
     // and one stop, the car must go to the stop (no other options).
+    // This contract is load-bearing for additive-composition tests
+    // like `wrong_direction_penalty_steers_away_from_reversing_car`
+    // which set weights via `new().with_*`.
     let (mut world, stops) = test_world();
     let elev = spawn_elevator(&mut world, 0.0);
     let group = test_group(&stops, vec![elev]);
@@ -27,6 +30,84 @@ fn default_weights_match_nearest_car_baseline() {
     let mut rsr = RsrDispatch::new();
     let decision = decide_one(&mut rsr, elev, 0.0, &group, &manifest, &mut world);
     assert_eq!(decision, DispatchDecision::GoToStop(stops[2]));
+
+    // Field-level invariant: every penalty/bonus is off at `new()`.
+    let baseline = RsrDispatch::new();
+    assert_eq!(baseline.wrong_direction_penalty, 0.0);
+    assert_eq!(baseline.coincident_car_call_bonus, 0.0);
+    assert_eq!(baseline.load_penalty_coeff, 0.0);
+    assert!((baseline.peak_direction_multiplier - 1.0).abs() < 1e-12);
+}
+
+/// `tuned()` and `Default::default()` ship the opinionated stack — every
+/// term turned on with calibrated weights. This is what
+/// [`BuiltinStrategy::Rsr.instantiate`] returns, so picking RSR in the
+/// playground actually exercises RSR, not a `NearestCar` equivalent.
+#[test]
+fn tuned_turns_on_every_penalty_and_bonus() {
+    let t = RsrDispatch::tuned();
+    assert!(
+        t.wrong_direction_penalty > 0.0,
+        "wrong_direction_penalty must be active"
+    );
+    assert!(
+        t.coincident_car_call_bonus > 0.0,
+        "coincident_car_call_bonus must be active"
+    );
+    assert!(
+        t.load_penalty_coeff > 0.0,
+        "load_penalty_coeff must be active"
+    );
+    assert!(
+        t.peak_direction_multiplier > 1.0,
+        "peak_direction_multiplier must scale up during peaks"
+    );
+
+    // `Default::default()` must equal `tuned()` — this ties the
+    // Builtin-strategy dropdown to the tuned shape so nobody "fixes"
+    // `default()` back to `new()` by accident.
+    let d = RsrDispatch::default();
+    assert_eq!(d.eta_weight, t.eta_weight);
+    assert_eq!(d.wrong_direction_penalty, t.wrong_direction_penalty);
+    assert_eq!(d.coincident_car_call_bonus, t.coincident_car_call_bonus);
+    assert_eq!(d.load_penalty_coeff, t.load_penalty_coeff);
+    assert_eq!(d.peak_direction_multiplier, t.peak_direction_multiplier);
+}
+
+/// End-to-end effect of the tuned default: a committed-up car
+/// refuses a below pickup when there's an idle alternative, even
+/// without any manual `with_wrong_direction_penalty` call.
+/// Pre-tuning, `RsrDispatch::default()` reduced to pure ETA and would
+/// pick whichever car was closest — reproducing the "wrong direction
+/// is free" bug in the out-of-the-box configuration.
+#[test]
+fn tuned_default_deflects_committed_car_from_backtrack_pickup() {
+    let (mut world, stops) = test_world();
+    let committed_up = spawn_elevator(&mut world, 6.0);
+    let idle_far = spawn_elevator(&mut world, 16.0);
+    world.elevator_mut(committed_up).unwrap().phase = ElevatorPhase::MovingToStop(stops[3]);
+
+    let group = test_group(&stops, vec![committed_up, idle_far]);
+    let mut manifest = DispatchManifest::default();
+    add_demand(&mut manifest, &mut world, stops[0], 70.0);
+
+    // Using `default()`, NOT `new().with_*` — the tuned wrong-direction
+    // penalty must fire automatically.
+    let mut rsr = RsrDispatch::default();
+    let decisions = decide_all(
+        &mut rsr,
+        &[(committed_up, 6.0), (idle_far, 16.0)],
+        &group,
+        &manifest,
+        &mut world,
+    );
+    let idle_dec = decisions.iter().find(|(e, _)| *e == idle_far).unwrap();
+    assert_eq!(
+        idle_dec.1,
+        DispatchDecision::GoToStop(stops[0]),
+        "tuned default must route the idle car, not the committed-up one \
+         forced to backtrack — the whole point of shipping non-zero weights"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Before: `BuiltinStrategy::Rsr.instantiate()` returned `RsrDispatch::new()` — every penalty and bonus at zero, which collapses the rank to `eta_weight · travel_time`, i.e. literal `NearestCarDispatch`. Picking \"RSR\" in the playground was strictly worse than picking \"Nearest Car\" (no aboard-rider path guard — fixed in #431, no direction discipline, no load balancing, no car-call merging).
- Now: `RsrDispatch::tuned()` / `Default::default()` ship the opinionated penalty stack with calibrated weights. `BuiltinStrategy::Rsr.instantiate()` uses `Default` so the dropdown maps to the real strategy.
- `new()` stays a `const fn` zero-baseline for additive-composition tests — nobody builds incremental setups like `new().with_wrong_direction_penalty(…)` and then had their baseline shifted out from under them.

## Tuned weights

| Field | Value | Rationale |
|---|---|---|
| `wrong_direction_penalty` | `15.0` | ≈ one shaft-length travel on a 20-stop commercial bank — large enough to deflect close-but-wrong-direction candidates, small enough that off-peak inter-floor reversals still flip under stronger demand. |
| `coincident_car_call_bonus` | `5.0` | Small merge bonus — prefer a car with a matching car-call over spawning a new trip, but not so big it overrides a much closer empty car. |
| `load_penalty_coeff` | `3.0` | Light load-balancing preference for empty cars on new work when cars are otherwise tied. |
| `peak_direction_multiplier` | `2.0` | Strong directional commitment during up-peak / down-peak. Off-peak stays unscaled for cheap inter-floor reversals. |

## Why split R2 from R3

Originally scoped together with a proportional-penalty rewrite (R3). Split so this PR is a pure *defaults* change — no field semantics change, no new fields, no serde-format churn. R3's semantic change to `wrong_direction_penalty` (flat constant → travel-time multiplier) deserves its own review cycle because it'd also retune the default value, and those are independently reviewable decisions.

## Test plan

- [x] `cargo test -p elevator-core --all-features` — 827 + doctests + scenarios, all green. 23 RSR tests including three new ones.
- [x] `cargo clippy -p elevator-core --all-features --all-targets` — clean.
- [x] `cargo fmt -p elevator-core --check` — clean.
- [x] `cargo check --workspace --all-features` — clean across core, bevy, ffi, gdext, wasm.
- [x] New tests:
  - `new_is_nearest_car_zero_baseline` — locks in the contract that `new()` remains the zero baseline. Without this, any future \"simplify the impls\" PR could silently merge `new` and `default`, breaking every single-term unit test.
  - `tuned_turns_on_every_penalty_and_bonus` — field-level assertion that every weight is active in `tuned()` *and* that `Default::default()` matches `tuned()` field-for-field.
  - `tuned_default_deflects_committed_car_from_backtrack_pickup` — end-to-end behavioural test: a committed-up car must refuse a below pickup under the tuned default. Uses `RsrDispatch::default()` directly (no manual `with_*` calls), so it actively exercises the shipped out-of-the-box behaviour.

## Notes

- Companion to PR #431 (RSR aboard-rider path guard). Both land before the remaining tuning work (R3 proportional penalty, R4 age-linear term).
- During scoping I also explored an ETD door-overhead normalisation (the suspected root cause of the Skyscraper SCAN-beats-ETD gap). Abandoned it — the hypothesis didn't survive testing, all realistic scenarios produced identical dispatch decisions under linear vs sqrt scaling. The real Skyscraper gap needs instrumentation before re-attempting.