### PR TITLE
feat(wasm): add RouteDto + shortestRoute binding

### DIFF
--- a/bindings.toml
+++ b/bindings.toml
@@ -368,7 +368,7 @@ ffi  = "ev_sim_set_rider_access"
 [[methods]]
 name = "shortest_route"
 category = "routes"
-wasm = "todo:PR-D"
+wasm = "shortestRoute"
 ffi  = "todo:PR-D"
 
 [[methods]]

--- a/crates/elevator-wasm/src/dto.rs
+++ b/crates/elevator-wasm/src/dto.rs
@@ -251,10 +251,45 @@ impl MetricsDto {
     }
 }
 
+/// A multi-stop route shaped for JS consumers as a flat array of stop
+/// entity ids. Returned by [`crate::WasmSim::shortestRoute`].
+///
+/// The first entry is the origin, the last is the destination, and any
+/// in-between entries are transfer points. Adjacent pairs become route
+/// legs internally; this projection drops the per-leg `via` (Group /
+/// Line / Walk) information since it isn't observable to the JS side
+/// without additional context.
+#[derive(Serialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct RouteDto {
+    /// Ordered stop entity ids (length >= 2 for a valid route). The
+    /// rider visits these in sequence; each adjacent pair is one leg.
+    pub stops: Vec<u32>,
+    /// Optional total cost in ticks (currently always `None` —
+    /// [`Simulation::shortest_route`] doesn't yet compute cost).
+    pub cost: Option<u64>,
+}
+
+impl From<elevator_core::components::Route> for RouteDto {
+    fn from(route: elevator_core::components::Route) -> Self {
+        // Flatten the leg chain into [from0, to0=from1, to1=from2, ...].
+        // Adjacent duplicates collapse — `RouteLeg.to == next.from` by
+        // construction, so the chain has `legs.len() + 1` distinct stops.
+        let mut stops: Vec<u32> = Vec::with_capacity(route.legs.len() + 1);
+        if let Some(first) = route.legs.first() {
+            stops.push(entity_to_u32(first.from));
+            for leg in &route.legs {
+                stops.push(entity_to_u32(leg.to));
+            }
+        }
+        Self { stops, cost: None }
+    }
+}
+
 /// Flattened event DTO. Every variant includes a `kind` discriminator and the
 /// engine tick at which it was emitted; the remaining fields vary by kind.
-/// Unknown variants (added to core later) fall back to `{ kind: "other" }` so
-/// the UI stays forward-compatible.
+/// Unknown variants (added to core later) fall back to `{ kind: "unknown" }`
+/// so the UI stays forward-compatible.
 #[derive(Serialize, Tsify)]
 #[tsify(into_wasm_abi)]
 #[serde(tag = "kind", rename_all = "kebab-case")]

--- a/crates/elevator-wasm/src/dto.rs
+++ b/crates/elevator-wasm/src/dto.rs
@@ -314,7 +314,7 @@ pub enum EventDto {
     },
     /// A rider was rejected from boarding (e.g., over capacity, access
     /// denied). `reason` is a kebab-case label drawn from
-    /// [`RejectionReason`].
+    /// [`elevator_core::error::RejectionReason`].
     RiderRejected {
         tick: u64,
         rider: u32,
@@ -384,13 +384,14 @@ pub enum EventDto {
         elevator: u32,
     },
     /// `command` is one of `"open"`, `"close"`, `"hold-open"`,
-    /// `"cancel-hold"` (kebab-case from [`crate::door::DoorCommand`]).
+    /// `"cancel-hold"` (kebab-case from
+    /// [`elevator_core::door::DoorCommand`]).
     DoorCommandQueued {
         tick: u64,
         elevator: u32,
         command: String,
     },
-    /// Same `command` set as [`DoorCommandQueued`].
+    /// Same `command` set as [`EventDto::DoorCommandQueued`].
     DoorCommandApplied {
         tick: u64,
         elevator: u32,

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -1641,8 +1641,8 @@ impl WasmSim {
     /// Compute the shortest multi-leg route between two stops using the
     /// line-graph topology. Returns `undefined` if no path exists.
     ///
-    /// The returned [`dto::RouteDto`] is a flat list of stops (origin
-    /// first, destination last) — adjacent pairs are individual legs.
+    /// The returned `RouteDto` is a flat list of stops (origin first,
+    /// destination last) — adjacent pairs are individual legs.
     #[wasm_bindgen(js_name = shortestRoute)]
     #[must_use]
     pub fn shortest_route(&self, from_stop_ref: u64, to_stop_ref: u64) -> Option<dto::RouteDto> {

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -1638,6 +1638,19 @@ impl WasmSim {
             .collect()
     }
 
+    /// Compute the shortest multi-leg route between two stops using the
+    /// line-graph topology. Returns `undefined` if no path exists.
+    ///
+    /// The returned [`dto::RouteDto`] is a flat list of stops (origin
+    /// first, destination last) — adjacent pairs are individual legs.
+    #[wasm_bindgen(js_name = shortestRoute)]
+    #[must_use]
+    pub fn shortest_route(&self, from_stop_ref: u64, to_stop_ref: u64) -> Option<dto::RouteDto> {
+        self.inner
+            .shortest_route(u64_to_entity(from_stop_ref), u64_to_entity(to_stop_ref))
+            .map(dto::RouteDto::from)
+    }
+
     // ── Per-elevator setters + lifecycle ─────────────────────────────
     //
     // Per-elevator parameter setters that sit alongside the existing


### PR DESCRIPTION
Wave 1 PR-B. Flat RouteDto: { stops, cost? } + binds shortestRoute. set_rider_route / reroute_rider deferred (need DTO->Route conversion design with group/line context). Wasm 104 -> 105 exported.