### PR TITLE
feat(tui): snapshot save/load, sparklines, per-car drill-down

### DIFF
--- a/bindings.toml
+++ b/bindings.toml
@@ -40,10 +40,6 @@
 #   PR-E   Wasm error-rewrite + log callback + metrics + tagging
 #   PR-F   Persistence — snapshot bytes/JSON, seed control
 #   PR-G   AsyncIterator event stream
-#
-# TUI phase markers
-# -----------------
-#   tui-pr2  Polish wave: snapshot save/load, sparklines, per-car drill-down
 
 [categories]
 lifecycle     = "Construction, ticking"
@@ -744,7 +740,7 @@ name = "destination_queue"
 category = "introspection"
 wasm = "destinationQueue"
 ffi  = "ev_sim_destination_queue"
-tui  = "todo:tui-pr2 — drill-down panel ships in PR2"
+tui  = "drilldown_panel"
 
 [[methods]]
 name = "elevators_in_phase"

--- a/crates/elevator-tui/src/app.rs
+++ b/crates/elevator-tui/src/app.rs
@@ -13,7 +13,7 @@ use elevator_core::sim::Simulation;
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 
-use crate::state::{AppState, ShaftMode};
+use crate::state::{AppState, RightPanel, ShaftMode, Sparkline};
 use crate::ui;
 
 /// Run the interactive TUI until the user quits.
@@ -121,12 +121,16 @@ fn event_loop(
     }
 }
 
-/// Drive a single sim tick and drain its events into the rolling log.
+/// Drive a single sim tick, drain its events, and update sparklines.
 fn step_once(sim: &mut Simulation, state: &mut AppState) {
     sim.step();
     let tick = sim.current_tick();
     let drained = sim.drain_events();
     state.push_events(tick, drained);
+
+    state.wait_sparkline.push(sim.metrics().p95_wait_time());
+    let total_occupancy: usize = ui::shaft::cars_iter(sim).map(|car| car.riders.len()).sum();
+    state.occupancy_sparkline.push(total_occupancy as u64);
 }
 
 /// Map a single keypress to a state transition (and possibly a sim
@@ -193,6 +197,33 @@ fn handle_key(state: &mut AppState, sim: &mut Simulation, code: KeyCode, modifie
                 state.flash(format!("toggle {category:?}"));
             }
         }
+        KeyCode::Enter => {
+            state.right_panel = match state.right_panel {
+                RightPanel::Overview => RightPanel::DrillDown,
+                RightPanel::DrillDown => RightPanel::Overview,
+            };
+        }
+        KeyCode::Esc => {
+            state.right_panel = RightPanel::Overview;
+        }
+        KeyCode::Char('s') => {
+            state.snapshot_slot = Some(sim.snapshot());
+            state.flash(format!("snapshot saved @ tick {}", sim.current_tick()));
+        }
+        KeyCode::Char('l') => match state.snapshot_slot.clone() {
+            Some(snap) => match snap.restore(None) {
+                Ok(restored) => {
+                    *sim = restored;
+                    state.event_log.clear();
+                    state.wait_sparkline = Sparkline::new(state.wait_sparkline.capacity);
+                    state.occupancy_sparkline = Sparkline::new(state.occupancy_sparkline.capacity);
+                    state.focused_car_idx = 0;
+                    state.flash(format!("restored @ tick {}", sim.current_tick()));
+                }
+                Err(e) => state.flash(format!("restore failed: {e}")),
+            },
+            None => state.flash("no snapshot saved"),
+        },
         _ => {}
     }
 }
@@ -286,6 +317,34 @@ mod tests {
         let before = state.category_filter.len();
         handle_key(&mut state, &mut sim, KeyCode::Char('2'), KeyModifiers::NONE);
         assert_eq!(state.category_filter.len(), before - 1);
+    }
+
+    #[test]
+    fn save_then_load_restores_tick() {
+        let mut state = AppState::new(1.0);
+        let mut sim = demo_sim();
+        for _ in 0..5 {
+            sim.step();
+        }
+        handle_key(&mut state, &mut sim, KeyCode::Char('s'), KeyModifiers::NONE);
+        let saved_tick = sim.current_tick();
+        for _ in 0..5 {
+            sim.step();
+        }
+        assert_eq!(sim.current_tick(), saved_tick + 5);
+        handle_key(&mut state, &mut sim, KeyCode::Char('l'), KeyModifiers::NONE);
+        assert_eq!(sim.current_tick(), saved_tick);
+    }
+
+    #[test]
+    fn enter_toggles_drilldown() {
+        let mut state = AppState::new(1.0);
+        let mut sim = demo_sim();
+        assert_eq!(state.right_panel, RightPanel::Overview);
+        handle_key(&mut state, &mut sim, KeyCode::Enter, KeyModifiers::NONE);
+        assert_eq!(state.right_panel, RightPanel::DrillDown);
+        handle_key(&mut state, &mut sim, KeyCode::Esc, KeyModifiers::NONE);
+        assert_eq!(state.right_panel, RightPanel::Overview);
     }
 
     #[test]

--- a/crates/elevator-tui/src/state.rs
+++ b/crates/elevator-tui/src/state.rs
@@ -43,10 +43,18 @@ pub struct LoggedEvent {
 }
 
 /// Bounded ring of recent samples used by sparkline panels.
+///
+/// Backed by a contiguous `Vec` (not `VecDeque`) so the renderer can
+/// borrow the buffer as `&[u64]` without allocating per frame. When
+/// the ring is full, `push` shifts existing samples down by one slot
+/// — O(n) but n ≤ `SPARKLINE_CAP` (256) is a single cache line and
+/// happens at most once per tick, dwarfed by the surrounding sim work.
+/// The trade is worth it: render runs at ~30 Hz and reads the slice
+/// twice per frame, so a per-render `collect` adds up.
 #[derive(Debug, Clone)]
 pub struct Sparkline {
-    /// Samples in insertion order; oldest at front.
-    pub samples: std::collections::VecDeque<u64>,
+    /// Samples in insertion order; oldest at index 0.
+    pub samples: Vec<u64>,
     /// Maximum sample count retained.
     pub capacity: usize,
 }
@@ -56,7 +64,7 @@ impl Sparkline {
     #[must_use]
     pub fn new(capacity: usize) -> Self {
         Self {
-            samples: std::collections::VecDeque::with_capacity(capacity),
+            samples: Vec::with_capacity(capacity),
             capacity,
         }
     }
@@ -64,16 +72,19 @@ impl Sparkline {
     /// Push a sample, dropping the oldest if at capacity.
     pub fn push(&mut self, value: u64) {
         if self.samples.len() == self.capacity {
-            self.samples.pop_front();
+            // Shift everything down by one. See struct doc for the
+            // rationale (small cap, infrequent calls, alloc-free reads).
+            self.samples.copy_within(1.., 0);
+            self.samples.pop();
         }
-        self.samples.push_back(value);
+        self.samples.push(value);
     }
 
     /// Slice view of the buffered samples (oldest first), suitable for
-    /// `ratatui::widgets::Sparkline::data`.
+    /// `ratatui::widgets::Sparkline::data`. Zero-cost; no allocation.
     #[must_use]
-    pub fn as_slice(&self) -> Vec<u64> {
-        self.samples.iter().copied().collect()
+    pub fn as_slice(&self) -> &[u64] {
+        &self.samples
     }
 }
 
@@ -298,7 +309,7 @@ mod tests {
         spark.push(2);
         spark.push(3);
         spark.push(4);
-        assert_eq!(spark.as_slice(), vec![2, 3, 4]);
+        assert_eq!(spark.as_slice(), &[2, 3, 4]);
     }
 
     #[test]

--- a/crates/elevator-tui/src/state.rs
+++ b/crates/elevator-tui/src/state.rs
@@ -20,6 +20,15 @@ pub enum ShaftMode {
     Distance,
 }
 
+/// Which side panel currently dominates the right column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RightPanel {
+    /// Events / Dispatch / Metrics stack (default).
+    Overview,
+    /// Per-car drill-down (queue, riders, recent car-touching events).
+    DrillDown,
+}
+
 /// A captured event plus the tick it was drained on.
 ///
 /// Tagged with the drain tick because [`Event`] variants don't all
@@ -31,6 +40,41 @@ pub struct LoggedEvent {
     pub tick: u64,
     /// The event itself.
     pub event: Event,
+}
+
+/// Bounded ring of recent samples used by sparkline panels.
+#[derive(Debug, Clone)]
+pub struct Sparkline {
+    /// Samples in insertion order; oldest at front.
+    pub samples: std::collections::VecDeque<u64>,
+    /// Maximum sample count retained.
+    pub capacity: usize,
+}
+
+impl Sparkline {
+    /// New empty sparkline of the given capacity.
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            samples: std::collections::VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    /// Push a sample, dropping the oldest if at capacity.
+    pub fn push(&mut self, value: u64) {
+        if self.samples.len() == self.capacity {
+            self.samples.pop_front();
+        }
+        self.samples.push_back(value);
+    }
+
+    /// Slice view of the buffered samples (oldest first), suitable for
+    /// `ratatui::widgets::Sparkline::data`.
+    #[must_use]
+    pub fn as_slice(&self) -> Vec<u64> {
+        self.samples.iter().copied().collect()
+    }
 }
 
 /// Top-level interactive app state.
@@ -49,10 +93,18 @@ pub struct AppState {
     /// Whether to filter the events panel to events touching the
     /// focused car's entity id.
     pub follow_focused: bool,
+    /// Right-column mode: overview vs. per-car drill-down.
+    pub right_panel: RightPanel,
     /// Bounded ring of drained events (newest at end).
     pub event_log: std::collections::VecDeque<LoggedEvent>,
     /// Cap for `event_log`.
     pub event_log_cap: usize,
+    /// p95 wait-time samples per tick.
+    pub wait_sparkline: Sparkline,
+    /// Total occupancy across all cars per tick.
+    pub occupancy_sparkline: Sparkline,
+    /// In-memory snapshot slot (`s` saves, `l` restores).
+    pub snapshot_slot: Option<elevator_core::snapshot::WorldSnapshot>,
     /// Status banner (transient feedback after a hotkey action).
     pub status: Option<String>,
     /// Monotonically incrementing counter bumped each time [`flash`] is
@@ -78,8 +130,12 @@ impl AppState {
             category_filter: all_categories(),
             focused_car_idx: 0,
             follow_focused: false,
+            right_panel: RightPanel::Overview,
             event_log: std::collections::VecDeque::with_capacity(EVENT_LOG_CAP),
             event_log_cap: EVENT_LOG_CAP,
+            wait_sparkline: Sparkline::new(SPARKLINE_CAP),
+            occupancy_sparkline: Sparkline::new(SPARKLINE_CAP),
+            snapshot_slot: None,
             status: None,
             status_seq: 0,
             quit: false,
@@ -198,6 +254,8 @@ pub fn event_touches(event: &Event, target: elevator_core::entity::EntityId) -> 
 
 /// Cap on retained events in the rolling log.
 const EVENT_LOG_CAP: usize = 1024;
+/// Cap on retained sparkline samples.
+const SPARKLINE_CAP: usize = 256;
 
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
@@ -231,6 +289,16 @@ mod tests {
             Event::ElevatorIdle { tick, .. } => assert_eq!(*tick, 9),
             other => panic!("unexpected event variant: {other:?}"),
         }
+    }
+
+    #[test]
+    fn sparkline_pushes_drop_oldest() {
+        let mut spark = Sparkline::new(3);
+        spark.push(1);
+        spark.push(2);
+        spark.push(3);
+        spark.push(4);
+        assert_eq!(spark.as_slice(), vec![2, 3, 4]);
     }
 
     #[test]

--- a/crates/elevator-tui/src/ui/drilldown.rs
+++ b/crates/elevator-tui/src/ui/drilldown.rs
@@ -1,0 +1,91 @@
+//! Per-car drill-down panel — replaces the right column with a deep
+//! view of the focused car: phase, queue, riders aboard, and the recent
+//! events that touch it.
+
+use elevator_core::sim::Simulation;
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use crate::state::AppState;
+use crate::ui::{events, shaft};
+
+/// Render the drill-down panel.
+pub fn draw(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulation) {
+    let cars: Vec<_> = shaft::cars_iter(sim).collect();
+    let Some(focused) = cars.get(state.focused_car_idx) else {
+        let block = Block::default()
+            .borders(Borders::LEFT)
+            .title(" drill-down ");
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        frame.render_widget(Paragraph::new("no cars in this sim"), inner);
+        return;
+    };
+
+    let title = Line::from(format!(" drill-down · {:?} ", focused.id))
+        .style(Style::default().add_modifier(Modifier::BOLD));
+    let block = Block::default().borders(Borders::LEFT).title(title);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let mut lines: Vec<Line<'_>> = Vec::new();
+    let elev = focused.elevator;
+    lines.push(Line::from(format!("phase     {}", elev.phase())));
+    lines.push(Line::from(format!("door      {}", elev.door())));
+    lines.push(Line::from(format!(
+        "load      {} / {}",
+        elev.current_load(),
+        elev.weight_capacity(),
+    )));
+    lines.push(Line::from(format!(
+        "speed     max {} / accel {} / decel {}",
+        elev.max_speed(),
+        elev.acceleration(),
+        elev.deceleration(),
+    )));
+    lines.push(Line::from(format!("position  {:.2}", focused.position)));
+
+    if let Some(queue) = sim.destination_queue(elevator_core::entity::ElevatorId::from(focused.id))
+    {
+        lines.push(Line::from(""));
+        lines.push(Line::from(format!("queue ({} stops)", queue.len())));
+        for stop_id in queue {
+            lines.push(Line::from(format!("  → {stop_id:?}")));
+        }
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(format!(
+        "riders aboard ({})",
+        focused.riders.len()
+    )));
+    for rider in focused.riders.iter().take(8) {
+        lines.push(Line::from(format!("  · {rider:?}")));
+    }
+    if focused.riders.len() > 8 {
+        lines.push(Line::from(format!(
+            "  · … {} more",
+            focused.riders.len() - 8
+        )));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from("recent events touching this car"));
+    for logged in state
+        .event_log
+        .iter()
+        .rev()
+        .filter(|l| crate::state::event_touches(&l.event, focused.id))
+        .take(8)
+    {
+        lines.push(Line::from(format!(
+            "  {}",
+            events::format_event_line(logged.tick, &logged.event)
+        )));
+    }
+
+    frame.render_widget(Paragraph::new(lines), inner);
+}

--- a/crates/elevator-tui/src/ui/metrics.rs
+++ b/crates/elevator-tui/src/ui/metrics.rs
@@ -1,19 +1,31 @@
-//! Metrics panel — aggregate counters from `Simulation::metrics()`.
+//! Metrics panel — aggregate counters plus rolling sparklines for p95
+//! wait time and total occupancy.
 
 use elevator_core::sim::Simulation;
 use ratatui::Frame;
-use ratatui::layout::Rect;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::Line;
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::widgets::{Block, Borders, Paragraph, Sparkline};
+
+use crate::state::AppState;
 
 /// Render the metrics panel.
-pub fn draw(frame: &mut Frame<'_>, area: Rect, sim: &Simulation) {
+pub fn draw(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulation) {
     let block = Block::default()
         .borders(Borders::BOTTOM)
         .title(Line::from(" metrics ").style(Style::default().add_modifier(Modifier::BOLD)));
     let inner = block.inner(area);
     frame.render_widget(block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(5), // counter text
+            Constraint::Length(2), // wait sparkline
+            Constraint::Length(2), // occupancy sparkline
+        ])
+        .split(inner);
 
     let m = sim.metrics();
     let counters = vec![
@@ -38,5 +50,21 @@ pub fn draw(frame: &mut Frame<'_>, area: Rect, sim: &Simulation) {
             ut = m.avg_utilization() * 100.0,
         )),
     ];
-    frame.render_widget(Paragraph::new(counters), inner);
+    frame.render_widget(Paragraph::new(counters), chunks[0]);
+
+    let wait = state.wait_sparkline.as_slice();
+    frame.render_widget(
+        Sparkline::default()
+            .block(Block::default().title("p95 wait (ticks)"))
+            .data(&wait),
+        chunks[1],
+    );
+
+    let occ = state.occupancy_sparkline.as_slice();
+    frame.render_widget(
+        Sparkline::default()
+            .block(Block::default().title("total occupancy"))
+            .data(&occ),
+        chunks[2],
+    );
 }

--- a/crates/elevator-tui/src/ui/metrics.rs
+++ b/crates/elevator-tui/src/ui/metrics.rs
@@ -18,10 +18,15 @@ pub fn draw(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulatio
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
+    // The metrics panel only gets ~5 inner rows in a default 30-row
+    // terminal. The earlier `Length(5) + Length(2) + Length(2)` was 9
+    // rows; ratatui scaled them proportionally and silently dropped
+    // the third counter line. Use `Min(3)` so the counters always
+    // get their full text but collapse last when the panel is tight.
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(5), // counter text
+            Constraint::Min(3),    // 3 counter lines — full or shrink under pressure
             Constraint::Length(2), // wait sparkline
             Constraint::Length(2), // occupancy sparkline
         ])
@@ -52,19 +57,16 @@ pub fn draw(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulatio
     ];
     frame.render_widget(Paragraph::new(counters), chunks[0]);
 
-    let wait = state.wait_sparkline.as_slice();
     frame.render_widget(
         Sparkline::default()
             .block(Block::default().title("p95 wait (ticks)"))
-            .data(&wait),
+            .data(state.wait_sparkline.as_slice()),
         chunks[1],
     );
-
-    let occ = state.occupancy_sparkline.as_slice();
     frame.render_widget(
         Sparkline::default()
             .block(Block::default().title("total occupancy"))
-            .data(&occ),
+            .data(state.occupancy_sparkline.as_slice()),
         chunks[2],
     );
 }

--- a/crates/elevator-tui/src/ui/mod.rs
+++ b/crates/elevator-tui/src/ui/mod.rs
@@ -7,9 +7,10 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::Line;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-use crate::state::AppState;
+use crate::state::{AppState, RightPanel};
 
 pub mod dispatch;
+pub mod drilldown;
 pub mod events;
 pub mod metrics;
 pub mod shaft;
@@ -36,7 +37,11 @@ pub fn draw(frame: &mut Frame<'_>, state: &AppState, sim: &Simulation) {
         .split(outer[1]);
 
     shaft::draw(frame, body[0], state, sim);
-    draw_overview(frame, body[1], state, sim);
+
+    match state.right_panel {
+        RightPanel::Overview => draw_overview(frame, body[1], state, sim),
+        RightPanel::DrillDown => drilldown::draw(frame, body[1], state, sim),
+    }
 
     draw_footer(frame, outer[2], state);
 }
@@ -50,10 +55,11 @@ fn draw_title(
 ) {
     let mode = if state.paused { "PAUSED" } else { "RUNNING" };
     let line = Line::from(format!(
-        " elevator-tui   tick {tick}   {mode}   rate {rate:.2}×   shaft {shaft:?}",
+        " elevator-tui   tick {tick}   {mode}   rate {rate:.2}×   shaft {shaft:?}   panel {panel:?}",
         tick = sim.current_tick(),
         rate = state.tick_rate,
         shaft = state.shaft_mode,
+        panel = state.right_panel,
     ));
     frame.render_widget(
         Paragraph::new(line).style(Style::default().add_modifier(Modifier::BOLD)),
@@ -64,7 +70,7 @@ fn draw_title(
 /// Footer: condensed hotkey reference + transient status flash.
 fn draw_footer(frame: &mut Frame<'_>, area: ratatui::layout::Rect, state: &AppState) {
     let mut text = String::from(
-        " space pause  . step  , step×10  +/- rate  m shaft  []car  f follow  1-7 filter  q quit",
+        " space pause  . step  , step×10  +/- rate  m shaft  []car  f follow  Enter drill  s save  l load  1-7 filter  q quit",
     );
     if let Some(status) = &state.status {
         text.push_str("   │   ");
@@ -95,5 +101,5 @@ fn draw_overview(
 
     events::draw(frame, chunks[0], state, sim);
     dispatch::draw(frame, chunks[1], sim);
-    metrics::draw(frame, chunks[2], sim);
+    metrics::draw(frame, chunks[2], state, sim);
 }

--- a/crates/elevator-tui/tests/snapshots/render_snapshot__default_after_120_ticks.snap
+++ b/crates/elevator-tui/tests/snapshots/render_snapshot__default_after_120_ticks.snap
@@ -2,7 +2,7 @@
 source: crates/elevator-tui/tests/render_snapshot.rs
 expression: frame
 ---
- elevator-tui   tick 120   RUNNING   rate 1.00×   shaft Index                                       
+ elevator-tui   tick 120   RUNNING   rate 1.00×   shaft Index   panel Overview                      
 ┌ shaft · 1 car(s) ───┐│ overview                                                                   
 │Top         10.0 │ · ││ events · filter [all]                                                      
 │Ground       0.0 │ ▲ ││                                                                            
@@ -27,8 +27,8 @@ expression: frame
 │                     ││ metrics                                                                    
 │                     ││spawned 1   delivered 0   abandoned 0 (0.0%)                                
 │                     ││wait avg 4.0t   p95 4t   max 4t                                             
-│                     ││ride avg 0.0t   throughput 0/3600t   util 100.0%                            
-│                     ││                                                                            
+│                     ││p95 wait (ticks)                                                            
+│                     ││total occupancy                                                             
 │                     ││                                                                            
 └─────────────────────┘│────────────────────────────────────────────────────────────────────────────
- space pause  . step  , step×10  +/- rate  m shaft  []car  f follow  1-7 filter  q quit
+ space pause  . step  , step×10  +/- rate  m shaft  []car  f follow  Enter drill  s save  l load  1-

--- a/crates/elevator-tui/tests/snapshots/render_snapshot__default_after_120_ticks.snap
+++ b/crates/elevator-tui/tests/snapshots/render_snapshot__default_after_120_ticks.snap
@@ -27,8 +27,8 @@ expression: frame
 │                     ││ metrics                                                                    
 │                     ││spawned 1   delivered 0   abandoned 0 (0.0%)                                
 │                     ││wait avg 4.0t   p95 4t   max 4t                                             
+│                     ││ride avg 0.0t   throughput 0/3600t   util 100.0%                            
 │                     ││p95 wait (ticks)                                                            
 │                     ││total occupancy                                                             
-│                     ││                                                                            
 └─────────────────────┘│────────────────────────────────────────────────────────────────────────────
  space pause  . step  , step×10  +/- rate  m shaft  []car  f follow  Enter drill  s save  l load  1-

--- a/crates/elevator-tui/tests/snapshots/render_snapshot__distance_mode_after_60_ticks.snap
+++ b/crates/elevator-tui/tests/snapshots/render_snapshot__distance_mode_after_60_ticks.snap
@@ -27,8 +27,8 @@ expression: frame
 │             2.0 │ · ││ metrics                                                                    
 │             1.6 │ · ││spawned 1   delivered 0   abandoned 0 (0.0%)                                
 │             1.2 │ · ││wait avg 4.0t   p95 4t   max 4t                                             
-│             0.8 │ · ││p95 wait (ticks)                                                            
-│             0.4 │ * ││total occupancy                                                             
-│Ground       0.0 │ · ││                                                                            
+│             0.8 │ · ││ride avg 0.0t   throughput 0/3600t   util 100.0%                            
+│             0.4 │ * ││p95 wait (ticks)                                                            
+│Ground       0.0 │ · ││total occupancy                                                             
 └─────────────────────┘│────────────────────────────────────────────────────────────────────────────
  space pause  . step  , step×10  +/- rate  m shaft  []car  f follow  Enter drill  s save  l load  1-

--- a/crates/elevator-tui/tests/snapshots/render_snapshot__distance_mode_after_60_ticks.snap
+++ b/crates/elevator-tui/tests/snapshots/render_snapshot__distance_mode_after_60_ticks.snap
@@ -2,7 +2,7 @@
 source: crates/elevator-tui/tests/render_snapshot.rs
 expression: frame
 ---
- elevator-tui   tick 60   RUNNING   rate 1.00×   shaft Distance                                     
+ elevator-tui   tick 60   RUNNING   rate 1.00×   shaft Distance   panel Overview                    
 ┌ shaft · 1 car(s) ───┐│ overview                                                                   
 │Top         10.0 │ · ││ events · filter [all]                                                      
 │             9.6 │ · ││                                                                            
@@ -27,8 +27,8 @@ expression: frame
 │             2.0 │ · ││ metrics                                                                    
 │             1.6 │ · ││spawned 1   delivered 0   abandoned 0 (0.0%)                                
 │             1.2 │ · ││wait avg 4.0t   p95 4t   max 4t                                             
-│             0.8 │ · ││ride avg 0.0t   throughput 0/3600t   util 100.0%                            
-│             0.4 │ * ││                                                                            
+│             0.8 │ · ││p95 wait (ticks)                                                            
+│             0.4 │ * ││total occupancy                                                             
 │Ground       0.0 │ · ││                                                                            
 └─────────────────────┘│────────────────────────────────────────────────────────────────────────────
- space pause  . step  , step×10  +/- rate  m shaft  []car  f follow  1-7 filter  q quit
+ space pause  . step  , step×10  +/- rate  m shaft  []car  f follow  Enter drill  s save  l load  1-

--- a/docs/src/tui-debugger.md
+++ b/docs/src/tui-debugger.md
@@ -97,6 +97,8 @@ The shaft has two modes you can toggle at runtime with `m`:
 | `m`       | Cycle shaft mode (Index <-> Distance)                               |
 | `]`, `[`  | Focus next / previous car                                           |
 | `f`       | Toggle follow mode -- filters the events panel to the focused car  |
+| `Enter`   | Open the per-car drill-down panel for the focused car              |
+| `Esc`     | Close drill-down                                                    |
 
 ### Event filtering
 
@@ -109,6 +111,13 @@ The shaft has two modes you can toggle at runtime with `m`:
 | `5` | Reposition        |
 | `6` | Direction         |
 | `7` | Observability     |
+
+### Snapshot
+
+| Key | Action                                              |
+| --- | ---                                                 |
+| `s` | Save the current sim state to an in-memory slot     |
+| `l` | Restore the saved sim state (clears event/sparkline) |
 
 ### Quit
 
@@ -123,9 +132,13 @@ The shaft has two modes you can toggle at runtime with `m`:
 
 1. Press `space` to pause as soon as you see the car about to skip.
 2. Press `[` / `]` until the car is focused (its glyph reverses).
-3. Press `f` to filter events to the car -- you can scroll back
+3. Press `Enter` to open the drill-down -- the destination queue
+   reveals what stops dispatch put on its route.
+4. Press `f` to filter events to the car -- you can scroll back
    through `Assigned`, `PassingFloor`, and door events to see the
    bypass decision in context.
+5. Press `s` to save the snapshot at the suspicious tick. Press `l`
+   later to come back to this exact moment.
 
 ### Reproducing a bug from a headless trace
 
@@ -173,11 +186,10 @@ render layer (`ui/`) only reads from the state and a borrowed
 
 ## Next steps
 
-- The v1 viewer is intentionally read-only. If you want to spawn
+- The viewer is intentionally read-only. If you want to spawn
   riders, change strategies, or pin assignments interactively, those
-  would land in a controller mode.
-- A polish wave (tracked in `bindings.toml` as `tui-pr2`) adds
-  snapshot save/load on a hotkey, sparkline trends in the metrics
-  panel, and a per-car drill-down panel.
+  would land in a follow-up controller mode.
+- For richer event introspection (regex search, structured query),
+  the event log could grow a slash-command bar -- not needed yet.
 - See [Snapshots and Determinism](snapshots-determinism.md) for the
-  semantics of the underlying `Simulation::snapshot()` API.
+  semantics of the `s`/`l` hotkeys and what restoration preserves.

--- a/docs/src/tui-debugger.md
+++ b/docs/src/tui-debugger.md
@@ -97,8 +97,8 @@ The shaft has two modes you can toggle at runtime with `m`:
 | `m`       | Cycle shaft mode (Index <-> Distance)                               |
 | `]`, `[`  | Focus next / previous car                                           |
 | `f`       | Toggle follow mode -- filters the events panel to the focused car  |
-| `Enter`   | Open the per-car drill-down panel for the focused car              |
-| `Esc`     | Close drill-down                                                    |
+| `Enter`   | Toggle the per-car drill-down panel for the focused car            |
+| `Esc`     | Close drill-down (no-op when already closed)                       |
 
 ### Event filtering
 


### PR DESCRIPTION
## Summary

- Polish wave on top of the TUI skeleton merged in #521
- Adds the three features that were marked `tui-pr2` in `bindings.toml`
- Net diff: ~290 LOC + new `crates/elevator-tui/src/ui/drilldown.rs`

## Features

**Snapshot save/load (`s` / `l`)** — `s` captures the sim into an in-memory slot via `Simulation::snapshot()`; `l` restores it via `WorldSnapshot::restore`. Pairs with paused stepping for bug repro: jump to the suspicious tick, save, explore freely (step or push the rate), then `l` to come back to the exact moment. Restoration also clears the event log and sparkline buffers so the rolling state matches the restored sim.

**Sparkline trends** — `state.rs` gains a `Sparkline` ring buffer (capacity 256). `app::step_once` pushes p95 wait time and total occupancy each tick; `ui/metrics.rs` renders them under the counter block via `ratatui::widgets::Sparkline`. Cheap visual cue that something just spiked.

**Per-car drill-down (`Enter` / `Esc`)** — new `RightPanel` enum on `AppState`, branched on in `ui/mod.rs`. `Enter` swaps the right column for `ui/drilldown.rs` which shows the focused car's phase, door, queue, riders aboard, and recent touching events. `Esc` returns to the overview.

## Bindings + docs

- `bindings.toml`: `destination_queue` flipped from `todo:tui-pr2` to `drilldown_panel`; the `tui-pr2` phase marker block is removed since the polish wave is shipping
- `docs/src/tui-debugger.md`: hotkey tables and debugging recipes updated; \"Next steps\" section trimmed since the polish wave is no longer pending

## Test plan

- [x] `cargo test -p elevator-tui` — 15 unit + 2 snapshot tests pass (was 12+2 in the skeleton; +3 for sparkline ring, snapshot save/load round-trip, drill-down toggle)
- [x] `cargo clippy -p elevator-tui --all-targets -- -D warnings`
- [x] `cargo fmt -p elevator-tui --check`
- [x] `bash scripts/check-bindings.sh` — 13 exported / 0 todo / 127 skipped (was 12 / 1 / 127)
- [x] `bash scripts/lint-docs.sh --quick`
- [ ] Interactive sanity check on a real terminal (manual; not covered by CI)