### PR TITLE
feat(dispatch): add linear waiting-age fairness term to RSR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.20.3"
+version = "15.22.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/dispatch/rsr.rs
+++ b/crates/elevator-core/src/dispatch/rsr.rs
@@ -104,12 +104,12 @@ pub struct RsrDispatch {
     ///
     /// Default `0.0` at [`new`](Self::new) / serde round-trip (keeps
     /// single-term mutant tests valid and snapshots backward-compatible);
-    /// [`tuned`](Self::tuned) / [`default`](Self::default) ship `0.005`,
-    /// calibrated so three 30-second waiters at a stop pull roughly
-    /// one short-trip ETA off the rank — strong enough to break ties
-    /// toward older calls, not strong enough to override travel
-    /// dominance on fresh demand. Matches the ETD tuned default so the
-    /// two strategies' fairness protection lines up.
+    /// [`tuned`](Self::tuned) / [`default`](Self::default) ship `0.002`,
+    /// lighter than ETD's 0.005 because RSR's wrong-direction penalty
+    /// and `pair_is_useful` path guard already handle two starvation
+    /// patterns that ETD needed the full-strength term for. See the
+    /// inline comment at `tuned()` for the harness numbers behind the
+    /// calibration.
     ///
     /// Mirrors the Lim 1983 / Barney–dos Santos 1985 CGC lineage
     /// already used in `EtdDispatch::age_linear_weight`; composes

--- a/crates/elevator-core/src/dispatch/rsr.rs
+++ b/crates/elevator-core/src/dispatch/rsr.rs
@@ -96,6 +96,26 @@ pub struct RsrDispatch {
     /// is installed — tests and custom sims that bypass the auto-install
     /// stay unaffected.
     pub peak_direction_multiplier: f64,
+    /// Coefficient on the linear waiting-age fairness bonus. Each
+    /// candidate stop's rank is reduced by `age_linear_weight · Σ
+    /// wait_ticks` across waiting riders at the stop, so stops hosting
+    /// older calls win ties without the quadratic blow-up a squared-
+    /// wait term would have.
+    ///
+    /// Default `0.0` at [`new`](Self::new) / serde round-trip (keeps
+    /// single-term mutant tests valid and snapshots backward-compatible);
+    /// [`tuned`](Self::tuned) / [`default`](Self::default) ship `0.005`,
+    /// calibrated so three 30-second waiters at a stop pull roughly
+    /// one short-trip ETA off the rank — strong enough to break ties
+    /// toward older calls, not strong enough to override travel
+    /// dominance on fresh demand. Matches the ETD tuned default so the
+    /// two strategies' fairness protection lines up.
+    ///
+    /// Mirrors the Lim 1983 / Barney–dos Santos 1985 CGC lineage
+    /// already used in `EtdDispatch::age_linear_weight`; composes
+    /// additively with the other penalty-stack terms.
+    #[serde(default)]
+    pub age_linear_weight: f64,
 }
 
 impl RsrDispatch {
@@ -121,6 +141,7 @@ impl RsrDispatch {
             coincident_car_call_bonus: 0.0,
             load_penalty_coeff: 0.0,
             peak_direction_multiplier: 1.0,
+            age_linear_weight: 0.0,
         }
     }
 
@@ -153,6 +174,19 @@ impl RsrDispatch {
             // (lobby-bound loads shouldn't reverse for new pickups).
             // Off-peak stays unscaled for cheap inter-floor reversals.
             peak_direction_multiplier: 2.0,
+            // Linear waiting-age fairness. Tuned at 0.002 against the
+            // `playground_audit` harness — lighter than ETD's 0.005
+            // default because RSR's wrong-direction penalty and
+            // `pair_is_useful` path guard already handle two of the
+            // starvation patterns ETD needed the full-strength term
+            // for. At 0.002 on the audit skyscraper (2 cars, heavy
+            // peak), RSR beats SCAN across delivered / avg_wait /
+            // max_wait; at 0.005 the same scenario improves further
+            // but bleeds a few extra abandonments out of the
+            // single-car office run as the age bonus pulls the lone
+            // car off fresh demand faster than it can cycle. 0.002
+            // is the tighter balance.
+            age_linear_weight: 0.002,
         }
     }
 
@@ -213,6 +247,23 @@ impl RsrDispatch {
             "eta_weight must be finite and non-negative, got {weight}"
         );
         self.eta_weight = weight;
+        self
+    }
+
+    /// Set the linear waiting-age fairness weight. Composes additively
+    /// with the other penalty/bonus terms; `0.0` disables the term.
+    ///
+    /// # Panics
+    /// Panics on non-finite or negative weights. A `NaN` weight would
+    /// propagate through `mul_add` and silently collapse the stack;
+    /// a negative weight would invert the fairness ordering.
+    #[must_use]
+    pub fn with_age_linear_weight(mut self, weight: f64) -> Self {
+        assert!(
+            weight.is_finite() && weight >= 0.0,
+            "age_linear_weight must be finite and non-negative, got {weight}"
+        );
+        self.age_linear_weight = weight;
         self
     }
 
@@ -320,6 +371,20 @@ impl DispatchStrategy for RsrDispatch {
                 let load_ratio = (car.current_load().value() / capacity).clamp(0.0, 1.0);
                 cost += self.load_penalty_coeff * load_ratio;
             }
+        }
+
+        // Linear waiting-age fairness bonus. Pulls stale calls forward
+        // without the quadratic blow-up a squared-wait term would have;
+        // prevents fresh lobby-side demand from indefinitely preempting
+        // older upper-floor waiters. Mirrors ETD's `age_linear_weight`.
+        if self.age_linear_weight > 0.0 {
+            let wait_sum: f64 = ctx
+                .manifest
+                .waiting_riders_at(ctx.stop)
+                .iter()
+                .map(|r| r.wait_ticks as f64)
+                .sum();
+            cost = self.age_linear_weight.mul_add(-wait_sum, cost);
         }
 
         let cost = cost.max(0.0);

--- a/crates/elevator-core/src/tests/rsr_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/rsr_dispatch_tests.rs
@@ -38,6 +38,7 @@ fn new_is_nearest_car_zero_baseline() {
     assert_eq!(baseline.coincident_car_call_bonus, 0.0);
     assert_eq!(baseline.load_penalty_coeff, 0.0);
     assert!((baseline.peak_direction_multiplier - 1.0).abs() < 1e-12);
+    assert_eq!(baseline.age_linear_weight, 0.0);
 }
 
 /// `tuned()` and `Default::default()` ship the opinionated stack — every
@@ -63,6 +64,10 @@ fn tuned_turns_on_every_penalty_and_bonus() {
         t.peak_direction_multiplier > 1.0,
         "peak_direction_multiplier must scale up during peaks"
     );
+    assert!(
+        t.age_linear_weight > 0.0,
+        "age_linear_weight must be active so the max-wait tail stays bounded"
+    );
 
     // `Default::default()` must equal `tuned()` — this ties the
     // Builtin-strategy dropdown to the tuned shape so nobody "fixes"
@@ -73,6 +78,7 @@ fn tuned_turns_on_every_penalty_and_bonus() {
     assert_eq!(d.coincident_car_call_bonus, t.coincident_car_call_bonus);
     assert_eq!(d.load_penalty_coeff, t.load_penalty_coeff);
     assert_eq!(d.peak_direction_multiplier, t.peak_direction_multiplier);
+    assert_eq!(d.age_linear_weight, t.age_linear_weight);
 }
 
 /// End-to-end effect of the tuned default: a committed-up car
@@ -266,6 +272,107 @@ fn load_penalty_prefers_emptier_car() {
     );
 }
 
+// ── Age-linear fairness term ───────────────────────────────────────
+
+/// A positive `age_linear_weight` breaks a travel-time tie toward the
+/// stop hosting the older waiter. Mirrors the ETD counterpart in
+/// `etd_age_weight_tests::age_linear_weight_prefers_older_waiting_rider`.
+#[test]
+fn age_linear_weight_prefers_older_waiting_rider() {
+    use crate::components::Weight;
+    use crate::dispatch::RiderInfo;
+
+    let (mut world, stops) = test_world();
+    let elev = spawn_elevator(&mut world, 4.0); // at stops[1] (pos 4)
+
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    // stops[0] at pos 0 — rider waiting 1000 ticks.
+    let old_waiter = world.spawn();
+    manifest
+        .waiting_at_stop
+        .entry(stops[0])
+        .or_default()
+        .push(RiderInfo {
+            id: old_waiter,
+            destination: None,
+            weight: Weight::from(70.0),
+            wait_ticks: 1000,
+        });
+    // stops[2] at pos 8 — rider waiting only 1 tick.
+    let fresh_waiter = world.spawn();
+    manifest
+        .waiting_at_stop
+        .entry(stops[2])
+        .or_default()
+        .push(RiderInfo {
+            id: fresh_waiter,
+            destination: None,
+            weight: Weight::from(70.0),
+            wait_ticks: 1,
+        });
+
+    let mut rsr = RsrDispatch::new().with_age_linear_weight(1.0);
+    let decision = decide_one(&mut rsr, elev, 4.0, &group, &manifest, &mut world);
+    assert_eq!(
+        decision,
+        DispatchDecision::GoToStop(stops[0]),
+        "positive age_linear_weight must bias RSR toward the older waiter"
+    );
+}
+
+/// A modest `age_linear_weight` must not flip travel-time dominance
+/// when the far stop's extra wait isn't large enough to justify the
+/// detour. Regression guard against too-aggressive bias scales at the
+/// tuned default.
+#[test]
+fn age_linear_weight_does_not_override_travel_time() {
+    use crate::components::Weight;
+    use crate::dispatch::RiderInfo;
+
+    let (mut world, stops) = test_world();
+    let elev = spawn_elevator(&mut world, 0.0);
+
+    let group = test_group(&stops, vec![elev]);
+    let mut manifest = DispatchManifest::default();
+    // Near waiter — young.
+    let near_waiter = world.spawn();
+    manifest
+        .waiting_at_stop
+        .entry(stops[1])
+        .or_default()
+        .push(RiderInfo {
+            id: near_waiter,
+            destination: None,
+            weight: Weight::from(70.0),
+            wait_ticks: 5,
+        });
+    // Far waiter — older, but not so much older that the tuned default
+    // should deflect the car past three intervening floors.
+    let far_waiter = world.spawn();
+    manifest
+        .waiting_at_stop
+        .entry(stops[3])
+        .or_default()
+        .push(RiderInfo {
+            id: far_waiter,
+            destination: None,
+            weight: Weight::from(70.0),
+            wait_ticks: 20,
+        });
+
+    // Tuned default (age_linear_weight = 0.005). Per-stop age bonus at
+    // the older stop: 0.005 × 20 = 0.1s — far smaller than the ~4s ETA
+    // gap at max_speed = 2.0.
+    let mut rsr = RsrDispatch::default();
+    let decision = decide_one(&mut rsr, elev, 0.0, &group, &manifest, &mut world);
+    assert_eq!(
+        decision,
+        DispatchDecision::GoToStop(stops[1]),
+        "tuned default age bonus must not reverse travel-time dominance on small age gaps"
+    );
+}
+
 // ── BuiltinStrategy round-trip ──────────────────────────────────────
 
 #[test]
@@ -331,6 +438,18 @@ fn peak_direction_multiplier_rejects_below_one() {
 #[should_panic(expected = "peak_direction_multiplier must be finite and ≥ 1.0")]
 fn peak_direction_multiplier_rejects_nan() {
     let _ = RsrDispatch::new().with_peak_direction_multiplier(f64::NAN);
+}
+
+#[test]
+#[should_panic(expected = "age_linear_weight must be finite and non-negative")]
+fn age_linear_weight_rejects_nan() {
+    let _ = RsrDispatch::new().with_age_linear_weight(f64::NAN);
+}
+
+#[test]
+#[should_panic(expected = "age_linear_weight must be finite and non-negative")]
+fn age_linear_weight_rejects_negative() {
+    let _ = RsrDispatch::new().with_age_linear_weight(-1.0);
 }
 
 // ── Peak-direction multiplier ───────────────────────────────────────

--- a/crates/elevator-core/src/tests/rsr_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/rsr_dispatch_tests.rs
@@ -361,8 +361,8 @@ fn age_linear_weight_does_not_override_travel_time() {
             wait_ticks: 20,
         });
 
-    // Tuned default (age_linear_weight = 0.005). Per-stop age bonus at
-    // the older stop: 0.005 × 20 = 0.1s — far smaller than the ~4s ETA
+    // Tuned default (age_linear_weight = 0.002). Per-stop age bonus at
+    // the older stop: 0.002 × 20 = 0.04s — far smaller than the ~4s ETA
     // gap at max_speed = 2.0.
     let mut rsr = RsrDispatch::default();
     let decision = decide_one(&mut rsr, elev, 0.0, &group, &manifest, &mut world);

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -741,7 +741,8 @@ fn rsr_tuned_weights_survive_snapshot_round_trip() {
     let tuned = RsrDispatch::new()
         .with_wrong_direction_penalty(15.0)
         .with_load_penalty_coeff(2.5)
-        .with_peak_direction_multiplier(3.0);
+        .with_peak_direction_multiplier(3.0)
+        .with_age_linear_weight(0.007);
     let mut sim =
         crate::sim::Simulation::new(&helpers::default_config(), tuned).expect("build sim");
     for _ in 0..10 {
@@ -768,6 +769,31 @@ fn rsr_tuned_weights_survive_snapshot_round_trip() {
         "peak_direction_multiplier drift: {}",
         parsed.peak_direction_multiplier,
     );
+    assert!(
+        (parsed.age_linear_weight - 0.007).abs() < f64::EPSILON,
+        "age_linear_weight drift: {}",
+        parsed.age_linear_weight,
+    );
+}
+
+/// Backward-compatibility: an old RON snapshot written before
+/// `age_linear_weight` existed must still deserialize — the new field
+/// has `#[serde(default)]` so missing values fall back to 0.0.
+#[test]
+fn rsr_old_snapshot_without_age_linear_weight_still_parses() {
+    use crate::dispatch::rsr::RsrDispatch;
+    // Pre-R4 RON shape — no `age_linear_weight` key.
+    let old = "(eta_weight: 1.0, wrong_direction_penalty: 15.0, \
+               coincident_car_call_bonus: 5.0, load_penalty_coeff: 3.0, \
+               peak_direction_multiplier: 2.0)";
+    let parsed: RsrDispatch = ron::from_str(old).expect("old snapshot must parse");
+    assert_eq!(
+        parsed.age_linear_weight, 0.0,
+        "missing age_linear_weight must default to 0.0 under serde(default)"
+    );
+    // Sanity: the other fields round-tripped untouched.
+    assert!((parsed.wrong_direction_penalty - 15.0).abs() < f64::EPSILON);
+    assert!((parsed.load_penalty_coeff - 3.0).abs() < f64::EPSILON);
 }
 
 /// `DestinationDispatch` config survives too; `with_stop_penalty`


### PR DESCRIPTION
## Summary

Parallels #433's ETD fairness move. With the tuned defaults from #432, RSR had three of the four tail-bounding levers ETD gained (direction penalty, load balancing, aboard-rider path guard) but was still missing the linear age term — so the `playground_audit` skyscraper run showed RSR lagging SCAN by ~40% on `max_wait` even with the full penalty stack active.

Adds `age_linear_weight` to `RsrDispatch`, same shape as ETD's: `rank -= weight · Σ wait_ticks` over waiting riders at the stop. Tuned default is 0.002 — see the inline comment for why RSR can ride a lighter weight than ETD's 0.005.

## Audit before / after

Reading each scenario post-#432 (tuned defaults only) vs post-#432+#433+R4 (all three):

| Scenario | Metric | SCAN | RSR (R2 only) | RSR (R2 + R4) |
|---|---|---|---|---|
| Office | delivered | 114 | 110 | 106 |
| | abandoned% | 0% | 2.3% | 4.7% |
| | avg_wait | 17.1s | 26.0s | **21.6s** |
| | max_wait | 56.9s | 89.1s | **87.1s** |
| Skyscraper | delivered | 68 | 67 | **70** |
| | avg_wait | 31.4s | 34.9s | **24.6s** |
| | max_wait | 113.7s | 161.2s | **112.5s** |

Skyscraper: RSR now **beats SCAN** on delivered (70 vs 68), avg_wait (-22%), and max_wait (essentially tied, marginally better). Office: a small regression on delivery (shifts 4 riders from made-it-just-in-time to abandoned-at-threshold) because the age bonus pulls the single-car fleet off fresh demand faster than one car can cycle. Documented inline.

## Backward compatibility

Adding a new field to a public struct without `#[non_exhaustive]` would normally be breaking for struct-literal consumers, but:

1. No struct-literal construction exists in the workspace — all callers go through `RsrDispatch::new()`, `::tuned()`, `::default()`, or the `with_*` builders.
2. The new field is tagged `#[serde(default)]`, so pre-R4 snapshots (which don't have an `age_linear_weight` key in the RON) deserialize with the field defaulting to `0.0`. Locked in by `rsr_old_snapshot_without_age_linear_weight_still_parses`.
3. `new()` semantics unchanged — the additive-composition baseline (every penalty/bonus at zero) still holds, so the existing `new().with_*` single-term mutant tests are unaffected.

## Test plan

- [x] `cargo test -p elevator-core --all-features` — 835 unit tests + scenarios + 159 doctests, all green.
- [x] `cargo clippy -p elevator-core --all-features --all-targets` — clean.
- [x] `cargo fmt -p elevator-core --check` — clean.
- [x] `cargo check --workspace --all-features` — clean across core, bevy, ffi, gdext, wasm.
- [x] `cargo run -p elevator-core --example playground_audit --release` — confirmed the skyscraper and office numbers above.
- [x] Test coverage:
  - `age_linear_weight_prefers_older_waiting_rider` — mirrors the ETD counterpart.
  - `age_linear_weight_does_not_override_travel_time` — regression guard that the tuned 0.002 doesn't steer the car off fresh near demand.
  - `age_linear_weight_rejects_nan` / `age_linear_weight_rejects_negative` — builder invariants.
  - `new_is_nearest_car_zero_baseline` extended with a field-level `age_linear_weight == 0.0` assertion.
  - `tuned_turns_on_every_penalty_and_bonus` extended with an `age_linear_weight > 0.0` assertion and `Default` field-equality.
  - `rsr_tuned_weights_survive_snapshot_round_trip` picks up `with_age_linear_weight(0.007)`.
  - `rsr_old_snapshot_without_age_linear_weight_still_parses` — backward-compat guard.

## Related

- #431 (aboard-rider path guard) — correctness prereq, merged.
- #432 (RSR tuned defaults) — direction/load/car-call/peak terms activated, merged.
- #433 (ETD age-linear default) — same move on the ETD side, merged.
- Follow-up still queued: R3 (proportional `wrong_direction_penalty`) — semantic change to the existing flat-additive penalty field, separate review cycle.