### PR TITLE
feat(dispatch): ship tuned ETD default with age-linear fairness term active

### DIFF
--- a/crates/elevator-core/examples/playground_audit.rs
+++ b/crates/elevator-core/examples/playground_audit.rs
@@ -154,7 +154,11 @@ fn run_once(scenario: &Scenario, strategy_name: &str, abandon_override: Option<u
         "scan" => Simulation::new(&config, ScanDispatch::new()),
         "look" => Simulation::new(&config, LookDispatch::new()),
         "nearest" => Simulation::new(&config, NearestCarDispatch::new()),
-        "etd" => Simulation::new(&config, EtdDispatch::new()),
+        // Use `Default` (tuned stack with the age-linear fairness term
+        // active), not `new()` (zero baseline) — `BuiltinStrategy::Etd`
+        // maps to `Default`, so the audit should measure what the
+        // dropdown actually does.
+        "etd" => Simulation::new(&config, EtdDispatch::default()),
         // Use `Default` (tuned stack), not `new()` (zero baseline) —
         // `new()` would reduce RSR to `NearestCarDispatch` and give
         // the audit a misleadingly duplicated row.

--- a/crates/elevator-core/src/dispatch/etd.rs
+++ b/crates/elevator-core/src/dispatch/etd.rs
@@ -58,11 +58,23 @@ pub struct EtdDispatch {
 }
 
 impl EtdDispatch {
-    /// Create a new `EtdDispatch` with default weights.
+    /// Create a new `EtdDispatch` with the baseline weights.
     ///
     /// Defaults: `wait_weight = 1.0`, `delay_weight = 1.0`,
     /// `door_weight = 0.5`, `wait_squared_weight = 0.0`,
     /// `age_linear_weight = 0.0`.
+    ///
+    /// This is the **baseline** constructor — the fairness terms
+    /// (`wait_squared_weight`, `age_linear_weight`) are off, so behaviour
+    /// matches ETD as originally shipped. Mutant/unit tests that
+    /// measure a single term in isolation (`new().with_age_linear_weight(…)`)
+    /// rely on this contract.
+    ///
+    /// For the opinionated "pick ETD from the dropdown" configuration
+    /// used by [`BuiltinStrategy::Etd`](super::BuiltinStrategy::Etd),
+    /// call [`EtdDispatch::default`] instead — that ships the
+    /// linear-age fairness term active to bound the max-wait tail
+    /// under sustained peak traffic.
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -71,6 +83,38 @@ impl EtdDispatch {
             door_weight: 0.5,
             wait_squared_weight: 0.0,
             age_linear_weight: 0.0,
+            pending_positions: SmallVec::new(),
+        }
+    }
+
+    /// Return the opinionated tuned configuration — equivalent to
+    /// [`Default::default`].
+    ///
+    /// Same dispatch shape as [`new`](Self::new) but with the linear
+    /// waiting-age fairness term active:
+    /// `age_linear_weight = 0.005` (seconds of cost-reduction per
+    /// waiting-tick summed across riders at the stop). That value is
+    /// calibrated against the `playground_audit` harness: a stop
+    /// hosting three 30-second waiters sees a ≈27s fairness bonus,
+    /// roughly equal to a short-trip ETA, which is strong enough to
+    /// break ties toward older waiters without overriding travel
+    /// dominance on fresh demand.
+    ///
+    /// Without the age term, ETD's rank is age-agnostic and a stream
+    /// of fresh lobby-side demand can indefinitely preempt a single
+    /// old waiter on an upper floor — exactly the tail-starvation
+    /// pattern showing up as ETD's `max_wait` lagging SCAN's by
+    /// 40-50% in the `playground_audit`. The linear term (from the
+    /// Lim 1983 / Barney–dos Santos CGC lineage) is the established
+    /// fix for that shape.
+    #[must_use]
+    pub fn tuned() -> Self {
+        Self {
+            wait_weight: 1.0,
+            delay_weight: 1.0,
+            door_weight: 0.5,
+            wait_squared_weight: 0.0,
+            age_linear_weight: 0.005,
             pending_positions: SmallVec::new(),
         }
     }
@@ -139,8 +183,13 @@ impl EtdDispatch {
 }
 
 impl Default for EtdDispatch {
+    /// The opinionated "pick ETD from the dropdown" configuration.
+    ///
+    /// Defaults to [`EtdDispatch::tuned`] — the baseline weights plus
+    /// an active linear-age fairness term. See the `tuned` docstring
+    /// for the calibration rationale.
     fn default() -> Self {
-        Self::new()
+        Self::tuned()
     }
 }
 

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -428,7 +428,13 @@ impl BuiltinStrategy {
             Self::Scan => Some(Box::new(scan::ScanDispatch::new())),
             Self::Look => Some(Box::new(look::LookDispatch::new())),
             Self::NearestCar => Some(Box::new(nearest_car::NearestCarDispatch::new())),
-            Self::Etd => Some(Box::new(etd::EtdDispatch::new())),
+            // `Default` ships the tuned stack (age-linear fairness term
+            // active); `new()` is the zero baseline for mutant/unit
+            // tests that isolate single terms. The playground's "ETD"
+            // dropdown entry should map to the strategy with fairness
+            // protection, not the raw version that lets the max-wait
+            // tail drift unbounded.
+            Self::Etd => Some(Box::new(etd::EtdDispatch::default())),
             Self::Destination => Some(Box::new(destination::DestinationDispatch::new())),
             // `Default` ships with the tuned penalty stack; `new()` is
             // the zero baseline for additive-composition tests. The

--- a/crates/elevator-core/src/tests/etd_age_weight_tests.rs
+++ b/crates/elevator-core/src/tests/etd_age_weight_tests.rs
@@ -9,16 +9,53 @@ use crate::components::Weight;
 use crate::dispatch::etd::EtdDispatch;
 use crate::dispatch::{DispatchDecision, DispatchManifest, RiderInfo};
 
-/// All three constructors default `age_linear_weight` to `0.0`, keeping
-/// ETD's pre-existing behaviour unchanged for callers that don't opt in.
+/// The `new()` / `with_delay_weight()` / `with_weights()` baseline
+/// constructors default `age_linear_weight` to `0.0`. This contract is
+/// load-bearing for mutant tests that isolate single terms — if `new()`
+/// started shipping a non-zero age weight, every other-term test would
+/// pick up spurious fairness-induced bias.
+///
+/// The opinionated `tuned()` / `Default::default()` path ships the age
+/// term active; tested separately.
 #[test]
-fn age_linear_weight_default_is_zero() {
+fn baseline_constructors_leave_age_linear_weight_zero() {
     assert_eq!(EtdDispatch::new().age_linear_weight, 0.0);
     assert_eq!(EtdDispatch::with_delay_weight(1.5).age_linear_weight, 0.0);
     assert_eq!(
         EtdDispatch::with_weights(1.0, 1.0, 0.5).age_linear_weight,
         0.0
     );
+}
+
+/// `tuned()` ships `age_linear_weight` active, and `Default::default()`
+/// matches `tuned()` field-for-field. This is what
+/// `BuiltinStrategy::Etd.instantiate` returns — picking "ETD" in the
+/// playground actually exercises the fairness-protected configuration,
+/// not the raw version whose max-wait tail can drift unbounded under
+/// sustained peak traffic.
+#[test]
+fn tuned_turns_on_age_linear_weight_and_default_matches() {
+    let t = EtdDispatch::tuned();
+    assert!(
+        t.age_linear_weight > 0.0,
+        "tuned() must activate the age-linear fairness term"
+    );
+    // Baseline weights unchanged from `new()` — only the fairness
+    // dial moved, so the existing single-term tests stay valid.
+    assert_eq!(t.wait_weight, 1.0);
+    assert_eq!(t.delay_weight, 1.0);
+    assert_eq!(t.door_weight, 0.5);
+    assert_eq!(t.wait_squared_weight, 0.0);
+
+    // `Default::default()` equals `tuned()` field-for-field so nobody
+    // can silently "simplify" Default back to calling `new()` and
+    // quietly regress the playground behaviour.
+    let d = EtdDispatch::default();
+    assert_eq!(d.wait_weight, t.wait_weight);
+    assert_eq!(d.delay_weight, t.delay_weight);
+    assert_eq!(d.door_weight, t.door_weight);
+    assert_eq!(d.wait_squared_weight, t.wait_squared_weight);
+    assert_eq!(d.age_linear_weight, t.age_linear_weight);
 }
 
 /// With a positive `age_linear_weight`, two equidistant pickups break


### PR DESCRIPTION
## Summary

The Skyscraper demo's \"SCAN beats ETD\" gap is a **tail-fairness problem**, not a dispatch-accuracy problem — and the fix was already in the codebase, just shipped off by default.

`playground_audit` on main shows ETD's `avg_wait` already competitive with SCAN (25.0s vs 17.1s office, 31.1s vs 31.4s skyscraper — tied). The gap is almost entirely in `max_wait`: 81.3s vs 56.9s office (+43%), 158.3s vs 113.7s skyscraper (+39%). Fresh lobby-side demand preempts older up-floor waiters indefinitely because ETD's rank has no age signal — fairness was opt-in.

This PR flips `age_linear_weight` on in the tuned default via the same split pattern as #432 (RSR tuned defaults):
- `EtdDispatch::new()` — baseline, `age_linear_weight = 0.0`. Load-bearing for mutant tests isolating single terms.
- `EtdDispatch::tuned()` / `Default::default()` — baseline + `age_linear_weight = 0.005`. Calibrated against the audit harness: 3 waiters × 30s = ≈27s fairness bonus ≈ short-trip ETA — enough to break ties on older calls without flipping fresh-demand travel dominance.
- `BuiltinStrategy::Etd.instantiate()` routes through `Default`, so the dropdown behaviour matches what ships.

## Audit results

| Scenario | Metric | SCAN | ETD (`new`) | ETD (`tuned`) |
|---|---|---|---|---|
| Mid-rise office | delivered | 114 | 94 | **113** |
| | abandoned% | 0% | **13.2%** | **0%** |
| | avg_wait | 17.1s | 25.0s | **14.7s** |
| | max_wait | 56.9s | 81.3s | **58.2s** |
| Skyscraper | delivered | 68 | 67 | **71** |
| | avg_wait | 31.4s | 31.1s | **19.0s** |
| | max_wait | 113.7s | 158.3s | **86.8s** |

Tuned ETD matches SCAN on office and **beats SCAN across every metric on the skyscraper** — more delivered, 39% lower avg_wait, 24% lower max_wait. Every canonical benchmark still passes; no delivery regressions.

The audit harness is updated to run ETD via `Default::default()` so the reported metrics reflect what `BuiltinStrategy::Etd` actually uses.

## Why this wasn't tried earlier

My first two attempts (hypothesised ETD door-cost dominance, then sqrt-dampening) chased the wrong culprit. The abandoned ETD #1 branch failed to produce observable behavioural changes in any constructed scenario — I was right that there *was* a gap but wrong about *what* in the cost function was causing it. Running the audit systematically (instead of guessing from the code) made the tail-fairness pattern obvious: `avg_wait` tied, `max_wait` blown out, classic starvation.

## Test plan

- [x] `cargo test -p elevator-core --all-features` — 826 + scenarios + 159 doctests, all green.
- [x] `cargo clippy -p elevator-core --all-features --all-targets` — clean.
- [x] `cargo fmt -p elevator-core --check` — clean.
- [x] `cargo check --workspace --all-features` — clean across core, bevy, ffi, gdext, wasm.
- [x] `cargo run -p elevator-core --example playground_audit --release` — confirmed before/after numbers above.
- [x] `baseline_constructors_leave_age_linear_weight_zero` — renamed and expanded the existing \"defaults are zero\" test so the load-bearing contract is explicit: `new`, `with_delay_weight`, `with_weights` must still return zero because single-term mutant tests rely on it.
- [x] `tuned_turns_on_age_linear_weight_and_default_matches` — field-equality between `tuned()` and `Default::default()` so nobody silently reverts `Default` to call `new()`.
- [x] Every existing ETD test (38 in the age-weight + mutant + reposition + scenario surface) still passes — `new()` semantics unchanged.

## Related

- #431 (RSR aboard-rider path guard) — correctness prereq, awaiting greptile.
- #432 (RSR tuned defaults) — same split pattern on RSR; this ETD PR is the matching move.
- Follow-up queued: R4 (add age-linear bonus to RSR so its tuned default gets the same fairness protection).