### PR TITLE
feat(playground): merge phase-strip into header

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -40,12 +40,12 @@
             ><span aria-hidden="true">&#9733;</span><span class="max-md:hidden">star</span></a
           >
           <a
-            class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content"
+            class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content max-md:hidden"
             href="https://docs.rs/elevator-core"
             >docs</a
           >
           <a
-            class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content"
+            class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content max-md:hidden"
             href="../"
             >guide</a
           >

--- a/playground/index.html
+++ b/playground/index.html
@@ -19,13 +19,12 @@
     <header
       class="top relative bg-gradient-to-b from-surface-secondary to-surface px-5 pt-3 pb-2.5 max-md:px-3.5 max-md:pt-2.5 max-md:pb-2"
     >
-      <div class="flex flex-wrap items-center gap-y-1 gap-x-3 min-w-0 max-md:gap-x-2">
+      <div class="flex flex-wrap items-center gap-y-1 gap-x-5 min-w-0 max-md:gap-x-3">
         <h1
           class="m-0 text-[14px] font-semibold tracking-[-0.005em] inline-flex items-center gap-2.5 whitespace-nowrap min-w-0 before:content-[''] before:inline-block before:flex-none before:w-2 before:h-2 before:rounded-[2px] before:bg-accent before:shadow-[0_0_10px_color-mix(in_srgb,var(--accent)_50%,transparent)] max-md:text-[12.5px] max-md:gap-2 max-md:tracking-[-0.01em]"
         >
           <span class="truncate"
-            ><span class="text-content-tertiary font-normal max-md:hidden"
-              >elevator-core <span class="text-content-tertiary/60">/</span> </span
+            ><span class="text-content-tertiary max-md:hidden">elevator-core / </span
             ><span class="text-content">playground</span></span
           >
         </h1>
@@ -34,36 +33,36 @@
           class="ml-auto md:order-3 flex items-center gap-4 shrink-0 max-md:gap-3"
           aria-label="External links"
         >
-          <button type="button" id="shortcuts" class="nav-btn" title="Keyboard shortcuts (press ?)">
-            ?
-          </button>
           <a
-            class="text-content-tertiary no-underline text-xs transition-colors hover:text-content inline-flex items-center gap-1"
+            class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content inline-flex items-center gap-1"
             href="https://github.com/andymai/elevator-core"
             aria-label="Star elevator-core on GitHub"
-            ><span aria-hidden="true">&#9733;</span><span class="max-md:hidden">Star</span></a
+            ><span aria-hidden="true">&#9733;</span><span class="max-md:hidden">star</span></a
           >
           <a
-            class="text-content-tertiary no-underline text-xs transition-colors hover:text-content"
+            class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content"
             href="https://docs.rs/elevator-core"
             >docs</a
           >
           <a
-            class="text-content-tertiary no-underline text-xs transition-colors hover:text-content"
+            class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content"
             href="../"
             >guide</a
           >
+          <button type="button" id="shortcuts" class="nav-btn" title="Keyboard shortcuts (press ?)">
+            ?
+          </button>
         </nav>
 
         <div
-          class="md:order-2 flex items-center gap-2 text-[11px] text-content-tertiary min-w-0 max-md:basis-full max-md:text-[10.5px]"
+          class="md:order-2 flex items-center gap-1.5 text-[11.5px] text-content-tertiary min-w-0 max-md:basis-full max-md:text-[10.5px]"
         >
           <span class="ctl-k">Phase</span>
           <span id="phase-label" class="text-content-secondary tabular-nums font-medium"
             >&mdash;</span
           >
           <div
-            class="hidden lg:flex items-center gap-x-3 gap-y-1 ml-2 flex-wrap text-[10.5px]"
+            class="flex max-lg:hidden items-center gap-x-3 gap-y-1 ml-3 flex-wrap text-[10.5px]"
             aria-label="Cabin color legend"
           >
             <span class="ctl-k">Cabin</span>
@@ -89,12 +88,12 @@
       </div>
 
       <div
-        class="absolute inset-x-0 bottom-0 h-px bg-surface-elevated overflow-hidden"
+        class="absolute inset-x-0 bottom-0 h-px bg-stroke-subtle overflow-hidden"
         aria-hidden="true"
       >
         <div
           id="phase-progress-fill"
-          class="absolute inset-y-0 left-0 w-0 bg-gradient-to-r from-accent to-accent-hover shadow-[0_0_6px_color-mix(in_srgb,var(--accent)_45%,transparent)] transition-[width] duration-normal ease-normal"
+          class="absolute inset-y-0 left-0 w-0 bg-gradient-to-r from-accent to-accent-hover transition-[width] duration-normal ease-normal"
         ></div>
       </div>
     </header>
@@ -109,7 +108,7 @@
       id="verdict-ribbon"
       hidden
       aria-label="Comparison scoreboard"
-      class="verdict-ribbon grid grid-cols-[auto_repeat(5,1fr)] gap-3 px-5 py-2.5 bg-surface-secondary border-b border-stroke-subtle text-[11px] tabular-nums max-md:grid-cols-2 max-md:px-3.5"
+      class="verdict-ribbon grid items-center grid-cols-[auto_repeat(5,1fr)] gap-3 px-5 py-2.5 bg-surface-secondary border-b border-stroke-subtle text-[11px] tabular-nums max-md:grid-cols-2 max-md:px-3.5"
     ></section>
 
     <main

--- a/playground/index.html
+++ b/playground/index.html
@@ -17,74 +17,79 @@
   </head>
   <body>
     <header
-      class="top flex items-center justify-between gap-3 px-5 py-3 bg-gradient-to-b from-surface-secondary to-surface border-b border-stroke-subtle relative max-md:px-3.5 max-md:py-2.5 max-md:gap-2"
+      class="top relative bg-gradient-to-b from-surface-secondary to-surface px-5 pt-3 pb-2.5 max-md:px-3.5 max-md:pt-2.5 max-md:pb-2"
     >
-      <h1
-        class="m-0 text-[14px] font-semibold tracking-[-0.005em] text-content inline-flex items-center gap-2.5 whitespace-nowrap min-w-0 before:content-[''] before:inline-block before:flex-none before:w-2 before:h-2 before:rounded-[2px] before:bg-accent before:shadow-[0_0_10px_color-mix(in_srgb,var(--accent)_50%,transparent)] max-md:text-[12.5px] max-md:gap-2 max-md:tracking-[-0.01em]"
-      >
-        <span class="truncate"><span class="max-md:hidden">elevator-core </span>playground</span>
-      </h1>
-      <nav class="flex items-center gap-4 max-md:gap-3 shrink-0">
-        <button type="button" id="shortcuts" class="nav-btn" title="Keyboard shortcuts (press ?)">
-          ?
-        </button>
-        <a
-          class="text-content-tertiary no-underline text-xs transition-colors hover:text-content"
-          href="https://github.com/andymai/elevator-core"
-          >repo</a
+      <div class="flex flex-wrap items-center gap-y-1 gap-x-3 min-w-0 max-md:gap-x-2">
+        <h1
+          class="m-0 text-[14px] font-semibold tracking-[-0.005em] inline-flex items-center gap-2.5 whitespace-nowrap min-w-0 before:content-[''] before:inline-block before:flex-none before:w-2 before:h-2 before:rounded-[2px] before:bg-accent before:shadow-[0_0_10px_color-mix(in_srgb,var(--accent)_50%,transparent)] max-md:text-[12.5px] max-md:gap-2 max-md:tracking-[-0.01em]"
         >
-        <a
-          class="text-content-tertiary no-underline text-xs transition-colors hover:text-content max-md:hidden"
-          href="https://docs.rs/elevator-core"
-          >docs</a
-        >
-        <a
-          class="text-content-tertiary no-underline text-xs transition-colors hover:text-content max-md:hidden"
-          href="../"
-          >guide</a
-        >
-      </nav>
-    </header>
+          <span class="truncate"
+            ><span class="text-content-tertiary font-normal max-md:hidden"
+              >elevator-core <span class="text-content-tertiary/60">/</span> </span
+            ><span class="text-content">playground</span></span
+          >
+        </h1>
 
-    <section
-      id="scenario-cards"
-      aria-label="Scenario picker"
-      class="scenario-cards flex flex-row flex-wrap items-center gap-1.5 px-5 py-1.5 border-b border-stroke-subtle max-md:gap-1.5 max-md:px-3.5 max-md:py-1.5 max-md:flex-nowrap max-md:overflow-x-auto max-md:snap-x max-md:snap-mandatory max-md:[-webkit-overflow-scrolling:touch] max-md:[scrollbar-width:none] max-md:[&::-webkit-scrollbar]:hidden"
-    ></section>
-
-    <section
-      id="phase-strip"
-      class="phase-strip flex flex-col gap-1 px-5 py-1.5 bg-surface border-b border-stroke-subtle text-[11px] text-content-tertiary max-md:px-3.5 max-md:py-1 max-md:text-[10.5px]"
-    >
-      <div class="flex items-center gap-2.5 flex-wrap max-md:gap-2">
-        <span class="ctl-k">Phase</span>
-        <span id="phase-label" class="text-content-secondary tabular-nums font-medium"
-          >&mdash;</span
+        <nav
+          class="ml-auto md:order-3 flex items-center gap-4 shrink-0 max-md:gap-3"
+          aria-label="External links"
         >
+          <button type="button" id="shortcuts" class="nav-btn" title="Keyboard shortcuts (press ?)">
+            ?
+          </button>
+          <a
+            class="text-content-tertiary no-underline text-xs transition-colors hover:text-content inline-flex items-center gap-1"
+            href="https://github.com/andymai/elevator-core"
+            aria-label="Star elevator-core on GitHub"
+            ><span aria-hidden="true">&#9733;</span><span class="max-md:hidden">Star</span></a
+          >
+          <a
+            class="text-content-tertiary no-underline text-xs transition-colors hover:text-content"
+            href="https://docs.rs/elevator-core"
+            >docs</a
+          >
+          <a
+            class="text-content-tertiary no-underline text-xs transition-colors hover:text-content"
+            href="../"
+            >guide</a
+          >
+        </nav>
+
         <div
-          class="ml-auto flex items-center gap-x-3 gap-y-1 flex-wrap text-[10.5px] max-md:gap-x-1.5 max-md:gap-y-0.5"
+          class="md:order-2 flex items-center gap-2 text-[11px] text-content-tertiary min-w-0 max-md:basis-full max-md:text-[10.5px]"
         >
-          <span class="ctl-k max-md:hidden">Cabin</span>
-          <span class="inline-flex items-center gap-1 whitespace-nowrap">
-            <span class="w-2 h-2 rounded-[2px] shrink-0" style="background: #6b6b75"></span>Idle
-          </span>
-          <span class="inline-flex items-center gap-1 whitespace-nowrap">
-            <span class="w-2 h-2 rounded-[2px] shrink-0" style="background: #f59e0b"></span>Moving
-          </span>
-          <span class="inline-flex items-center gap-1 whitespace-nowrap">
-            <span class="w-2 h-2 rounded-[2px] shrink-0" style="background: #a78bfa"></span
-            >Reposition
-          </span>
-          <span class="inline-flex items-center gap-1 whitespace-nowrap">
-            <span class="w-2 h-2 rounded-[2px] shrink-0" style="background: #fbbf24"></span>Doors
-          </span>
-          <span class="inline-flex items-center gap-1 whitespace-nowrap">
-            <span class="w-2 h-2 rounded-[2px] shrink-0" style="background: #7dd3fc"></span>Loading
-          </span>
+          <span class="ctl-k">Phase</span>
+          <span id="phase-label" class="text-content-secondary tabular-nums font-medium"
+            >&mdash;</span
+          >
+          <div
+            class="hidden lg:flex items-center gap-x-3 gap-y-1 ml-2 flex-wrap text-[10.5px]"
+            aria-label="Cabin color legend"
+          >
+            <span class="ctl-k">Cabin</span>
+            <span class="inline-flex items-center gap-1 whitespace-nowrap">
+              <span class="w-2 h-2 rounded-[2px] shrink-0" style="background: #6b6b75"></span>Idle
+            </span>
+            <span class="inline-flex items-center gap-1 whitespace-nowrap">
+              <span class="w-2 h-2 rounded-[2px] shrink-0" style="background: #f59e0b"></span>Moving
+            </span>
+            <span class="inline-flex items-center gap-1 whitespace-nowrap">
+              <span class="w-2 h-2 rounded-[2px] shrink-0" style="background: #a78bfa"></span
+              >Reposition
+            </span>
+            <span class="inline-flex items-center gap-1 whitespace-nowrap">
+              <span class="w-2 h-2 rounded-[2px] shrink-0" style="background: #fbbf24"></span>Doors
+            </span>
+            <span class="inline-flex items-center gap-1 whitespace-nowrap">
+              <span class="w-2 h-2 rounded-[2px] shrink-0" style="background: #7dd3fc"></span
+              >Loading
+            </span>
+          </div>
         </div>
       </div>
+
       <div
-        class="relative h-[2px] bg-surface-elevated rounded-[2px] overflow-hidden"
+        class="absolute inset-x-0 bottom-0 h-px bg-surface-elevated overflow-hidden"
         aria-hidden="true"
       >
         <div
@@ -92,7 +97,13 @@
           class="absolute inset-y-0 left-0 w-0 bg-gradient-to-r from-accent to-accent-hover shadow-[0_0_6px_color-mix(in_srgb,var(--accent)_45%,transparent)] transition-[width] duration-normal ease-normal"
         ></div>
       </div>
-    </section>
+    </header>
+
+    <section
+      id="scenario-cards"
+      aria-label="Scenario picker"
+      class="scenario-cards flex flex-row flex-wrap items-center gap-1.5 px-5 py-1.5 border-b border-stroke-subtle max-md:gap-1.5 max-md:px-3.5 max-md:py-1.5 max-md:flex-nowrap max-md:overflow-x-auto max-md:snap-x max-md:snap-mandatory max-md:[-webkit-overflow-scrolling:touch] max-md:[scrollbar-width:none] max-md:[&::-webkit-scrollbar]:hidden"
+    ></section>
 
     <section
       id="verdict-ribbon"

--- a/playground/src/render/draw-building.ts
+++ b/playground/src/render/draw-building.ts
@@ -51,9 +51,20 @@ export function drawShaftLabels(
   ctx.font = `600 ${s.fontSmall.toFixed(0)}px system-ui, -apple-system, "Segoe UI", sans-serif`;
   ctx.textBaseline = "alphabetic";
   ctx.textAlign = "center";
+  // Car headers (drawn separately) live in the same `padTop` band, so a
+  // group label whose natural Y sits inside that band collides with the
+  // matching "Car N". Pin colliding labels to the top of `padTop`; leave
+  // labels for partial-height groups (shafts that don't reach the top of
+  // the building) at their natural position above their shaft.
+  const carHeaderY = s.padTop - s.fontSmall * 0.5 - 2;
+  const carHeaderTop = carHeaderY - s.fontSmall * 0.5 - 1;
+  const carHeaderBottom = carHeaderY + s.fontSmall * 0.5 + 1;
+  const clampedY = Math.max(s.fontSmall + 0.5, carHeaderTop);
   for (const l of labels) {
+    const naturalY = l.top - 3;
+    const collides = naturalY > carHeaderTop && naturalY - s.fontSmall < carHeaderBottom;
     ctx.fillStyle = l.color;
-    ctx.fillText(l.text, l.cx, l.top - 3);
+    ctx.fillText(l.text, l.cx, collides ? clampedY : naturalY);
   }
 }
 
@@ -141,7 +152,10 @@ export function drawCarHeaders(
   cars: readonly CarDto[],
   carX: Map<number, number>,
 ): void {
-  const y = s.padTop / 2 + 1;
+  // Sit just above the shaft top so group labels (drawn at the top of
+  // `padTop`) have clearance. Was `padTop / 2 + 1`, which collided with
+  // the group label of any single-car bank that reached the building top.
+  const y = s.padTop - s.fontSmall * 0.5 - 2;
   ctx.font = `600 ${s.fontSmall.toFixed(0)}px system-ui, -apple-system, "Segoe UI", sans-serif`;
   ctx.textBaseline = "middle";
   ctx.textAlign = "center";

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -245,9 +245,8 @@
     opacity: 0.4;
   }
 
-  /* Controls and phase strip base styling moved to Tailwind utilities on the
- * respective HTML elements. See index.html `<section class="controls ...">`
- * and `<section class="phase-strip ...">`. */
+  /* Controls and header phase indicator base styling live on Tailwind
+ * utilities applied directly to the elements in index.html. */
 
   /* ── Tweak panel ───────────────────────────────────────────────────── */
 


### PR DESCRIPTION
## Summary

- Collapses the playground's title bar and phase-strip into a single header so the top of the page presents one coherent region with a single seam instead of two.
- Two-tone wordmark: `elevator-core` is muted, `playground` carries the emphasis (this page IS the playground, so it gets the visual weight).
- `repo` link promoted to a `★ Star` CTA pointing at the same `github.com/andymai/elevator-core` URL.
- Phase progress bar becomes a 1px hairline that doubles as the header's bottom seam (replaces `border-b border-stroke-subtle`); cabin color legend now appears only at `lg+` to keep tablet/mobile chrome tight.

## Implementation notes

- DOM order in the header is `wordmark → nav → phase`; `md:order-2` / `md:order-3` reorder them visually on desktop while letting `flex-wrap` + `basis-full` push the phase block onto a second row on mobile, so we get the desired desktop-vs-mobile layout from a single phase element rather than duplicating it.
- `#phase-label` and `#phase-progress-fill` IDs are preserved; `shell/loop.ts` and `shell/reset.ts` continue to work with no JS changes.
- Stale `phase-strip`-section comment in `style.css` updated to reflect the new structure.

## Link audit

| Link | Target | Verified against |
|---|---|---|
| `?` | opens `#shortcut-sheet` modal | inline JS handler |
| `★ Star` | `https://github.com/andymai/elevator-core` | `git remote` + workspace `Cargo.toml` `repository` |
| `docs` | `https://docs.rs/elevator-core` | `crates/elevator-core/Cargo.toml` `name` |
| `guide` | `../` (relative) | `.github/workflows/docs.yml` deploys playground into `target/book/playground/` so `../` resolves to mdBook root |

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 146/146 pass
- [x] `pnpm snap` regenerates desktop (1440×900) and iPhone 14 portrait (390×844) screenshots; both render the new header correctly
- [x] Pre-commit hook (lint-staged + typecheck + vitest) passes
- [ ] **Manual:** verify mobile landscape (~640×360) wrap behavior in `pnpm dev` — the `flex-wrap` + `basis-full` rules don't depend on orientation, but the mobile-P0 gate calls for an in-browser eyeball.