### PR TITLE
feat(wasm): elevatorsInPhase + skip drain_events_where

### DIFF
--- a/bindings.toml
+++ b/bindings.toml
@@ -304,8 +304,8 @@ ffi  = "ev_sim_drain_events"
 [[methods]]
 name = "drain_events_where"
 category = "events"
-wasm = "todo:PR-G"
-ffi  = "todo:PR-G"
+wasm = "skip:closure marshaling — JS consumers filter drainEvents() output client-side"
+ffi  = "skip:closure marshaling — C consumers filter drain_events output"
 
 [[methods]]
 name = "pending_events"
@@ -642,7 +642,7 @@ ffi  = "ev_sim_destination_queue"
 [[methods]]
 name = "elevators_in_phase"
 category = "introspection"
-wasm = "todo:PR-C"
+wasm = "elevatorsInPhase"
 ffi  = "todo:PR-C"
 
 [[methods]]

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -1757,6 +1757,34 @@ impl WasmSim {
 
     // ── Stop lookup + phase / direction queries ──────────────────────
 
+    /// Count elevators currently in the given phase. `phase` is one of:
+    /// `"idle"`, `"door-opening"`, `"loading"`, `"door-closing"`,
+    /// `"stopped"`. The two with payload variants
+    /// (`MovingToStop(EntityId)` and `Repositioning(EntityId)`) are
+    /// not exposed here — use `iterRepositioningElevators` or the per-
+    /// elevator phase via the snapshot for those.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if `phase` is not one of the supported labels.
+    #[wasm_bindgen(js_name = elevatorsInPhase)]
+    pub fn elevators_in_phase(&self, phase: &str) -> Result<u32, JsError> {
+        use elevator_core::prelude::ElevatorPhase;
+        let p = match phase {
+            "idle" => ElevatorPhase::Idle,
+            "door-opening" => ElevatorPhase::DoorOpening,
+            "loading" => ElevatorPhase::Loading,
+            "door-closing" => ElevatorPhase::DoorClosing,
+            "stopped" => ElevatorPhase::Stopped,
+            other => {
+                return Err(JsError::new(&format!(
+                    "phase must be one of idle / door-opening / loading / door-closing / stopped — got {other:?}"
+                )));
+            }
+        };
+        Ok(u32::try_from(self.inner.elevators_in_phase(p)).unwrap_or(u32::MAX))
+    }
+
     /// Resolve a config-time `StopId` (the small `u32` from the RON
     /// config) to its runtime `EntityId`. Returns `0` (slotmap-null)
     /// for unknown ids.


### PR DESCRIPTION
Adds elevatorsInPhase for the 5 no-payload ElevatorPhase variants. Marks drain_events_where as skip on both bindings per the v1.1 design choice (filter client-side instead of marshaling closures). Wasm 105 -> 106 exported.