### PR TITLE
feat(wasm): add TaggedMetricDto + metricsForTag binding

### DIFF
--- a/bindings.toml
+++ b/bindings.toml
@@ -887,7 +887,7 @@ ffi  = "todo:PR-E"
 [[methods]]
 name = "metrics_for_tag"
 category = "metrics"
-wasm = "todo:PR-E"
+wasm = "metricsForTag"
 ffi  = "todo:PR-E"
 
 # ─── Internal — exposes &World, &mut World, internal slices ───────────────

--- a/crates/elevator-wasm/src/dto.rs
+++ b/crates/elevator-wasm/src/dto.rs
@@ -286,6 +286,40 @@ impl From<elevator_core::components::Route> for RouteDto {
     }
 }
 
+/// Per-tag aggregates. Returned by
+/// [`crate::WasmSim::metricsForTag`].
+///
+/// Mirrors [`elevator_core::tagged_metrics::TaggedMetric`] field-for-field
+/// (no precision loss). Wait times stay in **ticks** here — JS consumers
+/// who want seconds multiply by `currentTick`-vs-prev-tick `dt` from the
+/// top-level metrics.
+#[derive(Serialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct TaggedMetricDto {
+    /// Average wait time in ticks (spawn → board) for tagged riders.
+    pub avg_wait_ticks: f64,
+    /// Maximum wait time observed in ticks for tagged riders.
+    pub max_wait_ticks: u64,
+    /// Total riders delivered carrying this tag.
+    pub total_delivered: u64,
+    /// Total riders abandoned carrying this tag.
+    pub total_abandoned: u64,
+    /// Total riders spawned carrying this tag.
+    pub total_spawned: u64,
+}
+
+impl From<&elevator_core::tagged_metrics::TaggedMetric> for TaggedMetricDto {
+    fn from(m: &elevator_core::tagged_metrics::TaggedMetric) -> Self {
+        Self {
+            avg_wait_ticks: m.avg_wait_time(),
+            max_wait_ticks: m.max_wait_time(),
+            total_delivered: m.total_delivered(),
+            total_abandoned: m.total_abandoned(),
+            total_spawned: m.total_spawned(),
+        }
+    }
+}
+
 /// Flattened event DTO. Every variant includes a `kind` discriminator and the
 /// engine tick at which it was emitted; the remaining fields vary by kind.
 /// Unknown variants (added to core later) fall back to `{ kind: "unknown" }`

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -1770,8 +1770,8 @@ impl WasmSim {
     /// Aggregate metrics for `tag`. Returns `undefined` if no riders
     /// carrying the tag have been recorded yet.
     ///
-    /// Wait times in the returned [`dto::TaggedMetricDto`] are in
-    /// **ticks** — multiply by `dt` for real-time seconds.
+    /// Wait times in the returned `TaggedMetricDto` are in **ticks** —
+    /// multiply by `dt` for real-time seconds.
     #[wasm_bindgen(js_name = metricsForTag)]
     #[must_use]
     pub fn metrics_for_tag(&self, tag: &str) -> Option<dto::TaggedMetricDto> {

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -1736,8 +1736,7 @@ impl WasmSim {
     //
     // Attach tags to entities for grouped metrics queries (e.g. "tower"
     // vs "annex" elevators, "weekday" vs "weekend" rider flows). The
-    // metrics_for_tag accessor is intentionally deferred — it returns a
-    // TaggedMetric reference that needs its own DTO design.
+    // per-tag aggregates surface via `metricsForTag`.
 
     /// Attach `tag` to `entity_ref`.
     ///

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -1768,6 +1768,19 @@ impl WasmSim {
             .collect()
     }
 
+    /// Aggregate metrics for `tag`. Returns `undefined` if no riders
+    /// carrying the tag have been recorded yet.
+    ///
+    /// Wait times in the returned [`dto::TaggedMetricDto`] are in
+    /// **ticks** — multiply by `dt` for real-time seconds.
+    #[wasm_bindgen(js_name = metricsForTag)]
+    #[must_use]
+    pub fn metrics_for_tag(&self, tag: &str) -> Option<dto::TaggedMetricDto> {
+        self.inner
+            .metrics_for_tag(tag)
+            .map(dto::TaggedMetricDto::from)
+    }
+
     // ── Stop lookup + phase / direction queries ──────────────────────
 
     /// Count elevators currently in the given phase. `phase` is one of:


### PR DESCRIPTION
Wave 2 PR. TaggedMetricDto mirrors core TaggedMetric field-for-field. metricsForTag(tag) returns Option<TaggedMetricDto>. Wasm 104 -> 105 exported.