### PR TITLE
feat(wasm): expose granular topology mutation API

### DIFF
--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -307,7 +307,12 @@ impl Simulation {
             .filter_map(|(eid, _, car)| (car.line == line).then_some(eid))
             .collect();
         for eid in car_ids {
-            let pos = self.world.position(eid).map_or(0.0, |p| p.value);
+            // Skip cars without a Position component — clamping requires
+            // a real reading, and writing velocity alone (without a
+            // matching position update) would silently desync the two.
+            let Some(pos) = self.world.position(eid).map(|p| p.value) else {
+                continue;
+            };
             if pos < min || pos > max {
                 let clamped = pos.clamp(min, max);
                 if let Some(p) = self.world.position_mut(eid) {

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -223,7 +223,29 @@ impl Simulation {
     /// # Errors
     ///
     /// Returns [`SimError::GroupNotFound`] if the specified group does not exist.
+    /// Returns [`SimError::InvalidConfig`] if `min_position` / `max_position`
+    /// is non-finite or `min_position > max_position` — broken bounds
+    /// would produce NaN positions on every car added to the line.
     pub fn add_line(&mut self, params: &LineParams) -> Result<EntityId, SimError> {
+        if !params.min_position.is_finite() || !params.max_position.is_finite() {
+            return Err(SimError::InvalidConfig {
+                field: "line.range",
+                reason: format!(
+                    "min/max must be finite (got min={}, max={})",
+                    params.min_position, params.max_position
+                ),
+            });
+        }
+        if params.min_position > params.max_position {
+            return Err(SimError::InvalidConfig {
+                field: "line.range",
+                reason: format!(
+                    "min ({}) must be <= max ({})",
+                    params.min_position, params.max_position
+                ),
+            });
+        }
+
         let group_id = params.group;
         let group = self
             .groups

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -268,6 +268,61 @@ impl Simulation {
         Ok(eid)
     }
 
+    /// Set the reachable position range of a line.
+    ///
+    /// Cars whose current position falls outside the new `[min, max]` are
+    /// clamped to the boundary. Phase is left untouched — a car mid-travel
+    /// keeps `MovingToStop` and the movement system reconciles on the
+    /// next tick.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SimError::LineNotFound`] if the line entity does not exist.
+    /// Returns [`SimError::InvalidConfig`] if `min` or `max` is non-finite
+    /// or `min > max`.
+    pub fn set_line_range(&mut self, line: EntityId, min: f64, max: f64) -> Result<(), SimError> {
+        if !min.is_finite() || !max.is_finite() {
+            return Err(SimError::InvalidConfig {
+                field: "line.range",
+                reason: format!("min/max must be finite (got min={min}, max={max})"),
+            });
+        }
+        if min > max {
+            return Err(SimError::InvalidConfig {
+                field: "line.range",
+                reason: format!("min ({min}) must be <= max ({max})"),
+            });
+        }
+        let line_ref = self
+            .world
+            .line_mut(line)
+            .ok_or(SimError::LineNotFound(line))?;
+        line_ref.min_position = min;
+        line_ref.max_position = max;
+
+        // Clamp any cars on this line whose position falls outside the new range.
+        let car_ids: Vec<EntityId> = self
+            .world
+            .iter_elevators()
+            .filter_map(|(eid, _, car)| (car.line == line).then_some(eid))
+            .collect();
+        for eid in car_ids {
+            let pos = self.world.position(eid).map_or(0.0, |p| p.value);
+            if pos < min || pos > max {
+                let clamped = pos.clamp(min, max);
+                if let Some(p) = self.world.position_mut(eid) {
+                    p.value = clamped;
+                }
+                if let Some(v) = self.world.velocity_mut(eid) {
+                    v.value = 0.0;
+                }
+            }
+        }
+
+        self.mark_topo_dirty();
+        Ok(())
+    }
+
     /// Remove a line and all its elevators from the simulation.
     ///
     /// Elevators on the line are disabled (not despawned) so riders are

--- a/crates/elevator-core/src/tests/topology_tests.rs
+++ b/crates/elevator-core/src/tests/topology_tests.rs
@@ -342,6 +342,36 @@ fn disabled_elevator_not_dispatched() {
 }
 
 #[test]
+fn add_line_rejects_invalid_bounds() {
+    use crate::components::Orientation;
+    use crate::sim::LineParams;
+
+    let config = default_config();
+    let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
+
+    let mut bad = LineParams::new("bad", GroupId(0));
+    bad.orientation = Orientation::default();
+
+    bad.min_position = f64::NAN;
+    bad.max_position = 10.0;
+    assert!(sim.add_line(&bad).is_err(), "NaN min should be rejected");
+
+    bad.min_position = 0.0;
+    bad.max_position = f64::INFINITY;
+    assert!(
+        sim.add_line(&bad).is_err(),
+        "infinite max should be rejected"
+    );
+
+    bad.min_position = 10.0;
+    bad.max_position = 5.0;
+    assert!(
+        sim.add_line(&bad).is_err(),
+        "inverted bounds should be rejected"
+    );
+}
+
+#[test]
 fn set_line_range_clamps_out_of_range_car() {
     let config = default_config();
     let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();

--- a/crates/elevator-core/src/tests/topology_tests.rs
+++ b/crates/elevator-core/src/tests/topology_tests.rs
@@ -342,6 +342,59 @@ fn disabled_elevator_not_dispatched() {
 }
 
 #[test]
+fn set_line_range_clamps_out_of_range_car() {
+    let config = default_config();
+    let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
+    let line = sim.lines_in_group(GroupId(0))[0];
+    let elevators = sim.groups()[0].lines()[0].elevators().to_vec();
+    assert!(!elevators.is_empty(), "default config should have a car");
+    let car = elevators[0];
+
+    // Move the car well above the building, then shrink the line below it.
+    if let Some(p) = sim.world_mut().position_mut(car) {
+        p.value = 100.0;
+    }
+
+    sim.set_line_range(line, 0.0, 10.0).unwrap();
+
+    let pos = sim.world().position(car).unwrap().value;
+    assert!(
+        (pos - 10.0).abs() < 1e-9,
+        "car should be clamped to new max (got {pos})"
+    );
+    let vel = sim.world().velocity(car).unwrap().value;
+    assert!(vel.abs() < 1e-9, "velocity should be zeroed on clamp");
+}
+
+#[test]
+fn set_line_range_rejects_inverted_bounds() {
+    let config = default_config();
+    let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
+    let line = sim.lines_in_group(GroupId(0))[0];
+
+    assert!(sim.set_line_range(line, 10.0, 5.0).is_err());
+}
+
+#[test]
+fn set_line_range_rejects_nonfinite_bounds() {
+    let config = default_config();
+    let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
+    let line = sim.lines_in_group(GroupId(0))[0];
+
+    assert!(sim.set_line_range(line, f64::NAN, 10.0).is_err());
+    assert!(sim.set_line_range(line, 0.0, f64::INFINITY).is_err());
+}
+
+#[test]
+fn set_line_range_unknown_line_is_error() {
+    let config = default_config();
+    let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
+
+    let bogus = sim.world_mut().spawn();
+    assert!(sim.set_line_range(bogus, 0.0, 10.0).is_err());
+}
+
+#[test]
 fn runtime_stop_has_no_stop_id() {
     let config = default_config();
     let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -427,15 +427,16 @@ impl WasmSim {
             .map_err(|e| JsError::new(&format!("remove_line: {e}")))
     }
 
-    /// Resize a line's reachable position range. Cars outside the new
-    /// range are clamped to the boundary.
+    /// Resize a line's reachable position range. The new range may
+    /// grow or shrink the line; cars outside the new bounds are
+    /// clamped to the boundary.
     ///
     /// # Errors
     ///
     /// Returns a JS error if the line does not exist or the range is
     /// non-finite or inverted.
-    #[wasm_bindgen(js_name = extendLineRange)]
-    pub fn extend_line_range(
+    #[wasm_bindgen(js_name = setLineRange)]
+    pub fn set_line_range(
         &mut self,
         line_ref: u64,
         min_position: f64,
@@ -443,7 +444,7 @@ impl WasmSim {
     ) -> Result<(), JsError> {
         self.inner
             .set_line_range(u64_to_entity(line_ref), min_position, max_position)
-            .map_err(|e| JsError::new(&format!("extend_line_range: {e}")))
+            .map_err(|e| JsError::new(&format!("set_line_range: {e}")))
     }
 
     /// Add a stop to a line at the given position. Returns the stop
@@ -491,6 +492,24 @@ impl WasmSim {
         max_speed: Option<f64>,
         weight_capacity: Option<f64>,
     ) -> Result<u64, JsError> {
+        // Validate at the boundary; `add_elevator` re-runs full physics
+        // checks, but rejecting NaN/inf here keeps the error message
+        // close to the source (the JS caller's argument).
+        if let Some(s) = max_speed
+            && (!s.is_finite() || s <= 0.0)
+        {
+            return Err(JsError::new(&format!(
+                "add_elevator: max_speed must be a positive finite number (got {s})"
+            )));
+        }
+        if let Some(w) = weight_capacity
+            && (!w.is_finite() || w <= 0.0)
+        {
+            return Err(JsError::new(&format!(
+                "add_elevator: weight_capacity must be a positive finite number (got {w})"
+            )));
+        }
+
         let mut params = elevator_core::sim::ElevatorParams::default();
         if let Some(s) = max_speed {
             params.max_speed = elevator_core::components::Speed::from(s);
@@ -539,17 +558,17 @@ impl WasmSim {
             .map_err(|e| JsError::new(&format!("press_hall_call: {e}")))
     }
 
-    /// Press a car-button (in-cab floor request).
+    /// Press a car-button (in-cab floor request) targeting `stop_ref`.
     ///
     /// # Errors
     ///
-    /// Returns a JS error if the elevator or floor does not exist.
+    /// Returns a JS error if the elevator or stop does not exist.
     #[wasm_bindgen(js_name = pressCarButton)]
-    pub fn press_car_button(&mut self, elevator_ref: u64, floor_ref: u64) -> Result<(), JsError> {
+    pub fn press_car_button(&mut self, elevator_ref: u64, stop_ref: u64) -> Result<(), JsError> {
         self.inner
             .press_car_button(
                 elevator_core::entity::ElevatorId::from(u64_to_entity(elevator_ref)),
-                u64_to_entity(floor_ref),
+                u64_to_entity(stop_ref),
             )
             .map_err(|e| JsError::new(&format!("press_car_button: {e}")))
     }

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -15,10 +15,26 @@ use elevator_core::dispatch::{
     BuiltinReposition, BuiltinStrategy, DestinationDispatch, EtdDispatch, HallCallMode,
     LookDispatch, NearestCarDispatch, RsrDispatch, ScanDispatch,
 };
+use elevator_core::entity::EntityId;
 use elevator_core::prelude::{Simulation, StopId};
+use slotmap::Key;
 use wasm_bindgen::prelude::*;
 
 mod dto;
+
+/// Encode an `EntityId` for the JS boundary as a `u64` (`BigInt` in JS).
+/// Carries slotmap's full FFI encoding (slot + version) so stale
+/// references fail cleanly instead of aliasing reused slots.
+fn entity_to_u64(id: EntityId) -> u64 {
+    id.data().as_ffi()
+}
+
+/// Decode a `u64` from JS back into an `EntityId`. The value must have
+/// originated from [`entity_to_u64`]; arbitrary bit patterns produce a
+/// `KeyData` that any subsequent world lookup will reject as missing.
+fn u64_to_entity(raw: u64) -> EntityId {
+    EntityId::from(slotmap::KeyData::from_ffi(raw))
+}
 
 /// Map a JS-facing strategy name to its `BuiltinStrategy` variant. Used to tag
 /// dispatcher instances so snapshots round-trip the active strategy id.
@@ -342,6 +358,200 @@ impl WasmSim {
         self.inner.stop_entity(StopId(stop_id)).map_or(0, |e| {
             u32::try_from(self.inner.waiting_count_at(e)).unwrap_or(u32::MAX)
         })
+    }
+
+    // ── Topology mutation API ────────────────────────────────────────
+    //
+    // Granular live mutations for consumers (notably SKYSTACK) where the
+    // player edits the building mid-sim. Entity references cross the JS
+    // boundary as `u64` (BigInt in JS) carrying slotmap's full FFI
+    // encoding — version bits included, so a stale reference to a
+    // despawned entity fails cleanly instead of aliasing a reused slot.
+
+    /// Add a new dispatch group with the given name and strategy.
+    /// Returns the group ID as a `u32` (groups have flat numeric IDs).
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if `dispatch_strategy` is not a recognised name
+    /// (`"scan" | "look" | "nearest" | "etd" | "destination" | "rsr"`).
+    #[wasm_bindgen(js_name = addGroup)]
+    pub fn add_group(&mut self, name: String, dispatch_strategy: &str) -> Result<u32, JsError> {
+        let group_id = match dispatch_strategy {
+            "scan" => self.inner.add_group(name, ScanDispatch::new()),
+            "look" => self.inner.add_group(name, LookDispatch::new()),
+            "nearest" => self.inner.add_group(name, NearestCarDispatch::new()),
+            "etd" => self.inner.add_group(name, EtdDispatch::new()),
+            "destination" => self.inner.add_group(name, DestinationDispatch::new()),
+            "rsr" => self.inner.add_group(name, RsrDispatch::new()),
+            other => return Err(JsError::new(&format!("unknown strategy: {other}"))),
+        };
+        Ok(group_id.0)
+    }
+
+    /// Add a new line to an existing group. Returns the line entity ref.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the group does not exist or the range is
+    /// non-finite or inverted.
+    #[wasm_bindgen(js_name = addLine)]
+    pub fn add_line(
+        &mut self,
+        group_id: u32,
+        name: String,
+        min_position: f64,
+        max_position: f64,
+        max_cars: Option<u32>,
+    ) -> Result<u64, JsError> {
+        let mut params =
+            elevator_core::sim::LineParams::new(name, elevator_core::ids::GroupId(group_id));
+        params.min_position = min_position;
+        params.max_position = max_position;
+        params.max_cars = max_cars.map(|n| n as usize);
+        self.inner
+            .add_line(&params)
+            .map(entity_to_u64)
+            .map_err(|e| JsError::new(&format!("add_line: {e}")))
+    }
+
+    /// Remove a line and all its elevators (riders ejected to nearest stop).
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the line does not exist.
+    #[wasm_bindgen(js_name = removeLine)]
+    pub fn remove_line(&mut self, line_ref: u64) -> Result<(), JsError> {
+        self.inner
+            .remove_line(u64_to_entity(line_ref))
+            .map_err(|e| JsError::new(&format!("remove_line: {e}")))
+    }
+
+    /// Resize a line's reachable position range. Cars outside the new
+    /// range are clamped to the boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the line does not exist or the range is
+    /// non-finite or inverted.
+    #[wasm_bindgen(js_name = extendLineRange)]
+    pub fn extend_line_range(
+        &mut self,
+        line_ref: u64,
+        min_position: f64,
+        max_position: f64,
+    ) -> Result<(), JsError> {
+        self.inner
+            .set_line_range(u64_to_entity(line_ref), min_position, max_position)
+            .map_err(|e| JsError::new(&format!("extend_line_range: {e}")))
+    }
+
+    /// Add a stop to a line at the given position. Returns the stop
+    /// entity ref.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the line does not exist or the position is
+    /// non-finite.
+    #[wasm_bindgen(js_name = addStop)]
+    pub fn add_stop(&mut self, line_ref: u64, name: String, position: f64) -> Result<u64, JsError> {
+        self.inner
+            .add_stop(name, position, u64_to_entity(line_ref))
+            .map(entity_to_u64)
+            .map_err(|e| JsError::new(&format!("add_stop: {e}")))
+    }
+
+    /// Remove a stop. In-flight riders to/from it are rerouted, ejected,
+    /// or abandoned per `Simulation::remove_stop` semantics.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the stop does not exist.
+    #[wasm_bindgen(js_name = removeStop)]
+    pub fn remove_stop(&mut self, stop_ref: u64) -> Result<(), JsError> {
+        self.inner
+            .remove_stop(u64_to_entity(stop_ref))
+            .map_err(|e| JsError::new(&format!("remove_stop: {e}")))
+    }
+
+    /// Add a new elevator to a line at `starting_position`. Optional
+    /// physics overrides; defaults match `ElevatorParams::default`.
+    /// Returns the elevator entity ref.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the line does not exist, the position is
+    /// non-finite, the physics are invalid, or the line's `max_cars` is
+    /// already reached.
+    #[wasm_bindgen(js_name = addElevator)]
+    pub fn add_elevator(
+        &mut self,
+        line_ref: u64,
+        starting_position: f64,
+        max_speed: Option<f64>,
+        weight_capacity: Option<f64>,
+    ) -> Result<u64, JsError> {
+        let mut params = elevator_core::sim::ElevatorParams::default();
+        if let Some(s) = max_speed {
+            params.max_speed = elevator_core::components::Speed::from(s);
+        }
+        if let Some(w) = weight_capacity {
+            params.weight_capacity = elevator_core::components::Weight::from(w);
+        }
+        self.inner
+            .add_elevator(&params, u64_to_entity(line_ref), starting_position)
+            .map(entity_to_u64)
+            .map_err(|e| JsError::new(&format!("add_elevator: {e}")))
+    }
+
+    /// Remove an elevator (riders ejected to the nearest enabled stop).
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the elevator does not exist.
+    #[wasm_bindgen(js_name = removeElevator)]
+    pub fn remove_elevator(&mut self, elevator_ref: u64) -> Result<(), JsError> {
+        self.inner
+            .remove_elevator(u64_to_entity(elevator_ref))
+            .map_err(|e| JsError::new(&format!("remove_elevator: {e}")))
+    }
+
+    /// Press a hall call at a stop with direction `"up"` or `"down"`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the stop does not exist or `direction` is
+    /// not `"up"` or `"down"`.
+    #[wasm_bindgen(js_name = pressHallCall)]
+    pub fn press_hall_call(&mut self, stop_ref: u64, direction: &str) -> Result<(), JsError> {
+        let dir = match direction {
+            "up" => elevator_core::components::CallDirection::Up,
+            "down" => elevator_core::components::CallDirection::Down,
+            other => {
+                return Err(JsError::new(&format!(
+                    "direction must be 'up' or 'down', got {other:?}"
+                )));
+            }
+        };
+        let stop = u64_to_entity(stop_ref);
+        self.inner
+            .press_hall_button(stop, dir)
+            .map_err(|e| JsError::new(&format!("press_hall_call: {e}")))
+    }
+
+    /// Press a car-button (in-cab floor request).
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the elevator or floor does not exist.
+    #[wasm_bindgen(js_name = pressCarButton)]
+    pub fn press_car_button(&mut self, elevator_ref: u64, floor_ref: u64) -> Result<(), JsError> {
+        self.inner
+            .press_car_button(
+                elevator_core::entity::ElevatorId::from(u64_to_entity(elevator_ref)),
+                u64_to_entity(floor_ref),
+            )
+            .map_err(|e| JsError::new(&format!("press_car_button: {e}")))
     }
 
     // ── Uniform elevator-physics setters ─────────────────────────────


### PR DESCRIPTION
## Summary

- Adds JS-callable mutations on `WasmSim` so consumers (notably the upcoming SKYSTACK port) can build a tower live mid-sim: `addGroup`, `addLine`, `removeLine`, `extendLineRange`, `addStop`, `removeStop`, `addElevator`, `removeElevator`, `pressHallCall`, `pressCarButton`.
- Entity refs cross the JS boundary as \`u64\` (BigInt in JS) carrying slotmap's full FFI encoding — version bits included, so a stale ref to a despawned entity fails cleanly instead of aliasing a reused slot.
- Adds \`Simulation::set_line_range(line, min, max)\` to core for the mutation API to wrap. Rejects NaN/inf and inverted bounds; clamps cars on the line whose position falls outside the new range and zeroes their velocity. Phase is left untouched so a moving car decelerates naturally on the next tick.
- All other new wasm methods are thin wrappers around existing \`Simulation::add_*\` / \`remove_*\` paths in \`sim/topology.rs\` (already covered by \`topology_tests.rs\`).

## Test plan

- [x] 4 new core tests: \`set_line_range_clamps_out_of_range_car\`, \`_rejects_inverted_bounds\`, \`_rejects_nonfinite_bounds\`, \`_unknown_line_is_error\`.
- [x] \`cargo test -p elevator-core -p elevator-wasm --all-features\` — 841 + integration + 159 doctests pass.
- [x] \`cargo clippy --all-features --all-targets -- -D warnings\` clean.
- [x] \`cargo check --workspace\` clean.
- [x] \`bash scripts/build-wasm.sh\` regenerates TS bindings cleanly; every new method appears in \`playground/public/pkg/elevator_wasm.d.ts\` with correct types (BigInt for entity refs, number for u32 group IDs).
- [x] End-to-end JS coverage lands with the SKYSTACK port (PR 5).