### PR TITLE
feat(tui): bashtop-inspired chrome, onboarding, richer demo

### DIFF
--- a/assets/config/default.ron
+++ b/assets/config/default.ron
@@ -1,23 +1,55 @@
+// Demo Tower — three elevators serving an 8-stop building.
+//
+// Tuned so the sim is visibly active within the first few seconds:
+// passengers spawn ~2/sec, weights vary, and the three cars develop
+// distinct behaviours under the default Scan dispatcher (the express
+// idles higher, the locals oscillate). For a sparser/faster mover
+// scenario see `space_elevator.ron`.
 SimConfig(
     building: BuildingConfig(
         name: "Demo Tower",
         stops: [
-            StopConfig(id: StopId(0), name: "Ground", position: 0.0),
-            StopConfig(id: StopId(1), name: "Floor 2", position: 4.0),
-            StopConfig(id: StopId(2), name: "Floor 3", position: 7.5),
-            StopConfig(id: StopId(3), name: "Floor 4", position: 11.0),
-            StopConfig(id: StopId(4), name: "Roof", position: 15.0),
+            StopConfig(id: StopId(0), name: "Lobby",   position: 0.0),
+            StopConfig(id: StopId(1), name: "L2",      position: 4.0),
+            StopConfig(id: StopId(2), name: "L3",      position: 7.5),
+            StopConfig(id: StopId(3), name: "L4",      position: 11.0),
+            StopConfig(id: StopId(4), name: "L5",      position: 14.5),
+            StopConfig(id: StopId(5), name: "L6",      position: 18.0),
+            StopConfig(id: StopId(6), name: "Sky",     position: 22.0),
+            StopConfig(id: StopId(7), name: "Roof",    position: 25.0),
         ],
     ),
     elevators: [
         ElevatorConfig(
             id: 0,
-            name: "Main",
+            name: "Express",
+            max_speed: 3.5,
+            acceleration: 2.0,
+            deceleration: 2.5,
+            weight_capacity: 1200.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 50,
+            door_transition_ticks: 12,
+        ),
+        ElevatorConfig(
+            id: 1,
+            name: "Local-A",
             max_speed: 2.0,
             acceleration: 1.5,
             deceleration: 2.0,
             weight_capacity: 800.0,
-            starting_stop: StopId(0),
+            starting_stop: StopId(2),
+            door_open_ticks: 60,
+            door_transition_ticks: 15,
+        ),
+        ElevatorConfig(
+            id: 2,
+            name: "Local-B",
+            max_speed: 2.0,
+            acceleration: 1.5,
+            deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(5),
             door_open_ticks: 60,
             door_transition_ticks: 15,
         ),
@@ -26,7 +58,7 @@ SimConfig(
         ticks_per_second: 60.0,
     ),
     passenger_spawning: PassengerSpawnConfig(
-        mean_interval_ticks: 120,
-        weight_range: (50.0, 100.0),
+        mean_interval_ticks: 30,
+        weight_range: (50.0, 110.0),
     ),
 )

--- a/crates/elevator-core/src/tests/config_tests.rs
+++ b/crates/elevator-core/src/tests/config_tests.rs
@@ -8,14 +8,18 @@ fn deserialize_default_ron() {
     let config: SimConfig = ron::from_str(ron_str).expect("Failed to deserialize default.ron");
 
     assert_eq!(config.building.name, "Demo Tower");
-    assert_eq!(config.building.stops.len(), 5);
-    assert!((config.building.stops[0].position - 0.0).abs() < f64::EPSILON);
-    assert!((config.building.stops[4].position - 15.0).abs() < f64::EPSILON);
-    assert_eq!(config.elevators.len(), 1);
-    assert!((config.elevators[0].max_speed.value() - 2.0).abs() < f64::EPSILON);
-    assert!((config.elevators[0].weight_capacity.value() - 800.0).abs() < f64::EPSILON);
+    assert_eq!(config.building.stops.len(), 8);
+    let first = config.building.stops.first().expect("at least one stop");
+    let last = config.building.stops.last().expect("at least one stop");
+    assert!((first.position - 0.0).abs() < f64::EPSILON);
+    assert!((last.position - 25.0).abs() < f64::EPSILON);
+    assert_eq!(config.elevators.len(), 3);
+    let express = &config.elevators[0];
+    assert_eq!(express.name, "Express");
+    assert!((express.max_speed.value() - 3.5).abs() < f64::EPSILON);
+    assert!((express.weight_capacity.value() - 1200.0).abs() < f64::EPSILON);
     assert!((config.simulation.ticks_per_second - 60.0).abs() < f64::EPSILON);
-    assert_eq!(config.passenger_spawning.mean_interval_ticks, 120);
+    assert_eq!(config.passenger_spawning.mean_interval_ticks, 30);
 }
 
 #[test]

--- a/crates/elevator-tui/src/app.rs
+++ b/crates/elevator-tui/src/app.rs
@@ -8,8 +8,10 @@ use anyhow::{Context as _, Result};
 use crossterm::event::{self, Event as TermEvent, KeyCode, KeyEventKind, KeyModifiers};
 use crossterm::execute;
 use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen};
+use elevator_core::config::SimConfig;
 use elevator_core::events::EventCategory;
 use elevator_core::sim::Simulation;
+use elevator_core::traffic::{PoissonSource, TrafficSource as _};
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 
@@ -20,18 +22,29 @@ use crate::ui;
 ///
 /// `initial_tick_rate` is multiplied by the sim's configured
 /// `ticks_per_second`; `1.0` runs the sim in real wall-clock time.
+/// When `show_welcome` is `false`, the first-launch welcome overlay is
+/// suppressed (e.g. `--no-welcome`).
+///
+/// `config` is required so the interactive loop can drive a
+/// [`PoissonSource`] each tick — without it the sim has no built-in
+/// spawner and the TUI sits forever on an empty event stream.
 ///
 /// # Errors
 ///
 /// Returns the underlying I/O error if terminal setup, polling, or
 /// rendering fails. The terminal is always restored on the way out
 /// (success, error, or panic via `Drop`).
-pub fn run(sim: Simulation, initial_tick_rate: f64) -> Result<()> {
+pub fn run(
+    sim: Simulation,
+    config: &SimConfig,
+    initial_tick_rate: f64,
+    show_welcome: bool,
+) -> Result<()> {
     let mut terminal = setup_terminal().context("setting up terminal")?;
     // RAII: the terminal is restored when `_guard` drops, whether
     // `event_loop` returns Ok, returns Err, or panics.
     let _guard = TerminalGuard;
-    event_loop(&mut terminal, sim, initial_tick_rate)
+    event_loop(&mut terminal, sim, config, initial_tick_rate, show_welcome)
 }
 
 /// Frame budget — caps render rate at ~30 fps.
@@ -42,9 +55,13 @@ const FRAME_BUDGET: Duration = Duration::from_millis(33);
 fn event_loop(
     terminal: &mut Terminal<CrosstermBackend<Stdout>>,
     mut sim: Simulation,
+    config: &SimConfig,
     initial_tick_rate: f64,
+    show_welcome: bool,
 ) -> Result<()> {
     let mut state = AppState::new(initial_tick_rate);
+    state.show_welcome = show_welcome;
+    let mut traffic = PoissonSource::from_config(config);
     let cfg_tps = sim.time().ticks_per_second();
     let mut accumulator = 0.0_f64;
     let mut last = Instant::now();
@@ -91,7 +108,7 @@ fn event_loop(
             let max_per_frame = (cfg_tps * state.tick_rate * 0.1).max(1.0).ceil();
             let mut budget = max_per_frame as u64;
             while accumulator >= 1.0 && budget > 0 {
-                step_once(&mut sim, &mut state);
+                step_once(&mut sim, &mut traffic, &mut state);
                 accumulator -= 1.0;
                 budget -= 1;
             }
@@ -121,38 +138,87 @@ fn event_loop(
     }
 }
 
-/// Drive a single sim tick, drain its events, and update sparklines.
-fn step_once(sim: &mut Simulation, state: &mut AppState) {
+/// Drive a single sim tick (with Poisson spawning), drain events,
+/// update sparklines.
+///
+/// Spawn requests are issued *before* the step so each new rider is in
+/// place before the dispatcher runs its planning pass. Failed spawns
+/// are silently dropped — they generally point at a config/topology
+/// mismatch and the next tick's request will tell the same story
+/// without us spamming the events panel.
+fn step_once(sim: &mut Simulation, traffic: &mut PoissonSource, state: &mut AppState) {
+    for req in traffic.generate(sim.current_tick()) {
+        let _ = sim.spawn_rider(req.origin, req.destination, req.weight);
+    }
     sim.step();
+    record_step(sim, state);
+}
+
+/// Step variant used when no traffic source is in scope (manual `.`
+/// stepping in unit tests, primarily). Doesn't spawn riders.
+fn step_no_traffic(sim: &mut Simulation, state: &mut AppState) {
+    sim.step();
+    record_step(sim, state);
+}
+
+/// Post-step bookkeeping: drain events into the log, update sparklines,
+/// roll the spawn bucket. Runs after every step — auto or manual.
+fn record_step(sim: &mut Simulation, state: &mut AppState) {
     let tick = sim.current_tick();
     let drained = sim.drain_events();
+    let spawned: u64 = drained
+        .iter()
+        .filter(|e| matches!(e, elevator_core::events::Event::RiderSpawned { .. }))
+        .count() as u64;
+    for _ in 0..spawned {
+        state.observe_spawn();
+    }
     state.push_events(tick, drained);
 
     state.wait_sparkline.push(sim.metrics().p95_wait_time());
     let total_occupancy: usize = ui::shaft::cars_iter(sim).map(|car| car.riders.len()).sum();
     state.occupancy_sparkline.push(total_occupancy as u64);
+    state.advance_spawn_bucket(tick, sim.time().ticks_per_second());
 }
 
 /// Map a single keypress to a state transition (and possibly a sim
 /// mutation, for single-step).
+#[allow(clippy::too_many_lines)]
 fn handle_key(state: &mut AppState, sim: &mut Simulation, code: KeyCode, modifiers: KeyModifiers) {
     if matches!(code, KeyCode::Char('c')) && modifiers.contains(KeyModifiers::CONTROL) {
         state.quit = true;
         return;
     }
+    // Welcome overlay swallows the first keypress, no matter what it is —
+    // including `q`, so a user who hits q-then-q doesn't accidentally
+    // quit while reading. Ctrl-C is checked above and still escapes.
+    if state.show_welcome {
+        state.show_welcome = false;
+        return;
+    }
+    // Help overlay closes on `?`, Esc, or `q` (and any of the explicit
+    // toggles below by re-pressing). `q` here means "close help", not
+    // "quit the app" — same justification as welcome above.
+    if state.show_help {
+        if matches!(code, KeyCode::Char('?' | 'q') | KeyCode::Esc) {
+            state.show_help = false;
+        }
+        return;
+    }
     match code {
+        KeyCode::Char('?') => state.show_help = true,
         KeyCode::Char('q') => state.quit = true,
         KeyCode::Char(' ') => {
             state.paused = !state.paused;
             state.flash(if state.paused { "paused" } else { "running" });
         }
         KeyCode::Char('.') => {
-            step_once(sim, state);
+            step_no_traffic(sim, state);
             state.flash(format!("step → tick {}", sim.current_tick()));
         }
         KeyCode::Char(',') => {
             for _ in 0..10 {
-                step_once(sim, state);
+                step_no_traffic(sim, state);
             }
             state.flash(format!("step ×10 → tick {}", sim.current_tick()));
         }
@@ -278,7 +344,7 @@ mod tests {
 
     #[test]
     fn space_toggles_pause() {
-        let mut state = AppState::new(1.0);
+        let mut state = AppState::new(1.0).without_welcome();
         let mut sim = demo_sim();
         assert!(!state.paused);
         handle_key(&mut state, &mut sim, KeyCode::Char(' '), KeyModifiers::NONE);
@@ -289,7 +355,7 @@ mod tests {
 
     #[test]
     fn dot_advances_one_tick() {
-        let mut state = AppState::new(1.0);
+        let mut state = AppState::new(1.0).without_welcome();
         let mut sim = demo_sim();
         let before = sim.current_tick();
         handle_key(&mut state, &mut sim, KeyCode::Char('.'), KeyModifiers::NONE);
@@ -298,7 +364,7 @@ mod tests {
 
     #[test]
     fn rate_clamps_to_safe_bounds() {
-        let mut state = AppState::new(1.0);
+        let mut state = AppState::new(1.0).without_welcome();
         let mut sim = demo_sim();
         for _ in 0..20 {
             handle_key(&mut state, &mut sim, KeyCode::Char('+'), KeyModifiers::NONE);
@@ -312,7 +378,7 @@ mod tests {
 
     #[test]
     fn category_digit_keys_toggle_filters() {
-        let mut state = AppState::new(1.0);
+        let mut state = AppState::new(1.0).without_welcome();
         let mut sim = demo_sim();
         let before = state.category_filter.len();
         handle_key(&mut state, &mut sim, KeyCode::Char('2'), KeyModifiers::NONE);
@@ -321,7 +387,7 @@ mod tests {
 
     #[test]
     fn save_then_load_restores_tick() {
-        let mut state = AppState::new(1.0);
+        let mut state = AppState::new(1.0).without_welcome();
         let mut sim = demo_sim();
         for _ in 0..5 {
             sim.step();
@@ -338,7 +404,7 @@ mod tests {
 
     #[test]
     fn enter_toggles_drilldown() {
-        let mut state = AppState::new(1.0);
+        let mut state = AppState::new(1.0).without_welcome();
         let mut sim = demo_sim();
         assert_eq!(state.right_panel, RightPanel::Overview);
         handle_key(&mut state, &mut sim, KeyCode::Enter, KeyModifiers::NONE);
@@ -349,7 +415,7 @@ mod tests {
 
     #[test]
     fn ctrl_c_quits() {
-        let mut state = AppState::new(1.0);
+        let mut state = AppState::new(1.0).without_welcome();
         let mut sim = demo_sim();
         handle_key(
             &mut state,

--- a/crates/elevator-tui/src/cli.rs
+++ b/crates/elevator-tui/src/cli.rs
@@ -36,4 +36,10 @@ pub struct Cli {
     /// with new arrivals. Ignored when interactive.
     #[arg(long)]
     pub no_traffic: bool,
+
+    /// Suppress the first-launch welcome overlay. Ignored in headless
+    /// mode; intended for scripted demos / screen recordings where the
+    /// overlay would obscure the first frames.
+    #[arg(long)]
+    pub no_welcome: bool,
 }

--- a/crates/elevator-tui/src/main.rs
+++ b/crates/elevator-tui/src/main.rs
@@ -11,6 +11,6 @@ fn main() -> anyhow::Result<()> {
     if cli.headless {
         headless::run(sim, &config, cli.until, cli.emit.as_deref(), cli.no_traffic)
     } else {
-        app::run(sim, cli.tick_rate)
+        app::run(sim, &config, cli.tick_rate, !cli.no_welcome)
     }
 }

--- a/crates/elevator-tui/src/state.rs
+++ b/crates/elevator-tui/src/state.rs
@@ -90,6 +90,7 @@ impl Sparkline {
 
 /// Top-level interactive app state.
 #[derive(Debug)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct AppState {
     /// Sim is paused (no auto-stepping). `space` toggles, `.` single-steps.
     pub paused: bool,
@@ -114,6 +115,15 @@ pub struct AppState {
     pub wait_sparkline: Sparkline,
     /// Total occupancy across all cars per tick.
     pub occupancy_sparkline: Sparkline,
+    /// Spawns-per-second samples, one per second of sim time.
+    /// Updated from the spawn counter every `ticks_per_second` ticks.
+    pub spawn_rate_sparkline: Sparkline,
+    /// Spawns observed in the current 1-second bucket. Reset to 0 each
+    /// time we push to [`spawn_rate_sparkline`](Self::spawn_rate_sparkline).
+    pub spawn_bucket: u64,
+    /// Tick at which the current spawn-rate bucket started; rolled over
+    /// once `current_tick - bucket_started_at >= ticks_per_second`.
+    pub bucket_started_at: u64,
     /// In-memory snapshot slot (`s` saves, `l` restores).
     pub snapshot_slot: Option<elevator_core::snapshot::WorldSnapshot>,
     /// Status banner (transient feedback after a hotkey action).
@@ -126,6 +136,11 @@ pub struct AppState {
     ///
     /// [`flash`]: Self::flash
     pub status_seq: u64,
+    /// Help overlay is visible (toggled by `?`).
+    pub show_help: bool,
+    /// First-launch welcome overlay is visible. Dismissed by any key.
+    /// Default `true` unless suppressed by `--no-welcome`.
+    pub show_welcome: bool,
     /// User has requested a clean exit.
     pub quit: bool,
 }
@@ -146,11 +161,46 @@ impl AppState {
             event_log_cap: EVENT_LOG_CAP,
             wait_sparkline: Sparkline::new(SPARKLINE_CAP),
             occupancy_sparkline: Sparkline::new(SPARKLINE_CAP),
+            spawn_rate_sparkline: Sparkline::new(SPARKLINE_CAP),
+            spawn_bucket: 0,
+            bucket_started_at: 0,
             snapshot_slot: None,
             status: None,
             status_seq: 0,
+            show_help: false,
+            show_welcome: true,
             quit: false,
         }
+    }
+
+    /// Suppress the first-launch welcome overlay. Honoured by `--no-welcome`.
+    #[must_use]
+    pub const fn without_welcome(mut self) -> Self {
+        self.show_welcome = false;
+        self
+    }
+
+    /// Roll the 1-second spawn-rate bucket forward, pushing samples to
+    /// [`spawn_rate_sparkline`](Self::spawn_rate_sparkline) every full
+    /// second of sim time. Called once per `step_once`.
+    pub fn advance_spawn_bucket(&mut self, current_tick: u64, ticks_per_second: f64) {
+        let window = ticks_per_second.max(1.0).round() as u64;
+        // Push at most one sample per call: even if `current_tick` jumps
+        // (`,` step×10), the bucket math is monotonic — leftover ticks
+        // roll into the next iteration. We don't backfill missed
+        // buckets because the metric is "spawns observed per real
+        // second", not "rate at every wall-clock second".
+        if current_tick.saturating_sub(self.bucket_started_at) >= window {
+            self.spawn_rate_sparkline.push(self.spawn_bucket);
+            self.spawn_bucket = 0;
+            self.bucket_started_at = current_tick;
+        }
+    }
+
+    /// Increment the rolling spawn bucket. Call once per `RiderSpawned`
+    /// event drained from the sim.
+    pub const fn observe_spawn(&mut self) {
+        self.spawn_bucket = self.spawn_bucket.saturating_add(1);
     }
 
     /// Append events drained from the sim, capped at `event_log_cap`.

--- a/crates/elevator-tui/src/ui/dispatch.rs
+++ b/crates/elevator-tui/src/ui/dispatch.rs
@@ -1,30 +1,43 @@
-//! Dispatch summary panel — what each car is currently doing and the
-//! demand picture every group sees.
+//! Dispatch summary panel — what each car is currently doing, plus a
+//! capacity gauge that fills toward red as the car gets full. The
+//! focused car is accented.
 
+use elevator_core::components::ElevatorPhase;
 use elevator_core::sim::Simulation;
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
-use ratatui::text::Line;
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Paragraph};
 
-use crate::ui::shaft;
+use crate::state::AppState;
+use crate::ui::{palette, shaft};
 
 /// Render the dispatch panel.
-pub fn draw(frame: &mut Frame<'_>, area: Rect, sim: &Simulation) {
+#[allow(clippy::too_many_lines)]
+pub fn draw(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulation) {
     let block = Block::default()
-        .borders(Borders::BOTTOM)
-        .title(Line::from(" dispatch ").style(Style::default().add_modifier(Modifier::BOLD)));
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(palette::DIM_STRONG))
+        .title(super::bracketed_title(
+            "dispatch",
+            Some("per-car state and load".into()),
+        ));
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
+    let cars: Vec<_> = shaft::cars_iter(sim).collect();
+    let focused_id = cars.get(state.focused_car_idx).map(|c| c.id);
+
     let mut lines: Vec<Line<'_>> = Vec::new();
 
-    // Per-group strategy + demand counts.
+    // One header row per group: strategy + summary numbers. Building
+    // configs typically have one group; this still handles N cleanly.
     for group in sim.groups() {
         let strategy = sim
             .strategy_id(group.id())
-            .map_or_else(|| "?".to_string(), |s| format!("{s:?}"));
+            .map_or_else(|| "?".into(), |s| format!("{s:?}"));
         let manifest = sim.build_dispatch_manifest(group);
         let waiting: usize = group
             .lines()
@@ -32,33 +45,125 @@ pub fn draw(frame: &mut Frame<'_>, area: Rect, sim: &Simulation) {
             .flat_map(|line| line.serves().iter().copied())
             .map(|stop| manifest.waiting_count_at(stop))
             .sum();
-        let cars = group
+        let car_count = group
             .lines()
             .iter()
             .map(|line| line.elevators().len())
             .sum::<usize>();
-        lines.push(Line::from(format!(
-            "{name:<12}  strategy={strategy}  cars={cars}  waiting={waiting}",
-            name = group.name(),
-        )));
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("{:<12}", group.name()),
+                Style::default()
+                    .fg(palette::TITLE)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" strategy=", Style::default().fg(palette::DIM)),
+            Span::styled(strategy, Style::default().fg(palette::DIM_STRONG)),
+            Span::styled("  cars=", Style::default().fg(palette::DIM)),
+            Span::styled(
+                car_count.to_string(),
+                Style::default().fg(palette::DIM_STRONG),
+            ),
+            Span::styled("  waiting=", Style::default().fg(palette::DIM)),
+            Span::styled(
+                waiting.to_string(),
+                if waiting > 0 {
+                    Style::default()
+                        .fg(palette::ACCENT)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(palette::DIM_STRONG)
+                },
+            ),
+        ]));
     }
 
-    // One row per car: phase, target, queue depth.
-    for car in shaft::cars_iter(sim) {
+    // One row per car: indexed name (Elevator runtime components don't
+    // carry the config-level name), phase, gauge, queue depth.
+    for (idx, car) in cars.iter().enumerate() {
+        let is_focused = focused_id == Some(car.id);
         let phase = car.elevator.phase();
+        let phase_str = phase_short(&phase);
         let target = phase
             .moving_target()
-            .map_or_else(String::new, |t| format!(" → {t:?}"));
+            .map_or_else(String::new, |t| format!("→{}", short_stop(sim, t)));
+        let load = car.elevator.current_load().value();
+        let cap = car.elevator.weight_capacity().value();
+        let ratio = if cap > 0.0 { load / cap } else { 0.0 };
+        let bar = capacity_bar(ratio, 10);
+        let bar_color = palette::bar_fill_for(ratio);
         let queue = sim
             .destination_queue(elevator_core::entity::ElevatorId::from(car.id))
             .map_or(0, <[_]>::len);
-        lines.push(Line::from(format!(
-            "  {:?}  phase={phase}{target}  queue={queue}  load={}/{}",
-            car.id,
-            car.elevator.current_load(),
-            car.elevator.weight_capacity(),
-        )));
+
+        let name_style = if is_focused {
+            Style::default()
+                .fg(palette::ACCENT)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(palette::TITLE)
+        };
+        let name = format!("car {}", idx + 1);
+
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {name:<8}"), name_style),
+            Span::styled(
+                format!(" {phase_str:<5}"),
+                Style::default().fg(palette::DIM_STRONG),
+            ),
+            Span::styled(format!("{target:<10}"), Style::default().fg(palette::DIM)),
+            Span::styled(" ", Style::default()),
+            Span::styled(bar, Style::default().fg(bar_color)),
+            Span::styled(
+                format!(" {load:>4.0}/{cap:<4.0}"),
+                Style::default().fg(palette::DIM_STRONG),
+            ),
+            Span::styled(
+                format!(" q={queue}"),
+                if queue > 0 {
+                    Style::default().fg(palette::WARN)
+                } else {
+                    Style::default().fg(palette::DIM)
+                },
+            ),
+        ]));
     }
 
     frame.render_widget(Paragraph::new(lines), inner);
+}
+
+/// `[████░░░░░░]` style ASCII bar. Ratio is clamped to `[0.0, 1.0]`.
+fn capacity_bar(ratio: f64, width: usize) -> String {
+    let r = ratio.clamp(0.0, 1.0);
+    let filled = (r * width as f64).round() as usize;
+    let mut s = String::with_capacity(width + 2);
+    s.push('[');
+    for i in 0..width {
+        s.push(if i < filled { '█' } else { '░' });
+    }
+    s.push(']');
+    s
+}
+
+/// 5-char phase label (`movg`, `door`, `load`, etc). Keeps the dispatch
+/// row aligned regardless of how `Display` formats `ElevatorPhase`.
+const fn phase_short(phase: &ElevatorPhase) -> &'static str {
+    match phase {
+        ElevatorPhase::Idle => "idle",
+        ElevatorPhase::Stopped => "stop",
+        ElevatorPhase::Loading => "load",
+        ElevatorPhase::DoorOpening => "open",
+        ElevatorPhase::DoorClosing => "shut",
+        ElevatorPhase::MovingToStop(_) => "movg",
+        ElevatorPhase::Repositioning(_) => "rep",
+        _ => "?",
+    }
+}
+
+/// Resolve a stop entity to its short display name (or its id slot if
+/// the name lookup fails — never blocks the dispatch row from rendering).
+fn short_stop(sim: &Simulation, stop: elevator_core::entity::EntityId) -> String {
+    sim.world()
+        .stop(stop)
+        .map_or_else(|| format!("{stop:?}"), |s| s.name().to_string())
 }

--- a/crates/elevator-tui/src/ui/drilldown.rs
+++ b/crates/elevator-tui/src/ui/drilldown.rs
@@ -5,29 +5,36 @@
 use elevator_core::sim::Simulation;
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Modifier, Style};
+use ratatui::style::Style;
 use ratatui::text::Line;
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::widgets::{Block, BorderType, Borders, Paragraph};
 
 use crate::state::AppState;
-use crate::ui::{events, shaft};
+use crate::ui::{events, palette, shaft};
 
 /// Render the drill-down panel.
 pub fn draw(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulation) {
     let cars: Vec<_> = shaft::cars_iter(sim).collect();
     let Some(focused) = cars.get(state.focused_car_idx) else {
         let block = Block::default()
-            .borders(Borders::LEFT)
-            .title(" drill-down ");
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(palette::DIM_STRONG))
+            .title(super::bracketed_title("drill-down", None));
         let inner = block.inner(area);
         frame.render_widget(block, area);
         frame.render_widget(Paragraph::new("no cars in this sim"), inner);
         return;
     };
 
-    let title = Line::from(format!(" drill-down · {:?} ", focused.id))
-        .style(Style::default().add_modifier(Modifier::BOLD));
-    let block = Block::default().borders(Borders::LEFT).title(title);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(palette::DIM_STRONG))
+        .title(super::bracketed_title(
+            "drill-down",
+            Some(format!("{:?}", focused.id)),
+        ));
     let inner = block.inner(area);
     frame.render_widget(block, area);
 

--- a/crates/elevator-tui/src/ui/events.rs
+++ b/crates/elevator-tui/src/ui/events.rs
@@ -4,20 +4,26 @@ use elevator_core::events::{Event, EventCategory};
 use elevator_core::sim::Simulation;
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Modifier, Style};
-use ratatui::text::Line;
-use ratatui::widgets::{Block, Borders, List, ListItem};
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, List, ListItem};
 
 use crate::state::AppState;
-use crate::ui::shaft;
+use crate::ui::{palette, shaft};
 
 /// Render the events panel.
 pub fn draw(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulation) {
     let cars: Vec<_> = shaft::cars_iter(sim).collect();
     let focused = cars.get(state.focused_car_idx).map(|c| c.id);
 
-    let title = build_title(state, focused);
-    let block = Block::default().borders(Borders::BOTTOM).title(title);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(palette::DIM_STRONG))
+        .title(super::bracketed_title(
+            "events",
+            Some(filter_summary(state, focused)),
+        ));
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
@@ -26,17 +32,26 @@ pub fn draw(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulatio
         .visible_events(focused)
         .rev() // newest at the top
         .take(visible_height)
-        .map(|logged| ListItem::new(Line::from(format_event_line(logged.tick, &logged.event))))
+        .map(|logged| {
+            ListItem::new(Line::from(vec![
+                Span::styled(
+                    format!("t={:>6} ", logged.tick),
+                    Style::default().fg(palette::DIM),
+                ),
+                Span::styled(
+                    format_event_body(&logged.event),
+                    Style::default().fg(category_color(logged.event.category())),
+                ),
+            ]))
+        })
         .collect();
 
     frame.render_widget(List::new(items), inner);
 }
 
-/// Compose the panel title with the active filter summary.
-fn build_title(
-    state: &AppState,
-    focused: Option<elevator_core::entity::EntityId>,
-) -> Line<'static> {
+/// Build the suffix shown in the bracketed panel title — filter and
+/// optional follow target.
+fn filter_summary(state: &AppState, focused: Option<elevator_core::entity::EntityId>) -> String {
     let cats: Vec<&'static str> = ALL_CATEGORIES_ORDERED
         .iter()
         .copied()
@@ -50,12 +65,25 @@ fn build_title(
         cats.join("·")
     };
     let follow = match (state.follow_focused, focused) {
-        (true, Some(id)) => format!(" follow={id:?}"),
-        (true, None) => " follow=(no car)".to_string(),
+        (true, Some(id)) => format!(" · follow={id:?}"),
+        (true, None) => " · follow=(no car)".to_string(),
         (false, _) => String::new(),
     };
-    Line::from(format!(" events · filter [{cats_str}]{follow} "))
-        .style(Style::default().add_modifier(Modifier::BOLD))
+    format!("filter [{cats_str}]{follow}")
+}
+
+/// Pick a tint per event category so the rolling log reads at a glance.
+const fn category_color(category: EventCategory) -> ratatui::style::Color {
+    match category {
+        EventCategory::Elevator => palette::TITLE,
+        EventCategory::Rider => palette::SUCCESS,
+        EventCategory::Dispatch => palette::ACCENT,
+        EventCategory::Reposition => palette::WARN,
+        EventCategory::Direction => palette::UP,
+        EventCategory::Observability => palette::DIM,
+        // Topology + future variants share the muted body tint.
+        _ => palette::DIM_STRONG,
+    }
 }
 
 /// Categories in the same order as the digit hotkeys (1 = first).
@@ -69,13 +97,18 @@ const ALL_CATEGORIES_ORDERED: &[(EventCategory, &str)] = &[
     (EventCategory::Observability, "Obs"),
 ];
 
-/// Compact one-line representation of an event for the rolling log.
-///
-/// Only the stable fields (tick, primary entity references, key
-/// state-change values) are rendered — full debug forms are too noisy
-/// to be useful in a scrolling stream.
+/// Tick-prefixed one-line representation; preserved for callers that
+/// want a single string (e.g. drilldown panel reuses this rendering).
 #[must_use]
 pub fn format_event_line(drain_tick: u64, event: &Event) -> String {
+    format!("t={drain_tick:>6}  {}", format_event_body(event))
+}
+
+/// Compact body-only representation (no tick prefix) used by the
+/// rolling-log renderer, which prints the tick in a separate `Span`
+/// so the prefix can be dimmed.
+#[must_use]
+pub fn format_event_body(event: &Event) -> String {
     use Event::{
         CapacityChanged, DoorClosed, DoorCommandApplied, DoorCommandQueued, DoorOpened,
         ElevatorArrived, ElevatorAssigned, ElevatorDeparted, ElevatorIdle, ElevatorRecalled,
@@ -83,7 +116,7 @@ pub fn format_event_line(drain_tick: u64, event: &Event) -> String {
         RiderBoarded, RiderEjected, RiderExited, RiderRejected, RiderRerouted, RiderSettled,
         RiderSpawned, ServiceModeChanged,
     };
-    let body = match event {
+    match event {
         ElevatorDeparted {
             elevator,
             from_stop,
@@ -162,6 +195,5 @@ pub fn format_event_line(drain_tick: u64, event: &Event) -> String {
         // above cover the common-case noise; long-tail variants are
         // still legible just less aligned.
         other => format!("{other:?}"),
-    };
-    format!("t={drain_tick:>6}  {body}")
+    }
 }

--- a/crates/elevator-tui/src/ui/help.rs
+++ b/crates/elevator-tui/src/ui/help.rs
@@ -1,0 +1,120 @@
+//! Help overlay (`?`).
+//!
+//! A modal-style centered panel listing every keybinding and glyph.
+//! The sim continues running underneath; dismissing the overlay reveals
+//! a frame that's already moved on. We render `Clear` first so the
+//! frame below doesn't bleed through.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph};
+
+use crate::ui::palette;
+
+/// Render a centered help modal over `area`.
+pub fn draw(frame: &mut Frame<'_>, area: Rect) {
+    let modal = centered(area, 72, 28);
+    frame.render_widget(Clear, modal);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(palette::ACCENT))
+        .title(super::bracketed_title(
+            "help",
+            Some("press ? or Esc to close".into()),
+        ));
+    let inner = block.inner(modal);
+    frame.render_widget(block, modal);
+
+    let lines = vec![
+        section("Playback"),
+        kv("space", "pause / resume"),
+        kv(". / ,", "step one tick / ten ticks"),
+        kv("+ / -", "halve or double tick rate (0.0625× – 64×)"),
+        Line::from(""),
+        section("Navigation"),
+        kv("[ / ]", "focus previous / next car"),
+        kv("f", "follow focused car (event filter)"),
+        kv("Enter", "toggle right panel: overview ↔ drill-down"),
+        kv("Esc", "close drill-down or this overlay"),
+        kv("m", "toggle shaft layout: index ↔ distance"),
+        Line::from(""),
+        section("Filters & Snapshots"),
+        kv("1..7", "toggle event categories (1 Elev, 2 Rdr, 3 Dsp,"),
+        kv("", "4 Top, 5 Rep, 6 Dir, 7 Obs)"),
+        kv("s / l", "save / restore in-memory snapshot"),
+        Line::from(""),
+        section("Glyphs"),
+        glyph_line("▲ ▼", palette::UP, "going up / going down"),
+        glyph_line("■", palette::DIM_STRONG, "stopped"),
+        glyph_line("L", palette::ACCENT, "loading riders"),
+        glyph_line("O / C", palette::ACCENT, "doors opening / closing"),
+        glyph_line("↑↓", palette::WARN, "active hall call (up / down)"),
+        glyph_line("(n)", palette::DIM_STRONG, "n riders waiting at this stop"),
+    ];
+
+    let inside = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Min(0),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+    frame.render_widget(Paragraph::new(lines), inside[1]);
+}
+
+/// Bold section header line.
+fn section(label: &str) -> Line<'static> {
+    Line::from(Span::styled(
+        format!("  {label}"),
+        Style::default()
+            .fg(palette::ACCENT)
+            .add_modifier(Modifier::BOLD),
+    ))
+}
+
+/// Key/binding row: padded key column + description.
+fn kv(key: &str, description: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::raw("    "),
+        Span::styled(
+            format!("{key:<8}"),
+            Style::default()
+                .fg(palette::TITLE)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            description.to_string(),
+            Style::default().fg(palette::DIM_STRONG),
+        ),
+    ])
+}
+
+/// Glyph row (colored glyph + dim explanation).
+fn glyph_line(glyph: &str, color: ratatui::style::Color, description: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::raw("    "),
+        Span::styled(format!("{glyph:<8}"), Style::default().fg(color)),
+        Span::styled(
+            description.to_string(),
+            Style::default().fg(palette::DIM_STRONG),
+        ),
+    ])
+}
+
+/// Center a fixed-size rectangle inside `area`. If `area` is smaller
+/// than `(w, h)`, the modal shrinks to fit.
+fn centered(area: Rect, w: u16, h: u16) -> Rect {
+    let w = w.min(area.width);
+    let h = h.min(area.height);
+    Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    }
+}

--- a/crates/elevator-tui/src/ui/help.rs
+++ b/crates/elevator-tui/src/ui/help.rs
@@ -15,7 +15,7 @@ use crate::ui::palette;
 
 /// Render a centered help modal over `area`.
 pub fn draw(frame: &mut Frame<'_>, area: Rect) {
-    let modal = centered(area, 72, 28);
+    let modal = super::centered_rect(area, 72, 28);
     frame.render_widget(Clear, modal);
 
     let block = Block::default()
@@ -104,17 +104,4 @@ fn glyph_line(glyph: &str, color: ratatui::style::Color, description: &str) -> L
             Style::default().fg(palette::DIM_STRONG),
         ),
     ])
-}
-
-/// Center a fixed-size rectangle inside `area`. If `area` is smaller
-/// than `(w, h)`, the modal shrinks to fit.
-fn centered(area: Rect, w: u16, h: u16) -> Rect {
-    let w = w.min(area.width);
-    let h = h.min(area.height);
-    Rect {
-        x: area.x + (area.width.saturating_sub(w)) / 2,
-        y: area.y + (area.height.saturating_sub(h)) / 2,
-        width: w,
-        height: h,
-    }
 }

--- a/crates/elevator-tui/src/ui/legend.rs
+++ b/crates/elevator-tui/src/ui/legend.rs
@@ -1,0 +1,34 @@
+//! Persistent glyph legend — a single row that explains what every
+//! symbol on the shaft means. Always visible so first-time users don't
+//! have to open the help overlay just to read the elevator log.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+
+use crate::ui::palette;
+
+/// Render the legend strip. Designed to fit in a single 1-row `area`.
+pub fn draw(frame: &mut Frame<'_>, area: Rect) {
+    let pair = |glyph: &'static str, label: &'static str, glyph_color| {
+        [
+            Span::styled(glyph, Style::default().fg(glyph_color)),
+            Span::styled(
+                format!(" {label}"),
+                Style::default().fg(palette::DIM_STRONG),
+            ),
+            Span::styled("  ", Style::default()),
+        ]
+    };
+    let mut spans = vec![Span::styled(" legend ", Style::default().fg(palette::DIM))];
+    spans.extend(pair("▲", "up", palette::UP));
+    spans.extend(pair("▼", "down", palette::DOWN));
+    spans.extend(pair("■", "stopped", palette::DIM_STRONG));
+    spans.extend(pair("L", "loading", palette::ACCENT));
+    spans.extend(pair("O/C", "doors", palette::ACCENT));
+    spans.extend(pair("↑↓", "hall call", palette::WARN));
+    spans.extend(pair("(n)", "waiting", palette::DIM_STRONG));
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}

--- a/crates/elevator-tui/src/ui/metrics.rs
+++ b/crates/elevator-tui/src/ui/metrics.rs
@@ -1,72 +1,145 @@
 //! Metrics panel — aggregate counters plus rolling sparklines for p95
-//! wait time and total occupancy.
+//! wait time and total occupancy. Sparkline colors track health so a
+//! glance is enough to spot a slow sim.
 
 use elevator_core::sim::Simulation;
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
-use ratatui::text::Line;
-use ratatui::widgets::{Block, Borders, Paragraph, Sparkline};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Paragraph, Sparkline};
 
 use crate::state::AppState;
+use crate::ui::palette;
 
 /// Render the metrics panel.
+#[allow(clippy::too_many_lines)]
 pub fn draw(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulation) {
     let block = Block::default()
-        .borders(Borders::BOTTOM)
-        .title(Line::from(" metrics ").style(Style::default().add_modifier(Modifier::BOLD)));
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(palette::DIM_STRONG))
+        .title(super::bracketed_title(
+            "metrics",
+            Some("aggregate health".into()),
+        ));
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    // The metrics panel only gets ~5 inner rows in a default 30-row
-    // terminal. The earlier `Length(5) + Length(2) + Length(2)` was 9
-    // rows; ratatui scaled them proportionally and silently dropped
-    // the third counter line. Use `Min(3)` so the counters always
-    // get their full text but collapse last when the panel is tight.
+    if inner.height == 0 {
+        return;
+    }
+
+    // Inside the panel:
+    //   3 counter rows, then two single-row labels + sparklines.
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Min(3),    // 3 counter lines — full or shrink under pressure
-            Constraint::Length(2), // wait sparkline
-            Constraint::Length(2), // occupancy sparkline
+            Constraint::Min(3),    // 3 counter lines
+            Constraint::Length(2), // wait sparkline header + bar
+            Constraint::Length(2), // occupancy sparkline header + bar
         ])
         .split(inner);
 
     let m = sim.metrics();
+    let abandon_rate = m.abandonment_rate();
+    let abandon_color = if abandon_rate < 0.05 {
+        palette::SUCCESS
+    } else if abandon_rate < 0.20 {
+        palette::WARN
+    } else {
+        palette::DANGER
+    };
+    let p95 = m.p95_wait_time();
     let counters = vec![
-        Line::from(format!(
-            "spawned {sp}   delivered {dl}   abandoned {ab} ({rate:.1}%)",
-            sp = m.total_spawned(),
-            dl = m.total_delivered(),
-            ab = m.total_abandoned(),
-            rate = m.abandonment_rate() * 100.0,
-        )),
-        Line::from(format!(
-            "wait avg {avg:.1}t   p95 {p95}t   max {max}t",
-            avg = m.avg_wait_time(),
-            p95 = m.p95_wait_time(),
-            max = m.max_wait_time(),
-        )),
-        Line::from(format!(
-            "ride avg {ride:.1}t   throughput {tp}/{w}t   util {ut:.1}%",
-            ride = m.avg_ride_time(),
-            tp = m.throughput(),
-            w = m.throughput_window_ticks(),
-            ut = m.avg_utilization() * 100.0,
-        )),
+        Line::from(vec![
+            label("spawned "),
+            value(m.total_spawned().to_string()),
+            label("   delivered "),
+            value(m.total_delivered().to_string()),
+            label("   abandoned "),
+            Span::styled(
+                format!("{}", m.total_abandoned()),
+                Style::default()
+                    .fg(abandon_color)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!(" ({:.1}%)", abandon_rate * 100.0),
+                Style::default().fg(abandon_color),
+            ),
+        ]),
+        Line::from(vec![
+            label("wait avg "),
+            value(format!("{:.1}t", m.avg_wait_time())),
+            label("   p95 "),
+            Span::styled(
+                format!("{p95}t"),
+                Style::default()
+                    .fg(palette::wait_color_for(p95))
+                    .add_modifier(Modifier::BOLD),
+            ),
+            label("   max "),
+            value(format!("{}t", m.max_wait_time())),
+        ]),
+        Line::from(vec![
+            label("ride avg "),
+            value(format!("{:.1}t", m.avg_ride_time())),
+            label("   throughput "),
+            value(format!(
+                "{}/{}t",
+                m.throughput(),
+                m.throughput_window_ticks()
+            )),
+            label("   util "),
+            value(format!("{:.0}%", m.avg_utilization() * 100.0)),
+        ]),
     ];
     frame.render_widget(Paragraph::new(counters), chunks[0]);
 
+    // p95 wait sparkline — color follows the most-recent sample.
+    let wait_color = state
+        .wait_sparkline
+        .as_slice()
+        .last()
+        .copied()
+        .map_or(palette::SUCCESS, palette::wait_color_for);
     frame.render_widget(
         Sparkline::default()
-            .block(Block::default().title("p95 wait (ticks)"))
+            .block(Block::default().title(Line::from(Span::styled(
+                "p95 wait (ticks)",
+                Style::default().fg(palette::DIM_STRONG),
+            ))))
+            .style(Style::default().fg(wait_color))
             .data(state.wait_sparkline.as_slice()),
         chunks[1],
     );
+
+    // Occupancy sparkline — uses the accent so it visually pairs with
+    // the dispatch panel above (capacity bars use the same tone).
     frame.render_widget(
         Sparkline::default()
-            .block(Block::default().title("total occupancy"))
+            .block(Block::default().title(Line::from(Span::styled(
+                "total occupancy",
+                Style::default().fg(palette::DIM_STRONG),
+            ))))
+            .style(Style::default().fg(palette::ACCENT))
             .data(state.occupancy_sparkline.as_slice()),
         chunks[2],
     );
+}
+
+/// Dim label span used to introduce a counter (e.g. `wait avg `).
+fn label(text: &str) -> Span<'static> {
+    Span::styled(text.to_string(), Style::default().fg(palette::DIM))
+}
+
+/// Bold body-tint span used for the number that follows a label.
+fn value(text: impl Into<String>) -> Span<'static> {
+    Span::styled(
+        text.into(),
+        Style::default()
+            .fg(palette::DIM_STRONG)
+            .add_modifier(Modifier::BOLD),
+    )
 }

--- a/crates/elevator-tui/src/ui/mod.rs
+++ b/crates/elevator-tui/src/ui/mod.rs
@@ -161,6 +161,22 @@ fn draw_overview(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simu
     metrics::draw(frame, chunks[3], state, sim);
 }
 
+/// Center a fixed-size rectangle inside `area`. If `area` is smaller
+/// than `(w, h)`, the modal shrinks to fit. Used by every modal
+/// overlay (help, welcome) — kept here so the geometry can't drift
+/// silently across copies.
+#[must_use]
+pub(super) fn centered_rect(area: Rect, w: u16, h: u16) -> Rect {
+    let w = w.min(area.width);
+    let h = h.min(area.height);
+    Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    }
+}
+
 /// Build a bracketed panel title `─┤ name · suffix ├─` styled in the
 /// palette accent. Spans render at the top-left of a bordered block.
 #[must_use]

--- a/crates/elevator-tui/src/ui/mod.rs
+++ b/crates/elevator-tui/src/ui/mod.rs
@@ -1,19 +1,25 @@
-//! Frame composition: title bar, body (shaft + right column), footer.
+//! Frame composition: title bar, legend strip, body (shaft + right
+//! column), footer, and modal overlays (welcome / help) on top.
 
 use elevator_core::sim::Simulation;
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
-use ratatui::text::Line;
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
 
 use crate::state::{AppState, RightPanel};
 
 pub mod dispatch;
 pub mod drilldown;
 pub mod events;
+pub mod help;
+pub mod legend;
 pub mod metrics;
+pub mod palette;
 pub mod shaft;
+pub mod traffic;
+pub mod welcome;
 
 /// Top-level draw entry — composes every panel for one frame.
 pub fn draw(frame: &mut Frame<'_>, state: &AppState, sim: &Simulation) {
@@ -21,12 +27,14 @@ pub fn draw(frame: &mut Frame<'_>, state: &AppState, sim: &Simulation) {
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(1), // title bar
+            Constraint::Length(1), // legend strip
             Constraint::Min(0),    // body
             Constraint::Length(1), // footer
         ])
         .split(frame.area());
 
     draw_title(frame, outer[0], state, sim);
+    legend::draw(frame, outer[1]);
 
     let body = Layout::default()
         .direction(Direction::Horizontal)
@@ -34,7 +42,7 @@ pub fn draw(frame: &mut Frame<'_>, state: &AppState, sim: &Simulation) {
             Constraint::Length(shaft::recommended_width(sim)),
             Constraint::Min(0),
         ])
-        .split(outer[1]);
+        .split(outer[2]);
 
     shaft::draw(frame, body[0], state, sim);
 
@@ -43,63 +51,130 @@ pub fn draw(frame: &mut Frame<'_>, state: &AppState, sim: &Simulation) {
         RightPanel::DrillDown => drilldown::draw(frame, body[1], state, sim),
     }
 
-    draw_footer(frame, outer[2], state);
-}
+    draw_footer(frame, outer[3], state);
 
-/// Status bar: tick, paused/running, rate, mode badge.
-fn draw_title(
-    frame: &mut Frame<'_>,
-    area: ratatui::layout::Rect,
-    state: &AppState,
-    sim: &Simulation,
-) {
-    let mode = if state.paused { "PAUSED" } else { "RUNNING" };
-    let line = Line::from(format!(
-        " elevator-tui   tick {tick}   {mode}   rate {rate:.2}×   shaft {shaft:?}   panel {panel:?}",
-        tick = sim.current_tick(),
-        rate = state.tick_rate,
-        shaft = state.shaft_mode,
-        panel = state.right_panel,
-    ));
-    frame.render_widget(
-        Paragraph::new(line).style(Style::default().add_modifier(Modifier::BOLD)),
-        area,
-    );
-}
-
-/// Footer: condensed hotkey reference + transient status flash.
-fn draw_footer(frame: &mut Frame<'_>, area: ratatui::layout::Rect, state: &AppState) {
-    let mut text = String::from(
-        " space pause  . step  , step×10  +/- rate  m shaft  []car  f follow  Enter drill  s save  l load  1-7 filter  q quit",
-    );
-    if let Some(status) = &state.status {
-        text.push_str("   │   ");
-        text.push_str(status);
+    // Modal overlays render last so they sit above every panel.
+    if state.show_help {
+        help::draw(frame, frame.area());
+    } else if state.show_welcome {
+        welcome::draw(frame, frame.area(), sim);
     }
-    frame.render_widget(Paragraph::new(text), area);
 }
 
-/// Right column = Events / Dispatch / Metrics stacked vertically.
-fn draw_overview(
-    frame: &mut Frame<'_>,
-    area: ratatui::layout::Rect,
-    state: &AppState,
-    sim: &Simulation,
-) {
-    let outer = Block::default().borders(Borders::LEFT).title(" overview ");
-    let inner = outer.inner(area);
-    frame.render_widget(outer, area);
+/// Title bar: app name, tick, run state, rate, modes, help hint.
+fn draw_title(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulation) {
+    let run_glyph = if state.paused { "❚❚" } else { "▶" };
+    let run_style = if state.paused {
+        Style::default().fg(palette::WARN)
+    } else {
+        Style::default().fg(palette::SUCCESS)
+    };
+    let spans = vec![
+        Span::styled(
+            " elevator-tui ",
+            Style::default()
+                .fg(palette::ACCENT)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("· ", Style::default().fg(palette::DIM)),
+        Span::styled(
+            format!("tick {}", sim.current_tick()),
+            Style::default().fg(palette::DIM_STRONG),
+        ),
+        Span::styled(" · ", Style::default().fg(palette::DIM)),
+        Span::styled(run_glyph.to_string(), run_style),
+        Span::styled(
+            format!(" {:.2}×", state.tick_rate),
+            Style::default().fg(palette::DIM_STRONG),
+        ),
+        Span::styled(" · ", Style::default().fg(palette::DIM)),
+        Span::styled(
+            format!("{:?}", state.shaft_mode).to_lowercase(),
+            Style::default().fg(palette::DIM_STRONG),
+        ),
+        Span::styled(" · ", Style::default().fg(palette::DIM)),
+        Span::styled(
+            format!("{:?}", state.right_panel).to_lowercase(),
+            Style::default().fg(palette::DIM_STRONG),
+        ),
+    ];
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+/// Footer: minimal hotkey hint + transient status flash.
+///
+/// The full keybinding list lives in the help overlay (`?`); this row
+/// stays under terminal-width pressure so it never truncates.
+fn draw_footer(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
+    let mut spans = vec![
+        Span::styled(" ?", Style::default().fg(palette::ACCENT)),
+        Span::styled(" help", Style::default().fg(palette::DIM_STRONG)),
+        Span::styled(" · ", Style::default().fg(palette::DIM)),
+        Span::styled("space", Style::default().fg(palette::ACCENT)),
+        Span::styled(" pause", Style::default().fg(palette::DIM_STRONG)),
+        Span::styled(" · ", Style::default().fg(palette::DIM)),
+        Span::styled("[ ]", Style::default().fg(palette::ACCENT)),
+        Span::styled(" car", Style::default().fg(palette::DIM_STRONG)),
+        Span::styled(" · ", Style::default().fg(palette::DIM)),
+        Span::styled("Enter", Style::default().fg(palette::ACCENT)),
+        Span::styled(" drill", Style::default().fg(palette::DIM_STRONG)),
+        Span::styled(" · ", Style::default().fg(palette::DIM)),
+        Span::styled("q", Style::default().fg(palette::ACCENT)),
+        Span::styled(" quit", Style::default().fg(palette::DIM_STRONG)),
+    ];
+    if let Some(status) = &state.status {
+        spans.push(Span::styled("   ◇ ", Style::default().fg(palette::DIM)));
+        spans.push(Span::styled(
+            status.clone(),
+            Style::default()
+                .fg(palette::ACCENT)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+/// Right column = Dispatch / Events / Traffic / Metrics stacked.
+fn draw_overview(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulation) {
+    // Dispatch fills proportionally to the car count so the panel keeps
+    // every car visible even on busier configs (group line + 1 row/car
+    // + a 2-row title border = `cars + 3`). Traffic is one sparkline
+    // line + border; metrics is 3 counter rows + 2 sparklines + border.
+    let car_count = u16::try_from(shaft::cars_iter(sim).count()).unwrap_or(u16::MAX);
+    let dispatch_h = car_count.saturating_add(4).clamp(6, 14);
+    let traffic_h = 4u16;
+    let metrics_h = 8u16;
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Percentage(50),
-            Constraint::Percentage(25),
-            Constraint::Percentage(25),
+            Constraint::Length(dispatch_h),
+            Constraint::Min(5), // events takes the slack
+            Constraint::Length(traffic_h),
+            Constraint::Length(metrics_h),
         ])
-        .split(inner);
+        .split(area);
 
-    events::draw(frame, chunks[0], state, sim);
-    dispatch::draw(frame, chunks[1], sim);
-    metrics::draw(frame, chunks[2], state, sim);
+    dispatch::draw(frame, chunks[0], state, sim);
+    events::draw(frame, chunks[1], state, sim);
+    traffic::draw(frame, chunks[2], state, sim);
+    metrics::draw(frame, chunks[3], state, sim);
+}
+
+/// Build a bracketed panel title `─┤ name · suffix ├─` styled in the
+/// palette accent. Spans render at the top-left of a bordered block.
+#[must_use]
+pub fn bracketed_title(name: &str, suffix: Option<String>) -> Line<'_> {
+    let mut spans = vec![
+        Span::styled("┤ ", Style::default().fg(palette::DIM_STRONG)),
+        Span::styled(name, palette::title_style()),
+    ];
+    if let Some(s) = suffix {
+        spans.push(Span::styled(
+            format!(" · {s}"),
+            Style::default().fg(palette::DIM_STRONG),
+        ));
+    }
+    spans.push(Span::styled(" ├", Style::default().fg(palette::DIM_STRONG)));
+    Line::from(spans)
 }

--- a/crates/elevator-tui/src/ui/palette.rs
+++ b/crates/elevator-tui/src/ui/palette.rs
@@ -1,0 +1,113 @@
+//! Warm-dark indexed palette.
+//!
+//! Colors are picked from xterm-256 so every renderer (truecolor or not,
+//! tmux or bare) shows the same hue. The palette intentionally avoids
+//! full-saturation primaries — an elevator log looks busy enough already
+//! without retina-burning red against jet black. Threshold helpers
+//! (`bar_fill_for`, `wait_color_for`) centralize the green→yellow→red
+//! ramp so every gauge agrees on what "hot" looks like.
+//!
+//! ## Indices, in case anyone is reading this offline
+//!
+//! | role            | xterm idx | what it looks like     |
+//! |-----------------|-----------|------------------------|
+//! | accent          | 215       | warm amber             |
+//! | success         | 78        | sage green             |
+//! | warn            | 221       | wheat                  |
+//! | danger          | 174       | terracotta             |
+//! | dim             | 240       | mid grey               |
+//! | `dim_strong`    | 244       | lighter grey           |
+//! | `surface_title` | 180       | warm beige             |
+//! | `direction_up`  | 114       | leaf green             |
+//! | `direction_down`| 209       | salmon                 |
+//!
+//! These are intentionally close to the playground's gridfinity-warm
+//! aesthetic and away from the default ratatui ANSI 0..15 set, which
+//! looks harsh on warm-dark terminals.
+
+use ratatui::style::{Color, Modifier, Style};
+
+/// Bracketed-title accent (matches `┤ title ├`).
+pub const ACCENT: Color = Color::Indexed(215);
+/// Healthy / under-threshold gauge color.
+pub const SUCCESS: Color = Color::Indexed(78);
+/// Mid-pressure warning color.
+pub const WARN: Color = Color::Indexed(221);
+/// Hot / over-budget color.
+pub const DANGER: Color = Color::Indexed(174);
+/// Subdued labels, axes, secondary numbers.
+pub const DIM: Color = Color::Indexed(240);
+/// Slightly brighter than `DIM` — body text in panels.
+pub const DIM_STRONG: Color = Color::Indexed(244);
+/// Warm cream used for panel titles in the bracketed header.
+pub const TITLE: Color = Color::Indexed(180);
+/// "Going up" tint.
+pub const UP: Color = Color::Indexed(114);
+/// "Going down" tint.
+pub const DOWN: Color = Color::Indexed(209);
+
+/// Title style used by every bordered panel: accent-colored, bold.
+#[must_use]
+pub fn title_style() -> Style {
+    Style::default().fg(TITLE).add_modifier(Modifier::BOLD)
+}
+
+/// Accent style for the focused car (bold + reverse + accent fg).
+#[must_use]
+pub fn focused_style() -> Style {
+    Style::default()
+        .fg(ACCENT)
+        .add_modifier(Modifier::BOLD)
+        .add_modifier(Modifier::REVERSED)
+}
+
+/// Choose a color along the green→yellow→red ramp from a 0..=1 fill ratio.
+/// `<60%` → green, `<85%` → yellow, otherwise red.
+#[must_use]
+pub const fn bar_fill_for(ratio: f64) -> Color {
+    if ratio < 0.60 {
+        SUCCESS
+    } else if ratio < 0.85 {
+        WARN
+    } else {
+        DANGER
+    }
+}
+
+/// Pick a color for a p95-wait sample (in ticks). Tuned for 60 t/s:
+/// `<60t` (1 s) is fine, `<180t` (3 s) is "watch it", anything more is hot.
+#[must_use]
+pub const fn wait_color_for(ticks_p95: u64) -> Color {
+    if ticks_p95 < 60 {
+        SUCCESS
+    } else if ticks_p95 < 180 {
+        WARN
+    } else {
+        DANGER
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bar_fill_thresholds() {
+        assert_eq!(bar_fill_for(0.0), SUCCESS);
+        assert_eq!(bar_fill_for(0.59), SUCCESS);
+        assert_eq!(bar_fill_for(0.60), WARN);
+        assert_eq!(bar_fill_for(0.84), WARN);
+        assert_eq!(bar_fill_for(0.85), DANGER);
+        assert_eq!(bar_fill_for(2.0), DANGER);
+    }
+
+    #[test]
+    fn wait_thresholds() {
+        assert_eq!(wait_color_for(0), SUCCESS);
+        assert_eq!(wait_color_for(59), SUCCESS);
+        assert_eq!(wait_color_for(60), WARN);
+        assert_eq!(wait_color_for(179), WARN);
+        assert_eq!(wait_color_for(180), DANGER);
+    }
+}

--- a/crates/elevator-tui/src/ui/shaft.rs
+++ b/crates/elevator-tui/src/ui/shaft.rs
@@ -1,5 +1,8 @@
-//! Shaft view — the leftmost panel showing each car's vertical position
-//! relative to its served stops.
+//! Shaft view — the leftmost panel showing each car's vertical position.
+//!
+//! Each row carries the served stop, optional hall-call lamps, the
+//! waiting-rider count, and one glyph per car so traffic pressure reads
+//! at a glance without leaving the panel.
 //!
 //! Two render modes share `cars_iter` and the per-car column derivation
 //! but differ in row scaling:
@@ -12,6 +15,9 @@
 //!   `space_elevator.ron`-class scenarios at the cost of leaving wide
 //!   blank stretches when stops are clumped.
 
+use std::collections::HashMap;
+
+use elevator_core::components::hall_call::CallDirection;
 use elevator_core::components::{Elevator, ElevatorPhase, Stop};
 use elevator_core::entity::EntityId;
 use elevator_core::sim::Simulation;
@@ -19,9 +25,10 @@ use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::widgets::{Block, BorderType, Borders, Paragraph};
 
 use crate::state::{AppState, ShaftMode};
+use crate::ui::palette;
 
 /// Resolved view of one car for rendering.
 pub struct CarView<'a> {
@@ -78,16 +85,17 @@ fn stops_top_down(sim: &Simulation) -> Vec<(EntityId, &Stop)> {
 /// Recommended panel width in cells. Each row is laid out as:
 ///
 /// ```text
-/// │name(10) pos(5) │ c c c c │
+/// │  ↑Lobby  0.0 (12) │ c c c │
 /// ```
 ///
-/// — i.e. 19 cells of label + delimiter, plus 2 cells per car (glyph
-/// + trailing space), wrapped in a 1-cell border on each side.
+/// The fixed prefix is 2 hall-call lamps + 10-char name + 6-char
+/// position + 5-char waiting count + a delimiter. Each car adds a
+/// glyph plus trailing space (2 cells), all wrapped in a 1-cell border.
 #[must_use]
 pub fn recommended_width(sim: &Simulation) -> u16 {
     let car_count: usize = cars_iter(sim).count();
     let cars: u16 = u16::try_from(car_count).unwrap_or(u16::MAX);
-    let base: u16 = 21; // label + pos + delim + borders
+    let base: u16 = 28; // hall-lamps + label + pos + waiting + delim + borders
     base.saturating_add(cars.saturating_mul(2))
 }
 
@@ -97,17 +105,36 @@ pub fn draw(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulatio
     let cars: Vec<CarView<'_>> = cars_iter(sim).collect();
     let focused = cars.get(state.focused_car_idx).map(|c| c.id);
 
+    let suffix = format!("{} cars · {:?}", cars.len(), state.shaft_mode).to_lowercase();
     let block = Block::default()
         .borders(Borders::ALL)
-        .title(format!(" shaft · {} car(s) ", cars.len()));
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(palette::DIM_STRONG))
+        .title(super::bracketed_title("shaft", Some(suffix)));
     let inner = block.inner(area);
     frame.render_widget(block, area);
+
+    // Aggregate hall-call directions per stop. `iter_hall_calls` yields
+    // one entry per `(stop, direction)` pair; we collapse to a tuple of
+    // (up?, down?) so the renderer doesn't have to scan twice per row.
+    let hall_calls: HashMap<EntityId, (bool, bool)> = {
+        let mut map: HashMap<EntityId, (bool, bool)> = HashMap::new();
+        for call in sim.world().iter_hall_calls() {
+            let entry = map.entry(call.stop).or_default();
+            match call.direction {
+                CallDirection::Up => entry.0 = true,
+                CallDirection::Down => entry.1 = true,
+                _ => {}
+            }
+        }
+        map
+    };
 
     // Index mode needs a per-car row anchor since `position` is a continuous
     // f64 between stops. Pick the closest stop by absolute distance — that
     // way moving cars appear at their current floor rather than vanishing
     // until they arrive.
-    let nearest_stop_by_car: std::collections::HashMap<EntityId, EntityId> = cars
+    let nearest_stop_by_car: HashMap<EntityId, EntityId> = cars
         .iter()
         .filter_map(|car| {
             stops
@@ -121,33 +148,54 @@ pub fn draw(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulatio
         })
         .collect();
 
+    let ctx = RenderCtx {
+        cars: &cars,
+        nearest_stop_by_car: &nearest_stop_by_car,
+        focused,
+        hall_calls: &hall_calls,
+        sim,
+    };
     let lines: Vec<Line<'_>> = match state.shaft_mode {
-        ShaftMode::Index => {
-            render_index_mode(&stops, &cars, &nearest_stop_by_car, focused, inner.height)
-        }
-        ShaftMode::Distance => render_distance_mode(&stops, &cars, focused, inner.height),
+        ShaftMode::Index => render_index_mode(&stops, &ctx, inner.height),
+        ShaftMode::Distance => render_distance_mode(&stops, &ctx, inner.height),
     };
     frame.render_widget(Paragraph::new(lines), inner);
+}
+
+/// Bundle of per-frame resolution data shared across stop rows.
+struct RenderCtx<'a> {
+    /// Every car in the sim, in deterministic group→line order.
+    cars: &'a [CarView<'a>],
+    /// Index-mode anchor: which stop row each car's continuous position
+    /// rounds to.
+    nearest_stop_by_car: &'a HashMap<EntityId, EntityId>,
+    /// Currently focused car, if any (highlighted in the per-car columns).
+    focused: Option<EntityId>,
+    /// Per-stop active hall-call directions: `(up?, down?)`.
+    hall_calls: &'a HashMap<EntityId, (bool, bool)>,
+    /// Borrowed simulation, used for waiting-rider counts and stop lookups.
+    sim: &'a Simulation,
 }
 
 /// One row per stop. Stop list truncates to fit the available height.
 fn render_index_mode<'a>(
     stops: &'a [(EntityId, &'a Stop)],
-    cars: &'a [CarView<'a>],
-    nearest_stop_by_car: &std::collections::HashMap<EntityId, EntityId>,
-    focused: Option<EntityId>,
+    ctx: &RenderCtx<'a>,
     height: u16,
 ) -> Vec<Line<'a>> {
     let max_rows = height as usize;
     let take = stops.len().min(max_rows.saturating_sub(1).max(1));
     let mut lines = Vec::with_capacity(take + 1);
     for (eid, stop) in stops.iter().take(take) {
-        lines.push(stop_row(*eid, stop, cars, nearest_stop_by_car, focused));
+        lines.push(stop_row(*eid, stop, ctx));
     }
     if stops.len() > take {
-        lines.push(Line::from(format!(
-            "  … {} more stop(s) hidden — narrow terminal",
-            stops.len() - take
+        lines.push(Line::from(Span::styled(
+            format!(
+                "  … {} more stop(s) hidden — narrow terminal",
+                stops.len() - take
+            ),
+            Style::default().fg(palette::DIM),
         )));
     }
     lines
@@ -158,8 +206,7 @@ fn render_index_mode<'a>(
 /// fraction of the range.
 fn render_distance_mode<'a>(
     stops: &'a [(EntityId, &'a Stop)],
-    cars: &'a [CarView<'a>],
-    focused: Option<EntityId>,
+    ctx: &RenderCtx<'a>,
     height: u16,
 ) -> Vec<Line<'a>> {
     if stops.is_empty() || height < 2 {
@@ -177,33 +224,64 @@ fn render_distance_mode<'a>(
             grid[row] = Some((*eid, *stop));
         }
     }
-    // Distance mode plots cars by their actual position (in `spacer_row`),
-    // so the per-row "nearest stop" map is unused. Pass an empty one.
-    let empty: std::collections::HashMap<EntityId, EntityId> = std::collections::HashMap::new();
     grid.into_iter()
         .enumerate()
         .map(|(row, slot)| match slot {
-            Some((eid, stop)) => stop_row(eid, stop, cars, &empty, focused),
-            None => spacer_row(cars.len(), row, rows, max_pos, min_pos, cars, focused),
+            Some((eid, stop)) => stop_row(eid, stop, ctx),
+            None => spacer_row(row, rows, max_pos, min_pos, ctx),
         })
         .collect()
 }
 
-/// Render one stop row: `name@pos │ c c c` where each `c` is a car
-/// glyph at its corresponding column index.
-fn stop_row<'a>(
-    stop_id: EntityId,
-    stop: &'a Stop,
-    cars: &'a [CarView<'a>],
-    nearest_stop_by_car: &std::collections::HashMap<EntityId, EntityId>,
-    focused: Option<EntityId>,
-) -> Line<'a> {
-    let label = format!("{:>10} ", truncate(stop.name(), 10));
-    let pos = format!("{:>5.1} ", stop.position());
-    let mut spans = vec![Span::raw(label), Span::raw(pos), Span::raw("│ ")];
-    for car in cars {
-        let here = nearest_stop_by_car.get(&car.id) == Some(&stop_id);
-        spans.push(car_glyph_for_stop(car, stop_id, stop, here, focused));
+/// Render one stop row: `↑Lobby   0.0 (3) │ ▲  ·  ▼` with the hall-call
+/// glyphs colored by demand.
+fn stop_row<'a>(stop_id: EntityId, stop: &'a Stop, ctx: &RenderCtx<'a>) -> Line<'a> {
+    let (up_call, down_call) = ctx
+        .hall_calls
+        .get(&stop_id)
+        .copied()
+        .unwrap_or((false, false));
+    let waiting = ctx.sim.waiting_count_at(stop_id);
+
+    let mut spans = Vec::with_capacity(8 + ctx.cars.len() * 2);
+    spans.push(Span::styled(
+        if up_call { "↑" } else { " " },
+        Style::default().fg(palette::WARN),
+    ));
+    spans.push(Span::styled(
+        if down_call { "↓" } else { " " },
+        Style::default().fg(palette::WARN),
+    ));
+    spans.push(Span::styled(
+        format!("{:>10}", truncate(stop.name(), 10)),
+        Style::default().fg(palette::TITLE),
+    ));
+    spans.push(Span::styled(
+        format!(" {:>5.1}", stop.position()),
+        Style::default().fg(palette::DIM_STRONG),
+    ));
+    let waiting_text = if waiting > 0 {
+        format!(" ({waiting:>2})")
+    } else {
+        "     ".to_string()
+    };
+    spans.push(Span::styled(
+        waiting_text,
+        if waiting > 0 {
+            Style::default()
+                .fg(palette::ACCENT)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(palette::DIM)
+        },
+    ));
+    spans.push(Span::styled(
+        " │ ",
+        Style::default().fg(palette::DIM_STRONG),
+    ));
+    for car in ctx.cars {
+        let here = ctx.nearest_stop_by_car.get(&car.id) == Some(&stop_id);
+        spans.push(car_glyph_for_stop(car, here, ctx.focused));
         spans.push(Span::raw(" "));
     }
     Line::from(spans)
@@ -213,28 +291,31 @@ fn stop_row<'a>(
 /// continuous position rounds to this row still get drawn in the right
 /// column; otherwise the slot is blank.
 fn spacer_row<'a>(
-    _car_count: usize,
     row: usize,
     rows: usize,
     max_pos: f64,
     min_pos: f64,
-    cars: &'a [CarView<'a>],
-    focused: Option<EntityId>,
+    ctx: &RenderCtx<'a>,
 ) -> Line<'a> {
     let span = (max_pos - min_pos).max(1e-9);
-    let label = format!("{:>10} ", "");
+    // `      ` is 2 lamp + 10 name + 6 pos + 5 waiting + 1 space columns.
     let row_pos_label = format!(
-        "{:>5.1} ",
-        (row as f64 / (rows as f64 - 1.0)).mul_add(-span, max_pos)
+        "{:>10} {:>5.1}     ",
+        "",
+        (row as f64 / (rows as f64 - 1.0)).mul_add(-span, max_pos),
     );
-    let mut spans = vec![Span::raw(label), Span::raw(row_pos_label), Span::raw("│ ")];
-    for car in cars {
+    let mut spans: Vec<Span<'_>> = vec![
+        Span::raw("  "),
+        Span::styled(row_pos_label, Style::default().fg(palette::DIM)),
+        Span::styled(" │ ", Style::default().fg(palette::DIM_STRONG)),
+    ];
+    for car in ctx.cars {
         let car_row = ((max_pos - car.position) / span * (rows as f64 - 1.0)).round() as usize;
         let car_row = car_row.min(rows - 1);
         let glyph = if car_row == row {
-            Span::styled("*", car_style(car, focused))
+            Span::styled("*", car_style(car.id, ctx.focused))
         } else {
-            Span::raw("·")
+            Span::styled("·", Style::default().fg(palette::DIM))
         };
         spans.push(glyph);
         spans.push(Span::raw(" "));
@@ -243,46 +324,44 @@ fn spacer_row<'a>(
 }
 
 /// Pick the glyph + style for a car at a given stop.
-fn car_glyph_for_stop<'a>(
-    car: &CarView<'a>,
-    _stop_id: EntityId,
-    _stop: &Stop,
-    here: bool,
-    focused: Option<EntityId>,
-) -> Span<'a> {
+fn car_glyph_for_stop<'a>(car: &CarView<'a>, here: bool, focused: Option<EntityId>) -> Span<'a> {
     if !here {
-        return Span::raw("·");
+        return Span::styled("·", Style::default().fg(palette::DIM));
     }
-    let glyph = match car.elevator.phase() {
-        ElevatorPhase::Loading => "L",
-        ElevatorPhase::DoorOpening => "O",
-        ElevatorPhase::DoorClosing => "C",
-        ElevatorPhase::Stopped => "■",
+    let (glyph, color) = match car.elevator.phase() {
+        ElevatorPhase::Loading => ("L", palette::ACCENT),
+        ElevatorPhase::DoorOpening => ("O", palette::ACCENT),
+        ElevatorPhase::DoorClosing => ("C", palette::ACCENT),
+        ElevatorPhase::Stopped => ("■", palette::DIM_STRONG),
         ElevatorPhase::MovingToStop(_) | ElevatorPhase::Repositioning(_) => {
             // Use a directional arrow so movement is visible even when
             // the car sits at the same row for several frames.
             if car.elevator.going_up() {
-                "▲"
+                ("▲", palette::UP)
             } else if car.elevator.going_down() {
-                "▼"
+                ("▼", palette::DOWN)
             } else {
-                "█"
+                ("█", palette::DIM_STRONG)
             }
         }
-        _ => "█",
+        _ => ("█", palette::DIM_STRONG),
     };
-    Span::styled(glyph, car_style(car, focused))
+    let style = if focused == Some(car.id) {
+        palette::focused_style()
+    } else {
+        Style::default().fg(color)
+    };
+    Span::styled(glyph, style)
 }
 
-/// Style used to highlight the focused car. Adds bold + reverse so the
-/// glyph stands out under any palette without depending on color.
-fn car_style(car: &CarView<'_>, focused: Option<EntityId>) -> Style {
-    if focused == Some(car.id) {
-        Style::default()
-            .add_modifier(Modifier::BOLD)
-            .add_modifier(Modifier::REVERSED)
+/// Style applied to a focused car glyph when no contextual color exists
+/// (e.g. `*` in distance mode). Bold + reverse for legibility under any
+/// background; falls through to the default style otherwise.
+fn car_style(id: EntityId, focused: Option<EntityId>) -> Style {
+    if focused == Some(id) {
+        palette::focused_style()
     } else {
-        Style::default()
+        Style::default().fg(palette::DIM_STRONG)
     }
 }
 

--- a/crates/elevator-tui/src/ui/traffic.rs
+++ b/crates/elevator-tui/src/ui/traffic.rs
@@ -36,8 +36,9 @@ pub fn draw(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulatio
     let avg_rate = if samples.is_empty() {
         0.0
     } else {
-        f64::from(u32::try_from(samples.iter().sum::<u64>()).unwrap_or(u32::MAX))
-            / samples.len() as f64
+        // `as f64` from u64 loses precision past 2^53 spawns/window — many
+        // years of continuous traffic at 60 t/s — which we don't model.
+        samples.iter().sum::<u64>() as f64 / samples.len() as f64
     };
     let header = Line::from(vec![
         Span::styled(

--- a/crates/elevator-tui/src/ui/traffic.rs
+++ b/crates/elevator-tui/src/ui/traffic.rs
@@ -1,0 +1,75 @@
+//! Traffic-shape mini panel — recent rider arrivals as a rolling
+//! sparkline. Answers "is the sim doing anything?" at a glance and
+//! makes Poisson spikes visible.
+
+use elevator_core::sim::Simulation;
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Paragraph, Sparkline};
+
+use crate::state::AppState;
+use crate::ui::palette;
+
+/// Render the traffic panel.
+pub fn draw(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulation) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(palette::DIM_STRONG))
+        .title(super::bracketed_title(
+            "traffic",
+            Some("arrivals/sec".into()),
+        ));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if inner.height == 0 {
+        return;
+    }
+
+    // Inline summary line (current bucket + window-wide rate).
+    let total_spawned = sim.metrics().total_spawned();
+    let samples = state.spawn_rate_sparkline.as_slice();
+    let current = state.spawn_bucket;
+    let avg_rate = if samples.is_empty() {
+        0.0
+    } else {
+        f64::from(u32::try_from(samples.iter().sum::<u64>()).unwrap_or(u32::MAX))
+            / samples.len() as f64
+    };
+    let header = Line::from(vec![
+        Span::styled(
+            format!("  {current:>2}/s now"),
+            Style::default()
+                .fg(palette::ACCENT)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("   avg {avg_rate:>4.1}/s"),
+            Style::default().fg(palette::DIM_STRONG),
+        ),
+        Span::styled(
+            format!("   total {total_spawned}"),
+            Style::default().fg(palette::DIM),
+        ),
+    ]);
+    frame.render_widget(Paragraph::new(header), Rect { height: 1, ..inner });
+
+    // Sparkline takes whatever rows remain.
+    if inner.height >= 2 {
+        let spark_rect = Rect {
+            x: inner.x,
+            y: inner.y + 1,
+            width: inner.width,
+            height: inner.height - 1,
+        };
+        frame.render_widget(
+            Sparkline::default()
+                .style(Style::default().fg(palette::SUCCESS))
+                .data(samples),
+            spark_rect,
+        );
+    }
+}

--- a/crates/elevator-tui/src/ui/welcome.rs
+++ b/crates/elevator-tui/src/ui/welcome.rs
@@ -1,0 +1,114 @@
+//! First-launch welcome overlay.
+//!
+//! Sits on top of a *running* sim — by the time the user finishes
+//! reading, the sparklines underneath already have data, so dismissing
+//! reveals a lively interface rather than a cold frame. Any keypress
+//! dismisses (handled in `app::handle_key`); `--no-welcome` suppresses
+//! it entirely.
+
+use elevator_core::sim::Simulation;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph};
+
+use crate::ui::palette;
+
+/// Render the welcome modal over `area`.
+pub fn draw(frame: &mut Frame<'_>, area: Rect, sim: &Simulation) {
+    let modal = centered(area, 64, 18);
+    frame.render_widget(Clear, modal);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(palette::ACCENT))
+        .title(super::bracketed_title(
+            "welcome",
+            Some("press any key to continue".into()),
+        ));
+    let inner = block.inner(modal);
+    frame.render_widget(block, modal);
+
+    let car_count = sim
+        .groups()
+        .iter()
+        .flat_map(|g| g.lines().iter())
+        .map(|l| l.elevators().len())
+        .sum::<usize>();
+    let stop_count = sim.stop_lookup_iter().count();
+
+    let lines = vec![
+        Line::from(""),
+        center_line(
+            "elevator-tui",
+            Style::default()
+                .fg(palette::ACCENT)
+                .add_modifier(Modifier::BOLD),
+        ),
+        center_line(
+            "live debugger for the elevator-core engine",
+            Style::default().fg(palette::DIM_STRONG),
+        ),
+        Line::from(""),
+        bullet(format!(
+            "loaded sim · {car_count} car(s) · {stop_count} stop(s) · {tps:.0} t/s",
+            tps = sim.time().ticks_per_second(),
+        )),
+        bullet("the shaft on the left shows each car against its served stops"),
+        bullet("the right column streams events, dispatch, traffic, and metrics"),
+        bullet("color-coded gauges fill up as cars get crowded — green→yellow→red"),
+        Line::from(""),
+        center_line(
+            "press ? at any time for the full keybinding list",
+            Style::default().fg(palette::TITLE),
+        ),
+        Line::from(""),
+        center_line(
+            "any key to begin",
+            Style::default()
+                .fg(palette::ACCENT)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ];
+
+    let inside = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Min(0),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+    frame.render_widget(Paragraph::new(lines), inside[1]);
+}
+
+/// A line whose text is centered within an 64-wide modal — uses
+/// arithmetic-padded `format!` rather than `Alignment::Center` so the
+/// surrounding `Paragraph` doesn't have to apply alignment per-call.
+fn center_line(text: &str, style: Style) -> Line<'_> {
+    Line::from(Span::styled(format!("{text:^60}"), style))
+}
+
+/// One bullet line in the body block.
+fn bullet(text: impl Into<String>) -> Line<'static> {
+    Line::from(vec![
+        Span::raw("    "),
+        Span::styled("• ", Style::default().fg(palette::ACCENT)),
+        Span::styled(text.into(), Style::default().fg(palette::DIM_STRONG)),
+    ])
+}
+
+/// Same centring helper as `help.rs` — kept local so the modules stay
+/// independent.
+fn centered(area: Rect, w: u16, h: u16) -> Rect {
+    let w = w.min(area.width);
+    let h = h.min(area.height);
+    Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    }
+}

--- a/crates/elevator-tui/src/ui/welcome.rs
+++ b/crates/elevator-tui/src/ui/welcome.rs
@@ -17,7 +17,7 @@ use crate::ui::palette;
 
 /// Render the welcome modal over `area`.
 pub fn draw(frame: &mut Frame<'_>, area: Rect, sim: &Simulation) {
-    let modal = centered(area, 64, 18);
+    let modal = super::centered_rect(area, 64, 18);
     frame.render_widget(Clear, modal);
 
     let block = Block::default()
@@ -98,17 +98,4 @@ fn bullet(text: impl Into<String>) -> Line<'static> {
         Span::styled("• ", Style::default().fg(palette::ACCENT)),
         Span::styled(text.into(), Style::default().fg(palette::DIM_STRONG)),
     ])
-}
-
-/// Same centring helper as `help.rs` — kept local so the modules stay
-/// independent.
-fn centered(area: Rect, w: u16, h: u16) -> Rect {
-    let w = w.min(area.width);
-    let h = h.min(area.height);
-    Rect {
-        x: area.x + (area.width.saturating_sub(w)) / 2,
-        y: area.y + (area.height.saturating_sub(h)) / 2,
-        width: w,
-        height: h,
-    }
 }

--- a/crates/elevator-tui/tests/live_walkthrough.rs
+++ b/crates/elevator-tui/tests/live_walkthrough.rs
@@ -1,0 +1,53 @@
+//! End-to-end smoke: load `default.ron`, drive a `PoissonSource` for
+//! 300 ticks (matching the interactive runner's tick-by-tick path), and
+//! verify the sim actually moved.
+//!
+//! What this catches that the other snapshot tests don't:
+//!   - The interactive runner forgetting to drive Poisson traffic — a
+//!     bug that left the events panel and metrics blank in any live
+//!     session even though headless mode worked. Asserting
+//!     `total_spawned() > 0` is enough; a full-frame snapshot would be
+//!     brittle because `PoissonSource` is unseeded.
+//!   - `default.ron` regressions: a config that builds but never spawns
+//!     riders inside 300 ticks would still pass headless's CLI checks
+//!     but produce a useless first-launch experience.
+//!
+//! Unit tests in `src/` cover `AppState` mechanics; this one exercises
+//! the integration path the user actually sees on `cargo run`.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use elevator_core::traffic::{PoissonSource, TrafficSource as _};
+use elevator_tui::config_io;
+
+#[test]
+fn live_default_traffic_drives_spawns() {
+    // Tests run with cwd = crate root; assets/ lives at the workspace root.
+    let cfg = config_io::load_config(std::path::Path::new("../../assets/config/default.ron"))
+        .expect("load default.ron");
+    let mut sim = config_io::build_simulation(&cfg).expect("build sim");
+    let mut traffic = PoissonSource::from_config(&cfg);
+
+    // Mirror exactly what `app::step_once` does each tick: ask the
+    // traffic source for spawn requests, hand them to the sim, then
+    // step. Anything else is a different code path and wouldn't catch
+    // the regression this test exists for.
+    while sim.current_tick() < 300 {
+        for req in traffic.generate(sim.current_tick()) {
+            let _ = sim.spawn_rider(req.origin, req.destination, req.weight);
+        }
+        sim.step();
+        let _ = sim.drain_events();
+    }
+
+    // 300 ticks at a 30-tick Poisson mean → 10 expected spawns; even at
+    // the very low tail of the distribution we should comfortably clear
+    // 1. A zero count means the runner skipped Poisson generation
+    // (the original bug) or the config parsed without `passenger_spawning`.
+    let spawned = sim.metrics().total_spawned();
+    assert!(
+        spawned > 0,
+        "default.ron should produce spawns within 300 ticks (got {spawned}); \
+         did the interactive runner stop driving the Poisson source?"
+    );
+}

--- a/crates/elevator-tui/tests/render_snapshot.rs
+++ b/crates/elevator-tui/tests/render_snapshot.rs
@@ -58,7 +58,7 @@ fn demo_sim(steps: u64) -> Simulation {
 #[test]
 fn frame_renders_after_a_few_ticks() {
     let sim = demo_sim(120);
-    let state = AppState::new(1.0);
+    let state = AppState::new(1.0).without_welcome();
     let frame = render(&sim, &state, 100, 30);
     insta::assert_snapshot!("default_after_120_ticks", frame);
 }
@@ -66,8 +66,25 @@ fn frame_renders_after_a_few_ticks() {
 #[test]
 fn frame_in_distance_mode() {
     let sim = demo_sim(60);
-    let mut state = AppState::new(1.0);
+    let mut state = AppState::new(1.0).without_welcome();
     state.shaft_mode = ShaftMode::Distance;
     let frame = render(&sim, &state, 100, 30);
     insta::assert_snapshot!("distance_mode_after_60_ticks", frame);
+}
+
+#[test]
+fn frame_with_welcome_overlay() {
+    let sim = demo_sim(60);
+    let state = AppState::new(1.0); // welcome shown by default
+    let frame = render(&sim, &state, 100, 30);
+    insta::assert_snapshot!("welcome_overlay", frame);
+}
+
+#[test]
+fn frame_with_help_overlay() {
+    let sim = demo_sim(60);
+    let mut state = AppState::new(1.0).without_welcome();
+    state.show_help = true;
+    let frame = render(&sim, &state, 100, 30);
+    insta::assert_snapshot!("help_overlay", frame);
 }

--- a/crates/elevator-tui/tests/snapshots/render_snapshot__default_after_120_ticks.snap
+++ b/crates/elevator-tui/tests/snapshots/render_snapshot__default_after_120_ticks.snap
@@ -2,33 +2,33 @@
 source: crates/elevator-tui/tests/render_snapshot.rs
 expression: frame
 ---
- elevator-tui   tick 120   RUNNING   rate 1.00×   shaft Index   panel Overview                      
-┌ shaft · 1 car(s) ───┐│ overview                                                                   
-│Top         10.0 │ · ││ events · filter [all]                                                      
-│Ground       0.0 │ ▲ ││                                                                            
-│                     ││                                                                            
-│                     ││                                                                            
-│                     ││                                                                            
-│                     ││                                                                            
-│                     ││                                                                            
-│                     ││                                                                            
-│                     ││                                                                            
-│                     ││                                                                            
-│                     ││                                                                            
-│                     ││                                                                            
-│                     ││                                                                            
-│                     ││────────────────────────────────────────────────────────────────────────────
-│                     ││ dispatch                                                                   
-│                     ││Default       strategy=Scan  cars=1  waiting=0                              
-│                     ││  EntityId(4v1)  phase=MovingToStop(EntityId(2v1)) → EntityId(2v1)  queue=1 
-│                     ││                                                                            
-│                     ││                                                                            
-│                     ││────────────────────────────────────────────────────────────────────────────
-│                     ││ metrics                                                                    
-│                     ││spawned 1   delivered 0   abandoned 0 (0.0%)                                
-│                     ││wait avg 4.0t   p95 4t   max 4t                                             
-│                     ││ride avg 0.0t   throughput 0/3600t   util 100.0%                            
-│                     ││p95 wait (ticks)                                                            
-│                     ││total occupancy                                                             
-└─────────────────────┘│────────────────────────────────────────────────────────────────────────────
- space pause  . step  , step×10  +/- rate  m shaft  []car  f follow  Enter drill  s save  l load  1-
+ elevator-tui · tick 120 · ▶ 1.00× · index · overview                                               
+ legend ▲ up  ▼ down  ■ stopped  L loading  O/C doors  ↑↓ hall call  (n) waiting                    
+╭┤ shaft · 1 cars · index ├──╮╭┤ dispatch · per-car state and load ├───────────────────────────────╮
+│  Top         10.0      │ · ││Default      strategy=Scan  cars=1  waiting=0                       │
+│  Ground       0.0      │ ▲ ││  car 1    movg →Top       [█░░░░░░░░░]   75/800  q=1               │
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            │╰────────────────────────────────────────────────────────────────────╯
+│                            │╭┤ events · filter [all] ├───────────────────────────────────────────╮
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            │╰────────────────────────────────────────────────────────────────────╯
+│                            │╭┤ traffic · arrivals/sec ├──────────────────────────────────────────╮
+│                            ││   0/s now   avg  0.0/s   total 1                                   │
+│                            ││                                                                    │
+│                            │╰────────────────────────────────────────────────────────────────────╯
+│                            │╭┤ metrics · aggregate health ├──────────────────────────────────────╮
+│                            ││spawned 1   delivered 0   abandoned 0 (0.0%)                        │
+│                            ││wait avg 4.0t   p95 4t   max 4t                                     │
+│                            ││ride avg 0.0t   throughput 0/3600t   util 100%                      │
+│                            ││p95 wait (ticks)                                                    │
+│                            ││                                                                    │
+│                            ││total occupancy                                                     │
+╰────────────────────────────╯╰────────────────────────────────────────────────────────────────────╯
+ ? help · space pause · [ ] car · Enter drill · q quit

--- a/crates/elevator-tui/tests/snapshots/render_snapshot__distance_mode_after_60_ticks.snap
+++ b/crates/elevator-tui/tests/snapshots/render_snapshot__distance_mode_after_60_ticks.snap
@@ -2,33 +2,33 @@
 source: crates/elevator-tui/tests/render_snapshot.rs
 expression: frame
 ---
- elevator-tui   tick 60   RUNNING   rate 1.00×   shaft Distance   panel Overview                    
-┌ shaft · 1 car(s) ───┐│ overview                                                                   
-│Top         10.0 │ · ││ events · filter [all]                                                      
-│             9.6 │ · ││                                                                            
-│             9.2 │ · ││                                                                            
-│             8.8 │ · ││                                                                            
-│             8.4 │ · ││                                                                            
-│             8.0 │ · ││                                                                            
-│             7.6 │ · ││                                                                            
-│             7.2 │ · ││                                                                            
-│             6.8 │ · ││                                                                            
-│             6.4 │ · ││                                                                            
-│             6.0 │ · ││                                                                            
-│             5.6 │ · ││                                                                            
-│             5.2 │ · ││                                                                            
-│             4.8 │ · ││────────────────────────────────────────────────────────────────────────────
-│             4.4 │ · ││ dispatch                                                                   
-│             4.0 │ · ││Default       strategy=Scan  cars=1  waiting=0                              
-│             3.6 │ · ││  EntityId(4v1)  phase=MovingToStop(EntityId(2v1)) → EntityId(2v1)  queue=1 
-│             3.2 │ · ││                                                                            
-│             2.8 │ · ││                                                                            
-│             2.4 │ · ││────────────────────────────────────────────────────────────────────────────
-│             2.0 │ · ││ metrics                                                                    
-│             1.6 │ · ││spawned 1   delivered 0   abandoned 0 (0.0%)                                
-│             1.2 │ · ││wait avg 4.0t   p95 4t   max 4t                                             
-│             0.8 │ · ││ride avg 0.0t   throughput 0/3600t   util 100.0%                            
-│             0.4 │ * ││p95 wait (ticks)                                                            
-│Ground       0.0 │ · ││total occupancy                                                             
-└─────────────────────┘│────────────────────────────────────────────────────────────────────────────
- space pause  . step  , step×10  +/- rate  m shaft  []car  f follow  Enter drill  s save  l load  1-
+ elevator-tui · tick 60 · ▶ 1.00× · distance · overview                                             
+ legend ▲ up  ▼ down  ■ stopped  L loading  O/C doors  ↑↓ hall call  (n) waiting                    
+╭┤ shaft · 1 cars · distance ╮╭┤ dispatch · per-car state and load ├───────────────────────────────╮
+│  Top         10.0      │ · ││Default      strategy=Scan  cars=1  waiting=0                       │
+│               9.6      │ · ││  car 1    movg →Top       [█░░░░░░░░░]   75/800  q=1               │
+│               9.2      │ · ││                                                                    │
+│               8.8      │ · ││                                                                    │
+│               8.3      │ · │╰────────────────────────────────────────────────────────────────────╯
+│               7.9      │ · │╭┤ events · filter [all] ├───────────────────────────────────────────╮
+│               7.5      │ · ││                                                                    │
+│               7.1      │ · ││                                                                    │
+│               6.7      │ · ││                                                                    │
+│               6.2      │ · ││                                                                    │
+│               5.8      │ · ││                                                                    │
+│               5.4      │ · ││                                                                    │
+│               5.0      │ · ││                                                                    │
+│               4.6      │ · │╰────────────────────────────────────────────────────────────────────╯
+│               4.2      │ · │╭┤ traffic · arrivals/sec ├──────────────────────────────────────────╮
+│               3.8      │ · ││   0/s now   avg  0.0/s   total 1                                   │
+│               3.3      │ · ││                                                                    │
+│               2.9      │ · │╰────────────────────────────────────────────────────────────────────╯
+│               2.5      │ · │╭┤ metrics · aggregate health ├──────────────────────────────────────╮
+│               2.1      │ · ││spawned 1   delivered 0   abandoned 0 (0.0%)                        │
+│               1.7      │ · ││wait avg 4.0t   p95 4t   max 4t                                     │
+│               1.2      │ · ││ride avg 0.0t   throughput 0/3600t   util 100%                      │
+│               0.8      │ · ││p95 wait (ticks)                                                    │
+│               0.4      │ * ││                                                                    │
+│  Ground       0.0      │ ▲ ││total occupancy                                                     │
+╰────────────────────────────╯╰────────────────────────────────────────────────────────────────────╯
+ ? help · space pause · [ ] car · Enter drill · q quit

--- a/crates/elevator-tui/tests/snapshots/render_snapshot__help_overlay.snap
+++ b/crates/elevator-tui/tests/snapshots/render_snapshot__help_overlay.snap
@@ -1,0 +1,34 @@
+---
+source: crates/elevator-tui/tests/render_snapshot.rs
+expression: frame
+---
+ elevator-tui · tick 60 · ▶ 1.00× · index · overview                                                
+ legend ▲ up  ╭┤ help · press ? or Esc to close ├────────────────────────────────────╮              
+╭┤ shaft · 1 c│                                                                      │─────────────╮
+│  Top        │  Playback                                                            │             │
+│  Ground     │    space   pause / resume                                            │             │
+│             │    . / ,   step one tick / ten ticks                                 │             │
+│             │    + / -   halve or double tick rate (0.0625× – 64×)                 │             │
+│             │                                                                      │─────────────╯
+│             │  Navigation                                                          │─────────────╮
+│             │    [ / ]   focus previous / next car                                 │             │
+│             │    f       follow focused car (event filter)                         │             │
+│             │    Enter   toggle right panel: overview ↔ drill-down                 │             │
+│             │    Esc     close drill-down or this overlay                          │             │
+│             │    m       toggle shaft layout: index ↔ distance                     │             │
+│             │                                                                      │             │
+│             │  Filters & Snapshots                                                 │             │
+│             │    1..7    toggle event categories (1 Elev, 2 Rdr, 3 Dsp,            │─────────────╯
+│             │            4 Top, 5 Rep, 6 Dir, 7 Obs)                               │─────────────╮
+│             │    s / l   save / restore in-memory snapshot                         │             │
+│             │                                                                      │             │
+│             │  Glyphs                                                              │─────────────╯
+│             │    ▲ ▼     going up / going down                                     │─────────────╮
+│             │    ■       stopped                                                   │             │
+│             │    L       loading riders                                            │             │
+│             │    O / C   doors opening / closing                                   │             │
+│             │    ↑↓      active hall call (up / down)                              │             │
+│             │    (n)     n riders waiting at this stop                             │             │
+│             │                                                                      │             │
+╰─────────────╰──────────────────────────────────────────────────────────────────────╯─────────────╯
+ ? help · space pause · [ ] car · Enter drill · q quit

--- a/crates/elevator-tui/tests/snapshots/render_snapshot__welcome_overlay.snap
+++ b/crates/elevator-tui/tests/snapshots/render_snapshot__welcome_overlay.snap
@@ -1,0 +1,34 @@
+---
+source: crates/elevator-tui/tests/render_snapshot.rs
+expression: frame
+---
+ elevator-tui · tick 60 · ▶ 1.00× · index · overview                                                
+ legend ▲ up  ▼ down  ■ stopped  L loading  O/C doors  ↑↓ hall call  (n) waiting                    
+╭┤ shaft · 1 cars · index ├──╮╭┤ dispatch · per-car state and load ├───────────────────────────────╮
+│  Top         10.0      │ · ││Default      strategy=Scan  cars=1  waiting=0                       │
+│  Ground       0.0      │ ▲ ││  car 1    movg →Top       [█░░░░░░░░░]   75/800  q=1               │
+│                            ││                                                                    │
+│                 ╭┤ welcome · press any key to continue ├───────────────────────╮                 │
+│                 │                                                              │─────────────────╯
+│                 │                                                              │─────────────────╮
+│                 │                        elevator-tui                          │                 │
+│                 │         live debugger for the elevator-core engine           │                 │
+│                 │                                                              │                 │
+│                 │    • loaded sim · 1 car(s) · 2 stop(s) · 60 t/s              │                 │
+│                 │    • the shaft on the left shows each car against its served │                 │
+│                 │    • the right column streams events, dispatch, traffic, and │                 │
+│                 │    • color-coded gauges fill up as cars get crowded — green→y│                 │
+│                 │                                                              │─────────────────╯
+│                 │      press ? at any time for the full keybinding list        │─────────────────╮
+│                 │                                                              │                 │
+│                 │                      any key to begin                        │                 │
+│                 │                                                              │─────────────────╯
+│                 │                                                              │─────────────────╮
+│                 │                                                              │                 │
+│                 ╰──────────────────────────────────────────────────────────────╯                 │
+│                            ││ride avg 0.0t   throughput 0/3600t   util 100%                      │
+│                            ││p95 wait (ticks)                                                    │
+│                            ││                                                                    │
+│                            ││total occupancy                                                     │
+╰────────────────────────────╯╰────────────────────────────────────────────────────────────────────╯
+ ? help · space pause · [ ] car · Enter drill · q quit


### PR DESCRIPTION
## Summary

- Bashtop-inspired visual revamp: rounded borders, bracketed accent titles, threshold-coloured gauges and sparklines, focused-car accent, persistent glyph legend, slim footer.
- Onboarding: first-launch welcome overlay (`--no-welcome` skips), `?` help overlay.
- New panels and content: per-car capacity gauges in dispatch, traffic-shape mini panel, per-stop demand column + hall-call lamps on the shaft.
- Replaces `default.ron` with a 3-car / 8-stop "Demo Tower" so the sim has visible work within the first second.
- **Fixes a runtime bug**: the interactive runner was calling `sim.step()` directly and never driving a `PoissonSource`, so any live session sat on an empty event stream regardless of the loaded config. Headless mode worked because it owned its own source. The auto loop now mirrors the headless spawn pump; manual `.`/`,` stepping deliberately skips spawning so debug walks stay deterministic. New `live_walkthrough.rs` regression test asserts `total_spawned() > 0` against the real `default.ron`.

## Test plan

- [x] `cargo test -p elevator-tui` — 22 tests pass (state, app, ui::palette, render snapshots × 4, live walkthrough, headless)
- [x] `cargo test -p elevator-core` — 852 tests pass (incl. updated `deserialize_default_ron` pin: 8 stops / 3 elevators)
- [x] `cargo clippy -p elevator-tui --all-features --tests -- -D warnings` clean
- [x] `cargo fmt -p elevator-tui --check` clean
- [x] Headless smoke: `cargo run -p elevator-tui -- --headless --until 1800 assets/config/default.ron` shows ~64 spawns / 17 deliveries / 100% util in 30 s sim
- [x] Visual snapshots regenerated for default + distance modes; new snapshots for help and welcome overlays
- [x] 256-colour indexed palette for tmux/screen compatibility (no `Color::Rgb`)