### PR TITLE
fix(core): filter dispatch candidates by line membership

### DIFF
--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -1317,6 +1317,17 @@ pub(crate) fn assign_with_scratch(
                         .find(|li| li.entity() == line_eid)
                         .map(LineInfo::serves)
                 });
+            // `None` here means the car's line isn't in this group's
+            // line list — a topology inconsistency that should be
+            // unreachable. We can't fail the dispatch tick over it (the
+            // sim still has to make progress), so the filter falls
+            // open: the car is treated as if it could reach any stop.
+            // The debug-assert catches it during testing without
+            // affecting release builds.
+            debug_assert!(
+                world.elevator(car_eid).is_none() || car_serves.is_some(),
+                "car {car_eid:?} on line not present in its group's lines list"
+            );
 
             for (j, &(stop_eid, stop_pos)) in pending_stops.iter().enumerate() {
                 if restricted.is_some_and(|r| r.contains(&stop_eid)) {

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -1294,9 +1294,36 @@ pub(crate) fn assign_with_scratch(
             let restricted = world
                 .elevator(car_eid)
                 .map(crate::components::Elevator::restricted_stops);
+
+            // The car's line's `serves` list is the set of stops it can
+            // physically reach. In a single-line group every stop is
+            // served (filter is a no-op); in a multi-line group (e.g.
+            // sky-lobby + service bank, or SKYSTACK's "coordinated"
+            // tower mode) a car on line A must not be assigned to a
+            // stop only line B serves — it would commit, sit there
+            // unable to reach, and starve the call. The pre-fix matrix
+            // happily ranked such cross-line pairs because no other
+            // gate caught them: `restricted_stops` is for explicit
+            // access denials, `pending_stops_minus_covered` filters
+            // stops not cars, and built-in strategies score on
+            // distance/direction without consulting line topology.
+            let car_serves: Option<&[EntityId]> = world
+                .elevator(car_eid)
+                .map(crate::components::Elevator::line)
+                .and_then(|line_eid| {
+                    group
+                        .lines()
+                        .iter()
+                        .find(|li| li.entity() == line_eid)
+                        .map(LineInfo::serves)
+                });
+
             for (j, &(stop_eid, stop_pos)) in pending_stops.iter().enumerate() {
                 if restricted.is_some_and(|r| r.contains(&stop_eid)) {
                     continue; // leave SENTINEL — this pair is unavailable
+                }
+                if car_serves.is_some_and(|s| !s.contains(&stop_eid)) {
+                    continue; // car's line doesn't reach this stop
                 }
                 let ctx = RankContext {
                     car: car_eid,

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -3349,3 +3349,164 @@ fn waiting_counts_by_line_partitions_by_route_group() {
         assert_eq!(*n, 1, "each line carries exactly one rider");
     }
 }
+
+/// Single group, two lines with disjoint stop sets — the dispatcher
+/// must not assign a car to a stop that car's line doesn't serve.
+///
+/// Pre-fix the cost matrix happily ranked every `(car, stop)` pair in
+/// the group; `restricted_stops` was the only filter, and built-in
+/// strategies score on distance/direction without consulting line
+/// topology. A car on line A would get assigned to a stop only line B
+/// served, sit there, never reach it, and starve the call.
+///
+/// Surfaced during the SKYSTACK port's "coordinated" mode (one group
+/// spanning multiple shafts).
+#[test]
+fn dispatch_does_not_assign_car_to_stop_its_line_does_not_serve() {
+    // One group, two lines:
+    //   Line A: serves stops 0 and 1
+    //   Line B: serves stops 2 and 3
+    // A car on Line B must NOT be dispatched to a hall call at stop 0.
+    let config = SimConfig {
+        building: BuildingConfig {
+            name: "Disjoint".into(),
+            stops: vec![
+                StopConfig {
+                    id: StopId(0),
+                    name: "A0".into(),
+                    position: 0.0,
+                },
+                StopConfig {
+                    id: StopId(1),
+                    name: "A1".into(),
+                    position: 4.0,
+                },
+                StopConfig {
+                    id: StopId(2),
+                    name: "B0".into(),
+                    position: 100.0,
+                },
+                StopConfig {
+                    id: StopId(3),
+                    name: "B1".into(),
+                    position: 104.0,
+                },
+            ],
+            lines: Some(vec![
+                LineConfig {
+                    id: 1,
+                    name: "A".into(),
+                    serves: vec![StopId(0), StopId(1)],
+                    elevators: vec![ElevatorConfig {
+                        id: 1,
+                        name: "carA".into(),
+                        max_speed: Speed::from(2.0),
+                        acceleration: Accel::from(1.5),
+                        deceleration: Accel::from(2.0),
+                        weight_capacity: Weight::from(800.0),
+                        starting_stop: StopId(0),
+                        door_open_ticks: 10,
+                        door_transition_ticks: 5,
+                        restricted_stops: Vec::new(),
+                        #[cfg(feature = "energy")]
+                        energy_profile: None,
+                        service_mode: None,
+                        inspection_speed_factor: 0.25,
+                        bypass_load_up_pct: None,
+                        bypass_load_down_pct: None,
+                    }],
+                    orientation: Orientation::Vertical,
+                    position: None,
+                    min_position: None,
+                    max_position: None,
+                    max_cars: None,
+                },
+                LineConfig {
+                    id: 2,
+                    name: "B".into(),
+                    serves: vec![StopId(2), StopId(3)],
+                    elevators: vec![ElevatorConfig {
+                        id: 2,
+                        name: "carB".into(),
+                        max_speed: Speed::from(2.0),
+                        acceleration: Accel::from(1.5),
+                        deceleration: Accel::from(2.0),
+                        weight_capacity: Weight::from(800.0),
+                        starting_stop: StopId(2),
+                        door_open_ticks: 10,
+                        door_transition_ticks: 5,
+                        restricted_stops: Vec::new(),
+                        #[cfg(feature = "energy")]
+                        energy_profile: None,
+                        service_mode: None,
+                        inspection_speed_factor: 0.25,
+                        bypass_load_up_pct: None,
+                        bypass_load_down_pct: None,
+                    }],
+                    orientation: Orientation::Vertical,
+                    position: None,
+                    min_position: None,
+                    max_position: None,
+                    max_cars: None,
+                },
+            ]),
+            groups: Some(vec![GroupConfig {
+                id: 0,
+                name: "shared".into(),
+                lines: vec![1, 2],
+                dispatch: crate::dispatch::BuiltinStrategy::Scan,
+                reposition: None,
+                hall_call_mode: None,
+                ack_latency_ticks: None,
+            }]),
+        },
+        elevators: Vec::new(),
+        simulation: SimulationParams {
+            ticks_per_second: 60.0,
+        },
+        passenger_spawning: PassengerSpawnConfig {
+            mean_interval_ticks: 120,
+            weight_range: (50.0, 100.0),
+        },
+    };
+
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+    let stop_a0 = sim.stop_entity(StopId(0)).unwrap();
+    let car_a = sim
+        .world()
+        .iter_elevators()
+        .find_map(|(eid, _, e)| (sim.world().line(e.line()).unwrap().name() == "A").then_some(eid))
+        .unwrap();
+    let car_b = sim
+        .world()
+        .iter_elevators()
+        .find_map(|(eid, _, e)| (sim.world().line(e.line()).unwrap().name() == "B").then_some(eid))
+        .unwrap();
+
+    // Spawn a rider routed via the shared group at stop A0 → A1. The
+    // dispatcher must pick car_a (line A serves both); car_b (line B)
+    // must never be assigned. Watch the ElevatorAssigned events.
+    sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
+
+    let mut saw_correct_assignment = false;
+    for _ in 0..200 {
+        for ev in sim.drain_events() {
+            if let SimEvent::ElevatorAssigned { elevator, stop, .. } = ev
+                && stop == stop_a0
+            {
+                assert_ne!(
+                    elevator, car_b,
+                    "car_b (line B) was assigned to stop A0 — line filter regressed"
+                );
+                if elevator == car_a {
+                    saw_correct_assignment = true;
+                }
+            }
+        }
+        sim.step();
+    }
+    assert!(
+        saw_correct_assignment,
+        "car_a (line A) should have been assigned to stop A0"
+    );
+}


### PR DESCRIPTION
## Summary

- Closes a real bug in multi-line dispatch: pre-fix the cost matrix happily ranked every `(car, stop)` pair within a group, with `restricted_stops` as the only short-circuit. Built-in strategies score on distance/direction without consulting line topology, so a car on line A could get assigned to a stop only line B served, sit there unable to reach it, and starve the call indefinitely.
- Surfaced during the SKYSTACK port's "coordinated" mode (one group spanning multiple shafts/lines, PR #455). The bridge sidesteps it by defaulting to one-group-per-shaft, but the bug is real for any multi-line group: sky-lobby + service bank, low/high banks sharing a transfer floor, etc.
- Fix: in the cost matrix loop, look up the car's line's `serves` list once per row, then short-circuit any `(car, stop)` pair where the stop isn't in that list. Single-line groups are unaffected (every stop is served — filter is a no-op).

## Test plan

- [x] New `dispatch_does_not_assign_car_to_stop_its_line_does_not_serve` in `multi_line_tests.rs`. Two lines with disjoint stop sets in one group; spawn a rider needing line A; verify line B's car is never assigned.
- [x] 849 lib + integration + 159 doctests pass — no existing test relied on the buggy cross-line behavior.
- [x] \`cargo clippy --all-features --all-targets -- -D warnings\` clean.
- [x] \`cargo check --workspace\` clean.

## Follow-up

This makes SKYSTACK's "coordinated" mode behave optimally — cars are assigned across shafts based on proximity within their reachable line, no more "wrong shaft picks up the call" surprises.