### PR TITLE
ci: run FFI smoke test on PRs, not just push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,18 @@ jobs:
 
   ffi-harness:
     name: FFI smoke test (${{ matrix.os }})
-    # Cross-platform FFI builds are slow — only run after merge to main.
-    if: github.event_name == 'push'
+    # Runs on every push and every PR. The push-only gate that lived
+    # here previously let two ABI bumps (#499 v3, #504 v4) land
+    # without updating the C# harness, leaving main red for hours
+    # before #514 caught it. The cost is real (3 cross-platform
+    # cdylib builds + dotnet build) but cheaper than reverting a
+    # broken main; rust-cache amortizes the cdylib build to ~30 s
+    # warm. Skip on release-please PRs (machine-generated version
+    # bumps don't change the FFI surface).
+    if: |
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.user.login != 'release-kun[bot]' ||
+      !startsWith(github.event.pull_request.title, 'chore(main): release')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Removes the `if: github.event_name == 'push'` gate from the `ffi-harness` job so cross-platform ABI struct-layout checks run on every PR, not only after merge.

## Why

The previous gate was a cost optimization — it kept the 3-platform cdylib + dotnet build out of PR CI to save GitHub Actions minutes. That decision broke us today: #499 (ABI v3) and #504 (ABI v4) both landed without updating `examples/csharp-harness/Program.cs`. The first time anyone saw the failure was the post-merge run on main. Main was red on every push for hours until #514 noticed.

The trade-off:

| | Before | After |
|---|---|---|
| Per-PR cost (warm cache) | 0 min | ~30 s × 3 platforms (parallel) |
| Per-PR cost (cold cache) | 0 min | ~5 min × 3 platforms (parallel) |
| ABI drift detection | post-merge | pre-merge |
| Time main can stay red | hours | ~0 |

`rust-cache@v2` hits roughly daily, so warm-cache cost dominates in steady state. Cold cache builds run in parallel with the existing `Check` job, so PR wall-clock time is unchanged. Release-please PRs skip via the same predicate the other jobs already use.

## Items considered but skipped

- **Path-based gating** (only run when `crates/elevator-ffi/**` or `examples/csharp-harness/**` changes) — `pull_request.paths` filters at the workflow level, not per job. Doing it per job needs `dorny/paths-filter` action or a custom diff step. Worth doing if PR CI minutes become a real concern; not worth doing speculatively.
- **Add `keywords` / `categories` to elevator-ffi/wasm/gdext `Cargo.toml`** — Explorer agent flagged this but all three crates have `publish = false`, so the metadata is inert (crates.io never displays it). Pure cosmetic.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` passes on the modified workflow
- [x] Predicate matches the existing format used by `check`, `supply-chain`, `wasm-gate`, `msrv` — same anti-loop guard around release-please PRs
- [ ] CI run on this PR will verify the harness actually executes and stays green