### PR TITLE
ci(bench): key criterion baseline by commit SHA to stop drift loop

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -38,20 +38,27 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libudev-dev libasound2-dev libwayland-dev libxkbcommon-dev libvulkan-dev
 
-      # Pull the previous nightly's Criterion baseline so the current run
-      # compares against it. The save-step's key is suffixed with
-      # `github.run_id` (so every run writes a unique key — GHA cache
-      # entries are immutable), so the restore here has to use
-      # `restore-keys` with a shared prefix to match *any* prior
-      # nightly's key. Without this the restore silently misses on every
-      # run and `cargo bench` only sees absolute numbers, making the
-      # nightly's whole point — regression detection vs yesterday —
-      # inoperative.
+      # Restore the Criterion baseline so this run compares against it.
+      # The cache key is suffixed with `github.sha`, so re-running the
+      # *same* commit always restores the *first* measurement of that
+      # commit (the save step below is gated on `cache-hit != 'true'`,
+      # so the per-SHA baseline is locked once written). This bounds
+      # drift to single-run variance instead of compounding it across
+      # nights — under the previous `run_id`-keyed scheme each nightly
+      # save overwrote the baseline with its own noisy output, which
+      # then became tomorrow's comparison floor.
+      #
+      # When a new commit lands the exact-key restore misses; the
+      # `restore-keys` prefix-fallback then pulls the most recent
+      # SHA's baseline so the new commit is compared against the prior
+      # known-good measurement. The save step writes a fresh entry
+      # under the new SHA, freezing it for subsequent nightlies.
       - name: Restore previous criterion baseline
+        id: restore-baseline
         uses: actions/cache/restore@v4
         with:
           path: target/criterion
-          key: criterion-baseline-${{ github.ref_name }}-never-matches-sentinel
+          key: criterion-baseline-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
             criterion-baseline-${{ github.ref_name }}-
 
@@ -90,11 +97,16 @@ jobs:
             bench-output.log
           retention-days: 30
 
+      # Only save when the exact-key restore missed — i.e. this is the
+      # first nightly to bench this SHA. Skipping on exact-match keeps
+      # the per-SHA baseline frozen at its first measurement, which is
+      # what stops the noise compounding loop.
       - name: Save new criterion baseline
+        if: steps.restore-baseline.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: target/criterion
-          key: criterion-baseline-${{ github.ref_name }}-${{ github.run_id }}
+          key: criterion-baseline-${{ github.ref_name }}-${{ github.sha }}
 
       # Open the regression issue *before* publishing to gh-pages so a
       # `git push` failure in the publish step (rate-limit, non-fast-forward,


### PR DESCRIPTION
## Summary

Closes the root cause behind the false-positive regression alerts in #442 and #444 (both already closed as runner noise).

The previous workflow keyed the cached Criterion baseline by `github.run_id` with a prefix `restore-keys` fallback. Each nightly's `cargo bench -- --save-baseline nightly` overwrote `target/criterion/<bench>/nightly/` with that run's just-measured numbers, then immutably cached *those* under a fresh `run_id`-suffixed key. Tomorrow's restore picked up today's noisy output as the comparison floor. Noise drifted monotonically across runs and eventually cleared the 5% magnitude filter PR #441 added — paging on identical code.

`gh run list --workflow bench-nightly.yml` confirmed all three of the recent nightlies (2026-04-23 / 2026-04-24 / 2026-04-25) ran against the same `headSha` (`64cd12c`), yet two of them filed regression issues with strictly increasing magnitudes — textbook compounding drift.

## Fix

Two coupled changes:

1. **Cache key uses `github.sha`** instead of `github.run_id`. Re-running the same commit hits the exact-key restore and gets the *first* measurement of that commit as the comparison baseline.
2. **Save step gated on `cache-hit != 'true'`**. Once a SHA's baseline is written it's locked — subsequent same-SHA runs skip the save (so even though `cargo bench --save-baseline nightly` overwrites the local files, the cache entry stays frozen).

New commits still get a meaningful comparison via the prefix-fallback against the previous SHA's locked baseline, then write a fresh entry under their own key. The drift loop is cut: per-SHA noise is bounded to single-run variance.

## One-time cost

The first nightly after this merges will compare against whatever drift-poisoned baseline currently sits in the cache (since the new SHA's exact key won't match yet) and may fire one last false-positive alert. After that the per-SHA scheme is in steady state. Mentioning here so the next morning's alert isn't surprising.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(...))'` — YAML parses
- [x] Pre-commit hook (fmt + clippy + tests + doc tests + workspace check + lockfile drift) passes
- [ ] Tonight's nightly: expected to fire one final regression issue against the drifted cache, then go quiet from 2026-04-27 onwards
- [ ] Verify on 2026-04-27 that the second post-merge nightly hits exact-key restore (`cache-hit: true`) and skips the save step