### PR TITLE
feat(playground): add manual-control demo with cabin cutaway

### DIFF
--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -617,6 +617,139 @@ impl WasmSim {
             .map_err(|e| JsError::new(&format!("press_car_button: {e}")))
     }
 
+    // ── Service mode + manual control ────────────────────────────────
+    //
+    // Wraps the per-elevator `ServiceMode` switch and the manual-mode
+    // door + velocity APIs at `crates/elevator-core/src/sim/manual.rs`.
+    // Door commands work in any mode (queued); velocity + emergency
+    // stop require `ServiceMode::Manual`.
+
+    /// Set an elevator's service mode.
+    ///
+    /// Accepts `"normal" | "independent" | "inspection" | "manual" |
+    /// "outofservice"`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the elevator does not exist or `mode` is
+    /// not a recognised name.
+    #[wasm_bindgen(js_name = setServiceMode)]
+    pub fn set_service_mode(&mut self, elevator_ref: u64, mode: &str) -> Result<(), JsError> {
+        use elevator_core::components::ServiceMode;
+        let parsed = match mode {
+            "normal" => ServiceMode::Normal,
+            "independent" => ServiceMode::Independent,
+            "inspection" => ServiceMode::Inspection,
+            "manual" => ServiceMode::Manual,
+            "outofservice" => ServiceMode::OutOfService,
+            other => {
+                return Err(JsError::new(&format!(
+                    "service mode must be one of normal | independent | inspection | manual | outofservice, got {other:?}"
+                )));
+            }
+        };
+        self.inner
+            .set_service_mode(u64_to_entity(elevator_ref), parsed)
+            .map_err(|e| JsError::new(&format!("set_service_mode: {e}")))
+    }
+
+    /// Request the doors of `elevator_ref` to open.
+    ///
+    /// Applied when the car next reaches a stop with closed/closing
+    /// doors; otherwise queued. Works in every service mode.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the elevator does not exist or is disabled.
+    #[wasm_bindgen(js_name = openDoor)]
+    pub fn open_door(&mut self, elevator_ref: u64) -> Result<(), JsError> {
+        self.inner
+            .open_door(elevator_core::entity::ElevatorId::from(u64_to_entity(
+                elevator_ref,
+            )))
+            .map_err(|e| JsError::new(&format!("open_door: {e}")))
+    }
+
+    /// Request the doors of `elevator_ref` to close now.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the elevator does not exist or is disabled.
+    #[wasm_bindgen(js_name = closeDoor)]
+    pub fn close_door(&mut self, elevator_ref: u64) -> Result<(), JsError> {
+        self.inner
+            .close_door(elevator_core::entity::ElevatorId::from(u64_to_entity(
+                elevator_ref,
+            )))
+            .map_err(|e| JsError::new(&format!("close_door: {e}")))
+    }
+
+    /// Extend the open dwell of `elevator_ref` by `ticks`. Cumulative.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if `ticks` is zero, the elevator does not exist,
+    /// or the elevator is disabled.
+    #[wasm_bindgen(js_name = holdDoor)]
+    pub fn hold_door(&mut self, elevator_ref: u64, ticks: u32) -> Result<(), JsError> {
+        self.inner
+            .hold_door(
+                elevator_core::entity::ElevatorId::from(u64_to_entity(elevator_ref)),
+                ticks,
+            )
+            .map_err(|e| JsError::new(&format!("hold_door: {e}")))
+    }
+
+    /// Cancel a pending hold extension on `elevator_ref`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the elevator does not exist or is disabled.
+    #[wasm_bindgen(js_name = cancelDoorHold)]
+    pub fn cancel_door_hold(&mut self, elevator_ref: u64) -> Result<(), JsError> {
+        self.inner
+            .cancel_door_hold(elevator_core::entity::ElevatorId::from(u64_to_entity(
+                elevator_ref,
+            )))
+            .map_err(|e| JsError::new(&format!("cancel_door_hold: {e}")))
+    }
+
+    /// Set the target velocity (m/s) for a `ServiceMode::Manual` elevator.
+    /// Positive values command upward travel, negative values downward.
+    /// The car ramps toward the target each tick using its configured
+    /// acceleration / deceleration.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the elevator is not in Manual mode, does
+    /// not exist, is disabled, or `velocity` is not finite.
+    #[wasm_bindgen(js_name = setTargetVelocity)]
+    pub fn set_target_velocity(&mut self, elevator_ref: u64, velocity: f64) -> Result<(), JsError> {
+        self.inner
+            .set_target_velocity(
+                elevator_core::entity::ElevatorId::from(u64_to_entity(elevator_ref)),
+                velocity,
+            )
+            .map_err(|e| JsError::new(&format!("set_target_velocity: {e}")))
+    }
+
+    /// Command an immediate stop on a `ServiceMode::Manual` elevator —
+    /// target velocity is set to zero and the car decelerates at its
+    /// configured rate.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the elevator is not in Manual mode, does
+    /// not exist, or is disabled.
+    #[wasm_bindgen(js_name = emergencyStop)]
+    pub fn emergency_stop(&mut self, elevator_ref: u64) -> Result<(), JsError> {
+        self.inner
+            .emergency_stop(elevator_core::entity::ElevatorId::from(u64_to_entity(
+                elevator_ref,
+            )))
+            .map_err(|e| JsError::new(&format!("emergency_stop: {e}")))
+    }
+
     /// Find the stop entity at `position` that's served by `line_ref`,
     /// or `0` (slotmap-null) if none. Lets consumers disambiguate
     /// co-located stops on different lines (sky-lobby served by

--- a/playground/index.html
+++ b/playground/index.html
@@ -114,7 +114,7 @@
     <main
       id="layout"
       data-mode="single"
-      class="layout grid gap-3.5 px-5 pt-3.5 pb-[calc(var(--controls-bar-h,52px)+16px)] flex-1 data-[mode=single]:grid-cols-1 data-[mode=compare]:grid-cols-2 max-md:gap-2.5 max-md:px-[calc(14px+env(safe-area-inset-left))] max-md:pr-[calc(14px+env(safe-area-inset-right))] max-md:pt-2.5 max-md:pb-[calc(var(--controls-bar-h,52px)+12px+env(safe-area-inset-bottom))] max-md:data-[mode=compare]:grid-cols-1 max-md:landscape:data-[mode=compare]:grid-cols-2"
+      class="layout grid gap-3.5 px-5 pt-3.5 pb-[calc(var(--controls-bar-h,52px)+16px)] flex-1 data-[mode=single]:grid-cols-1 data-[mode=compare]:grid-cols-2 data-[mode=manual-control]:grid-cols-[minmax(0,1fr)_360px] max-md:gap-2.5 max-md:px-[calc(14px+env(safe-area-inset-left))] max-md:pr-[calc(14px+env(safe-area-inset-right))] max-md:pt-2.5 max-md:pb-[calc(var(--controls-bar-h,52px)+12px+env(safe-area-inset-bottom))] max-md:data-[mode=compare]:grid-cols-1 max-md:landscape:data-[mode=compare]:grid-cols-2 max-md:data-[mode=manual-control]:grid-cols-1"
     >
       <section
         id="pane-a"
@@ -291,6 +291,58 @@
           <canvas id="shaft-b" class="absolute inset-0 w-full h-full block"></canvas>
         </div>
       </section>
+
+      <!-- Manual control side panel. Hidden by default (utilities-layer
+           rule keyed off layout's data-mode), surfaced when the active
+           scenario sets `manualControl`. Populated dynamically by
+           features/manual-controls. -->
+      <aside
+        id="manual-controls"
+        aria-label="Manual elevator controls"
+        class="manual-controls flex-col gap-3 min-w-0 p-3 bg-gradient-to-b from-surface-elevated to-surface-secondary border border-stroke-subtle rounded-lg shadow-md max-md:p-2.5 max-md:gap-2 overflow-y-auto"
+      >
+        <header class="flex items-center justify-between gap-2">
+          <span
+            class="inline-flex items-center gap-1.5 text-[12px] font-semibold tracking-[0.04em] uppercase text-content-secondary"
+            ><span
+              class="w-1.5 h-1.5 rounded-full bg-accent shadow-[0_0_8px_color-mix(in_srgb,var(--accent)_60%,transparent)]"
+              aria-hidden="true"
+            ></span
+            >Controls</span
+          >
+          <button
+            type="button"
+            id="manual-add-car"
+            class="manual-add-car text-[11px] font-medium px-2 py-1 rounded-sm border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover hover:text-content disabled:opacity-50 disabled:cursor-not-allowed"
+            hidden
+          >
+            Add Car B
+          </button>
+        </header>
+
+        <section aria-label="Hall calls" class="manual-section">
+          <h3 class="manual-section-title">Hall calls</h3>
+          <div id="manual-hall-buttons" class="flex flex-col gap-1"></div>
+        </section>
+
+        <section aria-label="Per-car controls" class="manual-section">
+          <h3 class="manual-section-title">Cars</h3>
+          <div id="manual-car-controls" class="flex flex-col gap-2"></div>
+        </section>
+
+        <section aria-label="Spawn rider" class="manual-section">
+          <h3 class="manual-section-title">Spawn rider</h3>
+          <div id="manual-spawn-form" class="flex flex-wrap items-end gap-1.5"></div>
+        </section>
+
+        <section aria-label="Event log" class="manual-section flex-1 min-h-0">
+          <h3 class="manual-section-title">Events</h3>
+          <ul
+            id="manual-event-log"
+            class="manual-event-log m-0 p-1.5 list-none flex flex-col gap-0.5 bg-surface border border-stroke-subtle rounded-sm text-[10.5px] tabular-nums text-content-tertiary overflow-y-auto h-[180px] max-md:h-[120px]"
+          ></ul>
+        </section>
+      </aside>
     </main>
 
     <!-- Bottom controls bar — transparent when idle, full opacity on hover/focus -->
@@ -379,6 +431,7 @@
       </section>
       <div class="controls-bar-inner">
         <label
+          id="compare-toggle"
           class="ctl-check flex flex-row items-center gap-2 px-2.5 py-1.5 bg-transparent border border-transparent rounded-md cursor-pointer transition-colors duration-fast select-none hover:bg-surface-hover hover:border-stroke-subtle"
         >
           <input id="compare" type="checkbox" />
@@ -421,7 +474,7 @@
           </span>
           <input id="speed" type="range" min="1" max="64" step="1" value="2" class="w-full" />
         </label>
-        <label class="controls-bar-field">
+        <label id="traffic-field" class="controls-bar-field">
           <span class="ctl-k">
             <span>Intensity</span>
             <span

--- a/playground/scripts/snap.mjs
+++ b/playground/scripts/snap.mjs
@@ -39,6 +39,10 @@ const SCENES = [
     url: `${BASE}/?s=space-elevator&c=0&a=scan`,
   },
   {
+    name: "manual-control",
+    url: `${BASE}/?s=manual-office&c=0&a=etd`,
+  },
+  {
     name: "strategy-popover-open",
     url: `${BASE}/?s=skyscraper-sky-lobby&c=0&a=scan`,
     // Open the strategy popover on pane A to capture its styling.

--- a/playground/src/__tests__/scenarios.test.ts
+++ b/playground/src/__tests__/scenarios.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { SCENARIOS, scenarioById } from "../domain/scenarios";
 
 describe("scenarios metadata", () => {
-  it("ships exactly 3 scenarios", () => {
-    expect(SCENARIOS).toHaveLength(3);
+  it("ships exactly 4 scenarios", () => {
+    expect(SCENARIOS).toHaveLength(4);
   });
 
   it("every id is unique", () => {
@@ -17,11 +17,18 @@ describe("scenarios metadata", () => {
     }
   });
 
-  it("every scenario has either phases or seedSpawns — never both empty", () => {
+  it("every scenario has phases, seedSpawns, or opts into manual-control", () => {
+    // Manual-control scenarios run with `phases: []` because riders are
+    // spawned by hand from the controls panel — there's no day cycle to
+    // schedule. Allow that case so the assertion catches truly empty
+    // scenarios while letting `manualControl` opt out.
     for (const s of SCENARIOS) {
       const phased = s.phases.length > 0;
       const seeded = s.seedSpawns > 0;
-      expect(phased || seeded, `${s.id} has neither phases nor seedSpawns`).toBe(true);
+      const manual = s.manualControl !== undefined;
+      expect(phased || seeded || manual, `${s.id} has no phases / seedSpawns / manualControl`).toBe(
+        true,
+      );
     }
   });
 

--- a/playground/src/domain/scenarios/scenarios.ts
+++ b/playground/src/domain/scenarios/scenarios.ts
@@ -648,10 +648,97 @@ const spaceElevator: ScenarioMeta = {
 )`,
 };
 
-// Order is intentional: scale-ascending. A 5-stop acute burst, then a
-// 13-stop sky-lobby tower, then a 2-stop tether 1 000 km tall — the
-// card strip reads as a "zoom out" from building to orbit.
-export const SCENARIOS: ScenarioMeta[] = [convention, skyscraper, spaceElevator];
+// ─── Manual control — small office, hands-on API showcase ───────────
+//
+// 5-floor office where the user drives the simulation by hand: hall
+// calls, car buttons, door commands, velocity slider, service-mode
+// dropdown, on-demand rider spawn, and live add/remove of a second
+// car. TrafficDriver is disabled (`phases: []`) so the only riders are
+// the ones the user spawns. Cars boot in `Normal` so spawned riders
+// auto-board and dispatch reacts to button presses; flipping a car to
+// `Manual` via the dropdown unlocks direct velocity control.
+//
+// Scale-wise this scenario sits below the convention burst (smaller
+// building, fewer cars, no traffic). It leads the SCENARIOS array so
+// first-time visitors land on the most approachable demo.
+
+const manualOffice: ScenarioMeta = {
+  id: "manual-office",
+  label: "Manual control",
+  description:
+    "5-floor office, no auto traffic. Press hall calls, car buttons, doors, and a velocity slider yourself; flip a car between Normal / Manual / Inspection / Out-of-service to see every service mode.",
+  defaultStrategy: "etd",
+  // Empty phases = TrafficDriver no-op (mirrors the convention's
+  // static post-keynote pattern). All riders are user-spawned.
+  phases: [],
+  seedSpawns: 0,
+  featureHint:
+    "Press buttons by hand. Spawn a rider, watch dispatch pick the car, then flip the car to Manual and drive it yourself with the velocity slider.",
+  buildingName: "Manual Office",
+  stops: [
+    { name: "Lobby", positionM: 0.0 },
+    { name: "Floor 2", positionM: 4.0 },
+    { name: "Floor 3", positionM: 8.0 },
+    { name: "Floor 4", positionM: 12.0 },
+    { name: "Floor 5", positionM: 16.0 },
+  ],
+  // 1 car by default; the `Add Car B` toggle in the controls panel
+  // demos `addElevator`. Cap at 2 — beyond two cabins the cutaway
+  // renderer's right pane would have to shrink each cab.
+  defaultCars: 1,
+  elevatorDefaults: {
+    maxSpeed: 2.0,
+    acceleration: 1.5,
+    deceleration: 2.0,
+    weightCapacity: 800.0,
+    doorOpenTicks: 240,
+    doorTransitionTicks: 60,
+  },
+  tweakRanges: {
+    cars: { min: 1, max: 2, step: 1 },
+    maxSpeed: { min: 0.5, max: 6, step: 0.5 },
+    weightCapacity: { min: 200, max: 1500, step: 100 },
+    doorCycleSec: { min: 2, max: 12, step: 0.5 },
+  },
+  passengerMeanIntervalTicks: 60,
+  passengerWeightRange: [55.0, 100.0],
+  manualControl: {
+    defaultServiceMode: "normal",
+    allowAddRemoveCar: true,
+  },
+  ron: `SimConfig(
+    building: BuildingConfig(
+        name: "Manual Office",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby",   position: 0.0),
+            StopConfig(id: StopId(1), name: "Floor 2", position: 4.0),
+            StopConfig(id: StopId(2), name: "Floor 3", position: 8.0),
+            StopConfig(id: StopId(3), name: "Floor 4", position: 12.0),
+            StopConfig(id: StopId(4), name: "Floor 5", position: 16.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car A",
+            max_speed: 2.0, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 240, door_transition_ticks: 60,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 60,
+        weight_range: (55.0, 100.0),
+    ),
+)`,
+};
+
+// Order is intentional: scale-ascending. Manual office sits first as
+// the most approachable starting point (5 stops, 1 car, hands-on);
+// then a 5-stop acute burst, a 42-stop sky-lobby tower, and a 4-stop
+// tether 35 786 km tall.
+export const SCENARIOS: ScenarioMeta[] = [manualOffice, convention, skyscraper, spaceElevator];
 
 export function scenarioById(id: string): ScenarioMeta {
   const match = SCENARIOS.find((s) => s.id === id);

--- a/playground/src/features/compare-pane/pane.ts
+++ b/playground/src/features/compare-pane/pane.ts
@@ -67,6 +67,14 @@ export async function makePane(
   // this hookup the renderer falls back to the standard per-line
   // column layout — which fails badly at 35,786 km axes.
   renderer.setTetherConfig(scenario.tether ?? null);
+  // Manual-control rendering is gated on the same opt-in pattern. The
+  // selectedCarId stays `null` here; the manual-controls panel updates
+  // it via `setManualControlState` once the user picks a car.
+  if (scenario.manualControl) {
+    renderer.setManualControlState({ selectedCarId: null });
+  } else {
+    renderer.setManualControlState(null);
+  }
   if (scenario.tether) {
     // Use the override-merged physics so a shared permalink with a
     // tweaked max-speed (e.g. `?s=space-elevator&ms=2000`) shows

--- a/playground/src/features/compare-pane/pane.ts
+++ b/playground/src/features/compare-pane/pane.ts
@@ -68,10 +68,15 @@ export async function makePane(
   // column layout — which fails badly at 35,786 km axes.
   renderer.setTetherConfig(scenario.tether ?? null);
   // Manual-control rendering is gated on the same opt-in pattern. The
-  // selectedCarId stays `null` here; the manual-controls panel updates
-  // it via `setManualControlState` once the user picks a car.
+  // panel.update() call from the loop pushes a richer state object
+  // each frame (selected car, per-car service mode, hall-call lamps);
+  // here we just toggle the cutaway path on with empty maps.
   if (scenario.manualControl) {
-    renderer.setManualControlState({ selectedCarId: null });
+    renderer.setManualControlState({
+      selectedCarId: null,
+      serviceModeByCar: new Map(),
+      hallCallsByStop: new Map(),
+    });
   } else {
     renderer.setManualControlState(null);
   }

--- a/playground/src/features/manual-controls/car-controls.ts
+++ b/playground/src/features/manual-controls/car-controls.ts
@@ -39,6 +39,14 @@ export interface CarControlsHandle {
   sync(view: WorldView, selectedRef: bigint | null): void;
   /** First car ref currently rendered, for cold-boot selection. */
   firstCarRef(): bigint | null;
+  /**
+   * Snapshot of every car block's currently-selected service mode,
+   * keyed by car ref. The panel reads this each frame and pushes it
+   * to the cabin renderer so the cabin badge / OOS door colour / OOS
+   * rider greying track the dropdown — without this, the renderer
+   * would never see service-mode changes.
+   */
+  serviceModes(): Map<bigint, ServiceModeName>;
 }
 
 const SERVICE_MODES: Array<{ value: ServiceModeName; label: string }> = [
@@ -114,6 +122,13 @@ export function mountCarControls(
     },
     firstCarRef(): bigint | null {
       return blocks[0]?.carRef ?? null;
+    },
+    serviceModes(): Map<bigint, ServiceModeName> {
+      const map = new Map<bigint, ServiceModeName>();
+      for (const block of blocks) {
+        map.set(block.carRef, block.modeSelect.value as ServiceModeName);
+      }
+      return map;
     },
   };
 }

--- a/playground/src/features/manual-controls/car-controls.ts
+++ b/playground/src/features/manual-controls/car-controls.ts
@@ -1,0 +1,283 @@
+import { el } from "../../platform";
+import type { CarView, ScenarioMeta, ServiceModeName, WorldView } from "../../types";
+
+/**
+ * Per-car control block: service-mode dropdown, in-cab car-buttons,
+ * door commands, manual-mode velocity slider, emergency stop.
+ *
+ * The car-button strip uses the scenario's stops (not WorldView's) so
+ * the floor labels stay stable even if `addStop` adds runtime stops
+ * mid-session — runtime stops would lack a friendly label and the
+ * scenario's hand-written names are the playground's only source.
+ */
+export interface CarControlsHandlers {
+  setServiceMode: (carRef: bigint, mode: ServiceModeName) => void;
+  pressCarButton: (carRef: bigint, stopRef: bigint) => void;
+  openDoor: (carRef: bigint) => void;
+  closeDoor: (carRef: bigint) => void;
+  holdDoor: (carRef: bigint, ticks: number) => void;
+  cancelDoorHold: (carRef: bigint) => void;
+  setTargetVelocity: (carRef: bigint, velocity: number) => void;
+  emergencyStop: (carRef: bigint) => void;
+  /** Notify panel state when the user clicks a car header to focus it. */
+  selectCar: (carRef: bigint) => void;
+}
+
+interface CarBlock {
+  carRef: bigint;
+  root: HTMLElement;
+  modeSelect: HTMLSelectElement;
+  carButtons: Map<bigint, HTMLButtonElement>;
+  velocitySlider: HTMLInputElement;
+  velocityRow: HTMLElement;
+  velocityReadout: HTMLElement;
+  estopBtn: HTMLButtonElement;
+  doorButtons: HTMLButtonElement[];
+}
+
+export interface CarControlsHandle {
+  sync(view: WorldView, selectedRef: bigint | null): void;
+  /** First car ref currently rendered, for cold-boot selection. */
+  firstCarRef(): bigint | null;
+}
+
+const SERVICE_MODES: Array<{ value: ServiceModeName; label: string }> = [
+  { value: "normal", label: "Normal" },
+  { value: "manual", label: "Manual" },
+  { value: "inspection", label: "Inspection" },
+  { value: "outofservice", label: "Out of service" },
+];
+
+export function mountCarControls(
+  container: HTMLElement,
+  scenario: ScenarioMeta,
+  initial: WorldView,
+  handlers: CarControlsHandlers,
+): CarControlsHandle {
+  container.replaceChildren();
+  const blocks: CarBlock[] = [];
+
+  // Build a name lookup once: scenario stops carry friendly labels;
+  // WorldView gives the entity refs. Match by name.
+  const nameByRef = new Map<bigint, string>(
+    initial.stops.map((s) => [BigInt(s.entity_id), s.name]),
+  );
+
+  // Stops served by *each* car. For the small office every car serves
+  // every stop, but we read it from WorldView to stay correct under
+  // multi-line scenarios should this UI ever be reused.
+  const servesByCar = new Map<bigint, bigint[]>();
+  for (const car of initial.cars) {
+    const carRef = BigInt(car.id);
+    const lineRef = BigInt(car.line);
+    const line = initial.lines.find((l) => BigInt(l.id) === lineRef);
+    const serves = line?.stop_ids.map((id) => BigInt(id)) ?? [];
+    servesByCar.set(carRef, serves);
+  }
+
+  for (const car of initial.cars) {
+    blocks.push(buildCarBlock(scenario, car, nameByRef, servesByCar, handlers));
+  }
+  for (const block of blocks) container.append(block.root);
+
+  return {
+    sync(view: WorldView, selectedRef: bigint | null): void {
+      for (const block of blocks) {
+        const car = view.cars.find((c) => BigInt(c.id) === block.carRef);
+        if (!car) continue;
+        // Highlight selected block via accent border. Lit on currently
+        // selected for cabin cutaway; dimmed otherwise.
+        block.root.dataset["selected"] = selectedRef === block.carRef ? "true" : "false";
+        block.root.style.borderColor =
+          selectedRef === block.carRef ? "color-mix(in srgb, var(--accent) 55%, transparent)" : "";
+        // Velocity readout follows the engine's physical velocity so
+        // users see the slider command vs actual motion. Manual mode
+        // keeps the slider live; other modes disable it.
+        const inManual = block.modeSelect.value === "manual";
+        block.velocityRow.dataset["disabled"] = inManual ? "false" : "true";
+        block.velocitySlider.disabled = !inManual;
+        block.estopBtn.disabled = !inManual;
+        block.velocityReadout.textContent = `${car.v.toFixed(1)} m/s`;
+        // Door buttons and car buttons remain enabled in every mode —
+        // the door-command queue is mode-agnostic and the engine just
+        // ignores car calls for OutOfService cars.
+        for (const btn of block.doorButtons) btn.disabled = false;
+        // Car-button lit state: the engine doesn't expose pending
+        // car-calls in WorldView, so we approximate from `target` —
+        // the dispatched stop. Good enough for a hands-on demo; a
+        // future enhancement could surface the full car-call queue.
+        for (const [stopRef, btn] of block.carButtons) {
+          btn.dataset["lit"] =
+            car.target !== undefined && BigInt(car.target) === stopRef ? "true" : "false";
+        }
+      }
+    },
+    firstCarRef(): bigint | null {
+      return blocks[0]?.carRef ?? null;
+    },
+  };
+}
+
+function buildCarBlock(
+  scenario: ScenarioMeta,
+  car: CarView,
+  nameByRef: Map<bigint, string>,
+  servesByCar: Map<bigint, bigint[]>,
+  handlers: CarControlsHandlers,
+): CarBlock {
+  const carRef = BigInt(car.id);
+  const root = el("div", "manual-car-block");
+  root.tabIndex = 0;
+  root.addEventListener("click", () => {
+    handlers.selectCar(carRef);
+  });
+  root.addEventListener("focus", () => {
+    handlers.selectCar(carRef);
+  });
+
+  const header = el("div", "manual-car-header");
+  const name = el("span", "manual-car-name", carLabel(car));
+  const modeSelect = document.createElement("select");
+  modeSelect.className = "manual-car-mode-select";
+  for (const m of SERVICE_MODES) {
+    const opt = document.createElement("option");
+    opt.value = m.value;
+    opt.textContent = m.label;
+    modeSelect.appendChild(opt);
+  }
+  // Default UI value follows the scenario's manualControl.defaultServiceMode;
+  // panel.ts applies the same value to the sim immediately after mount.
+  modeSelect.value = scenario.manualControl?.defaultServiceMode ?? "normal";
+  modeSelect.addEventListener("change", () => {
+    handlers.setServiceMode(carRef, modeSelect.value as ServiceModeName);
+  });
+  // Stop event bubbling so opening the dropdown doesn't re-trigger
+  // selectCar via the root click handler (already selected anyway,
+  // but keeps the focus-ring stable).
+  modeSelect.addEventListener("click", (e) => {
+    e.stopPropagation();
+  });
+  header.append(name, modeSelect);
+
+  // Car-button strip: one per stop the car's line serves. Top floor
+  // first to mirror the cabin cutaway's vertical orientation.
+  const carButtonsRow = el("div", "manual-car-buttons");
+  const serves = servesByCar.get(carRef) ?? [];
+  // Order by descending y in scenario (top floor first).
+  const ordered = [...serves].sort((a, b) => {
+    const ya = scenario.stops.find((s) => s.name === nameByRef.get(a))?.positionM ?? 0;
+    const yb = scenario.stops.find((s) => s.name === nameByRef.get(b))?.positionM ?? 0;
+    return yb - ya;
+  });
+  const carButtons = new Map<bigint, HTMLButtonElement>();
+  for (const stopRef of ordered) {
+    const label = nameByRef.get(stopRef) ?? "?";
+    const btn = el("button", "manual-car-btn");
+    btn.type = "button";
+    btn.title = `Car call: ${label}`;
+    // Compact label: first character of stop name + a digit if present.
+    btn.textContent = abbrev(label);
+    btn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      handlers.pressCarButton(carRef, stopRef);
+    });
+    carButtonsRow.append(btn);
+    carButtons.set(stopRef, btn);
+  }
+
+  // Door command row: Open / Close / Hold +30 / Cancel hold.
+  const doorRow = el("div", "manual-door-row");
+  const openBtn = doorBtn("Open", () => {
+    handlers.openDoor(carRef);
+  });
+  const closeBtn = doorBtn("Close", () => {
+    handlers.closeDoor(carRef);
+  });
+  const holdBtn = doorBtn("Hold +30", () => {
+    handlers.holdDoor(carRef, 30);
+  });
+  const cancelBtn = doorBtn("Cancel hold", () => {
+    handlers.cancelDoorHold(carRef);
+  });
+  doorRow.append(openBtn, closeBtn, holdBtn, cancelBtn);
+  const doorButtons = [openBtn, closeBtn, holdBtn, cancelBtn];
+
+  // Manual velocity row: slider commands `set_target_velocity`. Only
+  // active in Manual mode (engine rejects velocity commands in other
+  // modes — the disable mirrors that).
+  const velocityRow = el("div", "manual-velocity-row");
+  velocityRow.dataset["disabled"] = "true";
+  const maxSpeed = scenario.elevatorDefaults.maxSpeed;
+  const velocitySlider = document.createElement("input");
+  velocitySlider.type = "range";
+  velocitySlider.min = String(-maxSpeed);
+  velocitySlider.max = String(maxSpeed);
+  velocitySlider.step = "0.1";
+  velocitySlider.value = "0";
+  velocitySlider.disabled = true;
+  velocitySlider.addEventListener("input", () => {
+    handlers.setTargetVelocity(carRef, Number(velocitySlider.value));
+  });
+  velocitySlider.addEventListener("click", (e) => {
+    e.stopPropagation();
+  });
+  const velocityReadout = el("span", "manual-velocity-readout", "0.0 m/s");
+  velocityRow.append(el("span", "manual-velocity-label", "Vel"), velocitySlider, velocityReadout);
+
+  const estopBtn = el("button", "manual-estop-btn", "E-Stop");
+  estopBtn.type = "button";
+  estopBtn.disabled = true;
+  estopBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    handlers.emergencyStop(carRef);
+    // Snap slider back to zero so the next drag starts from rest —
+    // the engine has already zeroed `manual_target_velocity`.
+    velocitySlider.value = "0";
+  });
+
+  root.append(header, carButtonsRow, doorRow, velocityRow, estopBtn);
+
+  return {
+    carRef,
+    root,
+    modeSelect,
+    carButtons,
+    velocitySlider,
+    velocityRow,
+    velocityReadout,
+    estopBtn,
+    doorButtons,
+  };
+}
+
+function doorBtn(label: string, onClick: () => void): HTMLButtonElement {
+  const btn = el("button", "manual-door-btn", label);
+  btn.type = "button";
+  btn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    onClick();
+  });
+  return btn;
+}
+
+function carLabel(car: CarView): string {
+  // CarView has no name field; synthesise from id slot. The first
+  // car gets "Car A", subsequent runtime-added cars get sequential
+  // letters. Approximate — we don't have the scenario's RON name here.
+  return `Car ${slotLetter(car.id)}`;
+}
+
+function slotLetter(id: number): string {
+  // Pull the slot index out of the FFI-encoded id (low 32 bits) and
+  // map 0→A, 1→B, etc.
+
+  const slot = (id & 0xffff_ffff) % 26;
+  return String.fromCharCode(65 + slot);
+}
+
+function abbrev(label: string): string {
+  // "Lobby" → "L"; "Floor 2" → "2"; otherwise first character.
+  const num = label.match(/\d+/);
+  if (num) return num[0];
+  return label.charAt(0).toUpperCase();
+}

--- a/playground/src/features/manual-controls/event-log.ts
+++ b/playground/src/features/manual-controls/event-log.ts
@@ -1,0 +1,62 @@
+import type { EventDto } from "../../types";
+
+/**
+ * Filter `drainEvents` output to a curated set the manual demo
+ * surfaces in the event log. The full `EventDto` union covers
+ * lifecycle + dispatch + door events; this UI keeps the high-signal
+ * ones (boarding, exiting, doors, dispatch assignments) and ignores
+ * the rest so the log doesn't become a wall of "elevator-departed".
+ */
+const SURFACED: ReadonlySet<EventDto["kind"]> = new Set([
+  "rider-spawned",
+  "rider-boarded",
+  "rider-exited",
+  "rider-abandoned",
+  "door-opened",
+  "door-closed",
+  "elevator-assigned",
+]);
+
+const MAX_ENTRIES = 30;
+
+/**
+ * Append a frame's events to `logEl`, trimming to `MAX_ENTRIES`. Newest
+ * first so users see the latest activity without scrolling.
+ */
+export function appendEvents(logEl: HTMLElement, events: EventDto[]): void {
+  for (const ev of events) {
+    if (!SURFACED.has(ev.kind)) continue;
+    const li = document.createElement("li");
+    li.dataset["kind"] = ev.kind;
+    li.textContent = formatEvent(ev);
+    logEl.insertBefore(li, logEl.firstChild);
+  }
+  // Trim from the bottom (oldest first since we prepend new entries).
+  while (logEl.childElementCount > MAX_ENTRIES) {
+    logEl.lastElementChild?.remove();
+  }
+}
+
+function formatEvent(ev: EventDto): string {
+  // Pad the tick column so successive entries align — 6 digits covers
+  // the longest plausible session (~6 hours at 60 Hz).
+  const tick = String(ev.tick).padStart(6, " ");
+  switch (ev.kind) {
+    case "rider-spawned":
+      return `t=${tick} +rider r${ev.rider} ${ev.origin}→${ev.destination}`;
+    case "rider-boarded":
+      return `t=${tick} ▲ board r${ev.rider} into e${ev.elevator}`;
+    case "rider-exited":
+      return `t=${tick} ▼ exit  r${ev.rider} from e${ev.elevator} @${ev.stop}`;
+    case "rider-abandoned":
+      return `t=${tick} × abandon r${ev.rider} @${ev.stop}`;
+    case "door-opened":
+      return `t=${tick} doors open  e${ev.elevator}`;
+    case "door-closed":
+      return `t=${tick} doors close e${ev.elevator}`;
+    case "elevator-assigned":
+      return `t=${tick} dispatch e${ev.elevator} → ${ev.stop}`;
+    default:
+      return `t=${tick} ${ev.kind}`;
+  }
+}

--- a/playground/src/features/manual-controls/hall-buttons.ts
+++ b/playground/src/features/manual-controls/hall-buttons.ts
@@ -1,0 +1,89 @@
+import { el } from "../../platform";
+import type { ScenarioMeta, WorldView } from "../../types";
+
+/**
+ * Hall-call rows. One row per stop, each with the floor name on the
+ * left and `[▲][▼]` buttons on the right. Top floor has no `▲`,
+ * bottom floor has no `▼` — those calls would be trivially rejected
+ * by the engine, so omit them rather than render disabled affordances.
+ *
+ * Buttons fire `pressHallCall(stopRef, "up"|"down")` on click. The lit
+ * state is read each frame from `WorldView.stops[i].hall_calls.{up,down}`.
+ */
+export interface HallButtonHandlers {
+  onPress: (stopRef: bigint, direction: "up" | "down") => void;
+}
+
+export interface HallButtonsHandle {
+  /** Initial mount creates DOM; sync flips `data-lit` per frame. */
+  sync(view: WorldView): void;
+}
+
+export function mountHallButtons(
+  container: HTMLElement,
+  scenario: ScenarioMeta,
+  initial: WorldView,
+  handlers: HallButtonHandlers,
+): HallButtonsHandle {
+  container.replaceChildren();
+  // Match scenario stops to WorldView entries by name. Names are unique
+  // within a scenario (asserted by RON validation) so this is safe.
+  const stopByName = new Map(initial.stops.map((s) => [s.name, s]));
+  const rows: Array<{ stopRef: bigint; up?: HTMLButtonElement; down?: HTMLButtonElement }> = [];
+  // Top→bottom matches the cabin cutaway's vertical axis (highest
+  // floor at the top of the panel). Scenarios list stops bottom-up,
+  // so reverse for display.
+  const ordered = [...scenario.stops].reverse();
+  ordered.forEach((stop, i) => {
+    const view = stopByName.get(stop.name);
+    if (!view) return;
+    const isTop = i === 0;
+    const isBottom = i === ordered.length - 1;
+    const row = el("div", "manual-hall-row");
+    row.append(el("span", "manual-hall-name", stop.name));
+    // tsify emits u64 entity refs as TS `number`. Convert to BigInt
+    // for the mutation API which takes wasm-bindgen u64 → BigInt args.
+    const stopRef = BigInt(view.entity_id);
+    const entry: (typeof rows)[number] = { stopRef };
+    if (!isTop) {
+      const up = el("button", "manual-hall-btn");
+      up.type = "button";
+      up.textContent = "▲";
+      up.title = `Hall call: ${stop.name} ↑`;
+      up.addEventListener("click", () => {
+        handlers.onPress(stopRef, "up");
+      });
+      row.append(up);
+      entry.up = up;
+    } else {
+      // Spacer keeps grid columns aligned across rows.
+      row.append(el("span", "w-7"));
+    }
+    if (!isBottom) {
+      const down = el("button", "manual-hall-btn");
+      down.type = "button";
+      down.textContent = "▼";
+      down.title = `Hall call: ${stop.name} ↓`;
+      down.addEventListener("click", () => {
+        handlers.onPress(stopRef, "down");
+      });
+      row.append(down);
+      entry.down = down;
+    } else {
+      row.append(el("span", "w-7"));
+    }
+    rows.push(entry);
+    container.append(row);
+  });
+
+  return {
+    sync(view: WorldView): void {
+      for (const row of rows) {
+        const stop = view.stops.find((s) => BigInt(s.entity_id) === row.stopRef);
+        if (!stop) continue;
+        if (row.up) row.up.dataset["lit"] = stop.hall_calls.up ? "true" : "false";
+        if (row.down) row.down.dataset["lit"] = stop.hall_calls.down ? "true" : "false";
+      }
+    },
+  };
+}

--- a/playground/src/features/manual-controls/index.ts
+++ b/playground/src/features/manual-controls/index.ts
@@ -1,0 +1,2 @@
+export { mountManualControls, type ManualControlsHandle } from "./panel";
+export { selectedCarId } from "./panel";

--- a/playground/src/features/manual-controls/panel.ts
+++ b/playground/src/features/manual-controls/panel.ts
@@ -1,9 +1,11 @@
+import type { CanvasRenderer } from "../../render";
 import type { Sim } from "../../sim";
-import type { EventDto, ScenarioMeta, ServiceModeName } from "../../types";
+import type { CarControlsHandlers } from "./car-controls";
 import { mountCarControls, type CarControlsHandle } from "./car-controls";
 import { mountHallButtons, type HallButtonsHandle } from "./hall-buttons";
 import { mountSpawnForm } from "./spawn-form";
 import { appendEvents } from "./event-log";
+import type { EventDto, ScenarioMeta } from "../../types";
 
 /** Containers the panel hydrates. All must exist in `index.html`. */
 export interface ManualControlsRoots {
@@ -33,12 +35,17 @@ export function selectedCarId(): bigint | null {
 /**
  * Mount the manual-controls side panel against `sim` for `scenario`.
  * Builds the hall-button rows, per-car blocks, spawn form, and event
- * log; applies the scenario's `defaultServiceMode` to every car.
+ * log; applies the scenario's `defaultServiceMode` to every car. Holds
+ * a `renderer` reference so each `update()` tick can push the
+ * authoritative UI state (selected car, per-car mode, hall-call
+ * lamps) into `CabinRenderState` — without this push the cabin badge
+ * and shaft lamps stay stuck on initial values.
  */
 export function mountManualControls(
   sim: Sim,
   scenario: ScenarioMeta,
   roots: ManualControlsRoots,
+  renderer: CanvasRenderer,
 ): ManualControlsHandle {
   const meta = scenario.manualControl;
   if (!meta) {
@@ -59,16 +66,18 @@ export function mountManualControls(
     },
   });
 
-  const cars: CarControlsHandle = mountCarControls(roots.carControls, scenario, initialView, {
+  // Build the handlers object once; both initial mount and the
+  // `rebuildCarControls` path on Add/Remove Car share it.
+  const carHandlers: CarControlsHandlers = {
     setServiceMode: (carRef, mode) => {
-      sim.setServiceMode(carRef, mode);
+      safe(() => {
+        sim.setServiceMode(carRef, mode);
+      });
     },
     pressCarButton: (carRef, stopRef) => {
-      try {
+      safe(() => {
         sim.pressCarButton(carRef, stopRef);
-      } catch (e) {
-        console.warn("pressCarButton:", e);
-      }
+      });
     },
     openDoor: (carRef) => {
       safe(() => {
@@ -103,7 +112,14 @@ export function mountManualControls(
     selectCar: (carRef) => {
       SELECTED = carRef;
     },
-  });
+  };
+
+  let carsHandle: CarControlsHandle = mountCarControls(
+    roots.carControls,
+    scenario,
+    initialView,
+    carHandlers,
+  );
 
   // Apply the scenario's default service mode to every car so the UI
   // dropdown and the engine state agree on first paint. Skipped when
@@ -132,22 +148,22 @@ export function mountManualControls(
   // would confuse "what just happened" given the panel re-mounts.
   roots.eventLog.replaceChildren();
 
-  // Add Car B / Remove Car B toggle. Mutates topology via the sim's
-  // addElevator / removeElevator wasm bindings.
+  // Add Car B / Remove Car B toggle. Hidden when the scenario opts
+  // out via `allowAddRemoveCar: false`; otherwise toggles label
+  // between "Add Car B" and "Remove Car B" based on whether we're at
+  // the per-scenario car cap.
   const addCarBtn = roots.addCarBtn;
   const updateAddCarBtn = (): void => {
-    const view = sim.worldView();
-    const max = scenario.tweakRanges.cars.max;
-    if (!meta.allowAddRemoveCar || view.cars.length >= max) {
-      addCarBtn.hidden = view.cars.length === 1 || !meta.allowAddRemoveCar;
-      addCarBtn.textContent = view.cars.length >= max ? "Remove Car B" : "Add Car B";
-      addCarBtn.disabled = !meta.allowAddRemoveCar;
-      addCarBtn.hidden = !meta.allowAddRemoveCar;
+    if (!meta.allowAddRemoveCar) {
+      addCarBtn.hidden = true;
       return;
     }
+    const view = sim.worldView();
+    const max = scenario.tweakRanges.cars.max;
+    const atMax = view.cars.length >= max;
     addCarBtn.hidden = false;
     addCarBtn.disabled = false;
-    addCarBtn.textContent = view.cars.length >= 2 ? "Remove Car B" : "Add Car B";
+    addCarBtn.textContent = atMax ? "Remove Car B" : "Add Car B";
   };
   const onAddCar = (): void => {
     const view = sim.worldView();
@@ -175,59 +191,15 @@ export function mountManualControls(
         console.warn("addElevator:", e);
       }
     }
-    // Topology changed; the panel needs a full re-mount to surface the
-    // new car block. Rebuild via `mountCarControls` against the fresh
-    // worldView.
     rebuildCarControls();
     updateAddCarBtn();
   };
   addCarBtn.addEventListener("click", onAddCar);
   updateAddCarBtn();
 
-  let carsHandle = cars;
   const rebuildCarControls = (): void => {
     initialView = sim.worldView();
-    carsHandle = mountCarControls(roots.carControls, scenario, initialView, {
-      setServiceMode: (carRef, mode) => {
-        sim.setServiceMode(carRef, mode);
-      },
-      pressCarButton: (carRef, stopRef) => {
-        sim.pressCarButton(carRef, stopRef);
-      },
-      openDoor: (carRef) => {
-        safe(() => {
-          sim.openDoor(carRef);
-        });
-      },
-      closeDoor: (carRef) => {
-        safe(() => {
-          sim.closeDoor(carRef);
-        });
-      },
-      holdDoor: (carRef, ticks) => {
-        safe(() => {
-          sim.holdDoor(carRef, ticks);
-        });
-      },
-      cancelDoorHold: (carRef) => {
-        safe(() => {
-          sim.cancelDoorHold(carRef);
-        });
-      },
-      setTargetVelocity: (carRef, velocity) => {
-        safe(() => {
-          sim.setTargetVelocity(carRef, velocity);
-        });
-      },
-      emergencyStop: (carRef) => {
-        safe(() => {
-          sim.emergencyStop(carRef);
-        });
-      },
-      selectCar: (carRef) => {
-        SELECTED = carRef;
-      },
-    });
+    carsHandle = mountCarControls(roots.carControls, scenario, initialView, carHandlers);
     // If the previously selected car was removed, fall back to the
     // first remaining car so the cutaway always has a focus.
     if (SELECTED !== null && !initialView.cars.some((c) => BigInt(c.id) === SELECTED)) {
@@ -240,7 +212,7 @@ export function mountManualControls(
     if (meta.defaultServiceMode !== "normal") {
       for (const car of initialView.cars) {
         try {
-          sim.setServiceMode(BigInt(car.id), meta.defaultServiceMode satisfies ServiceModeName);
+          sim.setServiceMode(BigInt(car.id), meta.defaultServiceMode);
         } catch {
           /* ignore — engine validates */
         }
@@ -249,7 +221,7 @@ export function mountManualControls(
   };
 
   // Pick the first car as the initial cutaway focus.
-  SELECTED = cars.firstCarRef();
+  SELECTED = carsHandle.firstCarRef();
 
   return {
     update(currentSim, events): void {
@@ -263,6 +235,22 @@ export function mountManualControls(
       carsHandle.sync(view, SELECTED);
       appendEvents(roots.eventLog, events);
       updateAddCarBtn();
+      // Push authoritative UI state to the cabin renderer. Built
+      // here (not in the loop) because the panel owns all three
+      // sources: the dropdown values, the hall-call lamp state from
+      // worldView, and the selected-car focus.
+      const hallCallsByStop = new Map<bigint, { up: boolean; down: boolean }>();
+      for (const stop of view.stops) {
+        hallCallsByStop.set(BigInt(stop.entity_id), {
+          up: stop.hall_calls.up,
+          down: stop.hall_calls.down,
+        });
+      }
+      renderer.setManualControlState({
+        selectedCarId: SELECTED,
+        serviceModeByCar: carsHandle.serviceModes(),
+        hallCallsByStop,
+      });
     },
     selectedCarRef: () => SELECTED,
     dispose(): void {

--- a/playground/src/features/manual-controls/panel.ts
+++ b/playground/src/features/manual-controls/panel.ts
@@ -1,0 +1,285 @@
+import type { Sim } from "../../sim";
+import type { EventDto, ScenarioMeta, ServiceModeName } from "../../types";
+import { mountCarControls, type CarControlsHandle } from "./car-controls";
+import { mountHallButtons, type HallButtonsHandle } from "./hall-buttons";
+import { mountSpawnForm } from "./spawn-form";
+import { appendEvents } from "./event-log";
+
+/** Containers the panel hydrates. All must exist in `index.html`. */
+export interface ManualControlsRoots {
+  hallButtons: HTMLElement;
+  carControls: HTMLElement;
+  spawnForm: HTMLElement;
+  eventLog: HTMLElement;
+  addCarBtn: HTMLButtonElement;
+}
+
+export interface ManualControlsHandle {
+  /** Per-frame update with a fresh sim handle and worldView snapshot. */
+  update(sim: Sim, events: EventDto[]): void;
+  /** Currently focused car ref, or null if no car has been clicked yet. */
+  selectedCarRef(): bigint | null;
+  /** Tear down listeners — called when scenario switches away. */
+  dispose(): void;
+}
+
+// Module-level so the cabin renderer can read the focused car without
+// threading a handle through the render loop. Reset by `dispose()`.
+let SELECTED: bigint | null = null;
+export function selectedCarId(): bigint | null {
+  return SELECTED;
+}
+
+/**
+ * Mount the manual-controls side panel against `sim` for `scenario`.
+ * Builds the hall-button rows, per-car blocks, spawn form, and event
+ * log; applies the scenario's `defaultServiceMode` to every car.
+ */
+export function mountManualControls(
+  sim: Sim,
+  scenario: ScenarioMeta,
+  roots: ManualControlsRoots,
+): ManualControlsHandle {
+  const meta = scenario.manualControl;
+  if (!meta) {
+    throw new Error("mountManualControls called for non-manual scenario");
+  }
+  let initialView = sim.worldView();
+
+  const hall: HallButtonsHandle = mountHallButtons(roots.hallButtons, scenario, initialView, {
+    onPress: (stopRef, dir) => {
+      try {
+        sim.pressHallCall(stopRef, dir);
+      } catch (e) {
+        // Engine rejects calls outside the served range or from cars in
+        // a non-Normal mode. Swallow — the lit-state stays unchanged
+        // since the call wasn't actually accepted.
+        console.warn("pressHallCall:", e);
+      }
+    },
+  });
+
+  const cars: CarControlsHandle = mountCarControls(roots.carControls, scenario, initialView, {
+    setServiceMode: (carRef, mode) => {
+      sim.setServiceMode(carRef, mode);
+    },
+    pressCarButton: (carRef, stopRef) => {
+      try {
+        sim.pressCarButton(carRef, stopRef);
+      } catch (e) {
+        console.warn("pressCarButton:", e);
+      }
+    },
+    openDoor: (carRef) => {
+      safe(() => {
+        sim.openDoor(carRef);
+      });
+    },
+    closeDoor: (carRef) => {
+      safe(() => {
+        sim.closeDoor(carRef);
+      });
+    },
+    holdDoor: (carRef, ticks) => {
+      safe(() => {
+        sim.holdDoor(carRef, ticks);
+      });
+    },
+    cancelDoorHold: (carRef) => {
+      safe(() => {
+        sim.cancelDoorHold(carRef);
+      });
+    },
+    setTargetVelocity: (carRef, velocity) => {
+      safe(() => {
+        sim.setTargetVelocity(carRef, velocity);
+      });
+    },
+    emergencyStop: (carRef) => {
+      safe(() => {
+        sim.emergencyStop(carRef);
+      });
+    },
+    selectCar: (carRef) => {
+      SELECTED = carRef;
+    },
+  });
+
+  // Apply the scenario's default service mode to every car so the UI
+  // dropdown and the engine state agree on first paint. Skipped when
+  // the default is "normal" (the engine default) — pointless work.
+  if (meta.defaultServiceMode !== "normal") {
+    for (const car of initialView.cars) {
+      try {
+        sim.setServiceMode(BigInt(car.id), meta.defaultServiceMode);
+      } catch (e) {
+        console.warn("setServiceMode (boot):", e);
+      }
+    }
+  }
+
+  mountSpawnForm(roots.spawnForm, scenario, {
+    spawn: (origin, dest, weight) => {
+      try {
+        sim.spawnRider(origin, dest, weight);
+      } catch (e) {
+        console.warn("spawnRider:", e);
+      }
+    },
+  });
+
+  // Initial event-log clear — leftover entries from a prior scenario
+  // would confuse "what just happened" given the panel re-mounts.
+  roots.eventLog.replaceChildren();
+
+  // Add Car B / Remove Car B toggle. Mutates topology via the sim's
+  // addElevator / removeElevator wasm bindings.
+  const addCarBtn = roots.addCarBtn;
+  const updateAddCarBtn = (): void => {
+    const view = sim.worldView();
+    const max = scenario.tweakRanges.cars.max;
+    if (!meta.allowAddRemoveCar || view.cars.length >= max) {
+      addCarBtn.hidden = view.cars.length === 1 || !meta.allowAddRemoveCar;
+      addCarBtn.textContent = view.cars.length >= max ? "Remove Car B" : "Add Car B";
+      addCarBtn.disabled = !meta.allowAddRemoveCar;
+      addCarBtn.hidden = !meta.allowAddRemoveCar;
+      return;
+    }
+    addCarBtn.hidden = false;
+    addCarBtn.disabled = false;
+    addCarBtn.textContent = view.cars.length >= 2 ? "Remove Car B" : "Add Car B";
+  };
+  const onAddCar = (): void => {
+    const view = sim.worldView();
+    if (view.cars.length >= scenario.tweakRanges.cars.max) {
+      // Remove the last car. Riders aboard get ejected to the nearest
+      // enabled stop per `Simulation::remove_elevator` semantics.
+      const last = view.cars[view.cars.length - 1];
+      if (!last) return;
+      try {
+        sim.removeElevator(BigInt(last.id));
+      } catch (e) {
+        console.warn("removeElevator:", e);
+      }
+    } else {
+      // Add to the first line at the lobby (position 0). Inherits the
+      // scenario's elevator-physics defaults (max_speed / capacity).
+      const firstLine = view.lines[0];
+      if (!firstLine) return;
+      try {
+        sim.addElevator(BigInt(firstLine.id), 0, {
+          maxSpeed: scenario.elevatorDefaults.maxSpeed,
+          weightCapacity: scenario.elevatorDefaults.weightCapacity,
+        });
+      } catch (e) {
+        console.warn("addElevator:", e);
+      }
+    }
+    // Topology changed; the panel needs a full re-mount to surface the
+    // new car block. Rebuild via `mountCarControls` against the fresh
+    // worldView.
+    rebuildCarControls();
+    updateAddCarBtn();
+  };
+  addCarBtn.addEventListener("click", onAddCar);
+  updateAddCarBtn();
+
+  let carsHandle = cars;
+  const rebuildCarControls = (): void => {
+    initialView = sim.worldView();
+    carsHandle = mountCarControls(roots.carControls, scenario, initialView, {
+      setServiceMode: (carRef, mode) => {
+        sim.setServiceMode(carRef, mode);
+      },
+      pressCarButton: (carRef, stopRef) => {
+        sim.pressCarButton(carRef, stopRef);
+      },
+      openDoor: (carRef) => {
+        safe(() => {
+          sim.openDoor(carRef);
+        });
+      },
+      closeDoor: (carRef) => {
+        safe(() => {
+          sim.closeDoor(carRef);
+        });
+      },
+      holdDoor: (carRef, ticks) => {
+        safe(() => {
+          sim.holdDoor(carRef, ticks);
+        });
+      },
+      cancelDoorHold: (carRef) => {
+        safe(() => {
+          sim.cancelDoorHold(carRef);
+        });
+      },
+      setTargetVelocity: (carRef, velocity) => {
+        safe(() => {
+          sim.setTargetVelocity(carRef, velocity);
+        });
+      },
+      emergencyStop: (carRef) => {
+        safe(() => {
+          sim.emergencyStop(carRef);
+        });
+      },
+      selectCar: (carRef) => {
+        SELECTED = carRef;
+      },
+    });
+    // If the previously selected car was removed, fall back to the
+    // first remaining car so the cutaway always has a focus.
+    if (SELECTED !== null && !initialView.cars.some((c) => BigInt(c.id) === SELECTED)) {
+      SELECTED = carsHandle.firstCarRef();
+    }
+    if (SELECTED === null) {
+      SELECTED = carsHandle.firstCarRef();
+    }
+    // Re-apply the default service mode to any newly added cars.
+    if (meta.defaultServiceMode !== "normal") {
+      for (const car of initialView.cars) {
+        try {
+          sim.setServiceMode(BigInt(car.id), meta.defaultServiceMode satisfies ServiceModeName);
+        } catch {
+          /* ignore — engine validates */
+        }
+      }
+    }
+  };
+
+  // Pick the first car as the initial cutaway focus.
+  SELECTED = cars.firstCarRef();
+
+  return {
+    update(currentSim, events): void {
+      // The shell may swap `Sim` instances on a reset; rebuild
+      // controls against the new one if so.
+      if (currentSim !== sim) {
+        rebuildCarControls();
+      }
+      const view = currentSim.worldView();
+      hall.sync(view);
+      carsHandle.sync(view, SELECTED);
+      appendEvents(roots.eventLog, events);
+      updateAddCarBtn();
+    },
+    selectedCarRef: () => SELECTED,
+    dispose(): void {
+      addCarBtn.removeEventListener("click", onAddCar);
+      roots.hallButtons.replaceChildren();
+      roots.carControls.replaceChildren();
+      roots.spawnForm.replaceChildren();
+      roots.eventLog.replaceChildren();
+      SELECTED = null;
+    },
+  };
+}
+
+function safe(fn: () => void): void {
+  try {
+    fn();
+  } catch (e) {
+    console.warn("manual-controls action:", e);
+  }
+}

--- a/playground/src/features/manual-controls/spawn-form.ts
+++ b/playground/src/features/manual-controls/spawn-form.ts
@@ -1,0 +1,77 @@
+import { el } from "../../platform";
+import type { ScenarioMeta } from "../../types";
+
+/**
+ * Spawn-rider form: origin / destination dropdowns + weight input
+ * + spawn button. Wraps `Sim.spawnRider`, which takes config-level
+ * `StopId`s (small integers from the RON) — not entity refs.
+ */
+export interface SpawnFormHandlers {
+  spawn: (originStopId: number, destStopId: number, weight: number) => void;
+}
+
+export function mountSpawnForm(
+  container: HTMLElement,
+  scenario: ScenarioMeta,
+  handlers: SpawnFormHandlers,
+): void {
+  container.replaceChildren();
+
+  // Stops are listed by RON-config index, which maps 1:1 to StopId.
+  // The spawn API takes the `StopId(N)` value, so use the array index.
+  const stopOptions = scenario.stops.map((s, i) => ({ id: i, name: s.name }));
+
+  const fromField = stopField("From", stopOptions, 0);
+  const toField = stopField("To", stopOptions, Math.min(stopOptions.length - 1, 1));
+
+  const weightField = el("div", "manual-spawn-field");
+  weightField.append(el("span", "manual-spawn-label", "Weight"));
+  const weightInput = document.createElement("input");
+  weightInput.type = "number";
+  weightInput.className = "manual-spawn-weight";
+  weightInput.min = "20";
+  weightInput.max = "300";
+  weightInput.step = "5";
+  // Default = midpoint of scenario's weight range so the spawn lands
+  // squarely inside the boarding distribution and reads as "typical".
+  const [lo, hi] = scenario.passengerWeightRange;
+  weightInput.value = String(Math.round((lo + hi) / 2));
+  weightField.append(weightInput);
+
+  const spawnBtn = el("button", "manual-spawn-btn", "Spawn");
+  spawnBtn.type = "button";
+  spawnBtn.addEventListener("click", () => {
+    const origin = Number(fromField.select.value);
+    const dest = Number(toField.select.value);
+    if (origin === dest) return; // engine would reject; skip silently
+    const weight = Number(weightInput.value) || 75;
+    handlers.spawn(origin, dest, weight);
+  });
+
+  container.append(fromField.root, toField.root, weightField, spawnBtn);
+}
+
+interface StopFieldHandle {
+  root: HTMLElement;
+  select: HTMLSelectElement;
+}
+
+function stopField(
+  label: string,
+  options: Array<{ id: number; name: string }>,
+  defaultIndex: number,
+): StopFieldHandle {
+  const root = el("div", "manual-spawn-field");
+  root.append(el("span", "manual-spawn-label", label));
+  const select = document.createElement("select");
+  select.className = "manual-spawn-select";
+  for (const opt of options) {
+    const o = document.createElement("option");
+    o.value = String(opt.id);
+    o.textContent = opt.name;
+    select.appendChild(o);
+  }
+  select.value = String(options[defaultIndex]?.id ?? 0);
+  root.append(select);
+  return { root, select };
+}

--- a/playground/src/features/scenario-picker/switch.ts
+++ b/playground/src/features/scenario-picker/switch.ts
@@ -26,6 +26,8 @@ export interface ScenarioSwitchUi {
   paneB: ScenarioPaneHandles;
   scenarioCards: HTMLElement;
   toast: HTMLElement;
+  compareToggle: HTMLInputElement;
+  layout: HTMLElement;
 }
 
 /**
@@ -63,6 +65,22 @@ export async function switchScenario(
   hooks: ScenarioSwitchHooks,
 ): Promise<void> {
   const scenario = scenarioById(scenarioId);
+  // Manual-control scenarios force compare off, swap the layout mode,
+  // and toggle the body's `scenarioMode` flag (CSS rules in style.css
+  // hide the compare toggle and intensity slider keyed off that). Other
+  // scenarios clear the flag so the standard chrome reappears.
+  const isManual = scenario.manualControl !== undefined;
+  if (isManual) {
+    state.permalink.compare = false;
+    ui.compareToggle.checked = false;
+    document.body.dataset["scenarioMode"] = "manual-control";
+    ui.layout.dataset["mode"] = "manual-control";
+  } else {
+    delete document.body.dataset["scenarioMode"];
+    if (ui.layout.dataset["mode"] === "manual-control") {
+      ui.layout.dataset["mode"] = state.permalink.compare ? "compare" : "single";
+    }
+  }
   // Snap pane A (and pane B when in single-pane mode) to the
   // scenario's recommended strategy. In compare mode we leave both
   // panes alone so the user's comparison setup survives.

--- a/playground/src/render/draw-cabin.ts
+++ b/playground/src/render/draw-cabin.ts
@@ -19,9 +19,31 @@ import { drawRider, pickRiderVariant } from "./figures/rider";
  * pipeline — `renderer.ts` early-exits into this function when the
  * scenario's `manualControl` flag is set, mirroring the tether path.
  */
+/** Hall-call lamp state at one stop, keyed by stop entity ref. */
+export interface HallLampState {
+  up: boolean;
+  down: boolean;
+}
+
 export interface CabinRenderState {
   /** Currently focused car entity ref, or `null` for "first car". */
   selectedCarId: bigint | null;
+  /**
+   * Per-car service mode (drives the cabin badge, OOS door colour, OOS
+   * rider greying). Empty map = "everyone Normal" — every lookup falls
+   * through to the badge default. The panel rebuilds this each frame
+   * from the dropdown values so the renderer always tracks the
+   * authoritative UI state.
+   */
+  serviceModeByCar: Map<bigint, string>;
+  /**
+   * Per-stop hall-call lamp state. Sourced from
+   * `WorldView.stops[i].hall_calls.{up,down}` (the engine's
+   * acknowledged-call lamps), not from `waiting_up/waiting_down`
+   * (rider counts) — those can disagree in Manual mode where a user
+   * spawns a rider without pressing a hall call.
+   */
+  hallCallsByStop: Map<bigint, HallLampState>;
 }
 
 const CABIN_BG = "#1a1a1f";
@@ -44,7 +66,6 @@ export function drawCabinCutaway(
   w: number,
   h: number,
   state: CabinRenderState,
-  carServiceMode: Map<bigint, string>,
 ): void {
   if (snap.stops.length === 0 || w <= 0 || h <= 0) return;
 
@@ -63,7 +84,7 @@ export function drawCabinCutaway(
   }
 
   drawShaftPanel(ctx, snap, shaftX, topY, shaftW, bottomY - topY, state);
-  drawCabinPanel(ctx, snap, cabinX, topY, cabinW, bottomY - topY, state, carServiceMode);
+  drawCabinPanel(ctx, snap, cabinX, topY, cabinW, bottomY - topY, state);
 }
 
 function drawShaftPanel(
@@ -116,20 +137,17 @@ function drawShaftPanel(
     ctx.fillText(truncate(stop.name, 9), shaftLeft - 8, py);
 
     // Hall-call lamps as a tiny vertical pair on the shaft's left edge.
+    // Source: panel-supplied per-stop hall-call state from the engine
+    // (`WorldView.stops[i].hall_calls.{up,down}`). Falling back to
+    // `waiting_up/down` (rider counts) would diverge in Manual mode
+    // where a user spawns a rider without pressing a hall call.
+    const lamp = state.hallCallsByStop.get(BigInt(stop.entity_id));
     const lampX = shaftLeft - 4;
     const lampUpY = py - 4;
     const lampDownY = py + 4;
-    if (stop.waiting_up > 0) {
-      ctx.fillStyle = HALL_LAMP_ON;
-    } else {
-      ctx.fillStyle = HALL_LAMP_OFF;
-    }
+    ctx.fillStyle = lamp?.up ? HALL_LAMP_ON : HALL_LAMP_OFF;
     ctx.fillRect(lampX, lampUpY - 1, 3, 2);
-    if (stop.waiting_down > 0) {
-      ctx.fillStyle = HALL_LAMP_ON;
-    } else {
-      ctx.fillStyle = HALL_LAMP_OFF;
-    }
+    ctx.fillStyle = lamp?.down ? HALL_LAMP_ON : HALL_LAMP_OFF;
     ctx.fillRect(lampX, lampDownY - 1, 3, 2);
   }
 
@@ -166,7 +184,6 @@ function drawCabinPanel(
   w: number,
   h: number,
   state: CabinRenderState,
-  serviceModes: Map<bigint, string>,
 ): void {
   // Resolve which car to draw inside the cabin frame.
   const selected =
@@ -174,7 +191,9 @@ function drawCabinPanel(
       ? snap.cars.find((c) => BigInt(c.id) === state.selectedCarId)
       : snap.cars[0];
   const serviceMode =
-    selected !== undefined ? (serviceModes.get(BigInt(selected.id)) ?? "normal") : "normal";
+    selected !== undefined
+      ? (state.serviceModeByCar.get(BigInt(selected.id)) ?? "normal")
+      : "normal";
 
   // Cabin frame with rounded corners.
   const cabinTop = y + 26;

--- a/playground/src/render/draw-cabin.ts
+++ b/playground/src/render/draw-cabin.ts
@@ -1,0 +1,387 @@
+import type { CarDto, Snapshot, StopDto } from "../types";
+import { drawRider, pickRiderVariant } from "./figures/rider";
+
+/**
+ * Cabin cutaway renderer for the manual-control scenario.
+ *
+ * Layout split:
+ *   - Left 40 %: vertical shaft column showing every stop, hall-call
+ *     lamps next to each floor name, and small car rectangles sliding
+ *     vertically. A miniature of the building view, slimmed for the
+ *     side panel's tighter horizontal budget.
+ *   - Right 60 %: a single large cabin cross-section showing the
+ *     focused car. Floor label at the top (current floor or "between"),
+ *     rider silhouettes inside the cab (count proportional to load),
+ *     a 3×2 car-button panel in the lower-right, and an animated door
+ *     opening at the bottom edge that follows door FSM progress.
+ *
+ * The renderer stays additive over the existing `CanvasRenderer`
+ * pipeline — `renderer.ts` early-exits into this function when the
+ * scenario's `manualControl` flag is set, mirroring the tether path.
+ */
+export interface CabinRenderState {
+  /** Currently focused car entity ref, or `null` for "first car". */
+  selectedCarId: bigint | null;
+}
+
+const CABIN_BG = "#1a1a1f";
+const CABIN_FRAME = "#3a3a45";
+const SHAFT_FILL = "#252530";
+const FLOOR_TICK = "#3a3a45";
+const FLOOR_LABEL = "#8b8c92";
+const HALL_LAMP_OFF = "#3a3a45";
+const HALL_LAMP_ON = "#fbbf24";
+const RIDER_COLOR = "#a1a1aa";
+const CAR_BUTTON_OFF = "#252530";
+const CAR_BUTTON_ON = "#fbbf24";
+const CAR_FILL = "#f59e0b";
+const CAR_FILL_OOS = "#5b5b65";
+const TEXT_PRIMARY = "#fafafa";
+
+export function drawCabinCutaway(
+  ctx: CanvasRenderingContext2D,
+  snap: Snapshot,
+  w: number,
+  h: number,
+  state: CabinRenderState,
+  carServiceMode: Map<bigint, string>,
+): void {
+  if (snap.stops.length === 0 || w <= 0 || h <= 0) return;
+
+  const padding = 14;
+  const splitGap = 18;
+  const shaftW = Math.max(120, Math.round(w * 0.4) - splitGap / 2);
+  const shaftX = padding;
+  const cabinX = shaftX + shaftW + splitGap;
+  const cabinW = w - cabinX - padding;
+  const topY = padding;
+  const bottomY = h - padding;
+  if (cabinW < 80) {
+    // Very narrow viewport — fall back to shaft only.
+    drawShaftPanel(ctx, snap, shaftX, topY, w - 2 * padding, bottomY - topY, state);
+    return;
+  }
+
+  drawShaftPanel(ctx, snap, shaftX, topY, shaftW, bottomY - topY, state);
+  drawCabinPanel(ctx, snap, cabinX, topY, cabinW, bottomY - topY, state, carServiceMode);
+}
+
+function drawShaftPanel(
+  ctx: CanvasRenderingContext2D,
+  snap: Snapshot,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  state: CabinRenderState,
+): void {
+  // Compute axis bounds from stop positions.
+  const sortedStops = [...snap.stops].sort((a, b) => a.y - b.y);
+  const minY = sortedStops[0]?.y ?? 0;
+  const maxY = sortedStops[sortedStops.length - 1]?.y ?? minY + 1;
+  const yRange = Math.max(maxY - minY, 0.0001);
+
+  // Shaft rect — a single column straddling all stops.
+  const shaftPad = 6;
+  const shaftLeft = x + 64; // leave room for floor labels
+  const shaftWidth = Math.max(24, w - 64 - shaftPad);
+  const shaftTop = y + 12;
+  const shaftBottom = y + h - 12;
+  const shaftHeight = shaftBottom - shaftTop;
+
+  // Shaft fill.
+  ctx.fillStyle = SHAFT_FILL;
+  ctx.fillRect(shaftLeft, shaftTop, shaftWidth, shaftHeight);
+  ctx.strokeStyle = CABIN_FRAME;
+  ctx.lineWidth = 1;
+  ctx.strokeRect(shaftLeft + 0.5, shaftTop + 0.5, shaftWidth - 1, shaftHeight - 1);
+
+  const yToPx = (yMeters: number): number =>
+    shaftBottom - ((yMeters - minY) / yRange) * shaftHeight;
+
+  // Floor lines + labels + hall lamps. Iterate top→bottom for visual order.
+  ctx.font = "10px system-ui, sans-serif";
+  ctx.textBaseline = "middle";
+  for (const stop of [...snap.stops].sort((a, b) => b.y - a.y)) {
+    const py = yToPx(stop.y);
+    ctx.strokeStyle = FLOOR_TICK;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(shaftLeft, py + 0.5);
+    ctx.lineTo(shaftLeft + shaftWidth, py + 0.5);
+    ctx.stroke();
+
+    ctx.fillStyle = FLOOR_LABEL;
+    ctx.textAlign = "right";
+    ctx.fillText(truncate(stop.name, 9), shaftLeft - 8, py);
+
+    // Hall-call lamps as a tiny vertical pair on the shaft's left edge.
+    const lampX = shaftLeft - 4;
+    const lampUpY = py - 4;
+    const lampDownY = py + 4;
+    if (stop.waiting_up > 0) {
+      ctx.fillStyle = HALL_LAMP_ON;
+    } else {
+      ctx.fillStyle = HALL_LAMP_OFF;
+    }
+    ctx.fillRect(lampX, lampUpY - 1, 3, 2);
+    if (stop.waiting_down > 0) {
+      ctx.fillStyle = HALL_LAMP_ON;
+    } else {
+      ctx.fillStyle = HALL_LAMP_OFF;
+    }
+    ctx.fillRect(lampX, lampDownY - 1, 3, 2);
+  }
+
+  // Cars: small rectangles. Highlight the selected one.
+  const carWidth = Math.min(18, shaftWidth * 0.8);
+  const carHeight = 10;
+  const cars = [...snap.cars];
+  // Side-by-side if multiple cars share the shaft.
+  cars.forEach((car, i) => {
+    const carPx = yToPx(car.y);
+    const cx = shaftLeft + shaftWidth / 2 + (i - (cars.length - 1) / 2) * (carWidth + 4);
+    const isSelected = state.selectedCarId !== null && BigInt(car.id) === state.selectedCarId;
+    const fill = isSelected ? CAR_FILL : "#a3733b";
+    ctx.fillStyle = fill;
+    ctx.fillRect(cx - carWidth / 2, carPx - carHeight / 2, carWidth, carHeight);
+    if (isSelected) {
+      ctx.strokeStyle = TEXT_PRIMARY;
+      ctx.lineWidth = 1;
+      ctx.strokeRect(
+        cx - carWidth / 2 + 0.5,
+        carPx - carHeight / 2 + 0.5,
+        carWidth - 1,
+        carHeight - 1,
+      );
+    }
+  });
+}
+
+function drawCabinPanel(
+  ctx: CanvasRenderingContext2D,
+  snap: Snapshot,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  state: CabinRenderState,
+  serviceModes: Map<bigint, string>,
+): void {
+  // Resolve which car to draw inside the cabin frame.
+  const selected =
+    state.selectedCarId !== null
+      ? snap.cars.find((c) => BigInt(c.id) === state.selectedCarId)
+      : snap.cars[0];
+  const serviceMode =
+    selected !== undefined ? (serviceModes.get(BigInt(selected.id)) ?? "normal") : "normal";
+
+  // Cabin frame with rounded corners.
+  const cabinTop = y + 26;
+  const cabinBottom = y + h - 16;
+  const cabinHeight = cabinBottom - cabinTop;
+  const cabinLeft = x + 6;
+  const cabinRight = x + w - 6;
+  const cabinW = cabinRight - cabinLeft;
+
+  drawRoundedRect(ctx, cabinLeft, cabinTop, cabinW, cabinHeight, 6, CABIN_BG, CABIN_FRAME);
+
+  // Header: floor label + service mode badge.
+  const floorText = floorLabel(selected, snap.stops);
+  ctx.fillStyle = TEXT_PRIMARY;
+  ctx.textAlign = "left";
+  ctx.textBaseline = "alphabetic";
+  ctx.font = "600 13px system-ui, sans-serif";
+  ctx.fillText(floorText, cabinLeft + 10, y + 18);
+
+  // Service mode badge on the right.
+  if (selected !== undefined) {
+    drawServiceBadge(ctx, cabinRight - 4, y + 18, serviceMode);
+  }
+
+  // Rider silhouettes inside the cab. One figure per ~5 riders, capped
+  // at 4 figures so the cab doesn't get crowded; OutOfService greys the
+  // figures.
+  const riderCount = selected?.riders ?? 0;
+  const figureCount = Math.min(4, Math.max(0, Math.ceil(riderCount / 2)));
+  const cabFloorY = cabinBottom - 30;
+  const headR = Math.min(6, cabinHeight / 12);
+  if (figureCount > 0) {
+    const slotW = cabinW / (figureCount + 1);
+    const carIdNum = selected !== undefined ? selected.id : 0;
+    for (let i = 0; i < figureCount; i++) {
+      const fx = cabinLeft + slotW * (i + 1);
+      const variant = pickRiderVariant(carIdNum, i);
+      const color = serviceMode === "outofservice" ? "#5b5b65" : RIDER_COLOR;
+      drawRider(ctx, fx, cabFloorY, headR, color, variant);
+    }
+  }
+
+  // Car-button panel: 3×2 grid in the lower-right corner. Lit when the
+  // car has dispatched to that stop (proxy for an active car-call —
+  // car-call queue isn't in Snapshot DTOs).
+  drawCarButtonPanel(
+    ctx,
+    cabinRight - 70,
+    cabinTop + 8,
+    62,
+    Math.min(96, cabinHeight * 0.55),
+    snap.stops,
+    selected,
+  );
+
+  // Door at the bottom: animated based on the door FSM. The Snapshot
+  // DTO carries the phase as a string; use that to drive opening width.
+  drawCabDoor(ctx, cabinLeft + 4, cabinBottom - 4, cabinW - 8, selected, serviceMode);
+}
+
+function drawCarButtonPanel(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  stops: StopDto[],
+  selected: CarDto | undefined,
+): void {
+  drawRoundedRect(ctx, x, y, w, h, 4, "#0f0f12", "#3a3a45");
+  const sorted = [...stops].sort((a, b) => b.y - a.y);
+  const cols = 2;
+  const rows = Math.ceil(sorted.length / cols);
+  const cellW = (w - 8) / cols;
+  const cellH = (h - 8) / Math.max(rows, 1);
+  ctx.font = "600 9px system-ui, sans-serif";
+  ctx.textBaseline = "middle";
+  ctx.textAlign = "center";
+  sorted.forEach((stop, i) => {
+    const col = i % cols;
+    const row = Math.floor(i / cols);
+    const cx = x + 4 + col * cellW + cellW / 2;
+    const cy = y + 4 + row * cellH + cellH / 2;
+    const r = Math.min(cellW, cellH) / 2 - 2;
+    const lit =
+      selected !== undefined && selected.target !== undefined && selected.target === stop.entity_id;
+    ctx.fillStyle = lit ? CAR_BUTTON_ON : CAR_BUTTON_OFF;
+    ctx.beginPath();
+    ctx.arc(cx, cy, r, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.strokeStyle = lit ? "#fbbf24" : "#3a3a45";
+    ctx.lineWidth = 1;
+    ctx.stroke();
+    ctx.fillStyle = lit ? "#0f0f12" : FLOOR_LABEL;
+    ctx.fillText(buttonAbbrev(stop.name), cx, cy);
+  });
+}
+
+function drawCabDoor(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  selected: CarDto | undefined,
+  serviceMode: string,
+): void {
+  const doorH = 4;
+  // Phase-based open fraction. The Snapshot's CarDto.phase covers
+  // door-opening / loading (open) / door-closing / others (closed).
+  let openFrac = 0;
+  if (selected !== undefined) {
+    if (selected.phase === "loading") openFrac = 1;
+    else if (selected.phase === "door-opening") openFrac = 0.5;
+    else if (selected.phase === "door-closing") openFrac = 0.5;
+    else openFrac = 0;
+  }
+  const halfW = w / 2;
+  const gap = halfW * openFrac;
+  const fill = serviceMode === "outofservice" ? CAR_FILL_OOS : CAR_FILL;
+  ctx.fillStyle = fill;
+  // Left door panel.
+  ctx.fillRect(x, y - doorH, halfW - gap, doorH);
+  // Right door panel.
+  ctx.fillRect(x + halfW + gap, y - doorH, halfW - gap, doorH);
+}
+
+function drawRoundedRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+  fill: string,
+  stroke: string,
+): void {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+  ctx.fillStyle = fill;
+  ctx.fill();
+  ctx.strokeStyle = stroke;
+  ctx.lineWidth = 1;
+  ctx.stroke();
+}
+
+interface ServiceBadgeStyle {
+  label: string;
+  bg: string;
+  fg: string;
+}
+
+const SERVICE_BADGE_STYLES: Record<string, ServiceBadgeStyle> = {
+  normal: { label: "AUTO", bg: "#22c55e22", fg: "#22c55e" },
+  manual: { label: "MANUAL", bg: "#fbbf2433", fg: "#fbbf24" },
+  inspection: { label: "INSP", bg: "#a78bfa33", fg: "#a78bfa" },
+  outofservice: { label: "OFF", bg: "#ef444433", fg: "#ef4444" },
+  independent: { label: "IND", bg: "#a1a1aa33", fg: "#a1a1aa" },
+};
+
+function drawServiceBadge(
+  ctx: CanvasRenderingContext2D,
+  rightX: number,
+  baselineY: number,
+  serviceMode: string,
+): void {
+  const style = SERVICE_BADGE_STYLES[serviceMode] ?? SERVICE_BADGE_STYLES["normal"];
+  if (!style) return;
+  ctx.font = "600 9px system-ui, sans-serif";
+  const padX = 6;
+  const metrics = ctx.measureText(style.label);
+  const w = metrics.width + padX * 2;
+  const h = 14;
+  drawRoundedRect(ctx, rightX - w, baselineY - h + 2, w, h, 3, style.bg, style.fg);
+  ctx.fillStyle = style.fg;
+  ctx.textAlign = "right";
+  ctx.textBaseline = "middle";
+  ctx.fillText(style.label, rightX - padX, baselineY - h / 2 + 2);
+  // Reset text alignment.
+  ctx.textAlign = "left";
+  ctx.textBaseline = "alphabetic";
+}
+
+function floorLabel(car: CarDto | undefined, stops: StopDto[]): string {
+  if (!car) return "—";
+  // "At Floor 3" if the car is exactly at a stop; "Between" otherwise.
+  const tolerance = 0.25;
+  const stop = stops.find((s) => Math.abs(s.y - car.y) < tolerance);
+  if (stop) return stop.name;
+  return "Between";
+}
+
+function buttonAbbrev(name: string): string {
+  const num = name.match(/\d+/);
+  if (num) return num[0];
+  return name.charAt(0).toUpperCase();
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1) + "…";
+}

--- a/playground/src/render/renderer.ts
+++ b/playground/src/render/renderer.ts
@@ -7,6 +7,7 @@ import {
   drawShaftLabels,
   drawWaitingFigures,
 } from "./draw-building";
+import { drawCabinCutaway, type CabinRenderState } from "./draw-cabin";
 import { drawBubbles, drawCar, drawCarTrail, drawTargetMarkers } from "./draw-cars";
 import { drawTetherScene, type TetherRenderState } from "./draw-tether";
 import type { RiderVariant } from "./figures/rider";
@@ -69,6 +70,10 @@ export class CanvasRenderer {
   readonly #tweens: Tween[] = [];
   /** Set when the active scenario is a space-elevator-style tether. */
   #tether: TetherMeta | null = null;
+  /** Set when the active scenario is the manual-control cabin cutaway. */
+  #manualControl: CabinRenderState | null = null;
+  /** Per-car service mode hint, populated by the shell from the controls panel. */
+  readonly #serviceModeByCar: Map<bigint, string> = new Map();
   /** Per-car previous-frame velocity, used to classify trapezoidal phase. */
   readonly #prevVelocity: Map<number, number> = new Map();
   /** Active `max_speed` for HUD/ETA math; updated from the snapshot's max served range. */
@@ -124,6 +129,27 @@ export class CanvasRenderer {
   }
 
   /**
+   * Toggle the cabin-cutaway render path. When set, every other render
+   * branch is bypassed and `drawCabinCutaway` takes over the canvas.
+   * Mirrors the tether opt-in.
+   */
+  setManualControlState(state: CabinRenderState | null): void {
+    this.#manualControl = state;
+    this.#prevVelocity.clear();
+    this.#stopAssignments.clear();
+  }
+
+  /** Update the service-mode hint for a car (drives the cabin badge). */
+  setServiceModeFor(carRef: bigint, mode: string): void {
+    this.#serviceModeByCar.set(carRef, mode);
+  }
+
+  /** Drop all per-car service-mode hints (e.g. on scenario switch). */
+  clearServiceModes(): void {
+    this.#serviceModeByCar.clear();
+  }
+
+  /**
    * Report current physics knobs so the HUD's ETA / phase classifier
    * stay in sync with hot-swapped values from the tweak drawer.
    */
@@ -168,6 +194,11 @@ export class CanvasRenderer {
     }
     const s = this.#cachedScale;
     if (s === null) return;
+
+    if (this.#manualControl !== null) {
+      drawCabinCutaway(ctx, snap, w, h, this.#manualControl, this.#serviceModeByCar);
+      return;
+    }
 
     if (this.#tether !== null) {
       this.#drawTetherMode(snap, w, h, s, speedMultiplier, bubbles, this.#tether);

--- a/playground/src/render/renderer.ts
+++ b/playground/src/render/renderer.ts
@@ -72,8 +72,6 @@ export class CanvasRenderer {
   #tether: TetherMeta | null = null;
   /** Set when the active scenario is the manual-control cabin cutaway. */
   #manualControl: CabinRenderState | null = null;
-  /** Per-car service mode hint, populated by the shell from the controls panel. */
-  readonly #serviceModeByCar: Map<bigint, string> = new Map();
   /** Per-car previous-frame velocity, used to classify trapezoidal phase. */
   readonly #prevVelocity: Map<number, number> = new Map();
   /** Active `max_speed` for HUD/ETA math; updated from the snapshot's max served range. */
@@ -134,19 +132,16 @@ export class CanvasRenderer {
    * Mirrors the tether opt-in.
    */
   setManualControlState(state: CabinRenderState | null): void {
+    // Reuse the existing per-car kinematic / assignment caches as
+    // scenario-switch boundaries — same trick `setTetherConfig` uses.
+    // Only reset on a transition into or out of manual mode, not on
+    // the per-frame state replacement the loop does.
+    const transitioning = (state === null) !== (this.#manualControl === null);
     this.#manualControl = state;
-    this.#prevVelocity.clear();
-    this.#stopAssignments.clear();
-  }
-
-  /** Update the service-mode hint for a car (drives the cabin badge). */
-  setServiceModeFor(carRef: bigint, mode: string): void {
-    this.#serviceModeByCar.set(carRef, mode);
-  }
-
-  /** Drop all per-car service-mode hints (e.g. on scenario switch). */
-  clearServiceModes(): void {
-    this.#serviceModeByCar.clear();
+    if (transitioning) {
+      this.#prevVelocity.clear();
+      this.#stopAssignments.clear();
+    }
   }
 
   /**
@@ -196,7 +191,7 @@ export class CanvasRenderer {
     if (s === null) return;
 
     if (this.#manualControl !== null) {
-      drawCabinCutaway(ctx, snap, w, h, this.#manualControl, this.#serviceModeByCar);
+      drawCabinCutaway(ctx, snap, w, h, this.#manualControl);
       return;
     }
 

--- a/playground/src/shell/apply-permalink.ts
+++ b/playground/src/shell/apply-permalink.ts
@@ -22,8 +22,19 @@ export function randomSeedWord(): string {
 }
 
 export function applyPermalinkToUi(p: PermalinkState, ui: UiHandles): void {
-  ui.compareToggle.checked = p.compare;
-  ui.layout.dataset["mode"] = p.compare ? "compare" : "single";
+  const scenario = scenarioById(p.scenario);
+  // Manual-control scenarios swap the layout into a single-pane +
+  // side-controls grid that isn't expressible as compare on/off; honor
+  // that opt-in here so a fresh permalink load lands on the right
+  // layout from frame 0 (otherwise the layout flickers single → manual
+  // when boot.ts runs after this function).
+  const isManual = scenario.manualControl !== undefined;
+  ui.compareToggle.checked = isManual ? false : p.compare;
+  if (isManual) {
+    ui.layout.dataset["mode"] = "manual-control";
+  } else {
+    ui.layout.dataset["mode"] = p.compare ? "compare" : "single";
+  }
   ui.seedInput.value = p.seed;
   ui.speedInput.value = String(p.speed);
   ui.speedLabel.textContent = speedLabel(p.speed);
@@ -34,7 +45,6 @@ export function applyPermalinkToUi(p: PermalinkState, ui: UiHandles): void {
   renderPaneRepositionInfo(ui.paneA, p.repositionA);
   renderPaneRepositionInfo(ui.paneB, p.repositionB);
   syncScenarioCards(ui, p.scenario);
-  const scenario = scenarioById(p.scenario);
   // Auto-open the drawer when the permalink carries any override —
   // the recipient sees what the sender customized without an extra
   // click. A clean URL leaves the drawer closed so first-time

--- a/playground/src/shell/boot.ts
+++ b/playground/src/shell/boot.ts
@@ -71,6 +71,16 @@ export async function boot(): Promise<void> {
   // is the decode-side counterpart, done once at boot rather than in
   // every subsequent write path.
   permalink.overrides = compactOverrides(scenario, permalink.overrides);
+  // Manual-control scenarios force compare off and switch the layout
+  // mode upfront so the side panel shows from the first paint instead
+  // of flickering through compare mode then snapping in. The compare
+  // toggle and intensity slider are hidden via the body data attribute
+  // (CSS rules in style.css drive the actual hide).
+  if (scenario.manualControl !== undefined) {
+    permalink.compare = false;
+    document.body.dataset["scenarioMode"] = "manual-control";
+    ui.layout.dataset["mode"] = "manual-control";
+  }
   applyPermalinkToUi(permalink, ui);
   const state: State = {
     running: true,
@@ -82,6 +92,7 @@ export async function boot(): Promise<void> {
     lastFrameTime: performance.now(),
     initToken: 0,
     seeding: null,
+    manualControls: null,
   };
   attachListeners(state, ui);
   await resetAll(state, ui);

--- a/playground/src/shell/listeners.ts
+++ b/playground/src/shell/listeners.ts
@@ -62,6 +62,14 @@ export function attachListeners(state: State, ui: UiHandles): void {
   refreshStrategyPopovers(state, ui, doResetAll);
   refreshRepositionPopovers(state, ui, doResetAll);
   ui.compareToggle.addEventListener("change", () => {
+    // Manual-control scenarios hide the compare toggle via CSS but the
+    // keyboard shortcut `c` still synthesises a click. Guard against
+    // it: snap the toggle back to false and bail before any reset, so
+    // the layout-mode flip doesn't strand the side panel.
+    if (document.body.dataset["scenarioMode"] === "manual-control") {
+      ui.compareToggle.checked = false;
+      return;
+    }
     state.permalink = { ...state.permalink, compare: ui.compareToggle.checked };
     ui.layout.dataset["mode"] = state.permalink.compare ? "compare" : "single";
     // `also in …` badges depend on compare state, so re-render both

--- a/playground/src/shell/loop.ts
+++ b/playground/src/shell/loop.ts
@@ -68,14 +68,12 @@ export function loop(state: State, ui: UiHandles): void {
       });
 
       // Manual-control panel: refresh hall-call lit state, per-car
-      // controls, and append the frame's events to the log. Skipped
-      // for non-manual scenarios where `state.manualControls` is null.
-      // Also propagate the selected car ref to the renderer so the
-      // cabin cutaway tracks user-clicked focus.
+      // controls, and append the frame's events to the log. The panel
+      // pushes the full CabinRenderState (selected car, per-car
+      // service mode, hall-call lamps) into `paneA.renderer` itself,
+      // so the loop just needs to call `update()`.
       if (state.manualControls && state.paneA) {
         state.manualControls.update(state.paneA.sim, paneAEvents);
-        const selected = state.manualControls.selectedCarRef();
-        state.paneA.renderer.setManualControlState({ selectedCarId: selected });
       }
 
       // Progressive pre-seed: drain the remaining quota in per-frame

--- a/playground/src/shell/loop.ts
+++ b/playground/src/shell/loop.ts
@@ -40,9 +40,14 @@ export function loop(state: State, ui: UiHandles): void {
     const panesReady = paneA !== null && (!state.permalink.compare || paneB !== null);
     if (state.running && state.ready && panesReady) {
       const ticks = state.permalink.speed;
+      // Buffer paneA's events for the manual-controls log so it can
+      // surface them with no extra `drainEvents` call (which would
+      // miss them — events drain destructively).
+      let paneAEvents: ReturnType<typeof paneA.sim.drainEvents> = [];
       forEachPane(state, (pane) => {
         pane.sim.step(ticks);
         const events = pane.sim.drainEvents();
+        if (pane === state.paneA) paneAEvents = events;
         if (events.length > 0) {
           const snap = pane.sim.snapshot();
           updateBubbles(pane, events, snap);
@@ -61,6 +66,17 @@ export function loop(state: State, ui: UiHandles): void {
           }
         }
       });
+
+      // Manual-control panel: refresh hall-call lit state, per-car
+      // controls, and append the frame's events to the log. Skipped
+      // for non-manual scenarios where `state.manualControls` is null.
+      // Also propagate the selected car ref to the renderer so the
+      // cabin cutaway tracks user-clicked focus.
+      if (state.manualControls && state.paneA) {
+        state.manualControls.update(state.paneA.sim, paneAEvents);
+        const selected = state.manualControls.selectedCarRef();
+        state.paneA.renderer.setManualControlState({ selectedCarId: selected });
+      }
 
       // Progressive pre-seed: drain the remaining quota in per-frame
       // batches. While seeding is active we suppress the normal

--- a/playground/src/shell/reset.ts
+++ b/playground/src/shell/reset.ts
@@ -1,4 +1,5 @@
 import { type Pane, makePane, disposePane, forEachPane } from "../features/compare-pane";
+import { mountManualControls } from "../features/manual-controls";
 import { updatePhaseIndicator } from "../features/phase-strip";
 import { initMetricRows } from "../features/scoreboard";
 import { renderPaneStrategyInfo, renderPaneRepositionInfo } from "../features/strategy-picker";
@@ -53,6 +54,10 @@ export async function resetAll(state: State, ui: UiHandles): Promise<void> {
   disposePane(state.paneB);
   state.paneA = null;
   state.paneB = null;
+  // Drop any manual-controls panel from the previous scenario; the new
+  // scenario remounts below if it's also manual.
+  state.manualControls?.dispose();
+  state.manualControls = null;
   try {
     // Build both panes *before* attaching either to `state`. Attaching
     // pane A while pane B is still awaiting wasm instantiation lets
@@ -105,6 +110,22 @@ export async function resetAll(state: State, ui: UiHandles): Promise<void> {
     // `configureTraffic` once the quota drains, so the scenario's
     // day-cycle clock still starts from t=0.
     state.seeding = scenario.seedSpawns > 0 ? { remaining: scenario.seedSpawns } : null;
+    // Mount the manual-controls side panel for manual-control scenarios.
+    // The panel reads `paneA.sim` for entity refs and the worldView, and
+    // exposes a per-frame `update` the loop calls below.
+    if (scenario.manualControl !== undefined) {
+      state.manualControls = mountManualControls(paneA.sim, scenario, {
+        hallButtons: ui.manualHallButtons,
+        carControls: ui.manualCarControls,
+        spawnForm: ui.manualSpawnForm,
+        eventLog: ui.manualEventLog,
+        addCarBtn: ui.manualAddCarBtn,
+      });
+      // Sync the renderer's selectedCarId with the panel's initial
+      // selection so the cabin cutaway has a focus from frame 0.
+      const selected = state.manualControls.selectedCarRef();
+      paneA.renderer.setManualControlState({ selectedCarId: selected });
+    }
     updatePhaseIndicator(state, ui);
     renderTweakPanel(scenario, state.permalink.overrides, ui);
   } catch (err) {

--- a/playground/src/shell/reset.ts
+++ b/playground/src/shell/reset.ts
@@ -111,20 +111,22 @@ export async function resetAll(state: State, ui: UiHandles): Promise<void> {
     // day-cycle clock still starts from t=0.
     state.seeding = scenario.seedSpawns > 0 ? { remaining: scenario.seedSpawns } : null;
     // Mount the manual-controls side panel for manual-control scenarios.
-    // The panel reads `paneA.sim` for entity refs and the worldView, and
-    // exposes a per-frame `update` the loop calls below.
+    // The panel reads `paneA.sim` for entity refs and pushes the full
+    // CabinRenderState (selected car, per-car mode, hall-call lamps)
+    // into `paneA.renderer` on every `update()` tick.
     if (scenario.manualControl !== undefined) {
-      state.manualControls = mountManualControls(paneA.sim, scenario, {
-        hallButtons: ui.manualHallButtons,
-        carControls: ui.manualCarControls,
-        spawnForm: ui.manualSpawnForm,
-        eventLog: ui.manualEventLog,
-        addCarBtn: ui.manualAddCarBtn,
-      });
-      // Sync the renderer's selectedCarId with the panel's initial
-      // selection so the cabin cutaway has a focus from frame 0.
-      const selected = state.manualControls.selectedCarRef();
-      paneA.renderer.setManualControlState({ selectedCarId: selected });
+      state.manualControls = mountManualControls(
+        paneA.sim,
+        scenario,
+        {
+          hallButtons: ui.manualHallButtons,
+          carControls: ui.manualCarControls,
+          spawnForm: ui.manualSpawnForm,
+          eventLog: ui.manualEventLog,
+          addCarBtn: ui.manualAddCarBtn,
+        },
+        paneA.renderer,
+      );
     }
     updatePhaseIndicator(state, ui);
     renderTweakPanel(scenario, state.permalink.overrides, ui);

--- a/playground/src/shell/state.ts
+++ b/playground/src/shell/state.ts
@@ -1,4 +1,5 @@
 import type { Pane } from "../features/compare-pane";
+import type { ManualControlsHandle } from "../features/manual-controls";
 import type { TrafficDriver } from "../sim";
 import type { PermalinkState } from "../domain";
 
@@ -25,4 +26,11 @@ export interface State {
    * when not seeding (the common case for day-cycle scenarios).
    */
   seeding: { remaining: number } | null;
+  /**
+   * Mounted manual-controls panel handle, or `null` when the active
+   * scenario isn't a manual-control scenario. `resetAll` mounts it
+   * after paneA is built; the loop calls `update()` once per frame to
+   * refresh lit state and append new events.
+   */
+  manualControls: ManualControlsHandle | null;
 }

--- a/playground/src/shell/wire-ui.ts
+++ b/playground/src/shell/wire-ui.ts
@@ -30,6 +30,12 @@ export interface UiHandles {
   shortcutSheetClose: HTMLButtonElement;
   paneA: PaneHandles;
   paneB: PaneHandles;
+  manualControls: HTMLElement;
+  manualHallButtons: HTMLElement;
+  manualCarControls: HTMLElement;
+  manualSpawnForm: HTMLElement;
+  manualEventLog: HTMLElement;
+  manualAddCarBtn: HTMLButtonElement;
 }
 
 export function wireUi(): UiHandles {
@@ -106,6 +112,12 @@ export function wireUi(): UiHandles {
     shortcutSheetClose: q("shortcut-sheet-close") as HTMLButtonElement,
     paneA: paneHandles("a", COLOR_A),
     paneB: paneHandles("b", COLOR_B),
+    manualControls: q("manual-controls"),
+    manualHallButtons: q("manual-hall-buttons"),
+    manualCarControls: q("manual-car-controls"),
+    manualSpawnForm: q("manual-spawn-form"),
+    manualEventLog: q("manual-event-log"),
+    manualAddCarBtn: q("manual-add-car") as HTMLButtonElement,
   };
 
   renderScenarioCards(ui);

--- a/playground/src/sim/sim.ts
+++ b/playground/src/sim/sim.ts
@@ -2,9 +2,11 @@ import type {
   EventDto,
   MetricsDto,
   RepositionStrategyName,
+  ServiceModeName,
   Snapshot,
   StrategyName,
   TrafficMode,
+  WorldView,
 } from "../types";
 
 // Thin TS wrapper around `WasmSim`. The wasm-bindgen generated class
@@ -33,6 +35,7 @@ interface WasmSimInstance {
   setTrafficRate(ridersPerMinute: number): void;
   trafficRate(): number;
   snapshot(): Snapshot;
+  worldView(): WorldView;
   drainEvents(): EventDto[];
   metrics(): MetricsDto;
   waitingCountAt(stopId: number): number;
@@ -41,6 +44,23 @@ interface WasmSimInstance {
   setWeightCapacityAll(capacityKg: number): void;
   setDoorOpenTicksAll(ticks: number): void;
   setDoorTransitionTicksAll(ticks: number): void;
+  // Manual control + service mode (BigInt entity refs come from worldView()).
+  setServiceMode(elevatorRef: bigint, mode: string): void;
+  pressHallCall(stopRef: bigint, direction: string): void;
+  pressCarButton(elevatorRef: bigint, stopRef: bigint): void;
+  openDoor(elevatorRef: bigint): void;
+  closeDoor(elevatorRef: bigint): void;
+  holdDoor(elevatorRef: bigint, ticks: number): void;
+  cancelDoorHold(elevatorRef: bigint): void;
+  setTargetVelocity(elevatorRef: bigint, velocity: number): void;
+  emergencyStop(elevatorRef: bigint): void;
+  addElevator(
+    lineRef: bigint,
+    startingPosition: number,
+    maxSpeed?: number,
+    weightCapacity?: number,
+  ): bigint;
+  removeElevator(elevatorRef: bigint): void;
 }
 
 let modPromise: Promise<WasmModule> | null = null;
@@ -130,12 +150,74 @@ export class Sim {
     return this.#inner.snapshot();
   }
 
+  worldView(): WorldView {
+    return this.#inner.worldView();
+  }
+
   metrics(): MetricsDto {
     return this.#inner.metrics();
   }
 
   waitingCountAt(stopId: number): number {
     return this.#inner.waitingCountAt(stopId);
+  }
+
+  // ── Manual control + service mode ────────────────────────────────
+  // Entity refs are bigint, sourced from `worldView()`. Mirrors the
+  // wasm crate's section at crates/elevator-wasm/src/lib.rs (manual
+  // control + service mode block).
+
+  setServiceMode(elevatorRef: bigint, mode: ServiceModeName): void {
+    this.#inner.setServiceMode(elevatorRef, mode);
+  }
+
+  pressHallCall(stopRef: bigint, direction: "up" | "down"): void {
+    this.#inner.pressHallCall(stopRef, direction);
+  }
+
+  pressCarButton(elevatorRef: bigint, stopRef: bigint): void {
+    this.#inner.pressCarButton(elevatorRef, stopRef);
+  }
+
+  openDoor(elevatorRef: bigint): void {
+    this.#inner.openDoor(elevatorRef);
+  }
+
+  closeDoor(elevatorRef: bigint): void {
+    this.#inner.closeDoor(elevatorRef);
+  }
+
+  holdDoor(elevatorRef: bigint, ticks: number): void {
+    this.#inner.holdDoor(elevatorRef, ticks);
+  }
+
+  cancelDoorHold(elevatorRef: bigint): void {
+    this.#inner.cancelDoorHold(elevatorRef);
+  }
+
+  setTargetVelocity(elevatorRef: bigint, velocity: number): void {
+    this.#inner.setTargetVelocity(elevatorRef, velocity);
+  }
+
+  emergencyStop(elevatorRef: bigint): void {
+    this.#inner.emergencyStop(elevatorRef);
+  }
+
+  addElevator(
+    lineRef: bigint,
+    startingPosition: number,
+    options?: { maxSpeed?: number; weightCapacity?: number },
+  ): bigint {
+    return this.#inner.addElevator(
+      lineRef,
+      startingPosition,
+      options?.maxSpeed,
+      options?.weightCapacity,
+    );
+  }
+
+  removeElevator(elevatorRef: bigint): void {
+    this.#inner.removeElevator(elevatorRef);
   }
 
   applyPhysicsLive(params: {

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -1101,6 +1101,286 @@
     }
   }
 
+  /* ── Manual control panel ───────────────────────────────────────────── */
+
+  /* Side panel that replaces pane B in the manual-control scenario.
+   * Section titles, button rows, and the cabin-control sub-blocks. The
+   * scenario flips display:flex on via the data-mode utility-layer rule;
+   * everything below is structure for that case. */
+  .manual-section {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+  .manual-section:last-of-type {
+    border-bottom: 0;
+    padding-bottom: 0;
+  }
+  .manual-section-title {
+    margin: 0;
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+  }
+
+  /* Hall-call rows: floor name on the left, [▲][▼] buttons on the right. */
+  .manual-hall-row {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 4px;
+    border-radius: 4px;
+  }
+  .manual-hall-row:hover {
+    background: var(--bg-hover);
+  }
+  .manual-hall-name {
+    font-size: 11.5px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .manual-hall-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 22px;
+    padding: 0;
+    border: 1px solid var(--border-subtle);
+    border-radius: 3px;
+    background: var(--bg-elevated);
+    color: var(--text-tertiary);
+    font-size: 13px;
+    line-height: 1;
+    cursor: pointer;
+    transition:
+      background 80ms,
+      color 80ms,
+      border-color 80ms;
+  }
+  .manual-hall-btn:hover {
+    background: var(--bg-hover);
+    color: var(--text-secondary);
+  }
+  .manual-hall-btn[data-lit="true"] {
+    background: color-mix(in srgb, var(--accent) 22%, var(--bg-elevated));
+    border-color: color-mix(in srgb, var(--accent) 55%, transparent);
+    color: var(--accent-up);
+  }
+  .manual-hall-btn:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+
+  /* Per-car block: header with name + service-mode dropdown, button strip,
+   * door commands, velocity slider, e-stop. */
+  .manual-car-block {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 6px;
+    background: var(--bg-secondary);
+  }
+  .manual-car-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .manual-car-name {
+    font-size: 11.5px;
+    font-weight: 600;
+    color: var(--text-primary);
+    letter-spacing: 0.01em;
+  }
+  .manual-car-mode-select {
+    font-size: 11px;
+    padding: 2px 6px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 3px;
+    background: var(--bg-elevated);
+    color: var(--text-secondary);
+    cursor: pointer;
+  }
+  .manual-car-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+  .manual-car-btn {
+    width: 28px;
+    height: 24px;
+    padding: 0;
+    border: 1px solid var(--border-subtle);
+    border-radius: 50%;
+    background: var(--bg-elevated);
+    color: var(--text-tertiary);
+    font-size: 10.5px;
+    font-weight: 600;
+    cursor: pointer;
+    transition:
+      background 80ms,
+      color 80ms,
+      border-color 80ms;
+  }
+  .manual-car-btn:hover {
+    background: var(--bg-hover);
+    color: var(--text-secondary);
+  }
+  .manual-car-btn[data-lit="true"] {
+    background: color-mix(in srgb, var(--accent) 28%, var(--bg-elevated));
+    border-color: color-mix(in srgb, var(--accent) 60%, transparent);
+    color: var(--accent-up);
+  }
+  .manual-car-btn:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+
+  .manual-door-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding-top: 2px;
+  }
+  .manual-door-btn {
+    flex: 1 1 0;
+    min-width: 56px;
+    padding: 4px 6px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 3px;
+    background: var(--bg-elevated);
+    color: var(--text-secondary);
+    font-size: 10.5px;
+    font-weight: 500;
+    cursor: pointer;
+  }
+  .manual-door-btn:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+  }
+  .manual-door-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .manual-velocity-row {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 6px;
+  }
+  .manual-velocity-row[data-disabled="true"] {
+    opacity: 0.45;
+  }
+  .manual-velocity-label {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+  }
+  .manual-velocity-readout {
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-secondary);
+    min-width: 48px;
+    text-align: right;
+  }
+  .manual-estop-btn {
+    padding: 4px 8px;
+    border: 1px solid color-mix(in srgb, var(--bad) 50%, transparent);
+    border-radius: 3px;
+    background: color-mix(in srgb, var(--bad) 15%, var(--bg-elevated));
+    color: var(--bad);
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    cursor: pointer;
+  }
+  .manual-estop-btn:hover {
+    background: color-mix(in srgb, var(--bad) 25%, var(--bg-elevated));
+  }
+  .manual-estop-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  /* Spawn rider form: dropdowns + weight input + spawn button. */
+  .manual-spawn-field {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 1 1 80px;
+    min-width: 0;
+  }
+  .manual-spawn-label {
+    font-size: 9.5px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+  }
+  .manual-spawn-select,
+  .manual-spawn-weight {
+    width: 100%;
+    padding: 3px 6px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 3px;
+    background: var(--bg-elevated);
+    color: var(--text-secondary);
+    font-size: 11px;
+  }
+  .manual-spawn-btn {
+    flex: 0 0 auto;
+    padding: 5px 12px;
+    border: 1px solid color-mix(in srgb, var(--accent) 55%, transparent);
+    border-radius: 3px;
+    background: color-mix(in srgb, var(--accent) 18%, var(--bg-elevated));
+    color: var(--accent-up);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+  }
+  .manual-spawn-btn:hover {
+    background: color-mix(in srgb, var(--accent) 28%, var(--bg-elevated));
+  }
+
+  /* Event log line: monospaced, color-coded by event kind. */
+  .manual-event-log li {
+    margin: 0;
+    padding: 1px 4px;
+    border-radius: 2px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .manual-event-log li[data-kind="rider-boarded"] {
+    color: color-mix(in srgb, var(--ok) 80%, var(--text-secondary));
+  }
+  .manual-event-log li[data-kind="rider-exited"] {
+    color: color-mix(in srgb, var(--accent) 80%, var(--text-secondary));
+  }
+  .manual-event-log li[data-kind="door-opened"],
+  .manual-event-log li[data-kind="door-closed"] {
+    color: var(--text-tertiary);
+  }
+  .manual-event-log li[data-kind="elevator-assigned"] {
+    color: color-mix(in srgb, var(--accent) 60%, var(--text-secondary));
+  }
+
   /* ── Mobile ─────────────────────────────────────────────────────────── */
 
   /* Mobile-specific styling uses Tailwind `max-md:` variants on the HTML
@@ -1121,7 +1401,25 @@
    * ones regardless of selector specificity — the components-layer
    * version of this rule silently lost to `grid` on the utilities
    * layer, so the pane stayed visible even with data-mode=single. */
-  .layout[data-mode="single"] #pane-b {
+  .layout[data-mode="single"] #pane-b,
+  .layout[data-mode="manual-control"] #pane-b {
+    display: none;
+  }
+
+  /* Manual-control layout: surface the side panel, hide compare /
+   * intensity controls (no auto traffic = nothing to dial up, no
+   * second pane = nothing to compare). Side-panel display flips to
+   * `flex` so its children stack vertically inside the column.
+   * Hidden by default — only this rule's `display: flex` should
+   * surface it, so other scenarios don't see the empty panel. */
+  #manual-controls {
+    display: none;
+  }
+  .layout[data-mode="manual-control"] #manual-controls {
+    display: flex;
+  }
+  body[data-scenario-mode="manual-control"] #compare-toggle,
+  body[data-scenario-mode="manual-control"] #traffic-field {
     display: none;
   }
 

--- a/playground/src/types/index.ts
+++ b/playground/src/types/index.ts
@@ -4,6 +4,10 @@ export type {
   Snapshot,
   MetricsDto,
   EventDto,
+  WorldView,
+  CarView,
+  StopView,
+  DoorView,
 } from "../../public/pkg/elevator_wasm";
 export type { StrategyName, RepositionStrategyName, TrafficMode } from "./strategies";
 export type { CarBubble } from "./bubble";
@@ -14,6 +18,8 @@ export type {
   TweakRanges,
   ScenarioMeta,
   TetherMeta,
+  ManualControlMeta,
+  ServiceModeName,
 } from "./scenario";
 // Re-import RepositionStrategyName via strategies module — keeps the
 // scenario meta's `defaultReposition` field type-aligned with the

--- a/playground/src/types/scenario.ts
+++ b/playground/src/types/scenario.ts
@@ -80,6 +80,36 @@ export interface TweakRanges {
 }
 
 /**
+ * `ServiceMode` variants exposed in the playground UI. Mirrors a
+ * subset of `elevator_core::components::ServiceMode`. `Independent`
+ * is omitted on purpose — it overlaps with `Manual` semantically and
+ * would confuse the dropdown; consumers needing it can drop to the
+ * wasm API directly.
+ */
+export type ServiceModeName = "normal" | "manual" | "inspection" | "outofservice";
+
+/**
+ * Manual-control scenario metadata. Set only by scenarios that opt
+ * into the cabin-cutaway renderer + side controls panel layout
+ * (currently just the small office). Mirrors `tether?: TetherMeta`.
+ */
+export interface ManualControlMeta {
+  /**
+   * Service mode applied to every car after the sim builds. Normal
+   * keeps auto-loading and auto-dispatch on so spawned riders board
+   * on door open and hall calls assign cars — the manual buttons sit
+   * "alongside" rather than being the only way to drive the car. Users
+   * flip individual cars to Manual via the per-car dropdown.
+   */
+  defaultServiceMode: ServiceModeName;
+  /**
+   * Show the "Add Car B" / "Remove Car B" toggle in the controls
+   * panel. Maps to `addElevator` / `removeElevator` on the sim.
+   */
+  allowAddRemoveCar: boolean;
+}
+
+/**
  * Tether-mode rendering hints for space-elevator-style scenarios.
  * When present, the renderer collapses every car into a single shared
  * shaft and switches the altitude axis to a log scale that spans
@@ -158,6 +188,12 @@ export interface ScenarioMeta {
    * per-line column rendering.
    */
   tether?: TetherMeta;
+  /**
+   * Manual-control metadata. Set only by scenarios that swap the
+   * compare-pane chrome for the cabin-cutaway + controls-panel layout
+   * (small office demo). Mutually exclusive with `tether` in practice.
+   */
+  manualControl?: ManualControlMeta;
   /**
    * Default reposition (idle-parking) strategy applied on scenario
    * selection. Lobby is fine for skyscrapers but a tether climber


### PR DESCRIPTION
## Summary

Fourth playground scenario aimed at **game-integration evaluation**: a small 5-floor office where the user drives every interaction by hand. Hall calls, car buttons, on-demand rider spawn, per-car service-mode dropdown (Normal / Manual / Inspection / Out-of-service), door commands (open / close / hold +30 / cancel hold), manual-mode velocity slider, emergency stop, and an event log surfacing the dispatch / boarding / door events a game would hook.

The shaft is rendered as a **cabin cutaway**: vertical shaft column on the left with hall-call lamps and floor labels, plus a large cab cross-section on the right showing the focused car's interior with rider silhouettes, a lit-up car-button panel, animated doors, and a service-mode badge.

### What's new

- **wasm bindings** (mirror existing `Simulation` APIs in `elevator-core`): `setServiceMode`, `openDoor`, `closeDoor`, `holdDoor`, `cancelDoorHold`, `setTargetVelocity`, `emergencyStop`
- **`ManualControlMeta` flag** on `ScenarioMeta`, mirroring the `tether?` opt-in pattern used by the space-elevator demo
- **New scenario** `manual-office` (5 floors, 1–2 cars, Normal mode by default; switch any car to Manual to drive with the velocity slider)
- **New renderer path** (`draw-cabin.ts`) — cabin cutaway with rider silhouettes, lit car-button panel, animated door
- **New feature module** `playground/src/features/manual-controls/` — hall buttons, per-car blocks, spawn form, event log, "Add Car B" toggle

### Why default to Normal mode (not Manual)?

A game dev evaluating the library wants to see auto-dispatch and auto-boarding work — that's half the value of the engine. `ServiceMode::Manual` disables auto-loading entirely (riders won't board even when doors open), so the per-car dropdown is the surface that exposes Manual on demand. This way the demo shows *every* mode's behavior; pressing buttons "alongside" auto-dispatch is the expected flow, and seizing manual control of any car is one click away.

### Existing scenarios unaffected

- Compare toggle and intensity slider still visible in the other 3 scenarios
- `data-mode="manual-control"` is the new layout flag; `single` and `compare` are unchanged
- `TrafficDriver` is disabled via empty `phases: []` — already an idiom (convention burst's pre-seeded mode uses the same pattern)

## Test plan

- [x] `cargo clippy -p elevator-wasm --target wasm32-unknown-unknown -- -D warnings` clean
- [x] `cargo test -p elevator-core --all-features` all 159 tests pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 146 tests pass (added scenarioCount adjustment + manualControl exception in scenarios.test.ts)
- [x] Playwright smoke: layout + scenario mode flip correctly, hall call lights up, rider spawn produces 4 events, Manual-mode flip enables velocity slider, Add Car B grows car block count from 1 → 2, zero JS errors
- [x] Existing scenarios (skyscraper / convention / space-elevator) still load with compare toggle + intensity visible and zero JS errors
- [ ] Mobile P0: portrait + landscape on real device — controls panel stacks vertically below the shaft on `max-md`; canvas remains tappable