### PR TITLE
feat(tui): add terminal UI debugger crate (skeleton)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "alsa"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,10 +1842,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cbindgen"
@@ -1955,6 +1976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -1967,6 +1989,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1992,7 +2026,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2012,6 +2046,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,6 +2067,17 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
  "portable-atomic",
+]
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2316,6 +2375,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,6 +2421,40 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "dasp_sample"
@@ -2502,6 +2620,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "elevator-tui"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "crossterm",
+ "elevator-core",
+ "insta",
+ "ratatui",
+ "ron",
+ "serde",
+ "serde_json",
+ "slotmap",
+]
+
+[[package]]
 name = "elevator-wasm"
 version = "0.3.0"
 dependencies = [
@@ -2556,6 +2690,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -3127,6 +3267,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -3209,6 +3351,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3234,6 +3382,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inotify"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3251,6 +3408,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3521,6 +3703,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3591,6 +3782,18 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4579,6 +4782,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.11.1",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4789,6 +5013,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4930,6 +5160,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4950,6 +5211,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "skrifa"
@@ -5089,6 +5356,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "svg_fmt"
@@ -5512,10 +5801,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-truncate"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -5598,6 +5904,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/elevator-bevy",
     "crates/elevator-ffi",
     "crates/elevator-gdext",
+    "crates/elevator-tui",
     "crates/elevator-wasm",
 ]
 default-members = ["crates/elevator-bevy"]

--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ cargo run                                       # default 5-stop building
 cargo run -- assets/config/space_elevator.ron    # 1,000 km orbital tether
 ```
 
+## TUI debugger
+
+For tick-by-tick debugging or headless smoke runs, the workspace also ships [`elevator-tui`](crates/elevator-tui) — a terminal viewer with pause/step controls, event log, dispatch summary, and snapshot save/load on a hotkey. See the [TUI Debugger guide](https://andymai.github.io/elevator-core/tui-debugger.html).
+
+```sh
+cargo run -p elevator-tui -- assets/config/default.ron                    # interactive
+cargo run -p elevator-tui -- assets/config/default.ron --headless --until 5000  # CI smoke
+```
+
 ## Feature flags
 
 | Flag | Default | Adds |

--- a/bindings.toml
+++ b/bindings.toml
@@ -14,14 +14,19 @@
 #   category  = "<category>"           # required — see `[categories]` below
 #   wasm      = "<status>"             # required — see status values
 #   ffi       = "<status>"             # required — see status values
+#   tui       = "<status>"             # required — see status values
 #
 # Status values
 # -------------
-#   "<exported>"        — the method is exposed under this exported name
-#                         (e.g. "stepMany" for wasm, "ev_sim_step" for ffi)
+#   "<exported>"        — the method is exposed under this exported name.
+#                         For wasm/ffi this is the binding name (e.g.
+#                         "stepMany", "ev_sim_step"). For tui this is
+#                         the user-facing capability that uses it (e.g.
+#                         "events_panel", "metrics_panel").
 #   "skip:<reason>"     — intentionally not bound. Reason is mandatory and
 #                         must explain *why* (lifetimes, internal detail,
-#                         covered by another binding, etc.)
+#                         covered by another binding, read-only viewer,
+#                         etc.)
 #   "todo:<phase>"      — planned for binding in the named phase. Allowed
 #                         during phased rollout; CI emits a warning, not
 #                         an error. Once `phase` ships the entry must
@@ -35,6 +40,10 @@
 #   PR-E   Wasm error-rewrite + log callback + metrics + tagging
 #   PR-F   Persistence — snapshot bytes/JSON, seed control
 #   PR-G   AsyncIterator event stream
+#
+# TUI phase markers
+# -----------------
+#   tui-pr2  Polish wave: snapshot save/load, sparklines, per-car drill-down
 
 [categories]
 lifecycle     = "Construction, ticking"
@@ -60,24 +69,28 @@ name = "new"
 category = "lifecycle"
 wasm = "constructor"
 ffi  = "ev_sim_create"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "step"
 category = "lifecycle"
 wasm = "stepMany"  # exposes batched step, internally calls step in loop
 ffi  = "ev_sim_step"
+tui  = "auto_tick_or_dot_hotkey"
 
 [[methods]]
 name = "advance_tick"
 category = "lifecycle"
 wasm = "skip:internal — driven by step()"
 ffi  = "skip:internal — driven by step()"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "run_until_quiet"
 category = "lifecycle"
 wasm = "runUntilQuiet"
 ffi  = "ev_sim_run_until_quiet"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 # ─── Substep / phase-by-phase ticking ─────────────────────────────────────
 # Internal — exposing these would let consumers run an out-of-order tick
@@ -88,48 +101,56 @@ name = "run_advance_transient"
 category = "internal"
 wasm = "skip:internal — phase ordering invariant"
 ffi  = "skip:internal — phase ordering invariant"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "run_dispatch"
 category = "internal"
 wasm = "skip:internal — phase ordering invariant"
 ffi  = "skip:internal — phase ordering invariant"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "run_advance_queue"
 category = "internal"
 wasm = "skip:internal — phase ordering invariant"
 ffi  = "skip:internal — phase ordering invariant"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "run_doors"
 category = "internal"
 wasm = "skip:internal — phase ordering invariant"
 ffi  = "skip:internal — phase ordering invariant"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "run_loading"
 category = "internal"
 wasm = "skip:internal — phase ordering invariant"
 ffi  = "skip:internal — phase ordering invariant"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "run_metrics"
 category = "internal"
 wasm = "skip:internal — phase ordering invariant"
 ffi  = "skip:internal — phase ordering invariant"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "run_movement"
 category = "internal"
 wasm = "skip:internal — phase ordering invariant"
 ffi  = "skip:internal — phase ordering invariant"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "run_reposition"
 category = "internal"
 wasm = "skip:internal — phase ordering invariant"
 ffi  = "skip:internal — phase ordering invariant"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 # ─── Modes (the original concern: \"emergency stop doesn't work\") ────────
 
@@ -138,48 +159,56 @@ name = "set_service_mode"
 category = "modes"
 wasm = "setServiceMode"
 ffi  = "ev_sim_set_service_mode"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "service_mode"
 category = "modes"
 wasm = "serviceMode"
 ffi  = "ev_sim_service_mode"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "set_target_velocity"
 category = "modes"
 wasm = "setTargetVelocity"
 ffi  = "ev_sim_set_target_velocity"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "emergency_stop"
 category = "modes"
 wasm = "emergencyStop"
 ffi  = "ev_sim_emergency_stop"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "open_door"
 category = "modes"
 wasm = "openDoor"
 ffi  = "ev_sim_open_door"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "close_door"
 category = "modes"
 wasm = "closeDoor"
 ffi  = "ev_sim_close_door"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "hold_door"
 category = "modes"
 wasm = "holdDoor"
 ffi  = "ev_sim_hold_door"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "cancel_door_hold"
 category = "modes"
 wasm = "cancelDoorHold"
 ffi  = "ev_sim_cancel_door_hold"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 # ─── Dispatch ─────────────────────────────────────────────────────────────
 
@@ -188,84 +217,98 @@ name = "set_dispatch"
 category = "dispatch"
 wasm = "setStrategy"
 ffi  = "ev_sim_set_strategy"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "strategy_id"
 category = "dispatch"
 wasm = "strategyName"
 ffi  = "ev_sim_strategy_id"
+tui  = "dispatch_panel"
 
 [[methods]]
 name = "set_reposition"
 category = "dispatch"
 wasm = "setReposition"
 ffi  = "ev_sim_set_reposition"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "remove_reposition"
 category = "dispatch"
 wasm = "removeReposition"
 ffi  = "ev_sim_remove_reposition"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "reposition_id"
 category = "dispatch"
 wasm = "repositionStrategyName"
 ffi  = "ev_sim_reposition_id"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "build_dispatch_manifest"
 category = "internal"
 wasm = "skip:internal — strategies consume this"
 ffi  = "skip:internal — strategies consume this"
+tui  = "dispatch_panel"
 
 [[methods]]
 name = "peek_dispatch_manifest"
 category = "internal"
 wasm = "skip:internal — strategies consume this"
 ffi  = "skip:internal — strategies consume this"
+tui  = "dispatch_panel"
 
 [[methods]]
 name = "pin_assignment"
 category = "dispatch"
 wasm = "pinAssignment"
 ffi  = "ev_sim_pin_assignment"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "unpin_assignment"
 category = "dispatch"
 wasm = "unpinAssignment"
 ffi  = "ev_sim_unpin_assignment"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "assigned_car"
 category = "dispatch"
 wasm = "assignedCar"
 ffi  = "ev_sim_assigned_car"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "assigned_cars_by_line"
 category = "dispatch"
 wasm = "assignedCarsByLine"
 ffi  = "ev_sim_assigned_cars_by_line"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "best_eta"
 category = "dispatch"
 wasm = "bestEta"
 ffi  = "ev_sim_best_eta"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "eta_for_call"
 category = "dispatch"
 wasm = "etaForCall"
 ffi  = "ev_sim_eta_for_call"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "eta"
 category = "dispatch"
 wasm = "eta"
 ffi  = "ev_sim_eta"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 # ─── Buttons ──────────────────────────────────────────────────────────────
 
@@ -274,24 +317,28 @@ name = "press_hall_button"
 category = "buttons"
 wasm = "pressHallCall"
 ffi  = "ev_sim_press_hall_button"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "press_car_button"
 category = "buttons"
 wasm = "pressCarButton"
 ffi  = "ev_sim_press_car_button"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "hall_calls"
 category = "buttons"
 wasm = "hallCalls"
 ffi  = "ev_sim_hall_calls_snapshot"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "car_calls"
 category = "buttons"
 wasm = "carCalls"
 ffi  = "ev_sim_car_calls_snapshot"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 # ─── Events ───────────────────────────────────────────────────────────────
 
@@ -300,18 +347,21 @@ name = "drain_events"
 category = "events"
 wasm = "drainEvents"
 ffi  = "ev_sim_drain_events"
+tui  = "events_panel"
 
 [[methods]]
 name = "drain_events_where"
 category = "events"
 wasm = "skip:closure marshaling — JS consumers filter drainEvents() output client-side"
 ffi  = "skip:closure marshaling — C consumers filter drain_events output"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "pending_events"
 category = "events"
 wasm = "pendingEvents"
 ffi  = "ev_sim_pending_event_count"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 # ─── Riders ───────────────────────────────────────────────────────────────
 
@@ -320,24 +370,28 @@ name = "spawn_rider"
 category = "riders"
 wasm = "spawnRider"
 ffi  = "ev_sim_spawn_rider"
+tui  = "headless_poisson_traffic"
 
 [[methods]]
 name = "build_rider"
 category = "riders"
 wasm = "spawnRiderByRef"
 ffi  = "ev_sim_spawn_rider_ex"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "despawn_rider"
 category = "riders"
 wasm = "despawnRider"
 ffi  = "ev_sim_despawn_rider"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "settle_rider"
 category = "riders"
 wasm = "settleRider"
 ffi  = "ev_sim_settle_rider"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 # ─── Routes ───────────────────────────────────────────────────────────────
 
@@ -346,6 +400,7 @@ name = "reroute"
 category = "routes"
 wasm = "reroute"
 ffi  = "ev_sim_reroute"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "reroute_rider"
@@ -355,6 +410,7 @@ category = "routes"
 # group) ships alongside as `rerouteRiderDirect` / `ev_sim_reroute_rider_direct`.
 wasm = "rerouteRiderShortest"
 ffi  = "ev_sim_reroute_rider_shortest"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "set_rider_route"
@@ -362,30 +418,35 @@ category = "routes"
 # Two convenience overloads per binding. See `reroute_rider` above.
 wasm = "setRiderRouteShortest"
 ffi  = "ev_sim_set_rider_route_shortest"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "set_rider_access"
 category = "routes"
 wasm = "setRiderAccess"
 ffi  = "ev_sim_set_rider_access"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "shortest_route"
 category = "routes"
 wasm = "shortestRoute"
 ffi  = "ev_sim_shortest_route"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "transfer_points"
 category = "routes"
 wasm = "transferPoints"
 ffi  = "ev_sim_transfer_points"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "reachable_stops_from"
 category = "routes"
 wasm = "reachableStopsFrom"
 ffi  = "ev_sim_reachable_stops_from"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 # ─── Topology ─────────────────────────────────────────────────────────────
 
@@ -394,78 +455,91 @@ name = "add_group"
 category = "topology"
 wasm = "addGroup"
 ffi  = "ev_sim_add_group"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "add_line"
 category = "topology"
 wasm = "addLine"
 ffi  = "ev_sim_add_line"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "add_stop"
 category = "topology"
 wasm = "addStop"
 ffi  = "ev_sim_add_stop"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "add_stop_to_line"
 category = "topology"
 wasm = "addStopToLine"
 ffi  = "ev_sim_add_stop_to_line"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "add_elevator"
 category = "topology"
 wasm = "addElevator"
 ffi  = "ev_sim_add_elevator"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "remove_elevator"
 category = "topology"
 wasm = "removeElevator"
 ffi  = "ev_sim_remove_elevator"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "remove_line"
 category = "topology"
 wasm = "removeLine"
 ffi  = "ev_sim_remove_line"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "remove_stop"
 category = "topology"
 wasm = "removeStop"
 ffi  = "ev_sim_remove_stop"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "remove_stop_from_line"
 category = "topology"
 wasm = "removeStopFromLine"
 ffi  = "ev_sim_remove_stop_from_line"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "set_line_range"
 category = "topology"
 wasm = "setLineRange"
 ffi  = "ev_sim_set_line_range"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "assign_line_to_group"
 category = "topology"
 wasm = "assignLineToGroup"
 ffi  = "ev_sim_assign_line_to_group"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "reassign_elevator_to_line"
 category = "topology"
 wasm = "reassignElevatorToLine"
 ffi  = "ev_sim_reassign_elevator_to_line"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "set_elevator_restricted_stops"
 category = "topology"
 wasm = "setElevatorRestrictedStops"
 ffi  = "ev_sim_set_elevator_restricted_stops"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 # ─── Introspection ────────────────────────────────────────────────────────
 
@@ -474,270 +548,315 @@ name = "current_tick"
 category = "introspection"
 wasm = "currentTick"
 ffi  = "ev_sim_current_tick"
+tui  = "title_bar"
 
 [[methods]]
 name = "dt"
 category = "introspection"
 wasm = "dt"
 ffi  = "ev_sim_dt"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "metrics"
 category = "metrics"
 wasm = "metrics"
 ffi  = "ev_sim_metrics"
+tui  = "metrics_panel"
 
 [[methods]]
 name = "time"
 category = "internal"
 wasm = "skip:returns &TimeAdapter — internal layout"
 ffi  = "skip:returns &TimeAdapter — internal layout"
+tui  = "tick_rate_calc"
 
 [[methods]]
 name = "events_mut"
 category = "internal"
 wasm = "skip:returns &mut EventBus — never bound"
 ffi  = "skip:returns &mut EventBus — never bound"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "metrics_mut"
 category = "internal"
 wasm = "skip:returns &mut Metrics — never bound"
 ffi  = "skip:returns &mut Metrics — never bound"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "phase_context"
 category = "internal"
 wasm = "skip:returns PhaseContext — internal scheduling helper"
 ffi  = "skip:returns PhaseContext — internal scheduling helper"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "elevators_on_line"
 category = "introspection"
 wasm = "elevatorsOnLine"
 ffi  = "ev_sim_elevators_on_line"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "groups_serving_stop"
 category = "introspection"
 wasm = "groupsServingStop"
 ffi  = "ev_sim_groups_serving_stop"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "lines_in_group"
 category = "introspection"
 wasm = "linesInGroup"
 ffi  = "ev_sim_lines_in_group"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "lines_serving_stop"
 category = "introspection"
 wasm = "linesServingStop"
 ffi  = "ev_sim_lines_serving_stop"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "stops_served_by_line"
 category = "introspection"
 wasm = "stopsServedByLine"
 ffi  = "ev_sim_stops_served_by_line"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "line_for_elevator"
 category = "introspection"
 wasm = "lineForElevator"
 ffi  = "ev_sim_line_for_elevator"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "all_lines"
 category = "introspection"
 wasm = "allLines"
 ffi  = "ev_sim_all_lines"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "line_count"
 category = "introspection"
 wasm = "lineCount"
 ffi  = "ev_sim_line_count"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "stop_lookup_iter"
 category = "introspection"
 wasm = "stopLookupIter"
 ffi  = "ev_sim_stop_lookup_iter"
+tui  = "shaft_view"
 
 [[methods]]
 name = "stop_entity"
 category = "introspection"
 wasm = "stopEntity"
 ffi  = "ev_sim_stop_entity"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "find_stop_at_position_on_line"
 category = "introspection"
 wasm = "findStopAtPositionOnLine"
 ffi  = "ev_sim_find_stop_at_position_on_line"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "velocity"
 category = "introspection"
 wasm = "velocity"
 ffi  = "ev_sim_velocity"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "position_at"
 category = "introspection"
 wasm = "positionAt"
 ffi  = "ev_sim_position_at"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "elevator_load"
 category = "introspection"
 wasm = "elevatorLoad"
 ffi  = "ev_sim_elevator_load"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "occupancy"
 category = "introspection"
 wasm = "occupancy"
 ffi  = "ev_sim_occupancy"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "elevator_direction"
 category = "introspection"
 wasm = "elevatorDirection"
 ffi  = "ev_sim_elevator_direction"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "elevator_going_up"
 category = "introspection"
 wasm = "elevatorGoingUp"
 ffi  = "ev_sim_elevator_going_up"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "elevator_going_down"
 category = "introspection"
 wasm = "elevatorGoingDown"
 ffi  = "ev_sim_elevator_going_down"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "elevator_move_count"
 category = "introspection"
 wasm = "elevatorMoveCount"
 ffi  = "ev_sim_elevator_move_count"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "braking_distance"
 category = "introspection"
 wasm = "brakingDistance"
 ffi  = "ev_sim_braking_distance"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "future_stop_position"
 category = "introspection"
 wasm = "futureStopPosition"
 ffi  = "ev_sim_future_stop_position"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "destination_queue"
 category = "introspection"
 wasm = "destinationQueue"
 ffi  = "ev_sim_destination_queue"
+tui  = "todo:tui-pr2 — drill-down panel ships in PR2"
 
 [[methods]]
 name = "elevators_in_phase"
 category = "introspection"
 wasm = "elevatorsInPhase"
 ffi  = "ev_sim_elevators_in_phase"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "iter_repositioning_elevators"
 category = "introspection"
 wasm = "iterRepositioningElevators"
 ffi  = "ev_sim_iter_repositioning_elevators"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "idle_elevator_count"
 category = "introspection"
 wasm = "idleElevatorCount"
 ffi  = "ev_sim_idle_elevator_count"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "is_elevator"
 category = "introspection"
 wasm = "isElevator"
 ffi  = "ev_sim_is_elevator"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "is_rider"
 category = "introspection"
 wasm = "isRider"
 ffi  = "ev_sim_is_rider"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "is_stop"
 category = "introspection"
 wasm = "isStop"
 ffi  = "ev_sim_is_stop"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "is_disabled"
 category = "introspection"
 wasm = "isDisabled"
 ffi  = "ev_sim_is_disabled"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "waiting_at"
 category = "introspection"
 wasm = "waitingAt"
 ffi  = "ev_sim_waiting_at"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "waiting_count_at"
 category = "introspection"
 wasm = "waitingCountAt"
 ffi  = "ev_sim_waiting_count_at"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "waiting_counts_by_line_at"
 category = "introspection"
 wasm = "waitingCountsByLineAt"
 ffi  = "ev_sim_waiting_counts_by_line_at"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "waiting_direction_counts_at"
 category = "introspection"
 wasm = "waitingDirectionCountsAt"
 ffi  = "ev_sim_waiting_direction_counts_at"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "residents_at"
 category = "introspection"
 wasm = "residentsAt"
 ffi  = "ev_sim_residents_at"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "resident_count_at"
 category = "introspection"
 wasm = "residentCountAt"
 ffi  = "ev_sim_resident_count_at"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "abandoned_at"
 category = "introspection"
 wasm = "abandonedAt"
 ffi  = "ev_sim_abandoned_at"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "abandoned_count_at"
 category = "introspection"
 wasm = "abandonedCountAt"
 ffi  = "ev_sim_abandoned_count_at"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "riders_on"
 category = "introspection"
 wasm = "ridersOn"
 ffi  = "ev_sim_riders_on"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 # ─── Destinations ─────────────────────────────────────────────────────────
 
@@ -746,30 +865,35 @@ name = "push_destination"
 category = "destinations"
 wasm = "pushDestination"
 ffi  = "ev_sim_push_destination"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "push_destination_front"
 category = "destinations"
 wasm = "pushDestinationFront"
 ffi  = "ev_sim_push_destination_front"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "clear_destinations"
 category = "destinations"
 wasm = "clearDestinations"
 ffi  = "ev_sim_clear_destinations"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "abort_movement"
 category = "destinations"
 wasm = "abortMovement"
 ffi  = "ev_sim_abort_movement"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "recall_to"
 category = "destinations"
 wasm = "recallTo"
 ffi  = "ev_sim_recall_to"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 # ─── Parameters ───────────────────────────────────────────────────────────
 # Note: wasm exposes "*All" sweeping helpers (setMaxSpeedAll, etc.) that
@@ -781,54 +905,63 @@ name = "set_max_speed"
 category = "parameters"
 wasm = "setMaxSpeedAll"
 ffi  = "ev_sim_set_max_speed"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "set_acceleration"
 category = "parameters"
 wasm = "setAcceleration"
 ffi  = "ev_sim_set_acceleration"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "set_deceleration"
 category = "parameters"
 wasm = "setDeceleration"
 ffi  = "ev_sim_set_deceleration"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "set_door_open_ticks"
 category = "parameters"
 wasm = "setDoorOpenTicksAll"
 ffi  = "ev_sim_set_door_open_ticks"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "set_door_transition_ticks"
 category = "parameters"
 wasm = "setDoorTransitionTicksAll"
 ffi  = "ev_sim_set_door_transition_ticks"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "set_weight_capacity"
 category = "parameters"
 wasm = "setWeightCapacityAll"
 ffi  = "ev_sim_set_weight_capacity"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "set_arrival_log_retention_ticks"
 category = "parameters"
 wasm = "setArrivalLogRetentionTicks"
 ffi  = "ev_sim_set_arrival_log_retention_ticks"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "enable"
 category = "parameters"
 wasm = "enable"
 ffi  = "ev_sim_enable"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "disable"
 category = "parameters"
 wasm = "disable"
 ffi  = "ev_sim_disable"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 # ─── Hooks (closures don't survive the binding boundary) ──────────────────
 
@@ -837,36 +970,42 @@ name = "add_after_hook"
 category = "hooks"
 wasm = "skip:closures don't survive the wasm boundary — use streaming events"
 ffi  = "skip:closures don't survive the FFI boundary — use streaming events"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "add_before_hook"
 category = "hooks"
 wasm = "skip:closures don't survive the wasm boundary — use streaming events"
 ffi  = "skip:closures don't survive the FFI boundary — use streaming events"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "add_after_group_hook"
 category = "hooks"
 wasm = "skip:closures don't survive the wasm boundary"
 ffi  = "skip:closures don't survive the FFI boundary"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "add_before_group_hook"
 category = "hooks"
 wasm = "skip:closures don't survive the wasm boundary"
 ffi  = "skip:closures don't survive the FFI boundary"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "load_extensions"
 category = "hooks"
 wasm = "skip:builder-pattern entry point — runs at construction"
 ffi  = "skip:builder-pattern entry point — runs at construction"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "load_extensions_with"
 category = "hooks"
 wasm = "skip:takes a generic closure"
 ffi  = "skip:takes a generic closure"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 # ─── Tagging + per-tag metrics ────────────────────────────────────────────
 
@@ -875,24 +1014,28 @@ name = "tag_entity"
 category = "tagging"
 wasm = "tagEntity"
 ffi  = "ev_sim_tag_entity"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "untag_entity"
 category = "tagging"
 wasm = "untagEntity"
 ffi  = "ev_sim_untag_entity"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "all_tags"
 category = "tagging"
 wasm = "allTags"
 ffi  = "ev_sim_all_tags"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "metrics_for_tag"
 category = "metrics"
 wasm = "metricsForTag"
 ffi  = "ev_sim_metrics_for_tag"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 # ─── Internal — exposes &World, &mut World, internal slices ───────────────
 
@@ -901,33 +1044,39 @@ name = "world"
 category = "internal"
 wasm = "skip:returns &World — consumers use snapshot/worldView DTOs"
 ffi  = "skip:returns &World — consumers use ev_sim_frame"
+tui  = "shaft_view"
 
 [[methods]]
 name = "world_mut"
 category = "internal"
 wasm = "skip:returns &mut World — never bound"
 ffi  = "skip:returns &mut World — never bound"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "dispatchers"
 category = "internal"
 wasm = "skip:returns trait-object slice — never bound"
 ffi  = "skip:returns trait-object slice — never bound"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "dispatchers_mut"
 category = "internal"
 wasm = "skip:returns &mut trait-object slice — never bound"
 ffi  = "skip:returns &mut trait-object slice — never bound"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "groups"
 category = "internal"
 wasm = "skip:returns &[ElevatorGroup] — internal layout"
 ffi  = "skip:returns &[ElevatorGroup] — internal layout"
+tui  = "shaft_view"
 
 [[methods]]
 name = "groups_mut"
 category = "internal"
 wasm = "skip:returns &mut [ElevatorGroup] — never bound"
 ffi  = "skip:returns &mut [ElevatorGroup] — never bound"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"

--- a/crates/elevator-tui/Cargo.toml
+++ b/crates/elevator-tui/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "elevator-tui"
+version = "0.1.0"
+edition.workspace = true
+description = "Terminal UI debugger for elevator-core (interactive viewer + headless runner)"
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "elevator-tui"
+path = "src/main.rs"
+
+[dependencies]
+elevator-core = { path = "../elevator-core", features = ["traffic"] }
+ratatui = { version = "0.29", default-features = false, features = ["crossterm"] }
+crossterm = "0.28"
+clap = { version = "4.5", features = ["derive"] }
+ron.workspace = true
+serde.workspace = true
+serde_json = "1"
+anyhow = "1"
+
+[dev-dependencies]
+insta = "1"
+slotmap = { workspace = true }

--- a/crates/elevator-tui/src/app.rs
+++ b/crates/elevator-tui/src/app.rs
@@ -1,0 +1,283 @@
+//! Interactive event loop: terminal setup, key handling, sim driving,
+//! and per-frame rendering.
+
+use std::io::{self, Stdout};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context as _, Result};
+use crossterm::event::{self, Event as TermEvent, KeyCode, KeyEventKind, KeyModifiers};
+use crossterm::execute;
+use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen};
+use elevator_core::events::EventCategory;
+use elevator_core::sim::Simulation;
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+
+use crate::state::{AppState, ShaftMode};
+use crate::ui;
+
+/// Run the interactive TUI until the user quits.
+///
+/// `initial_tick_rate` is multiplied by the sim's configured
+/// `ticks_per_second`; `1.0` runs the sim in real wall-clock time.
+///
+/// # Errors
+///
+/// Returns the underlying I/O error if terminal setup, polling, or
+/// rendering fails. The terminal is always restored on the way out
+/// (success, error, or panic via `Drop`).
+pub fn run(sim: Simulation, initial_tick_rate: f64) -> Result<()> {
+    let mut terminal = setup_terminal().context("setting up terminal")?;
+    // RAII: the terminal is restored when `_guard` drops, whether
+    // `event_loop` returns Ok, returns Err, or panics.
+    let _guard = TerminalGuard;
+    event_loop(&mut terminal, sim, initial_tick_rate)
+}
+
+/// Frame budget — caps render rate at ~30 fps.
+const FRAME_BUDGET: Duration = Duration::from_millis(33);
+
+/// Inner loop, broken out so the terminal restoration in [`run`] runs
+/// even when this returns an error.
+fn event_loop(
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    mut sim: Simulation,
+    initial_tick_rate: f64,
+) -> Result<()> {
+    let mut state = AppState::new(initial_tick_rate);
+    let cfg_tps = sim.time().ticks_per_second();
+    let mut accumulator = 0.0_f64;
+    let mut last = Instant::now();
+    let mut status_set_at = Instant::now();
+
+    loop {
+        // Drain any input that arrived during the frame.
+        let frame_start = Instant::now();
+        while let Some(remaining) = FRAME_BUDGET.checked_sub(frame_start.elapsed()) {
+            if !event::poll(remaining).context("polling input")? {
+                break;
+            }
+            if let TermEvent::Key(key) = event::read().context("reading input")?
+                && key.kind == KeyEventKind::Press
+            {
+                handle_key(&mut state, &mut sim, key.code, key.modifiers);
+            }
+            if state.quit {
+                return Ok(());
+            }
+        }
+
+        // Auto-advance the sim if running.
+        let now = Instant::now();
+        let dt = now.duration_since(last).as_secs_f64();
+        last = now;
+        if state.paused {
+            accumulator = 0.0;
+        } else {
+            accumulator += dt * state.tick_rate * cfg_tps;
+            // Soft-cap to avoid runaway catch-up after a long pause or
+            // very-high rate setting; without this a 100x rate on a
+            // slow terminal could spin for seconds inside one frame.
+            let max_per_frame = (cfg_tps * state.tick_rate * 0.1).max(1.0).ceil();
+            let mut budget = max_per_frame as u64;
+            while accumulator >= 1.0 && budget > 0 {
+                step_once(&mut sim, &mut state);
+                accumulator -= 1.0;
+                budget -= 1;
+            }
+        }
+
+        // Auto-clear the status banner after a couple of seconds so it
+        // doesn't drift indefinitely on the footer.
+        if state.status.is_some() && status_set_at.elapsed() > Duration::from_secs(2) {
+            state.status = None;
+        } else if state.status.is_none() {
+            status_set_at = Instant::now();
+        }
+
+        terminal
+            .draw(|frame| ui::draw(frame, &state, &sim))
+            .context("drawing frame")?;
+    }
+}
+
+/// Drive a single sim tick and drain its events into the rolling log.
+fn step_once(sim: &mut Simulation, state: &mut AppState) {
+    sim.step();
+    let tick = sim.current_tick();
+    let drained = sim.drain_events();
+    state.push_events(tick, drained);
+}
+
+/// Map a single keypress to a state transition (and possibly a sim
+/// mutation, for single-step).
+fn handle_key(state: &mut AppState, sim: &mut Simulation, code: KeyCode, modifiers: KeyModifiers) {
+    if matches!(code, KeyCode::Char('c')) && modifiers.contains(KeyModifiers::CONTROL) {
+        state.quit = true;
+        return;
+    }
+    match code {
+        KeyCode::Char('q') => state.quit = true,
+        KeyCode::Char(' ') => {
+            state.paused = !state.paused;
+            state.flash(if state.paused { "paused" } else { "running" });
+        }
+        KeyCode::Char('.') => {
+            step_once(sim, state);
+            state.flash(format!("step → tick {}", sim.current_tick()));
+        }
+        KeyCode::Char(',') => {
+            for _ in 0..10 {
+                step_once(sim, state);
+            }
+            state.flash(format!("step ×10 → tick {}", sim.current_tick()));
+        }
+        KeyCode::Char('+' | '=') => {
+            state.tick_rate = (state.tick_rate * 2.0).min(64.0);
+            state.flash(format!("rate {:.2}×", state.tick_rate));
+        }
+        KeyCode::Char('-' | '_') => {
+            state.tick_rate = (state.tick_rate / 2.0).max(0.0625);
+            state.flash(format!("rate {:.2}×", state.tick_rate));
+        }
+        KeyCode::Char('m') => {
+            state.shaft_mode = match state.shaft_mode {
+                ShaftMode::Index => ShaftMode::Distance,
+                ShaftMode::Distance => ShaftMode::Index,
+            };
+            state.flash(format!("shaft: {:?}", state.shaft_mode));
+        }
+        KeyCode::Char(']') => {
+            let count = ui::shaft::cars_iter(sim).count();
+            if count > 0 {
+                state.focused_car_idx = (state.focused_car_idx + 1) % count;
+            }
+        }
+        KeyCode::Char('[') => {
+            let count = ui::shaft::cars_iter(sim).count();
+            if count > 0 {
+                state.focused_car_idx = (state.focused_car_idx + count - 1) % count;
+            }
+        }
+        KeyCode::Char('f') => {
+            state.follow_focused = !state.follow_focused;
+            state.flash(if state.follow_focused {
+                "follow on"
+            } else {
+                "follow off"
+            });
+        }
+        KeyCode::Char(digit @ '1'..='7') => {
+            if let Some(category) = digit_to_category(digit) {
+                state.toggle_category(category);
+                state.flash(format!("toggle {category:?}"));
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Map a digit `1..=7` to the matching [`EventCategory`] in declaration order.
+#[must_use]
+const fn digit_to_category(d: char) -> Option<EventCategory> {
+    Some(match d {
+        '1' => EventCategory::Elevator,
+        '2' => EventCategory::Rider,
+        '3' => EventCategory::Dispatch,
+        '4' => EventCategory::Topology,
+        '5' => EventCategory::Reposition,
+        '6' => EventCategory::Direction,
+        '7' => EventCategory::Observability,
+        _ => return None,
+    })
+}
+
+/// Switch the terminal into raw mode + alternate screen and wrap it
+/// in a [`Terminal`] backed by [`CrosstermBackend`].
+fn setup_terminal() -> io::Result<Terminal<CrosstermBackend<Stdout>>> {
+    crossterm::terminal::enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    Terminal::new(CrosstermBackend::new(stdout))
+}
+
+/// RAII guard that restores the terminal on drop. Acts as the safety
+/// net for panics inside [`event_loop`].
+struct TerminalGuard;
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = crossterm::terminal::disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use elevator_core::dispatch::scan::ScanDispatch;
+
+    fn demo_sim() -> Simulation {
+        elevator_core::builder::SimulationBuilder::demo()
+            .dispatch(ScanDispatch::new())
+            .build()
+            .expect("demo builder must succeed")
+    }
+
+    #[test]
+    fn space_toggles_pause() {
+        let mut state = AppState::new(1.0);
+        let mut sim = demo_sim();
+        assert!(!state.paused);
+        handle_key(&mut state, &mut sim, KeyCode::Char(' '), KeyModifiers::NONE);
+        assert!(state.paused);
+        handle_key(&mut state, &mut sim, KeyCode::Char(' '), KeyModifiers::NONE);
+        assert!(!state.paused);
+    }
+
+    #[test]
+    fn dot_advances_one_tick() {
+        let mut state = AppState::new(1.0);
+        let mut sim = demo_sim();
+        let before = sim.current_tick();
+        handle_key(&mut state, &mut sim, KeyCode::Char('.'), KeyModifiers::NONE);
+        assert_eq!(sim.current_tick(), before + 1);
+    }
+
+    #[test]
+    fn rate_clamps_to_safe_bounds() {
+        let mut state = AppState::new(1.0);
+        let mut sim = demo_sim();
+        for _ in 0..20 {
+            handle_key(&mut state, &mut sim, KeyCode::Char('+'), KeyModifiers::NONE);
+        }
+        assert!(state.tick_rate <= 64.0);
+        for _ in 0..20 {
+            handle_key(&mut state, &mut sim, KeyCode::Char('-'), KeyModifiers::NONE);
+        }
+        assert!(state.tick_rate >= 0.0625);
+    }
+
+    #[test]
+    fn category_digit_keys_toggle_filters() {
+        let mut state = AppState::new(1.0);
+        let mut sim = demo_sim();
+        let before = state.category_filter.len();
+        handle_key(&mut state, &mut sim, KeyCode::Char('2'), KeyModifiers::NONE);
+        assert_eq!(state.category_filter.len(), before - 1);
+    }
+
+    #[test]
+    fn ctrl_c_quits() {
+        let mut state = AppState::new(1.0);
+        let mut sim = demo_sim();
+        handle_key(
+            &mut state,
+            &mut sim,
+            KeyCode::Char('c'),
+            KeyModifiers::CONTROL,
+        );
+        assert!(state.quit);
+    }
+}

--- a/crates/elevator-tui/src/app.rs
+++ b/crates/elevator-tui/src/app.rs
@@ -75,15 +75,27 @@ fn event_loop(
             accumulator = 0.0;
         } else {
             accumulator += dt * state.tick_rate * cfg_tps;
-            // Soft-cap to avoid runaway catch-up after a long pause or
-            // very-high rate setting; without this a 100x rate on a
-            // slow terminal could spin for seconds inside one frame.
+            // Cap how many ticks we'll run inside one frame, then
+            // discard any leftover backlog. Without this two failure
+            // modes appear:
+            //   1. Spin: a 100× rate on a slow terminal would queue
+            //      seconds of work into a single frame's loop.
+            //   2. Catch-up after a long pause: even with a per-frame
+            //      cap, deferred ticks accumulate and the sim races
+            //      forward over the next several frames trying to
+            //      "catch up" wall time. Discarding the leftover
+            //      keeps wall-clock and sim time loosely synced; a
+            //      rate slider, not a backlog, is how the user asks
+            //      for fast playback.
             let max_per_frame = (cfg_tps * state.tick_rate * 0.1).max(1.0).ceil();
             let mut budget = max_per_frame as u64;
             while accumulator >= 1.0 && budget > 0 {
                 step_once(&mut sim, &mut state);
                 accumulator -= 1.0;
                 budget -= 1;
+            }
+            if accumulator > max_per_frame {
+                accumulator = 0.0;
             }
         }
 

--- a/crates/elevator-tui/src/app.rs
+++ b/crates/elevator-tui/src/app.rs
@@ -49,6 +49,7 @@ fn event_loop(
     let mut accumulator = 0.0_f64;
     let mut last = Instant::now();
     let mut status_set_at = Instant::now();
+    let mut last_status_seq = state.status_seq;
 
     loop {
         // Drain any input that arrived during the frame.
@@ -100,11 +101,18 @@ fn event_loop(
         }
 
         // Auto-clear the status banner after a couple of seconds so it
-        // doesn't drift indefinitely on the footer.
+        // doesn't drift indefinitely on the footer. The wall-clock
+        // timer is reset whenever `state.flash()` ran since the last
+        // frame (detected via `status_seq`), so a back-to-back
+        // replacement gets the full display window — fixing the bug
+        // where a 1.9 s-old flash being replaced would vanish ~0.1 s
+        // later.
+        if state.status_seq != last_status_seq {
+            status_set_at = Instant::now();
+            last_status_seq = state.status_seq;
+        }
         if state.status.is_some() && status_set_at.elapsed() > Duration::from_secs(2) {
             state.status = None;
-        } else if state.status.is_none() {
-            status_set_at = Instant::now();
         }
 
         terminal

--- a/crates/elevator-tui/src/cli.rs
+++ b/crates/elevator-tui/src/cli.rs
@@ -1,0 +1,39 @@
+//! Command-line interface definition.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+
+/// Terminal UI debugger for elevator-core.
+#[derive(Debug, Parser)]
+#[command(version, about)]
+pub struct Cli {
+    /// Path to a RON `SimConfig` file (e.g. `assets/config/default.ron`).
+    pub config: PathBuf,
+
+    /// Run non-interactively: step the sim, print summary, exit.
+    #[arg(long)]
+    pub headless: bool,
+
+    /// In headless mode, the absolute tick to stop at. Ignored when
+    /// interactive. Defaults to 1000.
+    #[arg(long, default_value_t = 1000)]
+    pub until: u64,
+
+    /// In headless mode, optional path to write the drained event stream
+    /// as JSON. Ignored when interactive.
+    #[arg(long)]
+    pub emit: Option<PathBuf>,
+
+    /// Initial interactive tick rate as a multiplier of the config's
+    /// `ticks_per_second`. `1.0` = real-time. Adjust live with `+`/`-`.
+    #[arg(long, default_value_t = 1.0)]
+    pub tick_rate: f64,
+
+    /// In headless mode, skip Poisson traffic generation. Useful when
+    /// you want to step a sim that's already been seeded externally
+    /// (snapshot restore, scripted spawn, etc.) without diluting it
+    /// with new arrivals. Ignored when interactive.
+    #[arg(long)]
+    pub no_traffic: bool,
+}

--- a/crates/elevator-tui/src/config_io.rs
+++ b/crates/elevator-tui/src/config_io.rs
@@ -1,0 +1,40 @@
+//! RON config loading + simulation construction.
+//!
+//! Mirrors what `elevator-bevy` does: read the file, parse as
+//! [`SimConfig`], hand it to a fresh [`Simulation`] with a default
+//! dispatch strategy.
+
+use std::path::Path;
+
+use anyhow::{Context as _, Result};
+use elevator_core::config::SimConfig;
+use elevator_core::dispatch::scan::ScanDispatch;
+use elevator_core::sim::Simulation;
+
+/// Read a RON config from `path`.
+///
+/// # Errors
+///
+/// Returns the underlying I/O error if the file cannot be read, or the
+/// RON deserialize error if it cannot be parsed.
+pub fn load_config(path: &Path) -> Result<SimConfig> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("reading config: {}", path.display()))?;
+    ron::from_str(&raw).with_context(|| format!("parsing config: {}", path.display()))
+}
+
+/// Build a [`Simulation`] from a parsed [`SimConfig`].
+///
+/// Uses [`ScanDispatch`] as the default strategy. Strategy selection is
+/// intentionally not exposed yet — the TUI's purpose is to debug
+/// whatever strategy the config opts into via `GroupConfig.dispatch`,
+/// and `ScanDispatch` only acts as the fallback for groups that don't
+/// override.
+///
+/// # Errors
+///
+/// Returns the validation error from [`Simulation::new`] if the config
+/// is structurally invalid.
+pub fn build_simulation(config: &SimConfig) -> Result<Simulation> {
+    Simulation::new(config, ScanDispatch::new()).context("building simulation from config")
+}

--- a/crates/elevator-tui/src/headless.rs
+++ b/crates/elevator-tui/src/headless.rs
@@ -1,0 +1,230 @@
+//! Non-interactive runner: step the sim for `--until` ticks, print a
+//! metrics summary, optionally emit the drained event stream as JSON.
+//!
+//! Intended uses:
+//!
+//! - **CI smoke**: `--until 5000` against each scenario in
+//!   `assets/config/`; non-zero exit on construction failure surfaces
+//!   regressions in config schema or builder validation.
+//! - **Bug repro**: pair with `--emit events.json` to capture an event
+//!   trace that can be diffed against a fixed run, attached to issues,
+//!   or fed back into a future replay tool.
+
+use std::path::Path;
+use std::time::Instant;
+
+use anyhow::{Context as _, Result};
+use elevator_core::config::SimConfig;
+use elevator_core::events::Event;
+use elevator_core::sim::Simulation;
+use elevator_core::traffic::{PoissonSource, TrafficSource as _};
+use serde::Serialize;
+
+/// Step `sim` until its `current_tick` reaches `until`, then write a
+/// summary to stdout. If `emit` is `Some`, also serialize every drained
+/// event to that path as JSON.
+///
+/// Unless `no_traffic` is set, a [`PoissonSource`] built from
+/// `config.passenger_spawning` is driven each tick — without it, the
+/// sim does nothing (no built-in spawner runs inside `Simulation`),
+/// which makes a smoke test useless.
+///
+/// Already-elapsed ticks (e.g. from a restored snapshot) are honoured —
+/// the runner stops as soon as `current_tick >= until`, so calling with
+/// `until = 0` is a no-op that still prints the summary.
+///
+/// # Errors
+///
+/// Returns the underlying I/O error if writing the JSON file fails, the
+/// serde error if event serialization fails, or a sim error if a Poisson
+/// spawn request references a stop the simulation rejects. The summary
+/// is printed before the error path is taken so the user still sees
+/// what happened.
+pub fn run(
+    mut sim: Simulation,
+    config: &SimConfig,
+    until: u64,
+    emit: Option<&Path>,
+    no_traffic: bool,
+) -> Result<()> {
+    let start = Instant::now();
+    let mut events: Vec<EventRecord> = Vec::new();
+    let mut traffic = (!no_traffic).then(|| PoissonSource::from_config(config));
+
+    while sim.current_tick() < until {
+        if let Some(source) = traffic.as_mut() {
+            for req in source.generate(sim.current_tick()) {
+                // A spawn failure usually means the config references a
+                // stop that doesn't exist — still useful to report,
+                // but should not abort the whole run since later ticks
+                // may produce valid spawns.
+                if let Err(e) = sim.spawn_rider(req.origin, req.destination, req.weight) {
+                    eprintln!("warn: spawn rejected: {e}");
+                }
+            }
+        }
+        sim.step();
+        let tick = sim.current_tick();
+        for event in sim.drain_events() {
+            events.push(EventRecord { tick, event });
+        }
+    }
+
+    let elapsed = start.elapsed();
+    print_summary(&sim, events.len(), elapsed);
+
+    if let Some(path) = emit {
+        let json = serde_json::to_vec_pretty(&EmittedTrace {
+            final_tick: sim.current_tick(),
+            event_count: events.len(),
+            events: &events,
+        })
+        .context("serializing event trace")?;
+        std::fs::write(path, json)
+            .with_context(|| format!("writing event trace: {}", path.display()))?;
+        println!("emitted {} events → {}", events.len(), path.display());
+    }
+
+    Ok(())
+}
+
+/// Single drained event tagged with the tick it was drained on.
+#[derive(Debug, Serialize)]
+struct EventRecord {
+    /// Tick the event was emitted from (drain tick).
+    tick: u64,
+    /// The event itself.
+    event: Event,
+}
+
+/// Outer envelope written to disk when `--emit` is given.
+#[derive(Debug, Serialize)]
+struct EmittedTrace<'a> {
+    /// Tick the run ended on.
+    final_tick: u64,
+    /// Count of events captured (mirrors `events.len()`, written for
+    /// quick eyeballing in JQ-less environments).
+    event_count: usize,
+    /// Every event drained during the run.
+    events: &'a [EventRecord],
+}
+
+/// Pretty-print the headless summary block.
+fn print_summary(sim: &Simulation, event_count: usize, elapsed: std::time::Duration) {
+    let metrics = sim.metrics();
+    let final_tick = sim.current_tick();
+    let cfg_tps = sim.time().ticks_per_second();
+    let sim_seconds = final_tick as f64 / cfg_tps;
+    let real_speed = if elapsed.as_secs_f64() > 0.0 {
+        sim_seconds / elapsed.as_secs_f64()
+    } else {
+        f64::INFINITY
+    };
+
+    println!("─── headless summary ───────────────────────────");
+    println!("final tick           {final_tick}");
+    println!("sim duration         {sim_seconds:.1}s @ {cfg_tps:.0} t/s");
+    println!(
+        "wall time            {:.3}s ({real_speed:.1}× realtime)",
+        elapsed.as_secs_f64()
+    );
+    println!("events drained       {event_count}");
+    println!("riders spawned       {}", metrics.total_spawned());
+    println!("riders delivered     {}", metrics.total_delivered());
+    println!(
+        "riders abandoned     {} ({:.1}%)",
+        metrics.total_abandoned(),
+        metrics.abandonment_rate() * 100.0
+    );
+    println!("avg wait             {:.1} ticks", metrics.avg_wait_time());
+    println!("p95 wait             {} ticks", metrics.p95_wait_time());
+    println!("avg ride             {:.1} ticks", metrics.avg_ride_time());
+    println!(
+        "throughput           {} delivered in last {} ticks",
+        metrics.throughput(),
+        metrics.throughput_window_ticks()
+    );
+    println!(
+        "avg utilization      {:.1}%",
+        metrics.avg_utilization() * 100.0
+    );
+    println!("────────────────────────────────────────────────");
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use elevator_core::builder::SimulationBuilder;
+    use elevator_core::dispatch::scan::ScanDispatch;
+
+    fn demo_pair() -> (Simulation, SimConfig) {
+        let builder = SimulationBuilder::demo().dispatch(ScanDispatch::new());
+        // Builder doesn't expose its assembled config directly, so
+        // hand-roll one matching the demo topology for the Poisson
+        // source. Mirrors what builder::demo configures internally.
+        let config = SimConfig {
+            building: elevator_core::config::BuildingConfig {
+                name: "Demo".into(),
+                stops: vec![
+                    elevator_core::stop::StopConfig {
+                        id: elevator_core::stop::StopId(0),
+                        name: "Ground".into(),
+                        position: 0.0,
+                    },
+                    elevator_core::stop::StopConfig {
+                        id: elevator_core::stop::StopId(1),
+                        name: "Top".into(),
+                        position: 10.0,
+                    },
+                ],
+                lines: None,
+                groups: None,
+            },
+            elevators: vec![],
+            simulation: elevator_core::config::SimulationParams {
+                ticks_per_second: 60.0,
+            },
+            passenger_spawning: elevator_core::config::PassengerSpawnConfig {
+                mean_interval_ticks: 30,
+                weight_range: (60.0, 90.0),
+            },
+        };
+        let sim = builder.build().expect("demo builder must succeed");
+        (sim, config)
+    }
+
+    #[test]
+    fn headless_advances_to_until_tick() {
+        let (sim, config) = demo_pair();
+        run(sim, &config, 100, None, true).expect("run succeeds");
+    }
+
+    #[test]
+    fn headless_below_current_tick_is_noop() {
+        let (mut sim, config) = demo_pair();
+        for _ in 0..50 {
+            sim.step();
+        }
+        let before = sim.current_tick();
+        run(sim, &config, 10, None, true).expect("run succeeds");
+        assert!(before > 10);
+    }
+
+    #[test]
+    fn headless_emit_writes_valid_json() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "elevator_tui_headless_emit_{}.json",
+            std::process::id()
+        ));
+        let (sim, config) = demo_pair();
+        run(sim, &config, 50, Some(&path), true).expect("run with emit succeeds");
+        let bytes = std::fs::read(&path).expect("emitted file readable");
+        let value: serde_json::Value =
+            serde_json::from_slice(&bytes).expect("emitted bytes are valid JSON");
+        assert!(value.get("final_tick").is_some());
+        assert!(value.get("events").and_then(|v| v.as_array()).is_some());
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/elevator-tui/src/lib.rs
+++ b/crates/elevator-tui/src/lib.rs
@@ -1,0 +1,20 @@
+//! Terminal UI debugger for `elevator-core`.
+//!
+//! Two modes share one binary:
+//!
+//! - **Interactive** (default): live viewer with shaft column, event log,
+//!   dispatch summary, and metrics; pause/step/rate hotkeys; category
+//!   filters and per-entity follow.
+//! - **Headless** (`--headless`): step the sim N ticks, print a metrics
+//!   summary, optionally emit the full event stream as JSON. Suitable
+//!   for CI smoke tests and bug-repro capture.
+//!
+//! See `docs/src/tui-debugger.md` for the full hotkey reference and
+//! debugging recipes.
+
+pub mod app;
+pub mod cli;
+pub mod config_io;
+pub mod headless;
+pub mod state;
+pub mod ui;

--- a/crates/elevator-tui/src/main.rs
+++ b/crates/elevator-tui/src/main.rs
@@ -1,0 +1,16 @@
+//! Entry point: parse CLI, branch to interactive or headless mode.
+
+use clap::Parser as _;
+use elevator_tui::{app, cli::Cli, config_io, headless};
+
+fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    let config = config_io::load_config(&cli.config)?;
+    let sim = config_io::build_simulation(&config)?;
+
+    if cli.headless {
+        headless::run(sim, &config, cli.until, cli.emit.as_deref(), cli.no_traffic)
+    } else {
+        app::run(sim, cli.tick_rate)
+    }
+}

--- a/crates/elevator-tui/src/state.rs
+++ b/crates/elevator-tui/src/state.rs
@@ -55,6 +55,14 @@ pub struct AppState {
     pub event_log_cap: usize,
     /// Status banner (transient feedback after a hotkey action).
     pub status: Option<String>,
+    /// Monotonically incrementing counter bumped each time [`flash`] is
+    /// called. The event loop watches this to reset its wall-clock
+    /// timer when one flash *replaces* another, so a new banner gets
+    /// its full display time even when the previous one was still
+    /// showing. (See `Self::flash`.)
+    ///
+    /// [`flash`]: Self::flash
+    pub status_seq: u64,
     /// User has requested a clean exit.
     pub quit: bool,
 }
@@ -73,6 +81,7 @@ impl AppState {
             event_log: std::collections::VecDeque::with_capacity(EVENT_LOG_CAP),
             event_log_cap: EVENT_LOG_CAP,
             status: None,
+            status_seq: 0,
             quit: false,
         }
     }
@@ -112,8 +121,13 @@ impl AppState {
     }
 
     /// Set a transient status banner.
+    ///
+    /// Increments [`status_seq`](Self::status_seq) so the event loop
+    /// can detect a back-to-back replacement and reset its display
+    /// timer.
     pub fn flash(&mut self, msg: impl Into<String>) {
         self.status = Some(msg.into());
+        self.status_seq = self.status_seq.wrapping_add(1);
     }
 }
 
@@ -217,6 +231,19 @@ mod tests {
             Event::ElevatorIdle { tick, .. } => assert_eq!(*tick, 9),
             other => panic!("unexpected event variant: {other:?}"),
         }
+    }
+
+    #[test]
+    fn flash_increments_status_seq_each_call() {
+        let mut state = AppState::new(1.0);
+        assert_eq!(state.status_seq, 0);
+        state.flash("first");
+        assert_eq!(state.status_seq, 1);
+        state.flash("second"); // replaces the first while still set
+        assert_eq!(state.status_seq, 2);
+        // The event loop in app.rs uses this counter to reset its
+        // wall-clock display timer; a stale counter would let the
+        // second flash inherit the first's age and disappear early.
     }
 
     #[test]

--- a/crates/elevator-tui/src/state.rs
+++ b/crates/elevator-tui/src/state.rs
@@ -117,8 +117,14 @@ impl AppState {
     }
 }
 
-/// Every known [`EventCategory`] variant. Updated when new categories
-/// land in core; tests pin the expected count.
+/// Every known [`EventCategory`] variant.
+///
+/// `EventCategory` is `#[non_exhaustive]`, so a downstream crate can't
+/// write an exhaustive `match` against it — adding a new variant in
+/// `elevator-core` would not be a compile error here. The test
+/// `all_categories_set_size_matches_known_variants` pins the count at
+/// runtime; if it fails after a core update, add the new variant
+/// here and a matching digit hotkey in `app::digit_to_category`.
 #[must_use]
 pub fn all_categories() -> HashSet<EventCategory> {
     HashSet::from([

--- a/crates/elevator-tui/src/state.rs
+++ b/crates/elevator-tui/src/state.rs
@@ -1,0 +1,223 @@
+//! Pure app state — no I/O, no terminal, no `Simulation` reference.
+//!
+//! Splitting this out keeps the rendering and input layers thin and lets
+//! us unit-test the state machine (filter toggles, follow target, mode
+//! flips) without standing up a real `Simulation`.
+
+use std::collections::HashSet;
+
+use elevator_core::events::{Event, EventCategory};
+
+/// How much vertical space the shaft devotes to each stop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShaftMode {
+    /// One row per stop, ignoring the gap between them. Compact, fits
+    /// tall buildings without scrolling.
+    Index,
+    /// Rows scaled to the actual stop positions. Honours non-uniform
+    /// configs (e.g. `space_elevator.ron`) at the cost of vertical
+    /// space when stops are clumped.
+    Distance,
+}
+
+/// A captured event plus the tick it was drained on.
+///
+/// Tagged with the drain tick because [`Event`] variants don't all
+/// carry a tick field uniformly, and the drain tick is sufficient for
+/// ordering and follow-mode queries.
+#[derive(Debug, Clone)]
+pub struct LoggedEvent {
+    /// Tick at which the event was drained.
+    pub tick: u64,
+    /// The event itself.
+    pub event: Event,
+}
+
+/// Top-level interactive app state.
+#[derive(Debug)]
+pub struct AppState {
+    /// Sim is paused (no auto-stepping). `space` toggles, `.` single-steps.
+    pub paused: bool,
+    /// Multiplier on the config's `ticks_per_second`. `+`/`-` adjust.
+    pub tick_rate: f64,
+    /// Index vs. distance shaft layout.
+    pub shaft_mode: ShaftMode,
+    /// Set of categories included in the events panel. Hotkey toggles.
+    pub category_filter: HashSet<EventCategory>,
+    /// Index of the currently focused car within the flat car list.
+    pub focused_car_idx: usize,
+    /// Whether to filter the events panel to events touching the
+    /// focused car's entity id.
+    pub follow_focused: bool,
+    /// Bounded ring of drained events (newest at end).
+    pub event_log: std::collections::VecDeque<LoggedEvent>,
+    /// Cap for `event_log`.
+    pub event_log_cap: usize,
+    /// Status banner (transient feedback after a hotkey action).
+    pub status: Option<String>,
+    /// User has requested a clean exit.
+    pub quit: bool,
+}
+
+impl AppState {
+    /// Default state for an interactive session.
+    #[must_use]
+    pub fn new(initial_tick_rate: f64) -> Self {
+        Self {
+            paused: false,
+            tick_rate: initial_tick_rate.max(0.0),
+            shaft_mode: ShaftMode::Index,
+            category_filter: all_categories(),
+            focused_car_idx: 0,
+            follow_focused: false,
+            event_log: std::collections::VecDeque::with_capacity(EVENT_LOG_CAP),
+            event_log_cap: EVENT_LOG_CAP,
+            status: None,
+            quit: false,
+        }
+    }
+
+    /// Append events drained from the sim, capped at `event_log_cap`.
+    pub fn push_events(&mut self, tick: u64, events: impl IntoIterator<Item = Event>) {
+        for event in events {
+            if self.event_log.len() == self.event_log_cap {
+                self.event_log.pop_front();
+            }
+            self.event_log.push_back(LoggedEvent { tick, event });
+        }
+    }
+
+    /// Toggle a category in the active filter set.
+    pub fn toggle_category(&mut self, category: EventCategory) {
+        if !self.category_filter.remove(&category) {
+            self.category_filter.insert(category);
+        }
+    }
+
+    /// Iterator over events the user wants to see, optionally filtered
+    /// by entity when follow mode is on. Double-ended so the renderer
+    /// can `.rev()` to show newest at the top of the panel.
+    #[must_use]
+    pub fn visible_events(
+        &self,
+        focused_entity: Option<elevator_core::entity::EntityId>,
+    ) -> impl DoubleEndedIterator<Item = &LoggedEvent> {
+        let follow = self.follow_focused.then_some(()).and(focused_entity);
+        self.event_log.iter().filter(move |logged| {
+            if !self.category_filter.contains(&logged.event.category()) {
+                return false;
+            }
+            follow.is_none_or(|target| event_touches(&logged.event, target))
+        })
+    }
+
+    /// Set a transient status banner.
+    pub fn flash(&mut self, msg: impl Into<String>) {
+        self.status = Some(msg.into());
+    }
+}
+
+/// Every known [`EventCategory`] variant. Updated when new categories
+/// land in core; tests pin the expected count.
+#[must_use]
+pub fn all_categories() -> HashSet<EventCategory> {
+    HashSet::from([
+        EventCategory::Elevator,
+        EventCategory::Rider,
+        EventCategory::Dispatch,
+        EventCategory::Topology,
+        EventCategory::Reposition,
+        EventCategory::Direction,
+        EventCategory::Observability,
+    ])
+}
+
+/// True when an event references the given entity in any of its
+/// commonly-named slots.
+///
+/// Cheap structural match; we don't reflect every variant — only the
+/// ones a follow filter would care about (cars and riders). Stops
+/// aren't followed today, so `at_stop`/`from_stop` are not consulted
+/// here.
+#[must_use]
+pub fn event_touches(event: &Event, target: elevator_core::entity::EntityId) -> bool {
+    use Event::{
+        CapacityChanged, DoorClosed, DoorCommandApplied, DoorCommandQueued, DoorOpened,
+        ElevatorArrived, ElevatorAssigned, ElevatorDeparted, ElevatorIdle, ElevatorRecalled,
+        ElevatorRepositioned, ElevatorRepositioning, MovementAborted, PassingFloor, RiderAbandoned,
+        RiderBoarded, RiderEjected, RiderExited, RiderRejected, RiderRerouted, RiderSettled,
+        RiderSpawned, ServiceModeChanged,
+    };
+    match event {
+        ElevatorDeparted { elevator, .. }
+        | ElevatorArrived { elevator, .. }
+        | DoorOpened { elevator, .. }
+        | DoorClosed { elevator, .. }
+        | DoorCommandQueued { elevator, .. }
+        | DoorCommandApplied { elevator, .. }
+        | PassingFloor { elevator, .. }
+        | MovementAborted { elevator, .. }
+        | ElevatorIdle { elevator, .. }
+        | ElevatorRepositioning { elevator, .. }
+        | ElevatorRepositioned { elevator, .. }
+        | ElevatorRecalled { elevator, .. }
+        | CapacityChanged { elevator, .. }
+        | ServiceModeChanged { elevator, .. }
+        | ElevatorAssigned { elevator, .. } => *elevator == target,
+        RiderSpawned { rider, .. }
+        | RiderBoarded { rider, .. }
+        | RiderExited { rider, .. }
+        | RiderRejected { rider, .. }
+        | RiderAbandoned { rider, .. }
+        | RiderEjected { rider, .. }
+        | RiderRerouted { rider, .. }
+        | RiderSettled { rider, .. } => *rider == target,
+        _ => false,
+    }
+}
+
+/// Cap on retained events in the rolling log.
+const EVENT_LOG_CAP: usize = 1024;
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn category_filter_toggles_round_trip() {
+        let mut state = AppState::new(1.0);
+        let initial = state.category_filter.len();
+        state.toggle_category(EventCategory::Rider);
+        assert_eq!(state.category_filter.len(), initial - 1);
+        state.toggle_category(EventCategory::Rider);
+        assert_eq!(state.category_filter.len(), initial);
+    }
+
+    #[test]
+    fn event_log_caps_at_capacity() {
+        let mut state = AppState::new(1.0);
+        state.event_log_cap = 3;
+        let elev = elevator_core::entity::EntityId::from(slotmap::KeyData::from_ffi(1));
+        let make = |n| Event::ElevatorIdle {
+            elevator: elev,
+            at_stop: None,
+            tick: n,
+        };
+        state.push_events(0, (0..10).map(make));
+        assert_eq!(state.event_log.len(), 3);
+        let latest = state.event_log.back().expect("non-empty after push");
+        match &latest.event {
+            Event::ElevatorIdle { tick, .. } => assert_eq!(*tick, 9),
+            other => panic!("unexpected event variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn all_categories_set_size_matches_known_variants() {
+        // Pin the expected count so a new EventCategory variant in core
+        // forces an update here. Bumping this is a one-line ack that the
+        // TUI's filter UI needs a new toggle hotkey too.
+        assert_eq!(all_categories().len(), 7);
+    }
+}

--- a/crates/elevator-tui/src/ui/dispatch.rs
+++ b/crates/elevator-tui/src/ui/dispatch.rs
@@ -1,0 +1,64 @@
+//! Dispatch summary panel — what each car is currently doing and the
+//! demand picture every group sees.
+
+use elevator_core::sim::Simulation;
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use crate::ui::shaft;
+
+/// Render the dispatch panel.
+pub fn draw(frame: &mut Frame<'_>, area: Rect, sim: &Simulation) {
+    let block = Block::default()
+        .borders(Borders::BOTTOM)
+        .title(Line::from(" dispatch ").style(Style::default().add_modifier(Modifier::BOLD)));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let mut lines: Vec<Line<'_>> = Vec::new();
+
+    // Per-group strategy + demand counts.
+    for group in sim.groups() {
+        let strategy = sim
+            .strategy_id(group.id())
+            .map_or_else(|| "?".to_string(), |s| format!("{s:?}"));
+        let manifest = sim.build_dispatch_manifest(group);
+        let waiting: usize = group
+            .lines()
+            .iter()
+            .flat_map(|line| line.serves().iter().copied())
+            .map(|stop| manifest.waiting_count_at(stop))
+            .sum();
+        let cars = group
+            .lines()
+            .iter()
+            .map(|line| line.elevators().len())
+            .sum::<usize>();
+        lines.push(Line::from(format!(
+            "{name:<12}  strategy={strategy}  cars={cars}  waiting={waiting}",
+            name = group.name(),
+        )));
+    }
+
+    // One row per car: phase, target, queue depth.
+    for car in shaft::cars_iter(sim) {
+        let phase = car.elevator.phase();
+        let target = phase
+            .moving_target()
+            .map_or_else(String::new, |t| format!(" → {t:?}"));
+        let queue = sim
+            .destination_queue(elevator_core::entity::ElevatorId::from(car.id))
+            .map_or(0, <[_]>::len);
+        lines.push(Line::from(format!(
+            "  {:?}  phase={phase}{target}  queue={queue}  load={}/{}",
+            car.id,
+            car.elevator.current_load(),
+            car.elevator.weight_capacity(),
+        )));
+    }
+
+    frame.render_widget(Paragraph::new(lines), inner);
+}

--- a/crates/elevator-tui/src/ui/events.rs
+++ b/crates/elevator-tui/src/ui/events.rs
@@ -1,0 +1,167 @@
+//! Events panel — filtered, scrollable view of the rolling event log.
+
+use elevator_core::events::{Event, EventCategory};
+use elevator_core::sim::Simulation;
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders, List, ListItem};
+
+use crate::state::AppState;
+use crate::ui::shaft;
+
+/// Render the events panel.
+pub fn draw(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulation) {
+    let cars: Vec<_> = shaft::cars_iter(sim).collect();
+    let focused = cars.get(state.focused_car_idx).map(|c| c.id);
+
+    let title = build_title(state, focused);
+    let block = Block::default().borders(Borders::BOTTOM).title(title);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let visible_height = inner.height as usize;
+    let items: Vec<ListItem<'_>> = state
+        .visible_events(focused)
+        .rev() // newest at the top
+        .take(visible_height)
+        .map(|logged| ListItem::new(Line::from(format_event_line(logged.tick, &logged.event))))
+        .collect();
+
+    frame.render_widget(List::new(items), inner);
+}
+
+/// Compose the panel title with the active filter summary.
+fn build_title(
+    state: &AppState,
+    focused: Option<elevator_core::entity::EntityId>,
+) -> Line<'static> {
+    let cats: Vec<&'static str> = ALL_CATEGORIES_ORDERED
+        .iter()
+        .copied()
+        .filter_map(|(category, label)| state.category_filter.contains(&category).then_some(label))
+        .collect();
+    let cats_str = if cats.len() == ALL_CATEGORIES_ORDERED.len() {
+        "all".to_string()
+    } else if cats.is_empty() {
+        "(none)".to_string()
+    } else {
+        cats.join("·")
+    };
+    let follow = match (state.follow_focused, focused) {
+        (true, Some(id)) => format!(" follow={id:?}"),
+        (true, None) => " follow=(no car)".to_string(),
+        (false, _) => String::new(),
+    };
+    Line::from(format!(" events · filter [{cats_str}]{follow} "))
+        .style(Style::default().add_modifier(Modifier::BOLD))
+}
+
+/// Categories in the same order as the digit hotkeys (1 = first).
+const ALL_CATEGORIES_ORDERED: &[(EventCategory, &str)] = &[
+    (EventCategory::Elevator, "Elev"),
+    (EventCategory::Rider, "Rdr"),
+    (EventCategory::Dispatch, "Dsp"),
+    (EventCategory::Topology, "Top"),
+    (EventCategory::Reposition, "Rep"),
+    (EventCategory::Direction, "Dir"),
+    (EventCategory::Observability, "Obs"),
+];
+
+/// Compact one-line representation of an event for the rolling log.
+///
+/// Only the stable fields (tick, primary entity references, key
+/// state-change values) are rendered — full debug forms are too noisy
+/// to be useful in a scrolling stream.
+#[must_use]
+pub fn format_event_line(drain_tick: u64, event: &Event) -> String {
+    use Event::{
+        CapacityChanged, DoorClosed, DoorCommandApplied, DoorCommandQueued, DoorOpened,
+        ElevatorArrived, ElevatorAssigned, ElevatorDeparted, ElevatorIdle, ElevatorRecalled,
+        ElevatorRepositioned, ElevatorRepositioning, MovementAborted, PassingFloor, RiderAbandoned,
+        RiderBoarded, RiderEjected, RiderExited, RiderRejected, RiderRerouted, RiderSettled,
+        RiderSpawned, ServiceModeChanged,
+    };
+    let body = match event {
+        ElevatorDeparted {
+            elevator,
+            from_stop,
+            ..
+        } => format!("ElevDeparted   e={elevator:?} from={from_stop:?}"),
+        ElevatorArrived {
+            elevator, at_stop, ..
+        } => format!("ElevArrived    e={elevator:?} at={at_stop:?}"),
+        DoorOpened { elevator, .. } => format!("DoorOpened     e={elevator:?}"),
+        DoorClosed { elevator, .. } => format!("DoorClosed     e={elevator:?}"),
+        DoorCommandQueued { elevator, .. } => format!("DoorCmdQueued  e={elevator:?}"),
+        DoorCommandApplied { elevator, .. } => format!("DoorCmdApplied e={elevator:?}"),
+        PassingFloor {
+            elevator,
+            stop,
+            moving_up,
+            ..
+        } => format!(
+            "PassingFloor   e={elevator:?} stop={stop:?} dir={}",
+            if *moving_up { "up" } else { "down" }
+        ),
+        MovementAborted {
+            elevator,
+            brake_target,
+            ..
+        } => {
+            format!("MoveAborted    e={elevator:?} → {brake_target:?}")
+        }
+        ElevatorIdle { elevator, .. } => format!("ElevIdle       e={elevator:?}"),
+        ElevatorAssigned { elevator, stop, .. } => {
+            format!("Assigned       e={elevator:?} stop={stop:?}")
+        }
+        ElevatorRepositioning {
+            elevator, to_stop, ..
+        } => {
+            format!("Repositioning  e={elevator:?} → {to_stop:?}")
+        }
+        ElevatorRepositioned { elevator, .. } => format!("Repositioned   e={elevator:?}"),
+        ElevatorRecalled { elevator, .. } => format!("Recalled       e={elevator:?}"),
+        CapacityChanged {
+            elevator,
+            current_load,
+            capacity,
+            ..
+        } => format!("CapacityChange e={elevator:?} {current_load:?}/{capacity:?}"),
+        ServiceModeChanged { elevator, to, .. } => {
+            format!("ServiceMode    e={elevator:?} → {to:?}")
+        }
+        RiderSpawned {
+            rider,
+            origin,
+            destination,
+            ..
+        } => {
+            format!("RiderSpawned   r={rider:?} {origin:?} → {destination:?}")
+        }
+        RiderBoarded {
+            rider, elevator, ..
+        } => format!("RiderBoarded   r={rider:?} e={elevator:?}"),
+        RiderExited {
+            rider,
+            elevator,
+            stop,
+            ..
+        } => {
+            format!("RiderExited    r={rider:?} e={elevator:?} at={stop:?}")
+        }
+        RiderRejected {
+            rider, elevator, ..
+        } => format!("RiderRejected  r={rider:?} e={elevator:?}"),
+        RiderAbandoned { rider, .. } => format!("RiderAbandoned r={rider:?}"),
+        RiderEjected { rider, .. } => format!("RiderEjected   r={rider:?}"),
+        RiderRerouted { rider, .. } => format!("RiderRerouted  r={rider:?}"),
+        RiderSettled { rider, .. } => format!("RiderSettled   r={rider:?}"),
+        // Anything else: fall back to short Debug. The compact strings
+        // above cover the common-case noise; long-tail variants are
+        // still legible just less aligned.
+        other => format!("{other:?}"),
+    };
+    format!("t={drain_tick:>6}  {body}")
+}

--- a/crates/elevator-tui/src/ui/metrics.rs
+++ b/crates/elevator-tui/src/ui/metrics.rs
@@ -1,0 +1,42 @@
+//! Metrics panel — aggregate counters from `Simulation::metrics()`.
+
+use elevator_core::sim::Simulation;
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+/// Render the metrics panel.
+pub fn draw(frame: &mut Frame<'_>, area: Rect, sim: &Simulation) {
+    let block = Block::default()
+        .borders(Borders::BOTTOM)
+        .title(Line::from(" metrics ").style(Style::default().add_modifier(Modifier::BOLD)));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let m = sim.metrics();
+    let counters = vec![
+        Line::from(format!(
+            "spawned {sp}   delivered {dl}   abandoned {ab} ({rate:.1}%)",
+            sp = m.total_spawned(),
+            dl = m.total_delivered(),
+            ab = m.total_abandoned(),
+            rate = m.abandonment_rate() * 100.0,
+        )),
+        Line::from(format!(
+            "wait avg {avg:.1}t   p95 {p95}t   max {max}t",
+            avg = m.avg_wait_time(),
+            p95 = m.p95_wait_time(),
+            max = m.max_wait_time(),
+        )),
+        Line::from(format!(
+            "ride avg {ride:.1}t   throughput {tp}/{w}t   util {ut:.1}%",
+            ride = m.avg_ride_time(),
+            tp = m.throughput(),
+            w = m.throughput_window_ticks(),
+            ut = m.avg_utilization() * 100.0,
+        )),
+    ];
+    frame.render_widget(Paragraph::new(counters), inner);
+}

--- a/crates/elevator-tui/src/ui/mod.rs
+++ b/crates/elevator-tui/src/ui/mod.rs
@@ -1,0 +1,99 @@
+//! Frame composition: title bar, body (shaft + right column), footer.
+
+use elevator_core::sim::Simulation;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use crate::state::AppState;
+
+pub mod dispatch;
+pub mod events;
+pub mod metrics;
+pub mod shaft;
+
+/// Top-level draw entry — composes every panel for one frame.
+pub fn draw(frame: &mut Frame<'_>, state: &AppState, sim: &Simulation) {
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // title bar
+            Constraint::Min(0),    // body
+            Constraint::Length(1), // footer
+        ])
+        .split(frame.area());
+
+    draw_title(frame, outer[0], state, sim);
+
+    let body = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Length(shaft::recommended_width(sim)),
+            Constraint::Min(0),
+        ])
+        .split(outer[1]);
+
+    shaft::draw(frame, body[0], state, sim);
+    draw_overview(frame, body[1], state, sim);
+
+    draw_footer(frame, outer[2], state);
+}
+
+/// Status bar: tick, paused/running, rate, mode badge.
+fn draw_title(
+    frame: &mut Frame<'_>,
+    area: ratatui::layout::Rect,
+    state: &AppState,
+    sim: &Simulation,
+) {
+    let mode = if state.paused { "PAUSED" } else { "RUNNING" };
+    let line = Line::from(format!(
+        " elevator-tui   tick {tick}   {mode}   rate {rate:.2}×   shaft {shaft:?}",
+        tick = sim.current_tick(),
+        rate = state.tick_rate,
+        shaft = state.shaft_mode,
+    ));
+    frame.render_widget(
+        Paragraph::new(line).style(Style::default().add_modifier(Modifier::BOLD)),
+        area,
+    );
+}
+
+/// Footer: condensed hotkey reference + transient status flash.
+fn draw_footer(frame: &mut Frame<'_>, area: ratatui::layout::Rect, state: &AppState) {
+    let mut text = String::from(
+        " space pause  . step  , step×10  +/- rate  m shaft  []car  f follow  1-7 filter  q quit",
+    );
+    if let Some(status) = &state.status {
+        text.push_str("   │   ");
+        text.push_str(status);
+    }
+    frame.render_widget(Paragraph::new(text), area);
+}
+
+/// Right column = Events / Dispatch / Metrics stacked vertically.
+fn draw_overview(
+    frame: &mut Frame<'_>,
+    area: ratatui::layout::Rect,
+    state: &AppState,
+    sim: &Simulation,
+) {
+    let outer = Block::default().borders(Borders::LEFT).title(" overview ");
+    let inner = outer.inner(area);
+    frame.render_widget(outer, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(50),
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+        ])
+        .split(inner);
+
+    events::draw(frame, chunks[0], state, sim);
+    dispatch::draw(frame, chunks[1], sim);
+    metrics::draw(frame, chunks[2], sim);
+}

--- a/crates/elevator-tui/src/ui/shaft.rs
+++ b/crates/elevator-tui/src/ui/shaft.rs
@@ -287,8 +287,13 @@ fn car_style(car: &CarView<'_>, focused: Option<EntityId>) -> Style {
 }
 
 /// Trim a string to `max` chars, padding with spaces if shorter.
+///
+/// Compares by character count, not byte length: a stop name like
+/// "Café" is 4 chars but 5 bytes, and would otherwise hit the
+/// truncation branch unnecessarily and emit a misaligned row.
 fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max {
+    let char_count = s.chars().count();
+    if char_count <= max {
         format!("{s:<max$}")
     } else {
         s.chars().take(max).collect()

--- a/crates/elevator-tui/src/ui/shaft.rs
+++ b/crates/elevator-tui/src/ui/shaft.rs
@@ -1,0 +1,296 @@
+//! Shaft view — the leftmost panel showing each car's vertical position
+//! relative to its served stops.
+//!
+//! Two render modes share `cars_iter` and the per-car column derivation
+//! but differ in row scaling:
+//!
+//! - **Index mode** allocates one row per stop, ignoring distance.
+//!   Compact and stable for tall buildings; truncates to fit when the
+//!   stop count exceeds the panel height.
+//! - **Distance mode** scales rows to actual stop positions, so a car
+//!   between two stops 80 km apart sits visibly mid-cable. Honours
+//!   `space_elevator.ron`-class scenarios at the cost of leaving wide
+//!   blank stretches when stops are clumped.
+
+use elevator_core::components::{Elevator, ElevatorPhase, Stop};
+use elevator_core::entity::EntityId;
+use elevator_core::sim::Simulation;
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use crate::state::{AppState, ShaftMode};
+
+/// Resolved view of one car for rendering.
+pub struct CarView<'a> {
+    /// Entity id of the car.
+    pub id: EntityId,
+    /// Borrowed `Elevator` component.
+    pub elevator: &'a Elevator,
+    /// Position along the shaft (rendered).
+    pub position: f64,
+    /// List of riders aboard, used for occupancy and follow-mode lookups.
+    pub riders: &'a [EntityId],
+}
+
+/// Iterate every car across every group, in deterministic group→line order.
+///
+/// Re-exported for `app.rs` so it can compute the focused-car index without
+/// duplicating the traversal.
+pub fn cars_iter(sim: &Simulation) -> impl Iterator<Item = CarView<'_>> + '_ {
+    sim.groups()
+        .iter()
+        .flat_map(|group| {
+            group
+                .lines()
+                .iter()
+                .flat_map(|line| line.elevators().iter())
+        })
+        .copied()
+        .filter_map(move |id| {
+            let elevator = sim.world().elevator(id)?;
+            let position = sim
+                .world()
+                .position(id)
+                .map_or(0.0, elevator_core::components::Position::value);
+            Some(CarView {
+                id,
+                elevator,
+                position,
+                riders: elevator.riders(),
+            })
+        })
+}
+
+/// Resolve every stop the sim knows about, sorted by position descending
+/// (top of shaft first — matches how a building elevation looks on screen).
+fn stops_top_down(sim: &Simulation) -> Vec<(EntityId, &Stop)> {
+    let mut stops: Vec<_> = sim
+        .stop_lookup_iter()
+        .filter_map(|(_, eid)| sim.world().stop(*eid).map(|s| (*eid, s)))
+        .collect();
+    stops.sort_by(|a, b| b.1.position().total_cmp(&a.1.position()));
+    stops
+}
+
+/// Recommended panel width in cells. Each row is laid out as:
+///
+/// ```text
+/// │name(10) pos(5) │ c c c c │
+/// ```
+///
+/// — i.e. 19 cells of label + delimiter, plus 2 cells per car (glyph
+/// + trailing space), wrapped in a 1-cell border on each side.
+#[must_use]
+pub fn recommended_width(sim: &Simulation) -> u16 {
+    let car_count: usize = cars_iter(sim).count();
+    let cars: u16 = u16::try_from(car_count).unwrap_or(u16::MAX);
+    let base: u16 = 21; // label + pos + delim + borders
+    base.saturating_add(cars.saturating_mul(2))
+}
+
+/// Render the shaft panel.
+pub fn draw(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulation) {
+    let stops = stops_top_down(sim);
+    let cars: Vec<CarView<'_>> = cars_iter(sim).collect();
+    let focused = cars.get(state.focused_car_idx).map(|c| c.id);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" shaft · {} car(s) ", cars.len()));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    // Index mode needs a per-car row anchor since `position` is a continuous
+    // f64 between stops. Pick the closest stop by absolute distance — that
+    // way moving cars appear at their current floor rather than vanishing
+    // until they arrive.
+    let nearest_stop_by_car: std::collections::HashMap<EntityId, EntityId> = cars
+        .iter()
+        .filter_map(|car| {
+            stops
+                .iter()
+                .min_by(|a, b| {
+                    (a.1.position() - car.position)
+                        .abs()
+                        .total_cmp(&(b.1.position() - car.position).abs())
+                })
+                .map(|(eid, _)| (car.id, *eid))
+        })
+        .collect();
+
+    let lines: Vec<Line<'_>> = match state.shaft_mode {
+        ShaftMode::Index => {
+            render_index_mode(&stops, &cars, &nearest_stop_by_car, focused, inner.height)
+        }
+        ShaftMode::Distance => render_distance_mode(&stops, &cars, focused, inner.height),
+    };
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+/// One row per stop. Stop list truncates to fit the available height.
+fn render_index_mode<'a>(
+    stops: &'a [(EntityId, &'a Stop)],
+    cars: &'a [CarView<'a>],
+    nearest_stop_by_car: &std::collections::HashMap<EntityId, EntityId>,
+    focused: Option<EntityId>,
+    height: u16,
+) -> Vec<Line<'a>> {
+    let max_rows = height as usize;
+    let take = stops.len().min(max_rows.saturating_sub(1).max(1));
+    let mut lines = Vec::with_capacity(take + 1);
+    for (eid, stop) in stops.iter().take(take) {
+        lines.push(stop_row(*eid, stop, cars, nearest_stop_by_car, focused));
+    }
+    if stops.len() > take {
+        lines.push(Line::from(format!(
+            "  … {} more stop(s) hidden — narrow terminal",
+            stops.len() - take
+        )));
+    }
+    lines
+}
+
+/// Rows scaled to actual stop positions. The full vertical range is
+/// quantized to `height` rows; a stop is placed in the row matching its
+/// fraction of the range.
+fn render_distance_mode<'a>(
+    stops: &'a [(EntityId, &'a Stop)],
+    cars: &'a [CarView<'a>],
+    focused: Option<EntityId>,
+    height: u16,
+) -> Vec<Line<'a>> {
+    if stops.is_empty() || height < 2 {
+        return Vec::new();
+    }
+    let max_pos = stops.first().map_or(0.0, |(_, stop)| stop.position());
+    let min_pos = stops.last().map_or(0.0, |(_, stop)| stop.position());
+    let span = (max_pos - min_pos).max(1e-9);
+    let rows = height as usize;
+    let mut grid: Vec<Option<(EntityId, &Stop)>> = vec![None; rows];
+    for (eid, stop) in stops {
+        let fraction = (max_pos - stop.position()) / span;
+        let row = ((fraction * (rows as f64 - 1.0)).round() as usize).min(rows - 1);
+        if grid[row].is_none() {
+            grid[row] = Some((*eid, *stop));
+        }
+    }
+    // Distance mode plots cars by their actual position (in `spacer_row`),
+    // so the per-row "nearest stop" map is unused. Pass an empty one.
+    let empty: std::collections::HashMap<EntityId, EntityId> = std::collections::HashMap::new();
+    grid.into_iter()
+        .enumerate()
+        .map(|(row, slot)| match slot {
+            Some((eid, stop)) => stop_row(eid, stop, cars, &empty, focused),
+            None => spacer_row(cars.len(), row, rows, max_pos, min_pos, cars, focused),
+        })
+        .collect()
+}
+
+/// Render one stop row: `name@pos │ c c c` where each `c` is a car
+/// glyph at its corresponding column index.
+fn stop_row<'a>(
+    stop_id: EntityId,
+    stop: &'a Stop,
+    cars: &'a [CarView<'a>],
+    nearest_stop_by_car: &std::collections::HashMap<EntityId, EntityId>,
+    focused: Option<EntityId>,
+) -> Line<'a> {
+    let label = format!("{:>10} ", truncate(stop.name(), 10));
+    let pos = format!("{:>5.1} ", stop.position());
+    let mut spans = vec![Span::raw(label), Span::raw(pos), Span::raw("│ ")];
+    for car in cars {
+        let here = nearest_stop_by_car.get(&car.id) == Some(&stop_id);
+        spans.push(car_glyph_for_stop(car, stop_id, stop, here, focused));
+        spans.push(Span::raw(" "));
+    }
+    Line::from(spans)
+}
+
+/// Render a row in distance mode that doesn't sit on a stop. Cars whose
+/// continuous position rounds to this row still get drawn in the right
+/// column; otherwise the slot is blank.
+fn spacer_row<'a>(
+    _car_count: usize,
+    row: usize,
+    rows: usize,
+    max_pos: f64,
+    min_pos: f64,
+    cars: &'a [CarView<'a>],
+    focused: Option<EntityId>,
+) -> Line<'a> {
+    let span = (max_pos - min_pos).max(1e-9);
+    let label = format!("{:>10} ", "");
+    let row_pos_label = format!(
+        "{:>5.1} ",
+        (row as f64 / (rows as f64 - 1.0)).mul_add(-span, max_pos)
+    );
+    let mut spans = vec![Span::raw(label), Span::raw(row_pos_label), Span::raw("│ ")];
+    for car in cars {
+        let car_row = ((max_pos - car.position) / span * (rows as f64 - 1.0)).round() as usize;
+        let car_row = car_row.min(rows - 1);
+        let glyph = if car_row == row {
+            Span::styled("*", car_style(car, focused))
+        } else {
+            Span::raw("·")
+        };
+        spans.push(glyph);
+        spans.push(Span::raw(" "));
+    }
+    Line::from(spans)
+}
+
+/// Pick the glyph + style for a car at a given stop.
+fn car_glyph_for_stop<'a>(
+    car: &CarView<'a>,
+    _stop_id: EntityId,
+    _stop: &Stop,
+    here: bool,
+    focused: Option<EntityId>,
+) -> Span<'a> {
+    if !here {
+        return Span::raw("·");
+    }
+    let glyph = match car.elevator.phase() {
+        ElevatorPhase::Loading => "L",
+        ElevatorPhase::DoorOpening => "O",
+        ElevatorPhase::DoorClosing => "C",
+        ElevatorPhase::Stopped => "■",
+        ElevatorPhase::MovingToStop(_) | ElevatorPhase::Repositioning(_) => {
+            // Use a directional arrow so movement is visible even when
+            // the car sits at the same row for several frames.
+            if car.elevator.going_up() {
+                "▲"
+            } else if car.elevator.going_down() {
+                "▼"
+            } else {
+                "█"
+            }
+        }
+        _ => "█",
+    };
+    Span::styled(glyph, car_style(car, focused))
+}
+
+/// Style used to highlight the focused car. Adds bold + reverse so the
+/// glyph stands out under any palette without depending on color.
+fn car_style(car: &CarView<'_>, focused: Option<EntityId>) -> Style {
+    if focused == Some(car.id) {
+        Style::default()
+            .add_modifier(Modifier::BOLD)
+            .add_modifier(Modifier::REVERSED)
+    } else {
+        Style::default()
+    }
+}
+
+/// Trim a string to `max` chars, padding with spaces if shorter.
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        format!("{s:<max$}")
+    } else {
+        s.chars().take(max).collect()
+    }
+}

--- a/crates/elevator-tui/tests/render_snapshot.rs
+++ b/crates/elevator-tui/tests/render_snapshot.rs
@@ -1,0 +1,73 @@
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+//! Snapshot test: render one frame against a known fixture and pin
+//! the resulting buffer with `insta`.
+//!
+//! What this catches:
+//!   - Layout regressions (panel widths/heights, missing borders).
+//!   - Format-string drift in the title / footer / per-line widgets.
+//!   - Accidental field renames in `Event` / `Elevator` / `Stop` that
+//!     change how the TUI renders them.
+//!
+//! What this *doesn't* catch:
+//!   - Live behaviour (key handling, follow-mode filtering, sparkline
+//!     evolution). Those are covered by unit tests in `src/`.
+//!
+//! Snapshots are regenerated with `INSTA_UPDATE=auto cargo test`.
+
+use elevator_core::dispatch::scan::ScanDispatch;
+use elevator_core::sim::Simulation;
+use elevator_tui::state::{AppState, ShaftMode};
+use elevator_tui::ui;
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+
+fn render(sim: &Simulation, state: &AppState, width: u16, height: u16) -> String {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal
+        .draw(|frame| ui::draw(frame, state, sim))
+        .expect("draw");
+    let buffer = terminal.backend().buffer().clone();
+    let mut out = String::new();
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            out.push_str(buffer[(x, y)].symbol());
+        }
+        out.push('\n');
+    }
+    out
+}
+
+fn demo_sim(steps: u64) -> Simulation {
+    let mut sim = elevator_core::builder::SimulationBuilder::demo()
+        .dispatch(ScanDispatch::new())
+        .build()
+        .expect("demo sim builds");
+    sim.spawn_rider(
+        elevator_core::stop::StopId(0),
+        elevator_core::stop::StopId(1),
+        75.0,
+    )
+    .expect("spawn rider");
+    for _ in 0..steps {
+        sim.step();
+    }
+    sim
+}
+
+#[test]
+fn frame_renders_after_a_few_ticks() {
+    let sim = demo_sim(120);
+    let state = AppState::new(1.0);
+    let frame = render(&sim, &state, 100, 30);
+    insta::assert_snapshot!("default_after_120_ticks", frame);
+}
+
+#[test]
+fn frame_in_distance_mode() {
+    let sim = demo_sim(60);
+    let mut state = AppState::new(1.0);
+    state.shaft_mode = ShaftMode::Distance;
+    let frame = render(&sim, &state, 100, 30);
+    insta::assert_snapshot!("distance_mode_after_60_ticks", frame);
+}

--- a/crates/elevator-tui/tests/snapshots/render_snapshot__default_after_120_ticks.snap
+++ b/crates/elevator-tui/tests/snapshots/render_snapshot__default_after_120_ticks.snap
@@ -1,0 +1,34 @@
+---
+source: crates/elevator-tui/tests/render_snapshot.rs
+expression: frame
+---
+ elevator-tui   tick 120   RUNNING   rate 1.00×   shaft Index                                       
+┌ shaft · 1 car(s) ───┐│ overview                                                                   
+│Top         10.0 │ · ││ events · filter [all]                                                      
+│Ground       0.0 │ ▲ ││                                                                            
+│                     ││                                                                            
+│                     ││                                                                            
+│                     ││                                                                            
+│                     ││                                                                            
+│                     ││                                                                            
+│                     ││                                                                            
+│                     ││                                                                            
+│                     ││                                                                            
+│                     ││                                                                            
+│                     ││                                                                            
+│                     ││                                                                            
+│                     ││────────────────────────────────────────────────────────────────────────────
+│                     ││ dispatch                                                                   
+│                     ││Default       strategy=Scan  cars=1  waiting=0                              
+│                     ││  EntityId(4v1)  phase=MovingToStop(EntityId(2v1)) → EntityId(2v1)  queue=1 
+│                     ││                                                                            
+│                     ││                                                                            
+│                     ││────────────────────────────────────────────────────────────────────────────
+│                     ││ metrics                                                                    
+│                     ││spawned 1   delivered 0   abandoned 0 (0.0%)                                
+│                     ││wait avg 4.0t   p95 4t   max 4t                                             
+│                     ││ride avg 0.0t   throughput 0/3600t   util 100.0%                            
+│                     ││                                                                            
+│                     ││                                                                            
+└─────────────────────┘│────────────────────────────────────────────────────────────────────────────
+ space pause  . step  , step×10  +/- rate  m shaft  []car  f follow  1-7 filter  q quit

--- a/crates/elevator-tui/tests/snapshots/render_snapshot__distance_mode_after_60_ticks.snap
+++ b/crates/elevator-tui/tests/snapshots/render_snapshot__distance_mode_after_60_ticks.snap
@@ -1,0 +1,34 @@
+---
+source: crates/elevator-tui/tests/render_snapshot.rs
+expression: frame
+---
+ elevator-tui   tick 60   RUNNING   rate 1.00×   shaft Distance                                     
+┌ shaft · 1 car(s) ───┐│ overview                                                                   
+│Top         10.0 │ · ││ events · filter [all]                                                      
+│             9.6 │ · ││                                                                            
+│             9.2 │ · ││                                                                            
+│             8.8 │ · ││                                                                            
+│             8.4 │ · ││                                                                            
+│             8.0 │ · ││                                                                            
+│             7.6 │ · ││                                                                            
+│             7.2 │ · ││                                                                            
+│             6.8 │ · ││                                                                            
+│             6.4 │ · ││                                                                            
+│             6.0 │ · ││                                                                            
+│             5.6 │ · ││                                                                            
+│             5.2 │ · ││                                                                            
+│             4.8 │ · ││────────────────────────────────────────────────────────────────────────────
+│             4.4 │ · ││ dispatch                                                                   
+│             4.0 │ · ││Default       strategy=Scan  cars=1  waiting=0                              
+│             3.6 │ · ││  EntityId(4v1)  phase=MovingToStop(EntityId(2v1)) → EntityId(2v1)  queue=1 
+│             3.2 │ · ││                                                                            
+│             2.8 │ · ││                                                                            
+│             2.4 │ · ││────────────────────────────────────────────────────────────────────────────
+│             2.0 │ · ││ metrics                                                                    
+│             1.6 │ · ││spawned 1   delivered 0   abandoned 0 (0.0%)                                
+│             1.2 │ · ││wait avg 4.0t   p95 4t   max 4t                                             
+│             0.8 │ · ││ride avg 0.0t   throughput 0/3600t   util 100.0%                            
+│             0.4 │ * ││                                                                            
+│Ground       0.0 │ · ││                                                                            
+└─────────────────────┘│────────────────────────────────────────────────────────────────────────────
+ space pause  . step  , step×10  +/- rate  m shaft  []car  f follow  1-7 filter  q quit

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -49,5 +49,6 @@
 
 - [Bevy Integration](bevy-integration.md)
 - [Headless and Non-Bevy Usage](headless-non-bevy.md)
+- [TUI Debugger](tui-debugger.md)
 - [Using the Bindings](using-the-bindings.md)
 - [Performance](performance.md)

--- a/docs/src/tui-debugger.md
+++ b/docs/src/tui-debugger.md
@@ -1,0 +1,183 @@
+# TUI Debugger
+
+`elevator-tui` is a terminal UI debugger for the simulation. It runs in
+two modes from one binary:
+
+- **Interactive** -- a live viewer with shaft column, scrolling event
+  log, dispatch summary, and metrics panel. Pause and step
+  tick-by-tick while you inspect what changed.
+- **Headless** -- step the sim for N ticks, print a metrics summary,
+  optionally emit the full event stream as JSON. Suitable for CI smoke
+  tests against every config in `assets/config/` and for capturing a
+  reproducible event trace to attach to a bug report.
+
+The TUI complements the existing surfaces: the Bevy demo cannot pause
+the sim cleanly, and the playground summarises events at a high level.
+For "why did this car make that decision on tick 4218" debugging, the
+TUI is the cheapest tool.
+
+## Quick start
+
+```bash
+# Interactive mode against the default scenario.
+cargo run -p elevator-tui -- assets/config/default.ron
+
+# Headless smoke run -- step 5000 ticks, print summary, exit.
+cargo run -p elevator-tui -- assets/config/default.ron --headless --until 5000
+
+# Headless run with full event capture for bug repro.
+cargo run -p elevator-tui --release -- \
+    assets/config/default.ron --headless --until 10000 --emit trace.json
+```
+
+The binary takes one positional argument (the RON config path) plus
+flags:
+
+| Flag                   | Default | Purpose                                                    |
+| ---                    | ---     | ---                                                        |
+| `--headless`           | off     | Run non-interactively and print a summary instead of a TUI |
+| `--until <N>`          | 1000    | (headless) absolute tick to stop at                        |
+| `--emit <PATH>`        | --      | (headless) write drained events as JSON                    |
+| `--no-traffic`         | off     | (headless) disable Poisson rider spawning                  |
+| `--tick-rate <FACTOR>` | 1.0     | (interactive) initial multiplier on config tick rate       |
+
+## Layout
+
+The interactive view is one shaft column on the left and a stacked
+right column with three panels: events (top), dispatch summary
+(middle), metrics (bottom).
+
+```text
+ elevator-tui   tick 842   RUNNING   rate 2.00x   shaft Index
++--shaft-(3-cars)--+--overview-----------------------------------------+
+|  Top   10.0 | . . . |  events . filter [all]                          |
+|  ...                |  t=842  ElevArrived   e=2v1 at=12v1             |
+|  F02    4.0 | . . . |  t=842  DoorOpened    e=2v1                     |
+|  Lobby  0.0 | A . . |  t=841  RiderBoarded  r=17v1 e=1v1              |
+|                     |  ...                                            |
+|                     |--------------------------------------------------|
+|                     |  dispatch                                        |
+|                     |  Default      strategy=Scan  cars=3  waiting=4  |
+|                     |    EntityId(2v1)  phase=Loading  queue=1        |
+|                     |--------------------------------------------------|
+|                     |  metrics                                         |
+|                     |  spawned 19  delivered 12  abandoned 0 (0.0%)   |
+|                     |  wait avg 32.1t   p95 84t   max 142t            |
++---------------------+--------------------------------------------------+
+ space pause  . step  , step*10  +/- rate  m shaft  []car  f follow ...
+```
+
+The shaft has two modes you can toggle at runtime with `m`:
+
+- **Index** (default): one row per stop, regardless of distance. The
+  car glyph appears at the stop closest to its current position, with
+  an arrow indicating direction (`▲` up, `▼` down). Compact for tall
+  buildings; doesn't honour non-uniform stop spacing.
+- **Distance**: rows are scaled to actual stop positions, so a car
+  drifting between two stops 80 km apart sits visibly mid-cable.
+  Honours `space_elevator.ron`-class scenarios at the cost of vertical
+  space when stops are clumped.
+
+## Hotkeys
+
+### Tick control
+
+| Key       | Action                                         |
+| ---       | ---                                            |
+| `space`   | Pause / resume auto-stepping                   |
+| `.`       | Single-step one tick (works while paused)      |
+| `,`       | Step 10 ticks                                  |
+| `+`, `=`  | Double the tick rate (cap 64x)                 |
+| `-`, `_`  | Halve the tick rate (floor 0.0625x)            |
+
+### Layout
+
+| Key       | Action                                                              |
+| ---       | ---                                                                 |
+| `m`       | Cycle shaft mode (Index <-> Distance)                               |
+| `]`, `[`  | Focus next / previous car                                           |
+| `f`       | Toggle follow mode -- filters the events panel to the focused car  |
+
+### Event filtering
+
+| Key | Toggle category   |
+| --- | ---               |
+| `1` | Elevator          |
+| `2` | Rider             |
+| `3` | Dispatch          |
+| `4` | Topology          |
+| `5` | Reposition        |
+| `6` | Direction         |
+| `7` | Observability     |
+
+### Quit
+
+| Key            | Action |
+| ---            | ---    |
+| `q`            | Quit   |
+| `Ctrl-C`       | Quit   |
+
+## Debugging recipes
+
+### "Why did this car bypass that floor?"
+
+1. Press `space` to pause as soon as you see the car about to skip.
+2. Press `[` / `]` until the car is focused (its glyph reverses).
+3. Press `f` to filter events to the car -- you can scroll back
+   through `Assigned`, `PassingFloor`, and door events to see the
+   bypass decision in context.
+
+### Reproducing a bug from a headless trace
+
+```bash
+cargo run -p elevator-tui --release -- \
+    assets/config/your_scenario.ron --headless --until 8000 --emit trace.json
+```
+
+Attach `trace.json` to the bug report. Each entry is `{ tick, event }`
+in drain order, so a future replay tool (or a one-off `jq` query) can
+reconstruct what happened tick-by-tick.
+
+### CI smoke test
+
+A non-zero exit means construction failed -- the simulation refused
+the config -- so the pattern below catches schema regressions across
+every shipped scenario:
+
+```bash
+for cfg in assets/config/*.ron; do
+    cargo run -q -p elevator-tui --release -- "$cfg" --headless --until 5000
+done
+```
+
+## Architecture notes
+
+The TUI is a pure consumer of the public `Simulation` API. Every
+method it calls is enumerated in `bindings.toml` under the `tui`
+column -- look there to see exactly what the read-only viewer touches
+and what is intentionally skipped (the v1 viewer is read-only and
+does not expose mutators). Adding new TUI panels generally means
+flipping a `tui = "skip:..."` to a `tui = "<panel_name>"`.
+
+The interactive renderer is `ratatui` + `crossterm`. The frame budget
+is ~33 ms (about 30 fps); inside one frame the loop polls input, then
+auto-advances the sim by however many ticks fit in `tick_rate ×
+ticks_per_second × elapsed_wall_time`. A soft cap prevents a high
+rate from spinning the loop for whole seconds at a stretch on slow
+terminals.
+
+State is split between `state.rs` (pure data, unit-testable without a
+real `Simulation`) and `app.rs` (terminal I/O + sim driving). The
+render layer (`ui/`) only reads from the state and a borrowed
+`&Simulation` -- it never mutates either.
+
+## Next steps
+
+- The v1 viewer is intentionally read-only. If you want to spawn
+  riders, change strategies, or pin assignments interactively, those
+  would land in a controller mode.
+- A polish wave (tracked in `bindings.toml` as `tui-pr2`) adds
+  snapshot save/load on a hotkey, sparkline trends in the metrics
+  panel, and a per-car drill-down panel.
+- See [Snapshots and Determinism](snapshots-determinism.md) for the
+  semantics of the underlying `Simulation::snapshot()` API.

--- a/scripts/check-bindings.sh
+++ b/scripts/check-bindings.sh
@@ -68,7 +68,7 @@ if [[ -n "$missing" ]]; then
   echo "$missing" | sed 's/^/  - /'
   echo ""
   echo "Add a [[methods]] entry to bindings.toml for each, with explicit"
-  echo "wasm + ffi status (exported name, skip:<reason>, or todo:<phase>)."
+  echo "wasm + ffi + tui status (exported name, skip:<reason>, or todo:<phase>)."
   status=1
 fi
 
@@ -80,12 +80,13 @@ if [[ -n "$stale" ]]; then
   status=1
 fi
 
-# Validate status fields and emit progress summary. Each `wasm =` / `ffi =`
-# line must be either an identifier (exported name), `skip:<reason>`, or
-# `todo:<phase>`. Anything else is malformed.
+# Validate status fields and emit progress summary. Each
+# `wasm = ` / `ffi = ` / `tui = ` line must be either an identifier
+# (exported name), `skip:<reason>`, or `todo:<phase>`. Anything else
+# is malformed.
 malformed=$(awk '
-  /^\s*(wasm|ffi)\s*=\s*"/ {
-    match($0, /^\s*(wasm|ffi)\s*=\s*"([^"]*)"/, m)
+  /^\s*(wasm|ffi|tui)\s*=\s*"/ {
+    match($0, /^\s*(wasm|ffi|tui)\s*=\s*"([^"]*)"/, m)
     binding = m[1]
     value = m[2]
     if (value ~ /^skip:.+/) next
@@ -110,11 +111,16 @@ fi
 # ── Progress summary ───────────────────────────────────────────────────
 total=$(echo "$code_methods" | wc -l)
 
-# Categorize each wasm / ffi status line.
+# Categorize each wasm / ffi / tui status line.
 read -r wasm_exported wasm_skipped wasm_todo \
-        ffi_exported  ffi_skipped  ffi_todo < <(
+        ffi_exported  ffi_skipped  ffi_todo \
+        tui_exported  tui_skipped  tui_todo < <(
   gawk '
-    BEGIN { we=0; ws=0; wt=0; fe=0; fs=0; ft=0 }
+    BEGIN {
+      we=0; ws=0; wt=0
+      fe=0; fs=0; ft=0
+      te=0; ts=0; tt=0
+    }
     /^\s*wasm\s*=\s*"/ {
       match($0, /^\s*wasm\s*=\s*"([^"]*)"/, m); v = m[1]
       if (v ~ /^skip:/) ws++
@@ -127,7 +133,13 @@ read -r wasm_exported wasm_skipped wasm_todo \
       else if (v ~ /^todo:/) ft++
       else fe++
     }
-    END { print we, ws, wt, fe, fs, ft }
+    /^\s*tui\s*=\s*"/ {
+      match($0, /^\s*tui\s*=\s*"([^"]*)"/, m); v = m[1]
+      if (v ~ /^skip:/) ts++
+      else if (v ~ /^todo:/) tt++
+      else te++
+    }
+    END { print we, ws, wt, fe, fs, ft, te, ts, tt }
   ' "$MANIFEST"
 )
 
@@ -136,3 +148,4 @@ echo ""
 printf "  %-12s %10s %10s %10s\n" "binding" "exported" "skipped" "todo"
 printf "  %-12s %10s %10s %10s\n" "wasm" "$wasm_exported" "$wasm_skipped" "$wasm_todo"
 printf "  %-12s %10s %10s %10s\n" "ffi"  "$ffi_exported"  "$ffi_skipped"  "$ffi_todo"
+printf "  %-12s %10s %10s %10s\n" "tui"  "$tui_exported"  "$tui_skipped"  "$tui_todo"


### PR DESCRIPTION
## Summary

- Adds `crates/elevator-tui` — a `ratatui`+`crossterm` consumer of the public `Simulation` API
- Two modes from one binary: **interactive** TUI (shaft + events + dispatch + metrics) and **headless** runner (`--headless --until N --emit trace.json`)
- Wires the TUI into the workspace contract: new `tui` column in `bindings.toml` with `check-bindings.sh` enforcing it; new mdBook chapter; README mention

## Why

Bevy can't pause the sim cleanly and the playground summarises events at a high level. For tick-by-tick "why did this car make that decision on tick 4218" debugging there was no ergonomic surface; this PR adds one. The headless mode also doubles as a CI smoke runner against every config in `assets/config/`.

## Scope (PR1 = skeleton)

In this PR:

- Shaft view — index mode (one row per stop) + distance mode (scaled to stop positions); car glyph at nearest stop with `▲`/`▼` direction arrows
- Events panel — category filter (`1`-`7` digit keys) + per-car follow (`f`)
- Dispatch panel — strategy + waiting count per group, phase + queue + load per car
- Metrics panel — counters (spawned/delivered/wait/throughput/utilization)
- Hotkeys — `space`/`.`/`,` (pause/step/×10), `+/-` (rate), `m` (shaft mode), `[]` (focus), `f` (follow), `1`-`7` (filter), `q` (quit)
- Headless — Poisson traffic by default (`--no-traffic` to disable), summary print, optional event-trace JSON emit
- Tests — 11 unit + 2 `ratatui::TestBackend` snapshot tests via `insta`
- Docs — new chapter, README link, `bindings.toml` schema update

Deferred to follow-up PR (`tui-pr2` in `bindings.toml`):

- `s` / `l` snapshot save/restore hotkeys
- Sparkline trends in metrics panel
- Per-car drill-down panel (`Enter`/`Esc`)

## Test plan

- [x] `cargo build -p elevator-tui`
- [x] `cargo test -p elevator-tui` (11 unit + 2 snapshot pass)
- [x] `cargo clippy -p elevator-tui --all-targets -- -D warnings`
- [x] `cargo fmt -p elevator-tui --check`
- [x] `bash scripts/check-bindings.sh` — 140 methods in sync; tui = 12 exported / 1 todo / 127 skipped
- [x] `bash scripts/lint-docs.sh --quick`
- [x] Smoke run: `cargo run -p elevator-tui -- assets/config/default.ron --headless --until 600` → 35 events, 6 spawned, 100% utilization
- [ ] Interactive run on a real terminal (manual; not covered by CI)