### PR TITLE
feat(bindings): add tagging APIs to wasm and FFI

### DIFF
--- a/bindings.toml
+++ b/bindings.toml
@@ -869,19 +869,19 @@ ffi  = "skip:takes a generic closure"
 [[methods]]
 name = "tag_entity"
 category = "tagging"
-wasm = "todo:PR-E"
-ffi  = "todo:PR-E"
+wasm = "tagEntity"
+ffi  = "ev_sim_tag_entity"
 
 [[methods]]
 name = "untag_entity"
 category = "tagging"
-wasm = "todo:PR-E"
-ffi  = "todo:PR-E"
+wasm = "untagEntity"
+ffi  = "ev_sim_untag_entity"
 
 [[methods]]
 name = "all_tags"
 category = "tagging"
-wasm = "todo:PR-E"
+wasm = "allTags"
 ffi  = "todo:PR-E"
 
 [[methods]]

--- a/crates/elevator-ffi/include/elevator_ffi.h
+++ b/crates/elevator-ffi/include/elevator_ffi.h
@@ -995,6 +995,26 @@ enum EvStatus ev_sim_set_elevator_restricted_stops(struct EvSim *handle,
                                                    uint32_t count);
 
 /**
+ * Attach `tag` to `entity_id`.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ * `tag` must be a null-terminated UTF-8 C string.
+ */
+enum EvStatus ev_sim_tag_entity(struct EvSim *handle, uint64_t entity_id, const char *tag);
+
+/**
+ * Remove `tag` from `entity_id`. No-op if the entity wasn't tagged.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ * `tag` must be a null-terminated UTF-8 C string.
+ */
+enum EvStatus ev_sim_untag_entity(struct EvSim *handle, uint64_t entity_id, const char *tag);
+
+/**
  * Replace a rider's destination with `new_destination_entity_id`. Used
  * for in-flight redirects (e.g. tenant changes mind).
  *

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -2299,6 +2299,95 @@ pub unsafe extern "C" fn ev_sim_set_elevator_restricted_stops(
     })
 }
 
+// ── Tagging ──────────────────────────────────────────────────────────────
+//
+// Attach string tags to entities for grouped metrics. Mirrors wasm's
+// tagEntity / untagEntity. The `all_tags` and `metrics_for_tag`
+// accessors are deferred — `all_tags` needs a string-buffer pattern
+// and `metrics_for_tag` needs a TaggedMetric DTO.
+
+/// Attach `tag` to `entity_id`.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+/// `tag` must be a null-terminated UTF-8 C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_tag_entity(
+    handle: *mut EvSim,
+    entity_id: u64,
+    tag: *const c_char,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() || tag.is_null() {
+            set_last_error("handle or tag is null");
+            return EvStatus::NullArg;
+        }
+        let Some(entity) = entity_from_u64(entity_id) else {
+            set_last_error("entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: caller guarantees null-terminated string.
+        let cstr = unsafe { CStr::from_ptr(tag) };
+        let tag_str = match cstr.to_str() {
+            Ok(s) => s.to_owned(),
+            Err(e) => {
+                set_last_error(format!("tag is not valid UTF-8: {e}"));
+                return EvStatus::InvalidUtf8;
+            }
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev.sim.tag_entity(entity, tag_str) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("tag_entity: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Remove `tag` from `entity_id`. No-op if the entity wasn't tagged.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+/// `tag` must be a null-terminated UTF-8 C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_untag_entity(
+    handle: *mut EvSim,
+    entity_id: u64,
+    tag: *const c_char,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() || tag.is_null() {
+            set_last_error("handle or tag is null");
+            return EvStatus::NullArg;
+        }
+        let Some(entity) = entity_from_u64(entity_id) else {
+            set_last_error("entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: caller guarantees null-terminated string.
+        let cstr = unsafe { CStr::from_ptr(tag) };
+        let tag_str = match cstr.to_str() {
+            Ok(s) => s,
+            Err(e) => {
+                set_last_error(format!("tag is not valid UTF-8: {e}"));
+                return EvStatus::InvalidUtf8;
+            }
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        ev.sim.untag_entity(entity, tag_str);
+        EvStatus::Ok
+    })
+}
+
 // ── Routes + rider lifecycle ─────────────────────────────────────────────
 //
 // Per-rider mutations (reroute, settle, access) and read-only graph

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -1706,6 +1706,42 @@ impl WasmSim {
             .map_err(|e| JsError::new(&format!("disable: {e}")))
     }
 
+    // ── Tagging + tagged metrics ─────────────────────────────────────
+    //
+    // Attach tags to entities for grouped metrics queries (e.g. "tower"
+    // vs "annex" elevators, "weekday" vs "weekend" rider flows). The
+    // metrics_for_tag accessor is intentionally deferred — it returns a
+    // TaggedMetric reference that needs its own DTO design.
+
+    /// Attach `tag` to `entity_ref`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if `entity_ref` does not exist.
+    #[wasm_bindgen(js_name = tagEntity)]
+    pub fn tag_entity(&mut self, entity_ref: u64, tag: String) -> Result<(), JsError> {
+        self.inner
+            .tag_entity(u64_to_entity(entity_ref), tag)
+            .map_err(|e| JsError::new(&format!("tag_entity: {e}")))
+    }
+
+    /// Remove `tag` from `entity_ref`. No-op if the entity wasn't tagged.
+    #[wasm_bindgen(js_name = untagEntity)]
+    pub fn untag_entity(&mut self, entity_ref: u64, tag: &str) {
+        self.inner.untag_entity(u64_to_entity(entity_ref), tag);
+    }
+
+    /// Every tag currently registered in the simulation.
+    #[wasm_bindgen(js_name = allTags)]
+    #[must_use]
+    pub fn all_tags(&self) -> Vec<String> {
+        self.inner
+            .all_tags()
+            .into_iter()
+            .map(String::from)
+            .collect()
+    }
+
     // ── Stop lookup + phase / direction queries ──────────────────────
 
     /// Resolve a config-time `StopId` (the small `u32` from the RON


### PR DESCRIPTION
Adds tagEntity / untagEntity to both bindings + allTags to wasm. metrics_for_tag and FFI all_tags deferred (need DTO / string-buffer design).