### PR TITLE
feat(skystack): add coordinated/independent grouping mode toggle

### DIFF
--- a/playground/public/skystack/README.md
+++ b/playground/public/skystack/README.md
@@ -26,14 +26,35 @@ This page is a thin wasm bridge over the upstream `Tower.html`:
 Renderer, mail, market, scenarios, weather, save/load, prestige,
 agent state machine, and the daily challenge are untouched.
 
+## Grouping modes
+
+Each scenario picks how shafts share dispatchers via the
+`groupingMode` field on the scenario definition (default
+`"independent"`):
+
+- **`independent`** — each shaft owns its own wasm dispatch group.
+  A car on shaft A only ever serves shaft A's hall calls. This is
+  the recommended default for normal play because dispatch behaves
+  exactly as you'd expect.
+- **`coordinated`** — every shaft shares one dispatch group. Cars
+  are assigned across shafts based on proximity. The "Coordinated
+  Tower" scenario uses this mode as a showcase. Caveat: dispatch
+  in a multi-line group does not currently filter cars by line
+  membership, so an occasional cross-shaft assignment can leave
+  a rider waiting longer than necessary. The per-line bookkeeping
+  under `assigned_cars_by_line` is correct; only the assignment
+  heuristic is suboptimal here.
+
+A URL override is available for testing without editing scenarios:
+append `?mode=coordinated` (or `?mode=independent`) to the page URL.
+
 ## v1 limitations
 
 - **Save/load**: in-flight wasm riders aren't serialized. On load
   the game rebuilds wasm topology from the grid; agents re-route
   through the bridge on their next tick.
-- **Mode**: each shaft becomes its own wasm dispatch group
-  ("independent mode"). PR 6 adds a "coordinated mode" toggle for
-  scenarios where neighbouring shafts should share a dispatcher.
+- **Mode-switch mid-game**: switching scenarios tears down and
+  rebuilds wasm topology, which respawns in-flight riders.
 - **Mobile**: upstream desktop layout. Mobile restyling tracked
   as a follow-up.
 

--- a/playground/public/skystack/Tower.html
+++ b/playground/public/skystack/Tower.html
@@ -2766,13 +2766,34 @@
           return col + "#" + idx;
         }
 
-        // Each SKYSTACK shaft maps to its own wasm group ("independent
-        // mode"). Coordinated mode (one group spanning all shafts)
-        // lands in PR 6 once dispatch can filter cars by line within a
-        // shared group.
+        // Default: each SKYSTACK shaft maps to its own wasm group
+        // ("independent mode"). Scenarios can opt into "coordinated"
+        // mode by setting `state.scenario.groupingMode = "coordinated"`
+        // — all shafts then share one group and dispatch picks the
+        // closest car across all shafts.
+        //
+        // CAVEAT: in coordinated mode, dispatch within a multi-line
+        // group does not currently filter cars by line membership.
+        // A car on shaft A may be assigned to a stop on shaft B, sit
+        // there with no way to reach it, and the rider waits longer
+        // than necessary. Use coordinated mode for showcase /
+        // experimentation; independent mode is the recommended
+        // default for normal play.
+        var SHARED_GROUP_KEY = "_tower";
+        function currentGroupingMode() {
+          // URL override (`?mode=coordinated`) for testing without
+          // touching scenario definitions.
+          try {
+            var p = new URLSearchParams(window.location.search).get("mode");
+            if (p === "coordinated" || p === "independent") return p;
+          } catch (e) {}
+          var sc = window.state && state.scenario;
+          if (sc && sc.groupingMode === "coordinated") return "coordinated";
+          return "independent";
+        }
         function ensureGroupFor(col) {
           if (!window.wasmSim || FAILED) return null;
-          var k = shaftKey(col);
+          var k = currentGroupingMode() === "coordinated" ? SHARED_GROUP_KEY : shaftKey(col);
           if (!WASM_GROUPS.has(k)) {
             try {
               var gid = window.wasmSim.addGroup(k, "look");
@@ -4564,6 +4585,22 @@
           difficulty: "Relaxed",
           init: function () {},
           goalText: null,
+        },
+        coordinated: {
+          name: "Coordinated Tower",
+          desc:
+            "Showcase: every shaft shares one wasm dispatch group. Cars are assigned across shafts based on proximity. " +
+            "Best with multi-shaft buildings; expect occasional dispatch quirks since dispatch doesn't yet filter by line.",
+          difficulty: "Experimental",
+          groupingMode: "coordinated",
+          init: function () {
+            state.cash = 5000000;
+            state.scenarioId = "coordinated";
+          },
+          goalText: "Reach 3★ with a coordinated multi-shaft layout",
+          goalTest: function () {
+            return state.stars >= 3;
+          },
         },
         sprint: {
           name: "Sprint",

--- a/playground/public/skystack/Tower.html
+++ b/playground/public/skystack/Tower.html
@@ -2787,7 +2787,7 @@
             var p = new URLSearchParams(window.location.search).get("mode");
             if (p === "coordinated" || p === "independent") return p;
           } catch (e) {}
-          var sc = window.state && state.scenario;
+          var sc = window.state && window.state.scenario;
           if (sc && sc.groupingMode === "coordinated") return "coordinated";
           return "independent";
         }

--- a/playground/src/__tests__/skystack-vendored.test.ts
+++ b/playground/src/__tests__/skystack-vendored.test.ts
@@ -42,4 +42,24 @@ describe("skystack vendored bundle", () => {
     expect(html).toMatch(/SkystackWasm\.tickAll\(/);
     expect(html).toMatch(/SkystackWasm\.drainEvents\(\)/);
   });
+
+  it("supports the coordinated/independent grouping-mode toggle", () => {
+    const html = readFileSync(resolve(SKYSTACK_DIR, "Tower.html"), "utf-8");
+    // Mode resolution function exists.
+    expect(html).toContain("currentGroupingMode");
+    // URL override is wired.
+    expect(html).toContain('"mode"');
+    expect(html).toContain('"coordinated"');
+    // Coordinated scenario shows up in SCENARIOS.
+    expect(html).toContain("coordinated: {");
+    expect(html).toContain('groupingMode: "coordinated"');
+  });
+
+  it("README documents both grouping modes", () => {
+    const readme = readFileSync(resolve(SKYSTACK_DIR, "README.md"), "utf-8");
+    expect(readme).toContain("Grouping modes");
+    expect(readme).toContain("`independent`");
+    expect(readme).toContain("`coordinated`");
+    expect(readme).toContain("?mode=coordinated");
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a per-scenario `groupingMode: "independent" | "coordinated"` toggle to SKYSTACK.
- **Independent** (default): each shaft owns its own wasm dispatch group — cars on shaft A only serve shaft A's hall calls. Recommended for normal play.
- **Coordinated**: every shaft shares one dispatch group — cars are assigned across shafts based on proximity. Showcases cross-shaft dispatch.
- Adds a "Coordinated Tower" scenario as the showcase / opt-in for the new mode.
- URL override `?mode=coordinated|independent` for testing without editing scenarios.

### Caveat (documented in README)

Dispatch in a multi-line group does not currently filter cars by line membership. In coordinated mode an occasional cross-shaft assignment can leave a rider waiting longer than necessary. The per-line bookkeeping under `assigned_cars_by_line` is correct; only the assignment heuristic is suboptimal here. Independent mode avoids the issue entirely.

A follow-up core fix (filter dispatch candidates by line membership) would make coordinated mode optimal; tracked separately.

## Test plan

- [x] 2 new SKYSTACK smoke tests verify the grouping-mode hooks (mode resolver, URL override, scenario flag) and README documentation.
- [x] All 6 SKYSTACK smoke tests pass.
- [x] \`pnpm build\` produces \`dist/skystack/Tower.html\`.
- [ ] Manual: open \`/skystack/Tower.html?mode=coordinated\` with a 2-shaft tower; press a hall call between shafts; verify the closer car responds (or times out per the documented caveat).