### PR TITLE
chore(deps): collapse elevator-wasm getrandom to single 0.4 dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2506,7 +2506,6 @@ name = "elevator-wasm"
 version = "0.1.0"
 dependencies = [
  "elevator-core",
- "getrandom 0.3.4",
  "getrandom 0.4.2",
  "ron",
  "serde",
@@ -2825,11 +2824,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/elevator-wasm/Cargo.toml
+++ b/crates/elevator-wasm/Cargo.toml
@@ -37,10 +37,9 @@ serde = { workspace = true }
 ron = { workspace = true }
 slotmap = { workspace = true }
 
-# getrandom's js backend is required for `rand` on wasm32 targets. Both
-# version trees in the dep graph (rand 0.10 pulls 0.4; some workspace members
-# still bring in 0.3) need the `wasm_js` backend enabled. Kept target-scoped so
+# getrandom's js backend is required for `rand` on wasm32 targets. Only one
+# version is in the dep graph today (rand 0.10 → getrandom 0.4); the explicit
+# direct dep is what flips on the `wasm_js` backend. Kept target-scoped so
 # native (x86_64) builds of this crate are unaffected.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.3", features = ["wasm_js"] }
-getrandom_v04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
+getrandom = { version = "0.4", features = ["wasm_js"] }

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -6,7 +6,7 @@
 //! strategy by name.
 //!
 //! The core crate stays engine-agnostic — all wasm-specific concerns (bindgen
-//! macros, JS types, `getrandom/js`) live here.
+//! macros, JS types, `getrandom/wasm_js`) live here.
 
 #![allow(clippy::needless_pass_by_value)]
 


### PR DESCRIPTION
## Summary

- `elevator-wasm` previously held two direct `getrandom` deps (0.3 and 0.4 via a `package = "getrandom"` alias) so each version tree could enable the `wasm_js` backend.
- Today only `rand 0.10 → getrandom 0.4` is on the wasm32 target — the 0.3 entry was kept alive solely by the explicit Cargo.toml line. Drop it, rename `getrandom_v04` back to plain `getrandom`, refresh the comment.
- Supersedes #447: dependabot bumped 0.3 → 0.4 but left the alias intact, producing `crate getrandom v0.4.2 multiple times with different names` in CI (failed both `wasm32 gate` and `cargo-deny`).
- Lock-file side effect: `getrandom 0.3.4` (still pulled transitively by bevy/winit on host) loses its `js-sys` / `wasm-bindgen` feature activation since nothing direct asks for `wasm_js` on it anymore.

## Test plan

- [x] `cargo check --workspace --all-features --all-targets` clean
- [x] `cargo check -p elevator-wasm --target wasm32-unknown-unknown` clean
- [x] `cargo deny check` — advisories / bans / licenses / sources all ok
- [x] Pre-commit hook (fmt, clippy, core tests, doc tests, workspace check) green
- [ ] CI `wasm32 gate (elevator-core)` passes
- [ ] CI `Supply chain (cargo-deny)` passes
- [ ] Greptile review