### PR TITLE
feat(ffi): add destinations + population queries

### DIFF
--- a/bindings.toml
+++ b/bindings.toml
@@ -637,7 +637,7 @@ ffi  = "ev_sim_future_stop_position"
 name = "destination_queue"
 category = "introspection"
 wasm = "destinationQueue"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_destination_queue"
 
 [[methods]]
 name = "elevators_in_phase"
@@ -685,13 +685,13 @@ ffi  = "ev_sim_is_disabled"
 name = "waiting_at"
 category = "introspection"
 wasm = "waitingAt"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_waiting_at"
 
 [[methods]]
 name = "waiting_count_at"
 category = "introspection"
 wasm = "waitingCountAt"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_waiting_count_at"
 
 [[methods]]
 name = "waiting_counts_by_line_at"
@@ -709,31 +709,31 @@ ffi  = "todo:PR-C"
 name = "residents_at"
 category = "introspection"
 wasm = "residentsAt"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_residents_at"
 
 [[methods]]
 name = "resident_count_at"
 category = "introspection"
 wasm = "residentCountAt"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_resident_count_at"
 
 [[methods]]
 name = "abandoned_at"
 category = "introspection"
 wasm = "abandonedAt"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_abandoned_at"
 
 [[methods]]
 name = "abandoned_count_at"
 category = "introspection"
 wasm = "abandonedCountAt"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_abandoned_count_at"
 
 [[methods]]
 name = "riders_on"
 category = "introspection"
 wasm = "ridersOn"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_riders_on"
 
 # ─── Destinations ─────────────────────────────────────────────────────────
 
@@ -741,31 +741,31 @@ ffi  = "todo:PR-C"
 name = "push_destination"
 category = "destinations"
 wasm = "pushDestination"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_push_destination"
 
 [[methods]]
 name = "push_destination_front"
 category = "destinations"
 wasm = "pushDestinationFront"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_push_destination_front"
 
 [[methods]]
 name = "clear_destinations"
 category = "destinations"
 wasm = "clearDestinations"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_clear_destinations"
 
 [[methods]]
 name = "abort_movement"
 category = "destinations"
 wasm = "abortMovement"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_abort_movement"
 
 [[methods]]
 name = "recall_to"
 category = "destinations"
 wasm = "recallTo"
-ffi  = "todo:PR-C"
+ffi  = "ev_sim_recall_to"
 
 # ─── Parameters ───────────────────────────────────────────────────────────
 # Note: wasm exposes "*All" sweeping helpers (setMaxSpeedAll, etc.) that

--- a/crates/elevator-ffi/include/elevator_ffi.h
+++ b/crates/elevator-ffi/include/elevator_ffi.h
@@ -1274,4 +1274,154 @@ uint64_t ev_sim_current_tick(struct EvSim *handle);
  */
 double ev_sim_dt(struct EvSim *handle);
 
+/**
+ * Append `stop_entity_id` to the back of `elevator_entity_id`'s
+ * destination queue. Adjacent duplicates are suppressed.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_push_destination(struct EvSim *handle,
+                                      uint64_t elevator_entity_id,
+                                      uint64_t stop_entity_id);
+
+/**
+ * Insert `stop_entity_id` at the front of the destination queue
+ * ("go here next").
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_push_destination_front(struct EvSim *handle,
+                                            uint64_t elevator_entity_id,
+                                            uint64_t stop_entity_id);
+
+/**
+ * Empty an elevator's destination queue. The in-flight trip continues
+ * to its current target — call [`ev_sim_abort_movement`] to also stop
+ * mid-flight.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_clear_destinations(struct EvSim *handle, uint64_t elevator_entity_id);
+
+/**
+ * Abort the elevator's in-flight movement; decelerate to nearest stop.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_abort_movement(struct EvSim *handle, uint64_t elevator_entity_id);
+
+/**
+ * Clear the queue and immediately recall to `stop_entity_id`. Emits a
+ * distinct `ElevatorRecalled` event.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_recall_to(struct EvSim *handle,
+                               uint64_t elevator_entity_id,
+                               uint64_t stop_entity_id);
+
+/**
+ * Snapshot of an elevator's destination queue.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`]. `out`
+ * must point to at least `capacity` writable `u64` slots when
+ * `capacity > 0`. `out_written` must be a writable `u32`.
+ */
+enum EvStatus ev_sim_destination_queue(struct EvSim *handle,
+                                       uint64_t elevator_entity_id,
+                                       uint64_t *out,
+                                       uint32_t capacity,
+                                       uint32_t *out_written);
+
+/**
+ * Riders waiting at `stop_entity_id`.
+ *
+ * # Safety
+ *
+ * See [`ev_sim_destination_queue`] for buffer requirements.
+ */
+enum EvStatus ev_sim_waiting_at(struct EvSim *handle,
+                                uint64_t stop_entity_id,
+                                uint64_t *out,
+                                uint32_t capacity,
+                                uint32_t *out_written);
+
+/**
+ * Number of riders waiting at `stop_entity_id`.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+uint32_t ev_sim_waiting_count_at(struct EvSim *handle, uint64_t stop_entity_id);
+
+/**
+ * Riders settled / resident at `stop_entity_id`.
+ *
+ * # Safety
+ *
+ * See [`ev_sim_destination_queue`] for buffer requirements.
+ */
+enum EvStatus ev_sim_residents_at(struct EvSim *handle,
+                                  uint64_t stop_entity_id,
+                                  uint64_t *out,
+                                  uint32_t capacity,
+                                  uint32_t *out_written);
+
+/**
+ * Number of resident riders at `stop_entity_id`.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+uint32_t ev_sim_resident_count_at(struct EvSim *handle, uint64_t stop_entity_id);
+
+/**
+ * Riders who abandoned the call at `stop_entity_id`.
+ *
+ * # Safety
+ *
+ * See [`ev_sim_destination_queue`] for buffer requirements.
+ */
+enum EvStatus ev_sim_abandoned_at(struct EvSim *handle,
+                                  uint64_t stop_entity_id,
+                                  uint64_t *out,
+                                  uint32_t capacity,
+                                  uint32_t *out_written);
+
+/**
+ * Number of abandoned riders at `stop_entity_id`.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+uint32_t ev_sim_abandoned_count_at(struct EvSim *handle, uint64_t stop_entity_id);
+
+/**
+ * Riders currently aboard `elevator_entity_id`.
+ *
+ * # Safety
+ *
+ * See [`ev_sim_destination_queue`] for buffer requirements.
+ */
+enum EvStatus ev_sim_riders_on(struct EvSim *handle,
+                               uint64_t elevator_entity_id,
+                               uint64_t *out,
+                               uint32_t capacity,
+                               uint32_t *out_written);
+
 #endif  /* ELEVATOR_FFI_H */

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -3045,6 +3045,481 @@ pub unsafe extern "C" fn ev_sim_dt(handle: *mut EvSim) -> f64 {
     })
 }
 
+// ── Destinations + recall ────────────────────────────────────────────────
+//
+// Direct control over a car's destination queue (mutators). Mirror of
+// the wasm pushDestination / pushDestinationFront / clearDestinations /
+// abortMovement / recallTo set.
+
+/// Append `stop_entity_id` to the back of `elevator_entity_id`'s
+/// destination queue. Adjacent duplicates are suppressed.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_push_destination(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+    stop_entity_id: u64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let (Some(elevator), Some(stop)) = (
+            entity_from_u64(elevator_entity_id),
+            entity_from_u64(stop_entity_id),
+        ) else {
+            set_last_error("elevator_entity_id or stop_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev.sim.push_destination(ElevatorId::from(elevator), stop) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("push_destination: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Insert `stop_entity_id` at the front of the destination queue
+/// ("go here next").
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_push_destination_front(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+    stop_entity_id: u64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let (Some(elevator), Some(stop)) = (
+            entity_from_u64(elevator_entity_id),
+            entity_from_u64(stop_entity_id),
+        ) else {
+            set_last_error("elevator_entity_id or stop_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev
+            .sim
+            .push_destination_front(ElevatorId::from(elevator), stop)
+        {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("push_destination_front: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Empty an elevator's destination queue. The in-flight trip continues
+/// to its current target — call [`ev_sim_abort_movement`] to also stop
+/// mid-flight.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_clear_destinations(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev.sim.clear_destinations(ElevatorId::from(elevator)) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("clear_destinations: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Abort the elevator's in-flight movement; decelerate to nearest stop.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_abort_movement(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev.sim.abort_movement(ElevatorId::from(elevator)) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("abort_movement: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Clear the queue and immediately recall to `stop_entity_id`. Emits a
+/// distinct `ElevatorRecalled` event.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_recall_to(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+    stop_entity_id: u64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let (Some(elevator), Some(stop)) = (
+            entity_from_u64(elevator_entity_id),
+            entity_from_u64(stop_entity_id),
+        ) else {
+            set_last_error("elevator_entity_id or stop_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev.sim.recall_to(ElevatorId::from(elevator), stop) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("recall_to: {e}"));
+                status
+            }
+        }
+    })
+}
+
+// ── Population queries (buffer pattern) ──────────────────────────────────
+//
+// Returns flat lists of `EntityId` (as `u64`) using the standard FFI
+// buffer pattern: caller passes (out_buf, capacity, out_written), and
+// the function writes up to `capacity` entries plus the actual count.
+// Pair with the `*_count_at` accessors to size the buffer first.
+
+/// Internal: shared "iterator → buffer" writer. Writes up to `capacity`
+/// entries to `out`, returns the count actually written.
+unsafe fn write_entity_buffer(
+    iter: impl Iterator<Item = EntityId>,
+    out: *mut u64,
+    capacity: u32,
+) -> u32 {
+    let mut written: u32 = 0;
+    for entity in iter.take(capacity as usize) {
+        // Safety: caller guarantees `out` points to at least `capacity`
+        // u64 slots; loop never overruns by construction (take(capacity)).
+        unsafe {
+            *out.add(written as usize) = entity_to_u64(entity);
+        }
+        written += 1;
+    }
+    written
+}
+
+/// Snapshot of an elevator's destination queue.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`]. `out`
+/// must point to at least `capacity` writable `u64` slots when
+/// `capacity > 0`. `out_written` must be a writable `u32`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_destination_queue(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+    out: *mut u64,
+    capacity: u32,
+    out_written: *mut u32,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() || out_written.is_null() {
+            set_last_error("handle or out_written is null");
+            return EvStatus::NullArg;
+        }
+        if capacity > 0 && out.is_null() {
+            set_last_error("out is null but capacity > 0");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        let queue = ev
+            .sim
+            .destination_queue(ElevatorId::from(elevator))
+            .unwrap_or(&[]);
+        // Safety: `out` validity guaranteed by caller.
+        let written = unsafe { write_entity_buffer(queue.iter().copied(), out, capacity) };
+        // Safety: out_written non-null per check above.
+        unsafe { *out_written = written };
+        EvStatus::Ok
+    })
+}
+
+/// Riders waiting at `stop_entity_id`.
+///
+/// # Safety
+///
+/// See [`ev_sim_destination_queue`] for buffer requirements.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_waiting_at(
+    handle: *mut EvSim,
+    stop_entity_id: u64,
+    out: *mut u64,
+    capacity: u32,
+    out_written: *mut u32,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() || out_written.is_null() {
+            set_last_error("handle or out_written is null");
+            return EvStatus::NullArg;
+        }
+        if capacity > 0 && out.is_null() {
+            set_last_error("out is null but capacity > 0");
+            return EvStatus::NullArg;
+        }
+        let Some(stop) = entity_from_u64(stop_entity_id) else {
+            set_last_error("stop_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        // Safety: `out` validity guaranteed by caller.
+        let written = unsafe { write_entity_buffer(ev.sim.waiting_at(stop), out, capacity) };
+        // Safety: out_written non-null per check above.
+        unsafe { *out_written = written };
+        EvStatus::Ok
+    })
+}
+
+/// Number of riders waiting at `stop_entity_id`.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_waiting_count_at(handle: *mut EvSim, stop_entity_id: u64) -> u32 {
+    guard(0, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return 0;
+        }
+        let Some(stop) = entity_from_u64(stop_entity_id) else {
+            return 0;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        u32::try_from(ev.sim.waiting_count_at(stop)).unwrap_or(u32::MAX)
+    })
+}
+
+/// Riders settled / resident at `stop_entity_id`.
+///
+/// # Safety
+///
+/// See [`ev_sim_destination_queue`] for buffer requirements.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_residents_at(
+    handle: *mut EvSim,
+    stop_entity_id: u64,
+    out: *mut u64,
+    capacity: u32,
+    out_written: *mut u32,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() || out_written.is_null() {
+            set_last_error("handle or out_written is null");
+            return EvStatus::NullArg;
+        }
+        if capacity > 0 && out.is_null() {
+            set_last_error("out is null but capacity > 0");
+            return EvStatus::NullArg;
+        }
+        let Some(stop) = entity_from_u64(stop_entity_id) else {
+            set_last_error("stop_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        // Safety: `out` validity guaranteed by caller.
+        let written = unsafe { write_entity_buffer(ev.sim.residents_at(stop), out, capacity) };
+        // Safety: out_written non-null per check above.
+        unsafe { *out_written = written };
+        EvStatus::Ok
+    })
+}
+
+/// Number of resident riders at `stop_entity_id`.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_resident_count_at(handle: *mut EvSim, stop_entity_id: u64) -> u32 {
+    guard(0, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return 0;
+        }
+        let Some(stop) = entity_from_u64(stop_entity_id) else {
+            return 0;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        u32::try_from(ev.sim.resident_count_at(stop)).unwrap_or(u32::MAX)
+    })
+}
+
+/// Riders who abandoned the call at `stop_entity_id`.
+///
+/// # Safety
+///
+/// See [`ev_sim_destination_queue`] for buffer requirements.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_abandoned_at(
+    handle: *mut EvSim,
+    stop_entity_id: u64,
+    out: *mut u64,
+    capacity: u32,
+    out_written: *mut u32,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() || out_written.is_null() {
+            set_last_error("handle or out_written is null");
+            return EvStatus::NullArg;
+        }
+        if capacity > 0 && out.is_null() {
+            set_last_error("out is null but capacity > 0");
+            return EvStatus::NullArg;
+        }
+        let Some(stop) = entity_from_u64(stop_entity_id) else {
+            set_last_error("stop_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        // Safety: `out` validity guaranteed by caller.
+        let written = unsafe { write_entity_buffer(ev.sim.abandoned_at(stop), out, capacity) };
+        // Safety: out_written non-null per check above.
+        unsafe { *out_written = written };
+        EvStatus::Ok
+    })
+}
+
+/// Number of abandoned riders at `stop_entity_id`.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_abandoned_count_at(handle: *mut EvSim, stop_entity_id: u64) -> u32 {
+    guard(0, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return 0;
+        }
+        let Some(stop) = entity_from_u64(stop_entity_id) else {
+            return 0;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        u32::try_from(ev.sim.abandoned_count_at(stop)).unwrap_or(u32::MAX)
+    })
+}
+
+/// Riders currently aboard `elevator_entity_id`.
+///
+/// # Safety
+///
+/// See [`ev_sim_destination_queue`] for buffer requirements.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_riders_on(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+    out: *mut u64,
+    capacity: u32,
+    out_written: *mut u32,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() || out_written.is_null() {
+            set_last_error("handle or out_written is null");
+            return EvStatus::NullArg;
+        }
+        if capacity > 0 && out.is_null() {
+            set_last_error("out is null but capacity > 0");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        let riders = ev.sim.riders_on(elevator);
+        // Safety: `out` validity guaranteed by caller.
+        let written = unsafe { write_entity_buffer(riders.iter().copied(), out, capacity) };
+        // Safety: out_written non-null per check above.
+        unsafe { *out_written = written };
+        EvStatus::Ok
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

13 new FFI exports mirroring the wasm destinations + population work in #479.

### Destination control (5 mutators)

| Symbol | Behavior |
|---|---|
| `ev_sim_push_destination` | Append to back of queue |
| `ev_sim_push_destination_front` | Insert at front |
| `ev_sim_clear_destinations` | Empty queue (in-flight trip continues) |
| `ev_sim_abort_movement` | Decelerate to nearest stop |
| `ev_sim_recall_to` | Clear + push, emits `ElevatorRecalled` |

### Population queries (8 accessors)

| Symbol | Returns | Notes |
|---|---|---|
| `ev_sim_destination_queue` | buffer | car queue snapshot |
| `ev_sim_waiting_at` | buffer | riders waiting at stop |
| `ev_sim_waiting_count_at` | `u32` | no allocation |
| `ev_sim_residents_at` | buffer | settled riders |
| `ev_sim_resident_count_at` | `u32` | no allocation |
| `ev_sim_abandoned_at` | buffer | gave-up riders |
| `ev_sim_abandoned_count_at` | `u32` | no allocation |
| `ev_sim_riders_on` | buffer | riders aboard car |

### Buffer pattern

For the slice/iterator returns (5 methods), I introduced the standard FFI buffer pattern:

\`\`\`c
ev_sim_waiting_at(handle, stop, out, capacity, &out_written);
\`\`\`

Function writes up to `capacity` entries to `out`, sets `*out_written` to the count actually written. Pair with the matching `*_count_at` accessor to size the buffer first. Pass `capacity = 0` and `out = NULL` to query the count alone (still sets `*out_written`).

Shared internal helper `write_entity_buffer` keeps the 5 buffer-pattern methods consistent — all use `.take(capacity)` so `out` is never overrun by construction.

### Coverage dashboard

Before:
\`\`\`
  binding        exported    skipped       todo
  ffi                  41         27         72
\`\`\`

After (against current main; PR #480 still in flight will add 17 more once merged):
\`\`\`
  binding        exported    skipped       todo
  ffi                  54         27         59
\`\`\`

After both PR #480 + this PR land, FFI will sit at ~71 exported, slightly ahead of wasm's 70. Both bindings will then be at near-complete v1 surface.

### Test plan

- [x] `cargo clippy -p elevator-ffi --all-targets -- -D warnings` clean
- [x] Pre-commit hook green
- [x] Binding-coverage gate passes (13 todo:PR-C → exported on FFI side)
- [x] C header regenerated; cbindgen output committed
- [ ] CI green
- [ ] Greptile review