### PR TITLE
ci(bench): suppress false-positive regression alerts

### DIFF
--- a/.github/scripts/filter-bench-regressions.py
+++ b/.github/scripts/filter-bench-regressions.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Filter Criterion "Performance has regressed." lines by median change %.
+
+Criterion's built-in regression detection is purely p-value-based: any
+statistically significant change fires, including sub-%% drift that's noise
+on a shared CI runner. This script reads `bench-output.log`, keeps only the
+regressions whose median change exceeds a threshold, and writes the same
+4-line context blocks the old `grep -B 3` emitted.
+
+Args:
+    sys.argv[1]: path to append `regressed=true|false` to ($GITHUB_OUTPUT).
+    sys.argv[2]: minimum |median change %| to alert on (e.g. "5.0").
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+CHANGE_RE = re.compile(
+    r"change:\s*\["
+    r"([+\-]?\d+(?:\.\d+)?)%\s+"
+    r"([+\-]?\d+(?:\.\d+)?)%\s+"
+    r"([+\-]?\d+(?:\.\d+)?)%"
+    r"\]"
+)
+
+
+def main() -> int:
+    github_output = Path(sys.argv[1])
+    threshold = float(sys.argv[2])
+
+    lines = Path("bench-output.log").read_text().splitlines(keepends=True)
+
+    out: list[str] = []
+    for i, line in enumerate(lines):
+        if "Performance has regressed." not in line:
+            continue
+        ctx = lines[max(0, i - 3) : i + 1]
+        change_line = next((l for l in ctx if "change:" in l), None)
+        if change_line:
+            m = CHANGE_RE.search(change_line)
+            if m and abs(float(m.group(2))) < threshold:
+                continue
+        out.extend(ctx)
+        out.append("\n")
+
+    if out:
+        Path("regressions.txt").write_text("".join(out))
+        print(f"== Regressions above {threshold}% detected ==")
+        sys.stdout.write("".join(out))
+        with github_output.open("a") as g:
+            g.write("regressed=true\n")
+    else:
+        print(f"No regressions above {threshold}% threshold.")
+        with github_output.open("a") as g:
+            g.write("regressed=false\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/filter-bench-regressions.py
+++ b/.github/scripts/filter-bench-regressions.py
@@ -3,13 +3,14 @@
 
 Criterion's built-in regression detection is purely p-value-based: any
 statistically significant change fires, including sub-%% drift that's noise
-on a shared CI runner. This script reads `bench-output.log`, keeps only the
-regressions whose median change exceeds a threshold, and writes the same
-4-line context blocks the old `grep -B 3` emitted.
+on a shared CI runner. This script keeps only the regressions whose median
+change exceeds a threshold, and writes the same 4-line context blocks the
+old `grep -B 3` emitted.
 
 Args:
     sys.argv[1]: path to append `regressed=true|false` to ($GITHUB_OUTPUT).
     sys.argv[2]: minimum |median change %| to alert on (e.g. "5.0").
+    sys.argv[3]: path to the Criterion bench output log to filter.
 """
 
 from __future__ import annotations
@@ -30,8 +31,9 @@ CHANGE_RE = re.compile(
 def main() -> int:
     github_output = Path(sys.argv[1])
     threshold = float(sys.argv[2])
+    bench_log = Path(sys.argv[3])
 
-    lines = Path("bench-output.log").read_text().splitlines(keepends=True)
+    lines = bench_log.read_text().splitlines(keepends=True)
 
     out: list[str] = []
     for i, line in enumerate(lines):

--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -65,24 +65,20 @@ jobs:
           cargo bench -p elevator-core --bench multi_line_bench  -- --save-baseline nightly 2>&1 | tee -a bench-output.log
           cargo bench -p elevator-core --bench query_bench       -- --save-baseline nightly 2>&1 | tee -a bench-output.log
 
-      # Extract any line tagged by Criterion as a significant regression
-      # (`change: ... Performance has regressed.`) and flag them. `-B 3`
-      # captures the preceding bench-name, `time:`, and `change:` lines so
-      # the resulting issue body actually identifies *which* bench regressed
-      # and by how much, rather than a stack of bare "Performance has
-      # regressed." lines.
+      # Criterion's "Performance has regressed." line fires on any
+      # statistically significant change, irrespective of magnitude. On a
+      # shared CI runner that produces false positives from sub-percent
+      # drift and from micro-benches whose measurements are dominated by
+      # timer jitter. The filter below keeps only regressions whose median
+      # change exceeds MIN_CHANGE_PCT, which is the signal we actually want
+      # to page on.
       - name: Detect regressions
         id: detect
+        env:
+          MIN_CHANGE_PCT: '5.0'
         run: |
-          if grep -qE 'Performance has regressed' bench-output.log; then
-            echo "regressed=true"  >> "$GITHUB_OUTPUT"
-            grep -B 3 -E 'Performance has regressed' bench-output.log > regressions.txt
-            echo "== Regressions detected =="
-            cat regressions.txt
-          else
-            echo "regressed=false" >> "$GITHUB_OUTPUT"
-            echo "No regressions detected."
-          fi
+          python3 .github/scripts/filter-bench-regressions.py \
+            "$GITHUB_OUTPUT" "$MIN_CHANGE_PCT"
 
       - name: Upload bench output
         if: always()

--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -78,7 +78,7 @@ jobs:
           MIN_CHANGE_PCT: '5.0'
         run: |
           python3 .github/scripts/filter-bench-regressions.py \
-            "$GITHUB_OUTPUT" "$MIN_CHANGE_PCT"
+            "$GITHUB_OUTPUT" "$MIN_CHANGE_PCT" bench-output.log
 
       - name: Upload bench output
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.23.0"
+version = "15.24.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/benches/sim_bench.rs
+++ b/crates/elevator-core/benches/sim_bench.rs
@@ -13,7 +13,6 @@ use elevator_core::config::{
     BuildingConfig, ElevatorConfig, PassengerSpawnConfig, SimConfig, SimulationParams,
 };
 use elevator_core::dispatch::scan::ScanDispatch;
-use elevator_core::movement::tick_movement;
 use elevator_core::sim::Simulation;
 use elevator_core::stop::{StopConfig, StopId};
 
@@ -91,17 +90,7 @@ fn bench_step(c: &mut Criterion) {
 }
 
 // ---------------------------------------------------------------------------
-// B) tick_movement in isolation
-// ---------------------------------------------------------------------------
-
-fn bench_tick_movement(c: &mut Criterion) {
-    c.bench_function("tick_movement", |b| {
-        b.iter(|| tick_movement(0.0, 0.0, 100.0, 2.0, 1.0, 1.0, 1.0));
-    });
-}
-
-// ---------------------------------------------------------------------------
-// C) Dispatch decisions
+// B) Dispatch decisions
 // ---------------------------------------------------------------------------
 
 fn bench_dispatch(c: &mut Criterion) {
@@ -125,5 +114,5 @@ fn bench_dispatch(c: &mut Criterion) {
 // Criterion harness
 // ---------------------------------------------------------------------------
 
-criterion_group!(benches, bench_step, bench_tick_movement, bench_dispatch);
+criterion_group!(benches, bench_step, bench_dispatch);
 criterion_main!(benches);


### PR DESCRIPTION
## Summary

Closes #439.

Issue #439 — and the four nightly runs before it — were triggered by Criterion's p-value-only regression detector on benches that either measure pure noise or drift sub-percent from night to night. Two targeted fixes make the nightly bench actionable again.

### Why the alerts are mostly noise

- **`tick_movement` bench**: body is `|| tick_movement(0.0, 0.0, 100.0, 2.0, 1.0, 1.0, 1.0)` with no `black_box`. The compiler folds most of the function and the measurement lands at 691–848 **picoseconds** — below timer precision on a shared CI runner. An 80% delta on ~150 ps is jitter, not a regression.
- **Detection step**: the existing `grep 'Performance has regressed.'` filter had no magnitude threshold. Criterion emits that line on any statistically significant change, so 0.5–3% run-to-run drift was reliably paging.
- **Drifting baseline**: `--save-baseline nightly` plus cache restore means today's baseline is yesterday's measurement. Small regressions compound silently across a multi-week window (last clean run: `3551202`, 2026-04-17) and eventually show up as a 10% headline.

### Changes

1. **Drop `bench_tick_movement`.** The function is already covered by unit tests in `movement.rs`, and full-tick cost is tracked by `sim_bench::bench_step` and the scaling benches.
2. **Filter regressions by magnitude.** New `.github/scripts/filter-bench-regressions.py` parses Criterion's `change: [low% median% high%]` line and keeps only regressions whose |median| ≥ `MIN_CHANGE_PCT` (5%). The workflow calls it in place of the old grep. Smoke-tested with realistic input: drops the 3.4% `multi_group_step` and 4.5% `query_riders` entries, keeps the 9%+ `dispatch_comparison` cluster.
3. **Sync Cargo.lock drift** (`15.23.0` → `15.24.0`) left behind by release-please PR #440 so the workspace builds clean.

### Non-goals

Not investigating the ~10% dispatch regression in this PR. That's most likely paid for by shipped features (TrafficDetector as a world resource, `p95_wait_time` in Metrics, RSR additive cost stack, AdaptiveParking reposition gating) that all landed in the same window. Once the noise floor is filtered out, genuine regressions will surface individually and can be triaged on merit.

## Test plan

- [x] `cargo check -p elevator-core --benches` passes after dropping `bench_tick_movement`
- [x] Pre-commit hook (fmt + clippy + core tests + doc tests + workspace check + lockfile drift) passes
- [x] Filter script smoke-tested against realistic Criterion output (below-threshold → `regressed=false`; above-threshold → `regressed=true` with preserved 4-line context block)
- [ ] Tonight's nightly run is quiet (or fires only on the real ~10% dispatch cluster, which I'll triage in a follow-up)