### PR TITLE
feat(core): per-line stop-at-position lookup

### DIFF
--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -817,6 +817,29 @@ impl Simulation {
             .map_or_else(Vec::new, |li| li.serves().to_vec())
     }
 
+    /// Find the stop at `position` that's served by `line`.
+    ///
+    /// Disambiguates the case where two stops on different lines share
+    /// the same physical position (e.g. parallel shafts at the same
+    /// floor, or a sky-lobby served by both a low and high bank). The
+    /// global [`World::find_stop_at_position`](crate::world::World::find_stop_at_position)
+    /// returns whichever stop wins the linear scan; this variant
+    /// scopes the lookup to the line's `serves` list so consumers
+    /// always get the stop *on the line they asked about*.
+    ///
+    /// Returns `None` if the line doesn't exist or no served stop
+    /// matches the position.
+    #[must_use]
+    pub fn find_stop_at_position_on_line(&self, position: f64, line: EntityId) -> Option<EntityId> {
+        let line_info = self
+            .groups
+            .iter()
+            .flat_map(ElevatorGroup::lines)
+            .find(|li| li.entity() == line)?;
+        self.world
+            .find_stop_at_position_in(position, line_info.serves())
+    }
+
     /// Get the line entity for an elevator.
     #[must_use]
     pub fn line_for_elevator(&self, elevator: EntityId) -> Option<EntityId> {

--- a/crates/elevator-core/src/tests/topology_tests.rs
+++ b/crates/elevator-core/src/tests/topology_tests.rs
@@ -439,3 +439,34 @@ fn runtime_stop_has_no_stop_id() {
     );
     // There's no StopId for the runtime stop — only EntityId.
 }
+
+#[test]
+fn find_stop_at_position_on_line_walks_group_topology() {
+    let config = default_config();
+    let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
+    let line = sim.lines_in_group(GroupId(0))[0];
+
+    let stop = sim.add_stop("Roof".into(), 20.0, line).unwrap();
+
+    // Happy path: line exists, stop position matches.
+    assert_eq!(
+        sim.find_stop_at_position_on_line(20.0, line),
+        Some(stop),
+        "lookup should find the stop on the line"
+    );
+
+    // None case 1: position has no stop on this line.
+    assert_eq!(
+        sim.find_stop_at_position_on_line(99.0, line),
+        None,
+        "no stop at position 99.0"
+    );
+
+    // None case 2: line entity doesn't exist.
+    let bogus = sim.world_mut().spawn();
+    assert_eq!(
+        sim.find_stop_at_position_on_line(20.0, bogus),
+        None,
+        "unknown line should resolve to None"
+    );
+}

--- a/crates/elevator-core/src/tests/world_tests.rs
+++ b/crates/elevator-core/src/tests/world_tests.rs
@@ -132,6 +132,51 @@ fn find_stop_at_position() {
 }
 
 #[test]
+fn find_stop_at_position_in_disambiguates_co_located_stops() {
+    // Two stops at the same physical position — global lookup is
+    // ambiguous; the per-line variant must respect the candidates
+    // filter so callers get the stop they actually meant.
+    let mut world = World::new();
+    let s_low = world.spawn();
+    world.set_stop(
+        s_low,
+        Stop {
+            name: "Lobby (low bank)".into(),
+            position: 0.0,
+        },
+    );
+    let s_high = world.spawn();
+    world.set_stop(
+        s_high,
+        Stop {
+            name: "Lobby (high bank)".into(),
+            position: 0.0,
+        },
+    );
+
+    // Asking for stops on the "high bank" line returns s_high regardless
+    // of which one wins the global linear scan.
+    let high_bank_stops = [s_high];
+    assert_eq!(
+        world.find_stop_at_position_in(0.0, &high_bank_stops),
+        Some(s_high)
+    );
+
+    let low_bank_stops = [s_low];
+    assert_eq!(
+        world.find_stop_at_position_in(0.0, &low_bank_stops),
+        Some(s_low)
+    );
+
+    // No candidates → None even when stops exist at the position.
+    assert_eq!(world.find_stop_at_position_in(0.0, &[]), None);
+
+    // Candidates at a different position → None.
+    let other_stops = [s_low];
+    assert_eq!(world.find_stop_at_position_in(50.0, &other_stops), None);
+}
+
+#[test]
 fn multiple_entities_independent() {
     let mut world = World::new();
     let a = world.spawn();

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -703,7 +703,8 @@ impl World {
             .filter(|(id, r)| r.phase == RiderPhase::Waiting && !self.is_disabled(*id))
     }
 
-    /// Find the stop entity at a given position (within epsilon).
+    /// Find the stop entity at a given position (within
+    /// [`STOP_POSITION_EPSILON`](Self::STOP_POSITION_EPSILON)).
     ///
     /// Global lookup — does not filter by line. When two stops on
     /// different lines share the same physical position the result is
@@ -713,9 +714,8 @@ impl World {
     /// when the caller knows which line's stops to consider.
     #[must_use]
     pub fn find_stop_at_position(&self, position: f64) -> Option<EntityId> {
-        const EPSILON: f64 = 1e-6;
         self.stops.iter().find_map(|(id, stop)| {
-            if (stop.position - position).abs() < EPSILON {
+            if (stop.position - position).abs() < Self::STOP_POSITION_EPSILON {
                 Some(id)
             } else {
                 None
@@ -741,13 +741,19 @@ impl World {
         position: f64,
         candidates: &[EntityId],
     ) -> Option<EntityId> {
-        const EPSILON: f64 = 1e-6;
         candidates.iter().copied().find(|&id| {
             self.stops
                 .get(id)
-                .is_some_and(|stop| (stop.position - position).abs() < EPSILON)
+                .is_some_and(|stop| (stop.position - position).abs() < Self::STOP_POSITION_EPSILON)
         })
     }
+
+    /// Tolerance for [`find_stop_at_position`](Self::find_stop_at_position)
+    /// and [`find_stop_at_position_in`](Self::find_stop_at_position_in).
+    /// Sub-micrometre — small enough that no two distinct floors should
+    /// land within it, large enough to absorb floating-point noise from
+    /// trapezoidal-velocity arrival math.
+    pub const STOP_POSITION_EPSILON: f64 = 1e-6;
 
     /// Find the stop entity nearest to a given position.
     ///

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -704,6 +704,13 @@ impl World {
     }
 
     /// Find the stop entity at a given position (within epsilon).
+    ///
+    /// Global lookup — does not filter by line. When two stops on
+    /// different lines share the same physical position the result is
+    /// whichever wins the linear scan, which is rarely what the
+    /// caller actually wants. Prefer
+    /// [`find_stop_at_position_in`](Self::find_stop_at_position_in)
+    /// when the caller knows which line's stops to consider.
     #[must_use]
     pub fn find_stop_at_position(&self, position: f64) -> Option<EntityId> {
         const EPSILON: f64 = 1e-6;
@@ -713,6 +720,32 @@ impl World {
             } else {
                 None
             }
+        })
+    }
+
+    /// Find the stop at a given position from within `candidates`.
+    ///
+    /// `candidates` is typically the `serves` list of a particular
+    /// [`LineInfo`](crate::dispatch::LineInfo) — i.e. the stops a
+    /// specific line can reach. Use this when a car arrives at a
+    /// position and you need *its* line's stop entity, not whichever
+    /// stop on any line happens to share the position. (Two parallel
+    /// shafts at the same physical floor, or a sky-lobby served by
+    /// both a low and high bank, both produce position collisions
+    /// the global lookup can't disambiguate.)
+    ///
+    /// O(n) over `candidates`, which is typically small.
+    #[must_use]
+    pub fn find_stop_at_position_in(
+        &self,
+        position: f64,
+        candidates: &[EntityId],
+    ) -> Option<EntityId> {
+        const EPSILON: f64 = 1e-6;
+        candidates.iter().copied().find(|&id| {
+            self.stops
+                .get(id)
+                .is_some_and(|stop| (stop.position - position).abs() < EPSILON)
         })
     }
 

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -616,6 +616,17 @@ impl WasmSim {
             .map_err(|e| JsError::new(&format!("press_car_button: {e}")))
     }
 
+    /// Find the stop entity at `position` that's served by `line_ref`,
+    /// or `0` (slotmap-null) if none. Lets consumers like SKYSTACK
+    /// disambiguate co-located stops on different lines without the
+    /// per-shaft offset hack the bridge currently uses.
+    #[wasm_bindgen(js_name = findStopAtPositionOnLine)]
+    pub fn find_stop_at_position_on_line(&self, position: f64, line_ref: u64) -> u64 {
+        self.inner
+            .find_stop_at_position_on_line(position, u64_to_entity(line_ref))
+            .map_or(0, entity_to_u64)
+    }
+
     // ── Uniform elevator-physics setters ─────────────────────────────
     //
     // Apply a single value to every elevator in the sim. Wired to the


### PR DESCRIPTION
## Summary

Two stops on different lines can share the same physical position (parallel shafts at the same floor, sky-lobby served by both a low and high bank, SKYSTACK shafts in coordinated mode). The existing \`World::find_stop_at_position\` does a global linear scan and returns whichever stop wins — rarely what the caller actually wants when they have a specific line in mind.

Adds two complementary APIs:

- \`World::find_stop_at_position_in(pos, candidates)\` — base layer. Caller provides an explicit slice of candidate stops (typically a line's \`serves\` list). Composable; doesn't depend on group state.
- \`Simulation::find_stop_at_position_on_line(pos, line)\` — ergonomic wrapper. Looks up the line's \`LineInfo\` from groups and forwards. Returns \`None\` if the line doesn't exist or no served stop matches.
- \`WasmSim::findStopAtPositionOnLine(pos, lineRef) -> bigint\` — JS-callable. Returns 0 (slotmap-null) when not found. Lets consumers like SKYSTACK disambiguate without the per-shaft offset hack the bridge currently uses.

Existing \`find_stop_at_position\` is unchanged (still global). Internal systems (loading, dispatch, doors, reposition, advance_queue) still use the global lookup; migrating each is a separate task that requires threading group state to the system call sites.

## Test plan

- [x] New \`find_stop_at_position_in_disambiguates_co_located_stops\` covers the disambiguation directly on \`World\`.
- [x] 849 lib + integration + 159 doctests pass.
- [x] \`cargo clippy --all-features --all-targets -- -D warnings\` clean.
- [x] TS bindings regenerate cleanly with \`findStopAtPositionOnLine\`.

## Follow-up

A future PR can migrate the 6 internal call sites (loading.rs:96, advance_queue.rs:75, doors.rs:196, dispatch/destination.rs:519, reposition.rs:121, dispatch.rs:237/281) to use the per-line variant. Each needs the car's line + the group's LineInfo threaded in.