### PR TITLE
feat(bindings): add route mutators (setRiderRoute, rerouteRider)

### DIFF
--- a/bindings.toml
+++ b/bindings.toml
@@ -350,14 +350,18 @@ ffi  = "ev_sim_reroute"
 [[methods]]
 name = "reroute_rider"
 category = "routes"
-wasm = "todo:PR-D"
-ffi  = "todo:PR-D"
+# Two convenience overloads per binding. The bindings file lists the
+# Shortest variant as the canonical name; Direct (single-leg via a named
+# group) ships alongside as `rerouteRiderDirect` / `ev_sim_reroute_rider_direct`.
+wasm = "rerouteRiderShortest"
+ffi  = "ev_sim_reroute_rider_shortest"
 
 [[methods]]
 name = "set_rider_route"
 category = "routes"
-wasm = "todo:PR-D"
-ffi  = "todo:PR-D"
+# Two convenience overloads per binding. See `reroute_rider` above.
+wasm = "setRiderRouteShortest"
+ffi  = "ev_sim_set_rider_route_shortest"
 
 [[methods]]
 name = "set_rider_access"

--- a/crates/elevator-ffi/include/elevator_ffi.h
+++ b/crates/elevator-ffi/include/elevator_ffi.h
@@ -1222,6 +1222,67 @@ enum EvStatus ev_sim_reroute(struct EvSim *handle,
 enum EvStatus ev_sim_settle_rider(struct EvSim *handle, uint64_t rider_entity_id);
 
 /**
+ * Replace a rider's remaining route with a single-leg route via
+ * `group_id`. Convenience wrapper for the common "send this rider via
+ * this group" case.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_set_rider_route_direct(struct EvSim *handle,
+                                            uint64_t rider_entity_id,
+                                            uint64_t from_stop_entity_id,
+                                            uint64_t to_stop_entity_id,
+                                            uint32_t group_id);
+
+/**
+ * Replace a rider's remaining route with a multi-leg route built from
+ * `shortest_route(rider's current_stop → to_stop)`.
+ *
+ * Returns [`EvStatus::NotFound`] if no route exists or the rider has
+ * no current stop.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_set_rider_route_shortest(struct EvSim *handle,
+                                              uint64_t rider_entity_id,
+                                              uint64_t to_stop_entity_id);
+
+/**
+ * Give a `Resident` rider a single-leg route via `group_id`,
+ * transitioning them back to `Waiting`. The route's first leg origin
+ * must match the rider's current stop.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_reroute_rider_direct(struct EvSim *handle,
+                                          uint64_t rider_entity_id,
+                                          uint64_t from_stop_entity_id,
+                                          uint64_t to_stop_entity_id,
+                                          uint32_t group_id);
+
+/**
+ * Give a `Resident` rider a multi-leg route to `to_stop` built from
+ * `shortest_route(rider's current_stop → to_stop)`, transitioning them
+ * back to `Waiting`.
+ *
+ * Returns [`EvStatus::NotFound`] if the rider has no current stop or
+ * no route exists.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_reroute_rider_shortest(struct EvSim *handle,
+                                            uint64_t rider_entity_id,
+                                            uint64_t to_stop_entity_id);
+
+/**
  * Replace a rider's allowed-stops set. Pass `count = 0` to clear.
  *
  * # Safety

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -2854,6 +2854,211 @@ pub unsafe extern "C" fn ev_sim_settle_rider(handle: *mut EvSim, rider_entity_id
     })
 }
 
+/// Replace a rider's remaining route with a single-leg route via
+/// `group_id`. Convenience wrapper for the common "send this rider via
+/// this group" case.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_set_rider_route_direct(
+    handle: *mut EvSim,
+    rider_entity_id: u64,
+    from_stop_entity_id: u64,
+    to_stop_entity_id: u64,
+    group_id: u32,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(rider) = entity_from_u64(rider_entity_id) else {
+            set_last_error("rider_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        let Some(from) = entity_from_u64(from_stop_entity_id) else {
+            set_last_error("from_stop_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        let Some(to) = entity_from_u64(to_stop_entity_id) else {
+            set_last_error("to_stop_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        let route = elevator_core::components::Route::direct(from, to, GroupId(group_id));
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev.sim.set_rider_route(rider, route) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("set_rider_route_direct: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Replace a rider's remaining route with a multi-leg route built from
+/// `shortest_route(rider's current_stop → to_stop)`.
+///
+/// Returns [`EvStatus::NotFound`] if no route exists or the rider has
+/// no current stop.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_set_rider_route_shortest(
+    handle: *mut EvSim,
+    rider_entity_id: u64,
+    to_stop_entity_id: u64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(rider) = entity_from_u64(rider_entity_id) else {
+            set_last_error("rider_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        let Some(to) = entity_from_u64(to_stop_entity_id) else {
+            set_last_error("to_stop_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        let Some(from) = ev
+            .sim
+            .world()
+            .rider(rider)
+            .and_then(elevator_core::components::Rider::current_stop)
+        else {
+            set_last_error("rider has no current stop");
+            return EvStatus::NotFound;
+        };
+        let Some(route) = ev.sim.shortest_route(from, to) else {
+            set_last_error("no route between rider's stop and to_stop");
+            return EvStatus::NotFound;
+        };
+        match ev.sim.set_rider_route(rider, route) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("set_rider_route_shortest: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Give a `Resident` rider a single-leg route via `group_id`,
+/// transitioning them back to `Waiting`. The route's first leg origin
+/// must match the rider's current stop.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_reroute_rider_direct(
+    handle: *mut EvSim,
+    rider_entity_id: u64,
+    from_stop_entity_id: u64,
+    to_stop_entity_id: u64,
+    group_id: u32,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(rider) = entity_from_u64(rider_entity_id) else {
+            set_last_error("rider_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        let Some(from) = entity_from_u64(from_stop_entity_id) else {
+            set_last_error("from_stop_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        let Some(to) = entity_from_u64(to_stop_entity_id) else {
+            set_last_error("to_stop_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        let route = elevator_core::components::Route::direct(from, to, GroupId(group_id));
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev.sim.reroute_rider(rider, route) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("reroute_rider_direct: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Give a `Resident` rider a multi-leg route to `to_stop` built from
+/// `shortest_route(rider's current_stop → to_stop)`, transitioning them
+/// back to `Waiting`.
+///
+/// Returns [`EvStatus::NotFound`] if the rider has no current stop or
+/// no route exists.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_reroute_rider_shortest(
+    handle: *mut EvSim,
+    rider_entity_id: u64,
+    to_stop_entity_id: u64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(rider) = entity_from_u64(rider_entity_id) else {
+            set_last_error("rider_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        let Some(to) = entity_from_u64(to_stop_entity_id) else {
+            set_last_error("to_stop_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        let Some(from) = ev
+            .sim
+            .world()
+            .rider(rider)
+            .and_then(elevator_core::components::Rider::current_stop)
+        else {
+            set_last_error("rider has no current stop");
+            return EvStatus::NotFound;
+        };
+        let Some(route) = ev.sim.shortest_route(from, to) else {
+            set_last_error("no route between rider's stop and to_stop");
+            return EvStatus::NotFound;
+        };
+        match ev.sim.reroute_rider(rider, route) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("reroute_rider_shortest: {e}"));
+                status
+            }
+        }
+    })
+}
+
 /// Replace a rider's allowed-stops set. Pass `count = 0` to clear.
 ///
 /// # Safety

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -1677,6 +1677,119 @@ impl WasmSim {
             .map(dto::RouteDto::from)
     }
 
+    /// Replace a rider's remaining route with a single-leg route via
+    /// `group_id`. Useful when the consumer already knows the group
+    /// the rider should use (e.g. an express bank).
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the rider does not exist.
+    #[wasm_bindgen(js_name = setRiderRouteDirect)]
+    pub fn set_rider_route_direct(
+        &mut self,
+        rider_ref: u64,
+        from_stop_ref: u64,
+        to_stop_ref: u64,
+        group_id: u32,
+    ) -> Result<(), JsError> {
+        let route = elevator_core::components::Route::direct(
+            u64_to_entity(from_stop_ref),
+            u64_to_entity(to_stop_ref),
+            elevator_core::ids::GroupId(group_id),
+        );
+        self.inner
+            .set_rider_route(u64_to_entity(rider_ref), route)
+            .map_err(|e| JsError::new(&format!("set_rider_route_direct: {e}")))
+    }
+
+    /// Replace a rider's remaining route with a multi-leg route built
+    /// from `shortest_route(rider's current_stop -> to_stop)`.
+    /// Convenience wrapper for the common "send this rider here" case.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the rider does not exist, has no current
+    /// stop, or no route to `to_stop` exists.
+    #[wasm_bindgen(js_name = setRiderRouteShortest)]
+    pub fn set_rider_route_shortest(
+        &mut self,
+        rider_ref: u64,
+        to_stop_ref: u64,
+    ) -> Result<(), JsError> {
+        let rider_eid = u64_to_entity(rider_ref);
+        let to_eid = u64_to_entity(to_stop_ref);
+        let from_eid = self
+            .inner
+            .world()
+            .rider(rider_eid)
+            .and_then(elevator_core::components::Rider::current_stop)
+            .ok_or_else(|| JsError::new("set_rider_route_shortest: rider has no current stop"))?;
+        let route = self.inner.shortest_route(from_eid, to_eid).ok_or_else(|| {
+            JsError::new("set_rider_route_shortest: no route between rider's stop and to_stop")
+        })?;
+        self.inner
+            .set_rider_route(rider_eid, route)
+            .map_err(|e| JsError::new(&format!("set_rider_route_shortest: {e}")))
+    }
+
+    /// Give a `Resident` rider a new single-leg route via `group_id`,
+    /// transitioning them back to `Waiting`. The route's first leg origin
+    /// must match the rider's current stop, so callers must know which
+    /// stop the resident is at.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the rider does not exist, is not in
+    /// `Resident` phase, or the route's origin does not match the
+    /// rider's current stop.
+    #[wasm_bindgen(js_name = rerouteRiderDirect)]
+    pub fn reroute_rider_direct(
+        &mut self,
+        rider_ref: u64,
+        from_stop_ref: u64,
+        to_stop_ref: u64,
+        group_id: u32,
+    ) -> Result<(), JsError> {
+        let route = elevator_core::components::Route::direct(
+            u64_to_entity(from_stop_ref),
+            u64_to_entity(to_stop_ref),
+            elevator_core::ids::GroupId(group_id),
+        );
+        self.inner
+            .reroute_rider(u64_to_entity(rider_ref), route)
+            .map_err(|e| JsError::new(&format!("reroute_rider_direct: {e}")))
+    }
+
+    /// Give a `Resident` rider a multi-leg route to `to_stop` built from
+    /// `shortest_route(rider's current_stop -> to_stop)`, transitioning
+    /// them back to `Waiting`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the rider does not exist, is not in
+    /// `Resident` phase, has no current stop, or no route exists.
+    #[wasm_bindgen(js_name = rerouteRiderShortest)]
+    pub fn reroute_rider_shortest(
+        &mut self,
+        rider_ref: u64,
+        to_stop_ref: u64,
+    ) -> Result<(), JsError> {
+        let rider_eid = u64_to_entity(rider_ref);
+        let to_eid = u64_to_entity(to_stop_ref);
+        let from_eid = self
+            .inner
+            .world()
+            .rider(rider_eid)
+            .and_then(elevator_core::components::Rider::current_stop)
+            .ok_or_else(|| JsError::new("reroute_rider_shortest: rider has no current stop"))?;
+        let route = self.inner.shortest_route(from_eid, to_eid).ok_or_else(|| {
+            JsError::new("reroute_rider_shortest: no route between rider's stop and to_stop")
+        })?;
+        self.inner
+            .reroute_rider(rider_eid, route)
+            .map_err(|e| JsError::new(&format!("reroute_rider_shortest: {e}")))
+    }
+
     // ── Per-elevator setters + lifecycle ─────────────────────────────
     //
     // Per-elevator parameter setters that sit alongside the existing


### PR DESCRIPTION
## Summary
Two convenience overloads per binding for `set_rider_route` and `reroute_rider`. Closes the last route-related todo in `bindings.toml`.

| Wasm | FFI | Purpose |
|---|---|---|
| `setRiderRouteDirect(rider, from, to, group_id)` | `ev_sim_set_rider_route_direct` | Single-leg via one group |
| `setRiderRouteShortest(rider, to_stop)` | `ev_sim_set_rider_route_shortest` | Multi-leg via `shortest_route(rider's current_stop -> to_stop)` |
| `rerouteRiderDirect(rider, from, to, group_id)` | `ev_sim_reroute_rider_direct` | Resident -> Waiting, single-leg |
| `rerouteRiderShortest(rider, to_stop)` | `ev_sim_reroute_rider_shortest` | Resident -> Waiting, shortest path |

## Design
- **Two overloads instead of full leg-encoded input.** Every existing core caller of `Route` uses `Route::direct` or feeds in a `shortest_route` result — nobody hand-builds multi-leg routes through the public API. Heavier leg-encoded shape can ship later if a consumer asks.
- **`*Shortest` is listed in `bindings.toml`** as the canonical name for each row; the `*Direct` companion ships alongside.
- **`current_stop` is read from the `Rider` component**, not a separate API call, so `*Shortest` works for any rider that has a current stop set.

## Bindings dashboard
- **wasm 110/28/2 → 112/28/0** (full coverage)
- ffi gains 4 exports here; after #501 + #502 rebase forward it will be 113/28/0.

## Test plan
- [x] `cargo clippy -p elevator-ffi --all-targets -- -D warnings`
- [x] `cargo clippy -p elevator-wasm --target wasm32-unknown-unknown -- -D warnings`
- [x] `cargo test -p elevator-ffi` (existing tests still green; new tests deferred to a follow-up since they need a Resident-phase rider, which the existing helpers don't set up)
- [x] `crates/elevator-ffi/include/elevator_ffi.h` regenerated
- [x] `scripts/check-bindings.sh` clean