### PR TITLE
fix(docs): un-mangle 8-phase mermaid diagram + lint the regression class

### DIFF
--- a/docs/src/simulation-loop.md
+++ b/docs/src/simulation-loop.md
@@ -7,13 +7,13 @@ Each call to `sim.step()` runs one simulation tick. A tick consists of eight pha
 ```mermaid
 flowchart TD
     STEP["sim.step()"] --> P1
-    P1["1. Advance Transient"] --> P2["2. Dispatch"]
-    P2 --> P3["3. Reposition"]
-    P3 --> P4["4. Advance Queue"]
-    P4 --> P5["5. Movement"]
-    P5 --> P6["6. Doors"]
-    P6 --> P7["7. Loading"]
-    P7 --> P8["8. Metrics"]
+    P1["Phase 1: Advance Transient"] --> P2["Phase 2: Dispatch"]
+    P2 --> P3["Phase 3: Reposition"]
+    P3 --> P4["Phase 4: Advance Queue"]
+    P4 --> P5["Phase 5: Movement"]
+    P5 --> P6["Phase 6: Doors"]
+    P6 --> P7["Phase 7: Loading"]
+    P7 --> P8["Phase 8: Metrics"]
     P8 --> ADV["advance_tick()
 flush events, tick += 1"]
 ```

--- a/scripts/lint-docs.sh
+++ b/scripts/lint-docs.sh
@@ -9,6 +9,10 @@
 #   5. No heading-level skips (e.g., ## then ####)
 #   6. No references to deleted files (old chapter names)
 #   7. Every chapter (except SUMMARY.md) has a "Next steps" section
+#   8. Mermaid node labels don't open with a markdown list/blockquote/heading
+#      marker -- mermaid renders those as the literal text
+#      "Unsupported markdown: list/blockquote/heading" instead of the
+#      intended label.
 #
 # Usage:
 #   scripts/lint-docs.sh          # run all checks
@@ -125,6 +129,25 @@ STALE_PATTERNS="\bapi-reference\.md\b|\bcore-concepts\.md\b|\bextensions-and-hoo
 while IFS=: read -r file line content; do
     err "$(basename "$file"):$line: stale reference: $content"
 done < <(grep -Pn "$STALE_PATTERNS" "$DOCS_SRC"/*.md 2>/dev/null || true)
+
+# ── 8. Mermaid label markdown-marker mangling ────────────────────
+# Inside ```mermaid fences, mermaid 10+/11 runs HTML-label text
+# through a markdown parser. A label that opens with `N.`, `N)`, `-`,
+# `*`, `+`, `>`, or `#` (each followed by a space) is interpreted as a
+# list/blockquote/heading and replaced with the literal text
+# "Unsupported markdown: list/blockquote/heading". Catch the family of
+# regressions before it hits the rendered docs.
+echo "checking mermaid node labels..."
+while IFS=: read -r file line content; do
+    err "$(basename "$file"):$line: mermaid label opens with a markdown marker (renders as 'Unsupported markdown: ...'): $content"
+done < <(awk '
+    FNR == 1                   { in_m=0 }
+    /^```mermaid[[:space:]]*$/ { in_m=1; next }
+    /^```/                     { in_m=0; next }
+    in_m && match($0, /"([0-9]+[.)]|[-*+]|>|#) /) {
+        printf "%s:%d:%s\n", FILENAME, FNR, $0
+    }
+' "$DOCS_SRC"/*.md)
 
 # ── Summary ──────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

- **Bug:** the 8-phase tick diagram in `simulation-loop.md` rendered as eight identical boxes saying *"Unsupported markdown: list"* on the published docs site. Mermaid 11 routes flowchart node labels through a markdown parser, and any label that opens with `N.`, `N)`, `-`, `*`, `+`, `>`, or `#` (each followed by a space) is replaced with literal `Unsupported markdown: <type>` text. Labels like `"1. Advance Transient"` therefore mangle.
- **Fix:** rename labels to `"Phase 1: Advance Transient"` … `"Phase 8: Metrics"`, matching the chapter's `## Phase N:` headings. The colon-after-word form is invisible to the markdown parser.
- **Regression guard:** new check #8 in `scripts/lint-docs.sh` flags any quoted label inside a ` ```mermaid ` fence that opens with one of the hazardous prefixes. The check is a fast `awk` regex — no Chromium / `mmdc` dep — and runs through the existing pre-commit hook (which already invokes `lint-docs.sh` when `docs/` files are staged).

The lint catches every member of the bug class, not just numbered lists:

| Prefix | Mermaid output |
|---|---|
| `1. ` / `1) ` | `Unsupported markdown: list` |
| `- ` / `* ` / `+ ` | `Unsupported markdown: list` |
| `> ` | `Unsupported markdown: blockquote` |
| `# ` | `Unsupported markdown: heading` |

Each was confirmed by rendering through `@mermaid-js/mermaid-cli` 11 and inspecting the resulting `<span class="nodeLabel">` text.

## Test plan

- [x] `bash scripts/lint-docs.sh --quick` passes against the fixed version
- [x] `bash scripts/lint-docs.sh` (with mdBook build) passes
- [x] Reverted the diagram fix locally and confirmed the lint reports `simulation-loop.md:10–16` with the offending content (correct file-relative line numbers via `FNR`, not cumulative `NR`)
- [x] Re-rendered the corrected diagram via `mmdc`; node labels now read `Phase 1: Advance Transient` … `Phase 8: Metrics` instead of the placeholder
- [x] Pre-commit hook ran fmt / clippy / core tests / doc tests / workspace check / docs lint cleanly