### PR TITLE
feat(wasm): add destinations + population queries

### DIFF
--- a/bindings.toml
+++ b/bindings.toml
@@ -636,7 +636,7 @@ ffi  = "todo:PR-C"
 [[methods]]
 name = "destination_queue"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "destinationQueue"
 ffi  = "todo:PR-C"
 
 [[methods]]
@@ -684,7 +684,7 @@ ffi  = "todo:PR-C"
 [[methods]]
 name = "waiting_at"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "waitingAt"
 ffi  = "todo:PR-C"
 
 [[methods]]
@@ -708,31 +708,31 @@ ffi  = "todo:PR-C"
 [[methods]]
 name = "residents_at"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "residentsAt"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "resident_count_at"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "residentCountAt"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "abandoned_at"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "abandonedAt"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "abandoned_count_at"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "abandonedCountAt"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "riders_on"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "ridersOn"
 ffi  = "todo:PR-C"
 
 # ─── Destinations ─────────────────────────────────────────────────────────
@@ -740,31 +740,31 @@ ffi  = "todo:PR-C"
 [[methods]]
 name = "push_destination"
 category = "destinations"
-wasm = "todo:PR-C"
+wasm = "pushDestination"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "push_destination_front"
 category = "destinations"
-wasm = "todo:PR-C"
+wasm = "pushDestinationFront"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "clear_destinations"
 category = "destinations"
-wasm = "todo:PR-C"
+wasm = "clearDestinations"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "abort_movement"
 category = "destinations"
-wasm = "todo:PR-C"
+wasm = "abortMovement"
 ffi  = "todo:PR-C"
 
 [[methods]]
 name = "recall_to"
 category = "destinations"
-wasm = "todo:PR-C"
+wasm = "recallTo"
 ffi  = "todo:PR-C"
 
 # ─── Parameters ───────────────────────────────────────────────────────────

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -1135,6 +1135,189 @@ impl WasmSim {
         self.inner.is_disabled(u64_to_entity(entity_ref))
     }
 
+    // ── Destinations + recall ────────────────────────────────────────
+    //
+    // Direct control over a car's destination queue, bypassing dispatch.
+    // Useful for scripted scenarios, NPC orchestration, or testing
+    // strategy edge cases without driving via hall calls. Each method
+    // takes a `u64` entity ref and returns a JS error on invalid inputs.
+
+    /// Append `stop_ref` to the back of `elevator_ref`'s destination queue.
+    /// Adjacent duplicates are suppressed (no-op if the queue's last
+    /// entry already equals `stop_ref`).
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if `elevator_ref` is not an elevator or
+    /// `stop_ref` is not a stop.
+    #[wasm_bindgen(js_name = pushDestination)]
+    pub fn push_destination(&mut self, elevator_ref: u64, stop_ref: u64) -> Result<(), JsError> {
+        self.inner
+            .push_destination(
+                elevator_core::entity::ElevatorId::from(u64_to_entity(elevator_ref)),
+                u64_to_entity(stop_ref),
+            )
+            .map_err(|e| JsError::new(&format!("push_destination: {e}")))
+    }
+
+    /// Insert `stop_ref` at the front of `elevator_ref`'s destination
+    /// queue ("go here next"). On the next `AdvanceQueue` phase the car
+    /// redirects to this new front if it differs from the current target.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if `elevator_ref` is not an elevator or
+    /// `stop_ref` is not a stop.
+    #[wasm_bindgen(js_name = pushDestinationFront)]
+    pub fn push_destination_front(
+        &mut self,
+        elevator_ref: u64,
+        stop_ref: u64,
+    ) -> Result<(), JsError> {
+        self.inner
+            .push_destination_front(
+                elevator_core::entity::ElevatorId::from(u64_to_entity(elevator_ref)),
+                u64_to_entity(stop_ref),
+            )
+            .map_err(|e| JsError::new(&format!("push_destination_front: {e}")))
+    }
+
+    /// Empty an elevator's destination queue. Any in-progress trip
+    /// continues to its current target (the queue is the *future*
+    /// schedule); to also abort the in-flight trip, call
+    /// `abortMovement` after.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if `elevator_ref` is not an elevator.
+    #[wasm_bindgen(js_name = clearDestinations)]
+    pub fn clear_destinations(&mut self, elevator_ref: u64) -> Result<(), JsError> {
+        self.inner
+            .clear_destinations(elevator_core::entity::ElevatorId::from(u64_to_entity(
+                elevator_ref,
+            )))
+            .map_err(|e| JsError::new(&format!("clear_destinations: {e}")))
+    }
+
+    /// Abort the elevator's in-flight movement. The car decelerates to
+    /// the nearest reachable stop; subsequent dispatch / queue entries
+    /// resume from there.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if `elevator_ref` is not an elevator.
+    #[wasm_bindgen(js_name = abortMovement)]
+    pub fn abort_movement(&mut self, elevator_ref: u64) -> Result<(), JsError> {
+        self.inner
+            .abort_movement(elevator_core::entity::ElevatorId::from(u64_to_entity(
+                elevator_ref,
+            )))
+            .map_err(|e| JsError::new(&format!("abort_movement: {e}")))
+    }
+
+    /// Clear the queue and immediately recall the elevator to `stop_ref`.
+    /// Equivalent to `clearDestinations` + `pushDestination(stop_ref)`,
+    /// emitted as a single `ElevatorRecalled` event so games can render a
+    /// distinct callout (lobby drill, fire-service recall, etc.).
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if `elevator_ref` is not an elevator or
+    /// `stop_ref` is not a stop.
+    #[wasm_bindgen(js_name = recallTo)]
+    pub fn recall_to(&mut self, elevator_ref: u64, stop_ref: u64) -> Result<(), JsError> {
+        self.inner
+            .recall_to(
+                elevator_core::entity::ElevatorId::from(u64_to_entity(elevator_ref)),
+                u64_to_entity(stop_ref),
+            )
+            .map_err(|e| JsError::new(&format!("recall_to: {e}")))
+    }
+
+    /// Snapshot of `elevator_ref`'s destination queue as a `Vec<u64>` of
+    /// stop refs in service order. Empty if the elevator has no queue or
+    /// is missing.
+    #[wasm_bindgen(js_name = destinationQueue)]
+    #[must_use]
+    pub fn destination_queue(&self, elevator_ref: u64) -> Vec<u64> {
+        self.inner
+            .destination_queue(elevator_core::entity::ElevatorId::from(u64_to_entity(
+                elevator_ref,
+            )))
+            .map(|q| q.iter().copied().map(entity_to_u64).collect())
+            .unwrap_or_default()
+    }
+
+    // ── Population queries (per-stop / per-elevator rider lists) ─────
+    //
+    // Returns flat `Vec<u64>` arrays of rider entity refs. Counts have
+    // dedicated `*_count_at` accessors that return `u32` directly to
+    // avoid the per-call allocation when the consumer only needs a size.
+
+    /// Riders currently waiting at `stop_ref`. Returns an empty array
+    /// for missing stops.
+    #[wasm_bindgen(js_name = waitingAt)]
+    #[must_use]
+    pub fn waiting_at(&self, stop_ref: u64) -> Vec<u64> {
+        self.inner
+            .waiting_at(u64_to_entity(stop_ref))
+            .map(entity_to_u64)
+            .collect()
+    }
+
+    /// Riders settled / resident at `stop_ref` (e.g. tenants for a
+    /// residential building's "home floor" model). Returns an empty
+    /// array for missing stops.
+    #[wasm_bindgen(js_name = residentsAt)]
+    #[must_use]
+    pub fn residents_at(&self, stop_ref: u64) -> Vec<u64> {
+        self.inner
+            .residents_at(u64_to_entity(stop_ref))
+            .map(entity_to_u64)
+            .collect()
+    }
+
+    /// Number of resident riders at `stop_ref`. Faster than counting
+    /// `residentsAt` since it skips the array allocation.
+    #[wasm_bindgen(js_name = residentCountAt)]
+    #[must_use]
+    pub fn resident_count_at(&self, stop_ref: u64) -> u32 {
+        u32::try_from(self.inner.resident_count_at(u64_to_entity(stop_ref))).unwrap_or(u32::MAX)
+    }
+
+    /// Riders who abandoned the call at `stop_ref` (gave up waiting).
+    /// Useful for rendering "frustrated" indicators or computing service
+    /// quality metrics. Returns an empty array for missing stops.
+    #[wasm_bindgen(js_name = abandonedAt)]
+    #[must_use]
+    pub fn abandoned_at(&self, stop_ref: u64) -> Vec<u64> {
+        self.inner
+            .abandoned_at(u64_to_entity(stop_ref))
+            .map(entity_to_u64)
+            .collect()
+    }
+
+    /// Number of abandoned riders at `stop_ref`. Faster than counting
+    /// `abandonedAt`.
+    #[wasm_bindgen(js_name = abandonedCountAt)]
+    #[must_use]
+    pub fn abandoned_count_at(&self, stop_ref: u64) -> u32 {
+        u32::try_from(self.inner.abandoned_count_at(u64_to_entity(stop_ref))).unwrap_or(u32::MAX)
+    }
+
+    /// Riders currently aboard `elevator_ref`. Empty if the cab is
+    /// empty or `elevator_ref` is not an elevator.
+    #[wasm_bindgen(js_name = ridersOn)]
+    #[must_use]
+    pub fn riders_on(&self, elevator_ref: u64) -> Vec<u64> {
+        self.inner
+            .riders_on(u64_to_entity(elevator_ref))
+            .iter()
+            .copied()
+            .map(entity_to_u64)
+            .collect()
+    }
+
     // ── Uniform elevator-physics setters ─────────────────────────────
     //
     // Apply a single value to every elevator in the sim. Wired to the


### PR DESCRIPTION
## Summary

12 new wasm exports covering direct destination control and per-stop / per-elevator rider population queries. Closes most of the `todo:PR-C` wasm-side gap.

### New exports

**Destinations + recall** (5 methods, return `Result`)

| Wasm | Behavior |
|---|---|
| `pushDestination` | Append to back of car's queue |
| `pushDestinationFront` | Insert at front (go here next) |
| `clearDestinations` | Empty queue (in-flight trip continues) |
| `abortMovement` | Decelerate to nearest stop |
| `recallTo` | Clear + push, emits `ElevatorRecalled` |

**Population queries** (7 methods, return `Vec<u64>` or `u32`)

| Wasm | Returns |
|---|---|
| `destinationQueue` | Car queue snapshot in service order |
| `waitingAt` | Riders waiting at stop |
| `residentsAt` | Riders settled at stop |
| `residentCountAt` | Count without allocation |
| `abandonedAt` | Riders who gave up waiting |
| `abandonedCountAt` | Count without allocation |
| `ridersOn` | Riders aboard car |

### Conventions

- `Vec<u64>` returns flatten the iterator/slice across the wasm boundary; entity refs use the existing `entity_to_u64` encoding.
- The split between `*At` (returns array) and `*CountAt` (returns u32 count) mirrors core. Count-only accessors skip the per-call allocation when the consumer only needs a size for UI rendering.
- `usize` → `u32` saturates at `u32::MAX` — matches the convention from earlier wasm PRs.

### Coverage dashboard

Before:
\`\`\`
  binding        exported    skipped       todo
  wasm                 58         27         55
\`\`\`

After:
\`\`\`
  binding        exported    skipped       todo
  wasm                 70         27         43
\`\`\`

Wasm advances by 12.

### Test plan

- [x] `cargo clippy -p elevator-wasm --target wasm32-unknown-unknown -- -D warnings` clean
- [x] Pre-commit hook green (fmt, clippy, core+doc tests, workspace check)
- [x] Binding-coverage gate passes (12 todo:PR-C → exported on wasm side)
- [ ] CI green
- [ ] Greptile review