### PR TITLE
feat(wasm): expose snapshot_bytes and from_snapshot_bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.26.0"
+version = "15.27.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -490,15 +490,21 @@ impl WasmSim {
     /// # Errors
     ///
     /// Returns a JS error if the bytes are not a valid envelope, the
-    /// crate version differs, or the snapshot references a custom
-    /// dispatch strategy (only built-in strategies are supported by
-    /// this wrapper — use the Rust API directly for custom strategies).
+    /// crate version differs, the snapshot references a custom dispatch
+    /// strategy (only built-in strategies are supported by this wrapper
+    /// — use the Rust API directly for custom strategies), or
+    /// `strategy` is not a recognised built-in name (matching the
+    /// `new()` constructor's contract so `strategyName()` always holds
+    /// a known label).
     #[wasm_bindgen(js_name = fromSnapshotBytes)]
     pub fn from_snapshot_bytes(
         bytes: &[u8],
         strategy: String,
         reposition: Option<String>,
     ) -> Result<Self, JsError> {
+        if strategy_id(&strategy).is_none() {
+            return Err(JsError::new(&format!("unknown strategy: {strategy}")));
+        }
         let inner = Simulation::restore_bytes(bytes, None)
             .map_err(|e| JsError::new(&format!("restore: {e}")))?;
         let reposition_name = reposition

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -29,7 +29,7 @@ mod dto;
 mod result;
 mod world_view;
 
-pub use result::{WasmU32Result, WasmU64Result, WasmVoidResult};
+pub use result::{WasmBytesResult, WasmU32Result, WasmU64Result, WasmVoidResult};
 
 /// Encode an `EntityId` for the JS boundary as a `u64` (`BigInt` in JS).
 /// Carries slotmap's full FFI encoding (slot + version) so stale
@@ -459,6 +459,58 @@ impl WasmSim {
     /// Pull a cheap snapshot for rendering.
     pub fn snapshot(&self) -> dto::Snapshot {
         dto::Snapshot::build(&self.inner)
+    }
+
+    /// Serialize the simulation to a self-describing postcard byte blob.
+    ///
+    /// Wraps [`Simulation::snapshot_bytes`]. The returned bytes carry a
+    /// magic prefix and the `elevator-core` crate version; restore via
+    /// [`Self::from_snapshot_bytes`] in the same crate version. Useful
+    /// for hibernation/rehydration in serverless runtimes (Cloudflare
+    /// Durable Objects) and for lockstep-checkpoint sync.
+    #[wasm_bindgen(js_name = snapshotBytes)]
+    pub fn snapshot_bytes(&self) -> WasmBytesResult {
+        self.inner.snapshot_bytes().into()
+    }
+
+    /// Reconstruct a `WasmSim` from postcard bytes produced by
+    /// [`Self::snapshot_bytes`].
+    ///
+    /// The `strategy` and `reposition` arguments restore wrapper-side
+    /// labels not stored in the snapshot envelope (the underlying
+    /// `Simulation` already auto-restores its built-in dispatch and
+    /// reposition strategies from the postcard payload). Pass the same
+    /// values used at original [`Self::new`] construction.
+    ///
+    /// `traffic_rate` resets to `0.0` on restore — callers that drive
+    /// arrivals externally (the tower-together case) don't use this
+    /// field; callers using built-in traffic should re-call
+    /// `setTrafficRate` after restore.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the bytes are not a valid envelope, the
+    /// crate version differs, or the snapshot references a custom
+    /// dispatch strategy (only built-in strategies are supported by
+    /// this wrapper — use the Rust API directly for custom strategies).
+    #[wasm_bindgen(js_name = fromSnapshotBytes)]
+    pub fn from_snapshot_bytes(
+        bytes: &[u8],
+        strategy: String,
+        reposition: Option<String>,
+    ) -> Result<Self, JsError> {
+        let inner = Simulation::restore_bytes(bytes, None)
+            .map_err(|e| JsError::new(&format!("restore: {e}")))?;
+        let reposition_name = reposition
+            .as_deref()
+            .map_or("adaptive", |s| if s.is_empty() { "adaptive" } else { s })
+            .to_string();
+        Ok(Self {
+            inner,
+            strategy_name: strategy,
+            reposition_name,
+            traffic_rate: 0.0,
+        })
     }
 
     /// Pull a richer game-facing view: door progress, direction lamps,

--- a/crates/elevator-wasm/src/result.rs
+++ b/crates/elevator-wasm/src/result.rs
@@ -92,6 +92,25 @@ pub enum WasmU32Result {
     },
 }
 
+/// Result shape for `Vec<u8>`-typed returns (snapshot bytes, etc.).
+/// On the TS side:
+/// `{ kind: "ok"; value: Uint8Array } | { kind: "err"; error: string }`.
+#[derive(Serialize, Tsify)]
+#[tsify(into_wasm_abi)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum WasmBytesResult {
+    /// Operation succeeded; `value` carries the byte buffer.
+    Ok {
+        /// The byte buffer.
+        value: Vec<u8>,
+    },
+    /// Operation failed; `error` carries the human-readable message.
+    Err {
+        /// The error message.
+        error: String,
+    },
+}
+
 impl<E: std::fmt::Display> From<Result<(), E>> for WasmVoidResult {
     fn from(r: Result<(), E>) -> Self {
         match r {
@@ -116,6 +135,17 @@ impl<E: std::fmt::Display> From<Result<u64, E>> for WasmU64Result {
 
 impl<E: std::fmt::Display> From<Result<u32, E>> for WasmU32Result {
     fn from(r: Result<u32, E>) -> Self {
+        match r {
+            Ok(value) => Self::Ok { value },
+            Err(e) => Self::Err {
+                error: e.to_string(),
+            },
+        }
+    }
+}
+
+impl<E: std::fmt::Display> From<Result<Vec<u8>, E>> for WasmBytesResult {
+    fn from(r: Result<Vec<u8>, E>) -> Self {
         match r {
             Ok(value) => Self::Ok { value },
             Err(e) => Self::Err {
@@ -161,6 +191,22 @@ impl WasmU32Result {
     /// Convenience constructor for the success case.
     #[must_use]
     pub const fn ok(value: u32) -> Self {
+        Self::Ok { value }
+    }
+
+    /// Convenience constructor for the failure case.
+    #[must_use]
+    pub fn err(message: impl Into<String>) -> Self {
+        Self::Err {
+            error: message.into(),
+        }
+    }
+}
+
+impl WasmBytesResult {
+    /// Convenience constructor for the success case.
+    #[must_use]
+    pub const fn ok(value: Vec<u8>) -> Self {
         Self::Ok { value }
     }
 

--- a/crates/elevator-wasm/src/result.rs
+++ b/crates/elevator-wasm/src/result.rs
@@ -5,10 +5,11 @@
 //! JS side). The Result-shape model lets TS consumers use exhaustive
 //! `switch (r.kind)` narrowing without try/catch wrappers.
 //!
-//! Three concrete result types cover the entire fallible surface:
+//! Four concrete result types cover the entire fallible surface:
 //! - [`WasmVoidResult`] for mutators that return `()`
 //! - [`WasmU64Result`] for entity-id returns
 //! - [`WasmU32Result`] for count returns
+//! - [`WasmBytesResult`] for byte-buffer returns
 //!
 //! On the TS side each is a discriminated union with a string `kind`
 //! discriminator:
@@ -206,7 +207,7 @@ impl WasmU32Result {
 impl WasmBytesResult {
     /// Convenience constructor for the success case.
     #[must_use]
-    pub const fn ok(value: Vec<u8>) -> Self {
+    pub fn ok(value: Vec<u8>) -> Self {
         Self::Ok { value }
     }
 

--- a/crates/elevator-wasm/tests/snapshot_bytes.rs
+++ b/crates/elevator-wasm/tests/snapshot_bytes.rs
@@ -1,0 +1,126 @@
+//! Round-trip tests for `WasmSim::snapshot_bytes` / `from_snapshot_bytes`.
+//!
+//! Uses the `WasmSim` wrapper directly on the host target (`cargo test`,
+//! not `wasm-pack test`). The `wasm_bindgen` attributes are no-ops on
+//! host targets *except* for any `Result<T, JsError>`-returning
+//! functions, which call into wasm-bindgen imports — those tests must
+//! run under `wasm-pack test`.
+//!
+//! ## Known asymmetry
+//!
+//! `snapshot_bytes(s) == snapshot_bytes(from_snapshot_bytes(snapshot_bytes(s)))`
+//! does *not* hold in general: the restore path materializes default
+//! metric-tag rows (e.g. `assigned_car`) that the original sim only
+//! lazy-allocates on first write. Once a sim has been restored once,
+//! subsequent snapshot/restore round-trips ARE byte-stable. Lockstep
+//! consumers that diff snapshots across runtimes should either both
+//! sides go through restore at least once before diffing, or rely on
+//! a higher-level equivalence (state-checksum API, not byte equality).
+
+use elevator_wasm::{WasmBytesResult, WasmSim};
+
+const SCENARIO: &str = r#"SimConfig(
+    building: BuildingConfig(
+        name: "Snapshot Round-Trip",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby",   position: 0.0),
+            StopConfig(id: StopId(1), name: "Floor 2", position: 4.0),
+            StopConfig(id: StopId(2), name: "Floor 3", position: 8.0),
+            StopConfig(id: StopId(3), name: "Floor 4", position: 12.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car 1",
+            max_speed: 2.2, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 90,
+        weight_range: (50.0, 100.0),
+    ),
+)"#;
+
+fn unwrap_bytes(r: WasmBytesResult) -> Vec<u8> {
+    match r {
+        WasmBytesResult::Ok { value } => value,
+        WasmBytesResult::Err { error } => panic!("snapshot_bytes failed: {error}"),
+    }
+}
+
+/// `snapshot → restore → snapshot → restore → snapshot` is idempotent
+/// after the first restore. The first cycle is asymmetric because
+/// restore materializes default metric-tag rows; once those are present,
+/// further snapshots are byte-stable.
+#[test]
+fn round_trip_is_idempotent_after_first_restore() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    sim.step_many(500);
+
+    let initial = unwrap_bytes(sim.snapshot_bytes());
+
+    let primed =
+        WasmSim::from_snapshot_bytes(&initial, "look".to_string(), None).expect("first restore");
+    let primed_bytes = unwrap_bytes(primed.snapshot_bytes());
+
+    let rebound = WasmSim::from_snapshot_bytes(&primed_bytes, "look".to_string(), None)
+        .expect("second restore");
+    let rebound_bytes = unwrap_bytes(rebound.snapshot_bytes());
+
+    assert_eq!(
+        primed_bytes, rebound_bytes,
+        "snapshots taken after the first restore must be byte-stable"
+    );
+}
+
+/// Two sims that both went through `restore_bytes` from the same source
+/// and were stepped identically afterward must produce the same bytes.
+/// This is the property lockstep consumers actually need.
+#[test]
+fn parallel_restored_sims_diverge_zero_after_identical_steps() {
+    let mut original = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    original.step_many(500);
+    let bytes = unwrap_bytes(original.snapshot_bytes());
+
+    let mut a = WasmSim::from_snapshot_bytes(&bytes, "look".to_string(), None).expect("restore a");
+    let mut b = WasmSim::from_snapshot_bytes(&bytes, "look".to_string(), None).expect("restore b");
+
+    a.step_many(1000);
+    b.step_many(1000);
+
+    assert_eq!(
+        unwrap_bytes(a.snapshot_bytes()),
+        unwrap_bytes(b.snapshot_bytes()),
+        "two parallel restored sims must stay bit-identical under the same input"
+    );
+}
+
+/// Tick + state advances post-restore — confirming the inner `Simulation`
+/// is genuinely live, not just deserialized state.
+#[test]
+fn restored_sim_advances_tick_counter() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    sim.step_many(500);
+    let initial_tick = sim.current_tick();
+
+    let bytes = unwrap_bytes(sim.snapshot_bytes());
+    let mut restored =
+        WasmSim::from_snapshot_bytes(&bytes, "look".to_string(), None).expect("restore");
+
+    assert_eq!(
+        restored.current_tick(),
+        initial_tick,
+        "restored tick counter must match source"
+    );
+
+    restored.step_many(100);
+    assert_eq!(
+        restored.current_tick(),
+        initial_tick + 100,
+        "stepping post-restore must advance the tick counter"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `snapshotBytes()` and `fromSnapshotBytes(bytes, strategy, reposition)` to the `WasmSim` wrapper, exposing the existing Rust `Simulation::snapshot_bytes` / `restore_bytes` APIs to JS consumers.
- Adds `WasmBytesResult` discriminated-union return type matching the existing `WasmU32Result` / `WasmU64Result` / `WasmVoidResult` pattern.

## Why

Required by consumers running lockstep simulation across heterogeneous runtimes (browser + Cloudflare Workers / Node) where:
- JSON-DTO snapshots (`WasmSim::snapshot()`) are too slow for periodic checkpoint sync, and
- The magic+version envelope is needed for safe cross-version handling on rehydration.

The Rust API has supported this since the snapshot envelope landed; only the JS surface was missing.

## Known asymmetry (documented in test module)

`snapshot(restore(snapshot(s)))` is **not** byte-equal to `snapshot(s)` in general — `restore` materializes default metric-tag rows (e.g. `assigned_car`) that an unrestored sim only lazy-allocates on first write. Round-trips ARE byte-stable after the first restore.

Lockstep consumers diffing snapshots across runtimes should either both go through restore once before diffing, or rely on a higher-level state-checksum API (future work).

## Test plan

- [x] `cargo test -p elevator-wasm --test snapshot_bytes` — 3 tests covering: idempotence after first restore, parallel-restored sims diverge zero under identical input, post-restore tick counter advances.
- [x] `cargo test -p elevator-wasm` — full crate (8 + 3 tests).
- [x] `cargo test -p elevator-core` — 852 tests.
- [x] `cargo clippy -p elevator-wasm --all-features --tests` — clean.
- [x] `cargo fmt -p elevator-wasm` — clean.
- [x] `bash scripts/check-bindings.sh` — 140 public methods in sync.
- [x] Pre-commit hook (workspace check, doc tests, etc.) — green.