### PR TITLE
fix(deps): bump rand 0.8.5 -> 0.8.6 (GHSA-cq8v-f236-94qc)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4337,7 +4337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
 ]
 
@@ -4687,9 +4687,9 @@ checksum = "019b4b213425016d7d84a153c4c73afb0946fbb4840e4eece7ba8848b9d6da22"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
  "serde",


### PR DESCRIPTION
## Summary

- Lockfile-only bump of transitive `rand 0.8.5 → 0.8.6` to clear Dependabot alert #5 (GHSA-cq8v-f236-94qc, low severity — `rand::rng()` unsoundness when paired with a custom logger).
- Edge: `wgpu-hal → ordered-float → rand 0.8.x`. `Cargo.toml` files are unchanged; only `Cargo.lock` moves.

## Notes on the other open alert

Alert #7 (`lru` GHSA-rhfx-m35p-ff5j, low) is **not** included here. The fix lives at `lru ≥ 0.16.3`, but `ratatui 0.29` (used by `elevator-tui`) pins `lru = "0.12"`, so a SemVer-respecting lockfile bump can't reach it. Closing this alert requires upgrading `ratatui` to `0.30` — a recent major release that splits the crate into `ratatui-core` / `ratatui-widgets` / `ratatui-crossterm` and will need a focused migration PR for the 8 modules in `crates/elevator-tui/src`. Out of scope for a security lockfile bump; happy to do it as a follow-up.

## Test plan

- [x] `cargo check --workspace` (incl. Bevy stack)
- [x] `cargo test -p elevator-core --all-features` (852 unit + 159 doc tests pass)
- [x] `cargo test -p elevator-tui` (17 tests pass — sanity-check unrelated TUI crate)
- [x] `cargo clippy -p elevator-core --all-features` (clean)
- [x] Full pre-commit hook passes (fmt, clippy, core tests, doc tests, workspace check)
- [ ] Wait for greptile review before merging