### PR TITLE
feat(bindings): add stop_lookup_iter to wasm and FFI

### DIFF
--- a/bindings.toml
+++ b/bindings.toml
@@ -558,8 +558,8 @@ ffi  = "ev_sim_line_count"
 [[methods]]
 name = "stop_lookup_iter"
 category = "introspection"
-wasm = "todo:PR-B"
-ffi  = "todo:PR-B"
+wasm = "stopLookupIter"
+ffi  = "ev_sim_stop_lookup_iter"
 
 [[methods]]
 name = "stop_entity"

--- a/crates/elevator-ffi/include/elevator_ffi.h
+++ b/crates/elevator-ffi/include/elevator_ffi.h
@@ -1087,6 +1087,24 @@ enum EvStatus ev_sim_transfer_points(struct EvSim *handle,
 uint64_t ev_sim_stop_entity(struct EvSim *handle, uint32_t stop_id);
 
 /**
+ * Snapshot of the config-time `StopId` → runtime `EntityId` map.
+ *
+ * Buffer-pattern accessor; emits flat `[stop_id_as_u64, entity_id, ...]`
+ * pairs (each pair = 2 `u64` slots). The number of pairs written is
+ * `*out_written / 2`.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`]. `out`
+ * must point to at least `capacity` writable `u64` slots when
+ * `capacity > 0`.
+ */
+enum EvStatus ev_sim_stop_lookup_iter(struct EvSim *handle,
+                                      uint64_t *out,
+                                      uint32_t capacity,
+                                      uint32_t *out_written);
+
+/**
  * Entity ids of every elevator currently repositioning.
  * Buffer-pattern accessor.
  *

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -2616,6 +2616,56 @@ pub unsafe extern "C" fn ev_sim_stop_entity(handle: *mut EvSim, stop_id: u32) ->
     })
 }
 
+/// Snapshot of the config-time `StopId` → runtime `EntityId` map.
+///
+/// Buffer-pattern accessor; emits flat `[stop_id_as_u64, entity_id, ...]`
+/// pairs (each pair = 2 `u64` slots). The number of pairs written is
+/// `*out_written / 2`.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`]. `out`
+/// must point to at least `capacity` writable `u64` slots when
+/// `capacity > 0`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_stop_lookup_iter(
+    handle: *mut EvSim,
+    out: *mut u64,
+    capacity: u32,
+    out_written: *mut u32,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() || out_written.is_null() {
+            set_last_error("handle or out_written is null");
+            return EvStatus::NullArg;
+        }
+        if capacity > 0 && out.is_null() {
+            set_last_error("out is null but capacity > 0");
+            return EvStatus::NullArg;
+        }
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        let mut written: u32 = 0;
+        for (stop_id, entity) in ev.sim.stop_lookup_iter() {
+            // Each pair takes 2 slots; stop if next pair would overflow.
+            if written + 2 > capacity {
+                break;
+            }
+            // Safety: caller guarantees `out` has at least `capacity`
+            // writable slots; bounds checked above.
+            unsafe {
+                *out.add(written as usize) = u64::from(stop_id.0);
+                *out.add(written as usize + 1) = entity_to_u64(*entity);
+            }
+            written += 2;
+        }
+        // Safety: out_written non-null per check above.
+        unsafe { *out_written = written };
+        EvStatus::Ok
+    })
+}
+
 /// Entity ids of every elevator currently repositioning.
 /// Buffer-pattern accessor.
 ///

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -1755,6 +1755,19 @@ impl WasmSim {
             .map_or(0, entity_to_u64)
     }
 
+    /// Snapshot of the config-time `StopId` → runtime `EntityId` map.
+    /// Returns a flat `[stop_id_as_u64, entity_id, ...]` array — the
+    /// `StopId` is zero-extended into the same `u64` slot the entity
+    /// uses. Pair count is `array.length / 2`.
+    #[wasm_bindgen(js_name = stopLookupIter)]
+    #[must_use]
+    pub fn stop_lookup_iter(&self) -> Vec<u64> {
+        self.inner
+            .stop_lookup_iter()
+            .flat_map(|(stop_id, entity)| [u64::from(stop_id.0), entity_to_u64(*entity)])
+            .collect()
+    }
+
     /// Entity ids of every elevator currently repositioning (heading to
     /// a parking stop with no rider obligation).
     #[wasm_bindgen(js_name = iterRepositioningElevators)]


### PR DESCRIPTION
Snapshot of the config-time StopId -> runtime EntityId map. Both bindings encode pairs as flat u64 arrays. Wasm 103 -> 104, FFI 98 -> 99 exported.