### PR TITLE
fix(playground): cockpit follow-up — overrides getter, kbd axes

### DIFF
--- a/playground/src/features/manual-controls/console.ts
+++ b/playground/src/features/manual-controls/console.ts
@@ -4,6 +4,14 @@ import type { ScenarioMeta, WorldView } from "../../types";
 import { mountThrottle, type ThrottleHandle } from "./throttle";
 
 /**
+ * Getter for the live overrides bag. Must read state at call time
+ * — the tweak-drawer hot-swap path replaces `state.permalink.overrides`
+ * with a new object without remounting the cockpit, so a captured
+ * reference goes stale immediately after the user nudges the slider.
+ */
+export type OverridesGetter = () => Overrides;
+
+/**
  * Cockpit console: the right-rail (or bottom-bar on mobile portrait)
  * driver controls. Hydrates the static markup placed in `index.html`
  * — caller passes in references to the existing throttle, door
@@ -39,7 +47,7 @@ const HOLD_TICKS = 60;
 export function mountCockpitConsole(
   sim: Sim,
   scenario: ScenarioMeta,
-  overrides: Overrides,
+  getOverrides: OverridesGetter,
   view: WorldView,
   roots: CockpitConsoleRoots,
 ): CockpitConsoleHandle {
@@ -53,11 +61,12 @@ export function mountCockpitConsole(
   // capturing a fresh ref then.
   const carRef = BigInt(firstCar.id);
 
-  // Resolve the effective max speed against user overrides. The
-  // scenario default (2 m/s) would diverge from the engine when the
-  // user cranks the slider via the tweak drawer; this keeps the
-  // throttle clamp aligned with the engine's actual ceiling.
-  const resolvedMaxSpeed = (): number => applyPhysicsOverrides(scenario, overrides).maxSpeed;
+  // Resolve the effective max speed against the *current* overrides.
+  // Calling `getOverrides()` each frame is mandatory: the tweak
+  // drawer's hot-swap path replaces the overrides object without
+  // remounting, so a captured snapshot would go stale and the
+  // throttle clamp would diverge from the engine's actual ceiling.
+  const resolvedMaxSpeed = (): number => applyPhysicsOverrides(scenario, getOverrides()).maxSpeed;
 
   // ─── Throttle ───────────────────────────────────────────────────
   const throttle: ThrottleHandle = mountThrottle(roots.throttle, {

--- a/playground/src/features/manual-controls/panel.ts
+++ b/playground/src/features/manual-controls/panel.ts
@@ -1,9 +1,9 @@
-import { applyPhysicsOverrides, type Overrides } from "../../domain";
+import { applyPhysicsOverrides } from "../../domain";
 import type { CanvasRenderer } from "../../render";
 import type { HitZone } from "../../render/draw-cockpit";
 import type { Sim } from "../../sim";
 import type { ScenarioMeta } from "../../types";
-import { mountCockpitConsole, type CockpitConsoleHandle } from "./console";
+import { mountCockpitConsole, type CockpitConsoleHandle, type OverridesGetter } from "./console";
 
 /** Static DOM containers the cockpit panel hydrates. All must exist in `index.html`. */
 export interface ManualControlsRoots {
@@ -35,9 +35,12 @@ export interface ManualControlsHandle {
  * `CockpitRenderState` (hall-call lamp map + hint copy) into the
  * renderer so the elevation reads the engine's authoritative state.
  *
- * `overrides` is the user's tweak-drawer state — needed so the
- * throttle clamp matches the engine's effective `maxSpeed` after a
- * tweak (the scenario's default would diverge otherwise).
+ * `getOverrides` returns the user's *current* tweak-drawer state.
+ * Must be a getter, not a value — the hot-swap path in
+ * `tweak-drawer/stepper.ts` replaces `state.permalink.overrides`
+ * with a new object without remounting the cockpit, so a captured
+ * snapshot would go stale and the throttle clamp would freeze at
+ * the boot-time max-speed.
  *
  * The scenario locks `cars` at 1 (`tweakRanges.cars: {min:1,max:1}`)
  * and `manualControl.allowAddRemoveCar: false`, which removes the
@@ -47,7 +50,7 @@ export interface ManualControlsHandle {
 export function mountManualControls(
   sim: Sim,
   scenario: ScenarioMeta,
-  overrides: Overrides,
+  getOverrides: OverridesGetter,
   roots: ManualControlsRoots,
   renderer: CanvasRenderer,
 ): ManualControlsHandle {
@@ -60,15 +63,21 @@ export function mountManualControls(
   // Cockpit console — the right-rail driver controls. The hint
   // banner is drawn on the canvas elevation, not in the console DOM,
   // so the console doesn't need a hint root.
-  const cockpit: CockpitConsoleHandle = mountCockpitConsole(sim, scenario, overrides, initialView, {
-    throttle: roots.throttle,
-    velocityReadout: roots.velocityReadout,
-    doorOpen: roots.doorOpen,
-    doorClose: roots.doorClose,
-    doorHold: roots.doorHold,
-    emergencyStop: roots.emergencyStop,
-    spawnRider: roots.spawnRider,
-  });
+  const cockpit: CockpitConsoleHandle = mountCockpitConsole(
+    sim,
+    scenario,
+    getOverrides,
+    initialView,
+    {
+      throttle: roots.throttle,
+      velocityReadout: roots.velocityReadout,
+      doorOpen: roots.doorOpen,
+      doorClose: roots.doorClose,
+      doorHold: roots.doorHold,
+      emergencyStop: roots.emergencyStop,
+      spawnRider: roots.spawnRider,
+    },
+  );
 
   // Apply the scenario's default service mode so the engine state
   // matches what the cockpit assumes (Manual = throttle drives the
@@ -143,7 +152,7 @@ export function mountManualControls(
       renderer.setCockpitState({
         hallCallsByStop,
         hint: scenario.featureHint,
-        maxSpeed: applyPhysicsOverrides(scenario, overrides).maxSpeed,
+        maxSpeed: applyPhysicsOverrides(scenario, getOverrides()).maxSpeed,
       });
     },
     dispose(): void {

--- a/playground/src/features/manual-controls/throttle.ts
+++ b/playground/src/features/manual-controls/throttle.ts
@@ -151,10 +151,12 @@ export function mountThrottle(host: HTMLElement, opts: ThrottleOptions): Throttl
       setValue(value - KEY_NUDGE_M_S, { spring: false });
       e.preventDefault();
     } else if (e.key === "Home") {
-      setValue(maxSpeed, { spring: false });
+      // ARIA `role="slider"`: Home = minimum value.
+      setValue(-maxSpeed, { spring: false });
       e.preventDefault();
     } else if (e.key === "End") {
-      setValue(-maxSpeed, { spring: false });
+      // ARIA `role="slider"`: End = maximum value.
+      setValue(maxSpeed, { spring: false });
       e.preventDefault();
     } else if (e.key === " " || e.key === "Spacebar") {
       setValue(0, { spring: true });

--- a/playground/src/features/manual-controls/throttle.ts
+++ b/playground/src/features/manual-controls/throttle.ts
@@ -138,12 +138,23 @@ export function mountThrottle(host: HTMLElement, opts: ThrottleOptions): Throttl
   };
 
   // ─── Keyboard ───────────────────────────────────────────────────
+  // Up/Right always nudge positive (ascend); Down/Left always nudge
+  // negative. Both axes are bound regardless of orientation so the
+  // ARIA slider role behaves naturally on desktop (vertical) and
+  // mobile portrait (horizontal). Home/End jump to the limits;
+  // Space recentres.
   const onKeyDown = (e: KeyboardEvent): void => {
-    if (e.key === "ArrowUp") {
+    if (e.key === "ArrowUp" || e.key === "ArrowRight") {
       setValue(value + KEY_NUDGE_M_S, { spring: false });
       e.preventDefault();
-    } else if (e.key === "ArrowDown") {
+    } else if (e.key === "ArrowDown" || e.key === "ArrowLeft") {
       setValue(value - KEY_NUDGE_M_S, { spring: false });
+      e.preventDefault();
+    } else if (e.key === "Home") {
+      setValue(maxSpeed, { spring: false });
+      e.preventDefault();
+    } else if (e.key === "End") {
+      setValue(-maxSpeed, { spring: false });
       e.preventDefault();
     } else if (e.key === " " || e.key === "Spacebar") {
       setValue(0, { spring: true });

--- a/playground/src/shell/reset.ts
+++ b/playground/src/shell/reset.ts
@@ -115,10 +115,14 @@ export async function resetAll(state: State, ui: UiHandles): Promise<void> {
     // CockpitRenderState (hall-call lamps + hint) into `paneA.renderer`
     // on every `update()` tick.
     if (scenario.manualControl !== undefined) {
+      // Pass a getter, not a value: the tweak-drawer hot-swap path
+      // replaces `state.permalink.overrides` with a fresh object on
+      // every change, so a captured snapshot would freeze the
+      // throttle clamp at boot-time max-speed.
       state.cockpit = mountManualControls(
         paneA.sim,
         scenario,
-        state.permalink.overrides,
+        () => state.permalink.overrides,
         {
           throttle: ui.cockpitThrottle,
           velocityReadout: ui.cockpitVelocity,

--- a/playground/src/shell/wire-ui.ts
+++ b/playground/src/shell/wire-ui.ts
@@ -30,7 +30,6 @@ export interface UiHandles {
   shortcutSheetClose: HTMLButtonElement;
   paneA: PaneHandles;
   paneB: PaneHandles;
-  cockpitConsole: HTMLElement;
   cockpitThrottle: HTMLElement;
   cockpitVelocity: HTMLElement;
   cockpitDoorOpen: HTMLButtonElement;
@@ -114,7 +113,6 @@ export function wireUi(): UiHandles {
     shortcutSheetClose: q("shortcut-sheet-close") as HTMLButtonElement,
     paneA: paneHandles("a", COLOR_A),
     paneB: paneHandles("b", COLOR_B),
-    cockpitConsole: q("cockpit-console"),
     cockpitThrottle: q("cockpit-throttle"),
     cockpitVelocity: q("cockpit-velocity"),
     cockpitDoorOpen: q("cockpit-door-open") as HTMLButtonElement,

--- a/playground/src/types/scenario.ts
+++ b/playground/src/types/scenario.ts
@@ -190,9 +190,10 @@ export interface ScenarioMeta {
    */
   tether?: TetherMeta;
   /**
-   * Manual-control metadata. Set only by scenarios that swap the
-   * compare-pane chrome for the cabin-cutaway + controls-panel layout
-   * (small office demo). Mutually exclusive with `tether` in practice.
+   * Operator-cockpit metadata. Set only by scenarios that swap the
+   * compare-pane chrome for the cockpit elevation + right-rail
+   * console layout (operator-cockpit demo). Mutually exclusive with
+   * `tether` in practice.
    */
   manualControl?: ManualControlMeta;
   /**


### PR DESCRIPTION
## Summary

Follow-up to #467 catching a P0 the first round missed plus two smaller fixes from a fresh review pass.

- **Throttle clamp / velocity ribbon were freezing at boot-time max-speed.** `mountManualControls` captured `state.permalink.overrides` by reference at mount, but the tweak-drawer hot-swap path (non-cars knobs) replaces that bag with a new object on every change *without* remounting the cockpit. So when the user nudged max-speed via the slider, the engine accepted the new ceiling but the throttle stayed pinned to the boot-time value. Fix: thread an `OverridesGetter` (`() => state.permalink.overrides`) so each frame reads the live state.
- **Throttle keyboard now responds to ArrowLeft / ArrowRight** (in addition to Up / Down) for ARIA-correct horizontal-slider behaviour on mobile portrait + iPad / external keyboards. Home / End jump to ±maxSpeed.
- Drop dead `cockpitConsole: HTMLElement` field from `UiHandles` — `#cockpit-console` is hit by CSS only, never read in JS.
- Refresh stale "cabin-cutaway + controls-panel" doc on `ScenarioMeta.manualControl` to match the cockpit framing.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm vitest run` — 147/147 pass
- [ ] Walk through: open cockpit, drag throttle to max, then crank max-speed slider in tweak drawer; throttle clamp follows the new ceiling without remounting
- [ ] Tab-focus throttle in mobile-portrait DevTools; ArrowRight increases velocity, ArrowLeft decreases, Home/End jump to limits
- [ ] Permalink stability: existing `?s=manual-office&...` links still load the cockpit