### PR TITLE
chore(release): track elevator-wasm + elevator-ffi in release-please

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,5 @@
 {
-  "crates/elevator-core": "15.26.0"
+  "crates/elevator-core": "15.26.0",
+  "crates/elevator-wasm": "0.1.0",
+  "crates/elevator-ffi": "0.9.0"
 }

--- a/crates/elevator-ffi/Cargo.toml
+++ b/crates/elevator-ffi/Cargo.toml
@@ -6,6 +6,10 @@ description = "C ABI for elevator-core (Unity / native interop)"
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+# Distributed as a prebuilt cdylib + header per platform, not via
+# crates.io. release-please still tracks the version + tag so consumers
+# can pin against a specific build.
+publish = false
 
 [lib]
 crate-type = ["cdylib", "staticlib", "rlib"]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,20 @@
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "include-component-in-tag": true
+    },
+    "crates/elevator-wasm": {
+      "release-type": "rust",
+      "component": "elevator-wasm",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "include-component-in-tag": true
+    },
+    "crates/elevator-ffi": {
+      "release-type": "rust",
+      "component": "elevator-ffi",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "include-component-in-tag": true
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
## Summary

Add `elevator-wasm` and `elevator-ffi` to `release-please-config.json` and the manifest so version bumps + CHANGELOG entries + GitHub tags are generated for them on the same cadence as `elevator-core`.

Neither is published to crates.io:
- `elevator-wasm` already has `publish = false` (consumers build the wasm themselves via `scripts/build-wasm.sh`)
- `elevator-ffi` gets `publish = false` here too; it ships as a prebuilt cdylib + header per platform, not a Rust dep. The flag makes the intent explicit and prevents an accidental `cargo publish` from leaking it.

## Why

After landing the binding-coverage push, both crates have stable surfaces that consumers will pin against. Without release-please tracking, every commit-touching-bindings re-bumps the version manually (or never bumps at all), which is what was happening on `elevator-ffi`'s changelog entries from before today's session. Pulling them into the same release-please config eliminates the manual step.

## Behavior

- The publish job in `.github/workflows/release-please.yml` is already gated on the `elevator-core` release output, so this change does **not** introduce any new crates.io publish path. It only opts the binding crates into release-please tag/changelog generation.
- Initial versions match the current `Cargo.toml`: `elevator-wasm 0.1.0`, `elevator-ffi 0.9.0`.
- `bump-minor-pre-major: true` on both so the 0.x cadence stays MINOR-on-breaking while the surface stabilizes.
- Conventional-commit scopes (`feat(wasm):`, `feat(ffi):`, `feat(bindings):`) are already in active use; release-please will attribute commits to packages based on which `crates/<pkg>/` paths they touch, so scoped commits work without further config.

## Test plan
- [x] Manifest + config edited; existing `crates/elevator-core` row preserved verbatim
- [x] `cargo check --workspace` clean (pre-commit hook runs this)
- [x] `cargo fmt --check` clean
- [x] No CI surface changes; the workflow is unmodified