### PR TITLE
fix(playground): manual-control demo design polish

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -301,7 +301,7 @@
         aria-label="Manual elevator controls"
         class="manual-controls flex-col gap-3 min-w-0 p-3 bg-gradient-to-b from-surface-elevated to-surface-secondary border border-stroke-subtle rounded-lg shadow-md max-md:p-2.5 max-md:gap-2 overflow-y-auto"
       >
-        <header class="flex items-center justify-between gap-2">
+        <header class="flex items-center gap-2">
           <span
             class="inline-flex items-center gap-1.5 text-[12px] font-semibold tracking-[0.04em] uppercase text-content-secondary"
             ><span
@@ -310,24 +310,24 @@
             ></span
             >Controls</span
           >
-          <button
-            type="button"
-            id="manual-add-car"
-            class="manual-add-car text-[11px] font-medium px-2 py-1 rounded-sm border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover hover:text-content disabled:opacity-50 disabled:cursor-not-allowed"
-            hidden
-          >
-            Add Car B
-          </button>
         </header>
+
+        <!-- Scenario feature hint — populated dynamically from
+             scenario.featureHint. Hidden when the scenario doesn't
+             carry one. -->
+        <p id="manual-feature-hint" class="manual-feature-hint" hidden></p>
 
         <section aria-label="Hall calls" class="manual-section">
           <h3 class="manual-section-title">Hall calls</h3>
-          <div id="manual-hall-buttons" class="flex flex-col gap-1"></div>
+          <div id="manual-hall-buttons" class="manual-hall-list"></div>
         </section>
 
         <section aria-label="Per-car controls" class="manual-section">
           <h3 class="manual-section-title">Cars</h3>
           <div id="manual-car-controls" class="flex flex-col gap-2"></div>
+          <button type="button" id="manual-add-car" class="manual-add-car-btn" hidden>
+            Add Car B
+          </button>
         </section>
 
         <section aria-label="Spawn rider" class="manual-section">
@@ -340,6 +340,7 @@
           <ul
             id="manual-event-log"
             class="manual-event-log m-0 p-1.5 list-none flex flex-col gap-0.5 bg-surface border border-stroke-subtle rounded-sm text-[10.5px] tabular-nums text-content-tertiary overflow-y-auto h-[180px] max-md:h-[120px]"
+            data-empty-hint="Press a button or spawn a rider to see events."
           ></ul>
         </section>
       </aside>

--- a/playground/src/features/compare-pane/pane.ts
+++ b/playground/src/features/compare-pane/pane.ts
@@ -73,7 +73,7 @@ export async function makePane(
   // here we just toggle the cutaway path on with empty maps.
   if (scenario.manualControl) {
     renderer.setManualControlState({
-      selectedCarId: null,
+      selectedCarSlot: null,
       serviceModeByCar: new Map(),
       hallCallsByStop: new Map(),
     });

--- a/playground/src/features/manual-controls/car-controls.ts
+++ b/playground/src/features/manual-controls/car-controls.ts
@@ -61,6 +61,14 @@ export function mountCarControls(
   scenario: ScenarioMeta,
   initial: WorldView,
   handlers: CarControlsHandlers,
+  /**
+   * Per-car mode to seed the dropdown with on (re)mount. Used by the
+   * panel's Add/Remove Car path to preserve user-picked modes across
+   * a rebuild — without this, adding Car B would snap Car A back to
+   * the scenario's default. Missing entries fall back to
+   * `scenario.manualControl.defaultServiceMode`.
+   */
+  initialModes?: Map<bigint, ServiceModeName>,
 ): CarControlsHandle {
   container.replaceChildren();
   const blocks: CarBlock[] = [];
@@ -84,7 +92,10 @@ export function mountCarControls(
   }
 
   for (const car of initial.cars) {
-    blocks.push(buildCarBlock(scenario, car, nameByRef, servesByCar, handlers));
+    const carRef = BigInt(car.id);
+    const initialMode =
+      initialModes?.get(carRef) ?? scenario.manualControl?.defaultServiceMode ?? "normal";
+    blocks.push(buildCarBlock(scenario, car, nameByRef, servesByCar, handlers, initialMode));
   }
   for (const block of blocks) container.append(block.root);
 
@@ -100,8 +111,13 @@ export function mountCarControls(
           selectedRef === block.carRef ? "color-mix(in srgb, var(--accent) 55%, transparent)" : "";
         // Velocity readout follows the engine's physical velocity so
         // users see the slider command vs actual motion. Manual mode
-        // keeps the slider live; other modes disable it.
-        const inManual = block.modeSelect.value === "manual";
+        // keeps the slider live; other modes disable it. The block's
+        // `data-mode` attribute drives a CSS rule that *collapses* the
+        // VEL row + E-Stop entirely outside manual mode — disabled
+        // affordances were pulling the eye toward unusable controls.
+        const mode = block.modeSelect.value;
+        const inManual = mode === "manual";
+        block.root.dataset["mode"] = mode;
         block.velocityRow.dataset["disabled"] = inManual ? "false" : "true";
         block.velocitySlider.disabled = !inManual;
         block.estopBtn.disabled = !inManual;
@@ -139,9 +155,14 @@ function buildCarBlock(
   nameByRef: Map<bigint, string>,
   servesByCar: Map<bigint, bigint[]>,
   handlers: CarControlsHandlers,
+  initialMode: ServiceModeName,
 ): CarBlock {
   const carRef = BigInt(car.id);
   const root = el("div", "manual-car-block");
+  // CSS reads `data-mode` to collapse the VEL row + E-Stop unless
+  // the block is in manual. The seeded value matches the dropdown
+  // initial selection so the first paint shows the right chrome.
+  root.dataset["mode"] = initialMode;
   root.tabIndex = 0;
   root.addEventListener("click", () => {
     handlers.selectCar(carRef);
@@ -160,9 +181,10 @@ function buildCarBlock(
     opt.textContent = m.label;
     modeSelect.appendChild(opt);
   }
-  // Default UI value follows the scenario's manualControl.defaultServiceMode;
-  // panel.ts applies the same value to the sim immediately after mount.
-  modeSelect.value = scenario.manualControl?.defaultServiceMode ?? "normal";
+  // Seeded dropdown value: caller-supplied (preserved across rebuild)
+  // or the scenario default. panel.ts applies the same value to the
+  // sim immediately after mount.
+  modeSelect.value = initialMode;
   modeSelect.addEventListener("change", () => {
     handlers.setServiceMode(carRef, modeSelect.value as ServiceModeName);
   });

--- a/playground/src/features/manual-controls/hall-buttons.ts
+++ b/playground/src/features/manual-controls/hall-buttons.ts
@@ -57,7 +57,7 @@ export function mountHallButtons(
       entry.up = up;
     } else {
       // Spacer keeps grid columns aligned across rows.
-      row.append(el("span", "w-7"));
+      row.append(el("span", "manual-hall-spacer"));
     }
     if (!isBottom) {
       const down = el("button", "manual-hall-btn");
@@ -70,7 +70,7 @@ export function mountHallButtons(
       row.append(down);
       entry.down = down;
     } else {
-      row.append(el("span", "w-7"));
+      row.append(el("span", "manual-hall-spacer"));
     }
     rows.push(entry);
     container.append(row);

--- a/playground/src/features/manual-controls/panel.ts
+++ b/playground/src/features/manual-controls/panel.ts
@@ -14,6 +14,7 @@ export interface ManualControlsRoots {
   spawnForm: HTMLElement;
   eventLog: HTMLElement;
   addCarBtn: HTMLButtonElement;
+  featureHint: HTMLElement;
 }
 
 export interface ManualControlsHandle {
@@ -148,6 +149,17 @@ export function mountManualControls(
   // would confuse "what just happened" given the panel re-mounts.
   roots.eventLog.replaceChildren();
 
+  // Surface the scenario's `featureHint` as a one-line orientation
+  // bar at the top of the panel. Hidden when the scenario doesn't
+  // carry one — every current manual scenario does, so this branch
+  // exists as forward-compat insurance.
+  if (scenario.featureHint && scenario.featureHint.length > 0) {
+    roots.featureHint.textContent = scenario.featureHint;
+    roots.featureHint.hidden = false;
+  } else {
+    roots.featureHint.hidden = true;
+  }
+
   // Add Car B / Remove Car B toggle. Hidden when the scenario opts
   // out via `allowAddRemoveCar: false`; otherwise toggles label
   // between "Add Car B" and "Remove Car B" based on whether we're at
@@ -198,8 +210,17 @@ export function mountManualControls(
   updateAddCarBtn();
 
   const rebuildCarControls = (): void => {
+    // Preserve user-picked modes across the remount — adding Car B
+    // shouldn't reset Car A's "Manual" pick to the scenario default.
+    const previousModes = carsHandle.serviceModes();
     initialView = sim.worldView();
-    carsHandle = mountCarControls(roots.carControls, scenario, initialView, carHandlers);
+    carsHandle = mountCarControls(
+      roots.carControls,
+      scenario,
+      initialView,
+      carHandlers,
+      previousModes,
+    );
     // If the previously selected car was removed, fall back to the
     // first remaining car so the cutaway always has a focus.
     if (SELECTED !== null && !initialView.cars.some((c) => BigInt(c.id) === SELECTED)) {
@@ -239,16 +260,27 @@ export function mountManualControls(
       // here (not in the loop) because the panel owns all three
       // sources: the dropdown values, the hall-call lamp state from
       // worldView, and the selected-car focus.
-      const hallCallsByStop = new Map<bigint, { up: boolean; down: boolean }>();
+      //
+      // Keys are u32 slots — same form as the Snapshot DTO's
+      // `CarDto.id` / `StopDto.entity_id` so the renderer can match
+      // with `===`. The full u64 refs we hold internally for the
+      // mutation API are masked to slot here once.
+      const SLOT_MASK = 0xffff_ffffn;
+      const toSlot = (ref: bigint): number => Number(ref & SLOT_MASK);
+      const hallCallsByStop = new Map<number, { up: boolean; down: boolean }>();
       for (const stop of view.stops) {
-        hallCallsByStop.set(BigInt(stop.entity_id), {
+        hallCallsByStop.set(stop.entity_id, {
           up: stop.hall_calls.up,
           down: stop.hall_calls.down,
         });
       }
+      const serviceModeByCar = new Map<number, string>();
+      for (const [carRef, mode] of carsHandle.serviceModes()) {
+        serviceModeByCar.set(toSlot(carRef), mode);
+      }
       renderer.setManualControlState({
-        selectedCarId: SELECTED,
-        serviceModeByCar: carsHandle.serviceModes(),
+        selectedCarSlot: SELECTED === null ? null : toSlot(SELECTED),
+        serviceModeByCar,
         hallCallsByStop,
       });
     },
@@ -259,6 +291,8 @@ export function mountManualControls(
       roots.carControls.replaceChildren();
       roots.spawnForm.replaceChildren();
       roots.eventLog.replaceChildren();
+      roots.featureHint.hidden = true;
+      roots.featureHint.textContent = "";
       SELECTED = null;
     },
   };

--- a/playground/src/render/draw-cabin.ts
+++ b/playground/src/render/draw-cabin.ts
@@ -259,11 +259,14 @@ function drawCabinPanel(
   const doorH = 10;
   const interiorTop = headerTop + headerH + 6;
   const interiorBottom = cabinBottom - doorH - 4;
-  const interiorH = Math.max(40, interiorBottom - interiorTop);
+  const interiorH = interiorBottom - interiorTop;
   // Inset interior slightly inside the cabin so the riders don't
   // touch the frame.
   const interiorLeft = cabinLeft + 10;
   const interiorRight = cabinRight - 10;
+  // Skip interior + door entirely on extremely short canvases — the
+  // header strip is the only thing that fits without overdrawing.
+  if (interiorH < 24) return;
   drawRoundedRect(
     ctx,
     interiorLeft,
@@ -275,10 +278,13 @@ function drawCabinPanel(
     CABIN_FRAME,
   );
 
-  // Car-button panel sits in the right-interior. Width fixed enough for
-  // a 2-column layout; height scales with available space (capped so it
-  // doesn't dominate when the cabin is tall).
-  const buttonPanelW = Math.min(80, Math.max(60, interiorRight - interiorLeft) * 0.32);
+  // Car-button panel sits in the right-interior. Take 32 % of the
+  // interior width with a 60 px floor and an 80 px cap. The `Math.max`
+  // wraps the multiplication so the floor actually applies — without
+  // the inner placement, narrow cabins produced a ~28 px panel whose
+  // 2-column cells were narrower than the button radius and visually
+  // overlapped.
+  const buttonPanelW = Math.min(80, Math.max(60, (interiorRight - interiorLeft) * 0.32));
   const buttonPanelH = Math.min(interiorH - 12, 110);
   const buttonPanelX = interiorRight - 6 - buttonPanelW;
   const buttonPanelY = interiorTop + 6;

--- a/playground/src/render/draw-cabin.ts
+++ b/playground/src/render/draw-cabin.ts
@@ -4,61 +4,82 @@ import { drawRider, pickRiderVariant } from "./figures/rider";
 /**
  * Cabin cutaway renderer for the manual-control scenario.
  *
- * Layout split:
- *   - Left 40 %: vertical shaft column showing every stop, hall-call
- *     lamps next to each floor name, and small car rectangles sliding
- *     vertically. A miniature of the building view, slimmed for the
- *     side panel's tighter horizontal budget.
- *   - Right 60 %: a single large cabin cross-section showing the
- *     focused car. Floor label at the top (current floor or "between"),
- *     rider silhouettes inside the cab (count proportional to load),
- *     a 3×2 car-button panel in the lower-right, and an animated door
- *     opening at the bottom edge that follows door FSM progress.
+ * Layout split (left → right):
+ *   - Shaft column (~35 % of width, capped at 200 px so the cabin
+ *     dominates on wide canvases): vertical column showing every stop,
+ *     hall-call lamps next to floor names, and small car rectangles
+ *     sliding vertically. Selected car is highlighted.
+ *   - Cabin cross-section (remaining width): a single large cab seen
+ *     from the side. Contains, top-to-bottom:
+ *       1. Header strip — floor label on the left, service-mode badge
+ *          (AUTO / MANUAL / INSP / OFF) on the right.
+ *       2. Cab interior — rider silhouettes standing on the cab floor,
+ *          one figure per ~2 riders capped at 4. Greys out for OOS.
+ *       3. Car-button panel — 2-column grid of round buttons in the
+ *          right interior, lit when the car has dispatched to that
+ *          stop (proxy for a pending car-call).
+ *       4. Door — animated horizontal slabs at the cab's bottom edge
+ *          that part proportionally to the door FSM phase.
  *
  * The renderer stays additive over the existing `CanvasRenderer`
  * pipeline — `renderer.ts` early-exits into this function when the
  * scenario's `manualControl` flag is set, mirroring the tether path.
  */
-/** Hall-call lamp state at one stop, keyed by stop entity ref. */
+
+/** Hall-call lamp state at one stop, keyed by stop entity slot (u32). */
 export interface HallLampState {
   up: boolean;
   down: boolean;
 }
 
+/**
+ * Cabin render state. Keys are u32 entity slots (`CarDto.id`,
+ * `StopDto.entity_id`) — the same form the Snapshot DTO carries. The
+ * panel converts from its internal full-u64 entity refs (which the
+ * mutation API needs) to u32 slots once when pushing this state, so
+ * the renderer can match snapshot entries with `===` instead of
+ * masking on every lookup.
+ */
 export interface CabinRenderState {
-  /** Currently focused car entity ref, or `null` for "first car". */
-  selectedCarId: bigint | null;
+  /** Slot of the currently focused car, or `null` for "first car". */
+  selectedCarSlot: number | null;
   /**
    * Per-car service mode (drives the cabin badge, OOS door colour, OOS
-   * rider greying). Empty map = "everyone Normal" — every lookup falls
-   * through to the badge default. The panel rebuilds this each frame
-   * from the dropdown values so the renderer always tracks the
-   * authoritative UI state.
+   * rider greying). Keyed by car slot (u32). Empty map = "everyone
+   * Normal" — every lookup falls through to the badge default.
    */
-  serviceModeByCar: Map<bigint, string>;
+  serviceModeByCar: Map<number, string>;
   /**
-   * Per-stop hall-call lamp state. Sourced from
-   * `WorldView.stops[i].hall_calls.{up,down}` (the engine's
+   * Per-stop hall-call lamp state. Keyed by stop slot (u32). Sourced
+   * from `WorldView.stops[i].hall_calls.{up,down}` (the engine's
    * acknowledged-call lamps), not from `waiting_up/waiting_down`
    * (rider counts) — those can disagree in Manual mode where a user
    * spawns a rider without pressing a hall call.
    */
-  hallCallsByStop: Map<bigint, HallLampState>;
+  hallCallsByStop: Map<number, HallLampState>;
 }
 
 const CABIN_BG = "#1a1a1f";
+const CABIN_INTERIOR = "#16161b";
 const CABIN_FRAME = "#3a3a45";
 const SHAFT_FILL = "#252530";
-const FLOOR_TICK = "#3a3a45";
+const FLOOR_TICK = "#2a2a35";
 const FLOOR_LABEL = "#8b8c92";
-const HALL_LAMP_OFF = "#3a3a45";
+const HALL_LAMP_OFF = "#2a2a35";
 const HALL_LAMP_ON = "#fbbf24";
 const RIDER_COLOR = "#a1a1aa";
-const CAR_BUTTON_OFF = "#252530";
-const CAR_BUTTON_ON = "#fbbf24";
+const RIDER_COLOR_OOS = "#5b5b65";
+const CAR_BUTTON_OFF_FILL = "#0f0f12";
+const CAR_BUTTON_OFF_STROKE = "#3a3a45";
+const CAR_BUTTON_OFF_LABEL = "#8b8c92";
+const CAR_BUTTON_ON_FILL = "#fbbf24";
+const CAR_BUTTON_ON_STROKE = "#fbbf24";
+const CAR_BUTTON_ON_LABEL = "#0f0f12";
 const CAR_FILL = "#f59e0b";
+const CAR_FILL_DIM = "#a3733b";
 const CAR_FILL_OOS = "#5b5b65";
 const TEXT_PRIMARY = "#fafafa";
+const DOOR_GAP_FILL = "#0f0f12";
 
 export function drawCabinCutaway(
   ctx: CanvasRenderingContext2D,
@@ -70,15 +91,22 @@ export function drawCabinCutaway(
   if (snap.stops.length === 0 || w <= 0 || h <= 0) return;
 
   const padding = 14;
-  const splitGap = 18;
-  const shaftW = Math.max(120, Math.round(w * 0.4) - splitGap / 2);
+  const splitGap = 14;
+  // Shaft column is sized as a fraction of canvas with a hard cap so
+  // wide desktop canvases don't waste space on the schematic — the
+  // cabin is the focal point. Floor in the cap a bit larger than the
+  // text width so labels never truncate at small viewports.
+  const shaftDesired = Math.round(w * 0.32);
+  const shaftW = Math.min(200, Math.max(120, shaftDesired));
   const shaftX = padding;
   const cabinX = shaftX + shaftW + splitGap;
   const cabinW = w - cabinX - padding;
   const topY = padding;
   const bottomY = h - padding;
-  if (cabinW < 80) {
-    // Very narrow viewport — fall back to shaft only.
+  if (cabinW < 110) {
+    // Very narrow viewport (e.g. mobile portrait pre-stack) — drop
+    // the cabin and let the shaft fill the canvas instead of squashing
+    // the cab into something illegible.
     drawShaftPanel(ctx, snap, shaftX, topY, w - 2 * padding, bottomY - topY, state);
     return;
   }
@@ -103,11 +131,13 @@ function drawShaftPanel(
   const yRange = Math.max(maxY - minY, 0.0001);
 
   // Shaft rect — a single column straddling all stops.
+  const labelGutter = 56;
+  const lampGutter = 8;
   const shaftPad = 6;
-  const shaftLeft = x + 64; // leave room for floor labels
-  const shaftWidth = Math.max(24, w - 64 - shaftPad);
-  const shaftTop = y + 12;
-  const shaftBottom = y + h - 12;
+  const shaftLeft = x + labelGutter + lampGutter;
+  const shaftWidth = Math.max(28, w - labelGutter - lampGutter - shaftPad);
+  const shaftTop = y + 16;
+  const shaftBottom = y + h - 16;
   const shaftHeight = shaftBottom - shaftTop;
 
   // Shaft fill.
@@ -134,33 +164,31 @@ function drawShaftPanel(
 
     ctx.fillStyle = FLOOR_LABEL;
     ctx.textAlign = "right";
-    ctx.fillText(truncate(stop.name, 9), shaftLeft - 8, py);
+    ctx.fillText(truncate(stop.name, 9), x + labelGutter, py);
 
-    // Hall-call lamps as a tiny vertical pair on the shaft's left edge.
-    // Source: panel-supplied per-stop hall-call state from the engine
-    // (`WorldView.stops[i].hall_calls.{up,down}`). Falling back to
-    // `waiting_up/down` (rider counts) would diverge in Manual mode
-    // where a user spawns a rider without pressing a hall call.
-    const lamp = state.hallCallsByStop.get(BigInt(stop.entity_id));
-    const lampX = shaftLeft - 4;
+    // Hall-call lamps as a vertical pair just outside the shaft's left
+    // edge. Sourced from the panel-supplied per-stop hall-call state
+    // so the lamps match the call buttons in the side panel exactly.
+    const lamp = state.hallCallsByStop.get(stop.entity_id);
+    const lampX = x + labelGutter + 2;
     const lampUpY = py - 4;
     const lampDownY = py + 4;
     ctx.fillStyle = lamp?.up ? HALL_LAMP_ON : HALL_LAMP_OFF;
-    ctx.fillRect(lampX, lampUpY - 1, 3, 2);
+    ctx.fillRect(lampX, lampUpY - 1, 4, 3);
     ctx.fillStyle = lamp?.down ? HALL_LAMP_ON : HALL_LAMP_OFF;
-    ctx.fillRect(lampX, lampDownY - 1, 3, 2);
+    ctx.fillRect(lampX, lampDownY - 1, 4, 3);
   }
 
   // Cars: small rectangles. Highlight the selected one.
-  const carWidth = Math.min(18, shaftWidth * 0.8);
-  const carHeight = 10;
   const cars = [...snap.cars];
-  // Side-by-side if multiple cars share the shaft.
+  const carWidth = Math.min(20, (shaftWidth - 4) / Math.max(cars.length, 1) - 4);
+  const carHeight = 12;
   cars.forEach((car, i) => {
     const carPx = yToPx(car.y);
     const cx = shaftLeft + shaftWidth / 2 + (i - (cars.length - 1) / 2) * (carWidth + 4);
-    const isSelected = state.selectedCarId !== null && BigInt(car.id) === state.selectedCarId;
-    const fill = isSelected ? CAR_FILL : "#a3733b";
+    const isSelected = state.selectedCarSlot !== null && car.id === state.selectedCarSlot;
+    const mode = state.serviceModeByCar.get(car.id) ?? "normal";
+    const fill = mode === "outofservice" ? CAR_FILL_OOS : isSelected ? CAR_FILL : CAR_FILL_DIM;
     ctx.fillStyle = fill;
     ctx.fillRect(cx - carWidth / 2, carPx - carHeight / 2, carWidth, carHeight);
     if (isSelected) {
@@ -187,71 +215,135 @@ function drawCabinPanel(
 ): void {
   // Resolve which car to draw inside the cabin frame.
   const selected =
-    state.selectedCarId !== null
-      ? snap.cars.find((c) => BigInt(c.id) === state.selectedCarId)
+    state.selectedCarSlot !== null
+      ? snap.cars.find((c) => c.id === state.selectedCarSlot)
       : snap.cars[0];
   const serviceMode =
-    selected !== undefined
-      ? (state.serviceModeByCar.get(BigInt(selected.id)) ?? "normal")
-      : "normal";
+    selected !== undefined ? (state.serviceModeByCar.get(selected.id) ?? "normal") : "normal";
 
-  // Cabin frame with rounded corners.
-  const cabinTop = y + 26;
-  const cabinBottom = y + h - 16;
+  // Cabin frame — a single rounded rect covering the full available
+  // area, with all interior layout in `cabin`-local coordinates.
+  const cabinTop = y + 4;
+  const cabinBottom = y + h - 4;
+  const cabinLeft = x;
+  const cabinRight = x + w;
   const cabinHeight = cabinBottom - cabinTop;
-  const cabinLeft = x + 6;
-  const cabinRight = x + w - 6;
   const cabinW = cabinRight - cabinLeft;
 
-  drawRoundedRect(ctx, cabinLeft, cabinTop, cabinW, cabinHeight, 6, CABIN_BG, CABIN_FRAME);
+  drawRoundedRect(ctx, cabinLeft, cabinTop, cabinW, cabinHeight, 8, CABIN_BG, CABIN_FRAME);
 
-  // Header: floor label + service mode badge.
+  // ── Header strip: floor label + service-mode badge ──
+  const headerTop = cabinTop + 8;
+  const headerH = 22;
+  const headerBaseline = headerTop + headerH / 2;
   const floorText = floorLabel(selected, snap.stops);
+  ctx.font = "600 13px system-ui, sans-serif";
   ctx.fillStyle = TEXT_PRIMARY;
   ctx.textAlign = "left";
-  ctx.textBaseline = "alphabetic";
-  ctx.font = "600 13px system-ui, sans-serif";
-  ctx.fillText(floorText, cabinLeft + 10, y + 18);
-
-  // Service mode badge on the right.
+  ctx.textBaseline = "middle";
+  ctx.fillText(floorText, cabinLeft + 14, headerBaseline);
   if (selected !== undefined) {
-    drawServiceBadge(ctx, cabinRight - 4, y + 18, serviceMode);
+    drawServiceBadge(ctx, cabinRight - 14, headerBaseline, serviceMode);
   }
 
-  // Rider silhouettes inside the cab. One figure per ~5 riders, capped
-  // at 4 figures so the cab doesn't get crowded; OutOfService greys the
-  // figures.
-  const riderCount = selected?.riders ?? 0;
-  const figureCount = Math.min(4, Math.max(0, Math.ceil(riderCount / 2)));
-  const cabFloorY = cabinBottom - 30;
-  const headR = Math.min(6, cabinHeight / 12);
-  if (figureCount > 0) {
-    const slotW = cabinW / (figureCount + 1);
-    const carIdNum = selected !== undefined ? selected.id : 0;
-    for (let i = 0; i < figureCount; i++) {
-      const fx = cabinLeft + slotW * (i + 1);
-      const variant = pickRiderVariant(carIdNum, i);
-      const color = serviceMode === "outofservice" ? "#5b5b65" : RIDER_COLOR;
-      drawRider(ctx, fx, cabFloorY, headR, color, variant);
-    }
-  }
+  // Header divider.
+  ctx.strokeStyle = CABIN_FRAME;
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(cabinLeft + 8, headerTop + headerH + 0.5);
+  ctx.lineTo(cabinRight - 8, headerTop + headerH + 0.5);
+  ctx.stroke();
 
-  // Car-button panel: 3×2 grid in the lower-right corner. Lit when the
-  // car has dispatched to that stop (proxy for an active car-call —
-  // car-call queue isn't in Snapshot DTOs).
+  // ── Interior region (riders + button panel) ──
+  // Reserve space at the bottom for the door bar.
+  const doorH = 10;
+  const interiorTop = headerTop + headerH + 6;
+  const interiorBottom = cabinBottom - doorH - 4;
+  const interiorH = Math.max(40, interiorBottom - interiorTop);
+  // Inset interior slightly inside the cabin so the riders don't
+  // touch the frame.
+  const interiorLeft = cabinLeft + 10;
+  const interiorRight = cabinRight - 10;
+  drawRoundedRect(
+    ctx,
+    interiorLeft,
+    interiorTop,
+    interiorRight - interiorLeft,
+    interiorH,
+    4,
+    CABIN_INTERIOR,
+    CABIN_FRAME,
+  );
+
+  // Car-button panel sits in the right-interior. Width fixed enough for
+  // a 2-column layout; height scales with available space (capped so it
+  // doesn't dominate when the cabin is tall).
+  const buttonPanelW = Math.min(80, Math.max(60, interiorRight - interiorLeft) * 0.32);
+  const buttonPanelH = Math.min(interiorH - 12, 110);
+  const buttonPanelX = interiorRight - 6 - buttonPanelW;
+  const buttonPanelY = interiorTop + 6;
   drawCarButtonPanel(
     ctx,
-    cabinRight - 70,
-    cabinTop + 8,
-    62,
-    Math.min(96, cabinHeight * 0.55),
+    buttonPanelX,
+    buttonPanelY,
+    buttonPanelW,
+    buttonPanelH,
     snap.stops,
     selected,
   );
 
-  // Door at the bottom: animated based on the door FSM. The Snapshot
-  // DTO carries the phase as a string; use that to drive opening width.
-  drawCabDoor(ctx, cabinLeft + 4, cabinBottom - 4, cabinW - 8, selected, serviceMode);
+  // Riders: stand on the interior floor, distributed across the width
+  // *not* taken by the button panel. Body height tuned to interior so
+  // figures fit even at smaller cabin heights.
+  drawCabRiders(
+    ctx,
+    interiorLeft + 8,
+    interiorTop + 6,
+    buttonPanelX - interiorLeft - 14,
+    interiorH - 12,
+    selected,
+    serviceMode,
+  );
+
+  // ── Door at the bottom ──
+  drawCabDoor(
+    ctx,
+    cabinLeft + 14,
+    cabinBottom - 6,
+    cabinRight - cabinLeft - 28,
+    doorH,
+    selected,
+    serviceMode,
+  );
+}
+
+function drawCabRiders(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  selected: CarDto | undefined,
+  serviceMode: string,
+): void {
+  const riderCount = selected?.riders ?? 0;
+  if (riderCount === 0 || w < 30 || h < 30) return;
+  // One figure per ~2 riders, capped so the cab doesn't get crowded.
+  const figureCount = Math.min(4, Math.max(1, Math.ceil(riderCount / 2)));
+  // Fit the figure body to the interior height. drawRider's standard
+  // variant has total height ≈ headR × 8.2; reserve 6 px of headroom.
+  const targetTotalH = Math.max(28, Math.min(h - 6, 56));
+  const headR = Math.max(2.5, targetTotalH / 8.2);
+  const floorY = y + h - 2;
+  const slotW = Math.min(w / figureCount, 22);
+  const startX = x + (w - slotW * figureCount) / 2 + slotW / 2;
+  const carIdNum = selected !== undefined ? selected.id : 0;
+  const color = serviceMode === "outofservice" ? RIDER_COLOR_OOS : RIDER_COLOR;
+  for (let i = 0; i < figureCount; i++) {
+    const fx = startX + i * slotW;
+    const variant = pickRiderVariant(carIdNum, i);
+    drawRider(ctx, fx, floorY, headR, color, variant);
+  }
 }
 
 function drawCarButtonPanel(
@@ -263,31 +355,32 @@ function drawCarButtonPanel(
   stops: StopDto[],
   selected: CarDto | undefined,
 ): void {
-  drawRoundedRect(ctx, x, y, w, h, 4, "#0f0f12", "#3a3a45");
+  drawRoundedRect(ctx, x, y, w, h, 4, "#0f0f12", CABIN_FRAME);
   const sorted = [...stops].sort((a, b) => b.y - a.y);
   const cols = 2;
   const rows = Math.ceil(sorted.length / cols);
-  const cellW = (w - 8) / cols;
-  const cellH = (h - 8) / Math.max(rows, 1);
-  ctx.font = "600 9px system-ui, sans-serif";
+  const innerPad = 5;
+  const cellW = (w - innerPad * 2) / cols;
+  const cellH = (h - innerPad * 2) / Math.max(rows, 1);
+  const r = Math.max(7, Math.min(cellW, cellH) / 2 - 3);
+  ctx.font = `600 ${Math.max(8, Math.round(r))}px system-ui, sans-serif`;
   ctx.textBaseline = "middle";
   ctx.textAlign = "center";
   sorted.forEach((stop, i) => {
     const col = i % cols;
     const row = Math.floor(i / cols);
-    const cx = x + 4 + col * cellW + cellW / 2;
-    const cy = y + 4 + row * cellH + cellH / 2;
-    const r = Math.min(cellW, cellH) / 2 - 2;
+    const cx = x + innerPad + col * cellW + cellW / 2;
+    const cy = y + innerPad + row * cellH + cellH / 2;
     const lit =
       selected !== undefined && selected.target !== undefined && selected.target === stop.entity_id;
-    ctx.fillStyle = lit ? CAR_BUTTON_ON : CAR_BUTTON_OFF;
+    ctx.fillStyle = lit ? CAR_BUTTON_ON_FILL : CAR_BUTTON_OFF_FILL;
     ctx.beginPath();
     ctx.arc(cx, cy, r, 0, Math.PI * 2);
     ctx.fill();
-    ctx.strokeStyle = lit ? "#fbbf24" : "#3a3a45";
+    ctx.strokeStyle = lit ? CAR_BUTTON_ON_STROKE : CAR_BUTTON_OFF_STROKE;
     ctx.lineWidth = 1;
     ctx.stroke();
-    ctx.fillStyle = lit ? "#0f0f12" : FLOOR_LABEL;
+    ctx.fillStyle = lit ? CAR_BUTTON_ON_LABEL : CAR_BUTTON_OFF_LABEL;
     ctx.fillText(buttonAbbrev(stop.name), cx, cy);
   });
 }
@@ -297,10 +390,10 @@ function drawCabDoor(
   x: number,
   y: number,
   w: number,
+  h: number,
   selected: CarDto | undefined,
   serviceMode: string,
 ): void {
-  const doorH = 4;
   // Phase-based open fraction. The Snapshot's CarDto.phase covers
   // door-opening / loading (open) / door-closing / others (closed).
   let openFrac = 0;
@@ -313,11 +406,13 @@ function drawCabDoor(
   const halfW = w / 2;
   const gap = halfW * openFrac;
   const fill = serviceMode === "outofservice" ? CAR_FILL_OOS : CAR_FILL;
+  // Door-gap background so the parted slabs look like they reveal a
+  // dark threshold rather than the cabin's dark interior.
+  ctx.fillStyle = DOOR_GAP_FILL;
+  ctx.fillRect(x, y - h, w, h);
   ctx.fillStyle = fill;
-  // Left door panel.
-  ctx.fillRect(x, y - doorH, halfW - gap, doorH);
-  // Right door panel.
-  ctx.fillRect(x + halfW + gap, y - doorH, halfW - gap, doorH);
+  ctx.fillRect(x, y - h, halfW - gap, h);
+  ctx.fillRect(x + halfW + gap, y - h, halfW - gap, h);
 }
 
 function drawRoundedRect(
@@ -355,43 +450,44 @@ interface ServiceBadgeStyle {
 }
 
 const SERVICE_BADGE_STYLES: Record<string, ServiceBadgeStyle> = {
-  normal: { label: "AUTO", bg: "#22c55e22", fg: "#22c55e" },
+  normal: { label: "AUTO", bg: "#22c55e2a", fg: "#22c55e" },
   manual: { label: "MANUAL", bg: "#fbbf2433", fg: "#fbbf24" },
   inspection: { label: "INSP", bg: "#a78bfa33", fg: "#a78bfa" },
-  outofservice: { label: "OFF", bg: "#ef444433", fg: "#ef4444" },
+  outofservice: { label: "OFF", bg: "#ef44443a", fg: "#ef4444" },
   independent: { label: "IND", bg: "#a1a1aa33", fg: "#a1a1aa" },
 };
 
 function drawServiceBadge(
   ctx: CanvasRenderingContext2D,
   rightX: number,
-  baselineY: number,
+  centerY: number,
   serviceMode: string,
 ): void {
   const style = SERVICE_BADGE_STYLES[serviceMode] ?? SERVICE_BADGE_STYLES["normal"];
   if (!style) return;
-  ctx.font = "600 9px system-ui, sans-serif";
-  const padX = 6;
+  ctx.font = "700 10px system-ui, sans-serif";
+  const padX = 8;
+  const padY = 5;
   const metrics = ctx.measureText(style.label);
   const w = metrics.width + padX * 2;
-  const h = 14;
-  drawRoundedRect(ctx, rightX - w, baselineY - h + 2, w, h, 3, style.bg, style.fg);
+  const h = 12 + padY * 2;
+  const left = rightX - w;
+  const top = centerY - h / 2;
+  drawRoundedRect(ctx, left, top, w, h, 4, style.bg, style.fg);
   ctx.fillStyle = style.fg;
-  ctx.textAlign = "right";
+  ctx.textAlign = "center";
   ctx.textBaseline = "middle";
-  ctx.fillText(style.label, rightX - padX, baselineY - h / 2 + 2);
-  // Reset text alignment.
+  ctx.fillText(style.label, left + w / 2, top + h / 2);
+  // Reset text alignment for subsequent draws.
   ctx.textAlign = "left";
-  ctx.textBaseline = "alphabetic";
 }
 
 function floorLabel(car: CarDto | undefined, stops: StopDto[]): string {
   if (!car) return "—";
-  // "At Floor 3" if the car is exactly at a stop; "Between" otherwise.
   const tolerance = 0.25;
   const stop = stops.find((s) => Math.abs(s.y - car.y) < tolerance);
   if (stop) return stop.name;
-  return "Between";
+  return "Between floors";
 }
 
 function buttonAbbrev(name: string): string {

--- a/playground/src/shell/reset.ts
+++ b/playground/src/shell/reset.ts
@@ -124,6 +124,7 @@ export async function resetAll(state: State, ui: UiHandles): Promise<void> {
           spawnForm: ui.manualSpawnForm,
           eventLog: ui.manualEventLog,
           addCarBtn: ui.manualAddCarBtn,
+          featureHint: ui.manualFeatureHint,
         },
         paneA.renderer,
       );

--- a/playground/src/shell/wire-ui.ts
+++ b/playground/src/shell/wire-ui.ts
@@ -36,6 +36,7 @@ export interface UiHandles {
   manualSpawnForm: HTMLElement;
   manualEventLog: HTMLElement;
   manualAddCarBtn: HTMLButtonElement;
+  manualFeatureHint: HTMLElement;
 }
 
 export function wireUi(): UiHandles {
@@ -118,6 +119,7 @@ export function wireUi(): UiHandles {
     manualSpawnForm: q("manual-spawn-form"),
     manualEventLog: q("manual-event-log"),
     manualAddCarBtn: q("manual-add-car") as HTMLButtonElement,
+    manualFeatureHint: q("manual-feature-hint"),
   };
 
   renderScenarioCards(ui);

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -1127,14 +1127,45 @@
     color: var(--text-tertiary);
   }
 
-  /* Hall-call rows: floor name on the left, [▲][▼] buttons on the right. */
+  /* One-line orientation banner shown above hall-calls. Faint accent
+   * left border + a single line of body copy. Hidden when the
+   * scenario doesn't carry a `featureHint`. */
+  .manual-feature-hint {
+    margin: 0;
+    padding: 6px 8px 6px 10px;
+    border-left: 2px solid color-mix(in srgb, var(--accent) 60%, transparent);
+    background: color-mix(in srgb, var(--accent) 6%, transparent);
+    border-radius: 3px;
+    font-size: 11px;
+    line-height: 1.35;
+    color: var(--text-secondary);
+    letter-spacing: 0.005em;
+  }
+
+  /* Hall-call list: rounded container around the rows so the column
+   * reads as a unit (real elevator panel). */
+  .manual-hall-list {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--border-subtle);
+    border-radius: 4px;
+    overflow: hidden;
+    background: var(--bg-secondary);
+  }
+
+  /* Hall-call rows: floor name on the left, [▲][▼] buttons on the right.
+   * Bordered separators between rows and a vertical rule between the
+   * up/down buttons mimic the column layout of a real call panel. */
   .manual-hall-row {
     display: grid;
     grid-template-columns: 1fr auto auto;
     align-items: center;
-    gap: 6px;
-    padding: 3px 4px;
-    border-radius: 4px;
+    gap: 0;
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+  .manual-hall-row:last-child {
+    border-bottom: 0;
   }
   .manual-hall-row:hover {
     background: var(--bg-hover);
@@ -1151,33 +1182,41 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 28px;
-    height: 22px;
+    width: 32px;
+    height: 24px;
     padding: 0;
-    border: 1px solid var(--border-subtle);
-    border-radius: 3px;
-    background: var(--bg-elevated);
+    border: 0;
+    border-left: 1px solid var(--border-subtle);
+    border-radius: 0;
+    background: transparent;
     color: var(--text-tertiary);
     font-size: 13px;
     line-height: 1;
     cursor: pointer;
     transition:
       background 80ms,
-      color 80ms,
-      border-color 80ms;
+      color 80ms;
   }
   .manual-hall-btn:hover {
-    background: var(--bg-hover);
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
     color: var(--text-secondary);
   }
   .manual-hall-btn[data-lit="true"] {
     background: color-mix(in srgb, var(--accent) 22%, var(--bg-elevated));
-    border-color: color-mix(in srgb, var(--accent) 55%, transparent);
     color: var(--accent-up);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 55%, transparent);
   }
   .manual-hall-btn:disabled {
     opacity: 0.35;
     cursor: not-allowed;
+  }
+  /* Spacer "button" used in place of an unavailable up/down on the
+   * top/bottom floors. Has no visual presence but keeps the row's
+   * column alignment consistent. */
+  .manual-hall-spacer {
+    width: 32px;
+    height: 24px;
+    border-left: 1px solid var(--border-subtle);
   }
 
   /* Per-car block: header with name + service-mode dropdown, button strip,
@@ -1280,8 +1319,13 @@
     align-items: center;
     gap: 6px;
   }
-  .manual-velocity-row[data-disabled="true"] {
-    opacity: 0.45;
+  /* Hide the velocity row + E-Stop unless the car block is in
+   * `manual` mode. Disabled affordances were pulling the eye toward
+   * unusable controls; collapsing them keeps the per-car block
+   * compact in the common (Normal) case. */
+  .manual-car-block:not([data-mode="manual"]) .manual-velocity-row,
+  .manual-car-block:not([data-mode="manual"]) .manual-estop-btn {
+    display: none;
   }
   .manual-velocity-label {
     font-size: 10px;
@@ -1315,6 +1359,47 @@
   .manual-estop-btn:disabled {
     opacity: 0.4;
     cursor: not-allowed;
+  }
+
+  /* Add / Remove Car B affordance — full-width secondary action at
+   * the bottom of the CARS section. Sits next to its target (the car
+   * block list) instead of in the aside header. */
+  .manual-add-car-btn {
+    width: 100%;
+    margin-top: 4px;
+    padding: 6px 10px;
+    border: 1px dashed var(--border-default);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    transition:
+      background 80ms,
+      color 80ms,
+      border-color 80ms;
+  }
+  .manual-add-car-btn:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+    border-color: var(--border-strong);
+  }
+  .manual-add-car-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  /* Empty-state hint for the event log — surfaced via ::before when
+   * the list has no rendered children. */
+  .manual-event-log:empty::before {
+    content: attr(data-empty-hint);
+    display: block;
+    padding: 4px;
+    color: var(--text-disabled);
+    font-style: italic;
+    font-size: 10.5px;
   }
 
   /* Spawn rider form: dropdowns + weight input + spawn button. */
@@ -1421,6 +1506,17 @@
   body[data-scenario-mode="manual-control"] #compare-toggle,
   body[data-scenario-mode="manual-control"] #traffic-field {
     display: none;
+  }
+  /* On mobile, the layout stacks pane A above the manual-controls
+   * aside. The fixed bottom controls bar would otherwise float over
+   * the aside's last item. Add bottom padding *inside* the aside so
+   * its content can scroll past the bar. (`overflow-y-auto` is
+   * already on the aside; the inner padding gives it room to scroll
+   * past the fixed bar at the viewport edge.) */
+  @media (max-width: 767px) {
+    .layout[data-mode="manual-control"] #manual-controls {
+      padding-bottom: calc(var(--controls-bar-h, 52px) + 16px + env(safe-area-inset-bottom));
+    }
   }
 
   .safe-top {


### PR DESCRIPTION
## Summary

Address the design review on the shipped manual-control scenario (#464). The cabin and panel were structurally there but underdelivered visually. Fixes the cabin emptiness, makes the service-mode badge readable, surfaces the `featureHint`, collapses unusable VEL/E-Stop in Normal mode, relocates Add Car B to its target section, and polishes the hall-call panel + mobile layout.

## Critical fixes

### Cabin: rebalance + render fixes
- 35/65 split (was 40/60) so the cabin gets room for header, riders, button panel, and door bar without collisions
- **Service-mode badge**: bigger (10 px bold, padded), proper background, sits in a header strip instead of floating. Now visible at desktop + mobile
- **Rider silhouettes**: scale `headR` to interior height so figures actually appear when riders are aboard. The shipped demo had an empty cab during trips — visible in the design review screenshots
- Floor label promoted to a dedicated header strip with a divider; reads as a proper cabin sign instead of a small caption
- **Latent bug fix**: `state.selectedCarId` was a u64 entity ref but `CarDto.id` is a u32 slot, so `BigInt(c.id) === state.selectedCarId` always failed past the first scenario boot. Flipped `CabinRenderState` keys to u32 slots end-to-end (panel masks once when pushing). The cabin now resolves its selected car correctly

### Mobile bottom-bar overlap (P0 per project rules)
- Manual-controls aside gets `padding-bottom: calc(var(--controls-bar-h) + 16 + safe-area)` on `max-md` so its scrollable content can clear the fixed bottom controls bar

## Polish

- **`featureHint` surfaced** as a one-line orientation banner above HALL CALLS (faint accent left-border). First-time visitors land on a guided "press buttons by hand…" entry point
- **Velocity slider + E-Stop** CSS-collapsed unless the per-car block has `data-mode="manual"`. Disabled affordances were pulling the eye toward unusable controls; per-car block now stays compact in the common (Normal) case
- **Service mode preserved across Add/Remove Car rebuild** — adding Car B no longer snaps Car A back to scenario default. `mountCarControls` now takes an optional `initialModes` map
- **Add Car B relocated** from aside header to a full-width dashed-border button at the bottom of CARS. Sits next to its target (the car block list)
- **Hall-call panel polish** — rounded container with internal row separators and column rule between up/down chevrons; reads as a real elevator call panel. Lit state uses inset accent ring
- **Empty event log** placeholder via `:empty::before` so the log doesn't read as a void on first load

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 146 tests pass
- [x] Playwright snapshots at desktop / mobile portrait / mobile landscape — cabin renders cleanly with badge + riders + button panel + door
- [x] Manual mode flip shows VEL slider + E-Stop; flipping back to Normal collapses them
- [x] Add Car B / Remove Car B preserves Car A's mode across the rebuild
- [x] OutOfService tints riders + door bar grey, badge reads "OFF"
- [x] Existing scenarios (skyscraper / convention / space-elevator) unaffected