### PR TITLE
feat(ffi): add per-elevator parameter setters (PR-C)

### DIFF
--- a/bindings.toml
+++ b/bindings.toml
@@ -776,55 +776,55 @@ ffi  = "todo:PR-C"
 name = "set_max_speed"
 category = "parameters"
 wasm = "setMaxSpeedAll"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_set_max_speed"
 
 [[methods]]
 name = "set_acceleration"
 category = "parameters"
 wasm = "todo:PR-C"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_set_acceleration"
 
 [[methods]]
 name = "set_deceleration"
 category = "parameters"
 wasm = "todo:PR-C"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_set_deceleration"
 
 [[methods]]
 name = "set_door_open_ticks"
 category = "parameters"
 wasm = "setDoorOpenTicksAll"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_set_door_open_ticks"
 
 [[methods]]
 name = "set_door_transition_ticks"
 category = "parameters"
 wasm = "setDoorTransitionTicksAll"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_set_door_transition_ticks"
 
 [[methods]]
 name = "set_weight_capacity"
 category = "parameters"
 wasm = "setWeightCapacityAll"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_set_weight_capacity"
 
 [[methods]]
 name = "set_arrival_log_retention_ticks"
 category = "parameters"
 wasm = "todo:PR-C"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_set_arrival_log_retention_ticks"
 
 [[methods]]
 name = "enable"
 category = "parameters"
 wasm = "todo:PR-C"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_enable"
 
 [[methods]]
 name = "disable"
 category = "parameters"
 wasm = "todo:PR-C"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_disable"
 
 # ─── Hooks (closures don't survive the binding boundary) ──────────────────
 

--- a/crates/elevator-ffi/include/elevator_ffi.h
+++ b/crates/elevator-ffi/include/elevator_ffi.h
@@ -1006,4 +1006,103 @@ enum EvStatus ev_sim_hold_door(struct EvSim *handle, uint64_t elevator_entity_id
  */
 enum EvStatus ev_sim_cancel_door_hold(struct EvSim *handle, uint64_t elevator_entity_id);
 
+/**
+ * Set the maximum travel speed (distance/tick) of an elevator.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_set_max_speed(struct EvSim *handle,
+                                   uint64_t elevator_entity_id,
+                                   double max_speed);
+
+/**
+ * Set the acceleration rate (distance/tick²) of an elevator.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_set_acceleration(struct EvSim *handle,
+                                      uint64_t elevator_entity_id,
+                                      double acceleration);
+
+/**
+ * Set the deceleration rate (distance/tick²) of an elevator.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_set_deceleration(struct EvSim *handle,
+                                      uint64_t elevator_entity_id,
+                                      double deceleration);
+
+/**
+ * Set the weight capacity (kg) of an elevator.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_set_weight_capacity(struct EvSim *handle,
+                                         uint64_t elevator_entity_id,
+                                         double capacity);
+
+/**
+ * Set door transition (open/close) duration in ticks. Applied on the
+ * next door cycle — an in-progress transition keeps its timing.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_set_door_transition_ticks(struct EvSim *handle,
+                                               uint64_t elevator_entity_id,
+                                               uint32_t ticks);
+
+/**
+ * Set how long doors hold fully open (ticks). Applied on the next door
+ * cycle — a door currently dwelling completes its existing dwell first.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_set_door_open_ticks(struct EvSim *handle,
+                                         uint64_t elevator_entity_id,
+                                         uint32_t ticks);
+
+/**
+ * Set how many ticks the per-rider arrival log retains. Global setting
+ * (not per-elevator). Higher = more memory but longer post-trip queries.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_set_arrival_log_retention_ticks(struct EvSim *handle,
+                                                     uint64_t retention_ticks);
+
+/**
+ * Enable a previously-disabled entity (elevator or stop).
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_enable(struct EvSim *handle, uint64_t entity_id);
+
+/**
+ * Disable an entity (elevator or stop). Disabled elevators eject riders
+ * and are excluded from dispatch; disabled stops invalidate routes that
+ * reference them.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_disable(struct EvSim *handle, uint64_t entity_id);
+
 #endif  /* ELEVATOR_FFI_H */

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -2321,6 +2321,321 @@ const fn mode_error_status(e: &elevator_core::error::SimError) -> EvStatus {
     }
 }
 
+// ── Per-elevator parameter setters ───────────────────────────────────────
+//
+// Runtime tuning of physics and door timings. All setters validate input
+// (positive-finite for f64 fields, non-zero for tick counts) and emit an
+// ElevatorUpgraded event per call. Mirrors the wasm crate's set*All
+// helpers, but operates on a single elevator — wasm's "all" wrappers loop
+// these per car under the hood.
+
+/// Set the maximum travel speed (distance/tick) of an elevator.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_set_max_speed(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+    max_speed: f64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev.sim.set_max_speed(ElevatorId::from(elevator), max_speed) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("set_max_speed: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Set the acceleration rate (distance/tick²) of an elevator.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_set_acceleration(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+    acceleration: f64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev
+            .sim
+            .set_acceleration(ElevatorId::from(elevator), acceleration)
+        {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("set_acceleration: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Set the deceleration rate (distance/tick²) of an elevator.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_set_deceleration(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+    deceleration: f64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev
+            .sim
+            .set_deceleration(ElevatorId::from(elevator), deceleration)
+        {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("set_deceleration: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Set the weight capacity (kg) of an elevator.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_set_weight_capacity(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+    capacity: f64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev
+            .sim
+            .set_weight_capacity(ElevatorId::from(elevator), capacity)
+        {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("set_weight_capacity: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Set door transition (open/close) duration in ticks. Applied on the
+/// next door cycle — an in-progress transition keeps its timing.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_set_door_transition_ticks(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+    ticks: u32,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev
+            .sim
+            .set_door_transition_ticks(ElevatorId::from(elevator), ticks)
+        {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("set_door_transition_ticks: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Set how long doors hold fully open (ticks). Applied on the next door
+/// cycle — a door currently dwelling completes its existing dwell first.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_set_door_open_ticks(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+    ticks: u32,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev
+            .sim
+            .set_door_open_ticks(ElevatorId::from(elevator), ticks)
+        {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("set_door_open_ticks: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Set how many ticks the per-rider arrival log retains. Global setting
+/// (not per-elevator). Higher = more memory but longer post-trip queries.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_set_arrival_log_retention_ticks(
+    handle: *mut EvSim,
+    retention_ticks: u64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        ev.sim.set_arrival_log_retention_ticks(retention_ticks);
+        EvStatus::Ok
+    })
+}
+
+/// Enable a previously-disabled entity (elevator or stop).
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_enable(handle: *mut EvSim, entity_id: u64) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(entity) = entity_from_u64(entity_id) else {
+            set_last_error("entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev.sim.enable(entity) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("enable: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Disable an entity (elevator or stop). Disabled elevators eject riders
+/// and are excluded from dispatch; disabled stops invalidate routes that
+/// reference them.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_disable(handle: *mut EvSim, entity_id: u64) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(entity) = entity_from_u64(entity_id) else {
+            set_last_error("entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev.sim.disable(entity) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("disable: {e}"));
+                status
+            }
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

9 new FFI exports for runtime physics, door, and lifecycle tuning. Mirrors the wasm crate's existing `set*All` aggregate sweeps — wasm loops these per-car under the hood, FFI consumers get the per-elevator primitives directly.

### New exports

| Symbol | Args | Notes |
|---|---|---|
| `ev_sim_set_max_speed` | `(handle, elev, f64)` | distance/tick |
| `ev_sim_set_acceleration` | `(handle, elev, f64)` | distance/tick² |
| `ev_sim_set_deceleration` | `(handle, elev, f64)` | distance/tick² |
| `ev_sim_set_weight_capacity` | `(handle, elev, f64)` | kg |
| `ev_sim_set_door_transition_ticks` | `(handle, elev, u32)` | applied next door cycle |
| `ev_sim_set_door_open_ticks` | `(handle, elev, u32)` | applied next dwell |
| `ev_sim_set_arrival_log_retention_ticks` | `(handle, u64)` | global, not per-elevator |
| `ev_sim_enable` | `(handle, entity_id)` | generic entity (elevator or stop) |
| `ev_sim_disable` | `(handle, entity_id)` | generic entity |

### Conventions

- All take a `u64` `EntityId`, decoded via the existing `entity_from_u64` helper.
- Input validation happens in core (`validate_positive_finite_f64`, `validate_nonzero_u32`); FFI surfaces errors via the existing `EvStatus` codes.
- All emit `ElevatorUpgraded` events on success — same as wasm's aggregate setters.
- Errors mapped via the shared `mode_error_status` helper introduced in PR-D: `EntityNotFound` / `NotAnElevator` → `NotFound`, fallback → `InvalidArg`.

### Coverage dashboard

Before:
\`\`\`
  binding        exported    skipped       todo
  ffi                  32         27         81
\`\`\`

After:
\`\`\`
  binding        exported    skipped       todo
  ffi                  41         27         72
\`\`\`

### Test plan

- [x] `cargo clippy -p elevator-ffi --all-targets -- -D warnings` clean
- [x] Pre-commit hook green (fmt, clippy, core+doc+ffi tests, workspace check)
- [x] Binding-coverage gate passes (9 todo:PR-C → exported on FFI side)
- [x] C header regenerated; cbindgen output committed
- [ ] CI green
- [ ] Greptile review