### PR TITLE
feat(ffi): add per-elevator + global introspection accessors

### DIFF
--- a/bindings.toml
+++ b/bindings.toml
@@ -469,13 +469,13 @@ ffi  = "todo:PR-B"
 name = "current_tick"
 category = "introspection"
 wasm = "currentTick"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_current_tick"
 
 [[methods]]
 name = "dt"
 category = "introspection"
 wasm = "dt"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_dt"
 
 [[methods]]
 name = "metrics"
@@ -577,61 +577,61 @@ ffi  = "todo:PR-C"
 name = "velocity"
 category = "introspection"
 wasm = "velocity"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_velocity"
 
 [[methods]]
 name = "position_at"
 category = "introspection"
 wasm = "positionAt"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_position_at"
 
 [[methods]]
 name = "elevator_load"
 category = "introspection"
 wasm = "elevatorLoad"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_elevator_load"
 
 [[methods]]
 name = "occupancy"
 category = "introspection"
 wasm = "occupancy"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_occupancy"
 
 [[methods]]
 name = "elevator_direction"
 category = "introspection"
 wasm = "elevatorDirection"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_elevator_direction"
 
 [[methods]]
 name = "elevator_going_up"
 category = "introspection"
 wasm = "elevatorGoingUp"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_elevator_going_up"
 
 [[methods]]
 name = "elevator_going_down"
 category = "introspection"
 wasm = "elevatorGoingDown"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_elevator_going_down"
 
 [[methods]]
 name = "elevator_move_count"
 category = "introspection"
 wasm = "elevatorMoveCount"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_elevator_move_count"
 
 [[methods]]
 name = "braking_distance"
 category = "introspection"
 wasm = "brakingDistance"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_braking_distance"
 
 [[methods]]
 name = "future_stop_position"
 category = "introspection"
 wasm = "futureStopPosition"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_future_stop_position"
 
 [[methods]]
 name = "destination_queue"
@@ -655,31 +655,31 @@ ffi  = "todo:PR-C"
 name = "idle_elevator_count"
 category = "introspection"
 wasm = "idleElevatorCount"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_idle_elevator_count"
 
 [[methods]]
 name = "is_elevator"
 category = "introspection"
 wasm = "isElevator"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_is_elevator"
 
 [[methods]]
 name = "is_rider"
 category = "introspection"
 wasm = "isRider"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_is_rider"
 
 [[methods]]
 name = "is_stop"
 category = "introspection"
 wasm = "isStop"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_is_stop"
 
 [[methods]]
 name = "is_disabled"
 category = "introspection"
 wasm = "isDisabled"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_is_disabled"
 
 [[methods]]
 name = "waiting_at"

--- a/crates/elevator-ffi/include/elevator_ffi.h
+++ b/crates/elevator-ffi/include/elevator_ffi.h
@@ -1105,4 +1105,173 @@ enum EvStatus ev_sim_enable(struct EvSim *handle, uint64_t entity_id);
  */
 enum EvStatus ev_sim_disable(struct EvSim *handle, uint64_t entity_id);
 
+/**
+ * Current velocity (distance/tick) of an elevator. Positive = up,
+ * negative = down. Returns `NaN` for non-elevator entities.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+double ev_sim_velocity(struct EvSim *handle, uint64_t elevator_entity_id);
+
+/**
+ * Sub-tick interpolated position of an entity. `alpha` in `[0.0, 1.0]`
+ * (`0.0` = current tick, `1.0` = next tick). Returns `NaN` for entities
+ * without a position component.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+double ev_sim_position_at(struct EvSim *handle, uint64_t entity_id, double alpha);
+
+/**
+ * Fraction of capacity occupied by weight, in `[0.0, 1.0]`. Returns
+ * `NaN` for non-elevator entities.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+double ev_sim_elevator_load(struct EvSim *handle, uint64_t elevator_entity_id);
+
+/**
+ * Number of riders currently aboard. Returns `0` for empty cabs and
+ * for non-elevator entities (disambiguate via [`ev_sim_is_elevator`]).
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+uint32_t ev_sim_occupancy(struct EvSim *handle, uint64_t elevator_entity_id);
+
+/**
+ * Indicator-lamp direction of an elevator: `1` = Up, `-1` = Down,
+ * `0` = Either / idle / missing entity. Encoding matches
+ * [`EvHallCall::direction`].
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+int8_t ev_sim_elevator_direction(struct EvSim *handle, uint64_t elevator_entity_id);
+
+/**
+ * Whether an elevator is currently committed upward. Returns `false`
+ * for missing entities.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+bool ev_sim_elevator_going_up(struct EvSim *handle, uint64_t elevator_entity_id);
+
+/**
+ * Whether an elevator is currently committed downward. Returns `false`
+ * for missing entities.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+bool ev_sim_elevator_going_down(struct EvSim *handle, uint64_t elevator_entity_id);
+
+/**
+ * Total number of completed trips since spawn. Returns `0` for missing
+ * entities.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+uint64_t ev_sim_elevator_move_count(struct EvSim *handle, uint64_t elevator_entity_id);
+
+/**
+ * Distance the elevator would travel if it began decelerating now from
+ * its current velocity. Returns `NaN` for stationary or missing
+ * entities.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+double ev_sim_braking_distance(struct EvSim *handle, uint64_t elevator_entity_id);
+
+/**
+ * Position of the next stop in the destination queue (or current
+ * target mid-trip). Returns `NaN` for empty queues / missing entities.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+double ev_sim_future_stop_position(struct EvSim *handle, uint64_t elevator_entity_id);
+
+/**
+ * Total number of currently-idle elevators across the simulation.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+uint32_t ev_sim_idle_elevator_count(struct EvSim *handle);
+
+/**
+ * Whether an entity is an elevator.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+bool ev_sim_is_elevator(struct EvSim *handle, uint64_t entity_id);
+
+/**
+ * Whether an entity is a rider.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+bool ev_sim_is_rider(struct EvSim *handle, uint64_t entity_id);
+
+/**
+ * Whether an entity is a stop.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+bool ev_sim_is_stop(struct EvSim *handle, uint64_t entity_id);
+
+/**
+ * Whether an entity is currently disabled. Returns `false` for both
+ * "enabled" and "doesn't exist" — distinguish via the type-check
+ * accessors first.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+bool ev_sim_is_disabled(struct EvSim *handle, uint64_t entity_id);
+
+/**
+ * Current simulation tick.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+uint64_t ev_sim_current_tick(struct EvSim *handle);
+
+/**
+ * Time delta per tick (seconds). Useful for converting ETA tick counts
+ * into real-time durations on the consumer side.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+double ev_sim_dt(struct EvSim *handle);
+
 #endif  /* ELEVATOR_FFI_H */

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -2636,6 +2636,415 @@ pub unsafe extern "C" fn ev_sim_disable(handle: *mut EvSim, entity_id: u64) -> E
     })
 }
 
+// ── Per-elevator + global introspection accessors ────────────────────────
+//
+// Read-only queries. All entity-taking accessors return a sentinel for
+// missing/disabled entities (NaN for f64, 0 for u64, false for bool).
+// This matches the existing FFI pattern (e.g. ev_sim_assigned_car
+// writes 0 to its out-param when the call has no assignment).
+//
+// Consumers that need to distinguish "missing" from "valid value" call
+// ev_sim_is_elevator / ev_sim_is_stop first, then read the accessor.
+
+/// Current velocity (distance/tick) of an elevator. Positive = up,
+/// negative = down. Returns `NaN` for non-elevator entities.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_velocity(handle: *mut EvSim, elevator_entity_id: u64) -> f64 {
+    guard(f64::NAN, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return f64::NAN;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            return f64::NAN;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        ev.sim.velocity(elevator).unwrap_or(f64::NAN)
+    })
+}
+
+/// Sub-tick interpolated position of an entity. `alpha` in `[0.0, 1.0]`
+/// (`0.0` = current tick, `1.0` = next tick). Returns `NaN` for entities
+/// without a position component.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_position_at(handle: *mut EvSim, entity_id: u64, alpha: f64) -> f64 {
+    guard(f64::NAN, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return f64::NAN;
+        }
+        let Some(entity) = entity_from_u64(entity_id) else {
+            return f64::NAN;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        ev.sim.position_at(entity, alpha).unwrap_or(f64::NAN)
+    })
+}
+
+/// Fraction of capacity occupied by weight, in `[0.0, 1.0]`. Returns
+/// `NaN` for non-elevator entities.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_elevator_load(handle: *mut EvSim, elevator_entity_id: u64) -> f64 {
+    guard(f64::NAN, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return f64::NAN;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            return f64::NAN;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        ev.sim
+            .elevator_load(ElevatorId::from(elevator))
+            .unwrap_or(f64::NAN)
+    })
+}
+
+/// Number of riders currently aboard. Returns `0` for empty cabs and
+/// for non-elevator entities (disambiguate via [`ev_sim_is_elevator`]).
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_occupancy(handle: *mut EvSim, elevator_entity_id: u64) -> u32 {
+    guard(0, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return 0;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            return 0;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        u32::try_from(ev.sim.occupancy(elevator)).unwrap_or(u32::MAX)
+    })
+}
+
+/// Indicator-lamp direction of an elevator: `1` = Up, `-1` = Down,
+/// `0` = Either / idle / missing entity. Encoding matches
+/// [`EvHallCall::direction`].
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_elevator_direction(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+) -> i8 {
+    guard(0, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return 0;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            return 0;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        match ev.sim.elevator_direction(elevator) {
+            Some(elevator_core::components::Direction::Up) => 1,
+            Some(elevator_core::components::Direction::Down) => -1,
+            _ => 0,
+        }
+    })
+}
+
+/// Whether an elevator is currently committed upward. Returns `false`
+/// for missing entities.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_elevator_going_up(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+) -> bool {
+    guard(false, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return false;
+        }
+        entity_from_u64(elevator_entity_id).is_some_and(|e| {
+            // Safety: validity guaranteed by caller.
+            let ev = unsafe { &*handle };
+            ev.sim.elevator_going_up(e).unwrap_or(false)
+        })
+    })
+}
+
+/// Whether an elevator is currently committed downward. Returns `false`
+/// for missing entities.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_elevator_going_down(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+) -> bool {
+    guard(false, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return false;
+        }
+        entity_from_u64(elevator_entity_id).is_some_and(|e| {
+            // Safety: validity guaranteed by caller.
+            let ev = unsafe { &*handle };
+            ev.sim.elevator_going_down(e).unwrap_or(false)
+        })
+    })
+}
+
+/// Total number of completed trips since spawn. Returns `0` for missing
+/// entities.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_elevator_move_count(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+) -> u64 {
+    guard(0, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return 0;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            return 0;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        ev.sim.elevator_move_count(elevator).unwrap_or(0)
+    })
+}
+
+/// Distance the elevator would travel if it began decelerating now from
+/// its current velocity. Returns `NaN` for stationary or missing
+/// entities.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_braking_distance(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+) -> f64 {
+    guard(f64::NAN, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return f64::NAN;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            return f64::NAN;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        ev.sim.braking_distance(elevator).unwrap_or(f64::NAN)
+    })
+}
+
+/// Position of the next stop in the destination queue (or current
+/// target mid-trip). Returns `NaN` for empty queues / missing entities.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_future_stop_position(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+) -> f64 {
+    guard(f64::NAN, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return f64::NAN;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            return f64::NAN;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        ev.sim.future_stop_position(elevator).unwrap_or(f64::NAN)
+    })
+}
+
+/// Total number of currently-idle elevators across the simulation.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_idle_elevator_count(handle: *mut EvSim) -> u32 {
+    guard(0, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return 0;
+        }
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        u32::try_from(ev.sim.idle_elevator_count()).unwrap_or(u32::MAX)
+    })
+}
+
+/// Whether an entity is an elevator.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_is_elevator(handle: *mut EvSim, entity_id: u64) -> bool {
+    guard(false, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return false;
+        }
+        entity_from_u64(entity_id).is_some_and(|e| {
+            // Safety: validity guaranteed by caller.
+            let ev = unsafe { &*handle };
+            ev.sim.is_elevator(e)
+        })
+    })
+}
+
+/// Whether an entity is a rider.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_is_rider(handle: *mut EvSim, entity_id: u64) -> bool {
+    guard(false, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return false;
+        }
+        entity_from_u64(entity_id).is_some_and(|e| {
+            // Safety: validity guaranteed by caller.
+            let ev = unsafe { &*handle };
+            ev.sim.is_rider(e)
+        })
+    })
+}
+
+/// Whether an entity is a stop.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_is_stop(handle: *mut EvSim, entity_id: u64) -> bool {
+    guard(false, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return false;
+        }
+        entity_from_u64(entity_id).is_some_and(|e| {
+            // Safety: validity guaranteed by caller.
+            let ev = unsafe { &*handle };
+            ev.sim.is_stop(e)
+        })
+    })
+}
+
+/// Whether an entity is currently disabled. Returns `false` for both
+/// "enabled" and "doesn't exist" — distinguish via the type-check
+/// accessors first.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_is_disabled(handle: *mut EvSim, entity_id: u64) -> bool {
+    guard(false, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return false;
+        }
+        entity_from_u64(entity_id).is_some_and(|e| {
+            // Safety: validity guaranteed by caller.
+            let ev = unsafe { &*handle };
+            ev.sim.is_disabled(e)
+        })
+    })
+}
+
+/// Current simulation tick.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_current_tick(handle: *mut EvSim) -> u64 {
+    guard(0, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return 0;
+        }
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        ev.sim.current_tick()
+    })
+}
+
+/// Time delta per tick (seconds). Useful for converting ETA tick counts
+/// into real-time durations on the consumer side.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_dt(handle: *mut EvSim) -> f64 {
+    guard(f64::NAN, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return f64::NAN;
+        }
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        ev.sim.dt()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

17 new FFI exports mirroring the wasm accessors landed in #477. After this lands, **both bindings are at exactly 58 exported methods** — first parity moment in the v1 push.

### New exports

| Symbol | Returns | Sentinel for missing |
|---|---|---|
| `ev_sim_velocity` | `f64` | `NaN` |
| `ev_sim_position_at(handle, entity, alpha)` | `f64` | `NaN` |
| `ev_sim_elevator_load` | `f64` | `NaN` |
| `ev_sim_occupancy` | `u32` | `0` |
| `ev_sim_elevator_direction` | `i8` (1/-1/0 for Up/Down/Either) | `0` |
| `ev_sim_elevator_going_up` | `bool` | `false` |
| `ev_sim_elevator_going_down` | `bool` | `false` |
| `ev_sim_elevator_move_count` | `u64` | `0` |
| `ev_sim_braking_distance` | `f64` | `NaN` |
| `ev_sim_future_stop_position` | `f64` | `NaN` |
| `ev_sim_idle_elevator_count` | `u32` | (global) |
| `ev_sim_is_elevator` | `bool` | `false` |
| `ev_sim_is_rider` | `bool` | `false` |
| `ev_sim_is_stop` | `bool` | `false` |
| `ev_sim_is_disabled` | `bool` | `false` |
| `ev_sim_current_tick` | `u64` | (global) |
| `ev_sim_dt` | `f64` | (global) |

### Conventions

- For C ABI, `Option<T>` is encoded via sentinels rather than out-params: `NaN` for `f64`, `0` for `u64`, `false` for `bool`, `0` for direction (matches `encode_direction`). Keeps the surface compact and matches the existing pattern (`ev_sim_assigned_car` writes `0` to its out-param when no assignment exists).
- Consumers that need to distinguish "missing" from "valid value" call `ev_sim_is_elevator` / `ev_sim_is_stop` first.

### Coverage dashboard

Before:
\`\`\`
  binding        exported    skipped       todo
  wasm                 58         27         55
  ffi                  41         27         72
\`\`\`

After:
\`\`\`
  binding        exported    skipped       todo
  wasm                 58         27         55
  ffi                  58         27         55
\`\`\`

🎉 **Wasm/FFI parity at 58 exported methods.**

### Test plan

- [x] `cargo clippy -p elevator-ffi --all-targets -- -D warnings` clean
- [x] Pre-commit hook green (fmt, clippy, core+doc+ffi tests, workspace check)
- [x] Binding-coverage gate passes (17 todo:PR-C → exported on FFI side)
- [x] C header regenerated; cbindgen output committed
- [ ] CI green
- [ ] Greptile review