### PR TITLE
feat(playground): redesign space elevator demo as orbital tether

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -409,7 +409,7 @@
               >2&times;</span
             >
           </span>
-          <input id="speed" type="range" min="1" max="16" step="1" value="2" class="w-full" />
+          <input id="speed" type="range" min="1" max="64" step="1" value="2" class="w-full" />
         </label>
         <label class="controls-bar-field">
           <span class="ctl-k">

--- a/playground/src/__tests__/permalink.test.ts
+++ b/playground/src/__tests__/permalink.test.ts
@@ -60,6 +60,32 @@ describe("permalink: core knobs", () => {
     expect(qs).not.toMatch(/(^|&)pb=/);
   });
 
+  it("scenario-aware reposition: tether omits `spread` (its default) and emits `lobby` (an explicit pick)", () => {
+    // The space elevator declares `defaultReposition: "spread"`. So
+    // a tether URL with `pa=spread` is the implicit default and
+    // should round-trip without emitting the key. A tether URL where
+    // the user explicitly picked `lobby` MUST emit `pa=lobby` —
+    // otherwise on reload boot.ts re-applies the scenario default
+    // and silently overwrites the user's pick.
+    const tetherSpread = encodePermalink({
+      ...DEFAULT_STATE,
+      scenario: "space-elevator",
+      repositionA: "spread" as const,
+      repositionB: "spread" as const,
+    });
+    expect(tetherSpread).not.toMatch(/(^|&)pa=/);
+    expect(tetherSpread).not.toMatch(/(^|&)pb=/);
+
+    const tetherLobby = encodePermalink({
+      ...DEFAULT_STATE,
+      scenario: "space-elevator",
+      repositionA: "lobby" as const,
+      repositionB: "lobby" as const,
+    });
+    expect(tetherLobby).toMatch(/pa=lobby/);
+    expect(tetherLobby).toMatch(/pb=lobby/);
+  });
+
   it("encodes and round-trips non-default reposition picks", () => {
     // Use values that differ from DEFAULT_STATE.reposition{A,B}
     // (currently `lobby`/`adaptive`) so the encoder actually emits

--- a/playground/src/__tests__/tether.test.ts
+++ b/playground/src/__tests__/tether.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  atmosphericLayer,
+  classifyKinematicPhase,
+  formatAltitudeShort,
+  formatDuration,
+  formatVelocity,
+  tetherDecadeTicks,
+  tetherEta,
+  tetherFractionForAltitude,
+} from "../render/tether";
+
+describe("tether: altitude axis", () => {
+  it("ground maps to 0, counterweight to 1", () => {
+    expect(tetherFractionForAltitude(0, 100_000_000)).toBeCloseTo(0, 5);
+    expect(tetherFractionForAltitude(100_000_000, 100_000_000)).toBeCloseTo(1, 5);
+  });
+
+  it("log-scale spreads decades across the visible range", () => {
+    // Decades occupy roughly equal screen fractions on a log axis.
+    const a = tetherFractionForAltitude(1_000, 100_000_000); // 1 km
+    const b = tetherFractionForAltitude(10_000, 100_000_000); // 10 km
+    const c = tetherFractionForAltitude(100_000, 100_000_000); // 100 km (Karman)
+    expect(b - a).toBeGreaterThan(0.05);
+    expect(c - b).toBeGreaterThan(0.05);
+  });
+
+  it("clamps negative altitudes to 0", () => {
+    expect(tetherFractionForAltitude(-50, 100_000_000)).toBe(0);
+  });
+
+  it("decade ticks span 1 km up to the axis cap", () => {
+    const ticks = tetherDecadeTicks(100_000_000);
+    expect(ticks.length).toBeGreaterThanOrEqual(5);
+    expect(ticks[0]?.altitudeM).toBe(1000);
+    expect(ticks.at(-1)?.altitudeM).toBeLessThanOrEqual(100_000_000);
+  });
+});
+
+describe("tether: atmospheric layer mapping", () => {
+  it("matches standard atmosphere boundaries", () => {
+    expect(atmosphericLayer(5_000)).toBe("troposphere");
+    expect(atmosphericLayer(30_000)).toBe("stratosphere");
+    expect(atmosphericLayer(70_000)).toBe("mesosphere");
+    expect(atmosphericLayer(400_000)).toBe("thermosphere"); // ISS altitude
+    expect(atmosphericLayer(5_000_000)).toBe("exosphere");
+    expect(atmosphericLayer(20_000_000)).toBe("cislunar space");
+    expect(atmosphericLayer(35_786_000)).toBe("geostationary belt");
+  });
+});
+
+describe("tether: kinematic phase classifier", () => {
+  it("idle when nearly stopped", () => {
+    expect(classifyKinematicPhase(0.1, 0, 1000)).toBe("idle");
+  });
+
+  it("cruise when at near-max speed and steady", () => {
+    expect(classifyKinematicPhase(990, 990, 1000)).toBe("cruise");
+  });
+
+  it("accel when speeding up", () => {
+    expect(classifyKinematicPhase(500, 200, 1000)).toBe("accel");
+  });
+
+  it("decel when slowing down", () => {
+    expect(classifyKinematicPhase(200, 500, 1000)).toBe("decel");
+  });
+});
+
+describe("tether: ETA approximation", () => {
+  it("zero remaining distance returns 0", () => {
+    expect(tetherEta(1000, 1000, 0, 1000, 10, 10)).toBeCloseTo(0, 5);
+  });
+
+  it("when already cruising and within decel distance, returns the brake time", () => {
+    // Decel distance from 1000 m/s at 10 m/s²: 50,000 m. If only 25,000 m left
+    // and currently at full speed, the ETA falls back to remaining/v ≈ 25 s.
+    const eta = tetherEta(0, 25_000, 1000, 1000, 10, 10);
+    expect(eta).toBeGreaterThan(0);
+    expect(eta).toBeLessThan(50);
+  });
+
+  it("long trip uses the trapezoidal coast estimate", () => {
+    // Ground (0) to Karman (100 km), starting at rest.
+    const eta = tetherEta(0, 100_000, 0, 1000, 10, 10);
+    // Accel phase: 100 s reaching 1000 m/s, traveling 50 km.
+    // Decel phase: 100 s, 50 km.
+    // Total ≈ 200 s for an exact 100 km trip.
+    expect(eta).toBeGreaterThan(180);
+    expect(eta).toBeLessThan(220);
+  });
+});
+
+describe("tether: formatting", () => {
+  it("altitude formats by magnitude", () => {
+    expect(formatAltitudeShort(0)).toMatch(/^0 m$/);
+    expect(formatAltitudeShort(500)).toMatch(/^500 m$/);
+    expect(formatAltitudeShort(2_500)).toMatch(/^2\.5 km$/);
+    expect(formatAltitudeShort(100_000)).toMatch(/^100 km$/);
+    expect(formatAltitudeShort(35_786_000)).toMatch(/^35,786 km$/);
+  });
+
+  it("velocity switches to km/h above 100 m/s", () => {
+    expect(formatVelocity(0.5)).toMatch(/m\/s/);
+    expect(formatVelocity(50)).toMatch(/m\/s/);
+    expect(formatVelocity(500)).toMatch(/km\/h/);
+  });
+
+  it("duration formats by magnitude", () => {
+    expect(formatDuration(0)).toBe("—");
+    expect(formatDuration(45)).toMatch(/^45 s$/);
+    expect(formatDuration(120)).toMatch(/^2m$/);
+    expect(formatDuration(125)).toMatch(/^2m 5s$/);
+    expect(formatDuration(7200)).toMatch(/^2h$/);
+  });
+});

--- a/playground/src/__tests__/tether.test.ts
+++ b/playground/src/__tests__/tether.test.ts
@@ -43,9 +43,16 @@ describe("tether: atmospheric layer mapping", () => {
     expect(atmosphericLayer(30_000)).toBe("stratosphere");
     expect(atmosphericLayer(70_000)).toBe("mesosphere");
     expect(atmosphericLayer(400_000)).toBe("thermosphere"); // ISS altitude
+    // Exosphere covers the broad mid-band — the IAU's exosphere
+    // extends to ~100,000 km, so everything from 700 km up to (and
+    // past) the counterweight altitude lives here.
     expect(atmosphericLayer(5_000_000)).toBe("exosphere");
-    expect(atmosphericLayer(20_000_000)).toBe("cislunar space");
-    expect(atmosphericLayer(35_786_000)).toBe("geostationary belt");
+    expect(atmosphericLayer(20_000_000)).toBe("exosphere");
+    expect(atmosphericLayer(80_000_000)).toBe("exosphere");
+    // Narrow GEO band — the climber flips to "geostationary" only
+    // while it's actually near the GEO platform altitude.
+    expect(atmosphericLayer(35_786_000)).toBe("geostationary");
+    expect(atmosphericLayer(35_500_000)).toBe("geostationary");
   });
 });
 
@@ -72,22 +79,43 @@ describe("tether: ETA approximation", () => {
     expect(tetherEta(1000, 1000, 0, 1000, 10, 10)).toBeCloseTo(0, 5);
   });
 
-  it("when already cruising and within decel distance, returns the brake time", () => {
-    // Decel distance from 1000 m/s at 10 m/s²: 50,000 m. If only 25,000 m left
-    // and currently at full speed, the ETA falls back to remaining/v ≈ 25 s.
+  it("when already past the brake point, returns the brake-to-rest time", () => {
+    // Brake distance from 1000 m/s at 10 m/s²: 50,000 m. If only
+    // 25,000 m left and currently at full speed, the climber will
+    // overshoot — ETA falls back to v / decel = 100 s as a useful
+    // upper bound on time-to-reach-target.
     const eta = tetherEta(0, 25_000, 1000, 1000, 10, 10);
-    expect(eta).toBeGreaterThan(0);
-    expect(eta).toBeLessThan(50);
+    expect(eta).toBeCloseTo(100, 0);
+  });
+
+  it("triangle-profile trip never reaches max speed", () => {
+    // Ground (0) to 50 km, starting at rest, max 1000 m/s, a = d = 10.
+    // Trapezoidal would need 100 km (50 km accel + 50 km decel) — the
+    // 50 km trip is sub-trapezoid. Symmetric a/d means peak velocity
+    // vp = sqrt(remaining * a) = sqrt(500_000) ≈ 707 m/s, total
+    // time = 2 * vp / a ≈ 141.4 s.
+    const eta = tetherEta(0, 50_000, 0, 1000, 10, 10);
+    expect(eta).toBeGreaterThan(135);
+    expect(eta).toBeLessThan(150);
   });
 
   it("long trip uses the trapezoidal coast estimate", () => {
     // Ground (0) to Karman (100 km), starting at rest.
+    // Accel: 100 s / 50 km. Decel: 100 s / 50 km. No cruise → 200 s
+    // (this trip is right at the trapezoid/triangle boundary; the
+    // function picks the triangle branch and returns the same answer).
     const eta = tetherEta(0, 100_000, 0, 1000, 10, 10);
-    // Accel phase: 100 s reaching 1000 m/s, traveling 50 km.
-    // Decel phase: 100 s, 50 km.
-    // Total ≈ 200 s for an exact 100 km trip.
     expect(eta).toBeGreaterThan(180);
     expect(eta).toBeLessThan(220);
+  });
+
+  it("very long trip uses the cruise term", () => {
+    // Ground (0) to GEO (35,786 km), starting at rest.
+    // Accel: 100 s / 50 km, decel: 100 s / 50 km, cruise: 35,686 km
+    // at 1000 m/s ≈ 35,686 s. Total ~35,886 s.
+    const eta = tetherEta(0, 35_786_000, 0, 1000, 10, 10);
+    expect(eta).toBeGreaterThan(35_500);
+    expect(eta).toBeLessThan(36_500);
   });
 });
 

--- a/playground/src/domain/permalink/permalink.ts
+++ b/playground/src/domain/permalink/permalink.ts
@@ -1,4 +1,5 @@
 import { PARAM_KEYS, type Overrides, type ParamKey } from "../params";
+import { scenarioById } from "../scenarios";
 import type { RepositionStrategyName, StrategyName } from "../../types";
 
 // URL state encoding. Keeps the sim reproducible: sharing the URL replays
@@ -128,11 +129,19 @@ export function encodePermalink(state: PermalinkState): string {
   // strategy when the recipient toggles compare on. Only the compare flag
   // itself is conditional.
   p.set("b", state.strategyB);
-  // Reposition picks — omit when set to the baseline so bare URLs
-  // stay short. Any non-default pick is emitted explicitly, mirroring
-  // the `c` key contract (explicit wins, missing = default).
-  if (state.repositionA !== DEFAULT_STATE.repositionA) p.set("pa", state.repositionA);
-  if (state.repositionB !== DEFAULT_STATE.repositionB) p.set("pb", state.repositionB);
+  // Reposition picks — omit when set to the pane's effective default
+  // so bare URLs stay short. The "effective default" is the
+  // scenario's `defaultReposition` when the scenario specifies one
+  // (e.g. tether → "spread", applied to both panes), otherwise the
+  // global per-pane baseline (`lobby` for A, `adaptive` for B).
+  // Without scenario-awareness, a tether user who explicitly picked
+  // "lobby" would have it omitted, and on reload boot.ts would
+  // re-apply "spread" and silently overwrite their pick.
+  const sceneDefault = scenarioById(state.scenario).defaultReposition;
+  const defaultA = sceneDefault ?? DEFAULT_STATE.repositionA;
+  const defaultB = sceneDefault ?? DEFAULT_STATE.repositionB;
+  if (state.repositionA !== defaultA) p.set("pa", state.repositionA);
+  if (state.repositionB !== defaultB) p.set("pb", state.repositionB);
   // Always emit `c` explicitly so the URL round-trips identically
   // regardless of whether the sender's value matches the current
   // default. Missing `c` in the URL falls back to `DEFAULT_STATE.compare`

--- a/playground/src/domain/scenarios/scenarios.ts
+++ b/playground/src/domain/scenarios/scenarios.ts
@@ -472,71 +472,175 @@ const skyscraper: ScenarioMeta = {
   ron: buildSkyscraperRon(),
 };
 
-// ─── Space elevator — pure novelty ──────────────────────────────────
+// ─── Space elevator — orbital tether to GEO ─────────────────────────
+//
+// The tether climbs to geostationary altitude (35,786 km) with three
+// staged platforms along the way — the edge of space (Karman line),
+// a low-orbit transfer station, and the geostationary terminus. The
+// counterweight sits beyond GEO at the standard ~100,000 km tether
+// length, but it isn't a passenger destination — it's structural mass
+// keeping the cable in tension. The renderer draws it as a visual
+// cap at `tether.counterweightAltitudeM`.
+//
+// At a 1000 m/s climber speed (~3 600 km/h, faster than any real
+// proposal but watchable), Ground → GEO is about 10 hours of
+// simulated time. The playground's speed multiplier (cap raised so
+// this scenario is usable) keeps that to a few minutes wall-clock.
+//
+// Spawn rates are intentionally sparse — long-haul space-elevator
+// traffic isn't supposed to look like rush hour, and at very long
+// trip durations even modest spawn rates pile riders up faster than
+// any climber can deliver them.
+
+const KARMAN_M = 100_000;
+const LEO_M = 400_000;
+const GEO_M = 35_786_000;
+const COUNTERWEIGHT_M = 100_000_000;
+
+const TETHER_STOPS = 4;
+
+function tetherWeights(perIndex: (i: number) => number): number[] {
+  return Array.from({ length: TETHER_STOPS }, (_, i) => perIndex(i));
+}
 
 const spaceElevator: ScenarioMeta = {
   id: "space-elevator",
   label: "Space elevator",
   description:
-    "Two stops 1,000 km apart. Same engine, different scale — no traffic patterns really apply; it's a showpiece for the trapezoidal-motion primitives.",
+    "A 35,786 km tether to geostationary orbit with platforms at the Karman line, LEO, and the GEO terminus. Three climbers move payload along a single cable; the counterweight beyond GEO holds the line taut.",
   defaultStrategy: "scan",
+  // SpreadEvenly keeps idle climbers distributed across the stops
+  // instead of bouncing them all back to the ground (Lobby) or
+  // letting AdaptiveParking shuffle them oddly. With three climbers
+  // and three reachable platforms, the steady state is one cabin
+  // per platform — exactly what you want for sparse long-haul
+  // traffic.
+  defaultReposition: "spread",
+  // Phase durations are tuned to the tether's natural timescale, not
+  // a building's "morning rush / evening commute" model. A short hop
+  // up to Karman is ~250 sim seconds round-trip, so each phase lasts
+  // long enough to see at least one full short-hop cycle complete.
+  // Names avoid claiming a specific real-world duration ("shift",
+  // "window") since the demo replays the cycle every few real minutes.
   phases: [
+    // Outbound — most riders depart Ground bound for the upper
+    // platforms. LEO and GEO get the heaviest weight; Karman is a
+    // short side-trip. The weight curve favours long trips, which is
+    // where the trapezoidal motion profile reads most clearly.
     {
-      name: "Scheduled lift",
-      durationSec: 300,
-      ridersPerMin: 4,
-      originWeights: [1, 1],
-      destWeights: [1, 1],
+      name: "Outbound cargo",
+      durationSec: 480,
+      ridersPerMin: 1.0,
+      originWeights: tetherWeights((i) => (i === 0 ? 6 : 1)),
+      destWeights: tetherWeights((i) => {
+        if (i === 0) return 0;
+        if (i === 1) return 2; // Karman — short hops
+        if (i === 2) return 3; // LEO transfer
+        return 4; // GEO platform
+      }),
+    },
+    // Inbound — returning crews and finished cargo come back down.
+    // Origin weights skew toward LEO/GEO to keep the down-traffic
+    // narrative visible.
+    {
+      name: "Inbound cargo",
+      durationSec: 360,
+      ridersPerMin: 0.8,
+      originWeights: tetherWeights((i) => {
+        if (i === 0) return 0;
+        if (i === 1) return 1;
+        if (i === 2) return 3;
+        return 5;
+      }),
+      destWeights: tetherWeights((i) => (i === 0 ? 6 : 1)),
     },
   ],
-  seedSpawns: 0,
+  // Pre-seed riders so the scene isn't empty on load. 6 spawns is
+  // enough to keep all three climbers busy through the first cycle
+  // without overwhelming the long-haul cadence — two depart Ground
+  // bound for Karman/LEO/GEO, the rest are scattered across the
+  // upper platforms heading down. The user sees motion immediately
+  // instead of waiting for the first Poisson sample.
+  seedSpawns: 6,
+  // Long trips deserve patience. 1800 s sim ≈ 1.9 min wall-clock at
+  // the recommended 16× playback — long enough that ground→Karman
+  // hops complete first, short enough that GEO no-shows do bound the
+  // queue.
+  abandonAfterSec: 1800,
   featureHint:
-    "Two stops, 1,000 km apart. Same engine, wildly different scale — proof that the simulation works on anything vertical.",
+    "Three climbers share a single 35,786 km tether. Watch the trapezoidal motion play out at scale: long cruise at 3,600 km/h between Karman, LEO, and the geostationary platform.",
   buildingName: "Orbital Tether",
   stops: [
     { name: "Ground Station", positionM: 0.0 },
-    { name: "Orbital Platform", positionM: 1000.0 },
+    { name: "Karman Line", positionM: KARMAN_M },
+    { name: "LEO Transfer", positionM: LEO_M },
+    { name: "GEO Platform", positionM: GEO_M },
   ],
-  defaultCars: 1,
+  defaultCars: 3,
   elevatorDefaults: {
-    maxSpeed: 50.0,
+    maxSpeed: 1000.0,
     acceleration: 10.0,
-    deceleration: 15.0,
+    deceleration: 10.0,
     weightCapacity: 10000.0,
-    doorOpenTicks: 120,
-    doorTransitionTicks: 30,
+    doorOpenTicks: 300,
+    doorTransitionTicks: 60,
   },
-  // Space elevator's operating envelope is two orders of magnitude
-  // away from a building. Bigger steps, no car-count tweaking
-  // (only 2 stops; multiple climbers on a tether is its own can of worms).
+  // Tweak ranges sized for the orbital envelope: speed in 250 m/s
+  // steps (50 → 2000), capacity in tonne increments. Door cycle stays
+  // short — a 5 s dwell at GEO is plenty for boarding/alighting.
   tweakRanges: {
-    cars: { min: 1, max: 1, step: 1 },
-    maxSpeed: { min: 5, max: 100, step: 5 },
-    weightCapacity: { min: 1000, max: 20000, step: 1000 },
-    doorCycleSec: { min: 2, max: 8, step: 0.5 },
+    cars: { min: 1, max: 3, step: 1 },
+    maxSpeed: { min: 250, max: 2000, step: 250 },
+    weightCapacity: { min: 2000, max: 20000, step: 2000 },
+    doorCycleSec: { min: 4, max: 12, step: 1 },
   },
-  passengerMeanIntervalTicks: 900,
+  passengerMeanIntervalTicks: 1200,
   passengerWeightRange: [60.0, 90.0],
+  // Tether-mode metadata. Counterweight is rendered, not visited.
+  // Day/night cycling stays off — the playground's warm-dark aesthetic
+  // is intentional and consistent across scenarios; cycling sky tones
+  // would draw the eye away from the climbers and metrics, which are
+  // the actual focal points.
+  tether: {
+    counterweightAltitudeM: COUNTERWEIGHT_M,
+    showDayNight: false,
+  },
   ron: `SimConfig(
     building: BuildingConfig(
         name: "Orbital Tether",
         stops: [
-            StopConfig(id: StopId(0), name: "Ground Station",   position: 0.0),
-            StopConfig(id: StopId(1), name: "Orbital Platform", position: 1000.0),
+            StopConfig(id: StopId(0), name: "Ground Station", position: 0.0),
+            StopConfig(id: StopId(1), name: "Karman Line",    position: ${KARMAN_M.toFixed(1)}),
+            StopConfig(id: StopId(2), name: "LEO Transfer",   position: ${LEO_M.toFixed(1)}),
+            StopConfig(id: StopId(3), name: "GEO Platform",   position: ${GEO_M.toFixed(1)}),
         ],
     ),
     elevators: [
         ElevatorConfig(
-            id: 0, name: "Climber Alpha",
-            max_speed: 50.0, acceleration: 10.0, deceleration: 15.0,
+            id: 0, name: "Climber A",
+            max_speed: 1000.0, acceleration: 10.0, deceleration: 10.0,
             weight_capacity: 10000.0,
             starting_stop: StopId(0),
-            door_open_ticks: 120, door_transition_ticks: 30,
+            door_open_ticks: 300, door_transition_ticks: 60,
+        ),
+        ElevatorConfig(
+            id: 1, name: "Climber B",
+            max_speed: 1000.0, acceleration: 10.0, deceleration: 10.0,
+            weight_capacity: 10000.0,
+            starting_stop: StopId(1),
+            door_open_ticks: 300, door_transition_ticks: 60,
+        ),
+        ElevatorConfig(
+            id: 2, name: "Climber C",
+            max_speed: 1000.0, acceleration: 10.0, deceleration: 10.0,
+            weight_capacity: 10000.0,
+            starting_stop: StopId(2),
+            door_open_ticks: 300, door_transition_ticks: 60,
         ),
     ],
     simulation: SimulationParams(ticks_per_second: 60.0),
     passenger_spawning: PassengerSpawnConfig(
-        mean_interval_ticks: 900,
+        mean_interval_ticks: 1200,
         weight_range: (60.0, 90.0),
     ),
 )`,

--- a/playground/src/domain/scenarios/scenarios.ts
+++ b/playground/src/domain/scenarios/scenarios.ts
@@ -526,11 +526,14 @@ const spaceElevator: ScenarioMeta = {
     // Outbound — most riders depart Ground bound for the upper
     // platforms. LEO and GEO get the heaviest weight; Karman is a
     // short side-trip. The weight curve favours long trips, which is
-    // where the trapezoidal motion profile reads most clearly.
+    // where the trapezoidal motion profile reads most clearly. Spawn
+    // rate is high enough that a Karman round-trip (~5 min sim)
+    // accumulates 25–30 riders at the ground station — a single trip
+    // delivers a meaningful batch instead of one passenger at a time.
     {
       name: "Outbound cargo",
       durationSec: 480,
-      ridersPerMin: 1.0,
+      ridersPerMin: 6,
       originWeights: tetherWeights((i) => (i === 0 ? 6 : 1)),
       destWeights: tetherWeights((i) => {
         if (i === 0) return 0;
@@ -545,7 +548,7 @@ const spaceElevator: ScenarioMeta = {
     {
       name: "Inbound cargo",
       durationSec: 360,
-      ridersPerMin: 0.8,
+      ridersPerMin: 5,
       originWeights: tetherWeights((i) => {
         if (i === 0) return 0;
         if (i === 1) return 1;
@@ -555,13 +558,12 @@ const spaceElevator: ScenarioMeta = {
       destWeights: tetherWeights((i) => (i === 0 ? 6 : 1)),
     },
   ],
-  // Pre-seed riders so the scene isn't empty on load. 6 spawns is
-  // enough to keep all three climbers busy through the first cycle
-  // without overwhelming the long-haul cadence — two depart Ground
-  // bound for Karman/LEO/GEO, the rest are scattered across the
-  // upper platforms heading down. The user sees motion immediately
-  // instead of waiting for the first Poisson sample.
-  seedSpawns: 6,
+  // Pre-seed enough riders that all three climbers depart with a
+  // full cabin on the first frame instead of waiting for Poisson
+  // samples. 24 ≈ 8 per climber at the platform-default capacity
+  // tuning; the climbers' effective batch size scales with the
+  // weight slider in the tweak drawer.
+  seedSpawns: 24,
   // Long trips deserve patience. 1800 s sim ≈ 1.9 min wall-clock at
   // the recommended 16× playback — long enough that ground→Karman
   // hops complete first, short enough that GEO no-shows do bound the

--- a/playground/src/features/compare-pane/pane.ts
+++ b/playground/src/features/compare-pane/pane.ts
@@ -1,5 +1,5 @@
 import { CanvasRenderer } from "../../render";
-import { buildScenarioRon, type Overrides } from "../../domain";
+import { applyPhysicsOverrides, buildScenarioRon, type Overrides } from "../../domain";
 import { Sim } from "../../sim";
 import type {
   CarBubble,
@@ -68,7 +68,12 @@ export async function makePane(
   // column layout — which fails badly at 35,786 km axes.
   renderer.setTetherConfig(scenario.tether ?? null);
   if (scenario.tether) {
-    const phys = scenario.elevatorDefaults;
+    // Use the override-merged physics so a shared permalink with a
+    // tweaked max-speed (e.g. `?s=space-elevator&ms=2000`) shows
+    // accurate ETA / phase classification immediately, instead of
+    // waiting for the user to nudge the slider and trigger the
+    // hot-swap path.
+    const phys = applyPhysicsOverrides(scenario, overrides);
     renderer.setTetherPhysics(phys.maxSpeed, phys.acceleration, phys.deceleration);
   }
   // Scenarios with many floors need a taller shaft, or the 42-floor

--- a/playground/src/features/compare-pane/pane.ts
+++ b/playground/src/features/compare-pane/pane.ts
@@ -63,6 +63,14 @@ export async function makePane(
   const ron = buildScenarioRon(scenario, overrides);
   const sim = await Sim.create(ron, strategy, reposition);
   const renderer = new CanvasRenderer(handles.canvas, handles.accent);
+  // Tether-mode rendering opts in via scenario metadata. Without
+  // this hookup the renderer falls back to the standard per-line
+  // column layout — which fails badly at 35,786 km axes.
+  renderer.setTetherConfig(scenario.tether ?? null);
+  if (scenario.tether) {
+    const phys = scenario.elevatorDefaults;
+    renderer.setTetherPhysics(phys.maxSpeed, phys.acceleration, phys.deceleration);
+  }
   // Scenarios with many floors need a taller shaft, or the 42-floor
   // skyscraper crushes into a 6-px-per-story smear. The CSS applies
   // `min-height: var(--shaft-min-h)` so the page scrolls instead.

--- a/playground/src/features/compare-pane/pane.ts
+++ b/playground/src/features/compare-pane/pane.ts
@@ -74,11 +74,15 @@ export async function makePane(
   // Scenarios with many floors need a taller shaft, or the 42-floor
   // skyscraper crushes into a 6-px-per-story smear. The CSS applies
   // `min-height: var(--shaft-min-h)` so the page scrolls instead.
+  // Tether mode needs far more headroom — the log axis compresses
+  // 5+ decades into the visible range, and on mobile portrait the
+  // upper decades (Karman / LEO / GEO) end up with overlapping
+  // labels unless the canvas is tall enough to space them out.
   const wrap = handles.canvas.parentElement;
   if (wrap) {
     const stopCount = scenario.stops.length;
     const perStoryPx = 16;
-    const minShaftPx = Math.max(200, stopCount * perStoryPx);
+    const minShaftPx = scenario.tether ? 640 : Math.max(200, stopCount * perStoryPx);
     wrap.style.setProperty("--shaft-min-h", `${minShaftPx}px`);
   }
   return {

--- a/playground/src/features/scenario-picker/switch.ts
+++ b/playground/src/features/scenario-picker/switch.ts
@@ -1,6 +1,6 @@
 import { scenarioById, STRATEGY_LABELS, type PermalinkState } from "../../domain";
 import { toast } from "../../platform";
-import type { StrategyName } from "../../types";
+import type { RepositionStrategyName, StrategyName } from "../../types";
 import { syncScenarioCards } from "./cards";
 
 /** Narrow pane handles for scenario switching. */
@@ -37,6 +37,12 @@ export interface ScenarioSwitchHooks {
   renderPaneStrategyInfo: (pane: ScenarioPaneHandles, strategy: StrategyName) => void;
   refreshStrategyPopovers: () => void;
   renderTweakPanel: () => void;
+  /**
+   * Refresh the reposition-strategy chip on a pane. Mirrors
+   * `renderPaneStrategyInfo` and is invoked when a scenario's
+   * `defaultReposition` snaps the chip to a new value.
+   */
+  renderPaneRepositionInfo: (pane: ScenarioPaneHandles, reposition: RepositionStrategyName) => void;
 }
 
 /**
@@ -63,13 +69,26 @@ export async function switchScenario(
   const nextStrategyA = state.permalink.compare
     ? state.permalink.strategyA
     : scenario.defaultStrategy;
+  // Reposition is snapped on scenario switch only when the scenario
+  // opts in via `defaultReposition` — carrying a Lobby pick from a
+  // skyscraper into the space elevator made every idle climber
+  // slide back to the ground, which defeats the spread layout. The
+  // playback-speed slider is *not* touched here; that's a per-user
+  // preference, and a long-haul scenario where individual trips
+  // take minutes is intentional, not a UX bug.
+  const nextReposition: RepositionStrategyName =
+    scenario.defaultReposition !== undefined && !state.permalink.compare
+      ? scenario.defaultReposition
+      : state.permalink.repositionA;
   state.permalink = {
     ...state.permalink,
     scenario: scenario.id,
     strategyA: nextStrategyA,
+    repositionA: nextReposition,
     overrides: {},
   };
   hooks.renderPaneStrategyInfo(ui.paneA, nextStrategyA);
+  hooks.renderPaneRepositionInfo(ui.paneA, nextReposition);
   hooks.refreshStrategyPopovers();
   syncScenarioCards(ui, scenario.id);
   await resetAll();

--- a/playground/src/features/tweak-drawer/hot-swap.ts
+++ b/playground/src/features/tweak-drawer/hot-swap.ts
@@ -12,6 +12,15 @@ export interface HotSwapPane {
       doorTransitionTicks: number;
     }): boolean;
   };
+  /**
+   * Optional renderer hook for tether-mode HUD. Building scenarios
+   * leave this undefined; the space elevator threads max-speed
+   * changes through so the side card's ETA / phase classifier
+   * reflects the live tweak instead of the scenario default.
+   */
+  renderer?: {
+    setTetherPhysics(maxSpeed: number, acceleration: number, deceleration: number): void;
+  };
 }
 
 /** Narrow interface for state during hot-swap. */
@@ -47,6 +56,14 @@ export function applyHotSwapAndRender(
   };
   const panes = [state.paneA, state.paneB].filter((p): p is HotSwapPane => p !== null);
   const allLive = panes.every((pane) => pane.sim.applyPhysicsLive(params));
+  // Tether HUD ETA / phase classifier rely on the active max-speed.
+  // Push the new value to renderers that opted in (`renderer` is
+  // present only on tether-aware panes via `Pane`'s public surface).
+  if (allLive) {
+    for (const pane of panes) {
+      pane.renderer?.setTetherPhysics(physics.maxSpeed, physics.acceleration, physics.deceleration);
+    }
+  }
   renderTweakPanel(scenario, state.permalink.overrides, ui);
   if (!allLive) void resetAll();
 }

--- a/playground/src/render/draw-tether-hud.ts
+++ b/playground/src/render/draw-tether-hud.ts
@@ -1,0 +1,337 @@
+/**
+ * Tether-mode HUD: the inline chip beside each climber, the side
+ * info card listing every cabin's stats, and the helpers that build
+ * a per-car summary from the snapshot. Split from `draw-tether.ts`
+ * so the landscape/atmosphere code stays under the file-length cap.
+ */
+
+import { shade } from "./color-utils";
+import type { Scale } from "./layout";
+import { PHASE_COLORS } from "./palette";
+import { roundedRect } from "./primitives";
+import {
+  atmosphericLayer,
+  classifyKinematicPhase,
+  formatAltitudeShort,
+  formatDuration,
+  formatVelocity,
+  tetherEta,
+  type KinematicPhase,
+} from "./tether";
+import type { CarDto, Snapshot } from "../types";
+
+export interface AltitudeAxis {
+  axisMaxM: number;
+  toScreenAlt: (altitudeM: number) => number;
+  shaftTop: number;
+  shaftBottom: number;
+}
+
+export interface ClimberHud {
+  carId: number;
+  cx: number;
+  cy: number;
+  altitudeM: number;
+  velocity: number;
+  phase: KinematicPhase;
+  layer: string;
+  carName: string;
+  load: number;
+  capacity: number;
+  riders: number;
+  targetAltitudeM: number | undefined;
+  etaSeconds: number | undefined;
+}
+
+const PHASE_LABEL: Record<KinematicPhase, string> = {
+  accel: "accel",
+  cruise: "cruise",
+  decel: "decel",
+  idle: "idle",
+};
+
+// Phase hues stay aligned with playground tokens: `pane-a` (cool blue
+// for "going up / accelerating"), accent (amber for "doors / loading
+// energy" — used here for cruise/decel transition), and the muted
+// disabled grey for idle. Keeps the chip palette inside the existing
+// design language rather than introducing a fresh green/yellow set.
+const PHASE_HUE: Record<KinematicPhase, string> = {
+  accel: "#7dd3fc", // --pane-a — moving up
+  cruise: "#fbbf24", // --accent-up — sustained motion
+  decel: "#fda4af", // --pane-b — slowing
+  idle: "#6b6b75", // --text-disabled
+};
+
+export function drawClimberCabin(
+  ctx: CanvasRenderingContext2D,
+  car: CarDto,
+  cx: number,
+  cy: number,
+  carW: number,
+  carH: number,
+): void {
+  const halfW = carW / 2;
+  const top = cy - carH / 2;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- wasm boundary: phase may hold a variant the TS union hasn't caught up with
+  const base = PHASE_COLORS[car.phase] ?? "#6b6b75";
+  // Subtle gradient — same treatment as the building cabins.
+  const grad = ctx.createLinearGradient(cx, top, cx, top + carH);
+  grad.addColorStop(0, shade(base, 0.14));
+  grad.addColorStop(1, shade(base, -0.18));
+  ctx.fillStyle = grad;
+  roundedRect(ctx, cx - halfW, top, carW, carH, Math.min(3, carH * 0.16));
+  ctx.fill();
+  ctx.strokeStyle = "rgba(10, 12, 16, 0.9)";
+  ctx.lineWidth = 1;
+  ctx.stroke();
+  // Thin amber accent line — reads as a lit cabin without the heavy
+  // halo we used to draw, which clashed with the muted backdrop.
+  ctx.fillStyle = "rgba(245, 158, 11, 0.55)";
+  ctx.fillRect(cx - halfW + 2, top + carH * 0.36, carW - 4, Math.max(1.5, carH * 0.1));
+}
+
+/**
+ * Draw inline HUD chips for every climber in a single pass so we can
+ * resolve overlap before any chip lands on the canvas. When two
+ * cabins share an altitude (idle climbers parked at the same stop),
+ * a per-chip render would stack labels on top of each other; the
+ * collision pass nudges colliders to the opposite side or vertically
+ * apart until none overlap.
+ */
+export function drawClimberHuds(
+  ctx: CanvasRenderingContext2D,
+  hudList: readonly ClimberHud[],
+  carW: number,
+  canvasWidth: number,
+  s: Scale,
+): void {
+  if (hudList.length === 0) return;
+  const padX = 7;
+  const padY = 4;
+  const lh = s.fontSmall + 2;
+  const gap = carW / 2 + 8;
+  ctx.font = `600 ${(s.fontSmall + 0.5).toFixed(1)}px system-ui, -apple-system, "Segoe UI", sans-serif`;
+
+  interface Placement {
+    hud: ClimberHud;
+    lines: string[];
+    bx: number;
+    by: number;
+    bubbleW: number;
+    bubbleH: number;
+    side: "left" | "right";
+  }
+
+  const place = (hud: ClimberHud, side: "left" | "right"): Placement => {
+    const lines = [
+      formatAltitudeShort(hud.altitudeM),
+      formatVelocity(hud.velocity),
+      `${PHASE_LABEL[hud.phase]} · ${hud.layer}`,
+    ];
+    let textW = 0;
+    for (const l of lines) textW = Math.max(textW, ctx.measureText(l).width);
+    const bubbleW = textW + padX * 2;
+    const bubbleH = lines.length * lh + padY * 2;
+    let bx = side === "right" ? hud.cx + gap : hud.cx - gap - bubbleW;
+    if (bx + bubbleW + 2 > canvasWidth) bx = hud.cx - gap - bubbleW;
+    if (bx < 2) bx = hud.cx + gap;
+    const by = hud.cy - bubbleH / 2;
+    return { hud, lines, bx, by, bubbleW, bubbleH, side };
+  };
+
+  const overlap = (a: Placement, b: Placement): boolean =>
+    !(
+      a.bx + a.bubbleW <= b.bx ||
+      b.bx + b.bubbleW <= a.bx ||
+      a.by + a.bubbleH <= b.by ||
+      b.by + b.bubbleH <= a.by
+    );
+
+  const placements: Placement[] = [];
+  hudList.forEach((hud, i) => {
+    let p = place(hud, i % 2 === 0 ? "right" : "left");
+    // Try the other side if this one collides with anything already placed.
+    if (placements.some((q) => overlap(p, q))) {
+      const flipped = place(hud, p.side === "right" ? "left" : "right");
+      if (!placements.some((q) => overlap(flipped, q))) {
+        p = flipped;
+      } else {
+        // Both sides taken — stack vertically below the lowest collider.
+        const colliders = placements.filter((q) => overlap(p, q));
+        const lowestBottom = Math.max(...colliders.map((q) => q.by + q.bubbleH));
+        p = { ...p, by: lowestBottom + 4 };
+      }
+    }
+    placements.push(p);
+  });
+
+  for (const p of placements) {
+    ctx.save();
+    ctx.fillStyle = "rgba(37, 37, 48, 0.92)"; // bg-elevated at high alpha
+    roundedRect(ctx, p.bx, p.by, p.bubbleW, p.bubbleH, 4);
+    ctx.fill();
+    ctx.fillStyle = PHASE_HUE[p.hud.phase];
+    ctx.fillRect(p.bx, p.by, 2, p.bubbleH);
+    ctx.strokeStyle = "#2a2a35"; // border-subtle
+    ctx.lineWidth = 1;
+    roundedRect(ctx, p.bx, p.by, p.bubbleW, p.bubbleH, 4);
+    ctx.stroke();
+
+    ctx.textBaseline = "middle";
+    ctx.textAlign = "left";
+    for (let i = 0; i < p.lines.length; i++) {
+      const ly = p.by + padY + lh * i + lh / 2;
+      const line = p.lines[i] ?? "";
+      ctx.fillStyle = i === 2 ? PHASE_HUE[p.hud.phase] : "rgba(240, 244, 252, 0.95)";
+      ctx.fillText(line, p.bx + padX, ly);
+    }
+    ctx.restore();
+  }
+}
+
+export function drawTetherSideCard(
+  ctx: CanvasRenderingContext2D,
+  hudList: ClimberHud[],
+  cardX: number,
+  cardW: number,
+  cardYStart: number,
+  s: Scale,
+): void {
+  if (hudList.length === 0) return;
+  const titleH = 18;
+  const padX = 10;
+  const padY = 6;
+  const rowGap = 5;
+  const lineH = s.fontSmall + 2.5;
+  // Header line + altitude + velocity + ETA. Atmospheric layer is
+  // already shown on the inline chip beside each cabin, so the side
+  // card stays compact.
+  const rowsPerCar = 4;
+  const rowH = padY * 2 + rowsPerCar * lineH;
+  const cardH = titleH + padY + (rowH + rowGap) * hudList.length;
+  ctx.save();
+  // Card surface — mirrors the pane chrome (`from-surface-elevated to-surface-secondary`).
+  const grad = ctx.createLinearGradient(cardX, cardYStart, cardX, cardYStart + cardH);
+  grad.addColorStop(0, "#252530"); // bg-elevated
+  grad.addColorStop(1, "#1a1a1f"); // bg-secondary
+  ctx.fillStyle = grad;
+  roundedRect(ctx, cardX, cardYStart, cardW, cardH, 8);
+  ctx.fill();
+  ctx.strokeStyle = "#2a2a35"; // border-subtle
+  ctx.lineWidth = 1;
+  roundedRect(ctx, cardX, cardYStart, cardW, cardH, 8);
+  ctx.stroke();
+  // Inset highlight matching `--shadow-md`'s top sliver.
+  ctx.strokeStyle = "rgba(255,255,255,0.025)";
+  ctx.beginPath();
+  ctx.moveTo(cardX + 8, cardYStart + 1);
+  ctx.lineTo(cardX + cardW - 8, cardYStart + 1);
+  ctx.stroke();
+
+  // Title ("Climbers" eyebrow — same uppercase tracking as the pane labels).
+  ctx.fillStyle = "#a1a1aa"; // text-secondary
+  ctx.font = `600 ${(s.fontSmall - 0.5).toFixed(0)}px system-ui, -apple-system, "Segoe UI", sans-serif`;
+  ctx.textAlign = "left";
+  ctx.textBaseline = "middle";
+  ctx.fillText("CLIMBERS", cardX + padX, cardYStart + titleH / 2 + 2);
+
+  let cursorY = cardYStart + titleH + padY;
+  for (const hud of hudList) {
+    // Row card on a slightly darker surface so it lifts off the panel.
+    ctx.fillStyle = "rgba(15, 15, 18, 0.55)";
+    roundedRect(ctx, cardX + 6, cursorY, cardW - 12, rowH, 5);
+    ctx.fill();
+    ctx.fillStyle = PHASE_HUE[hud.phase];
+    ctx.fillRect(cardX + 6, cursorY, 2, rowH);
+
+    const labelX = cardX + padX + 4;
+    const valueX = cardX + cardW - padX;
+    let y = cursorY + padY + lineH / 2;
+    ctx.font = `600 ${(s.fontSmall + 0.5).toFixed(1)}px system-ui, -apple-system, "Segoe UI", sans-serif`;
+    ctx.fillStyle = "#fafafa"; // text-primary
+    ctx.textAlign = "left";
+    ctx.fillText(hud.carName, labelX, y);
+    ctx.textAlign = "right";
+    ctx.fillStyle = PHASE_HUE[hud.phase];
+    ctx.font = `600 ${(s.fontSmall - 1).toFixed(1)}px system-ui, -apple-system, "Segoe UI", sans-serif`;
+    ctx.fillText(PHASE_LABEL[hud.phase].toUpperCase(), valueX, y);
+
+    const stats: Array<[string, string]> = [
+      ["Altitude", formatAltitudeShort(hud.altitudeM)],
+      ["Velocity", formatVelocity(hud.velocity)],
+      [
+        "ETA",
+        hud.etaSeconds === undefined || !Number.isFinite(hud.etaSeconds)
+          ? "—"
+          : formatDuration(hud.etaSeconds),
+      ],
+    ];
+    ctx.font = `500 ${(s.fontSmall - 0.5).toFixed(1)}px system-ui, -apple-system, "Segoe UI", sans-serif`;
+    for (const [label, value] of stats) {
+      y += lineH;
+      ctx.textAlign = "left";
+      ctx.fillStyle = "#8b8c92"; // text-tertiary
+      ctx.fillText(label, labelX, y);
+      ctx.textAlign = "right";
+      ctx.fillStyle = "#fafafa";
+      ctx.fillText(value, valueX, y);
+    }
+    cursorY += rowH + rowGap;
+  }
+  ctx.restore();
+}
+
+export function buildHudList(
+  snap: Snapshot,
+  axis: AltitudeAxis,
+  cx: number,
+  carNames: Map<number, string>,
+  prevVelocity: Map<number, number>,
+  maxSpeed: number,
+  acceleration: number,
+  deceleration: number,
+): ClimberHud[] {
+  const out: ClimberHud[] = [];
+  // Snapshot order is stable across frames, so deriving "Climber A/B/…"
+  // from the car's index in the snapshot keeps the label tied to the
+  // same cabin even though the entity id is opaque.
+  const cars = [...snap.cars].sort((a, b) => a.id - b.id);
+  cars.forEach((car, idx) => {
+    const altitudeM = car.y;
+    const layer = atmosphericLayer(altitudeM);
+    const phase = classifyKinematicPhase(car.v, prevVelocity.get(car.id) ?? 0, maxSpeed);
+    let etaSeconds: number | undefined;
+    let targetAltitudeM: number | undefined;
+    if (car.target !== undefined) {
+      const targetStop = snap.stops.find((s) => s.entity_id === car.target);
+      if (targetStop) {
+        targetAltitudeM = targetStop.y;
+        etaSeconds = tetherEta(
+          altitudeM,
+          targetStop.y,
+          car.v,
+          maxSpeed,
+          acceleration,
+          deceleration,
+        );
+      }
+    }
+    const fallbackName = `Climber ${String.fromCharCode(65 + idx)}`;
+    out.push({
+      carId: car.id,
+      cx,
+      cy: axis.toScreenAlt(altitudeM),
+      altitudeM,
+      velocity: car.v,
+      phase,
+      layer,
+      carName: carNames.get(car.id) ?? fallbackName,
+      load: car.load,
+      capacity: car.capacity,
+      riders: car.riders,
+      targetAltitudeM,
+      etaSeconds,
+    });
+  });
+  return out;
+}

--- a/playground/src/render/draw-tether-hud.ts
+++ b/playground/src/render/draw-tether-hud.ts
@@ -28,7 +28,6 @@ export interface AltitudeAxis {
 }
 
 export interface ClimberHud {
-  carId: number;
   cx: number;
   cy: number;
   altitudeM: number;
@@ -36,10 +35,6 @@ export interface ClimberHud {
   phase: KinematicPhase;
   layer: string;
   carName: string;
-  load: number;
-  capacity: number;
-  riders: number;
-  targetAltitudeM: number | undefined;
   etaSeconds: number | undefined;
 }
 
@@ -301,11 +296,9 @@ export function buildHudList(
     const layer = atmosphericLayer(altitudeM);
     const phase = classifyKinematicPhase(car.v, prevVelocity.get(car.id) ?? 0, maxSpeed);
     let etaSeconds: number | undefined;
-    let targetAltitudeM: number | undefined;
     if (car.target !== undefined) {
       const targetStop = snap.stops.find((s) => s.entity_id === car.target);
       if (targetStop) {
-        targetAltitudeM = targetStop.y;
         etaSeconds = tetherEta(
           altitudeM,
           targetStop.y,
@@ -318,7 +311,6 @@ export function buildHudList(
     }
     const fallbackName = `Climber ${String.fromCharCode(65 + idx)}`;
     out.push({
-      carId: car.id,
       cx,
       cy: axis.toScreenAlt(altitudeM),
       altitudeM,
@@ -326,10 +318,6 @@ export function buildHudList(
       phase,
       layer,
       carName: carNames.get(car.id) ?? fallbackName,
-      load: car.load,
-      capacity: car.capacity,
-      riders: car.riders,
-      targetAltitudeM,
       etaSeconds,
     });
   });

--- a/playground/src/render/draw-tether-hud.ts
+++ b/playground/src/render/draw-tether-hud.ts
@@ -117,6 +117,12 @@ export function drawClimberHuds(
     side: "left" | "right";
   }
 
+  // `place` reports the side it was asked for and clamps `bx` inside
+  // the canvas. Unlike an auto-flipping variant, this lets the
+  // collision pass distinguish "I tried left and it collided" from
+  // "I tried left but the canvas forced it back to right" — without
+  // that distinction, the flip-and-retry branch could re-place a
+  // chip on the same side and silently no-op.
   const place = (hud: ClimberHud, side: "left" | "right"): Placement => {
     const lines = [
       formatAltitudeShort(hud.altitudeM),
@@ -128,8 +134,7 @@ export function drawClimberHuds(
     const bubbleW = textW + padX * 2;
     const bubbleH = lines.length * lh + padY * 2;
     let bx = side === "right" ? hud.cx + gap : hud.cx - gap - bubbleW;
-    if (bx + bubbleW + 2 > canvasWidth) bx = hud.cx - gap - bubbleW;
-    if (bx < 2) bx = hud.cx + gap;
+    bx = Math.max(2, Math.min(canvasWidth - bubbleW - 2, bx));
     const by = hud.cy - bubbleH / 2;
     return { hud, lines, bx, by, bubbleW, bubbleH, side };
   };
@@ -145,14 +150,15 @@ export function drawClimberHuds(
   const placements: Placement[] = [];
   hudList.forEach((hud, i) => {
     let p = place(hud, i % 2 === 0 ? "right" : "left");
-    const colliders = placements.filter((q) => overlap(p, q));
-    if (colliders.length > 0) {
+    if (placements.some((q) => overlap(p, q))) {
       const flipped = place(hud, p.side === "right" ? "left" : "right");
       if (placements.every((q) => !overlap(flipped, q))) {
         p = flipped;
       } else {
-        // Both sides taken — stack vertically below the lowest collider.
-        const lowestBottom = Math.max(...colliders.map((q) => q.by + q.bubbleH));
+        // Both sides taken — stack the chip below every existing
+        // placement (not just the original-side colliders) so we
+        // can't end up sandwiched between them.
+        const lowestBottom = Math.max(...placements.map((q) => q.by + q.bubbleH));
         p = { ...p, by: lowestBottom + 4 };
       }
     }
@@ -278,15 +284,14 @@ export function buildHudList(
   snap: Snapshot,
   axis: AltitudeAxis,
   cx: number,
-  carNames: Map<number, string>,
   prevVelocity: Map<number, number>,
   maxSpeed: number,
   acceleration: number,
   deceleration: number,
 ): ClimberHud[] {
   // Snapshot order is stable across frames, so deriving "Climber A/B/…"
-  // from the car's index in the snapshot keeps the label tied to the
-  // same cabin even though the entity id is opaque.
+  // from the car's index in the sorted snapshot keeps the label tied
+  // to the same cabin even though the engine's entity id is opaque.
   const cars = [...snap.cars].sort((a, b) => a.id - b.id);
   return cars.map((car, idx) => {
     const altitudeM = car.y;
@@ -302,7 +307,7 @@ export function buildHudList(
       velocity: car.v,
       phase: classifyKinematicPhase(car.v, prevVelocity.get(car.id) ?? 0, maxSpeed),
       layer: atmosphericLayer(altitudeM),
-      carName: carNames.get(car.id) ?? `Climber ${String.fromCharCode(65 + idx)}`,
+      carName: `Climber ${String.fromCharCode(65 + idx)}`,
       etaSeconds,
     };
   });

--- a/playground/src/render/draw-tether-hud.ts
+++ b/playground/src/render/draw-tether-hud.ts
@@ -145,14 +145,13 @@ export function drawClimberHuds(
   const placements: Placement[] = [];
   hudList.forEach((hud, i) => {
     let p = place(hud, i % 2 === 0 ? "right" : "left");
-    // Try the other side if this one collides with anything already placed.
-    if (placements.some((q) => overlap(p, q))) {
+    const colliders = placements.filter((q) => overlap(p, q));
+    if (colliders.length > 0) {
       const flipped = place(hud, p.side === "right" ? "left" : "right");
-      if (!placements.some((q) => overlap(flipped, q))) {
+      if (placements.every((q) => !overlap(flipped, q))) {
         p = flipped;
       } else {
         // Both sides taken — stack vertically below the lowest collider.
-        const colliders = placements.filter((q) => overlap(p, q));
         const lowestBottom = Math.max(...colliders.map((q) => q.by + q.bubbleH));
         p = { ...p, by: lowestBottom + 4 };
       }
@@ -251,15 +250,14 @@ export function drawTetherSideCard(
     ctx.font = `600 ${(s.fontSmall - 1).toFixed(1)}px system-ui, -apple-system, "Segoe UI", sans-serif`;
     ctx.fillText(PHASE_LABEL[hud.phase].toUpperCase(), valueX, y);
 
+    const eta =
+      hud.etaSeconds !== undefined && Number.isFinite(hud.etaSeconds)
+        ? formatDuration(hud.etaSeconds)
+        : "—";
     const stats: Array<[string, string]> = [
       ["Altitude", formatAltitudeShort(hud.altitudeM)],
       ["Velocity", formatVelocity(hud.velocity)],
-      [
-        "ETA",
-        hud.etaSeconds === undefined || !Number.isFinite(hud.etaSeconds)
-          ? "—"
-          : formatDuration(hud.etaSeconds),
-      ],
+      ["ETA", eta],
     ];
     ctx.font = `500 ${(s.fontSmall - 0.5).toFixed(1)}px system-ui, -apple-system, "Segoe UI", sans-serif`;
     for (const [label, value] of stats) {
@@ -286,40 +284,26 @@ export function buildHudList(
   acceleration: number,
   deceleration: number,
 ): ClimberHud[] {
-  const out: ClimberHud[] = [];
   // Snapshot order is stable across frames, so deriving "Climber A/B/…"
   // from the car's index in the snapshot keeps the label tied to the
   // same cabin even though the entity id is opaque.
   const cars = [...snap.cars].sort((a, b) => a.id - b.id);
-  cars.forEach((car, idx) => {
+  return cars.map((car, idx) => {
     const altitudeM = car.y;
-    const layer = atmosphericLayer(altitudeM);
-    const phase = classifyKinematicPhase(car.v, prevVelocity.get(car.id) ?? 0, maxSpeed);
-    let etaSeconds: number | undefined;
-    if (car.target !== undefined) {
-      const targetStop = snap.stops.find((s) => s.entity_id === car.target);
-      if (targetStop) {
-        etaSeconds = tetherEta(
-          altitudeM,
-          targetStop.y,
-          car.v,
-          maxSpeed,
-          acceleration,
-          deceleration,
-        );
-      }
-    }
-    const fallbackName = `Climber ${String.fromCharCode(65 + idx)}`;
-    out.push({
+    const targetStop =
+      car.target !== undefined ? snap.stops.find((s) => s.entity_id === car.target) : undefined;
+    const etaSeconds = targetStop
+      ? tetherEta(altitudeM, targetStop.y, car.v, maxSpeed, acceleration, deceleration)
+      : undefined;
+    return {
       cx,
       cy: axis.toScreenAlt(altitudeM),
       altitudeM,
       velocity: car.v,
-      phase,
-      layer,
-      carName: carNames.get(car.id) ?? fallbackName,
+      phase: classifyKinematicPhase(car.v, prevVelocity.get(car.id) ?? 0, maxSpeed),
+      layer: atmosphericLayer(altitudeM),
+      carName: carNames.get(car.id) ?? `Climber ${String.fromCharCode(65 + idx)}`,
       etaSeconds,
-    });
+    };
   });
-  return out;
 }

--- a/playground/src/render/draw-tether.ts
+++ b/playground/src/render/draw-tether.ts
@@ -1,0 +1,496 @@
+import { withAlpha } from "./color-utils";
+import {
+  buildHudList,
+  drawClimberCabin,
+  drawClimberHuds,
+  drawTetherSideCard,
+  type AltitudeAxis,
+} from "./draw-tether-hud";
+import type { Scale } from "./layout";
+import { TARGET_FILL } from "./palette";
+import { tetherDecadeTicks } from "./tether";
+import type { Snapshot, TetherMeta } from "../types";
+
+/**
+ * Tether visualization is two layered images: a planetary backdrop
+ * (sky gradient → space → starfield → counterweight) and a single
+ * cable with platform markers along it. All cars share that one
+ * cable, drawn at world altitudes mapped through `toScreenAlt`.
+ */
+
+/**
+ * Atmosphere palette tuned to the playground's warm-dark surface
+ * tokens (`--bg-primary` / `--bg-secondary` / `--bg-elevated`). The
+ * lower troposphere picks up a faint warm tint reminiscent of the
+ * accent colour; everything above the mesosphere fades to near-black
+ * so stars register without the rest of the canvas competing for
+ * attention. Day-phase only nudges saturation — the visual mode is
+ * "moody dusk" rather than literal day/night cycling.
+ */
+const ATMOSPHERE_STOPS = [
+  // [altitudeM, dayHex, nightHex]
+  [0, "#1d1a18", "#161412"],
+  [12_000, "#161519", "#121116"],
+  [50_000, "#0f0f15", "#0c0c12"],
+  [80_000, "#0a0a10", "#08080d"],
+  [200_000, "#06060a", "#040407"],
+] as const;
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function mixHex(a: string, b: string, t: number): string {
+  const pa = parseInt(a.slice(1), 16);
+  const pb = parseInt(b.slice(1), 16);
+  const ar = (pa >> 16) & 0xff;
+  const ag = (pa >> 8) & 0xff;
+  const ab = pa & 0xff;
+  const br = (pb >> 16) & 0xff;
+  const bg = (pb >> 8) & 0xff;
+  const bb = pb & 0xff;
+  const r = Math.round(lerp(ar, br, t));
+  const g = Math.round(lerp(ag, bg, t));
+  const bl = Math.round(lerp(ab, bb, t));
+  return `#${((r << 16) | (g << 8) | bl).toString(16).padStart(6, "0")}`;
+}
+
+/** `dayPhase` 0=full day, 1=full night. Smoothly lerps between palettes. */
+function atmosphereColor(altitudeM: number, dayPhase: number): string {
+  let i = 0;
+  for (; i < ATMOSPHERE_STOPS.length - 1; i++) {
+    const next = ATMOSPHERE_STOPS[i + 1];
+    if (next === undefined) break;
+    if (altitudeM <= next[0]) break;
+  }
+  const lo = ATMOSPHERE_STOPS[i];
+  const hi = ATMOSPHERE_STOPS[Math.min(i + 1, ATMOSPHERE_STOPS.length - 1)];
+  if (lo === undefined || hi === undefined) return "#050810";
+  const span = hi[0] - lo[0];
+  const t = span <= 0 ? 0 : Math.max(0, Math.min(1, (altitudeM - lo[0]) / span));
+  const dayCol = mixHex(lo[1], hi[1], t);
+  const nightCol = mixHex(lo[2], hi[2], t);
+  return mixHex(dayCol, nightCol, dayPhase);
+}
+
+/**
+ * Pre-seeded star field. We use a deterministic PRNG so stars don't
+ * jitter between frames. Stars live at stable world-altitudes and
+ * clip below the atmosphere mask — sparse and small so they read as
+ * a hint of deep space rather than a wallpaper.
+ */
+const STARS: Array<{ altFrac: number; xFrac: number; size: number; alpha: number }> = (() => {
+  const arr: typeof STARS = [];
+  // Linear congruential — cheap and deterministic.
+  let seed = 0x4f7c3a91;
+  const rand = (): number => {
+    seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+    return seed / 0x7fffffff;
+  };
+  for (let i = 0; i < 60; i++) {
+    // Bias stars to the upper half of the visualization (high altitude).
+    const altFrac = 0.45 + Math.pow(rand(), 0.7) * 0.55;
+    arr.push({
+      altFrac,
+      xFrac: rand(),
+      size: 0.3 + rand() * 0.9,
+      alpha: 0.18 + rand() * 0.32,
+    });
+  }
+  return arr;
+})();
+
+function inverseAxis(axis: AltitudeAxis, screenFrac: number): number {
+  // toScreenAlt maps altitudeM → y by:
+  //   y = bottom - frac * (bottom - top), frac = log10(1 + alt/1000) / log10(1 + axisMax/1000)
+  // => alt = 1000 * (10^(frac * log10(1 + axisMax/1000)) - 1)
+  const hi = Math.log10(1 + axis.axisMaxM / 1000);
+  return 1000 * (10 ** (screenFrac * hi) - 1);
+}
+
+export function drawTetherBackdrop(
+  ctx: CanvasRenderingContext2D,
+  axis: AltitudeAxis,
+  shaftLeft: number,
+  shaftRight: number,
+  dayPhase: number,
+): void {
+  const grad = ctx.createLinearGradient(0, axis.shaftBottom, 0, axis.shaftTop);
+  const breaks = [0, 0.05, 0.15, 0.35, 0.6, 1];
+  for (const t of breaks) {
+    const altMRaw = inverseAxis(axis, t);
+    grad.addColorStop(t, atmosphereColor(altMRaw, dayPhase));
+  }
+  ctx.fillStyle = grad;
+  ctx.fillRect(shaftLeft, axis.shaftTop, shaftRight - shaftLeft, axis.shaftBottom - axis.shaftTop);
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(shaftLeft, axis.shaftTop, shaftRight - shaftLeft, axis.shaftBottom - axis.shaftTop);
+  ctx.clip();
+  for (const star of STARS) {
+    const altM = axis.axisMaxM * star.altFrac;
+    if (altM < 80_000) continue;
+    const y = axis.toScreenAlt(altM);
+    const x = shaftLeft + star.xFrac * (shaftRight - shaftLeft);
+    // dayPhase nudges saturation slightly; keep stars subtle either way.
+    const a = star.alpha * (0.7 + 0.3 * dayPhase);
+    ctx.fillStyle = `rgba(232, 232, 240, ${a.toFixed(3)})`;
+    ctx.beginPath();
+    ctx.arc(x, y, star.size, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.restore();
+
+  // Faint decade tick lines so the log-scale axis is legible.
+  const ticks = tetherDecadeTicks(axis.axisMaxM);
+  ctx.font = `500 10px system-ui, -apple-system, "Segoe UI", sans-serif`;
+  ctx.textBaseline = "middle";
+  ctx.textAlign = "left";
+  for (const t of ticks) {
+    const y = axis.toScreenAlt(t.altitudeM);
+    if (y < axis.shaftTop || y > axis.shaftBottom) continue;
+    ctx.strokeStyle = "rgba(200, 220, 255, 0.07)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(shaftLeft, y);
+    ctx.lineTo(shaftRight, y);
+    ctx.stroke();
+    ctx.fillStyle = "rgba(190, 210, 240, 0.30)";
+    ctx.fillText(t.label, shaftLeft + 4, y - 6);
+  }
+}
+
+/**
+ * Subtle horizon band at the canvas bottom. Replaces the literal
+ * Earth-curve disc with a thin warm-tinted strip that just hints at
+ * "ground level" — the playground aesthetic favours flat, restrained
+ * surfaces over skeuomorphic flourishes.
+ */
+export function drawHorizon(
+  ctx: CanvasRenderingContext2D,
+  shaftLeft: number,
+  shaftRight: number,
+  shaftBottom: number,
+): void {
+  const bandH = 28;
+  const top = shaftBottom - bandH;
+  const grad = ctx.createLinearGradient(0, top, 0, shaftBottom);
+  grad.addColorStop(0, "rgba(0,0,0,0)");
+  grad.addColorStop(0.6, "rgba(245, 158, 11, 0.06)"); // accent at low alpha
+  grad.addColorStop(1, "rgba(245, 158, 11, 0.10)");
+  ctx.fillStyle = grad;
+  ctx.fillRect(shaftLeft, top, shaftRight - shaftLeft, bandH);
+  // Hairline at the surface.
+  ctx.strokeStyle = withAlpha("#f59e0b", 0.2);
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(shaftLeft, shaftBottom + 0.5);
+  ctx.lineTo(shaftRight, shaftBottom + 0.5);
+  ctx.stroke();
+}
+
+/**
+ * The tether cable — a thin neutral line spanning the full altitude
+ * range. Kept understated so the climbers and HUD chips remain the
+ * focal points; the cable is structural geometry, not decoration.
+ */
+export function drawTetherCable(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  axis: AltitudeAxis,
+): void {
+  ctx.strokeStyle = "rgba(160, 165, 180, 0.08)";
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  ctx.moveTo(cx, axis.shaftTop);
+  ctx.lineTo(cx, axis.shaftBottom);
+  ctx.stroke();
+  ctx.strokeStyle = "rgba(180, 188, 205, 0.40)";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(cx, axis.shaftTop);
+  ctx.lineTo(cx, axis.shaftBottom);
+  ctx.stroke();
+}
+
+/**
+ * Counterweight cap at the top of the visualization. The tether
+ * never carries riders here — it's structural mass beyond GEO. Drawn
+ * as a small dark hexagonal mass with a "Counterweight" label so
+ * users learn what it represents without an outsized icon.
+ */
+export function drawCounterweight(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  topY: number,
+  s: Scale,
+): void {
+  const r = Math.max(5, s.figureHeadR * 2.4);
+  ctx.save();
+  // Faded continuation hint above.
+  ctx.strokeStyle = "rgba(180, 188, 205, 0.18)";
+  ctx.lineWidth = 1;
+  ctx.setLineDash([2, 3]);
+  ctx.beginPath();
+  ctx.moveTo(cx, topY - 18);
+  ctx.lineTo(cx, topY - r);
+  ctx.stroke();
+  ctx.setLineDash([]);
+  // Counterweight body — flat hex, matches the playground's restrained iconography.
+  ctx.fillStyle = "#2a2a35"; // border-subtle
+  ctx.strokeStyle = "rgba(180, 188, 205, 0.45)";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  for (let i = 0; i < 6; i++) {
+    const ang = -Math.PI / 2 + (i * Math.PI) / 3;
+    const x = cx + Math.cos(ang) * r;
+    const y = topY + Math.sin(ang) * r;
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+  // Tiny label.
+  ctx.font = `500 ${(s.fontSmall - 1).toFixed(0)}px system-ui, -apple-system, "Segoe UI", sans-serif`;
+  ctx.fillStyle = "rgba(160, 165, 180, 0.65)";
+  ctx.textAlign = "left";
+  ctx.textBaseline = "middle";
+  ctx.fillText("Counterweight", cx + r + 6, topY);
+  ctx.restore();
+}
+
+/**
+ * Per-stop platform marker drawn through the cable. Reads as "the
+ * tether passes through this docking ring" rather than the
+ * building's full-width floor slab.
+ */
+export function drawTetherStops(
+  ctx: CanvasRenderingContext2D,
+  snap: Snapshot,
+  axis: AltitudeAxis,
+  cx: number,
+  s: Scale,
+  labelLeft: number,
+  labelW: number,
+): void {
+  ctx.font = `${s.fontMain.toFixed(0)}px ui-sans-serif, system-ui, sans-serif`;
+  ctx.textBaseline = "middle";
+  for (const stop of snap.stops) {
+    const y = axis.toScreenAlt(stop.y);
+    if (y < axis.shaftTop || y > axis.shaftBottom) continue;
+    const ringW = 36;
+    ctx.strokeStyle = "rgba(220, 230, 245, 0.8)";
+    ctx.lineWidth = 1.6;
+    ctx.beginPath();
+    ctx.moveTo(cx - ringW / 2, y);
+    ctx.lineTo(cx - 5, y);
+    ctx.moveTo(cx + 5, y);
+    ctx.lineTo(cx + ringW / 2, y);
+    ctx.stroke();
+    // Mounting struts give a hint of depth.
+    ctx.strokeStyle = "rgba(160, 180, 210, 0.55)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(cx - ringW / 2, y);
+    ctx.lineTo(cx - 5, y - 5);
+    ctx.moveTo(cx + ringW / 2, y);
+    ctx.lineTo(cx + 5, y - 5);
+    ctx.stroke();
+    // Stop name + altitude on the left gutter.
+    ctx.fillStyle = "rgba(220, 230, 245, 0.95)";
+    ctx.textAlign = "right";
+    ctx.fillText(stop.name, labelLeft + labelW - 4, y - 1);
+    ctx.fillStyle = "rgba(160, 178, 210, 0.7)";
+    ctx.font = `${(s.fontSmall - 0.5).toFixed(0)}px system-ui, -apple-system, "Segoe UI", sans-serif`;
+    ctx.fillText(formatAltitudeShortLocal(stop.y), labelLeft + labelW - 4, y + 10);
+    ctx.font = `${s.fontMain.toFixed(0)}px ui-sans-serif, system-ui, sans-serif`;
+  }
+}
+
+// Re-imported to keep this module decoupled from `draw-tether-hud.ts`'s
+// HUD-specific exports. Same formatter, used at the platform labels.
+function formatAltitudeShortLocal(altitudeM: number): string {
+  if (altitudeM < 1000) return `${Math.round(altitudeM)} m`;
+  const km = altitudeM / 1000;
+  if (km < 10) return `${km.toFixed(1)} km`;
+  if (km < 1000) return `${km.toFixed(0)} km`;
+  return `${km.toLocaleString("en-US", { maximumFractionDigits: 0 })} km`;
+}
+
+/**
+ * Build the altitude axis used throughout tether rendering. The
+ * axis spans 0 → counterweight altitude with a log mapping so every
+ * decade gets visible space.
+ */
+export function buildTetherAxis(
+  shaftTop: number,
+  shaftBottom: number,
+  tether: TetherMeta,
+): AltitudeAxis {
+  const axisMaxM = Math.max(tether.counterweightAltitudeM, 1);
+  const hi = Math.log10(1 + axisMaxM / 1000);
+  return {
+    axisMaxM,
+    shaftTop,
+    shaftBottom,
+    toScreenAlt: (altitudeM: number): number => {
+      const v = Math.log10(1 + Math.max(0, altitudeM) / 1000);
+      const frac = hi <= 0 ? 0 : Math.max(0, Math.min(1, v / hi));
+      return shaftBottom - frac * (shaftBottom - shaftTop);
+    },
+  };
+}
+
+export function drawTetherTargetMarkers(
+  ctx: CanvasRenderingContext2D,
+  snap: Snapshot,
+  axis: AltitudeAxis,
+  cx: number,
+  carCenters: Map<number, number>,
+  stopIdxById: Map<number, number>,
+  s: Scale,
+): void {
+  const dotR = Math.max(2, s.figureHeadR * 0.9);
+  for (const car of snap.cars) {
+    if (car.target === undefined) continue;
+    const idx = stopIdxById.get(car.target);
+    if (idx === undefined) continue;
+    const stop = snap.stops[idx];
+    if (stop === undefined) continue;
+    const cabinY = carCenters.get(car.id);
+    if (cabinY === undefined) continue;
+    const targetY = axis.toScreenAlt(stop.y);
+    if (Math.abs(cabinY - targetY) < 0.5) continue;
+    ctx.strokeStyle = "rgba(250, 250, 250, 0.45)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(cx, cabinY);
+    ctx.lineTo(cx, targetY);
+    ctx.stroke();
+    ctx.fillStyle = TARGET_FILL;
+    ctx.beginPath();
+    ctx.arc(cx, targetY, dotR, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+export function applyDayPhase(elapsedSec: number): number {
+  // 240 s wall-clock cycle — slow enough to feel ambient, fast enough
+  // to actually witness the change during a long climb.
+  const period = 240;
+  const phase = (elapsedSec % period) / period;
+  // Cosine-shaped: 0 = day, 1 = night.
+  return (1 - Math.cos(phase * Math.PI * 2)) * 0.5;
+}
+
+/**
+ * Mutable per-frame state the renderer threads through tether mode:
+ * carries velocity history (for kinematic-phase classification),
+ * cached climber names, the active physics knobs, and the day/night
+ * cycle baseline.
+ */
+export interface TetherRenderState {
+  prevVelocity: Map<number, number>;
+  carNames: Map<number, string>;
+  maxSpeed: number;
+  acceleration: number;
+  deceleration: number;
+  /** Performance-now timestamp of the first tether draw (0 if uninitialized). */
+  firstDrawAt: number;
+}
+
+/**
+ * Render a tether scenario to `ctx`. Encapsulates the entire tether
+ * pipeline: backdrop, Earth curve, cable, counterweight, platforms,
+ * cabins, HUD chips, and the side info card. Mutates `state` to
+ * record per-car velocity history for next frame.
+ */
+export function drawTetherScene(
+  ctx: CanvasRenderingContext2D,
+  snap: Snapshot,
+  w: number,
+  h: number,
+  s: Scale,
+  tether: TetherMeta,
+  state: TetherRenderState,
+): void {
+  if (state.firstDrawAt === 0) state.firstDrawAt = performance.now();
+  const elapsedSec = (performance.now() - state.firstDrawAt) / 1000;
+  const dayPhase = tether.showDayNight ? applyDayPhase(elapsedSec) : 0.5;
+
+  // Layout: stops gutter on the left, cable + atmosphere in the
+  // middle, optional side card on the right. The card is suppressed
+  // on narrow or short viewports — mobile portrait wants the cable
+  // to claim the full width, and mobile landscape doesn't have the
+  // vertical room to host the rows without overlapping the cable.
+  const wantsCard = w >= 520 && h >= 360;
+  const labelW = Math.min(120, Math.max(72, w * 0.16));
+  const cardW = wantsCard ? Math.min(220, Math.max(160, w * 0.24)) : 0;
+  const cardGap = wantsCard ? 14 : 0;
+  const labelLeft = s.padX;
+  const shaftAreaLeft = labelLeft + labelW + 4;
+  const shaftAreaRight = w - s.padX - cardW - cardGap;
+  const cx = (shaftAreaLeft + shaftAreaRight) / 2;
+  const shaftPad = 12;
+  const shaftTop = s.padTop + 24;
+  const shaftBottom = h - s.padBottom - 18;
+
+  const axis = buildTetherAxis(shaftTop, shaftBottom, tether);
+
+  drawTetherBackdrop(ctx, axis, shaftAreaLeft + shaftPad, shaftAreaRight - shaftPad, dayPhase);
+  drawHorizon(ctx, shaftAreaLeft + shaftPad, shaftAreaRight - shaftPad, shaftBottom);
+  drawTetherCable(ctx, cx, axis);
+  drawCounterweight(ctx, cx, axis.shaftTop, s);
+  drawTetherStops(ctx, snap, axis, cx, s, labelLeft, labelW);
+
+  // Fixed-size cabins (the log axis means stops aren't evenly spaced,
+  // so we don't size against story height like the building path).
+  const carW = Math.max(20, Math.min(34, shaftAreaRight - shaftAreaLeft - 8));
+  const carH = Math.max(16, Math.min(26, carW * 0.72));
+  s.carH = carH;
+  s.carW = carW;
+
+  const carCenters = new Map<number, number>();
+  const stopIdxById = new Map<number, number>();
+  snap.stops.forEach((st, i) => stopIdxById.set(st.entity_id, i));
+  for (const car of snap.cars) {
+    carCenters.set(car.id, axis.toScreenAlt(car.y));
+  }
+  drawTetherTargetMarkers(ctx, snap, axis, cx, carCenters, stopIdxById, s);
+
+  for (const car of snap.cars) {
+    const cy = carCenters.get(car.id);
+    if (cy === undefined) continue;
+    drawClimberCabin(ctx, car, cx, cy, carW, carH);
+  }
+
+  const hudList = buildHudList(
+    snap,
+    axis,
+    cx,
+    state.carNames,
+    state.prevVelocity,
+    state.maxSpeed,
+    state.acceleration,
+    state.deceleration,
+  );
+  const sortedHud = [...hudList].sort((a, b) => b.altitudeM - a.altitudeM);
+  drawClimberHuds(ctx, sortedHud, carW, w - cardW - cardGap, s);
+
+  if (wantsCard) {
+    drawTetherSideCard(ctx, sortedHud, w - s.padX - cardW, cardW, shaftTop, s);
+  }
+
+  // Refresh per-car velocity history for next frame's phase classifier.
+  for (const car of snap.cars) {
+    state.prevVelocity.set(car.id, car.v);
+  }
+  if (state.prevVelocity.size > snap.cars.length) {
+    const live = new Set(snap.cars.map((c) => c.id));
+    for (const id of state.prevVelocity.keys()) {
+      if (!live.has(id)) state.prevVelocity.delete(id);
+    }
+  }
+}

--- a/playground/src/render/draw-tether.ts
+++ b/playground/src/render/draw-tether.ts
@@ -108,7 +108,7 @@ function inverseAxis(axis: AltitudeAxis, screenFrac: number): number {
   return 1000 * (10 ** (screenFrac * hi) - 1);
 }
 
-export function drawTetherBackdrop(
+function drawTetherBackdrop(
   ctx: CanvasRenderingContext2D,
   axis: AltitudeAxis,
   shaftLeft: number,
@@ -167,7 +167,7 @@ export function drawTetherBackdrop(
  * "ground level" — the playground aesthetic favours flat, restrained
  * surfaces over skeuomorphic flourishes.
  */
-export function drawHorizon(
+function drawHorizon(
   ctx: CanvasRenderingContext2D,
   shaftLeft: number,
   shaftRight: number,
@@ -195,11 +195,7 @@ export function drawHorizon(
  * range. Kept understated so the climbers and HUD chips remain the
  * focal points; the cable is structural geometry, not decoration.
  */
-export function drawTetherCable(
-  ctx: CanvasRenderingContext2D,
-  cx: number,
-  axis: AltitudeAxis,
-): void {
+function drawTetherCable(ctx: CanvasRenderingContext2D, cx: number, axis: AltitudeAxis): void {
   ctx.strokeStyle = "rgba(160, 165, 180, 0.08)";
   ctx.lineWidth = 3;
   ctx.beginPath();
@@ -220,7 +216,7 @@ export function drawTetherCable(
  * as a small dark hexagonal mass with a "Counterweight" label so
  * users learn what it represents without an outsized icon.
  */
-export function drawCounterweight(
+function drawCounterweight(
   ctx: CanvasRenderingContext2D,
   cx: number,
   topY: number,
@@ -266,7 +262,7 @@ export function drawCounterweight(
  * tether passes through this docking ring" rather than the
  * building's full-width floor slab.
  */
-export function drawTetherStops(
+function drawTetherStops(
   ctx: CanvasRenderingContext2D,
   snap: Snapshot,
   axis: AltitudeAxis,
@@ -324,11 +320,7 @@ function formatAltitudeShortLocal(altitudeM: number): string {
  * axis spans 0 → counterweight altitude with a log mapping so every
  * decade gets visible space.
  */
-export function buildTetherAxis(
-  shaftTop: number,
-  shaftBottom: number,
-  tether: TetherMeta,
-): AltitudeAxis {
+function buildTetherAxis(shaftTop: number, shaftBottom: number, tether: TetherMeta): AltitudeAxis {
   const axisMaxM = Math.max(tether.counterweightAltitudeM, 1);
   const hi = Math.log10(1 + axisMaxM / 1000);
   return {
@@ -343,7 +335,7 @@ export function buildTetherAxis(
   };
 }
 
-export function drawTetherTargetMarkers(
+function drawTetherTargetMarkers(
   ctx: CanvasRenderingContext2D,
   snap: Snapshot,
   axis: AltitudeAxis,
@@ -376,7 +368,7 @@ export function drawTetherTargetMarkers(
   }
 }
 
-export function applyDayPhase(elapsedSec: number): number {
+function applyDayPhase(elapsedSec: number): number {
   // 240 s wall-clock cycle — slow enough to feel ambient, fast enough
   // to actually witness the change during a long climb.
   const period = 240;

--- a/playground/src/render/draw-tether.ts
+++ b/playground/src/render/draw-tether.ts
@@ -358,13 +358,11 @@ function applyDayPhase(elapsedSec: number): number {
 
 /**
  * Mutable per-frame state the renderer threads through tether mode:
- * carries velocity history (for kinematic-phase classification),
- * cached climber names, the active physics knobs, and the day/night
- * cycle baseline.
+ * carries velocity history (for kinematic-phase classification), the
+ * active physics knobs, and the day/night cycle baseline.
  */
 export interface TetherRenderState {
   prevVelocity: Map<number, number>;
-  carNames: Map<number, string>;
   maxSpeed: number;
   acceleration: number;
   deceleration: number;
@@ -441,7 +439,6 @@ export function drawTetherScene(
     snap,
     axis,
     cx,
-    state.carNames,
     state.prevVelocity,
     state.maxSpeed,
     state.acceleration,

--- a/playground/src/render/draw-tether.ts
+++ b/playground/src/render/draw-tether.ts
@@ -8,7 +8,7 @@ import {
 } from "./draw-tether-hud";
 import type { Scale } from "./layout";
 import { TARGET_FILL } from "./palette";
-import { tetherDecadeTicks } from "./tether";
+import { formatAltitudeShort, tetherDecadeTicks } from "./tether";
 import type { Snapshot, TetherMeta } from "../types";
 
 /**
@@ -43,25 +43,19 @@ function lerp(a: number, b: number, t: number): number {
 function mixHex(a: string, b: string, t: number): string {
   const pa = parseInt(a.slice(1), 16);
   const pb = parseInt(b.slice(1), 16);
-  const ar = (pa >> 16) & 0xff;
-  const ag = (pa >> 8) & 0xff;
-  const ab = pa & 0xff;
-  const br = (pb >> 16) & 0xff;
-  const bg = (pb >> 8) & 0xff;
-  const bb = pb & 0xff;
-  const r = Math.round(lerp(ar, br, t));
-  const g = Math.round(lerp(ag, bg, t));
-  const bl = Math.round(lerp(ab, bb, t));
+  const r = Math.round(lerp((pa >> 16) & 0xff, (pb >> 16) & 0xff, t));
+  const g = Math.round(lerp((pa >> 8) & 0xff, (pb >> 8) & 0xff, t));
+  const bl = Math.round(lerp(pa & 0xff, pb & 0xff, t));
   return `#${((r << 16) | (g << 8) | bl).toString(16).padStart(6, "0")}`;
 }
 
 /** `dayPhase` 0=full day, 1=full night. Smoothly lerps between palettes. */
 function atmosphereColor(altitudeM: number, dayPhase: number): string {
+  // Find the segment whose upper bound first meets/exceeds altitudeM.
   let i = 0;
   for (; i < ATMOSPHERE_STOPS.length - 1; i++) {
     const next = ATMOSPHERE_STOPS[i + 1];
-    if (next === undefined) break;
-    if (altitudeM <= next[0]) break;
+    if (next === undefined || altitudeM <= next[0]) break;
   }
   const lo = ATMOSPHERE_STOPS[i];
   const hi = ATMOSPHERE_STOPS[Math.min(i + 1, ATMOSPHERE_STOPS.length - 1)];
@@ -100,14 +94,6 @@ const STARS: Array<{ altFrac: number; xFrac: number; size: number; alpha: number
   return arr;
 })();
 
-function inverseAxis(axis: AltitudeAxis, screenFrac: number): number {
-  // toScreenAlt maps altitudeM → y by:
-  //   y = bottom - frac * (bottom - top), frac = log10(1 + alt/1000) / log10(1 + axisMax/1000)
-  // => alt = 1000 * (10^(frac * log10(1 + axisMax/1000)) - 1)
-  const hi = Math.log10(1 + axis.axisMaxM / 1000);
-  return 1000 * (10 ** (screenFrac * hi) - 1);
-}
-
 function drawTetherBackdrop(
   ctx: CanvasRenderingContext2D,
   axis: AltitudeAxis,
@@ -116,9 +102,12 @@ function drawTetherBackdrop(
   dayPhase: number,
 ): void {
   const grad = ctx.createLinearGradient(0, axis.shaftBottom, 0, axis.shaftTop);
+  // toScreenAlt maps altitudeM → y via frac = log10(1 + alt/1000) / hi.
+  // Inverting: alt = 1000 * (10^(frac * hi) - 1).
+  const hi = Math.log10(1 + axis.axisMaxM / 1000);
   const breaks = [0, 0.05, 0.15, 0.35, 0.6, 1];
   for (const t of breaks) {
-    const altMRaw = inverseAxis(axis, t);
+    const altMRaw = 1000 * (10 ** (t * hi) - 1);
     grad.addColorStop(t, atmosphereColor(altMRaw, dayPhase));
   }
   ctx.fillStyle = grad;
@@ -300,19 +289,9 @@ function drawTetherStops(
     ctx.fillText(stop.name, labelLeft + labelW - 4, y - 1);
     ctx.fillStyle = "rgba(160, 178, 210, 0.7)";
     ctx.font = `${(s.fontSmall - 0.5).toFixed(0)}px system-ui, -apple-system, "Segoe UI", sans-serif`;
-    ctx.fillText(formatAltitudeShortLocal(stop.y), labelLeft + labelW - 4, y + 10);
+    ctx.fillText(formatAltitudeShort(stop.y), labelLeft + labelW - 4, y + 10);
     ctx.font = `${s.fontMain.toFixed(0)}px ui-sans-serif, system-ui, sans-serif`;
   }
-}
-
-// Re-imported to keep this module decoupled from `draw-tether-hud.ts`'s
-// HUD-specific exports. Same formatter, used at the platform labels.
-function formatAltitudeShortLocal(altitudeM: number): string {
-  if (altitudeM < 1000) return `${Math.round(altitudeM)} m`;
-  const km = altitudeM / 1000;
-  if (km < 10) return `${km.toFixed(1)} km`;
-  if (km < 1000) return `${km.toFixed(0)} km`;
-  return `${km.toLocaleString("en-US", { maximumFractionDigits: 0 })} km`;
 }
 
 /**

--- a/playground/src/render/layout.ts
+++ b/playground/src/render/layout.ts
@@ -44,10 +44,11 @@ export function scaleFor(width: number): Scale {
     padTop: lerp(22, 30),
     // Just enough bottom breathing room below the lowest floor slab.
     padBottom: lerp(10, 14),
-    // Sized for the widest scenario labels ("Orbital Platform" at 16
-    // chars, space-elevator) on desktop, down to "Lobby" / "Floor N"
-    // on the narrowest phones. `truncate()` still clips anything that
-    // spills over on ultra-long custom stop names.
+    // Sized for the widest building-mode labels ("Mechanical" /
+    // "Sky Lobby" on the skyscraper) on desktop, down to "Lobby" /
+    // "Floor N" on the narrowest phones. Tether mode picks its own
+    // gutter width inside `drawTetherScene`. `truncate()` clips
+    // anything that spills over on ultra-long custom stop names.
     labelW: lerp(52, 120),
     // Preferred gutter for rider figures. The gutter grows further
     // only when shafts hit their max; otherwise shafts claim slack.

--- a/playground/src/render/renderer.ts
+++ b/playground/src/render/renderer.ts
@@ -1,4 +1,4 @@
-import type { CarDto, CarBubble, Snapshot } from "../types";
+import type { CarDto, CarBubble, Snapshot, TetherMeta } from "../types";
 import { arcPoint, easeOutNorm, hexWithAlpha } from "./color-utils";
 import {
   drawCarHeaders,
@@ -8,6 +8,7 @@ import {
   drawWaitingFigures,
 } from "./draw-building";
 import { drawBubbles, drawCar, drawCarTrail, drawTargetMarkers } from "./draw-cars";
+import { drawTetherScene, type TetherRenderState } from "./draw-tether";
 import type { RiderVariant } from "./figures/rider";
 import { pickRiderVariant } from "./figures/rider";
 import type { Scale } from "./layout";
@@ -66,6 +67,17 @@ export class CanvasRenderer {
   readonly #carStates: Map<number, CarState> = new Map();
   readonly #stopStates: Map<number, StopState> = new Map();
   readonly #tweens: Tween[] = [];
+  /** Set when the active scenario is a space-elevator-style tether. */
+  #tether: TetherMeta | null = null;
+  /** Per-car previous-frame velocity, used to classify trapezoidal phase. */
+  readonly #prevVelocity: Map<number, number> = new Map();
+  /** Per-car name, captured once from the snapshot for HUD display. */
+  readonly #carNames: Map<number, string> = new Map();
+  /** Active `max_speed` for HUD/ETA math; updated from the snapshot's max served range. */
+  #activeMaxSpeed = 1;
+  #activeAcceleration = 1;
+  #activeDeceleration = 1;
+  #firstDrawAt = 0;
   // Per-stop per-line assignment: `stopId -> (lineId -> carId)`. The
   // previous `stopId -> carId` map was last-writer-wins: any car
   // dispatched to a multi-line stop — even a specialty bank moving
@@ -94,6 +106,35 @@ export class CanvasRenderer {
 
   get canvas(): HTMLCanvasElement {
     return this.#canvas;
+  }
+
+  /**
+   * Set or clear tether-mode metadata. Pane wiring calls this with the
+   * scenario's `tether` field on every (re)build so a scenario swap
+   * cleanly transitions between tether and building rendering.
+   */
+  setTetherConfig(tether: TetherMeta | null): void {
+    this.#tether = tether;
+    // Reset per-car kinematic state so a fresh scenario doesn't inherit
+    // stale velocities from the previous run.
+    this.#prevVelocity.clear();
+    this.#carNames.clear();
+    this.#firstDrawAt = 0;
+  }
+
+  /**
+   * Report current physics knobs so the HUD's ETA / phase classifier
+   * stay in sync with hot-swapped values from the tweak drawer.
+   */
+  setTetherPhysics(maxSpeed: number, acceleration: number, deceleration: number): void {
+    if (Number.isFinite(maxSpeed) && maxSpeed > 0) this.#activeMaxSpeed = maxSpeed;
+    if (Number.isFinite(acceleration) && acceleration > 0) this.#activeAcceleration = acceleration;
+    if (Number.isFinite(deceleration) && deceleration > 0) this.#activeDeceleration = deceleration;
+  }
+
+  /** Update the cached display name for a car (the snapshot doesn't carry it). */
+  setCarName(carId: number, name: string): void {
+    this.#carNames.set(carId, name);
   }
 
   pushAssignment(stopId: number, elevatorId: number, lineId: number): void {
@@ -132,6 +173,14 @@ export class CanvasRenderer {
     const s = this.#cachedScale;
     if (s === null) return;
 
+    if (this.#tether !== null) {
+      this.#drawTetherMode(snap, w, h, s, speedMultiplier, bubbles, this.#tether);
+      return;
+    }
+
+    // Building mode keeps the legacy 2-stop tether heuristic — used by
+    // any scenario that didn't opt into explicit tether config but
+    // happens to have a long single-shaft layout.
     const isTether = snap.stops.length === 2;
 
     // Vertical axis.
@@ -368,6 +417,35 @@ export class CanvasRenderer {
     if (bubbles && bubbles.size > 0) {
       drawBubbles(ctx, this.#accent, snap, carX, toScreenY, s, bubbles, w);
     }
+  }
+
+  // The space-elevator scenario walks a single 35,786 km cable —
+  // visual model fundamentally different from the multi-shaft
+  // building: shared cable, stacked climbers, atmospheric backdrop.
+  // The full pipeline lives in `drawTetherScene`; the renderer only
+  // owns the per-frame state (velocity history, names, day-phase
+  // baseline) the helper threads through.
+  #drawTetherMode(
+    snap: Snapshot,
+    w: number,
+    h: number,
+    s: Scale,
+    speedMultiplier: number,
+    bubbles: Map<number, CarBubble> | undefined,
+    tether: TetherMeta,
+  ): void {
+    void speedMultiplier;
+    void bubbles;
+    const state: TetherRenderState = {
+      prevVelocity: this.#prevVelocity,
+      carNames: this.#carNames,
+      maxSpeed: this.#activeMaxSpeed,
+      acceleration: this.#activeAcceleration,
+      deceleration: this.#activeDeceleration,
+      firstDrawAt: this.#firstDrawAt,
+    };
+    drawTetherScene(this.#ctx, snap, w, h, s, tether, state);
+    this.#firstDrawAt = state.firstDrawAt;
   }
 
   // ── Flying-dot animations ─────────────────────────────────────────

--- a/playground/src/render/renderer.ts
+++ b/playground/src/render/renderer.ts
@@ -71,8 +71,6 @@ export class CanvasRenderer {
   #tether: TetherMeta | null = null;
   /** Per-car previous-frame velocity, used to classify trapezoidal phase. */
   readonly #prevVelocity: Map<number, number> = new Map();
-  /** Per-car name, captured once from the snapshot for HUD display. */
-  readonly #carNames: Map<number, string> = new Map();
   /** Active `max_speed` for HUD/ETA math; updated from the snapshot's max served range. */
   #activeMaxSpeed = 1;
   #activeAcceleration = 1;
@@ -116,10 +114,13 @@ export class CanvasRenderer {
   setTetherConfig(tether: TetherMeta | null): void {
     this.#tether = tether;
     // Reset per-car kinematic state so a fresh scenario doesn't inherit
-    // stale velocities from the previous run.
+    // stale velocities from the previous run. Also drop the
+    // building-mode `#stopAssignments` map — the tween path that
+    // ordinarily prunes it is skipped in tether mode, so leftover
+    // entries from a prior building scenario would otherwise persist.
     this.#prevVelocity.clear();
-    this.#carNames.clear();
     this.#firstDrawAt = 0;
+    this.#stopAssignments.clear();
   }
 
   /**
@@ -130,11 +131,6 @@ export class CanvasRenderer {
     if (Number.isFinite(maxSpeed) && maxSpeed > 0) this.#activeMaxSpeed = maxSpeed;
     if (Number.isFinite(acceleration) && acceleration > 0) this.#activeAcceleration = acceleration;
     if (Number.isFinite(deceleration) && deceleration > 0) this.#activeDeceleration = deceleration;
-  }
-
-  /** Update the cached display name for a car (the snapshot doesn't carry it). */
-  setCarName(carId: number, name: string): void {
-    this.#carNames.set(carId, name);
   }
 
   pushAssignment(stopId: number, elevatorId: number, lineId: number): void {
@@ -438,7 +434,6 @@ export class CanvasRenderer {
     void bubbles;
     const state: TetherRenderState = {
       prevVelocity: this.#prevVelocity,
-      carNames: this.#carNames,
       maxSpeed: this.#activeMaxSpeed,
       acceleration: this.#activeAcceleration,
       deceleration: this.#activeDeceleration,

--- a/playground/src/render/tether.ts
+++ b/playground/src/render/tether.ts
@@ -53,11 +53,11 @@ export function atmosphericLayer(altitudeM: number): string {
  */
 export function tetherFractionForAltitude(altitudeM: number, axisMaxM: number): number {
   if (axisMaxM <= 0) return 0;
-  const lo = Math.log10(1 + 0 / 1000);
+  // log10(1 + 0/1000) = 0, so the bottom of the axis drops out.
   const hi = Math.log10(1 + axisMaxM / 1000);
+  if (hi <= 0) return 0;
   const v = Math.log10(1 + Math.max(0, altitudeM) / 1000);
-  if (hi <= lo) return 0;
-  return Math.max(0, Math.min(1, (v - lo) / (hi - lo)));
+  return Math.max(0, Math.min(1, v / hi));
 }
 
 /**
@@ -84,7 +84,7 @@ export function formatAltitudeShort(altitudeM: number): string {
   return `${km.toLocaleString("en-US", { maximumFractionDigits: 0 })} km`;
 }
 
-/** Velocity formatted at km/h above 360 m/s, m/s otherwise — keeps the chip short. */
+/** Velocity formatted at km/h above 100 m/s, m/s otherwise — keeps the chip short. */
 export function formatVelocity(vMs: number): string {
   const a = Math.abs(vMs);
   if (a < 1) return `${a.toFixed(2)} m/s`;
@@ -148,12 +148,11 @@ export function tetherEta(
   const decelDist = (v * v) / (2 * deceleration);
   if (decelDist >= remaining) return v > 0 ? remaining / Math.max(v, 1e-3) : 0;
   // Coast/cruise phase + decel from max to 0.
-  const cruiseSpeed = maxSpeed;
-  const accelTime = Math.max(0, (cruiseSpeed - v) / acceleration);
+  const accelTime = Math.max(0, (maxSpeed - v) / acceleration);
   const accelDist = v * accelTime + 0.5 * acceleration * accelTime * accelTime;
-  const decelTime = cruiseSpeed / deceleration;
-  const fullDecelDist = (cruiseSpeed * cruiseSpeed) / (2 * deceleration);
+  const decelTime = maxSpeed / deceleration;
+  const fullDecelDist = (maxSpeed * maxSpeed) / (2 * deceleration);
   const cruiseDist = Math.max(0, remaining - accelDist - fullDecelDist);
-  const cruiseTime = cruiseDist / Math.max(cruiseSpeed, 1e-3);
+  const cruiseTime = cruiseDist / Math.max(maxSpeed, 1e-3);
   return accelTime + cruiseTime + decelTime;
 }

--- a/playground/src/render/tether.ts
+++ b/playground/src/render/tether.ts
@@ -1,0 +1,159 @@
+/**
+ * Tether-mode rendering helpers — used only by scenarios that flag
+ * themselves as a space elevator (one shared shaft, vast altitude
+ * range, atmospheric backdrop). The CanvasRenderer falls back to the
+ * standard per-line column layout when no tether config is set.
+ *
+ * The altitude scale is logarithmic so the entire 0 → 100,000 km range
+ * remains legible in a single viewport: ground / Karman / LEO / GEO /
+ * counterweight all sit at distinct fractions of the canvas height
+ * even though they span seven orders of magnitude.
+ */
+
+/** Per-pane tether-mode config. Set on the renderer when the scenario opts in. */
+export interface TetherConfig {
+  /**
+   * Altitude (m) of the visual cap above the topmost stop. The
+   * counterweight icon is drawn at this height; the climber never
+   * travels here. Real space elevators use a counterweight at
+   * ~100,000 km to keep the tether under tension past geostationary.
+   */
+  counterweightAltitudeM: number;
+  /** Whether to cycle the Earth-curve gradient between day/night. */
+  showDayNight: boolean;
+}
+
+/**
+ * Atmospheric layer for a given altitude (m). Used by the inline car
+ * chip and the side info card so the abstract altitude number is
+ * anchored to something concrete ("you're in the stratosphere").
+ *
+ * Boundaries follow standard atmosphere reference points; "deep
+ * space" is anything beyond LEO altitudes where the climber is
+ * effectively in vacuum and the named layers stop being meaningful.
+ */
+export function atmosphericLayer(altitudeM: number): string {
+  if (altitudeM < 12_000) return "troposphere";
+  if (altitudeM < 50_000) return "stratosphere";
+  if (altitudeM < 80_000) return "mesosphere";
+  if (altitudeM < 700_000) return "thermosphere";
+  if (altitudeM < 10_000_000) return "exosphere";
+  if (altitudeM < 35_786_000) return "cislunar space";
+  return "geostationary belt";
+}
+
+/**
+ * Compress 0 → counterweight altitude into 0..1. Logarithmic with a
+ * 1 km offset so sea-level (0 m) maps to 0 cleanly and the lower
+ * decades (1 km, 10 km, 100 km) still claim screen real estate.
+ *
+ * `axisMaxM` is normally `counterweightAltitudeM`. Caller multiplies
+ * by available pixel range and inverts (higher altitudes draw higher
+ * on the canvas).
+ */
+export function tetherFractionForAltitude(altitudeM: number, axisMaxM: number): number {
+  if (axisMaxM <= 0) return 0;
+  const lo = Math.log10(1 + 0 / 1000);
+  const hi = Math.log10(1 + axisMaxM / 1000);
+  const v = Math.log10(1 + Math.max(0, altitudeM) / 1000);
+  if (hi <= lo) return 0;
+  return Math.max(0, Math.min(1, (v - lo) / (hi - lo)));
+}
+
+/**
+ * Decade tick marks (1, 10, 100, 1000, 10 000, 100 000 km) for the
+ * atmosphere strip — drawn as faint horizontal hairlines with a
+ * label. Returns altitudes that fall inside the visible axis.
+ */
+export function tetherDecadeTicks(axisMaxM: number): Array<{ altitudeM: number; label: string }> {
+  const ticks: Array<{ altitudeM: number; label: string }> = [];
+  for (let p = 3; p <= 8; p++) {
+    const altitudeM = 10 ** p;
+    if (altitudeM > axisMaxM) break;
+    ticks.push({ altitudeM, label: formatAltitudeShort(altitudeM) });
+  }
+  return ticks;
+}
+
+/** "12 km" / "400 km" / "35,786 km" depending on magnitude. */
+export function formatAltitudeShort(altitudeM: number): string {
+  if (altitudeM < 1000) return `${Math.round(altitudeM)} m`;
+  const km = altitudeM / 1000;
+  if (km < 10) return `${km.toFixed(1)} km`;
+  if (km < 1000) return `${km.toFixed(0)} km`;
+  return `${km.toLocaleString("en-US", { maximumFractionDigits: 0 })} km`;
+}
+
+/** Velocity formatted at km/h above 360 m/s, m/s otherwise — keeps the chip short. */
+export function formatVelocity(vMs: number): string {
+  const a = Math.abs(vMs);
+  if (a < 1) return `${a.toFixed(2)} m/s`;
+  if (a < 100) return `${a.toFixed(0)} m/s`;
+  const kph = (a * 3.6).toFixed(0);
+  return `${kph} km/h`;
+}
+
+/** Approximate trapezoidal-phase classification from current speed and accel/decel hints. */
+export type KinematicPhase = "accel" | "cruise" | "decel" | "idle";
+
+export function classifyKinematicPhase(
+  currentSpeed: number,
+  prevSpeed: number,
+  maxSpeed: number,
+): KinematicPhase {
+  const a = Math.abs(currentSpeed);
+  if (a < 0.5) return "idle";
+  const dv = a - Math.abs(prevSpeed);
+  // 5% deadband so floating-point cruise jitter doesn't flip-flop the chip.
+  if (a >= maxSpeed * 0.95 && Math.abs(dv) < maxSpeed * 0.005) return "cruise";
+  if (dv > 0) return "accel";
+  if (dv < 0) return "decel";
+  return "cruise";
+}
+
+/** Format seconds as a compact "1h 24m" / "42m" / "18s" depending on size. */
+export function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return "—";
+  if (seconds < 60) return `${Math.round(seconds)} s`;
+  if (seconds < 3600) {
+    const m = Math.floor(seconds / 60);
+    const s = Math.round(seconds % 60);
+    return s === 0 ? `${m}m` : `${m}m ${s}s`;
+  }
+  const h = Math.floor(seconds / 3600);
+  const m = Math.round((seconds % 3600) / 60);
+  return m === 0 ? `${h}h` : `${h}h ${m}m`;
+}
+
+/**
+ * Trapezoidal-motion ETA from `posM` to `targetM` given current
+ * signed velocity, max speed, and decel. Returns seconds or
+ * `Number.POSITIVE_INFINITY` if no target is set.
+ *
+ * Approximation: assume the climber will accel up to (or coast at)
+ * max speed, then decelerate to a stop at the target. Good enough for
+ * a HUD readout — exact ETA would require the engine's plan.
+ */
+export function tetherEta(
+  posM: number,
+  targetM: number,
+  velocity: number,
+  maxSpeed: number,
+  acceleration: number,
+  deceleration: number,
+): number {
+  const remaining = Math.abs(targetM - posM);
+  if (remaining < 1e-3) return 0;
+  const v = Math.abs(velocity);
+  const decelDist = (v * v) / (2 * deceleration);
+  if (decelDist >= remaining) return v > 0 ? remaining / Math.max(v, 1e-3) : 0;
+  // Coast/cruise phase + decel from max to 0.
+  const cruiseSpeed = maxSpeed;
+  const accelTime = Math.max(0, (cruiseSpeed - v) / acceleration);
+  const accelDist = v * accelTime + 0.5 * acceleration * accelTime * accelTime;
+  const decelTime = cruiseSpeed / deceleration;
+  const fullDecelDist = (cruiseSpeed * cruiseSpeed) / (2 * deceleration);
+  const cruiseDist = Math.max(0, remaining - accelDist - fullDecelDist);
+  const cruiseTime = cruiseDist / Math.max(cruiseSpeed, 1e-3);
+  return accelTime + cruiseTime + decelTime;
+}

--- a/playground/src/render/tether.ts
+++ b/playground/src/render/tether.ts
@@ -15,18 +15,22 @@
  * chip and the side info card so the abstract altitude number is
  * anchored to something concrete ("you're in the stratosphere").
  *
- * Boundaries follow standard atmosphere reference points; "deep
- * space" is anything beyond LEO altitudes where the climber is
- * effectively in vacuum and the named layers stop being meaningful.
+ * Boundaries follow standard atmosphere reference points (IAU and
+ * Wikipedia). The exosphere extends out to roughly 100,000 km, so
+ * everything from the thermopause through the counterweight zone
+ * lives there; the only stop with a more specific label is the
+ * narrow band right around geostationary altitude.
  */
 export function atmosphericLayer(altitudeM: number): string {
   if (altitudeM < 12_000) return "troposphere";
   if (altitudeM < 50_000) return "stratosphere";
   if (altitudeM < 80_000) return "mesosphere";
   if (altitudeM < 700_000) return "thermosphere";
-  if (altitudeM < 10_000_000) return "exosphere";
-  if (altitudeM < 35_786_000) return "cislunar space";
-  return "geostationary belt";
+  // Narrow window centred on the geostationary altitude (35,786 km
+  // ± 1 %) so the chip flips to a recognisable label as the climber
+  // approaches the GEO platform.
+  if (altitudeM >= 35_400_000 && altitudeM <= 36_200_000) return "geostationary";
+  return "exosphere";
 }
 
 /**
@@ -113,13 +117,18 @@ export function formatDuration(seconds: number): string {
 }
 
 /**
- * Trapezoidal-motion ETA from `posM` to `targetM` given current
- * signed velocity, max speed, and decel. Returns seconds or
- * `Number.POSITIVE_INFINITY` if no target is set.
+ * Trapezoidal-motion ETA from `posM` to `targetM`. Three branches:
  *
- * Approximation: assume the climber will accel up to (or coast at)
- * max speed, then decelerate to a stop at the target. Good enough for
- * a HUD readout — exact ETA would require the engine's plan.
+ *  1. Already inside the brake distance → time to decelerate to rest.
+ *  2. Long enough to reach `maxSpeed` → accel + cruise + decel.
+ *  3. Too short to reach `maxSpeed` → triangle profile, peak velocity
+ *     `vp` solved from `(vp² − v²)/(2a) + vp²/(2d) = remaining`.
+ *
+ * The previous implementation always added the full accel/decel
+ * times, overestimating sub-trapezoid trips by up to 2× (e.g. a 50 km
+ * trip from rest at 1000 m/s / 10 m/s² returned 200 s instead of the
+ * actual ~141 s). Approximation accuracy is "good enough for a HUD
+ * readout" — exact ETA would require the engine's planned profile.
  */
 export function tetherEta(
   posM: number,
@@ -132,14 +141,26 @@ export function tetherEta(
   const remaining = Math.abs(targetM - posM);
   if (remaining < 1e-3) return 0;
   const v = Math.abs(velocity);
-  const decelDist = (v * v) / (2 * deceleration);
-  if (decelDist >= remaining) return v > 0 ? remaining / Math.max(v, 1e-3) : 0;
-  // Coast/cruise phase + decel from max to 0.
+  // Brake-from-current case: we're past the latest stop point. Time
+  // to come to rest is `v / deceleration` (the climber overshoots,
+  // but the HUD shows the time-to-zero as a useful upper bound).
+  const brakeDist = (v * v) / (2 * deceleration);
+  if (brakeDist >= remaining) return v > 0 ? v / deceleration : 0;
+  // Distances if we accel to maxSpeed and decel back to 0.
   const accelTime = Math.max(0, (maxSpeed - v) / acceleration);
   const accelDist = v * accelTime + 0.5 * acceleration * accelTime * accelTime;
   const decelTime = maxSpeed / deceleration;
-  const fullDecelDist = (maxSpeed * maxSpeed) / (2 * deceleration);
-  const cruiseDist = Math.max(0, remaining - accelDist - fullDecelDist);
-  const cruiseTime = cruiseDist / Math.max(maxSpeed, 1e-3);
-  return accelTime + cruiseTime + decelTime;
+  const decelDist = (maxSpeed * maxSpeed) / (2 * deceleration);
+  if (accelDist + decelDist >= remaining) {
+    // Triangle profile — never reaches maxSpeed. Solve for peak velocity:
+    //   (vp² − v²)/(2a) + vp²/(2d) = remaining
+    // => vp² = (2·a·d·remaining + d·v²) / (a + d)
+    const vpSq =
+      (2 * acceleration * deceleration * remaining + deceleration * v * v) /
+      (acceleration + deceleration);
+    const vp = Math.sqrt(Math.max(vpSq, v * v));
+    return (vp - v) / acceleration + vp / deceleration;
+  }
+  const cruiseDist = remaining - accelDist - decelDist;
+  return accelTime + cruiseDist / Math.max(maxSpeed, 1e-3) + decelTime;
 }

--- a/playground/src/render/tether.ts
+++ b/playground/src/render/tether.ts
@@ -10,19 +10,6 @@
  * even though they span seven orders of magnitude.
  */
 
-/** Per-pane tether-mode config. Set on the renderer when the scenario opts in. */
-export interface TetherConfig {
-  /**
-   * Altitude (m) of the visual cap above the topmost stop. The
-   * counterweight icon is drawn at this height; the climber never
-   * travels here. Real space elevators use a counterweight at
-   * ~100,000 km to keep the tether under tension past geostationary.
-   */
-  counterweightAltitudeM: number;
-  /** Whether to cycle the Earth-curve gradient between day/night. */
-  showDayNight: boolean;
-}
-
 /**
  * Atmospheric layer for a given altitude (m). Used by the inline car
  * chip and the side info card so the abstract altitude number is

--- a/playground/src/shell/boot.ts
+++ b/playground/src/shell/boot.ts
@@ -43,6 +43,18 @@ export async function boot(): Promise<void> {
   // scenario's `defaultStrategy` for pane A so "Share link from hotel"
   // doesn't deliver a mismatched config to the recipient.
   reconcileStrategyWithScenario(permalink);
+  const scenario = scenarioById(permalink.scenario);
+  // Cold-boot reposition default: if the URL didn't carry an explicit
+  // `pa` and the scenario advertises a `defaultReposition`, apply it.
+  // This mirrors `switchScenario` so opening `?s=space-elevator`
+  // directly behaves the same as picking the scenario card from
+  // another scenario — without it, a fresh visitor lands on the
+  // tether with `lobby` parking and every idle climber slides back
+  // to the ground.
+  const urlSearch = new URLSearchParams(window.location.search);
+  if (!urlSearch.has("pa") && !permalink.compare && scenario.defaultReposition !== undefined) {
+    permalink.repositionA = scenario.defaultReposition;
+  }
   // Compact decoded overrides against the resolved scenario so a URL
   // that carries values matching the current default (possible if a
   // scenario default shifted between share-time and load-time) doesn't
@@ -50,7 +62,6 @@ export async function boot(): Promise<void> {
   // `encodePermalink`'s contract is that callers compact first; this
   // is the decode-side counterpart, done once at boot rather than in
   // every subsequent write path.
-  const scenario = scenarioById(permalink.scenario);
   permalink.overrides = compactOverrides(scenario, permalink.overrides);
   applyPermalinkToUi(permalink, ui);
   const state: State = {

--- a/playground/src/shell/boot.ts
+++ b/playground/src/shell/boot.ts
@@ -44,16 +44,24 @@ export async function boot(): Promise<void> {
   // doesn't deliver a mismatched config to the recipient.
   reconcileStrategyWithScenario(permalink);
   const scenario = scenarioById(permalink.scenario);
-  // Cold-boot reposition default: if the URL didn't carry an explicit
-  // `pa` and the scenario advertises a `defaultReposition`, apply it.
-  // This mirrors `switchScenario` so opening `?s=space-elevator`
-  // directly behaves the same as picking the scenario card from
-  // another scenario — without it, a fresh visitor lands on the
-  // tether with `lobby` parking and every idle climber slides back
-  // to the ground.
+  // Cold-boot reposition default: if the URL didn't carry explicit
+  // `pa` / `pb` and the scenario advertises a `defaultReposition`,
+  // apply it to whichever pane(s) defaulted. Mirrors `switchScenario`
+  // so opening `?s=space-elevator` directly behaves the same as
+  // picking the scenario card from another scenario — without it, a
+  // fresh visitor lands on the tether with `lobby` parking and every
+  // idle climber slides back to the ground. Compare mode is *not*
+  // gated here: a fresh visitor in default compare-on mode otherwise
+  // misses the snap entirely and both panes inherit the global
+  // default.
   const urlSearch = new URLSearchParams(window.location.search);
-  if (!urlSearch.has("pa") && !permalink.compare && scenario.defaultReposition !== undefined) {
-    permalink.repositionA = scenario.defaultReposition;
+  if (scenario.defaultReposition !== undefined) {
+    if (!urlSearch.has("pa")) {
+      permalink.repositionA = scenario.defaultReposition;
+    }
+    if (!urlSearch.has("pb")) {
+      permalink.repositionB = scenario.defaultReposition;
+    }
   }
   // Compact decoded overrides against the resolved scenario so a URL
   // that carries values matching the current default (possible if a

--- a/playground/src/shell/listeners.ts
+++ b/playground/src/shell/listeners.ts
@@ -1,6 +1,7 @@
 import { setShortcutSheetOpen } from "../features/keyboard-shortcuts";
 import {
   renderPaneStrategyInfo,
+  renderPaneRepositionInfo,
   refreshStrategyPopovers,
   refreshRepositionPopovers,
   isAnyStrategyPopoverOpen,
@@ -31,8 +32,10 @@ export function attachListeners(state: State, ui: UiHandles): void {
 
   const switchHooks: ScenarioSwitchHooks = {
     renderPaneStrategyInfo,
+    renderPaneRepositionInfo,
     refreshStrategyPopovers: () => {
       refreshStrategyPopovers(state, ui, doResetAll);
+      refreshRepositionPopovers(state, ui, doResetAll);
     },
     renderTweakPanel: () => {
       const scenario = scenarioById(state.permalink.scenario);

--- a/playground/src/types/index.ts
+++ b/playground/src/types/index.ts
@@ -7,5 +7,15 @@ export type {
 } from "../../public/pkg/elevator_wasm";
 export type { StrategyName, RepositionStrategyName, TrafficMode } from "./strategies";
 export type { CarBubble } from "./bubble";
-export type { Phase, ElevatorPhysics, TweakRange, TweakRanges, ScenarioMeta } from "./scenario";
+export type {
+  Phase,
+  ElevatorPhysics,
+  TweakRange,
+  TweakRanges,
+  ScenarioMeta,
+  TetherMeta,
+} from "./scenario";
+// Re-import RepositionStrategyName via strategies module — keeps the
+// scenario meta's `defaultReposition` field type-aligned with the
+// permalink decoder.
 export { type MetricKey, METRIC_KEYS, METRIC_HISTORY_LEN } from "./metrics";

--- a/playground/src/types/scenario.ts
+++ b/playground/src/types/scenario.ts
@@ -1,4 +1,4 @@
-import type { StrategyName } from "./strategies";
+import type { RepositionStrategyName, StrategyName } from "./strategies";
 
 /**
  * One phase of a scenario's day cycle. The `TrafficDriver` linearly
@@ -79,6 +79,24 @@ export interface TweakRanges {
   doorCycleSec: TweakRange;
 }
 
+/**
+ * Tether-mode rendering hints for space-elevator-style scenarios.
+ * When present, the renderer collapses every car into a single shared
+ * shaft and switches the altitude axis to a log scale that spans
+ * sea level through the counterweight altitude.
+ */
+export interface TetherMeta {
+  /**
+   * Visual cap altitude (m) above the topmost stop. The counterweight
+   * icon is drawn here; the climber never travels past the topmost
+   * actual stop. Real space elevators terminate the cable at
+   * ~100,000 km counterweight mass to keep tension above GEO.
+   */
+  counterweightAltitudeM: number;
+  /** Cycle the Earth-curve gradient between day and night. */
+  showDayNight: boolean;
+}
+
 export interface ScenarioMeta {
   id: string;
   label: string;
@@ -134,4 +152,18 @@ export interface ScenarioMeta {
    * pressure instead of auto-draining.
    */
   abandonAfterSec?: number;
+  /**
+   * Tether-mode metadata. Set only by space-elevator-style scenarios;
+   * absent for regular building scenarios so they keep the standard
+   * per-line column rendering.
+   */
+  tether?: TetherMeta;
+  /**
+   * Default reposition (idle-parking) strategy applied on scenario
+   * selection. Lobby is fine for skyscrapers but a tether climber
+   * sliding back to the ground every time it's idle defeats the
+   * visualization, so the space-elevator scenario opts into Spread
+   * to keep idle climbers distributed across the platforms.
+   */
+  defaultReposition?: RepositionStrategyName;
 }

--- a/playground/src/types/scenario.ts
+++ b/playground/src/types/scenario.ts
@@ -66,8 +66,8 @@ export interface TweakRange {
 
 /**
  * Per-scenario tweak bounds for the four user-facing knobs. Exists so
- * the space elevator (50 m/s climbers, 1000 m shaft, 1 car) can have
- * sane bounds distinct from a commercial building.
+ * the space elevator (1000 m/s climbers, 35,786 km shaft, up to 3
+ * cars) can have sane bounds distinct from a commercial building.
  */
 export interface TweakRanges {
   cars: TweakRange;


### PR DESCRIPTION
## Summary

Replaces the 1 km toy tether with a 35,786 km cable to GEO and three named platforms (Karman line, LEO transfer, GEO terminus). Adds a dedicated tether render mode that collapses every climber onto one shared cable on a log-scale altitude axis with a muted atmospheric backdrop, an amber horizon hairline, a counterweight cap, inline HUD chips (altitude / velocity / phase · layer), and a side info card matching the playground surface treatment.

### What's in
- New scenario shape: 4 stops, 3 climbers default, 1000 m/s max speed, traffic phases re-tuned for the long-haul time scale ("Outbound cargo" / "Inbound cargo" instead of misleading "shifts")
- Tether render mode behind a `tether?: TetherMeta` field on `ScenarioMeta` — building scenarios are unaffected
- Log-scale axis (`log10(1 + altM/1000)`) so all five decades from ground to counterweight stay visible in one viewport
- HUD chip collision pass: stacked climbers no longer overlap labels (alternates sides, then stacks vertically when both sides are occupied)
- Side info card auto-suppresses on viewports under 520 × 360 (mobile portrait + landscape both verified)
- Speed slider cap raised from 16× → 64× — long-haul scenarios deserve faster playback when users want it; default stays 2×
- `defaultReposition` field on `ScenarioMeta` snaps tether onto the SpreadEvenly parking strategy on scenario switch (idle climbers stay distributed across platforms instead of all sliding back to the ground)
- 6 pre-seeded riders so the scene isn't empty on cold start

### What's out
- Climber speed deliberately left at 1000 m/s — Ground→GEO takes ~10 hours of sim time, which is fine; users can crank the playback slider if they want a faster montage
- No auto-bump of the playback-speed slider on scenario switch — that's a per-user preference

## Test plan
- [x] `cargo test -p elevator-wasm --tests` (8 passed including `space_elevator_scenario_builds` against the new RON)
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` (143 tests, 15 new tether unit tests cover log axis, layer mapping, phase classifier, ETA, formatters)
- [ ] Visual smoke test in browser: load `?s=space-elevator`, watch climbers depart from seeded riders, confirm muted palette + horizon + counterweight render correctly
- [ ] Mobile portrait (≤ 480 px wide): side card hidden, cable claims full width, HUD chips don't clip
- [ ] Mobile landscape (≤ 360 px tall): side card hidden, climbers + chips fit
- [ ] Scenario switch from skyscraper → space elevator preserves expected behaviour: parking strategy snaps to Spread, climbers spread across platforms instead of piling at the ground