### PR TITLE
feat(bindings): add mode APIs to wasm and FFI (PR-D)

### DIFF
--- a/bindings.toml
+++ b/bindings.toml
@@ -136,50 +136,50 @@ ffi  = "skip:internal — phase ordering invariant"
 [[methods]]
 name = "set_service_mode"
 category = "modes"
-wasm = "todo:PR-D"
-ffi  = "todo:PR-D"
+wasm = "setServiceMode"
+ffi  = "ev_sim_set_service_mode"
 
 [[methods]]
 name = "service_mode"
 category = "modes"
-wasm = "todo:PR-D"
-ffi  = "todo:PR-D"
+wasm = "serviceMode"
+ffi  = "ev_sim_service_mode"
 
 [[methods]]
 name = "set_target_velocity"
 category = "modes"
-wasm = "todo:PR-D"
-ffi  = "todo:PR-D"
+wasm = "setTargetVelocity"
+ffi  = "ev_sim_set_target_velocity"
 
 [[methods]]
 name = "emergency_stop"
 category = "modes"
-wasm = "todo:PR-D"
-ffi  = "todo:PR-D"
+wasm = "emergencyStop"
+ffi  = "ev_sim_emergency_stop"
 
 [[methods]]
 name = "open_door"
 category = "modes"
-wasm = "todo:PR-D"
-ffi  = "todo:PR-D"
+wasm = "openDoor"
+ffi  = "ev_sim_open_door"
 
 [[methods]]
 name = "close_door"
 category = "modes"
-wasm = "todo:PR-D"
-ffi  = "todo:PR-D"
+wasm = "closeDoor"
+ffi  = "ev_sim_close_door"
 
 [[methods]]
 name = "hold_door"
 category = "modes"
-wasm = "todo:PR-D"
-ffi  = "todo:PR-D"
+wasm = "holdDoor"
+ffi  = "ev_sim_hold_door"
 
 [[methods]]
 name = "cancel_door_hold"
 category = "modes"
-wasm = "todo:PR-D"
-ffi  = "todo:PR-D"
+wasm = "cancelDoorHold"
+ffi  = "ev_sim_cancel_door_hold"
 
 # ─── Dispatch ─────────────────────────────────────────────────────────────
 

--- a/crates/elevator-ffi/include/elevator_ffi.h
+++ b/crates/elevator-ffi/include/elevator_ffi.h
@@ -129,6 +129,34 @@ typedef enum EvStrategy {
 } EvStrategy;
 
 /**
+ * Operational service mode for an elevator. Mirrors
+ * [`elevator_core::components::ServiceMode`].
+ */
+typedef enum EvServiceMode {
+    /**
+     * Normal operation: dispatch assigns stops, doors auto-cycle.
+     */
+    Normal = 0,
+    /**
+     * Excluded from dispatch and repositioning. Consumer drives movement.
+     */
+    Independent = 1,
+    /**
+     * Reduced speed, doors hold open indefinitely.
+     */
+    Inspection = 2,
+    /**
+     * Driven by direct velocity commands. Doors follow manual API.
+     */
+    Manual = 3,
+    /**
+     * Shut down: excluded from dispatch, no auto-boarding, fully inert
+     * once idle.
+     */
+    OutOfService = 4,
+} EvServiceMode;
+
+/**
  * Opaque simulation handle. Layout is not part of the ABI.
  */
 typedef struct EvSim EvSim;
@@ -872,5 +900,110 @@ enum EvStatus ev_sim_remove_stop(struct EvSim *handle, uint64_t stop_entity_id);
  * `handle` must be a valid pointer returned by [`ev_sim_create`].
  */
 enum EvStatus ev_sim_remove_elevator(struct EvSim *handle, uint64_t elevator_entity_id);
+
+/**
+ * Set the operational mode of an elevator.
+ *
+ * Modes are orthogonal to the elevator's phase — switching mode does not
+ * teleport the car, but it changes how subsequent ticks treat it.
+ * Leaving Manual zeroes velocity and clears any queued door commands.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_set_service_mode(struct EvSim *handle,
+                                      uint64_t elevator_entity_id,
+                                      enum EvServiceMode mode);
+
+/**
+ * Get the current operational mode of an elevator.
+ *
+ * Writes the mode to `*out_mode`. Returns `Normal` for missing/disabled
+ * elevators (matches core's `service_mode` accessor, which returns the
+ * default rather than erroring). Use [`ev_sim_frame`] to verify existence.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ * `out_mode` must be a valid pointer to a writable [`EvServiceMode`].
+ */
+enum EvStatus ev_sim_service_mode(struct EvSim *handle,
+                                  uint64_t elevator_entity_id,
+                                  enum EvServiceMode *out_mode);
+
+/**
+ * Set the target velocity for a Manual-mode elevator.
+ *
+ * Positive values command upward travel, negative values downward. The
+ * car ramps toward the target each tick using its configured
+ * acceleration / deceleration.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_set_target_velocity(struct EvSim *handle,
+                                         uint64_t elevator_entity_id,
+                                         double velocity);
+
+/**
+ * Command an immediate stop on a Manual-mode elevator.
+ *
+ * Sets the target velocity to zero; the car decelerates at its
+ * configured rate. Emits a distinct event so games can distinguish an
+ * emergency stop from a deliberate hold (`target_velocity` payload is
+ * `None` in the event).
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_emergency_stop(struct EvSim *handle, uint64_t elevator_entity_id);
+
+/**
+ * Request the doors of an elevator to open.
+ *
+ * Applied immediately when the car is stopped at a stop with
+ * closed/closing doors; otherwise queued until the car next arrives.
+ * No-op if doors are already open.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_open_door(struct EvSim *handle, uint64_t elevator_entity_id);
+
+/**
+ * Request the doors to close now. Forces an early close unless a rider is
+ * mid-boarding/exiting (in which case the close waits). If doors are
+ * opening, the close queues until they reach fully-open.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_close_door(struct EvSim *handle, uint64_t elevator_entity_id);
+
+/**
+ * Extend the doors' open dwell by `ticks`. Cumulative — repeat calls add.
+ * If doors aren't open yet, the hold queues and applies when they reach
+ * fully-open.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_hold_door(struct EvSim *handle, uint64_t elevator_entity_id, uint32_t ticks);
+
+/**
+ * Cancel any pending hold extension on the doors. If the base open timer
+ * has already elapsed, the doors close on the next doors-phase tick.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_cancel_door_hold(struct EvSim *handle, uint64_t elevator_entity_id);
 
 #endif  /* ELEVATOR_FFI_H */

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -363,6 +363,54 @@ impl EvStrategy {
     }
 }
 
+// ── Service mode ─────────────────────────────────────────────────────────
+
+/// Operational service mode for an elevator. Mirrors
+/// [`elevator_core::components::ServiceMode`].
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvServiceMode {
+    /// Normal operation: dispatch assigns stops, doors auto-cycle.
+    Normal = 0,
+    /// Excluded from dispatch and repositioning. Consumer drives movement.
+    Independent = 1,
+    /// Reduced speed, doors hold open indefinitely.
+    Inspection = 2,
+    /// Driven by direct velocity commands. Doors follow manual API.
+    Manual = 3,
+    /// Shut down: excluded from dispatch, no auto-boarding, fully inert
+    /// once idle.
+    OutOfService = 4,
+}
+
+impl EvServiceMode {
+    const fn to_core(self) -> elevator_core::components::ServiceMode {
+        use elevator_core::components::ServiceMode;
+        match self {
+            Self::Normal => ServiceMode::Normal,
+            Self::Independent => ServiceMode::Independent,
+            Self::Inspection => ServiceMode::Inspection,
+            Self::Manual => ServiceMode::Manual,
+            Self::OutOfService => ServiceMode::OutOfService,
+        }
+    }
+
+    const fn from_core(mode: elevator_core::components::ServiceMode) -> Self {
+        use elevator_core::components::ServiceMode;
+        match mode {
+            ServiceMode::Normal => Self::Normal,
+            ServiceMode::Independent => Self::Independent,
+            ServiceMode::Inspection => Self::Inspection,
+            ServiceMode::Manual => Self::Manual,
+            // ServiceMode is #[non_exhaustive]; future variants fall back
+            // here so an unknown numeric tag never reaches C consumers.
+            // Add a matching EvServiceMode variant in the same release
+            // that adds the core variant.
+            ServiceMode::OutOfService | _ => Self::OutOfService,
+        }
+    }
+}
+
 // ── FFI entrypoints ──────────────────────────────────────────────────────
 
 fn guard<R, F>(fallback: R, f: F) -> R
@@ -1955,6 +2003,322 @@ pub unsafe extern "C" fn ev_sim_remove_elevator(
             }
         }
     })
+}
+
+// ── Service mode + manual control ─────────────────────────────────────────
+//
+// Brings FFI to parity with the core `ServiceMode` API and the Manual-mode
+// command set (set_target_velocity, emergency_stop, manual door commands).
+//
+// All entrypoints take a u64 entity id (raw EntityId / ElevatorId via the
+// existing entity_to_u64 / entity_from_u64 helpers). Errors map to existing
+// EvStatus codes with structured last_error messages.
+
+/// Set the operational mode of an elevator.
+///
+/// Modes are orthogonal to the elevator's phase — switching mode does not
+/// teleport the car, but it changes how subsequent ticks treat it.
+/// Leaving Manual zeroes velocity and clears any queued door commands.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_set_service_mode(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+    mode: EvServiceMode,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev.sim.set_service_mode(elevator, mode.to_core()) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = match e {
+                    elevator_core::error::SimError::EntityNotFound(_) => EvStatus::NotFound,
+                    _ => EvStatus::InvalidArg,
+                };
+                set_last_error(format!("set_service_mode: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Get the current operational mode of an elevator.
+///
+/// Writes the mode to `*out_mode`. Returns `Normal` for missing/disabled
+/// elevators (matches core's `service_mode` accessor, which returns the
+/// default rather than erroring). Use [`ev_sim_frame`] to verify existence.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+/// `out_mode` must be a valid pointer to a writable [`EvServiceMode`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_service_mode(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+    out_mode: *mut EvServiceMode,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() || out_mode.is_null() {
+            set_last_error("handle or out_mode is null");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        let mode = EvServiceMode::from_core(ev.sim.service_mode(elevator));
+        // Safety: caller guarantees out_mode is writable.
+        unsafe { *out_mode = mode };
+        EvStatus::Ok
+    })
+}
+
+/// Set the target velocity for a Manual-mode elevator.
+///
+/// Positive values command upward travel, negative values downward. The
+/// car ramps toward the target each tick using its configured
+/// acceleration / deceleration.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_set_target_velocity(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+    velocity: f64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev
+            .sim
+            .set_target_velocity(ElevatorId::from(elevator), velocity)
+        {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("set_target_velocity: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Command an immediate stop on a Manual-mode elevator.
+///
+/// Sets the target velocity to zero; the car decelerates at its
+/// configured rate. Emits a distinct event so games can distinguish an
+/// emergency stop from a deliberate hold (`target_velocity` payload is
+/// `None` in the event).
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_emergency_stop(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev.sim.emergency_stop(ElevatorId::from(elevator)) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("emergency_stop: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Request the doors of an elevator to open.
+///
+/// Applied immediately when the car is stopped at a stop with
+/// closed/closing doors; otherwise queued until the car next arrives.
+/// No-op if doors are already open.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_open_door(handle: *mut EvSim, elevator_entity_id: u64) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev.sim.open_door(ElevatorId::from(elevator)) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("open_door: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Request the doors to close now. Forces an early close unless a rider is
+/// mid-boarding/exiting (in which case the close waits). If doors are
+/// opening, the close queues until they reach fully-open.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_close_door(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev.sim.close_door(ElevatorId::from(elevator)) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("close_door: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Extend the doors' open dwell by `ticks`. Cumulative — repeat calls add.
+/// If doors aren't open yet, the hold queues and applies when they reach
+/// fully-open.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_hold_door(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+    ticks: u32,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev.sim.hold_door(ElevatorId::from(elevator), ticks) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("hold_door: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Cancel any pending hold extension on the doors. If the base open timer
+/// has already elapsed, the doors close on the next doors-phase tick.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_cancel_door_hold(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev.sim.cancel_door_hold(ElevatorId::from(elevator)) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("cancel_door_hold: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Internal: shared error-to-status mapping for the manual-mode and door
+/// commands.
+///
+/// `NotFound` for missing entities, `InvalidArg` for everything else
+/// (wrong service mode, disabled elevator, non-finite velocity).
+const fn mode_error_status(e: &elevator_core::error::SimError) -> EvStatus {
+    use elevator_core::error::SimError;
+    match e {
+        SimError::EntityNotFound(_) | SimError::NotAnElevator(_) => EvStatus::NotFound,
+        _ => EvStatus::InvalidArg,
+    }
 }
 
 #[cfg(test)]

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -37,6 +37,36 @@ fn u64_to_entity(raw: u64) -> EntityId {
     EntityId::from(slotmap::KeyData::from_ffi(raw))
 }
 
+/// Map a JS-facing service-mode label to its `ServiceMode` variant. The
+/// label set is part of the wasm public contract; new variants in
+/// `ServiceMode` must add a label here in the same release.
+fn parse_service_mode(label: &str) -> Option<elevator_core::components::ServiceMode> {
+    use elevator_core::components::ServiceMode;
+    match label {
+        "normal" => Some(ServiceMode::Normal),
+        "independent" => Some(ServiceMode::Independent),
+        "inspection" => Some(ServiceMode::Inspection),
+        "manual" => Some(ServiceMode::Manual),
+        "out-of-service" => Some(ServiceMode::OutOfService),
+        _ => None,
+    }
+}
+
+/// Inverse of [`parse_service_mode`]. Falls back to `"out-of-service"` for
+/// unknown variants — `ServiceMode` is `#[non_exhaustive]`, so a new core
+/// variant without a label here surfaces as that fallback rather than
+/// panicking. Add a label in the same release that adds the variant.
+const fn format_service_mode(mode: elevator_core::components::ServiceMode) -> &'static str {
+    use elevator_core::components::ServiceMode;
+    match mode {
+        ServiceMode::Normal => "normal",
+        ServiceMode::Independent => "independent",
+        ServiceMode::Inspection => "inspection",
+        ServiceMode::Manual => "manual",
+        ServiceMode::OutOfService | _ => "out-of-service",
+    }
+}
+
 /// Map a JS-facing strategy name to its `BuiltinStrategy` variant. Used to tag
 /// dispatcher instances so snapshots round-trip the active strategy id.
 fn strategy_id(name: &str) -> Option<BuiltinStrategy> {
@@ -627,6 +657,137 @@ impl WasmSim {
         self.inner
             .find_stop_at_position_on_line(position, u64_to_entity(line_ref))
             .map_or(0, entity_to_u64)
+    }
+
+    // ── Service mode + manual control ────────────────────────────────
+    //
+    // Mirrors the core API for switching between Normal / Independent /
+    // Inspection / Manual / OutOfService modes, plus the Manual-mode
+    // command set (target velocity, emergency stop, manual door commands).
+
+    /// Set the operational mode of an elevator.
+    ///
+    /// `mode` is one of: `"normal"`, `"independent"`, `"inspection"`,
+    /// `"manual"`, `"out-of-service"`. Modes are orthogonal to the
+    /// elevator's phase. Leaving Manual zeroes velocity and clears any
+    /// queued door commands.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the elevator does not exist or the mode
+    /// label is unknown.
+    #[wasm_bindgen(js_name = setServiceMode)]
+    pub fn set_service_mode(&mut self, elevator_ref: u64, mode: &str) -> Result<(), JsError> {
+        let mode = parse_service_mode(mode)
+            .ok_or_else(|| JsError::new(&format!("unknown service mode: {mode}")))?;
+        self.inner
+            .set_service_mode(u64_to_entity(elevator_ref), mode)
+            .map_err(|e| JsError::new(&format!("set_service_mode: {e}")))
+    }
+
+    /// Get the current operational mode of an elevator as a label string.
+    /// Returns `"normal"` for missing/disabled elevators (matches core's
+    /// `service_mode` accessor, which returns the default rather than
+    /// erroring).
+    #[wasm_bindgen(js_name = serviceMode)]
+    #[must_use]
+    pub fn service_mode(&self, elevator_ref: u64) -> String {
+        format_service_mode(self.inner.service_mode(u64_to_entity(elevator_ref))).to_string()
+    }
+
+    /// Set the target velocity for a Manual-mode elevator (distance/tick).
+    /// Positive = up, negative = down. The car ramps toward the target
+    /// using its configured acceleration / deceleration.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the elevator does not exist, is not in
+    /// Manual mode, or `velocity` is non-finite.
+    #[wasm_bindgen(js_name = setTargetVelocity)]
+    pub fn set_target_velocity(&mut self, elevator_ref: u64, velocity: f64) -> Result<(), JsError> {
+        self.inner
+            .set_target_velocity(
+                elevator_core::entity::ElevatorId::from(u64_to_entity(elevator_ref)),
+                velocity,
+            )
+            .map_err(|e| JsError::new(&format!("set_target_velocity: {e}")))
+    }
+
+    /// Command an immediate stop on a Manual-mode elevator. Sets the
+    /// target velocity to zero and emits a distinct event so games can
+    /// distinguish an emergency stop from a deliberate hold.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the elevator does not exist or is not in
+    /// Manual mode.
+    #[wasm_bindgen(js_name = emergencyStop)]
+    pub fn emergency_stop(&mut self, elevator_ref: u64) -> Result<(), JsError> {
+        self.inner
+            .emergency_stop(elevator_core::entity::ElevatorId::from(u64_to_entity(
+                elevator_ref,
+            )))
+            .map_err(|e| JsError::new(&format!("emergency_stop: {e}")))
+    }
+
+    /// Request the doors of an elevator to open. Applied immediately at a
+    /// stopped car with closed/closing doors; otherwise queued.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the elevator does not exist or is disabled.
+    #[wasm_bindgen(js_name = openDoor)]
+    pub fn open_door(&mut self, elevator_ref: u64) -> Result<(), JsError> {
+        self.inner
+            .open_door(elevator_core::entity::ElevatorId::from(u64_to_entity(
+                elevator_ref,
+            )))
+            .map_err(|e| JsError::new(&format!("open_door: {e}")))
+    }
+
+    /// Request the doors to close now. Forces an early close unless a
+    /// rider is mid-boarding/exiting.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the elevator does not exist or is disabled.
+    #[wasm_bindgen(js_name = closeDoor)]
+    pub fn close_door(&mut self, elevator_ref: u64) -> Result<(), JsError> {
+        self.inner
+            .close_door(elevator_core::entity::ElevatorId::from(u64_to_entity(
+                elevator_ref,
+            )))
+            .map_err(|e| JsError::new(&format!("close_door: {e}")))
+    }
+
+    /// Extend the doors' open dwell by `ticks`. Cumulative across calls.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the elevator does not exist, is disabled,
+    /// or `ticks` is zero.
+    #[wasm_bindgen(js_name = holdDoor)]
+    pub fn hold_door(&mut self, elevator_ref: u64, ticks: u32) -> Result<(), JsError> {
+        self.inner
+            .hold_door(
+                elevator_core::entity::ElevatorId::from(u64_to_entity(elevator_ref)),
+                ticks,
+            )
+            .map_err(|e| JsError::new(&format!("hold_door: {e}")))
+    }
+
+    /// Cancel any pending hold extension on the doors.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the elevator does not exist or is disabled.
+    #[wasm_bindgen(js_name = cancelDoorHold)]
+    pub fn cancel_door_hold(&mut self, elevator_ref: u64) -> Result<(), JsError> {
+        self.inner
+            .cancel_door_hold(elevator_core::entity::ElevatorId::from(u64_to_entity(
+                elevator_ref,
+            )))
+            .map_err(|e| JsError::new(&format!("cancel_door_hold: {e}")))
     }
 
     // ── Uniform elevator-physics setters ─────────────────────────────


### PR DESCRIPTION
## Summary

Brings both bindings up to v1 parity for the **`ServiceMode` + Manual control** surface — the gap that prompted "modes like emergency stop don't actually work" from a playground-side debug session.

This is **PR-D** of the multi-PR push to make `elevator-wasm` (and `elevator-ffi`) fully-supported library crates. Closes the largest single gap from the original concern.

### New exports (8 in each binding)

| Method | Wasm | FFI |
|---|---|---|
| `set_service_mode` | `setServiceMode` | `ev_sim_set_service_mode` |
| `service_mode` (getter) | `serviceMode` | `ev_sim_service_mode` |
| `set_target_velocity` | `setTargetVelocity` | `ev_sim_set_target_velocity` |
| `emergency_stop` | `emergencyStop` | `ev_sim_emergency_stop` |
| `open_door` | `openDoor` | `ev_sim_open_door` |
| `close_door` | `closeDoor` | `ev_sim_close_door` |
| `hold_door` | `holdDoor` | `ev_sim_hold_door` |
| `cancel_door_hold` | `cancelDoorHold` | `ev_sim_cancel_door_hold` |

### Conventions

- **Wasm** uses string labels for `ServiceMode` (`"normal"` / `"independent"` / `"inspection"` / `"manual"` / `"out-of-service"`) matching the existing strategy-name convention. New helpers `parse_service_mode` / `format_service_mode` keep the JS contract lossless and round-trippable.
- **FFI** gets a new `repr(C)` `EvServiceMode` enum with `to_core` / `from_core` helpers. Future `ServiceMode` variants (it's `#[non_exhaustive]`) fall back to `OutOfService` rather than surfacing an unknown numeric tag — comment notes the same release must add a matching `EvServiceMode` variant.
- **FFI error mapping** follows the pattern from PR-B (#474): `EntityNotFound` / `NotAnElevator` → `NotFound`, fallback → `InvalidArg`. Shared helper `mode_error_status` keeps it consistent across the seven Manual-mode entry points.

### Coverage dashboard

Before:
\`\`\`
  binding        exported    skipped       todo
  wasm                 28         27         85
  ffi                  24         27         89
\`\`\`

After:
\`\`\`
  binding        exported    skipped       todo
  wasm                 36         27         77
  ffi                  32         27         81
\`\`\`

Both bindings advance by 8.

### Test plan

- [x] Pre-commit hook green (fmt, clippy, core+doc+ffi tests, workspace check)
- [x] `cargo clippy -p elevator-ffi --all-targets -- -D warnings` clean
- [x] `cargo clippy -p elevator-wasm --target wasm32-unknown-unknown -- -D warnings` clean
- [x] `scripts/check-bindings.sh` reports 8 mode methods exported on both sides
- [ ] CI green
- [ ] Greptile review

### What this unblocks

The original concern from the debug session was that you can't trigger `emergency_stop` from the playground or Unity. After this PR:
- The playground can call `sim.setServiceMode(carRef, 'manual')` then `sim.setTargetVelocity(carRef, 1.5)` and `sim.emergencyStop(carRef)`.
- Unity / .NET consumers get the same surface via the C ABI.

Reintroducing a UI for these in the playground is a separate concern (the cockpit demo was reverted in #469/#471 for design reasons, not API ones). The bindings are now ready when a UI wants them.