### PR TITLE
feat(wasm): add per-elevator introspection accessors

### DIFF
--- a/bindings.toml
+++ b/bindings.toml
@@ -576,61 +576,61 @@ ffi  = "todo:PR-C"
 [[methods]]
 name = "velocity"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "velocity"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "position_at"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "positionAt"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "elevator_load"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "elevatorLoad"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "occupancy"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "occupancy"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "elevator_direction"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "elevatorDirection"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "elevator_going_up"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "elevatorGoingUp"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "elevator_going_down"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "elevatorGoingDown"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "elevator_move_count"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "elevatorMoveCount"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "braking_distance"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "brakingDistance"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "future_stop_position"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "futureStopPosition"
 ffi  = "todo:PR-C"
 
 [[methods]]
@@ -654,31 +654,31 @@ ffi  = "todo:PR-C"
 [[methods]]
 name = "idle_elevator_count"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "idleElevatorCount"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "is_elevator"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "isElevator"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "is_rider"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "isRider"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "is_stop"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "isStop"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "is_disabled"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "isDisabled"
 ffi  = "todo:PR-C"
 
 [[methods]]

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -104,6 +104,17 @@ fn parse_call_direction(label: &str) -> Result<elevator_core::components::CallDi
     }
 }
 
+/// Format a `Direction` as the JS-facing label string (`"up"`, `"down"`,
+/// or `"either"`). Mirrors the parsing convention used by `bestEta`.
+const fn format_direction(dir: elevator_core::components::Direction) -> &'static str {
+    use elevator_core::components::Direction;
+    match dir {
+        Direction::Up => "up",
+        Direction::Down => "down",
+        Direction::Either | _ => "either",
+    }
+}
+
 /// Map a JS-facing strategy name to its `BuiltinStrategy` variant. Used to tag
 /// dispatcher instances so snapshots round-trip the active strategy id.
 fn strategy_id(name: &str) -> Option<BuiltinStrategy> {
@@ -982,6 +993,146 @@ impl WasmSim {
             .best_eta(stop, dir)
             .map(|(eid, d)| vec![entity_to_u64(eid), duration_to_ticks(d, dt)])
             .unwrap_or_default())
+    }
+
+    // ── Per-elevator introspection accessors ─────────────────────────
+    //
+    // Read-only queries for individual cars. All `Option<T>` returns
+    // surface as `T | undefined` in JS via wasm-bindgen's standard
+    // mapping; missing/disabled entities return `undefined`. Direction
+    // labels match the rest of the wasm contract (`"up"` / `"down"` /
+    // `"either"`).
+
+    /// Current velocity (distance/tick) of `elevator_ref`. Positive = up,
+    /// negative = down. Returns `undefined` if the entity has no velocity
+    /// component (i.e. is not an elevator).
+    #[wasm_bindgen(js_name = velocity)]
+    #[must_use]
+    pub fn velocity(&self, elevator_ref: u64) -> Option<f64> {
+        self.inner.velocity(u64_to_entity(elevator_ref))
+    }
+
+    /// Sub-tick interpolated position of `entity_ref` for smooth render
+    /// frames. `alpha` is in `[0.0, 1.0]` — `0.0` = current tick,
+    /// `1.0` = next tick. Returns `undefined` if the entity has no
+    /// position component.
+    #[wasm_bindgen(js_name = positionAt)]
+    #[must_use]
+    pub fn position_at(&self, entity_ref: u64, alpha: f64) -> Option<f64> {
+        self.inner.position_at(u64_to_entity(entity_ref), alpha)
+    }
+
+    /// Fraction of `elevator_ref`'s capacity currently occupied (by weight),
+    /// in `[0.0, 1.0]`. Returns `undefined` for missing entities.
+    #[wasm_bindgen(js_name = elevatorLoad)]
+    #[must_use]
+    pub fn elevator_load(&self, elevator_ref: u64) -> Option<f64> {
+        self.inner
+            .elevator_load(elevator_core::entity::ElevatorId::from(u64_to_entity(
+                elevator_ref,
+            )))
+    }
+
+    /// Number of riders currently aboard `elevator_ref`. Returns `0` for
+    /// missing entities (`Simulation::occupancy` returns 0 for both
+    /// "not an elevator" and "empty cab" — distinguish via `isElevator`).
+    #[wasm_bindgen(js_name = occupancy)]
+    #[must_use]
+    pub fn occupancy(&self, elevator_ref: u64) -> u32 {
+        u32::try_from(self.inner.occupancy(u64_to_entity(elevator_ref))).unwrap_or(u32::MAX)
+    }
+
+    /// Indicator-lamp direction of `elevator_ref`: `"up"`, `"down"`, or
+    /// `"either"` (idle / no committed direction). Returns `undefined`
+    /// for missing entities.
+    #[wasm_bindgen(js_name = elevatorDirection)]
+    #[must_use]
+    pub fn elevator_direction(&self, elevator_ref: u64) -> Option<String> {
+        self.inner
+            .elevator_direction(u64_to_entity(elevator_ref))
+            .map(|d| format_direction(d).to_string())
+    }
+
+    /// Whether `elevator_ref` is currently committed upward. Returns
+    /// `undefined` for missing entities. A car that's `Either`-direction
+    /// reports `false` here and `false` in `elevatorGoingDown`.
+    #[wasm_bindgen(js_name = elevatorGoingUp)]
+    #[must_use]
+    pub fn elevator_going_up(&self, elevator_ref: u64) -> Option<bool> {
+        self.inner.elevator_going_up(u64_to_entity(elevator_ref))
+    }
+
+    /// Whether `elevator_ref` is currently committed downward. Returns
+    /// `undefined` for missing entities.
+    #[wasm_bindgen(js_name = elevatorGoingDown)]
+    #[must_use]
+    pub fn elevator_going_down(&self, elevator_ref: u64) -> Option<bool> {
+        self.inner.elevator_going_down(u64_to_entity(elevator_ref))
+    }
+
+    /// Total number of completed trips by `elevator_ref` since spawn.
+    /// Returns `undefined` for missing entities.
+    #[wasm_bindgen(js_name = elevatorMoveCount)]
+    #[must_use]
+    pub fn elevator_move_count(&self, elevator_ref: u64) -> Option<u64> {
+        self.inner.elevator_move_count(u64_to_entity(elevator_ref))
+    }
+
+    /// Distance `elevator_ref` would travel if it began decelerating
+    /// from its current velocity at its configured deceleration rate.
+    /// Returns `undefined` for missing entities or stationary cars.
+    #[wasm_bindgen(js_name = brakingDistance)]
+    #[must_use]
+    pub fn braking_distance(&self, elevator_ref: u64) -> Option<f64> {
+        self.inner.braking_distance(u64_to_entity(elevator_ref))
+    }
+
+    /// Position of the next stop in `elevator_ref`'s destination queue,
+    /// or current target if mid-trip. Returns `undefined` if the queue
+    /// is empty or the entity is not an elevator.
+    #[wasm_bindgen(js_name = futureStopPosition)]
+    #[must_use]
+    pub fn future_stop_position(&self, elevator_ref: u64) -> Option<f64> {
+        self.inner.future_stop_position(u64_to_entity(elevator_ref))
+    }
+
+    /// Total number of currently-idle elevators across the simulation.
+    /// "Idle" = phase is `Idle` (not parked at a stop with riders or
+    /// repositioning).
+    #[wasm_bindgen(js_name = idleElevatorCount)]
+    #[must_use]
+    pub fn idle_elevator_count(&self) -> u32 {
+        u32::try_from(self.inner.idle_elevator_count()).unwrap_or(u32::MAX)
+    }
+
+    /// Whether `entity_ref` resolves to an elevator entity in the world.
+    #[wasm_bindgen(js_name = isElevator)]
+    #[must_use]
+    pub fn is_elevator(&self, entity_ref: u64) -> bool {
+        self.inner.is_elevator(u64_to_entity(entity_ref))
+    }
+
+    /// Whether `entity_ref` resolves to a rider entity in the world.
+    #[wasm_bindgen(js_name = isRider)]
+    #[must_use]
+    pub fn is_rider(&self, entity_ref: u64) -> bool {
+        self.inner.is_rider(u64_to_entity(entity_ref))
+    }
+
+    /// Whether `entity_ref` resolves to a stop entity in the world.
+    #[wasm_bindgen(js_name = isStop)]
+    #[must_use]
+    pub fn is_stop(&self, entity_ref: u64) -> bool {
+        self.inner.is_stop(u64_to_entity(entity_ref))
+    }
+
+    /// Whether `entity_ref` is currently disabled (out of service / not
+    /// participating in dispatch). Returns `false` for nonexistent
+    /// entities — distinguish via `isElevator` / `isStop` first.
+    #[wasm_bindgen(js_name = isDisabled)]
+    #[must_use]
+    pub fn is_disabled(&self, entity_ref: u64) -> bool {
+        self.inner.is_disabled(u64_to_entity(entity_ref))
     }
 
     // ── Uniform elevator-physics setters ─────────────────────────────


### PR DESCRIPTION
## Summary

15 simple read-only accessors on `WasmSim`, mirroring core's per-elevator API. All are direct delegations to `Simulation::*` with the standard `u64` entity-ref boundary — `wasm-bindgen` surfaces `Option<T>` as `T | undefined` in TypeScript, so missing/disabled entities cleanly return `undefined`.

### New exports

| Wasm | Returns | Core |
|---|---|---|
| `velocity` | `f64?` | `Simulation::velocity` |
| `positionAt` | `f64?` | `Simulation::position_at` |
| `elevatorLoad` | `f64?` | `Simulation::elevator_load` |
| `occupancy` | `u32` | `Simulation::occupancy` |
| `elevatorDirection` | `string?` | `Simulation::elevator_direction` |
| `elevatorGoingUp` | `bool?` | `Simulation::elevator_going_up` |
| `elevatorGoingDown` | `bool?` | `Simulation::elevator_going_down` |
| `elevatorMoveCount` | `u64?` | `Simulation::elevator_move_count` |
| `brakingDistance` | `f64?` | `Simulation::braking_distance` |
| `futureStopPosition` | `f64?` | `Simulation::future_stop_position` |
| `idleElevatorCount` | `u32` | `Simulation::idle_elevator_count` |
| `isElevator` | `bool` | `Simulation::is_elevator` |
| `isRider` | `bool` | `Simulation::is_rider` |
| `isStop` | `bool` | `Simulation::is_stop` |
| `isDisabled` | `bool` | `Simulation::is_disabled` |

### Conventions

- `elevatorDirection` returns a string label (`"up"` / `"down"` / `"either"`) matching the `bestEta` convention introduced in PR-B wave 2B. New helper `format_direction` is the inverse of the existing `parse_call_direction`.
- `usize` → `u32` saturates at `u32::MAX` for `occupancy` and `idleElevatorCount`. Both are bounded in practice (no realistic sim has 4B+ idle elevators), but the saturating cast is the standard pattern from PR-B wave 2B's `duration_to_ticks`.
- `occupancy` returns `0` for both empty cabs and missing entities; consumers disambiguate via `isElevator` (matches core's behavior).

### Coverage dashboard

Before:
\`\`\`
  binding        exported    skipped       todo
  wasm                 43         27         70
\`\`\`

After:
\`\`\`
  binding        exported    skipped       todo
  wasm                 58         27         55
\`\`\`

Wasm advances by 15. FFI unchanged (this PR is wasm-only).

### Test plan

- [x] `cargo clippy -p elevator-wasm --target wasm32-unknown-unknown -- -D warnings` clean
- [x] Pre-commit hook green (fmt, clippy, core+doc tests, workspace check)
- [x] Binding-coverage gate passes (15 todo:PR-C → exported on wasm side)
- [ ] CI green
- [ ] Greptile review