### PR TITLE
docs: replace fictional gameplay scenarios with real-world examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cbindgen",
  "elevator-core",

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -139,29 +139,32 @@ Advisory parameters for traffic generators. The core library does **not** spawn 
 | `mean_interval_ticks` | Average ticks between passenger spawns (Poisson distribution) |
 | `weight_range` | `(min, max)` for uniformly distributed rider weight |
 
-## The space elevator
+## Long shafts and arbitrary distances
 
-To demonstrate that stops are truly arbitrary, the repository includes `space_elevator.ron`:
+Stops carry arbitrary `f64` positions, so the same engine drives a five-floor office and a kilometres-deep mine. The example below treats one position unit as one metre -- the engine doesn't enforce a unit, so any internally-consistent convention works.
+
+A deep mine shaft is a useful stress test: real production hoists at sites like Mponeng run skips at 16-18 m/s over 2-3 km of vertical travel, with cage-loading dwell times measured in tens of seconds rather than the few seconds an office cab needs.
 
 ```ron
 SimConfig(
     building: BuildingConfig(
-        name: "Orbital Tether",
+        name: "Mine Shaft 1",
         stops: [
-            StopConfig(id: StopId(0), name: "Ground Station", position: 0.0),
-            StopConfig(id: StopId(1), name: "Orbital Platform", position: 1000.0),
+            StopConfig(id: StopId(0), name: "Surface",   position:     0.0),
+            StopConfig(id: StopId(1), name: "Mid-level", position: -1200.0),
+            StopConfig(id: StopId(2), name: "Bottom",    position: -2400.0),
         ],
     ),
     elevators: [
         ElevatorConfig(
             id: 0,
-            name: "Climber Alpha",
-            max_speed: 50.0,
-            acceleration: 10.0,
-            deceleration: 15.0,
-            weight_capacity: 10000.0,
+            name: "Cage A",
+            max_speed: 18.0,           // ~m/s, deep-shaft hoist class.
+            acceleration: 1.5,
+            deceleration: 2.5,
+            weight_capacity: 12000.0,  // miners + skip ore + tools.
             starting_stop: StopId(0),
-            door_open_ticks: 120,
+            door_open_ticks: 120,      // crew loading takes time.
             door_transition_ticks: 30,
         ),
     ],
@@ -169,7 +172,9 @@ SimConfig(
 )
 ```
 
-The stops are 1,000 distance units apart, the elevator has a max speed of 50, and the doors take twice as long to cycle. The same simulation engine handles both a 5-story office and an orbital tether.
+The stops sit 1,200 metres apart (under the metre convention chosen above), positions are negative (down from the surface datum), and the doors hold open six times longer than an office default. The same simulation engine handles both a five-story office and a 2.4 km mine shaft -- the only thing that changes is the config.
+
+The repository also bundles `assets/config/space_elevator.ron` -- two stops separated by 1,000 distance units (interpret the unit however you like) -- as a stress test for very high `max_speed` values and very long door cycles.
 
 ## Validation
 

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -1,6 +1,6 @@
 # Extensions
 
-The core library is deliberately unopinionated -- it provides riders, elevators, and stops, but your game decides what a rider *means*. Maybe riders have a VIP status, a mood, a destination preference, or a cargo manifest. Extensions let you layer game-specific data on top of any entity without forking or wrapping the library.
+The core library is deliberately unopinionated -- it provides riders, elevators, and stops, but caller code decides what a rider *means*. A rider could be a hotel guest with a priority class, an office tenant with a tenant id, a hospital patient with a transport type, or a freight crate with a manifest. Extensions let you layer caller-defined data on top of any entity without forking or wrapping the library.
 
 ## Extension components
 
@@ -14,9 +14,13 @@ Extension types must implement `Serialize` and `DeserializeOwned` (for snapshot 
 use serde::{Serialize, Deserialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct VipTag {
-    level: u32,
-    lounge_access: bool,
+struct GuestPriority {
+    /// 0 = standard guest, 1 = elite, 2 = top-tier suite.
+    priority_class: u8,
+    /// Floor where the guest's room lives. A custom dispatch
+    /// strategy can consult this to favour the express bank that
+    /// serves the high-floor suites.
+    suite_floor: u32,
 }
 ```
 
@@ -27,7 +31,7 @@ Call `.with_ext::<T>()` on the builder to register the extension type. The type 
 ```rust,no_run
 # use serde::{Serialize, Deserialize};
 # #[derive(Debug, Clone, Serialize, Deserialize)]
-# struct VipTag { level: u32, lounge_access: bool }
+# struct GuestPriority { priority_class: u8, suite_floor: u32 }
 use elevator_core::prelude::*;
 use elevator_core::config::ElevatorConfig;
 use elevator_core::stop::StopId;
@@ -37,7 +41,7 @@ fn main() -> Result<(), SimError> {
         .stop(StopId(0), "Ground", 0.0)
         .stop(StopId(1), "Top", 10.0)
         .elevator(ElevatorConfig::default())
-        .with_ext::<VipTag>()
+        .with_ext::<GuestPriority>()
         .build()?;
     Ok(())
 }
@@ -50,20 +54,20 @@ Use `world.insert_ext()` to attach your component to an entity:
 ```rust,no_run
 # use serde::{Serialize, Deserialize};
 # #[derive(Debug, Clone, Serialize, Deserialize)]
-# struct VipTag { level: u32, lounge_access: bool }
+# struct GuestPriority { priority_class: u8, suite_floor: u32 }
 # use elevator_core::prelude::*;
 # fn main() -> Result<(), SimError> {
 # let mut sim = SimulationBuilder::new()
 #     .stop(StopId(0), "Ground", 0.0)
 #     .stop(StopId(1), "Top", 10.0)
 #     .elevator(ElevatorConfig::default())
-#     .with_ext::<VipTag>()
+#     .with_ext::<GuestPriority>()
 #     .build()?;
 let rider_id = sim.spawn_rider(StopId(0), StopId(1), 75.0)?;
 
 sim.world_mut().insert_ext(
     rider_id.entity(),
-    VipTag { level: 3, lounge_access: true },
+    GuestPriority { priority_class: 2, suite_floor: 47 },
     ExtKey::from_type_name(),
 );
 # Ok(())
@@ -77,17 +81,17 @@ Use `world.ext()` for a cloned value, `world.ext_ref()` for a zero-copy borrow, 
 ```rust,no_run
 # use serde::{Serialize, Deserialize};
 # #[derive(Debug, Clone, Serialize, Deserialize)]
-# struct VipTag { level: u32, lounge_access: bool }
+# struct GuestPriority { priority_class: u8, suite_floor: u32 }
 # use elevator_core::prelude::*;
 # fn run(sim: &mut Simulation, rider_id: EntityId) {
 // Read (cloned)
-if let Some(vip) = sim.world().ext::<VipTag>(rider_id) {
-    println!("VIP level: {}", vip.level);
+if let Some(guest) = sim.world().ext::<GuestPriority>(rider_id) {
+    println!("priority class: {}", guest.priority_class);
 }
 
-// Mutate
-if let Some(vip) = sim.world_mut().ext_mut::<VipTag>(rider_id) {
-    vip.level += 1;
+// Mutate -- promote the guest's class.
+if let Some(guest) = sim.world_mut().ext_mut::<GuestPriority>(rider_id) {
+    guest.priority_class = guest.priority_class.saturating_add(1);
 }
 # }
 ```
@@ -99,18 +103,18 @@ Extensions integrate with the query builder for ECS-style iteration:
 ```rust,no_run
 # use serde::{Serialize, Deserialize};
 # #[derive(Debug, Clone, Serialize, Deserialize)]
-# struct VipTag { level: u32, lounge_access: bool }
+# struct GuestPriority { priority_class: u8, suite_floor: u32 }
 # use elevator_core::prelude::*;
 # use elevator_core::query::Ext;
 # fn run(world: &mut World) {
 // Read-only iteration (cloned via Ext<T>)
-for (id, vip) in world.query::<(EntityId, &Ext<VipTag>)>().iter() {
-    println!("{:?} is VIP level {}", id, vip.level);
+for (id, guest) in world.query::<(EntityId, &Ext<GuestPriority>)>().iter() {
+    println!("{:?} is priority class {}", id, guest.priority_class);
 }
 
-// Mutable access
-world.query_ext_mut::<VipTag>().for_each_mut(|id, tag| {
-    tag.level += 1;
+// Mutable access -- promote everyone by one class (with saturation).
+world.query_ext_mut::<GuestPriority>().for_each_mut(|_id, guest| {
+    guest.priority_class = guest.priority_class.saturating_add(1);
 });
 # }
 ```
@@ -139,14 +143,14 @@ if let Some(value) = sim.world_mut().resource_mut::<u32>() {
 # }
 ```
 
-Resources are useful for game state that hooks need to read or write -- score counters, time-of-day multipliers, spawn rate controllers, and so on.
+Resources are useful for caller-side state that hooks need to read or write -- a tick-of-day clock mirror, a peak-traffic multiplier, a spawn-rate controller, and so on.
 
 ## Extension vs. resource: which do I want?
 
 | Need | Use |
 |---|---|
-| Per-entity data that varies by rider/elevator (VIP status, mood, cargo) | **Extension** (`with_ext` + `insert_ext`) |
-| One-of value for the whole sim (score, difficulty, tick clock mirror) | **Resource** (`insert_resource`) |
+| Per-entity data that varies by rider/elevator (priority class, transport type, cargo manifest) | **Extension** (`with_ext` + `insert_ext`) |
+| One-of value for the whole sim (time-of-day, traffic profile, tick clock mirror) | **Resource** (`insert_resource`) |
 | Data that must survive snapshot save/load | **Extension** (registered by name; resources are not snapshotted) |
 | Quick scratchpad you can wipe between ticks | **Resource** |
 | Query "all entities that have X" | **Extension** (query or iterate + filter on `get_ext`) |
@@ -164,10 +168,10 @@ Extension components are serialized by their registered type name into the `Worl
 # use elevator_core::prelude::*;
 # use elevator_core::snapshot::WorldSnapshot;
 # use serde::{Serialize, Deserialize};
-# #[derive(Clone, Serialize, Deserialize)] struct VipTag { level: u32 }
+# #[derive(Clone, Serialize, Deserialize)] struct GuestPriority { priority_class: u8, suite_floor: u32 }
 # fn run(snapshot: WorldSnapshot) {
 let mut sim = snapshot.restore(None).unwrap();
-sim.world_mut().register_ext::<VipTag>(ExtKey::from_type_name());
+sim.world_mut().register_ext::<GuestPriority>(ExtKey::from_type_name());
 sim.load_extensions();
 # }
 ```

--- a/docs/src/hall-calls.md
+++ b/docs/src/hall-calls.md
@@ -45,27 +45,34 @@ Car calls follow the same pattern: `CarButtonPressed` fires on the first press p
 
 ## Scripted control
 
-Games can drive the call system outside the normal rider flow:
+Game and operator code can drive the call system outside the normal rider flow. A common case: a hospital service elevator has to be commandeered for a code blue -- pull the nearest service car to the ER for a priority pickup, override dispatch so this specific car (not whichever one dispatch would have chosen) answers that hall call, then release the override once the call is served.
 
 ```rust,no_run
 # use elevator_core::prelude::*;
 # use elevator_core::components::hall_call::CallDirection;
 # fn run(
 #     sim: &mut Simulation,
-#     lobby: StopId,
-#     penthouse: EntityId,
-#     villain_car: ElevatorId,
+#     er: EntityId,
+#     service_car: ElevatorId,
 # ) -> Result<(), SimError> {
-// An NPC walks up and presses the down button.
-sim.press_hall_button(lobby, CallDirection::Down)?;
+// Code blue: the transport team presses the up button at the ER.
+sim.press_hall_button(er, CallDirection::Up)?;
 
-// Cutscene pins the villain's elevator to the penthouse.
-sim.pin_assignment(villain_car, penthouse, CallDirection::Up)?;
+// Pin the priority car to that specific (stop, direction) call so
+// dispatch commits it to the ER pickup instead of whatever it would
+// have chosen on its own.
+sim.pin_assignment(service_car, er, CallDirection::Up)?;
 
-// Player hijacks -- release the pin and hard-abort the car's trip so
-// it brakes immediately instead of finishing the current leg.
-sim.unpin_assignment(penthouse, CallDirection::Up);
-sim.abort_movement(villain_car)?;
+// The car was mid-route on a routine call -- abort it so the car
+// brakes immediately instead of finishing that leg before serving
+// the priority transport.
+sim.abort_movement(service_car)?;
+
+// The patient boards at the ER and rides to the ICU via the normal
+// car-call path -- the destination is set when the rider boards, not
+// by the pin. Once the hall call has been served, release the pin so
+// the car returns to the general dispatch pool.
+sim.unpin_assignment(er, CallDirection::Up);
 # Ok(())
 # }
 ```

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -13,9 +13,9 @@
 
 ## What can you build?
 
-The library models **stops at arbitrary distances** along a shaft axis, not uniform floors. That means you can simulate a 5-story office building where each floor is 4 meters apart, a 160-story skyscraper with sky lobbies and express zones, or -- why not -- a **space elevator** climbing 1,000 km from a ground station to an orbital platform. The `space_elevator.ron` config included in the repo does exactly that.
+The library models **stops at arbitrary distances** along a shaft axis, not uniform floors. That means you can simulate a 5-story office where each floor is 4 metres apart, a 160-story skyscraper with sky lobbies and express zones, or a 2.4 km mine shaft where a single hoist serves the surface, a mid-level, and the working face. The engine doesn't enforce any particular unit -- positions are plain `f64` values, and the bundled `assets/config/space_elevator.ron` stretches that to 1,000 distance units between two stops as an upper-bound stress test.
 
-The core crate provides primitives, not opinions. Riders are generic entities that ride elevators. Your game decides whether they are office workers, hotel guests, cargo pallets, or astronauts. You attach semantics through the [extension storage system](extensions.md), and the simulation handles the physics and logistics.
+The core crate provides primitives, not opinions. Riders are generic entities that ride elevators. Caller code decides whether they are office tenants, hotel guests, hospital patients, miners, or freight pallets. You attach semantics through the [extension storage system](extensions.md), and the simulation handles the physics and logistics.
 
 ## What elevator-core is *not*
 

--- a/docs/src/lifecycle-hooks.md
+++ b/docs/src/lifecycle-hooks.md
@@ -122,9 +122,9 @@ The `before(Phase::Dispatch)` slot is a particularly convenient place to inject 
 
 ## Combining extensions and hooks: worked example
 
-The real power comes from using extensions and hooks together. This walkthrough tracks how long each rider has been waiting and prints a warning if they wait too long.
+A facilities team monitoring an office tower wants to know whenever a tenant has been waiting for an elevator for more than 90 seconds during peak traffic -- it is a service-level indicator and feeds an end-of-day report. This walkthrough flags each over-budget wait exactly once via a `SlaBreach` extension component plus an `after(Phase::Metrics)` hook.
 
-The hook closure cannot call `sim.current_tick()` directly (the simulation is borrowed during the tick), so we store the tick in a `World` resource and update it each iteration.
+The hook closure cannot call `sim.current_tick()` directly (the simulation is borrowed during the tick), so the tick is mirrored into a `World` resource that the hook reads.
 
 ```rust,no_run
 use elevator_core::prelude::*;
@@ -133,10 +133,15 @@ use elevator_core::hooks::Phase;
 use elevator_core::stop::StopId;
 use serde::{Serialize, Deserialize};
 
+/// Per-rider flag that latches the first time a tenant breaches the
+/// 90-second SLA so we report each wait at most once.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct WaitWarning {
-    warned: bool,
+struct SlaBreach {
+    reported: bool,
 }
+
+// 60 ticks/sec * 90 sec = 5_400 ticks.
+const SLA_BUDGET_TICKS: u64 = 5_400;
 
 fn main() -> Result<(), SimError> {
     let mut sim = SimulationBuilder::new()
@@ -144,9 +149,9 @@ fn main() -> Result<(), SimError> {
         .stop(StopId(1), "Floor 2", 4.0)
         .stop(StopId(2), "Floor 3", 8.0)
         .elevator(ElevatorConfig { starting_stop: StopId(0), ..Default::default() })
-        .with_ext::<WaitWarning>()
+        .with_ext::<SlaBreach>()
         .after(Phase::Metrics, |world| {
-            // Check all waiting riders for long waits.
+            // Scan every rider; flag the first time they cross the SLA budget.
             let rider_ids: Vec<EntityId> = world.rider_ids();
             for rid in rider_ids {
                 let Some(rider) = world.rider(rid) else { continue };
@@ -156,11 +161,14 @@ fn main() -> Result<(), SimError> {
                     .map_or(0, |t| t.0);
                 let wait = current_tick.saturating_sub(rider.spawn_tick());
 
-                if wait > 300 {
-                    if let Some(warning) = world.ext_mut::<WaitWarning>(rid) {
-                        if !warning.warned {
-                            warning.warned = true;
-                            println!("WARNING: rider {:?} has been waiting {} ticks!", rid, wait);
+                if wait > SLA_BUDGET_TICKS {
+                    if let Some(breach) = world.ext_mut::<SlaBreach>(rid) {
+                        if !breach.reported {
+                            breach.reported = true;
+                            println!(
+                                "SLA breach: rider {:?} waited {} ticks (>{} budget)",
+                                rid, wait, SLA_BUDGET_TICKS,
+                            );
                         }
                     }
                 }
@@ -171,12 +179,12 @@ fn main() -> Result<(), SimError> {
     // Seed the resource the hook reads.
     sim.world_mut().insert_resource(CurrentTick(0));
 
-    // Spawn some riders and attach extensions.
+    // Spawn a tenant and attach the SLA tracker.
     let r1 = sim.spawn_rider(StopId(0), StopId(2), 75.0)?;
-    sim.world_mut().insert_ext(r1.entity(), WaitWarning { warned: false }, ExtKey::from_type_name());
+    sim.world_mut().insert_ext(r1.entity(), SlaBreach { reported: false }, ExtKey::from_type_name());
 
-    for _ in 0..600 {
-        // Update the current tick resource before stepping.
+    for _ in 0..6_000 {
+        // Mirror the current tick into the resource before stepping.
         let now = sim.current_tick();
         if let Some(t) = sim.world_mut().resource_mut::<CurrentTick>() {
             t.0 = now;
@@ -190,7 +198,7 @@ fn main() -> Result<(), SimError> {
 struct CurrentTick(u64);
 ```
 
-This pattern -- define a component, register it, attach it on spawn, read/write it in a hook -- is the standard way to add game-specific behavior to the simulation.
+This pattern -- define a component, register it, attach it on spawn, read/write it in a hook -- is the standard way to layer caller-defined behaviour on top of the simulation.
 
 ## Next steps
 

--- a/docs/src/manual-inspection-modes.md
+++ b/docs/src/manual-inspection-modes.md
@@ -104,7 +104,7 @@ Run it with `cargo run -p elevator-core --example manual_driver`.
 
 Inspection mode reduces the elevator's speed by its `inspection_speed_factor` (default: 0.25, configurable per elevator). Doors hold open indefinitely rather than auto-cycling. The elevator still participates in dispatch -- it just moves slowly.
 
-This mode is useful for maintenance scenarios or UI elements that let a building manager "ride along" at reduced speed.
+This mode is useful for maintenance walk-throughs and operator-driven inspection runs -- the cab moves slowly enough for a technician to listen for anomalies along the shaft, and the doors stay open at each stop until the operator dismisses them.
 
 ```rust,no_run
 # use elevator_core::prelude::*;

--- a/docs/src/rider-lifecycle.md
+++ b/docs/src/rider-lifecycle.md
@@ -1,6 +1,6 @@
 # Rider Lifecycle
 
-Riders are the demand side of the simulation. A rider is anything that rides an elevator -- the library assigns no semantics beyond that. Games add meaning (passengers, NPCs, cargo) via [extension storage](extensions.md). This chapter covers the full lifecycle, patience and preferences, access control, and population tracking.
+Riders are the demand side of the simulation. A rider is anything that rides an elevator -- the library assigns no semantics beyond that. Caller code adds meaning (office tenants, hotel guests, freight crates) via [extension storage](extensions.md). This chapter covers the full lifecycle, patience and preferences, access control, and population tracking.
 
 ## Phase diagram
 
@@ -36,9 +36,9 @@ stateDiagram-v2
 | `Riding` | Inside the elevator | Loading phase exits the rider when the elevator arrives at their destination |
 | `Exiting` | Leaving the elevator | AdvanceTransient: becomes `Arrived` (route complete), or `Walking` (multi-leg) |
 | `Walking` | Transferring between stops | Teleported immediately to the next leg's origin, then becomes `Waiting` |
-| `Arrived` | At final destination | Your game decides: `settle_rider()`, `despawn_rider()`, or leave in place |
-| `Abandoned` | Left the queue at a stop | Patience ran out or `abandon_on_full` triggered; your game can settle or despawn |
-| `Resident` | Parked at a stop, not seeking an elevator | Your game called `settle_rider()` on an Arrived or Abandoned rider |
+| `Arrived` | At final destination | Caller decides: `settle_rider()`, `despawn_rider()`, or leave in place |
+| `Abandoned` | Left the queue at a stop | Patience ran out or `abandon_on_full` triggered; caller can settle or despawn |
+| `Resident` | Parked at a stop, not seeking an elevator | Caller invoked `settle_rider()` on an Arrived or Abandoned rider |
 
 Each transition emits an event: `RiderSpawned`, `RiderBoarded`, `RiderExited`, `RiderAbandoned`, `RiderSettled`, `RiderRerouted`, `RiderDespawned`.
 
@@ -95,7 +95,7 @@ let rider = sim.build_rider(StopId(0), StopId(2))
     .unwrap();
 ```
 
-When `skip_full_elevator` is true and the load exceeds `max_crowding_factor`, the rider silently skips the car. A `RiderSkipped` event fires so game UI can animate the reaction. The rider remains `Waiting` for the next car -- unless `abandon_on_full` escalates it to `Abandoned`.
+When `skip_full_elevator` is true and the load exceeds `max_crowding_factor`, the rider silently skips the car. A `RiderSkipped` event fires so caller code or UI can react. The rider remains `Waiting` for the next car -- unless `abandon_on_full` escalates it to `Abandoned`.
 
 ## Access control
 
@@ -118,11 +118,11 @@ let rider = sim.build_rider(StopId(0), StopId(1))
 
 ## Managing arrived riders
 
-Once a rider reaches `Arrived` or `Abandoned`, the simulation stops managing them. Your game code decides what happens next using three methods:
+Once a rider reaches `Arrived` or `Abandoned`, the simulation stops managing them. Caller code decides what happens next using three methods:
 
-**`sim.settle_rider(id)`** -- transitions an `Arrived` or `Abandoned` rider to `Resident`. Residents are parked at a stop, tracked by the population index, and invisible to dispatch. Use this for NPCs that "live" on a floor.
+**`sim.settle_rider(id)`** -- transitions an `Arrived` or `Abandoned` rider to `Resident`. Residents are parked at a stop, tracked by the population index, and invisible to dispatch. Use this for occupants who live or work on a floor between elevator trips: a tenant in their office, a hotel guest in their room, a patient on a ward.
 
-**`sim.reroute_rider(id, route)`** -- sends a `Resident` rider back to `Waiting` with a new multi-leg route. Use this when a settled NPC needs to go somewhere.
+**`sim.reroute_rider(id, route)`** -- sends a `Resident` rider back to `Waiting` with a new multi-leg route. Use this when a settled occupant has a new destination -- a tenant heading to lunch, a guest checking out.
 
 **`sim.reroute(id, new_destination)`** -- changes a `Waiting` rider's destination. The rider stays at their stop and waits for an elevator serving the new route. Useful for mid-wait plan changes.
 
@@ -133,11 +133,12 @@ Once a rider reaches `Arrived` or `Abandoned`, the simulation stops managing the
 # let mut sim: Simulation = todo!();
 # let rider: RiderId = todo!();
 # let new_route: Route = todo!();
-// Rider arrived at their floor -- settle them as a resident.
+// Tenant arrived at their floor -- settle them so they hold position
+// at the stop without re-entering the dispatch queue.
 sim.settle_rider(rider).unwrap();
 
-// Later, the resident wants to go somewhere else.
-// reroute_rider takes a full Route and works on Resident riders.
+// Later, the same tenant heads back down. reroute_rider takes a full
+// Route and only works on Resident riders.
 sim.reroute_rider(rider.entity(), new_route).unwrap();
 ```
 
@@ -153,10 +154,10 @@ The simulation maintains a reverse index (`RiderIndex`) for O(1) per-stop popula
 
 Each returns an iterator of `EntityId` values. Use `.count()` for totals or `.collect::<Vec<_>>()` to materialize.
 
-These queries are useful for game logic (spawn limits, crowd visualization), dispatch strategies (demand weighting), and analytics (per-floor breakdowns).
+These queries are useful for caller-side logic (spawn limits, crowd visualisation), dispatch strategies (demand weighting), and analytics (per-floor breakdowns).
 
 ## Next steps
 
 - [Door Control](door-control.md) -- understand when riders can board and exit
 - [Events and Metrics](events-metrics.md) -- track rider events and aggregate wait/ride times
-- [Extensions](extensions.md) -- attach game-specific data to riders
+- [Extensions](extensions.md) -- attach caller-defined data to riders


### PR DESCRIPTION
## Summary

Sweeps the mdBook chapters for game-fiction framings that crept in during early authoring and replaces them with grounded scenarios drawn from real building domains (office, hotel, hospital, mine).

**Tone rule applied throughout:** keep `your game can …` only where the feature itself is game-specific (scripted hall presses, pinning, manual mode). Use operational language (`caller`, `your code`) elsewhere so the docs read as engineering library documentation when game-fiction adds nothing.

## Per-chapter changes

| Chapter | Before | After |
|---|---|---|
| `hall-calls.md` Scripted control | villain's elevator + cutscene + player hijacks | hospital code-blue: pin a service car ER → ICU and abort current trip |
| `rider-lifecycle.md` Resident phase | "NPCs that 'live' on a floor" | building occupants — tenant in office, guest in hotel, patient on ward |
| `extensions.md` worked example | `VipTag { level: u32, lounge_access: bool }` | `GuestPriority { priority_class: u8, suite_floor: u32 }` |
| `configuration.md` § The space elevator | Orbital tether / Climber Alpha at 1,000 distance units | Deep mine shaft (Surface 0 / Mid -1,200m / Bottom -2,400m) at ~18 m/s, Mponeng-class |
| `introduction.md` hook | "or — why not — a space elevator climbing 1,000 km" | "a 2.4 km mine shaft" with a parenthetical pointer to `space_elevator.ron` for the upper bound |
| `manual-inspection-modes.md` | building manager "ride along" | maintenance walk-throughs and operator-driven inspection runs |
| `lifecycle-hooks.md` worked example | generic 300-tick `WaitWarning` | office facilities 90-second SLA monitor, `SlaBreach`, `SLA_BUDGET_TICKS = 5_400` constant with seconds-to-ticks math |

The hospital code-blue snippet exercises the same API surface as the original villain example (`press_hall_button` → `pin_assignment` → `abort_movement` → `unpin_assignment`) so the educational shape is preserved; only the motivation changed.

The actual `assets/config/space_elevator.ron` file is left as-is — it's a real bundled artifact referenced by examples, tests, and CLAUDE.md. The docs reframe it as "an even more extreme stress-test config" rather than the canonical "arbitrary distance" example.

## Cargo.lock

`elevator-ffi 0.10.1 → 0.10.2` is included to resolve existing drift on `main` between `Cargo.toml` (bumped to `0.10.2` in release commit `be257ba`) and `Cargo.lock` (still at `0.10.1`). The pre-commit drift guard catches this.

## Test plan

- [x] `bash scripts/lint-docs.sh` (full mode, includes mdBook build) passes
- [x] `cargo test --doc -p elevator-core` — 159 passing
- [x] Pre-commit hook (fmt, clippy, core tests, doc tests, workspace check, docs lint) clean
- [x] Spot-checked: every renamed identifier (`VipTag` → `GuestPriority`, `WaitWarning` → `SlaBreach`, `villain_car` → `service_car`, etc.) consistent across struct definitions, hidden doctest blocks, and prose
- [x] Mermaid lint from PR #518 still passes (no diagrams touched here)