### PR TITLE
feat(dispatch): per-line hall-call assignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.22.0"
+version = "15.23.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/components/hall_call.rs
+++ b/crates/elevator-core/src/components/hall_call.rs
@@ -105,7 +105,7 @@ pub struct HallCall {
     /// without one overwriting another. Within a single line the latest
     /// assignment replaces the previous one.
     ///
-    /// Pre-15.24 snapshots stored a single `assigned_car: Option<EntityId>`
+    /// Pre-15.23 snapshots stored a single `assigned_car: Option<EntityId>`
     /// field. Those snapshots silently drop the transient assignment on
     /// load (serde's default unknown-field handling); the next dispatch
     /// pass repopulates this map.

--- a/crates/elevator-core/src/components/hall_call.rs
+++ b/crates/elevator-core/src/components/hall_call.rs
@@ -14,11 +14,17 @@
 //!    `HallCall::press_tick` is set; `acknowledged_at` is `None`.
 //! 2. **Acknowledged** — after the group's `ack_latency_ticks` have elapsed,
 //!    `acknowledged_at` is set and the call becomes visible to dispatch.
-//! 3. **Assigned** — dispatch pairs the call with a car. `assigned_car`
-//!    records which one.
+//! 3. **Assigned** — dispatch pairs the call with a car. The assignment
+//!    is keyed per-line in [`HallCall::assigned_cars_by_line`] so a stop
+//!    shared by multiple lines (e.g. a sky-lobby served by low, high, and
+//!    express banks) can record every bank's choice independently. Within
+//!    a single line the latest assignment replaces the previous one; across
+//!    lines the map grows until the call is cleared or the car is removed.
 //! 4. **Cleared** — the assigned car arrives at this stop with its
 //!    indicator lamps matching `direction` and opens doors. The HallCall
 //!    is removed; an `Event::HallCallCleared` is emitted.
+
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
@@ -92,8 +98,19 @@ pub struct HallCall {
     /// [`HallCallMode::Destination`](crate::dispatch::HallCallMode) mode
     /// (lobby kiosk); `None` in Classic mode.
     pub destination: Option<EntityId>,
-    /// Car assigned to this call by dispatch, if any.
-    pub assigned_car: Option<EntityId>,
+    /// Cars assigned to this call by dispatch, keyed by the line entity
+    /// the car runs on. A stop served by multiple lines can hold one
+    /// entry per line simultaneously — the low-bank car, the express
+    /// car, and the service car can all be en route to the same lobby
+    /// without one overwriting another. Within a single line the latest
+    /// assignment replaces the previous one.
+    ///
+    /// Pre-15.24 snapshots stored a single `assigned_car: Option<EntityId>`
+    /// field. Those snapshots silently drop the transient assignment on
+    /// load (serde's default unknown-field handling); the next dispatch
+    /// pass repopulates this map.
+    #[serde(default)]
+    pub assigned_cars_by_line: BTreeMap<EntityId, EntityId>,
     /// When `true`, dispatch is forbidden from reassigning this call to
     /// a different car. Set by
     /// [`Simulation::pin_assignment`](crate::sim::Simulation::pin_assignment).
@@ -112,7 +129,7 @@ impl HallCall {
             ack_latency_ticks: 0,
             pending_riders: Vec::new(),
             destination: None,
-            assigned_car: None,
+            assigned_cars_by_line: BTreeMap::new(),
             pinned: false,
         }
     }
@@ -122,5 +139,18 @@ impl HallCall {
     #[must_use]
     pub const fn is_acknowledged(&self) -> bool {
         self.acknowledged_at.is_some()
+    }
+
+    /// Any car currently assigned to this call, preferring the entry
+    /// with the numerically smallest line-entity key (stable across
+    /// ticks because `BTreeMap` iteration is ordered). `None` when no
+    /// line has recorded an assignment yet.
+    ///
+    /// This matches the pre-per-line `assigned_car` semantics for
+    /// callers that just want "is anyone coming?" The richer shape is
+    /// available directly on [`assigned_cars_by_line`](Self::assigned_cars_by_line).
+    #[must_use]
+    pub fn any_assigned_car(&self) -> Option<EntityId> {
+        self.assigned_cars_by_line.values().next().copied()
     }
 }

--- a/crates/elevator-core/src/sim/calls.rs
+++ b/crates/elevator-core/src/sim/calls.rs
@@ -103,7 +103,7 @@ impl super::Simulation {
         let Some(call) = self.world.hall_call_mut(stop, direction) else {
             return Err(SimError::HallCallNotFound { stop, direction });
         };
-        call.assigned_car = Some(car);
+        call.assigned_cars_by_line.insert(car_line, car);
         call.pinned = true;
         Ok(())
     }
@@ -134,11 +134,38 @@ impl super::Simulation {
 
     /// Car currently assigned to serve the call at `(stop, direction)`,
     /// if dispatch has made an assignment yet.
+    ///
+    /// At stops served by multiple lines a single call can hold one
+    /// assignment per line; this accessor returns the entry with the
+    /// numerically smallest line-entity key (stable across ticks). Use
+    /// [`assigned_cars_by_line`](Self::assigned_cars_by_line) when the
+    /// full per-line list matters.
     #[must_use]
     pub fn assigned_car(&self, stop: EntityId, direction: CallDirection) -> Option<EntityId> {
         self.world
             .hall_call(stop, direction)
-            .and_then(|c| c.assigned_car)
+            .and_then(HallCall::any_assigned_car)
+    }
+
+    /// Per-line cars assigned to the call at `(stop, direction)`.
+    /// Returns an empty slice when dispatch has no assignments yet; one
+    /// entry per line that has a car committed. Iteration order is
+    /// stable by line-entity id (`BTreeMap` ordering).
+    #[must_use]
+    pub fn assigned_cars_by_line(
+        &self,
+        stop: EntityId,
+        direction: CallDirection,
+    ) -> Vec<(EntityId, EntityId)> {
+        self.world
+            .hall_call(stop, direction)
+            .map(|c| {
+                c.assigned_cars_by_line
+                    .iter()
+                    .map(|(&line, &car)| (line, car))
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     /// Estimated ticks remaining before the assigned car reaches the
@@ -155,7 +182,9 @@ impl super::Simulation {
             .world
             .hall_call(stop, direction)
             .ok_or(EtaError::NotAStop(stop))?;
-        let car = call.assigned_car.ok_or(EtaError::NoCarAssigned(stop))?;
+        let car = call
+            .any_assigned_car()
+            .ok_or(EtaError::NoCarAssigned(stop))?;
         let car_pos = self
             .world
             .position(car)

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -7,7 +7,7 @@
 use std::collections::HashSet;
 
 use crate::components::{
-    CallDirection, Elevator, ElevatorPhase, RiderPhase, RiderPhaseKind, Route,
+    CallDirection, Elevator, ElevatorPhase, RiderPhase, RiderPhaseKind, Route, TransportMode,
 };
 use crate::dispatch::ElevatorGroup;
 use crate::entity::{ElevatorId, EntityId, RiderId};
@@ -459,6 +459,51 @@ impl Simulation {
         (up, down)
     }
 
+    /// Partition waiting riders at `stop` by the line that will serve
+    /// their current route leg. Each entry is `(line_entity, count)`.
+    ///
+    /// Attribution rules:
+    /// - `TransportMode::Line(l)` riders are attributed to `l` exactly.
+    /// - `TransportMode::Group(g)` riders are attributed to the first
+    ///   line in group `g` whose `serves` list contains `stop`. Groups
+    ///   with a single line (the common case) attribute unambiguously.
+    /// - `TransportMode::Walk` riders and route-less / same-position
+    ///   riders are excluded — they have no intrinsic line to summon.
+    ///
+    /// Runs in `O(waiting riders at stop · lines in their group)`.
+    /// Intended for per-frame rendering code that needs to split the
+    /// waiting queue across multi-line stops (e.g. a sky-lobby shared
+    /// by low-bank, express, and service lines).
+    #[must_use]
+    pub fn waiting_counts_by_line_at(&self, stop: EntityId) -> Vec<(EntityId, u32)> {
+        use std::collections::BTreeMap;
+        let mut by_line: BTreeMap<EntityId, u32> = BTreeMap::new();
+        for &rider in self.rider_index.waiting_at(stop) {
+            let Some(line) = self.resolve_line_for_waiting(rider, stop) else {
+                continue;
+            };
+            *by_line.entry(line).or_insert(0) += 1;
+        }
+        by_line.into_iter().collect()
+    }
+
+    /// Resolve the line entity that should "claim" `rider` for their
+    /// current leg starting at `stop`. Used by
+    /// [`waiting_counts_by_line_at`](Self::waiting_counts_by_line_at).
+    fn resolve_line_for_waiting(&self, rider: EntityId, stop: EntityId) -> Option<EntityId> {
+        let leg = self.world.route(rider).and_then(Route::current)?;
+        match leg.via {
+            TransportMode::Line(l) => Some(l),
+            TransportMode::Group(g) => self.groups.iter().find(|gr| gr.id() == g).and_then(|gr| {
+                gr.lines()
+                    .iter()
+                    .find(|li| li.serves().contains(&stop))
+                    .map(crate::dispatch::LineInfo::entity)
+            }),
+            TransportMode::Walk => None,
+        }
+    }
+
     /// Iterate over abandoned rider IDs at a stop (O(1) lookup).
     pub fn abandoned_at(&self, stop: EntityId) -> impl Iterator<Item = EntityId> + '_ {
         self.rider_index.abandoned_at(stop).iter().copied()
@@ -522,10 +567,15 @@ impl Simulation {
             // Same for hall-call assignments — pre-fix, a pinned hall
             // call to the disabled car was permanently stranded because
             // dispatch kept committing the disabled car as the assignee
-            // and other cars couldn't take the call. (#292)
+            // and other cars couldn't take the call. (#292) Now that
+            // assignments are per-line, drop only the line entries that
+            // reference the disabled car; other lines at the same stop
+            // keep their cars. The pin is lifted only when *every*
+            // remaining entry has been cleared, since a pin protects the
+            // whole call, not a single line's assignment.
             for hc in self.world.iter_hall_calls_mut() {
-                if hc.assigned_car == Some(id) {
-                    hc.assigned_car = None;
+                hc.assigned_cars_by_line.retain(|_, car| *car != id);
+                if hc.assigned_cars_by_line.is_empty() {
                     hc.pinned = false;
                 }
             }

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -550,10 +550,10 @@ impl WorldSnapshot {
     ///
     /// `HallCall` cross-references stops, cars, riders, and optional
     /// destinations — all `EntityId`s must be remapped through `id_remap`.
-    /// Pre-per-line snapshots carry a single `assigned_car` field via the
-    /// `legacy_assigned_car` compat slot; we migrate it into the new
-    /// per-line map using the car's line as resolved from the restored
-    /// world.
+    /// Pre-15.23 snapshots stored a single `assigned_car` field, silently
+    /// dropped by `#[serde(default)]` on `assigned_cars_by_line`; the
+    /// next dispatch pass repopulates the empty map, so no explicit
+    /// migration is attempted here.
     fn attach_hall_calls(
         &self,
         world: &mut crate::world::World,

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -550,6 +550,10 @@ impl WorldSnapshot {
     ///
     /// `HallCall` cross-references stops, cars, riders, and optional
     /// destinations — all `EntityId`s must be remapped through `id_remap`.
+    /// Pre-per-line snapshots carry a single `assigned_car` field via the
+    /// `legacy_assigned_car` compat slot; we migrate it into the new
+    /// per-line map using the car's line as resolved from the restored
+    /// world.
     fn attach_hall_calls(
         &self,
         world: &mut crate::world::World,
@@ -561,7 +565,11 @@ impl WorldSnapshot {
             let mut c = hc.clone();
             c.stop = remap(c.stop);
             c.destination = remap_opt(c.destination);
-            c.assigned_car = remap_opt(c.assigned_car);
+            c.assigned_cars_by_line = c
+                .assigned_cars_by_line
+                .iter()
+                .map(|(&line, &car)| (remap(line), remap(car)))
+                .collect();
             c.pending_riders = c.pending_riders.iter().map(|&r| remap(r)).collect();
             world.set_hall_call(c);
         }
@@ -704,7 +712,8 @@ impl WorldSnapshot {
         }
         for hc in hall_calls {
             check(hc.stop);
-            if let Some(car) = hc.assigned_car {
+            for (&line, &car) in &hc.assigned_cars_by_line {
+                check(line);
                 check(car);
             }
             if let Some(dest) = hc.destination {

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -43,16 +43,20 @@ pub fn run(
         // Apply pinned hall-call assignments first. Pinned pairs are
         // committed straight to `GoToStop` and excluded from the normal
         // Hungarian matching so neither the car nor the stop can be
-        // reassigned while the pin is in effect.
+        // reassigned while the pin is in effect. A single pinned call
+        // can hold multiple per-line assignments at a multi-line stop;
+        // every car whose line this group contains pins independently.
         for c in world.iter_hall_calls() {
             if !c.pinned {
                 continue;
             }
-            let Some(car) = c.assigned_car else {
+            if !group.stop_entities().contains(&c.stop) {
                 continue;
-            };
-            if group.stop_entities().contains(&c.stop) && group.elevator_entities().contains(&car) {
-                scratch.pinned_pairs.push((car, c.stop));
+            }
+            for &car in c.assigned_cars_by_line.values() {
+                if group.elevator_entities().contains(&car) {
+                    scratch.pinned_pairs.push((car, c.stop));
+                }
             }
         }
 
@@ -372,17 +376,23 @@ fn record_hall_assignment(world: &mut World, stop: EntityId, car: EntityId) {
     }
 }
 
-/// Helper: set `assigned_car` on a hall call if it exists and is unpinned.
+/// Helper: record that `car` is assigned to the `(stop, direction)`
+/// call if it exists and is unpinned. Keyed by the car's line — a new
+/// assignment on a different line is *added*, not overwriting other
+/// lines' entries. Within the same line, the latest writer wins.
 fn update_assignment(
     world: &mut World,
     stop: EntityId,
     direction: crate::components::CallDirection,
     car: EntityId,
 ) {
+    let Some(line) = world.elevator(car).map(crate::components::Elevator::line) else {
+        return;
+    };
     if let Some(call) = world.hall_call_mut(stop, direction)
         && !call.pinned
     {
-        call.assigned_car = Some(car);
+        call.assigned_cars_by_line.insert(line, car);
     }
 }
 

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -77,7 +77,7 @@ fn pin_assignment_pins_and_assigns() {
     sim.press_hall_button(stop, CallDirection::Up).unwrap();
     sim.pin_assignment(car, stop, CallDirection::Up).unwrap();
     let call = sim.world().hall_call(stop, CallDirection::Up).unwrap();
-    assert_eq!(call.assigned_car, Some(car.entity()));
+    assert_eq!(call.any_assigned_car(), Some(car.entity()));
     assert!(call.pinned);
     sim.unpin_assignment(stop, CallDirection::Up);
     let call = sim.world().hall_call(stop, CallDirection::Up).unwrap();

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -3246,3 +3246,106 @@ fn advance_queue_arrive_in_place_resets_direction_indicators() {
          dispatch.rs's arrive-in-place semantics"
     );
 }
+
+// ── Per-line hall-call assignment at a shared stop ───────────────────────────
+
+/// Two groups (each with one line) both serve Bottom and Top. Press
+/// the Up button at Bottom and pin one car from each group — both
+/// assignments must land in `assigned_cars_by_line` simultaneously,
+/// keyed by the respective line entities. Pre-refactor the second pin
+/// clobbered the first in a single `assigned_car` slot, so games
+/// querying the call saw only the latest writer — the symptom the
+/// playground surfaced as waiters jumping onto whichever specialty
+/// shaft was dispatched most recently.
+#[test]
+fn multi_line_stop_holds_one_assignment_per_line() {
+    use crate::components::CallDirection;
+
+    let config = overlapping_groups_config();
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+    let bottom = sim.stop_entity(StopId(0)).unwrap();
+
+    let car_a = ElevatorId::from(
+        sim.world()
+            .elevator_ids()
+            .first()
+            .copied()
+            .expect("line A must have a car"),
+    );
+    let car_b = ElevatorId::from(
+        sim.world()
+            .elevator_ids()
+            .get(1)
+            .copied()
+            .expect("line B must have a car"),
+    );
+
+    let line_a = sim.world().elevator(car_a.entity()).unwrap().line();
+    let line_b = sim.world().elevator(car_b.entity()).unwrap().line();
+    assert_ne!(
+        line_a, line_b,
+        "precondition: cars must be on distinct lines"
+    );
+
+    sim.press_hall_button(bottom, CallDirection::Up).unwrap();
+    sim.pin_assignment(car_a, bottom, CallDirection::Up)
+        .unwrap();
+    sim.pin_assignment(car_b, bottom, CallDirection::Up)
+        .unwrap();
+
+    let assignments = sim.assigned_cars_by_line(bottom, CallDirection::Up);
+    let as_map: std::collections::BTreeMap<_, _> = assignments.into_iter().collect();
+    assert_eq!(
+        as_map.get(&line_a).copied(),
+        Some(car_a.entity()),
+        "line A's entry must reflect its pinned car"
+    );
+    assert_eq!(
+        as_map.get(&line_b).copied(),
+        Some(car_b.entity()),
+        "line B's entry must reflect its pinned car — pre-refactor this \
+         overwrote line A's slot"
+    );
+    assert_eq!(as_map.len(), 2, "one entry per line, no sharing");
+}
+
+/// `waiting_counts_by_line_at` splits waiters by their route leg's line.
+/// A rider routed via Group(A) and another via Group(B) — both at the
+/// same shared origin — produce two entries that sum to 2.
+#[test]
+fn waiting_counts_by_line_partitions_by_route_group() {
+    let config = overlapping_groups_config();
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+    let bottom = sim.stop_entity(StopId(0)).unwrap();
+    let top = sim.stop_entity(StopId(1)).unwrap();
+
+    // Build two riders with explicit routes through different groups.
+    let mk_route = |g: GroupId| Route {
+        legs: vec![RouteLeg {
+            from: bottom,
+            to: top,
+            via: TransportMode::Group(g),
+        }],
+        current_leg: 0,
+    };
+    sim.build_rider(bottom, top)
+        .unwrap()
+        .weight(70.0)
+        .route(mk_route(GroupId(0)))
+        .spawn()
+        .unwrap();
+    sim.build_rider(bottom, top)
+        .unwrap()
+        .weight(70.0)
+        .route(mk_route(GroupId(1)))
+        .spawn()
+        .unwrap();
+
+    let counts = sim.waiting_counts_by_line_at(bottom);
+    let total: u32 = counts.iter().map(|(_, n)| n).sum();
+    assert_eq!(total, 2, "both waiting riders accounted for");
+    assert_eq!(counts.len(), 2, "one entry per distinct line");
+    for (_line, n) in &counts {
+        assert_eq!(*n, 1, "each line carries exactly one rider");
+    }
+}

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -471,11 +471,11 @@ fn snapshot_preserves_hall_calls_and_pinning() {
     assert_eq!(call.direction, CallDirection::Up);
     assert!(call.pinned, "pinning flag must round-trip");
     let assigned = call
-        .assigned_car
-        .expect("assigned_car must round-trip through restore");
+        .any_assigned_car()
+        .expect("an assigned car must round-trip through restore");
     assert!(
         restored.world().elevator(assigned).is_some(),
-        "assigned_car must point to a live elevator in the restored \
+        "assigned car must point to a live elevator in the restored \
          world — a dangling (un-remapped) EntityId would slip past an \
          is_some() check",
     );

--- a/crates/elevator-ffi/include/elevator_ffi.h
+++ b/crates/elevator-ffi/include/elevator_ffi.h
@@ -321,6 +321,21 @@ typedef struct EvFrame {
 } EvFrame;
 
 /**
+ * One `(line, car)` assignment on a hall call. Read by
+ * [`ev_sim_assigned_cars_by_line`].
+ */
+typedef struct EvAssignment {
+    /**
+     * Line entity id the car runs on.
+     */
+    uint64_t line_entity_id;
+    /**
+     * Car entity id assigned to this line's share of the call.
+     */
+    uint64_t car_entity_id;
+} EvAssignment;
+
+/**
  * C-ABI-flat projection of a `HallCall` for FFI consumers.
  */
 typedef struct EvHallCall {
@@ -342,6 +357,12 @@ typedef struct EvHallCall {
     uint64_t acknowledged_at;
     /**
      * Car currently assigned to serve the call; `0` if none.
+     *
+     * At a stop served by multiple lines (e.g. a sky-lobby) a call can
+     * hold one assignment per line. This field mirrors the FFI's
+     * historical single-value shape and surfaces whichever entry has
+     * the numerically smallest line-entity id. Use
+     * [`ev_sim_assigned_cars_by_line`] to read every line's entry.
      */
     uint64_t assigned_car;
     /**
@@ -568,6 +589,31 @@ enum EvStatus ev_sim_assigned_car(struct EvSim *handle,
                                   uint64_t stop_entity_id,
                                   int8_t direction,
                                   uint64_t *out_elevator);
+
+/**
+ * Per-line car assignments at the hall call `(stop, direction)`.
+ *
+ * Writes up to `capacity` [`EvAssignment`] records to `out` and the
+ * number actually written to `out_written`. Lines with no assignment
+ * are omitted. Iteration order follows the `BTreeMap` keyed by line
+ * entity id — stable across ticks.
+ *
+ * Use [`ev_sim_assigned_car`] for the single-value convenience view;
+ * this call is for consumers that need every line's assignment at a
+ * multi-line stop (e.g. a sky-lobby served by low, high, and express
+ * banks).
+ *
+ * # Safety
+ *
+ * `handle`, `out`, and `out_written` must be valid pointers. `out`
+ * must point to a buffer of at least `capacity` [`EvAssignment`]s.
+ */
+enum EvStatus ev_sim_assigned_cars_by_line(struct EvSim *handle,
+                                           uint64_t stop_entity_id,
+                                           int8_t direction,
+                                           struct EvAssignment *out,
+                                           uint32_t capacity,
+                                           uint32_t *out_written);
 
 /**
  * Estimated ticks remaining before the assigned car reaches the call.

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -935,6 +935,70 @@ pub unsafe extern "C" fn ev_sim_assigned_car(
     })
 }
 
+/// Per-line car assignments at the hall call `(stop, direction)`.
+///
+/// Writes up to `capacity` [`EvAssignment`] records to `out` and the
+/// number actually written to `out_written`. Lines with no assignment
+/// are omitted. Iteration order follows the `BTreeMap` keyed by line
+/// entity id — stable across ticks.
+///
+/// Use [`ev_sim_assigned_car`] for the single-value convenience view;
+/// this call is for consumers that need every line's assignment at a
+/// multi-line stop (e.g. a sky-lobby served by low, high, and express
+/// banks).
+///
+/// # Safety
+///
+/// `handle`, `out`, and `out_written` must be valid pointers. `out`
+/// must point to a buffer of at least `capacity` [`EvAssignment`]s.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_assigned_cars_by_line(
+    handle: *mut EvSim,
+    stop_entity_id: u64,
+    direction: i8,
+    out: *mut EvAssignment,
+    capacity: u32,
+    out_written: *mut u32,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() || out.is_null() || out_written.is_null() {
+            set_last_error("null argument");
+            return EvStatus::NullArg;
+        }
+        let Some(dir) = call_direction_from_i8(direction) else {
+            set_last_error("direction must be 1 (Up) or -1 (Down)");
+            return EvStatus::InvalidArg;
+        };
+        let Some(stop) = entity_from_u64(stop_entity_id) else {
+            set_last_error("invalid stop_entity_id");
+            return EvStatus::InvalidArg;
+        };
+        let ev = unsafe { &*handle };
+        let mut written: u32 = 0;
+        for (line, car) in ev
+            .sim
+            .assigned_cars_by_line(stop, dir)
+            .into_iter()
+            .take(capacity as usize)
+        {
+            let record = EvAssignment {
+                line_entity_id: entity_to_u64(line),
+                car_entity_id: entity_to_u64(car),
+            };
+            // Safety: caller guarantees `out` has at least `capacity` entries
+            // and we wrote fewer than `capacity` before this increment.
+            unsafe {
+                std::ptr::write(out.add(written as usize), record);
+            }
+            written += 1;
+        }
+        // Safety: validated non-null above.
+        unsafe { std::ptr::write(out_written, written) };
+        EvStatus::Ok
+    })
+}
+
 /// Estimated ticks remaining before the assigned car reaches the call.
 ///
 /// Writes the tick count to `out_ticks`, or `u64::MAX` when no car is
@@ -1027,7 +1091,12 @@ pub unsafe extern "C" fn ev_sim_hall_calls_snapshot(
                 },
                 press_tick: call.press_tick,
                 acknowledged_at: call.acknowledged_at.unwrap_or(u64::MAX),
-                assigned_car: call.assigned_car.map_or(0, entity_to_u64),
+                // Pick the lexicographically-first line's entry as the
+                // single-value `assigned_car` view. A stop served by
+                // multiple lines can hold one assignment per line; C
+                // consumers that need the full set should call
+                // `ev_sim_assigned_cars_by_line`.
+                assigned_car: call.any_assigned_car().map_or(0, entity_to_u64),
                 destination_entity_id: call.destination.map_or(0, entity_to_u64),
                 pinned: u8::from(call.pinned),
                 pending_rider_count: u32::try_from(call.pending_riders.len()).unwrap_or(u32::MAX),
@@ -1058,6 +1127,12 @@ pub struct EvHallCall {
     /// Tick at which the call was acknowledged; `u64::MAX` if pending.
     pub acknowledged_at: u64,
     /// Car currently assigned to serve the call; `0` if none.
+    ///
+    /// At a stop served by multiple lines (e.g. a sky-lobby) a call can
+    /// hold one assignment per line. This field mirrors the FFI's
+    /// historical single-value shape and surfaces whichever entry has
+    /// the numerically smallest line-entity id. Use
+    /// [`ev_sim_assigned_cars_by_line`] to read every line's entry.
     pub assigned_car: u64,
     /// Destination stop entity id in DCS (`HallCallMode::Destination`)
     /// mode, or `0` when the call has no destination (Classic mode,
@@ -1067,6 +1142,17 @@ pub struct EvHallCall {
     pub pinned: u8,
     /// Number of riders aggregated onto this call.
     pub pending_rider_count: u32,
+}
+
+/// One `(line, car)` assignment on a hall call. Read by
+/// [`ev_sim_assigned_cars_by_line`].
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct EvAssignment {
+    /// Line entity id the car runs on.
+    pub line_entity_id: u64,
+    /// Car entity id assigned to this line's share of the call.
+    pub car_entity_id: u64,
 }
 
 /// Discriminator for [`EvEvent::kind`]. Kept as explicit integer

--- a/crates/elevator-wasm/src/dto.rs
+++ b/crates/elevator-wasm/src/dto.rs
@@ -50,6 +50,16 @@ pub struct CarDto {
     pub max_served_y: f64,
 }
 
+/// One line's share of a stop's waiting queue.
+#[derive(Serialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct WaitingByLine {
+    /// Line entity id. Matches `CarDto.line` for cars running on this line.
+    pub line: u32,
+    /// Waiting riders whose current route leg routes through this line.
+    pub count: u32,
+}
+
 /// Per-stop rendering snapshot.
 #[derive(Serialize, Tsify)]
 #[tsify(into_wasm_abi)]
@@ -73,6 +83,12 @@ pub struct StopDto {
     pub waiting_up: u32,
     /// Waiting riders whose current route destination lies below this stop.
     pub waiting_down: u32,
+    /// Waiting riders partitioned by the line that will serve their
+    /// current route leg. Sums to `waiting` minus any riders without a
+    /// Route / with a Walk leg. Used by the renderer to split the
+    /// waiting queue across multi-line stops (sky-lobby, street lobby
+    /// with service bank, etc.).
+    pub waiting_by_line: Vec<WaitingByLine>,
     /// Resident rider count (O(1)).
     pub residents: u32,
 }
@@ -161,6 +177,14 @@ impl Snapshot {
             .iter_stops()
             .map(|(id, stop)| {
                 let (up, down) = sim.waiting_direction_counts_at(id);
+                let waiting_by_line = sim
+                    .waiting_counts_by_line_at(id)
+                    .into_iter()
+                    .map(|(line, count)| WaitingByLine {
+                        line: entity_to_u32(line),
+                        count,
+                    })
+                    .collect();
                 StopDto {
                     entity_id: entity_to_u32(id),
                     stop_id: entity_to_stop_id.get(&id).copied().unwrap_or(u32::MAX),
@@ -169,6 +193,7 @@ impl Snapshot {
                     waiting: u32::try_from(sim.waiting_count_at(id)).unwrap_or(u32::MAX),
                     waiting_up: u32::try_from(up).unwrap_or(u32::MAX),
                     waiting_down: u32::try_from(down).unwrap_or(u32::MAX),
+                    waiting_by_line,
                     residents: u32::try_from(sim.resident_count_at(id)).unwrap_or(u32::MAX),
                 }
             })

--- a/docs/src/hall-calls.md
+++ b/docs/src/hall-calls.md
@@ -38,7 +38,7 @@ A hall call moves through four stages:
 
 1. **Press** -- either implicit (via `sim.spawn_rider()`) or explicit (`sim.press_hall_button()`). The first press for a given `(stop, direction)` emits `HallButtonPressed`.
 2. **Acknowledge** -- after the group's `ack_latency_ticks` have elapsed, the call becomes visible to dispatch and `HallCallAcknowledged` fires. This models real-world controller latency.
-3. **Assign** -- dispatch commits a car and writes it to `HallCall::assigned_car`. Games can read this via `sim.assigned_car(stop, direction)` for lobby displays (e.g., "your elevator will be car B").
+3. **Assign** -- dispatch commits a car and writes it to `HallCall::assigned_cars_by_line`, keyed by the car's line entity. Stops shared by multiple lines (e.g. a sky-lobby served by low, high, and express banks) carry one entry per line; within a single line the latest assignment replaces the previous one. Games can read a single representative car via `sim.assigned_car(stop, direction)` for lobby displays, or the full per-line set via `sim.assigned_cars_by_line(stop, direction)`.
 4. **Clear** -- when the assigned car opens doors at the stop with direction indicators matching the call direction, the `HallCall` is removed and `HallCallCleared` fires.
 
 Car calls follow the same pattern: `CarButtonPressed` fires on the first press per `(car, floor)`, and the loading phase removes a `CarCall` when the last pending rider for that floor exits.
@@ -87,7 +87,9 @@ Both knobs generate events (`RiderSkipped`, `RiderAbandoned`) so game UI can rea
 |--------|---------|
 | `sim.hall_calls()` | Iterator over every active hall call -- use for lobby lamp panels, per-floor button animation |
 | `sim.car_calls(car)` | Floor buttons currently pressed inside a car -- use for cab button-panel rendering |
-| `sim.assigned_car(stop, direction)` | DCS-style "your elevator will be car B" indicator |
+| `sim.assigned_car(stop, direction)` | DCS-style "your elevator will be car B" indicator (first entry at multi-line stops) |
+| `sim.assigned_cars_by_line(stop, direction)` | Full `(line, car)` list at a stop; one entry per line with a committed car |
+| `sim.waiting_counts_by_line_at(stop)` | Waiting-rider count per line; splits the queue for multi-line rendering |
 | `sim.eta_for_call(stop, direction)` | Countdown timer for hall displays |
 
 ## Events
@@ -102,7 +104,7 @@ Both knobs generate events (`RiderSkipped`, `RiderAbandoned`) so game UI can rea
 
 ## FFI
 
-Unity and native consumers can drive the call layer through the `elevator-ffi` C ABI. See the FFI module for `ev_sim_press_hall_button`, `ev_sim_press_car_button`, `ev_sim_pin_assignment`, `ev_sim_unpin_assignment`, `ev_sim_assigned_car`, `ev_sim_eta_for_call`, and the `EvHallCall` snapshot record.
+Unity and native consumers can drive the call layer through the `elevator-ffi` C ABI. See the FFI module for `ev_sim_press_hall_button`, `ev_sim_press_car_button`, `ev_sim_pin_assignment`, `ev_sim_unpin_assignment`, `ev_sim_assigned_car`, `ev_sim_assigned_cars_by_line`, `ev_sim_eta_for_call`, and the `EvHallCall` snapshot record. `EvHallCall.assigned_car` keeps its historical single-value shape (returning whichever line has the numerically smallest entity id); use `ev_sim_assigned_cars_by_line` to iterate every line's assignment at a shared stop.
 
 ## Next steps
 

--- a/playground/src/__tests__/bubbles.test.ts
+++ b/playground/src/__tests__/bubbles.test.ts
@@ -15,6 +15,7 @@ function makeSnapshot(stops: { entity_id: number; name: string }[]): Snapshot {
       waiting: 0,
       waiting_up: 0,
       waiting_down: 0,
+      waiting_by_line: [],
       residents: 0,
     })),
   };

--- a/playground/src/__tests__/layout.test.ts
+++ b/playground/src/__tests__/layout.test.ts
@@ -13,6 +13,7 @@ function makeStop(entity_id: number, y: number, name = `Stop ${entity_id}`): Sto
     waiting: 0,
     waiting_up: 0,
     waiting_down: 0,
+    waiting_by_line: [],
     residents: 0,
   };
 }

--- a/playground/src/__tests__/traffic.test.ts
+++ b/playground/src/__tests__/traffic.test.ts
@@ -18,6 +18,7 @@ function snapshotWithStops(n: number): Snapshot {
       waiting: 0,
       waiting_up: 0,
       waiting_down: 0,
+      waiting_by_line: [],
       residents: 0,
     })),
   };

--- a/playground/src/render/draw-building.ts
+++ b/playground/src/render/draw-building.ts
@@ -158,7 +158,18 @@ export function drawCarHeaders(
 
 /**
  * Draw waiting riders at the queue area of their assigned elevator.
- * Unassigned riders are hidden until dispatch assigns them.
+ *
+ * Each line gets its own share of the queue (from `stop.waiting_by_line`,
+ * supplied by core) and is drawn next to that line's assigned car. A
+ * stop served by multiple lines — e.g. a sky-lobby shared by the low,
+ * express, and service banks — correctly splits its queue by which
+ * line each rider's route leg selects, instead of all waiters snapping
+ * to whichever shaft was dispatched last.
+ *
+ * Lines whose group has no car currently committed to this stop are
+ * hidden (those waiters aren't renderable without a shaft to queue at).
+ * Route-less riders don't appear in `waiting_by_line`; they never need
+ * a car, so hiding them from the gutter matches the current behavior.
  */
 export function drawWaitingFigures(
   ctx: CanvasRenderingContext2D,
@@ -166,21 +177,25 @@ export function drawWaitingFigures(
   toScreenY: (y: number) => number,
   s: Scale,
   carQueueRegion: Map<number, { start: number; end: number }>,
-  stopAssignments: Map<number, number>,
+  stopAssignments: Map<number, Map<number, number>>,
 ): void {
   for (const stop of snap.stops) {
-    const totalWaiting = stop.waiting_up + stop.waiting_down;
-    if (totalWaiting === 0) continue;
-
-    const assignedCarId = stopAssignments.get(stop.entity_id);
-    if (assignedCarId === undefined) continue;
-    const qr = carQueueRegion.get(assignedCarId);
-    if (qr === undefined) continue;
-    const queueAvailW = qr.end - qr.start;
-    if (queueAvailW <= s.figureStride) continue;
+    if (stop.waiting_by_line.length === 0) continue;
+    const byLine = stopAssignments.get(stop.entity_id);
+    if (byLine === undefined || byLine.size === 0) continue;
 
     const y = toScreenY(stop.y);
     const color = stop.waiting_up >= stop.waiting_down ? UP_COLOR : DOWN_COLOR;
-    drawFigureRow(ctx, qr.end - 2, y, -1, queueAvailW, totalWaiting, color, s, stop.entity_id);
+
+    for (const entry of stop.waiting_by_line) {
+      if (entry.count === 0) continue;
+      const carId = byLine.get(entry.line);
+      if (carId === undefined) continue;
+      const qr = carQueueRegion.get(carId);
+      if (qr === undefined) continue;
+      const queueAvailW = qr.end - qr.start;
+      if (queueAvailW <= s.figureStride) continue;
+      drawFigureRow(ctx, qr.end - 2, y, -1, queueAvailW, entry.count, color, s, stop.entity_id);
+    }
   }
 }

--- a/playground/src/render/renderer.ts
+++ b/playground/src/render/renderer.ts
@@ -66,7 +66,14 @@ export class CanvasRenderer {
   readonly #carStates: Map<number, CarState> = new Map();
   readonly #stopStates: Map<number, StopState> = new Map();
   readonly #tweens: Tween[] = [];
-  readonly #stopAssignments: Map<number, number> = new Map();
+  // Per-stop per-line assignment: `stopId -> (lineId -> carId)`. The
+  // previous `stopId -> carId` map was last-writer-wins: any car
+  // dispatched to a multi-line stop — even a specialty bank moving
+  // for its own sliver of demand — claimed the entire waiting gutter.
+  // Keying by line lets every bank record its car independently, and
+  // the renderer pairs each line's slice of `waiting_by_line` (from
+  // core) with that line's active car.
+  readonly #stopAssignments: Map<number, Map<number, number>> = new Map();
 
   constructor(canvas: HTMLCanvasElement, accent: string) {
     this.#canvas = canvas;
@@ -89,8 +96,13 @@ export class CanvasRenderer {
     return this.#canvas;
   }
 
-  pushAssignment(stopId: number, elevatorId: number): void {
-    this.#stopAssignments.set(stopId, elevatorId);
+  pushAssignment(stopId: number, elevatorId: number, lineId: number): void {
+    let byLine = this.#stopAssignments.get(stopId);
+    if (byLine === undefined) {
+      byLine = new Map();
+      this.#stopAssignments.set(stopId, byLine);
+    }
+    byLine.set(lineId, elevatorId);
   }
 
   #resize(): void {
@@ -405,7 +417,14 @@ export class CanvasRenderer {
               originX = (qs + qe) / 2;
             }
             const color = useUp ? UP_COLOR : DOWN_COLOR;
-            this.#stopAssignments.delete(loadStop.entity_id);
+            // Clear just this car's line entry; other lines at the same
+            // stop (e.g. a VIP still en route for an exec-only rider)
+            // keep their waiters visible at their own shafts.
+            const byLine = this.#stopAssignments.get(loadStop.entity_id);
+            if (byLine !== undefined) {
+              byLine.delete(car.line);
+              if (byLine.size === 0) this.#stopAssignments.delete(loadStop.entity_id);
+            }
             for (let k = 0; k < count; k++) {
               carTweens.push(() =>
                 this.#tweens.push({

--- a/playground/src/shell/loop.ts
+++ b/playground/src/shell/loop.ts
@@ -46,9 +46,17 @@ export function loop(state: State, ui: UiHandles): void {
         if (events.length > 0) {
           const snap = pane.sim.snapshot();
           updateBubbles(pane, events, snap);
+          // Resolve line at event time from the current snapshot so the
+          // renderer can key assignments per-(stop, line). Unknown cars
+          // (disabled, despawned) skip the map — they wouldn't draw anyway.
+          const carLine = new Map<number, number>();
+          for (const car of snap.cars) carLine.set(car.id, car.line);
           for (const ev of events) {
             if (ev.kind === "elevator-assigned") {
-              pane.renderer.pushAssignment(ev.stop, ev.elevator);
+              const line = carLine.get(ev.elevator);
+              if (line !== undefined) {
+                pane.renderer.pushAssignment(ev.stop, ev.elevator, line);
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary

- `HallCall.assigned_car: Option<EntityId>` → `assigned_cars_by_line: BTreeMap<LineEntity, CarEntity>`. Stops served by multiple lines (e.g. the Skyscraper sky-lobby with Low, High, Executive, Service banks) now hold one assignment per line instead of last-writer-wins.
- New query API: `Simulation::assigned_cars_by_line(stop, direction)` returns every committed `(line, car)` pair; `waiting_counts_by_line_at(stop)` splits the waiting queue by the line each rider's route leg selects. The existing `assigned_car(stop, direction)` stays for source compat and returns the entry with the smallest line-entity key.
- wasm `StopDto.waiting_by_line: Vec<WaitingByLine { line, count }>` feeds a new renderer `Map<stopId, Map<lineId, carId>>` so every shaft draws its own share of the queue — no more flicker when VIP or Service is briefly dispatched.
- FFI stays C-ABI-stable: `EvHallCall.assigned_car` keeps its single-value shape; new `ev_sim_assigned_cars_by_line` accessor yields the full per-line list via `EvAssignment` records.

## Why

In the playground demo, waiters at the Skyscraper Lobby would jump to the VIP or Service shaft whenever those specialty banks dispatched for their own sliver of demand, making it look like the queue was misrouted. Physical dispatch was correct — it was the `assigned_car` single-slot that couldn't represent "three banks are all coming for their own subset of the crowd."

## Behavioral notes

- Group(G) route legs attribute to the first line in the group that serves the stop (covers the 1-line-per-group common case; the Skyscraper config has this shape).
- Pre-15.24 snapshots silently drop the transient `assigned_car` field on load (serde's default unknown-field handling); the next dispatch pass repopulates the per-line map. Bincode positional encoding made a legacy-compat deserialize impractical.
- Elevator removal retains other lines' entries for the same call; the pin lifts only when every entry references a dead car.

## Test plan

- [x] `cargo test -p elevator-core --all-features` — 837 unit + 159 doc tests
- [x] Two new tests in `multi_line_tests.rs`: `multi_line_stop_holds_one_assignment_per_line` and `waiting_counts_by_line_partitions_by_route_group`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo run -p elevator-core --example playground_audit --release` — metrics unchanged (dispatch behavior is identical; only the recording shape changed)
- [x] Playground: typecheck + lint + `pnpm test` (128 tests)
- [x] `scripts/lint-docs.sh`
- [ ] Visually confirm multi-line Skyscraper rendering in the dev server (mobile portrait + landscape)