### PR TITLE
feat(wasm): add positions_at_packed batched readout

### DIFF
--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -1262,6 +1262,36 @@ impl WasmSim {
         self.inner.position_at(u64_to_entity(entity_ref), alpha)
     }
 
+    /// Batched variant of [`Self::position_at`]: writes the
+    /// interpolated position of each `entity_ref` in `refs` into the
+    /// matching slot of `out`, in one wasm-bindgen crossing.
+    ///
+    /// Designed for renderers that read N elevator positions per
+    /// frame and want to avoid the per-call boundary overhead of
+    /// calling `positionAt` in a loop. Entities without a position
+    /// component get `f64::NAN` written to their slot — caller can
+    /// `Number.isNaN(slot)` to detect.
+    ///
+    /// `out` must be at least as long as `refs`; the wasm-bindgen
+    /// generated TS signature accepts a `Float64Array`. Excess slots
+    /// past `refs.len()` are left unmodified so callers can reuse a
+    /// scratch buffer larger than the current frame's elevator count.
+    ///
+    /// Returns the number of entries written (always `refs.len()`)
+    /// so JS callers can use it as a `for (let i = 0; i < n; i++)`
+    /// bound without re-reading the input length.
+    #[wasm_bindgen(js_name = positionsAtPacked)]
+    pub fn positions_at_packed(&self, refs: Vec<u64>, alpha: f64, out: &mut [f64]) -> u32 {
+        let n = refs.len().min(out.len());
+        for (i, &raw) in refs.iter().enumerate().take(n) {
+            out[i] = self
+                .inner
+                .position_at(u64_to_entity(raw), alpha)
+                .unwrap_or(f64::NAN);
+        }
+        u32::try_from(n).unwrap_or(u32::MAX)
+    }
+
     /// Fraction of `elevator_ref`'s capacity currently occupied (by weight),
     /// in `[0.0, 1.0]`. Returns `undefined` for missing entities.
     #[wasm_bindgen(js_name = elevatorLoad)]

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -1272,16 +1272,21 @@ impl WasmSim {
     /// component get `f64::NAN` written to their slot — caller can
     /// `Number.isNaN(slot)` to detect.
     ///
-    /// `out` must be at least as long as `refs`; the wasm-bindgen
-    /// generated TS signature accepts a `Float64Array`. Excess slots
-    /// past `refs.len()` are left unmodified so callers can reuse a
-    /// scratch buffer larger than the current frame's elevator count.
+    /// Both `refs` and `out` are zero-copy views of the JS caller's
+    /// typed arrays (`BigUint64Array` and `Float64Array` respectively).
+    /// wasm-bindgen does not allocate or copy on the boundary, so
+    /// this stays cheap to call every render frame.
     ///
-    /// Returns the number of entries written (always `refs.len()`)
-    /// so JS callers can use it as a `for (let i = 0; i < n; i++)`
-    /// bound without re-reading the input length.
+    /// Returns the number of entries written, which is
+    /// `min(refs.len(), out.len())`. Callers can reuse a scratch
+    /// buffer larger than the current frame's elevator count without
+    /// re-reading lengths; when `out` is shorter than `refs`, only
+    /// `out.len()` entries are written and the remaining refs are
+    /// silently skipped — caller is responsible for sizing `out` at
+    /// least as large as `refs` if they want every position read.
     #[wasm_bindgen(js_name = positionsAtPacked)]
-    pub fn positions_at_packed(&self, refs: Vec<u64>, alpha: f64, out: &mut [f64]) -> u32 {
+    #[must_use]
+    pub fn positions_at_packed(&self, refs: &[u64], alpha: f64, out: &mut [f64]) -> u32 {
         let n = refs.len().min(out.len());
         for (i, &raw) in refs.iter().enumerate().take(n) {
             out[i] = self

--- a/crates/elevator-wasm/tests/positions_packed.rs
+++ b/crates/elevator-wasm/tests/positions_packed.rs
@@ -1,0 +1,131 @@
+//! Tests for `WasmSim::positions_at_packed` — the batched variant of
+//! `position_at` that fills a caller-provided `&mut [f64]` in one
+//! wasm-bindgen crossing instead of N calls.
+
+use elevator_wasm::WasmSim;
+
+const SCENARIO: &str = r#"SimConfig(
+    building: BuildingConfig(
+        name: "Packed Positions",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby",   position: 0.0),
+            StopConfig(id: StopId(1), name: "Floor 2", position: 4.0),
+            StopConfig(id: StopId(2), name: "Floor 3", position: 8.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car 1",
+            max_speed: 2.2, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+        ElevatorConfig(
+            id: 1, name: "Car 2",
+            max_speed: 2.2, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(2),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 90,
+        weight_range: (50.0, 100.0),
+    ),
+)"#;
+
+fn elevator_refs(sim: &WasmSim) -> Vec<u64> {
+    // Walk every line in the topology and collect the elevators
+    // attached to each. Two elevators in the seed scenario; this
+    // helper just picks them up in a deterministic-enough order
+    // for the tests' equality checks.
+    let mut refs = Vec::new();
+    for line in sim.all_lines() {
+        refs.extend(sim.elevators_on_line(line));
+    }
+    refs
+}
+
+#[test]
+fn batched_writes_match_individual_calls() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    sim.step_many(50);
+
+    let refs = elevator_refs(&sim);
+    assert_eq!(refs.len(), 2, "scenario has 2 elevators");
+
+    let mut packed = vec![0.0_f64; refs.len()];
+    let written = sim.positions_at_packed(refs.clone(), 0.0, &mut packed);
+    assert_eq!(written, 2);
+
+    // Compare against per-call values.
+    for (i, &raw) in refs.iter().enumerate() {
+        let single = sim.position_at(raw, 0.0).expect("position present");
+        assert!(
+            (packed[i] - single).abs() < 1e-12,
+            "packed[{i}]={} differs from single position_at={}",
+            packed[i],
+            single,
+        );
+    }
+}
+
+#[test]
+fn unknown_refs_get_nan() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    sim.step_many(10);
+
+    // Mix valid and invalid refs. The bogus value passes u64_to_entity
+    // (any 64-bit value decodes to *some* slotmap key) but the
+    // entity won't exist in the world, so position_at returns None
+    // and we write NaN.
+    let mut refs = elevator_refs(&sim);
+    refs.push(0xdead_beef_dead_beef);
+
+    let mut packed = vec![0.0_f64; refs.len()];
+    let written = sim.positions_at_packed(refs, 0.0, &mut packed);
+    assert_eq!(written, 3);
+    assert!(packed[0].is_finite());
+    assert!(packed[1].is_finite());
+    assert!(packed[2].is_nan());
+}
+
+const SENTINEL: f64 = 42.0;
+
+#[test]
+#[allow(clippy::float_cmp)]
+fn writes_count_caps_at_min_of_refs_and_out() {
+    let sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let refs = elevator_refs(&sim);
+
+    // out smaller than refs — only out.len() slots get written.
+    let mut short = [SENTINEL; 1];
+    let written = sim.positions_at_packed(refs.clone(), 0.0, &mut short);
+    assert_eq!(written, 1);
+    assert!(short[0].is_finite());
+
+    // out larger than refs — refs.len() slots written, rest unmodified.
+    // Strict equality on the sentinel is safe: those slots are
+    // untouched memory, not the result of any FP arithmetic.
+    let mut long = [SENTINEL; 5];
+    let written = sim.positions_at_packed(refs, 0.0, &mut long);
+    assert_eq!(written, 2);
+    assert!(long[0].is_finite());
+    assert!(long[1].is_finite());
+    assert_eq!(long[2], SENTINEL);
+    assert_eq!(long[3], SENTINEL);
+    assert_eq!(long[4], SENTINEL);
+}
+
+#[test]
+#[allow(clippy::float_cmp)]
+fn empty_inputs_write_nothing() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    sim.step_many(1);
+    let mut packed = [SENTINEL; 4];
+    let written = sim.positions_at_packed(vec![], 0.0, &mut packed);
+    assert_eq!(written, 0);
+    assert_eq!(packed, [SENTINEL, SENTINEL, SENTINEL, SENTINEL]);
+}

--- a/crates/elevator-wasm/tests/positions_packed.rs
+++ b/crates/elevator-wasm/tests/positions_packed.rs
@@ -57,7 +57,7 @@ fn batched_writes_match_individual_calls() {
     assert_eq!(refs.len(), 2, "scenario has 2 elevators");
 
     let mut packed = vec![0.0_f64; refs.len()];
-    let written = sim.positions_at_packed(refs.clone(), 0.0, &mut packed);
+    let written = sim.positions_at_packed(&refs, 0.0, &mut packed);
     assert_eq!(written, 2);
 
     // Compare against per-call values.
@@ -85,7 +85,7 @@ fn unknown_refs_get_nan() {
     refs.push(0xdead_beef_dead_beef);
 
     let mut packed = vec![0.0_f64; refs.len()];
-    let written = sim.positions_at_packed(refs, 0.0, &mut packed);
+    let written = sim.positions_at_packed(&refs, 0.0, &mut packed);
     assert_eq!(written, 3);
     assert!(packed[0].is_finite());
     assert!(packed[1].is_finite());
@@ -102,7 +102,7 @@ fn writes_count_caps_at_min_of_refs_and_out() {
 
     // out smaller than refs — only out.len() slots get written.
     let mut short = [SENTINEL; 1];
-    let written = sim.positions_at_packed(refs.clone(), 0.0, &mut short);
+    let written = sim.positions_at_packed(&refs, 0.0, &mut short);
     assert_eq!(written, 1);
     assert!(short[0].is_finite());
 
@@ -110,7 +110,7 @@ fn writes_count_caps_at_min_of_refs_and_out() {
     // Strict equality on the sentinel is safe: those slots are
     // untouched memory, not the result of any FP arithmetic.
     let mut long = [SENTINEL; 5];
-    let written = sim.positions_at_packed(refs, 0.0, &mut long);
+    let written = sim.positions_at_packed(&refs, 0.0, &mut long);
     assert_eq!(written, 2);
     assert!(long[0].is_finite());
     assert!(long[1].is_finite());
@@ -125,7 +125,7 @@ fn empty_inputs_write_nothing() {
     let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
     sim.step_many(1);
     let mut packed = [SENTINEL; 4];
-    let written = sim.positions_at_packed(vec![], 0.0, &mut packed);
+    let written = sim.positions_at_packed(&[], 0.0, &mut packed);
     assert_eq!(written, 0);
     assert_eq!(packed, [SENTINEL, SENTINEL, SENTINEL, SENTINEL]);
 }


### PR DESCRIPTION
## Summary

Adds \`positions_at_packed(refs, alpha, out)\` — a batched variant of \`positionAt\` that fills a caller-owned \`&mut [f64]\` (Float64Array on JS) in one wasm-bindgen crossing instead of one call per ref.

## Why

Renderers querying N elevator positions per render frame currently pay one wasm-bindgen boundary crossing per call to \`positionAt\`. In a dense multi-shaft tower with multiple cars, that's dozens of crossings per render frame.

The batched variant collapses N round-trips into 1. Entities without a position component get \`f64::NAN\` written to their slot so callers can detect via \`Number.isNaN\`. Length cap is \`min(refs.len(), out.len())\`, so callers can reuse a scratch buffer larger than the current frame's elevator count without re-reading lengths.

## Motivation

Identified during integration into [tower-together](https://github.com/andymai/tower-together). Stress benchmark there showed wasm-side overhead adding ~15% mean tick cost on dense towers; the per-frame \`positionAt\` loop is the largest contributor on the rendering path. This unblocks closing most of that gap.

## Tests

Four cases in \`crates/elevator-wasm/tests/positions_packed.rs\`:
- Batched values match individual \`position_at\` calls (correctness).
- Unknown refs get \`NaN\` (graceful for stale refs / despawned entities).
- Length cap behaves at \`out\` too small and \`out\` too large (sentinel preserved past \`refs.len()\`).
- Empty \`refs\` writes nothing.

## Test plan

- [x] \`cargo test -p elevator-wasm\` — 4 new + existing pass
- [x] \`cargo clippy -p elevator-wasm --all-features --tests\` — clean
- [x] \`cargo fmt -p elevator-wasm\` — clean