### PR TITLE
refactor(core): migrate internal find_stop callers to per-line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.25.0"
+version = "15.25.1"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -252,7 +252,7 @@ impl DispatchStrategy for DestinationDispatch {
         // monotone order. This is the source of truth per tick and avoids
         // incremental-insertion drift (duplicates, orphaned entries).
         for &car_eid in &candidate_cars {
-            rebuild_car_queue(world, car_eid);
+            rebuild_car_queue(world, group, car_eid);
         }
     }
 
@@ -461,7 +461,7 @@ pub fn clear_assignments_to(world: &mut crate::world::World, car_eid: EntityId) 
 /// sweep. A third run is appended when a rider's trip reverses the sweep
 /// twice (origin behind, dest ahead of origin in the original sweep).
 #[allow(clippy::too_many_lines)]
-fn rebuild_car_queue(world: &mut crate::world::World, car_eid: EntityId) {
+fn rebuild_car_queue(world: &mut crate::world::World, group: &ElevatorGroup, car_eid: EntityId) {
     use crate::components::RiderPhase;
 
     // Local type for gathered (origin?, dest) trips.
@@ -516,7 +516,14 @@ fn rebuild_car_queue(world: &mut crate::world::World, car_eid: EntityId) {
             ElevatorPhase::MovingToStop(_) | ElevatorPhase::Repositioning(_)
         );
         if stopped_here {
-            world.find_stop_at_position(car_pos)
+            // Per-line lookup so a car parked at a sky-lobby served
+            // by multiple banks resolves to its own bank's stop.
+            let serves =
+                crate::dispatch::elevator_line_serves(world, std::slice::from_ref(group), car_eid);
+            serves.map_or_else(
+                || world.find_stop_at_position(car_pos),
+                |s| world.find_stop_at_position_in(car_pos, s),
+            )
         } else {
             None
         }

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -789,6 +789,33 @@ impl ElevatorGroup {
     }
 }
 
+/// Look up the `serves` list for an elevator's line.
+///
+/// Walks `groups` to find the [`LineInfo`] whose entity matches the
+/// car's current `line()`. Returns `None` if the car has no line
+/// registered in any group (an inconsistent state — should be
+/// unreachable in a healthy sim).
+///
+/// Helper for callers of
+/// [`World::find_stop_at_position_in`](crate::world::World::find_stop_at_position_in)
+/// that already have group context: `find_stop_at_position(pos)` is
+/// global (any line wins) and ambiguous when two lines share a
+/// position; passing the elevator's serves list scopes the lookup to
+/// *its* line.
+#[must_use]
+pub fn elevator_line_serves<'a>(
+    world: &World,
+    groups: &'a [ElevatorGroup],
+    elevator: EntityId,
+) -> Option<&'a [EntityId]> {
+    let line_eid = world.elevator(elevator)?.line();
+    groups
+        .iter()
+        .flat_map(ElevatorGroup::lines)
+        .find(|li| li.entity() == line_eid)
+        .map(LineInfo::serves)
+}
+
 /// Context passed to [`DispatchStrategy::rank`].
 ///
 /// Bundles the per-call arguments into a single struct so future context

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -802,6 +802,10 @@ impl ElevatorGroup {
 /// global (any line wins) and ambiguous when two lines share a
 /// position; passing the elevator's serves list scopes the lookup to
 /// *its* line.
+///
+/// Cost: `O(groups × lines_per_group)` per call. For loops over many
+/// elevators per tick, prefer [`build_line_serves_index`] +
+/// [`elevator_line_serves_indexed`] to amortize the line walk.
 #[must_use]
 pub fn elevator_line_serves<'a>(
     world: &World,
@@ -814,6 +818,34 @@ pub fn elevator_line_serves<'a>(
         .flat_map(ElevatorGroup::lines)
         .find(|li| li.entity() == line_eid)
         .map(LineInfo::serves)
+}
+
+/// Pre-built index mapping each line entity to its `serves` slice.
+/// Built once with [`build_line_serves_index`]; queried with
+/// [`elevator_line_serves_indexed`] for O(1) per-elevator lookup.
+pub type LineServesIndex<'a> = std::collections::HashMap<EntityId, &'a [EntityId]>;
+
+/// Build a [`LineServesIndex`] from the group list. O(groups × lines).
+/// Call once per substep / system and reuse across the elevator loop.
+#[must_use]
+pub fn build_line_serves_index(groups: &[ElevatorGroup]) -> LineServesIndex<'_> {
+    let mut idx: LineServesIndex<'_> = std::collections::HashMap::new();
+    for li in groups.iter().flat_map(ElevatorGroup::lines) {
+        idx.insert(li.entity(), li.serves());
+    }
+    idx
+}
+
+/// Indexed variant of [`elevator_line_serves`]. O(1) per call given
+/// a pre-built [`LineServesIndex`].
+#[must_use]
+pub fn elevator_line_serves_indexed<'a>(
+    world: &World,
+    index: &LineServesIndex<'a>,
+    elevator: EntityId,
+) -> Option<&'a [EntityId]> {
+    let line_eid = world.elevator(elevator)?.line();
+    index.get(&line_eid).copied()
 }
 
 /// Context passed to [`DispatchStrategy::rank`].

--- a/crates/elevator-core/src/sim/substep.rs
+++ b/crates/elevator-core/src/sim/substep.rs
@@ -149,6 +149,7 @@ impl super::Simulation {
             &mut self.world,
             &mut self.events,
             &ctx,
+            &self.groups,
             &self.elevator_ids_buf,
         );
         for group in &self.groups {
@@ -171,6 +172,7 @@ impl super::Simulation {
             &mut self.world,
             &mut self.events,
             &ctx,
+            &self.groups,
             &self.elevator_ids_buf,
             &mut self.rider_index,
         );
@@ -198,6 +200,7 @@ impl super::Simulation {
             &mut self.world,
             &mut self.events,
             &ctx,
+            &self.groups,
             &self.elevator_ids_buf,
         );
         for group in &self.groups {

--- a/crates/elevator-core/src/systems/advance_queue.rs
+++ b/crates/elevator-core/src/systems/advance_queue.rs
@@ -48,6 +48,10 @@ pub fn run(
     groups: &[crate::dispatch::ElevatorGroup],
     elevator_ids: &[EntityId],
 ) {
+    // Hoist the line→serves walk out of the per-elevator loop so the
+    // O(groups × lines) work runs once per phase rather than per car.
+    let serves_index = crate::dispatch::build_line_serves_index(groups);
+
     for &eid in elevator_ids {
         if world.is_disabled(eid) {
             continue;
@@ -73,7 +77,8 @@ pub fn run(
             ElevatorPhase::Idle | ElevatorPhase::Stopped => {
                 let Some(next) = front else { continue };
                 let pos = world.position(eid).map_or(0.0, |p| p.value);
-                let serves = crate::dispatch::elevator_line_serves(world, groups, eid);
+                let serves =
+                    crate::dispatch::elevator_line_serves_indexed(world, &serves_index, eid);
                 let at_stop = serves.map_or_else(
                     || world.find_stop_at_position(pos),
                     |s| world.find_stop_at_position_in(pos, s),

--- a/crates/elevator-core/src/systems/advance_queue.rs
+++ b/crates/elevator-core/src/systems/advance_queue.rs
@@ -45,6 +45,7 @@ pub fn run(
     world: &mut World,
     events: &mut EventBus,
     ctx: &PhaseContext,
+    groups: &[crate::dispatch::ElevatorGroup],
     elevator_ids: &[EntityId],
 ) {
     for &eid in elevator_ids {
@@ -72,7 +73,11 @@ pub fn run(
             ElevatorPhase::Idle | ElevatorPhase::Stopped => {
                 let Some(next) = front else { continue };
                 let pos = world.position(eid).map_or(0.0, |p| p.value);
-                let at_stop = world.find_stop_at_position(pos);
+                let serves = crate::dispatch::elevator_line_serves(world, groups, eid);
+                let at_stop = serves.map_or_else(
+                    || world.find_stop_at_position(pos),
+                    |s| world.find_stop_at_position_in(pos, s),
+                );
                 if at_stop == Some(next) {
                     // Already at the queued stop — pop and open doors.
                     if let Some(q) = world.destination_queue_mut(eid) {

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -156,7 +156,7 @@ pub fn run(
                     || (matches!(c.phase, ElevatorPhase::MovingToStop(_)) && c.riders.is_empty())
             });
             if eligible {
-                commit_go_to_stop(world, events, ctx, car_eid, stop_eid);
+                commit_go_to_stop(world, events, ctx, groups, car_eid, stop_eid);
             }
         }
 
@@ -187,7 +187,7 @@ pub fn run(
         for (eid, decision) in result.decisions {
             match decision {
                 DispatchDecision::GoToStop(stop_eid) => {
-                    commit_go_to_stop(world, events, ctx, eid, stop_eid);
+                    commit_go_to_stop(world, events, ctx, groups, eid, stop_eid);
                     // Update the call's `assigned_car` so games querying
                     // `sim.assigned_car(...)` see dispatch's choice. The
                     // direction written matches the car's travel
@@ -218,7 +218,7 @@ pub fn run(
                                 da.total_cmp(&db)
                             });
                         if let Some(stop) = dest {
-                            commit_go_to_stop(world, events, ctx, eid, stop);
+                            commit_go_to_stop(world, events, ctx, groups, eid, stop);
                             continue;
                         }
                     }
@@ -232,9 +232,13 @@ pub fn run(
                     // Reset indicators to both-lit when returning to idle.
                     update_indicators(world, events, eid, true, true, ctx.tick);
                     if !was_idle {
-                        let at_stop = world
-                            .position(eid)
-                            .and_then(|p| world.find_stop_at_position(p.value));
+                        let serves = crate::dispatch::elevator_line_serves(world, groups, eid);
+                        let at_stop = world.position(eid).and_then(|p| {
+                            serves.map_or_else(
+                                || world.find_stop_at_position(p.value),
+                                |s| world.find_stop_at_position_in(p.value, s),
+                            )
+                        });
                         events.emit(Event::ElevatorIdle {
                             elevator: eid,
                             at_stop,
@@ -256,6 +260,7 @@ fn commit_go_to_stop(
     world: &mut World,
     events: &mut EventBus,
     ctx: &PhaseContext,
+    groups: &[ElevatorGroup],
     eid: EntityId,
     stop_eid: EntityId,
 ) {
@@ -278,7 +283,11 @@ fn commit_go_to_stop(
     }
 
     let pos = world.position(eid).map_or(0.0, |p| p.value);
-    let current_stop = world.find_stop_at_position(pos);
+    let serves = crate::dispatch::elevator_line_serves(world, groups, eid);
+    let current_stop = serves.map_or_else(
+        || world.find_stop_at_position(pos),
+        |s| world.find_stop_at_position_in(pos, s),
+    );
 
     events.emit(Event::ElevatorAssigned {
         elevator: eid,

--- a/crates/elevator-core/src/systems/doors.rs
+++ b/crates/elevator-core/src/systems/doors.rs
@@ -13,6 +13,7 @@ pub fn run(
     world: &mut World,
     events: &mut EventBus,
     ctx: &PhaseContext,
+    groups: &[crate::dispatch::ElevatorGroup],
     elevator_ids: &[crate::entity::EntityId],
 ) {
     // Cars that just finished opening doors — collected so hall-call
@@ -28,7 +29,7 @@ pub fn run(
             .service_mode(eid)
             .is_some_and(|m| *m == crate::components::ServiceMode::Inspection);
 
-        process_door_commands(world, events, ctx, eid);
+        process_door_commands(world, events, ctx, groups, eid);
 
         let Some(car) = world.elevator_mut(eid) else {
             continue;
@@ -138,6 +139,7 @@ fn process_door_commands(
     world: &mut World,
     events: &mut EventBus,
     ctx: &PhaseContext,
+    groups: &[crate::dispatch::ElevatorGroup],
     eid: EntityId,
 ) {
     // Take the queue out so we can apply commands that need mutable world access.
@@ -151,7 +153,7 @@ fn process_door_commands(
     let mut remaining: Vec<DoorCommand> = Vec::new();
 
     for cmd in queue {
-        if try_apply_command(world, eid, cmd) {
+        if try_apply_command(world, groups, eid, cmd) {
             events.emit(Event::DoorCommandApplied {
                 elevator: eid,
                 command: cmd,
@@ -170,14 +172,19 @@ fn process_door_commands(
 /// Try to apply `cmd`. Returns `true` if it was applied (or is a no-op in
 /// the current state — a no-op still counts as "applied" since there is
 /// nothing to defer), `false` if it should remain queued.
-fn try_apply_command(world: &mut World, eid: EntityId, cmd: DoorCommand) -> bool {
+fn try_apply_command(
+    world: &mut World,
+    groups: &[crate::dispatch::ElevatorGroup],
+    eid: EntityId,
+    cmd: DoorCommand,
+) -> bool {
     let Some(car) = world.elevator(eid) else {
         return true;
     };
     let phase = car.phase;
 
     match cmd {
-        DoorCommand::Open => apply_open(world, eid, phase),
+        DoorCommand::Open => apply_open(world, groups, eid, phase),
         DoorCommand::Close => apply_close(world, eid, phase),
         DoorCommand::HoldOpen { ticks } => apply_hold(world, eid, phase, ticks),
         DoorCommand::CancelHold => apply_cancel_hold(world, eid, phase),
@@ -186,14 +193,24 @@ fn try_apply_command(world: &mut World, eid: EntityId, cmd: DoorCommand) -> bool
 
 /// Apply a pending `Open` command. Returns `false` to leave the command
 /// queued (car is mid-flight), `true` if applied or a no-op now.
-fn apply_open(world: &mut World, eid: EntityId, phase: ElevatorPhase) -> bool {
+fn apply_open(
+    world: &mut World,
+    groups: &[crate::dispatch::ElevatorGroup],
+    eid: EntityId,
+    phase: ElevatorPhase,
+) -> bool {
     match phase {
         // Already open or opening — no-op.
         ElevatorPhase::DoorOpening | ElevatorPhase::Loading => true,
         ElevatorPhase::Stopped | ElevatorPhase::Idle => {
-            // Must actually be parked at a stop to open doors.
+            // Must actually be parked at a stop on the car's line.
             let pos = world.position(eid).map_or(0.0, |p| p.value);
-            if world.find_stop_at_position(pos).is_none() {
+            let serves = crate::dispatch::elevator_line_serves(world, groups, eid);
+            let at_stop = serves.map_or_else(
+                || world.find_stop_at_position(pos),
+                |s| world.find_stop_at_position_in(pos, s),
+            );
+            if at_stop.is_none() {
                 return false;
             }
             if let Some(car) = world.elevator_mut(eid) {

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -68,6 +68,7 @@ enum LoadAction {
 #[allow(clippy::too_many_lines)]
 fn collect_actions(
     world: &World,
+    groups: &[crate::dispatch::ElevatorGroup],
     elevator_ids: &[EntityId],
     rider_index: &RiderIndex,
 ) -> Vec<LoadAction> {
@@ -93,7 +94,15 @@ fn collect_actions(
         }
 
         let pos = world.position(eid).map_or(0.0, |p| p.value);
-        let Some(current_stop) = world.find_stop_at_position(pos) else {
+        // Per-line lookup: a sky-lobby served by multiple banks
+        // would otherwise resolve to whichever line's stop wins the
+        // global linear scan, breaking exit/board matching for
+        // riders on the bank this car *isn't* serving.
+        let serves = crate::dispatch::elevator_line_serves(world, groups, eid);
+        let Some(current_stop) = serves.map_or_else(
+            || world.find_stop_at_position(pos),
+            |s| world.find_stop_at_position_in(pos, s),
+        ) else {
             continue;
         };
 
@@ -517,9 +526,10 @@ pub fn run(
     world: &mut World,
     events: &mut EventBus,
     ctx: &PhaseContext,
+    groups: &[crate::dispatch::ElevatorGroup],
     elevator_ids: &[EntityId],
     rider_index: &mut RiderIndex,
 ) {
-    let actions = collect_actions(world, elevator_ids, rider_index);
+    let actions = collect_actions(world, groups, elevator_ids, rider_index);
     apply_actions(actions, world, events, ctx, rider_index);
 }

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -74,6 +74,10 @@ fn collect_actions(
 ) -> Vec<LoadAction> {
     let mut actions: Vec<LoadAction> = Vec::new();
 
+    // Hoist the line→serves lookup out of the per-elevator loop so the
+    // O(groups × lines) walk runs once per phase, not once per car.
+    let serves_index = crate::dispatch::build_line_serves_index(groups);
+
     for &eid in elevator_ids {
         if world.is_disabled(eid) {
             continue;
@@ -98,7 +102,7 @@ fn collect_actions(
         // would otherwise resolve to whichever line's stop wins the
         // global linear scan, breaking exit/board matching for
         // riders on the bank this car *isn't* serving.
-        let serves = crate::dispatch::elevator_line_serves(world, groups, eid);
+        let serves = crate::dispatch::elevator_line_serves_indexed(world, &serves_index, eid);
         let Some(current_stop) = serves.map_or_else(
             || world.find_stop_at_position(pos),
             |s| world.find_stop_at_position_in(pos, s),

--- a/crates/elevator-core/src/systems/reposition.rs
+++ b/crates/elevator-core/src/systems/reposition.rs
@@ -116,15 +116,22 @@ pub fn run(
                 tick: ctx.tick,
             });
 
-            // Emit departure from current stop if applicable.
-            if let Some(pos) = elev_pos
-                && let Some(from) = world.find_stop_at_position(pos)
-            {
-                events.emit(Event::ElevatorDeparted {
-                    elevator: elev_eid,
-                    from_stop: from,
-                    tick: ctx.tick,
-                });
+            // Emit departure from current stop if applicable. Use the
+            // per-line lookup so a sky-lobby served by multiple banks
+            // doesn't ambiguously resolve to the wrong line's stop.
+            if let Some(pos) = elev_pos {
+                let serves = crate::dispatch::elevator_line_serves(world, groups, elev_eid);
+                let from = serves.map_or_else(
+                    || world.find_stop_at_position(pos),
+                    |s| world.find_stop_at_position_in(pos, s),
+                );
+                if let Some(from) = from {
+                    events.emit(Event::ElevatorDeparted {
+                        elevator: elev_eid,
+                        from_stop: from,
+                        tick: ctx.tick,
+                    });
+                }
             }
         }
     }

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -3526,17 +3526,12 @@ fn loading_resolves_co_located_stops_to_the_cars_own_line() {
     let config = SimConfig {
         building: BuildingConfig {
             name: "Co-located".into(),
+            // Order matters: declare B's stops first so they receive
+            // lower entity IDs and win the global linear scan in
+            // `find_stop_at_position`. With A first the global lookup
+            // returns A's stops by ID order and the test passes even
+            // without the per-line fix — false-positive guard.
             stops: vec![
-                StopConfig {
-                    id: StopId(0),
-                    name: "A0".into(),
-                    position: 0.0,
-                },
-                StopConfig {
-                    id: StopId(1),
-                    name: "A_top".into(),
-                    position: 8.0,
-                },
                 StopConfig {
                     id: StopId(2),
                     name: "B0".into(),
@@ -3545,6 +3540,16 @@ fn loading_resolves_co_located_stops_to_the_cars_own_line() {
                 StopConfig {
                     id: StopId(3),
                     name: "B_top".into(),
+                    position: 8.0,
+                },
+                StopConfig {
+                    id: StopId(0),
+                    name: "A0".into(),
+                    position: 0.0,
+                },
+                StopConfig {
+                    id: StopId(1),
+                    name: "A_top".into(),
                     position: 8.0,
                 },
             ],

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -3658,4 +3658,19 @@ fn loading_resolves_co_located_stops_to_the_cars_own_line() {
         Some(stop_a_top),
         "rider must exit at line A's top stop, not line B's"
     );
+
+    // Symmetric check: line B must not have been involved at all.
+    // Pre-fix the loading lookup might pick the wrong line's stop and
+    // try to board/exit on the wrong car; verify line B's car never
+    // carried this rider.
+    let car_b = sim
+        .world()
+        .iter_elevators()
+        .find_map(|(eid, _, e)| (sim.world().line(e.line()).unwrap().name() == "B").then_some(eid))
+        .unwrap();
+    let car_b_riders = sim.world().elevator(car_b).unwrap().riders();
+    assert!(
+        !car_b_riders.contains(&rider.entity()),
+        "rider must never have boarded line B's car"
+    );
 }

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -3510,3 +3510,152 @@ fn dispatch_does_not_assign_car_to_stop_its_line_does_not_serve() {
         "car_a (line A) should have been assigned to stop A0"
     );
 }
+
+/// Two lines, two stops at the same physical position (one per line).
+/// A car parked at the position must load/exit riders bound for *its*
+/// line's stop, not whichever stop wins the global linear scan.
+///
+/// Pre-fix the loading system used the global lookup; with two stops
+/// at position 0.0 the wrong line's stop could win the scan, no rider
+/// would match `route.current_destination()`, and the car would sit
+/// idle with riders aboard.
+#[test]
+fn loading_resolves_co_located_stops_to_the_cars_own_line() {
+    use crate::components::RiderPhase;
+
+    let config = SimConfig {
+        building: BuildingConfig {
+            name: "Co-located".into(),
+            stops: vec![
+                StopConfig {
+                    id: StopId(0),
+                    name: "A0".into(),
+                    position: 0.0,
+                },
+                StopConfig {
+                    id: StopId(1),
+                    name: "A_top".into(),
+                    position: 8.0,
+                },
+                StopConfig {
+                    id: StopId(2),
+                    name: "B0".into(),
+                    position: 0.0,
+                },
+                StopConfig {
+                    id: StopId(3),
+                    name: "B_top".into(),
+                    position: 8.0,
+                },
+            ],
+            lines: Some(vec![
+                LineConfig {
+                    id: 1,
+                    name: "A".into(),
+                    serves: vec![StopId(0), StopId(1)],
+                    elevators: vec![ElevatorConfig {
+                        id: 1,
+                        name: "carA".into(),
+                        max_speed: Speed::from(2.0),
+                        acceleration: Accel::from(1.5),
+                        deceleration: Accel::from(2.0),
+                        weight_capacity: Weight::from(800.0),
+                        starting_stop: StopId(0),
+                        door_open_ticks: 10,
+                        door_transition_ticks: 5,
+                        restricted_stops: Vec::new(),
+                        #[cfg(feature = "energy")]
+                        energy_profile: None,
+                        service_mode: None,
+                        inspection_speed_factor: 0.25,
+                        bypass_load_up_pct: None,
+                        bypass_load_down_pct: None,
+                    }],
+                    orientation: Orientation::Vertical,
+                    position: None,
+                    min_position: None,
+                    max_position: None,
+                    max_cars: None,
+                },
+                LineConfig {
+                    id: 2,
+                    name: "B".into(),
+                    serves: vec![StopId(2), StopId(3)],
+                    elevators: vec![ElevatorConfig {
+                        id: 2,
+                        name: "carB".into(),
+                        max_speed: Speed::from(2.0),
+                        acceleration: Accel::from(1.5),
+                        deceleration: Accel::from(2.0),
+                        weight_capacity: Weight::from(800.0),
+                        starting_stop: StopId(2),
+                        door_open_ticks: 10,
+                        door_transition_ticks: 5,
+                        restricted_stops: Vec::new(),
+                        #[cfg(feature = "energy")]
+                        energy_profile: None,
+                        service_mode: None,
+                        inspection_speed_factor: 0.25,
+                        bypass_load_up_pct: None,
+                        bypass_load_down_pct: None,
+                    }],
+                    orientation: Orientation::Vertical,
+                    position: None,
+                    min_position: None,
+                    max_position: None,
+                    max_cars: None,
+                },
+            ]),
+            groups: Some(vec![
+                GroupConfig {
+                    id: 0,
+                    name: "A".into(),
+                    lines: vec![1],
+                    dispatch: crate::dispatch::BuiltinStrategy::Scan,
+                    reposition: None,
+                    hall_call_mode: None,
+                    ack_latency_ticks: None,
+                },
+                GroupConfig {
+                    id: 1,
+                    name: "B".into(),
+                    lines: vec![2],
+                    dispatch: crate::dispatch::BuiltinStrategy::Scan,
+                    reposition: None,
+                    hall_call_mode: None,
+                    ack_latency_ticks: None,
+                },
+            ]),
+        },
+        elevators: Vec::new(),
+        simulation: SimulationParams {
+            ticks_per_second: 60.0,
+        },
+        passenger_spawning: PassengerSpawnConfig {
+            mean_interval_ticks: 120,
+            weight_range: (50.0, 100.0),
+        },
+    };
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+    let stop_a_top = sim.stop_entity(StopId(1)).unwrap();
+
+    // Spawn a rider on line A: A0 → A_top.
+    let rider = sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
+
+    let mut delivered = false;
+    for _ in 0..2000 {
+        sim.step();
+        let r = sim.world().rider(rider.entity()).unwrap();
+        if r.phase() == RiderPhase::Arrived {
+            delivered = true;
+            break;
+        }
+    }
+    assert!(delivered, "rider should be delivered with co-located stops");
+    let r = sim.world().rider(rider.entity()).unwrap();
+    assert_eq!(
+        r.current_stop(),
+        Some(stop_a_top),
+        "rider must exit at line A's top stop, not line B's"
+    );
+}


### PR DESCRIPTION
## Summary

The 6 internal \`find_stop_at_position\` call sites — loading.rs, doors.rs, advance_queue.rs, dispatch.rs (×2), reposition.rs, destination.rs — were doing global stop lookups. PR #457 added the per-line variants but the systems hadn't adopted them.

The bug only manifests when two stops on different lines share a physical position (sky-lobby served by multiple banks, parallel shafts at the same floor, SKYSTACK shafts in coordinated mode). PR #456's dispatch line filter prevents the wrong-line stop from ever being a car's *target*, but the loading system's \`route.current_destination()\` check would still fail silently if the global lookup picked the wrong-line stop, leaving riders aboard with no exit.

## Changes

- New public free helper \`dispatch::elevator_line_serves(world, groups, elevator)\` that walks groups to find the car's line's \`serves\` list. Returns \`None\` when the car has no line registered (an inconsistent state — the helper falls open and callers default to the global lookup).
- Threads \`groups: &[ElevatorGroup]\` through \`loading::run\`, \`doors::run\`, \`advance_queue::run\`. \`dispatch::run\` and \`reposition::run\` already had it.
- At each call site: look up the car's serves list; use \`World::find_stop_at_position_in(pos, serves)\`; fall back to the global \`find_stop_at_position\` when serves is \`None\`.
- \`commit_go_to_stop\` and \`process_door_commands\` get \`groups\` parameters threaded through their (previously private) signatures.
- DCS's \`rebuild_car_queue\` takes the single \`&ElevatorGroup\` it's already running for.

## Test plan

- [x] New \`loading_resolves_co_located_stops_to_the_cars_own_line\` — two lines with stops at the same physical position; rider on line A is correctly delivered to line A's top stop, not line B's. Pre-fix this would hang because the loading lookup would resolve to whichever stop won the global linear scan.
- [x] 852 lib + integration + 159 doctests pass.
- [x] \`cargo clippy --all-features --all-targets -- -D warnings\` clean.
- [x] \`cargo check --workspace\` clean (no FFI/wasm/bevy drift).

## SKYSTACK impact

Once this lands, the SKYSTACK bridge can drop its sub-millimetre per-shaft offset hack (\`col * 0.0001\`) — the loading system will resolve the right stop even when two shafts have stops at exactly the same physical floor. Tracked as a follow-up bridge cleanup; this PR doesn't touch the bridge.