### PR TITLE
fix(examples): csharp harness for FFI ABI v4 (main is red)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "cbindgen",
  "elevator-core",

--- a/examples/csharp-harness/Program.cs
+++ b/examples/csharp-harness/Program.cs
@@ -116,22 +116,30 @@ internal static class Native
     public const byte EV_RIDER_EXITED = 8;
     public const byte EV_RIDER_ABANDONED = 9;
 
-    // Explicit layout so the 6 bytes of padding before `tick`
-    // (natural u64 alignment on the Rust #[repr(C)] side) are
-    // reserved here too, rather than relying on the CLR's default
-    // Sequential packing rules matching by coincidence across all
-    // three target ABIs.
-    [StructLayout(LayoutKind.Explicit, Size = 48)]
+    // Explicit layout mirrors the Rust #[repr(C)] EvEvent at ABI v4
+    // (80 bytes). The first 8 bytes pack four single-byte fields and
+    // a u32 group id; bytes 8..80 are eight u64/f64 slots in their
+    // natural order. Relying on the CLR's default Sequential packing
+    // could match by coincidence on one platform but skew on
+    // another, so explicit FieldOffsets are spelled out for every
+    // platform target.
+    [StructLayout(LayoutKind.Explicit, Size = 80)]
     public struct EvEvent
     {
         [FieldOffset(0)] public byte kind;
         [FieldOffset(1)] public sbyte direction;
-        // bytes 2..8 are padding (reserved for alignment)
+        [FieldOffset(2)] public byte code1;
+        [FieldOffset(3)] public byte code2;
+        [FieldOffset(4)] public uint group;
         [FieldOffset(8)] public ulong tick;
         [FieldOffset(16)] public ulong stop;
         [FieldOffset(24)] public ulong car;
         [FieldOffset(32)] public ulong rider;
         [FieldOffset(40)] public ulong floor;
+        [FieldOffset(48)] public ulong entity;
+        [FieldOffset(56)] public ulong count;
+        [FieldOffset(64)] public double f1;
+        [FieldOffset(72)] public double f2;
     }
 
     [DllImport(Lib)] public static extern uint ev_abi_version();
@@ -172,7 +180,7 @@ internal static class Native
 internal static class Program
 {
     private const int TICKS = 600;
-    private const uint EXPECTED_ABI = 2;
+    private const uint EXPECTED_ABI = 4;
 
     private static int Main(string[] args)
     {


### PR DESCRIPTION
## Summary

**Main has been red since #504 landed.** The FFI smoke test on every push to main has been failing with `ABI mismatch: harness expects 2, lib reports 4` because `examples/csharp-harness/Program.cs` was never updated past the v2 ABI it was originally written against. This PR brings the harness in sync with the v4 layout.

### Changes

1. `EXPECTED_ABI`: `2` → `4`.
2. `EvEvent` struct widened from 48 bytes to 80 bytes with explicit `FieldOffset` for every v4 slot:

```csharp
[StructLayout(LayoutKind.Explicit, Size = 80)]
public struct EvEvent
{
    [FieldOffset(0)]  public byte   kind;
    [FieldOffset(1)]  public sbyte  direction;
    [FieldOffset(2)]  public byte   code1;
    [FieldOffset(3)]  public byte   code2;
    [FieldOffset(4)]  public uint   group;
    [FieldOffset(8)]  public ulong  tick;
    [FieldOffset(16)] public ulong  stop;
    [FieldOffset(24)] public ulong  car;
    [FieldOffset(32)] public ulong  rider;
    [FieldOffset(40)] public ulong  floor;
    [FieldOffset(48)] public ulong  entity;
    [FieldOffset(56)] public ulong  count;
    [FieldOffset(64)] public double f1;
    [FieldOffset(72)] public double f2;
}
```

Mirrors the Rust `#[repr(C)]` `EvEvent` verbatim — first 8 bytes pack four single-byte fields and a u32 group id, then eight u64/f64 slots in their natural order.

### Why nobody caught this

The `ffi-harness` job is gated on `if: github.event_name == 'push'` (CI YAML), so it does **not** run on PR builds. PRs go green; only the post-merge run on main fails. The two ABI bumps (#499 and #504) each shipped without flagging this job because their authors never saw it run.

### Test plan
- [x] Built `elevator-ffi` release cdylib + harness locally
- [x] `dotnet run -c Release` against `assets/config/default.ron` reports `ABI version: 4` and completes the 600-tick run
- [x] Drained events count matches expected (12)

### Follow-up

Worth considering: enabling the FFI smoke test on PRs (it's currently push-only because it adds ~3 platforms × build time to PR CI). Cross-platform ABI struct layout drift is exactly the class of bug PR-time CI is supposed to catch. Out of scope for this PR.