### PR TITLE
feat(skystack): replace SCAN scheduler with elevator-core wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.24.1"
+version = "15.25.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -317,6 +317,38 @@ impl WasmSim {
             .map_err(|e| JsError::new(&format!("spawn: {e}")))
     }
 
+    /// Spawn a rider between two stops identified by their entity refs
+    /// (`BigInt`). Companion to [`spawn_rider`](Self::spawn_rider) for
+    /// runtime-added stops that have no config-time `StopId`.
+    /// Returns the new rider's entity ref so consumers can correlate
+    /// with subsequent `rider-*` events.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if either stop does not exist, the origin
+    /// equals the destination, or no group serves both stops.
+    #[wasm_bindgen(js_name = spawnRiderByRef)]
+    pub fn spawn_rider_by_ref(
+        &mut self,
+        origin_ref: u64,
+        destination_ref: u64,
+        weight: f64,
+        patience_ticks: Option<u32>,
+    ) -> Result<u64, JsError> {
+        let mut builder = self
+            .inner
+            .build_rider(u64_to_entity(origin_ref), u64_to_entity(destination_ref))
+            .map_err(|e| JsError::new(&format!("spawn: {e}")))?
+            .weight(weight);
+        if let Some(ticks) = patience_ticks.filter(|&t| t > 0) {
+            builder = builder.patience(u64::from(ticks));
+        }
+        builder
+            .spawn()
+            .map(|rid| entity_to_u64(rid.entity()))
+            .map_err(|e| JsError::new(&format!("spawn: {e}")))
+    }
+
     /// Record a target traffic rate (riders per minute). The playground driver
     /// interprets this value externally and calls [`spawn_rider`](Self::spawn_rider)
     /// accordingly — the core sim is unaffected so determinism is preserved.

--- a/crates/elevator-wasm/tests/playground_scenarios.rs
+++ b/crates/elevator-wasm/tests/playground_scenarios.rs
@@ -310,6 +310,65 @@ fn space_elevator_scenario_builds() {
     }
 }
 
+/// SKYSTACK builds the world entirely at runtime (no config-time
+/// `StopId`s) and spawns riders by entity ref. Exercise the same code
+/// path the JS bridge takes: empty group → line → stops → elevator →
+/// `build_rider(EntityId, EntityId)` → step until delivered.
+#[test]
+fn skystack_runtime_world_delivers_a_rider() {
+    use elevator_core::prelude::SimulationBuilder;
+    use elevator_core::sim::LineParams;
+
+    // The SKYSTACK bridge creates one group per shaft ("independent
+    // mode" in PR 5). The new shaft's group has its own dispatcher
+    // and only its cars are eligible for its line's hall calls.
+    let mut sim = SimulationBuilder::demo().build().unwrap();
+
+    // Position the new shaft well away from the demo's stops so
+    // `find_stop_at_position` returns the right entity at boundaries.
+    let group = sim.add_group("shaft-0", ScanDispatch::new());
+    let mut line_params = LineParams::new("shaft-0", group);
+    line_params.min_position = 100.0;
+    line_params.max_position = 112.0;
+    line_params.max_cars = Some(4);
+    let line = sim.add_line(&line_params).expect("add_line");
+
+    let stop_lobby = sim.add_stop("F0".into(), 100.0, line).expect("add_stop F0");
+    let stop_floor3 = sim.add_stop("F3".into(), 109.0, line).expect("add_stop F3");
+
+    let params = elevator_core::sim::ElevatorParams {
+        max_speed: elevator_core::components::Speed::from(2.0),
+        ..elevator_core::sim::ElevatorParams::default()
+    };
+    let _car = sim
+        .add_elevator(&params, line, 100.0)
+        .expect("add_elevator");
+
+    // SKYSTACK passes EntityIds (BigInts in JS) — exercise the same
+    // path through `build_rider`.
+    let rider = sim
+        .build_rider(stop_lobby, stop_floor3)
+        .expect("build_rider with entity refs")
+        .weight(70.0)
+        .spawn()
+        .expect("spawn");
+
+    let mut delivered = false;
+    for _ in 0..5000 {
+        sim.step();
+        let r = sim.world().rider(rider.entity()).unwrap();
+        if r.phase() == elevator_core::components::RiderPhase::Arrived {
+            delivered = true;
+            break;
+        }
+    }
+    assert!(
+        delivered,
+        "rider should reach destination within 5000 ticks"
+    );
+    assert!(sim.metrics().total_delivered() >= 1);
+}
+
 /// Office's group-time ETD hook swaps the active strategy to a tuned
 /// `EtdDispatch`. Make sure the swap path the wasm wrapper uses actually
 /// lands the weight on the instance.

--- a/playground/public/skystack/README.md
+++ b/playground/public/skystack/README.md
@@ -10,16 +10,36 @@ commit `c05dc685b59ca25e3ca63916ad0b2a7555758bbc`.
 
 ## What's modified
 
-This commit drops the upstream file in unchanged except for an
-attribution header. The game still uses its own SCAN elevator scheduler.
+This page is a thin wasm bridge over the upstream `Tower.html`:
 
-A follow-up PR surgically replaces the elevator subsystem
-(`tickElevator`, `tickCar`, `rebuildElevators`, hall-call queues, agent
-boarding) with calls into `elevator-core`'s wasm bundle at `../pkg/`.
-Renderer, mail, market, scenarios, weather, save/load, prestige, and
-the daily challenge are untouched in both this PR and the follow-up.
+- **Wasm bootstrap** (`<script type="module">`) loads
+  `../pkg/elevator_wasm.js` and exposes `WasmSim` on `window`.
+- **`SkystackWasm` JS namespace** reconciles wasm topology against
+  `state.elevators` whenever `rebuildElevators()` runs, steps the
+  wasm sim per game minute, drains rider events, and mirrors car
+  positions back into `state.elevators[].cars[].floatY` so the
+  existing renderer just works.
+- **`stepToward`'s elevator branch** routes new boarding requests
+  through `wasmSim.spawnRiderByRef()` + `pressHallCall()` instead
+  of pushing into the legacy `e.queueUp`/`queueDown` queues.
 
-## Best on desktop
+Renderer, mail, market, scenarios, weather, save/load, prestige,
+agent state machine, and the daily challenge are untouched.
 
-The upstream layout targets desktop. Mobile responsiveness is tracked
-as a follow-up.
+## v1 limitations
+
+- **Save/load**: in-flight wasm riders aren't serialized. On load
+  the game rebuilds wasm topology from the grid; agents re-route
+  through the bridge on their next tick.
+- **Mode**: each shaft becomes its own wasm dispatch group
+  ("independent mode"). PR 6 adds a "coordinated mode" toggle for
+  scenarios where neighbouring shafts should share a dispatcher.
+- **Mobile**: upstream desktop layout. Mobile restyling tracked
+  as a follow-up.
+
+## Fallback behaviour
+
+If the wasm bundle fails to load (network error, missing `pkg/`),
+`SkystackWasm.isReady()` returns `false` and the legacy SCAN
+scheduler runs as before. A red banner surfaces the wasm error
+to the player.

--- a/playground/public/skystack/Tower.html
+++ b/playground/public/skystack/Tower.html
@@ -2638,16 +2638,19 @@
 
       window.wasmReady = (async () => {
         await init();
-        // Empty world: SKYSTACK adds groups/lines/stops/cars at runtime
-        // via `rebuildElevators` once a game is loaded. The minimum
-        // valid RON is just a non-empty stops + elevators list — we
-        // construct a 2-stop / 1-elevator stub then immediately
-        // remove its line to leave a clean slate.
+        // The minimum valid `SimConfig` requires a non-empty stops +
+        // elevators list. The stub is positioned far outside any
+        // plausible SKYSTACK shaft (negative-million metres) so it
+        // can't collide with player-built topology via
+        // `find_stop_at_position` even briefly. The stub is harmless
+        // — no riders are ever spawned into it — so leaving it in
+        // place is safer than depending on a wasm-side `removeGroup`
+        // that doesn't exist yet (tracked as follow-up).
         var stub =
           "SimConfig(" +
           'building: BuildingConfig(name: "Skystack", stops: [' +
-          'StopConfig(id: StopId(0), name: "_stub0", position: 0.0),' +
-          'StopConfig(id: StopId(1), name: "_stub1", position: 3.0)' +
+          'StopConfig(id: StopId(0), name: "_stub0", position: -1000000.0),' +
+          'StopConfig(id: StopId(1), name: "_stub1", position: -999997.0)' +
           "])," +
           "elevators: [ElevatorConfig(" +
           'id: 0, name: "_stub", max_speed: 2.0, acceleration: 1.5,' +
@@ -2660,14 +2663,23 @@
         var sim = new WasmSim(stub, "look", "adaptive");
         window.wasmSim = sim;
         return sim;
-      })().catch((err) => {
-        console.error("[skystack] wasm init failed:", err);
-        var b = document.createElement("div");
-        b.style.cssText =
-          "position:fixed;top:0;left:0;right:0;background:#a00;color:#fff;padding:8px;z-index:9999;font:12px monospace";
-        b.textContent = "SKYSTACK: elevator-core wasm failed to load: " + err.message;
-        document.body.appendChild(b);
-      });
+      })()
+        .then((sim) => {
+          // Catch-up reconcile: if the player started a game before the
+          // wasm bundle finished loading, `rebuildElevators` already ran
+          // against an empty wasm world. Reconcile now so the wasm sim
+          // mirrors the existing JS shaft state on the next tick.
+          if (sim && window.SkystackWasm) window.SkystackWasm.reconcileTopology();
+          return sim;
+        })
+        .catch((err) => {
+          console.error("[skystack] wasm init failed:", err);
+          var b = document.createElement("div");
+          b.style.cssText =
+            "position:fixed;top:0;left:0;right:0;background:#a00;color:#fff;padding:8px;z-index:9999;font:12px monospace";
+          b.textContent = "SKYSTACK: elevator-core wasm failed to load: " + err.message;
+          document.body.appendChild(b);
+        });
     </script>
 
     <script>
@@ -2788,15 +2800,19 @@
             wantLines.set(k, { col: e.shaftX, minY: e.minY, maxY: e.maxY, cars: e.cars });
           }
 
-          // Drop wasm lines (and the entire group, since each shaft
-          // owns its own group in v1) that no longer exist in JS.
+          // Drop wasm lines whose JS shaft is gone. Reuse the group:
+          // there's no `removeGroup` in core yet, so deleting the JS
+          // map entry while the wasm group lingered would leak. By
+          // keeping the WASM_GROUPS entry, a later
+          // `ensureGroupFor(col)` for the same column reattaches a
+          // new line to the existing group instead of creating a
+          // second one. Bounded growth: ≤ GRID_W groups (~28).
           for (var k of Array.from(WASM_LINES.keys())) {
             if (!wantLines.has(k)) {
               try {
                 window.wasmSim.removeLine(WASM_LINES.get(k));
               } catch (e) {}
               WASM_LINES.delete(k);
-              WASM_GROUPS.delete(k);
               // Also drop stops + cars under this shaft from our maps.
               for (var sk of Array.from(WASM_STOPS.keys())) {
                 if (sk.split(":")[0] === k.slice(1)) WASM_STOPS.delete(sk);
@@ -2903,7 +2919,15 @@
           if (Number(origin) === Number(dest)) return false; // same-floor; nothing to ride
           try {
             var weight = agent.weight || 75.0;
-            var ridRef = window.wasmSim.spawnRiderByRef(origin, dest, weight, 0);
+            // Default patience = ~50 wasm ticks (5 s at 10 Hz).
+            // Passing `0` would map to `Some(0)` which Rust filters
+            // away → infinite patience → abandonment events never
+            // fire. Use a finite default; SKYSTACK already has
+            // its own complaint timer (180 game-min) but the wasm
+            // patience triggers `rider-abandoned` so the bridge can
+            // mark the agent as `leaving` cleanly.
+            var patience = agent.wasmPatienceTicks != null ? agent.wasmPatienceTicks : 600;
+            var ridRef = window.wasmSim.spawnRiderByRef(origin, dest, weight, patience);
             window.wasmSim.pressHallCall(origin, toY > fromY ? "up" : "down");
             agent.wasmRiderRef = ridRef;
             agent.wasmShaftCol = col;

--- a/playground/public/skystack/Tower.html
+++ b/playground/public/skystack/Tower.html
@@ -8137,9 +8137,20 @@
               // fall through to legacy queue so the agent isn't stuck.
             }
             if (a.wasmRiderRef !== undefined) {
-              // Already in flight — wait for rider-exited.
-              a.waiting = true;
-              return false;
+              if (SkystackWasm.isFailed()) {
+                // Wasm died mid-flight — drainEvents no-ops, so
+                // rider-exited will never fire and the agent would
+                // be stuck forever. Bail to the legacy queue path
+                // below by clearing the wasm flags.
+                a.wasmRiderRef = undefined;
+                a.wasmShaftCol = undefined;
+                a.wasmFromY = undefined;
+                a.wasmToY = undefined;
+              } else {
+                // Already in flight — wait for rider-exited.
+                a.waiting = true;
+                return false;
+              }
             }
             var goingUp = ty > a.y;
             var queue = goingUp ? elev.queueUp : elev.queueDown;

--- a/playground/public/skystack/Tower.html
+++ b/playground/public/skystack/Tower.html
@@ -2800,26 +2800,42 @@
             wantLines.set(k, { col: e.shaftX, minY: e.minY, maxY: e.maxY, cars: e.cars });
           }
 
-          // Drop wasm lines whose JS shaft is gone. Reuse the group:
-          // there's no `removeGroup` in core yet, so deleting the JS
-          // map entry while the wasm group lingered would leak. By
-          // keeping the WASM_GROUPS entry, a later
+          // Drop wasm lines whose JS shaft is gone. `removeLine` only
+          // disables (doesn't despawn) the line's elevators and does
+          // nothing to its stops, so we explicitly remove each stop
+          // and elevator before the line — otherwise stale entities
+          // sit at the demolished shaft's positions and a re-built
+          // shaft on the same column would collide via
+          // `find_stop_at_position`.
+          //
+          // Reuse the group: there's no `removeGroup` in core yet,
+          // so leaving the WASM_GROUPS entry means a later
           // `ensureGroupFor(col)` for the same column reattaches a
-          // new line to the existing group instead of creating a
-          // second one. Bounded growth: ≤ GRID_W groups (~28).
+          // new line to the existing group instead of leaking a
+          // fresh one. Bounded growth: ≤ GRID_W groups (~28).
           for (var k of Array.from(WASM_LINES.keys())) {
             if (!wantLines.has(k)) {
+              var col = k.slice(1);
+              for (var sk of Array.from(WASM_STOPS.keys())) {
+                if (sk.split(":")[0] === col) {
+                  try {
+                    window.wasmSim.removeStop(WASM_STOPS.get(sk));
+                  } catch (e) {}
+                  WASM_STOPS.delete(sk);
+                }
+              }
+              for (var ck of Array.from(WASM_CARS.keys())) {
+                if (ck.split("#")[0] === col) {
+                  try {
+                    window.wasmSim.removeElevator(WASM_CARS.get(ck));
+                  } catch (e) {}
+                  WASM_CARS.delete(ck);
+                }
+              }
               try {
                 window.wasmSim.removeLine(WASM_LINES.get(k));
               } catch (e) {}
               WASM_LINES.delete(k);
-              // Also drop stops + cars under this shaft from our maps.
-              for (var sk of Array.from(WASM_STOPS.keys())) {
-                if (sk.split(":")[0] === k.slice(1)) WASM_STOPS.delete(sk);
-              }
-              for (var ck of Array.from(WASM_CARS.keys())) {
-                if (ck.split("#")[0] === k.slice(1)) WASM_CARS.delete(ck);
-              }
             }
           }
 

--- a/playground/public/skystack/Tower.html
+++ b/playground/public/skystack/Tower.html
@@ -3009,7 +3009,12 @@
               var agent4 = aid3 !== undefined ? findAgent(aid3) : null;
               if (agent4) {
                 // Treat as if they gave up — leave the building.
+                // Clear `waiting` so `tickAgent` actually processes
+                // the new "leaving" phase next tick (the `waiting`
+                // flag is set when an agent enters the hall queue
+                // and gates further movement until cleared).
                 agent4.phase = "leaving";
+                agent4.waiting = false;
                 agent4.inElevator = null;
                 agent4.wasmRiderRef = undefined;
               }

--- a/playground/public/skystack/Tower.html
+++ b/playground/public/skystack/Tower.html
@@ -2623,6 +2623,53 @@
       </div>
     </div>
 
+    <!-- elevator-core wasm bootstrap. Loads the wasm bundle from the
+         playground's shared `pkg/` directory and exposes `WasmSim`
+         on `window`. The inline script below `await window.wasmReady`
+         before its first sim use. Pre-PR-5 SKYSTACK ran its own SCAN
+         scheduler; this PR routes elevator dispatch + movement +
+         loading through `wasmSim` and uses the existing JS state
+         tree as a render mirror. -->
+    <script type="module">
+      import init, { WasmSim } from "../pkg/elevator_wasm.js";
+
+      window.SKYSTACK_FLOOR_HEIGHT_M = 3.0;
+      window.SKYSTACK_SIM_TICKS_PER_GAME_MIN = 2;
+
+      window.wasmReady = (async () => {
+        await init();
+        // Empty world: SKYSTACK adds groups/lines/stops/cars at runtime
+        // via `rebuildElevators` once a game is loaded. The minimum
+        // valid RON is just a non-empty stops + elevators list — we
+        // construct a 2-stop / 1-elevator stub then immediately
+        // remove its line to leave a clean slate.
+        var stub =
+          "SimConfig(" +
+          'building: BuildingConfig(name: "Skystack", stops: [' +
+          'StopConfig(id: StopId(0), name: "_stub0", position: 0.0),' +
+          'StopConfig(id: StopId(1), name: "_stub1", position: 3.0)' +
+          "])," +
+          "elevators: [ElevatorConfig(" +
+          'id: 0, name: "_stub", max_speed: 2.0, acceleration: 1.5,' +
+          "deceleration: 2.0, weight_capacity: 800.0," +
+          "starting_stop: StopId(0), door_open_ticks: 10, door_transition_ticks: 5" +
+          ")]," +
+          "simulation: SimulationParams(ticks_per_second: 10.0)," +
+          "passenger_spawning: PassengerSpawnConfig(mean_interval_ticks: 120, weight_range: (50.0, 100.0))" +
+          ")";
+        var sim = new WasmSim(stub, "look", "adaptive");
+        window.wasmSim = sim;
+        return sim;
+      })().catch((err) => {
+        console.error("[skystack] wasm init failed:", err);
+        var b = document.createElement("div");
+        b.style.cssText =
+          "position:fixed;top:0;left:0;right:0;background:#a00;color:#fff;padding:8px;z-index:9999;font:12px monospace";
+        b.textContent = "SKYSTACK: elevator-core wasm failed to load: " + err.message;
+        document.body.appendChild(b);
+      });
+    </script>
+
     <script>
       /* Surface JS errors as an on-screen banner. Production Tauri/WebView2 has
    no visible devtools, so silent errors (null dereference, missing DOM, etc.)
@@ -2671,6 +2718,322 @@
       var FLOOR_MIN = -8;
       var FLOOR_MAX = 80;
       var GROUND_Y = 0; // floor 0 is ground
+
+      /* ===== ELEVATOR-CORE WASM BRIDGE ===========================
+         SKYSTACK keeps `state.elevators` (per-shaft metadata + cars)
+         as a JS-side render mirror. The wasm sim is the source of
+         truth for car positions, dispatch, doors, and rider lifecycle.
+         Each game tick:
+           1. SkystackWasm.reconcileTopology() — apply grid edits.
+           2. SkystackWasm.tickAll(N) — step the sim N times.
+           3. SkystackWasm.drainEvents() — process rider events.
+           4. SkystackWasm.syncMirror() — update state.elevators[].cars
+              from worldView() so the existing renderer just works. */
+      var SkystackWasm = (function () {
+        var FLOOR_H = 3.0; // metres per floor — matches wasm bootstrap
+        var SHAFT_OFFSET = 0.0001; // per-column offset to break position ties.
+        // `find_stop_at_position` is global (not per-line), so two shafts
+        // with stops at the same physical floor would collide on
+        // arrival. Offset each shaft by `col * SHAFT_OFFSET` so the
+        // closest-stop lookup returns the correct shaft. Visually
+        // imperceptible (sub-millimetre per column).
+        var WASM_GROUPS = new Map(); // shaft column key → wasm group id (number)
+        var WASM_LINES = new Map(); // shaft column key → wasm line ref (bigint)
+        var WASM_STOPS = new Map(); // (col + ":" + floorY) → wasm stop ref (bigint)
+        var WASM_CARS = new Map(); // (col + ":" + carIdx) → wasm car ref (bigint)
+        var RIDER_TO_AGENT = new Map(); // wasm rider ref (bigint) → agent.id
+        var FAILED = false; // sticky after a wasm error; bridge no-ops thereafter
+
+        function shaftKey(col) {
+          return "c" + col;
+        }
+        function stopKey(col, fy) {
+          return col + ":" + fy;
+        }
+        function carKey(col, idx) {
+          return col + "#" + idx;
+        }
+
+        // Each SKYSTACK shaft maps to its own wasm group ("independent
+        // mode"). Coordinated mode (one group spanning all shafts)
+        // lands in PR 6 once dispatch can filter cars by line within a
+        // shared group.
+        function ensureGroupFor(col) {
+          if (!window.wasmSim || FAILED) return null;
+          var k = shaftKey(col);
+          if (!WASM_GROUPS.has(k)) {
+            try {
+              var gid = window.wasmSim.addGroup(k, "look");
+              WASM_GROUPS.set(k, gid);
+            } catch (e) {
+              console.error("[skystack] addGroup failed:", e);
+              FAILED = true;
+              return null;
+            }
+          }
+          return WASM_GROUPS.get(k);
+        }
+
+        // Walk the JS-side state.elevators metadata and reconcile
+        // wasm topology against it. Called from rebuildElevators after
+        // SKYSTACK has discovered shafts from the grid.
+        function reconcileTopology() {
+          if (!window.wasmSim || FAILED) return;
+
+          // Collect the "wanted" set from current state.elevators.
+          var wantLines = new Map(); // shaftKey → {col, minY, maxY, cars: [{}]}
+          for (var ei = 0; ei < state.elevators.length; ei++) {
+            var e = state.elevators[ei];
+            var k = shaftKey(e.shaftX);
+            wantLines.set(k, { col: e.shaftX, minY: e.minY, maxY: e.maxY, cars: e.cars });
+          }
+
+          // Drop wasm lines (and the entire group, since each shaft
+          // owns its own group in v1) that no longer exist in JS.
+          for (var k of Array.from(WASM_LINES.keys())) {
+            if (!wantLines.has(k)) {
+              try {
+                window.wasmSim.removeLine(WASM_LINES.get(k));
+              } catch (e) {}
+              WASM_LINES.delete(k);
+              WASM_GROUPS.delete(k);
+              // Also drop stops + cars under this shaft from our maps.
+              for (var sk of Array.from(WASM_STOPS.keys())) {
+                if (sk.split(":")[0] === k.slice(1)) WASM_STOPS.delete(sk);
+              }
+              for (var ck of Array.from(WASM_CARS.keys())) {
+                if (ck.split("#")[0] === k.slice(1)) WASM_CARS.delete(ck);
+              }
+            }
+          }
+
+          // Add or extend lines, plus reconcile their stops + cars.
+          wantLines.forEach(function (want, k) {
+            var gid = ensureGroupFor(want.col);
+            if (gid === null) return;
+            var lineRef = WASM_LINES.get(k);
+            var off = want.col * SHAFT_OFFSET;
+            var min = want.minY * FLOOR_H + off;
+            var max = want.maxY * FLOOR_H + off;
+            try {
+              if (lineRef === undefined) {
+                lineRef = window.wasmSim.addLine(gid, k, min, max, 4);
+                WASM_LINES.set(k, lineRef);
+              } else {
+                window.wasmSim.setLineRange(lineRef, min, max);
+              }
+            } catch (e) {
+              console.error("[skystack] line topology failed:", e);
+              FAILED = true;
+              return;
+            }
+
+            // Reconcile stops on this shaft. The "wanted" set is every
+            // floor between minY and maxY (each shaft cell gets its
+            // own wasm stop; SCAN-era SKYSTACK didn't model floors as
+            // entities so we pick the simplest mapping).
+            var wantedStops = new Set();
+            for (var fy = want.minY; fy <= want.maxY; fy++) {
+              var sk = stopKey(want.col, fy);
+              wantedStops.add(sk);
+              if (!WASM_STOPS.has(sk)) {
+                try {
+                  var sref = window.wasmSim.addStop(lineRef, "F" + fy, fy * FLOOR_H + off);
+                  WASM_STOPS.set(sk, sref);
+                } catch (e) {
+                  console.error("[skystack] addStop failed:", e);
+                }
+              }
+            }
+            // Drop stops the player demolished (PR #448 ensures
+            // in-flight riders are rerouted/ejected gracefully).
+            for (var sk of Array.from(WASM_STOPS.keys())) {
+              if (sk.split(":")[0] !== String(want.col)) continue;
+              if (!wantedStops.has(sk)) {
+                try {
+                  window.wasmSim.removeStop(WASM_STOPS.get(sk));
+                } catch (e) {}
+                WASM_STOPS.delete(sk);
+              }
+            }
+
+            // Reconcile cars: ensure one wasm elevator per JS car.
+            var wantedCars = new Set();
+            for (var ci = 0; ci < want.cars.length; ci++) {
+              var ck = carKey(want.col, ci);
+              wantedCars.add(ck);
+              if (!WASM_CARS.has(ck)) {
+                try {
+                  var startY = (want.cars[ci].y || want.minY) * FLOOR_H + off;
+                  var cref = window.wasmSim.addElevator(lineRef, startY);
+                  WASM_CARS.set(ck, cref);
+                } catch (e) {
+                  console.error("[skystack] addElevator failed:", e);
+                }
+              }
+            }
+            for (var ck of Array.from(WASM_CARS.keys())) {
+              if (ck.split("#")[0] !== String(want.col)) continue;
+              if (!wantedCars.has(ck)) {
+                try {
+                  window.wasmSim.removeElevator(WASM_CARS.get(ck));
+                } catch (e) {}
+                WASM_CARS.delete(ck);
+              }
+            }
+          });
+        }
+
+        // Convert a JS `(col, fy)` pair to a wasm stop ref. Returns
+        // null if the stop hasn't been registered yet (player just
+        // built it; reconcile hasn't run).
+        function stopRef(col, fy) {
+          return WASM_STOPS.get(stopKey(col, fy)) || null;
+        }
+
+        // Press a hall call for an agent waiting at (col, fromY) heading
+        // to toY. Returns true on success. The agent's `wasmRiderRef`
+        // is set so subsequent ticks can correlate exit events.
+        function requestRide(agent, col, fromY, toY) {
+          if (!window.wasmSim || FAILED) return false;
+          if (agent.wasmRiderRef !== undefined) return true; // already in flight
+          var origin = stopRef(col, fromY);
+          var dest = stopRef(col, toY);
+          if (!origin || !dest) return false;
+          if (Number(origin) === Number(dest)) return false; // same-floor; nothing to ride
+          try {
+            var weight = agent.weight || 75.0;
+            var ridRef = window.wasmSim.spawnRiderByRef(origin, dest, weight, 0);
+            window.wasmSim.pressHallCall(origin, toY > fromY ? "up" : "down");
+            agent.wasmRiderRef = ridRef;
+            agent.wasmShaftCol = col;
+            agent.wasmFromY = fromY;
+            agent.wasmToY = toY;
+            RIDER_TO_AGENT.set(String(ridRef), agent.id);
+            return true;
+          } catch (e) {
+            console.error("[skystack] requestRide failed:", e);
+            return false;
+          }
+        }
+
+        // Step wasm simulation by N sim-ticks. Game-min ≈ 2 sim ticks.
+        function tickAll(n) {
+          if (!window.wasmSim || FAILED) return;
+          try {
+            window.wasmSim.stepMany(n);
+          } catch (e) {
+            console.error("[skystack] stepMany failed:", e);
+            FAILED = true;
+          }
+        }
+
+        // Drain wasm events; correlate riders to agents and resolve
+        // boarding / exit / abandonment.
+        function drainEvents() {
+          if (!window.wasmSim || FAILED) return;
+          var events;
+          try {
+            events = window.wasmSim.drainEvents();
+          } catch (e) {
+            return;
+          }
+          for (var i = 0; i < events.length; i++) {
+            var ev = events[i];
+            if (ev.kind === "rider-spawned") {
+              // Correlation already established by requestRide; nothing
+              // more to do. (Kept here as documentation.)
+            } else if (ev.kind === "rider-boarded") {
+              var aid = RIDER_TO_AGENT.get(String(ev.rider));
+              var agent2 = aid !== undefined ? findAgent(aid) : null;
+              if (agent2) {
+                agent2.waitTicks = 0;
+                agent2.waiting = false;
+              }
+            } else if (ev.kind === "rider-exited") {
+              var aid2 = RIDER_TO_AGENT.get(String(ev.rider));
+              var agent3 = aid2 !== undefined ? findAgent(aid2) : null;
+              if (agent3 && agent3.wasmToY !== undefined) {
+                // Place the agent at the exit floor. The next
+                // tickAgent() will resume horizontal walking.
+                agent3.y = agent3.wasmToY;
+                agent3.inElevator = null;
+                agent3.wasmRiderRef = undefined;
+                agent3.wasmShaftCol = undefined;
+                agent3.wasmFromY = undefined;
+                agent3.wasmToY = undefined;
+              }
+              RIDER_TO_AGENT.delete(String(ev.rider));
+            } else if (ev.kind === "rider-abandoned") {
+              var aid3 = RIDER_TO_AGENT.get(String(ev.rider));
+              var agent4 = aid3 !== undefined ? findAgent(aid3) : null;
+              if (agent4) {
+                // Treat as if they gave up — leave the building.
+                agent4.phase = "leaving";
+                agent4.inElevator = null;
+                agent4.wasmRiderRef = undefined;
+              }
+              RIDER_TO_AGENT.delete(String(ev.rider));
+            }
+          }
+        }
+
+        // Mirror wasm car positions back into state.elevators so the
+        // existing renderer (drawElevatorCar) works unchanged.
+        function syncMirror() {
+          if (!window.wasmSim || FAILED) return;
+          var view;
+          try {
+            view = window.wasmSim.worldView();
+          } catch (e) {
+            return;
+          }
+          var carById = new Map();
+          for (var i = 0; i < view.cars.length; i++) {
+            carById.set(String(view.cars[i].id), view.cars[i]);
+          }
+          for (var ei = 0; ei < state.elevators.length; ei++) {
+            var elev = state.elevators[ei];
+            var off = elev.shaftX * SHAFT_OFFSET;
+            for (var ci = 0; ci < elev.cars.length; ci++) {
+              var ref = WASM_CARS.get(carKey(elev.shaftX, ci));
+              if (ref === undefined) continue;
+              var wc = carById.get(String(ref));
+              if (!wc) continue;
+              var floorY = (wc.y - off) / FLOOR_H;
+              elev.cars[ci].floatY = floorY;
+              elev.cars[ci].y = Math.round(floorY);
+              // Mirror passengers as wasm rider refs translated to
+              // agent ids (when known). The renderer uses this to
+              // count passengers and to find agents for in-elevator
+              // overlay drawing.
+              var passengers = [];
+              for (var ri = 0; ri < wc.rider_ids.length; ri++) {
+                var aid = RIDER_TO_AGENT.get(String(wc.rider_ids[ri]));
+                if (aid !== undefined) passengers.push(aid);
+              }
+              elev.cars[ci].passengers = passengers;
+              elev.cars[ci].dir = wc.v >= 0 ? 1 : -1;
+            }
+          }
+        }
+
+        return {
+          reconcileTopology: reconcileTopology,
+          tickAll: tickAll,
+          drainEvents: drainEvents,
+          syncMirror: syncMirror,
+          requestRide: requestRide,
+          stopRef: stopRef,
+          isReady: function () {
+            return !!window.wasmSim && !FAILED;
+          },
+          isFailed: function () {
+            return FAILED;
+          },
+        };
+      })();
+      window.SkystackWasm = SkystackWasm;
 
       /* ===== UNIT TYPES ===== */
       var UNITS = {
@@ -6868,6 +7231,10 @@
             cars: cars,
           });
         }
+        // Push the new shaft topology to the wasm sim. Safe to call
+        // before wasm is ready — reconcileTopology no-ops in that case
+        // and the next call (after wasmReady resolves) catches up.
+        SkystackWasm.reconcileTopology();
       }
 
       function addElevatorCar(gx, gy) {
@@ -6895,6 +7262,9 @@
             }
             e.cars.push({ y: e.minY, floatY: e.minY, dir: 1, passengers: [], stopTimer: 0 });
             state.cash -= cost;
+            // Push the new car to wasm too. Reconcile is a single
+            // entry-point that picks up the new entry in `e.cars`.
+            SkystackWasm.reconcileTopology();
             showToast("Added elevator car (+1, now " + e.cars.length + ")");
             return;
           }
@@ -7015,7 +7385,19 @@
           tickAgent(state.agents[i]);
           if (state.agents[i].state === "gone") state.agents.splice(i, 1);
         }
-        for (var ei = 0; ei < state.elevators.length; ei++) tickElevator(state.elevators[ei]);
+        // Wasm sim drives elevator dispatch + movement + loading.
+        // Each game-minute = SKYSTACK_SIM_TICKS_PER_GAME_MIN sim ticks.
+        if (SkystackWasm.isReady()) {
+          SkystackWasm.tickAll(window.SKYSTACK_SIM_TICKS_PER_GAME_MIN || 2);
+          SkystackWasm.drainEvents();
+          SkystackWasm.syncMirror();
+        } else {
+          // Wasm not yet loaded — fall back to the legacy SCAN
+          // scheduler so the game stays playable during the initial
+          // page load (~1s on slow connections). Drops out as soon
+          // as wasmReady resolves.
+          for (var ei = 0; ei < state.elevators.length; ei++) tickElevator(state.elevators[ei]);
+        }
         // Decay active events
         tickEvents();
       }
@@ -7700,6 +8082,25 @@
           if (transport.kind === "elevator") {
             var elev = state.elevators[transport.elevIdx];
             if (!elev) return false;
+            // Route through wasm when ready: spawn a Rider and press
+            // the hall call. The agent is "in flight" until the
+            // `rider-exited` event places them at `ty`. Fall back to
+            // the legacy queue if wasm hasn't loaded or the bridge
+            // failed (so the game stays playable during page load).
+            if (SkystackWasm.isReady() && a.wasmRiderRef === undefined) {
+              if (SkystackWasm.requestRide(a, elev.shaftX, a.y, ty)) {
+                a.inElevator = elev;
+                a.waiting = true;
+                return false;
+              }
+              // requestRide failed (e.g. stop not yet reconciled) —
+              // fall through to legacy queue so the agent isn't stuck.
+            }
+            if (a.wasmRiderRef !== undefined) {
+              // Already in flight — wait for rider-exited.
+              a.waiting = true;
+              return false;
+            }
             var goingUp = ty > a.y;
             var queue = goingUp ? elev.queueUp : elev.queueDown;
             if (!queue[a.y]) queue[a.y] = [];

--- a/playground/src/__tests__/skystack-vendored.test.ts
+++ b/playground/src/__tests__/skystack-vendored.test.ts
@@ -24,4 +24,22 @@ describe("skystack vendored bundle", () => {
     const readme = readFileSync(resolve(SKYSTACK_DIR, "README.md"), "utf-8");
     expect(readme).toContain("c05dc685b59ca25e3ca63916ad0b2a7555758bbc");
   });
+
+  it("wires the elevator-core wasm bridge", () => {
+    const html = readFileSync(resolve(SKYSTACK_DIR, "Tower.html"), "utf-8");
+    // Wasm bootstrap module imports the shared bundle.
+    expect(html).toMatch(
+      /<script\s+type="module">[\s\S]*import\s+init,\s*\{\s*WasmSim\s*\}\s*from\s*"\.\.\/pkg\/elevator_wasm\.js"/,
+    );
+    expect(html).toContain("window.wasmReady");
+    // SkystackWasm namespace is the JS-side bridge.
+    expect(html).toContain("SkystackWasm");
+    expect(html).toContain("reconcileTopology");
+    expect(html).toContain("requestRide");
+    // rebuildElevators triggers the bridge.
+    expect(html).toMatch(/SkystackWasm\.reconcileTopology\(\)/);
+    // simMinute drives the wasm sim and drains events when ready.
+    expect(html).toMatch(/SkystackWasm\.tickAll\(/);
+    expect(html).toMatch(/SkystackWasm\.drainEvents\(\)/);
+  });
 });


### PR DESCRIPTION
## Summary

- Surgically routes SKYSTACK's elevator dispatch + movement + loading through `wasmSim` while preserving everything else (renderer, mail, market, scenarios, weather, save/load, prestige, agent state machine, daily challenge).
- Adds a small `<script type="module">` wasm bootstrap and a ~250-line `SkystackWasm` JS namespace that reconciles wasm topology against `state.elevators`, steps the sim per game-minute, drains rider events, and mirrors car positions back into `state.elevators[].cars[].floatY` so the existing renderer just works.
- `stepToward`'s elevator branch now routes new boarding requests through `wasmSim.spawnRiderByRef()` + `pressHallCall()` instead of pushing into the legacy `e.queueUp/queueDown` queues.
- Each shaft becomes its own wasm dispatch group ("independent mode"). Coordinated mode lands in PR 6.
- Adds `WasmSim::spawnRiderByRef(origin_ref, dest_ref, weight, patience?) -> bigint` — companion to the existing `spawnRider` (which takes `StopId(u32)`) for runtime-added stops with no config-time `StopId`. Returns the rider entity ref so callers correlate with `rider-*` events.
- Maps grid Y → wasm position with `fy * 3.0 + col * 0.0001` — the per-column offset breaks `find_stop_at_position` ties when two shafts have stops at the same physical floor.

### Fallback behaviour

If the wasm bundle fails to load, `SkystackWasm.isReady()` returns false and the legacy SCAN scheduler runs as before. A red banner surfaces the wasm error to the player. Per-tick `requestRide` also falls through to the legacy queue if a stop hasn't been reconciled yet (race between grid edit and bridge sync).

### v1 limitations (documented in README)

- Save/load: in-flight wasm riders aren't serialized; agents re-route through the bridge on their next tick after load.
- Mode: independent only; coordinated lands in PR 6.
- Mobile: upstream desktop layout unchanged.

## Test plan

- [x] New `skystack_runtime_world_delivers_a_rider` Rust test exercises the same code path the bridge takes (add_group → add_line → add_stops → add_elevator → build_rider with EntityIds → step until delivered).
- [x] Updated playground smoke test asserts the wasm bootstrap module, SkystackWasm namespace, and key bridge call sites are present.
- [x] 848 lib + integration + 159 doctests pass.
- [x] 132 playground tests pass (1 new bridge smoke).
- [x] \`cargo clippy --all-features --all-targets -- -D warnings\` clean.
- [x] \`pnpm build\` produces \`dist/skystack/Tower.html\`.
- [ ] Manual: open /skystack/Tower.html, build a 5-floor tower with 1 shaft + 1 car, place a worker on floor 1 → 3, watch them ride. Then add a 2nd shaft mid-game and demolish a floor mid-trip.