### PR TITLE
feat(core): deterministic-fp feature flag for cross-host bit equality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.27.0"
+version = "15.28.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-wasm"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "elevator-core",
  "getrandom 0.4.2",

--- a/crates/elevator-core/Cargo.toml
+++ b/crates/elevator-core/Cargo.toml
@@ -18,6 +18,15 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["traffic"]
 traffic = ["dep:rand"]
 energy = []
+# Replace `f64::mul_add` calls with the equivalent `(a * b) + c`
+# expression. The hardware-FMA path is deterministic on
+# wasm32-unknown-unknown (lowered to libm fma) but the spec doesn't
+# guarantee bit-equality across all targets — relevant for consumers
+# running lockstep across heterogeneous hosts (native + wasm32, etc.).
+# Trades one rounding step for two; the precision difference is
+# below the threshold any consumer cares about, while the
+# host-independence guarantee tightens.
+deterministic-fp = []
 
 [lints]
 workspace = true

--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -341,7 +341,8 @@ impl DestinationDispatch {
                 .filter(|p| *p > lo + 1e-9 && *p < hi - 1e-9)
                 .count()
         });
-        let pickup_time = (intervening_committed as f64).mul_add(door_overhead, pickup_travel);
+        let pickup_time =
+            crate::fp::fma(intervening_committed as f64, door_overhead, pickup_travel);
 
         // Ride time: origin → dest travel + door overhead at origin pickup.
         let ride_dist = (origin_pos - dest_pos).abs();

--- a/crates/elevator-core/src/dispatch/etd.rs
+++ b/crates/elevator-core/src/dispatch/etd.rs
@@ -232,7 +232,7 @@ impl DispatchStrategy for EtdDispatch {
                     w * w
                 })
                 .sum();
-            cost = self.wait_squared_weight.mul_add(-wait_sq, cost).max(0.0);
+            cost = crate::fp::fma(self.wait_squared_weight, -wait_sq, cost).max(0.0);
         }
         if self.age_linear_weight > 0.0 {
             let wait_sum: f64 = ctx
@@ -241,7 +241,7 @@ impl DispatchStrategy for EtdDispatch {
                 .iter()
                 .map(|r| r.wait_ticks as f64)
                 .sum();
-            cost = self.age_linear_weight.mul_add(-wait_sum, cost).max(0.0);
+            cost = crate::fp::fma(self.age_linear_weight, -wait_sum, cost).max(0.0);
         }
         if cost.is_finite() { Some(cost) } else { None }
     }
@@ -350,11 +350,13 @@ impl EtdDispatch {
             _ => 0.0,
         };
 
-        let raw = self.wait_weight.mul_add(
+        let raw = crate::fp::fma(
+            self.wait_weight,
             travel_time,
-            self.delay_weight.mul_add(
+            crate::fp::fma(
+                self.delay_weight,
                 existing_rider_delay,
-                self.door_weight.mul_add(door_cost, direction_bonus),
+                crate::fp::fma(self.door_weight, door_cost, direction_bonus),
             ),
         );
         raw.max(0.0)

--- a/crates/elevator-core/src/dispatch/rsr.rs
+++ b/crates/elevator-core/src/dispatch/rsr.rs
@@ -384,7 +384,7 @@ impl DispatchStrategy for RsrDispatch {
                 .iter()
                 .map(|r| r.wait_ticks as f64)
                 .sum();
-            cost = self.age_linear_weight.mul_add(-wait_sum, cost);
+            cost = crate::fp::fma(self.age_linear_weight, -wait_sum, cost);
         }
 
         let cost = cost.max(0.0);

--- a/crates/elevator-core/src/energy.rs
+++ b/crates/elevator-core/src/energy.rs
@@ -130,9 +130,11 @@ pub(crate) fn compute_tick_energy(
         return (profile.idle_cost_per_tick, 0.0);
     }
 
-    let consumed = profile
-        .weight_factor
-        .mul_add(current_load, profile.move_cost_per_tick);
+    let consumed = crate::fp::fma(
+        profile.weight_factor,
+        current_load,
+        profile.move_cost_per_tick,
+    );
     let regenerated = if velocity < 0.0 {
         consumed * profile.regen_factor
     } else {

--- a/crates/elevator-core/src/eta.rs
+++ b/crates/elevator-core/src/eta.rs
@@ -42,7 +42,8 @@ pub fn travel_time(distance: f64, v0: f64, v_max: f64, accel: f64, decel: f64) -
 
     // Triangular peak velocity (no cruise): solve d_accel(v) + d_decel(v) = d
     // → v² = (2·d·a·decel + v0²·decel) / (a + decel)
-    let v_peak_sq = decel.mul_add(v0 * v0, 2.0 * distance * accel * decel) / (accel + decel);
+    let v_peak_sq =
+        crate::fp::fma(decel, v0 * v0, 2.0 * distance * accel * decel) / (accel + decel);
     let v_peak = v_peak_sq.sqrt();
 
     if v_peak <= v_max {
@@ -50,7 +51,7 @@ pub fn travel_time(distance: f64, v0: f64, v_max: f64, accel: f64, decel: f64) -
         (v_peak - v0) / accel + v_peak / decel
     } else {
         // Trapezoidal: accel v0→v_max, cruise at v_max, decel v_max→0
-        let d_accel = v_max.mul_add(v_max, -(v0 * v0)) / (2.0 * accel);
+        let d_accel = crate::fp::fma(v_max, v_max, -(v0 * v0)) / (2.0 * accel);
         let d_decel = v_max * v_max / (2.0 * decel);
         let d_cruise = distance - d_accel - d_decel;
         (v_max - v0) / accel + d_cruise / v_max + v_max / decel

--- a/crates/elevator-core/src/fp.rs
+++ b/crates/elevator-core/src/fp.rs
@@ -1,0 +1,39 @@
+//! Floating-point helpers that the engine routes through to give
+//! consumers a single switch for cross-host determinism.
+//!
+//! By default these are zero-cost wrappers — `fma` lowers to
+//! `f64::mul_add`, which on hardware-FMA targets is one rounded
+//! operation. With the `deterministic-fp` feature flag set, `fma`
+//! becomes `(a * b) + c` (two rounded operations) — slightly less
+//! precise, but bit-identical across every target without relying
+//! on the host's libm or hardware FMA. Required for consumers
+//! running lockstep across heterogeneous hosts (native + wasm32,
+//! browser + worker, etc.) who need byte-equal sim outputs.
+//!
+//! All `f64::mul_add` call sites in the engine should go through
+//! `fma` so the feature flag covers the whole hot path.
+
+/// Fused multiply-add: returns `(a * b) + c`.
+///
+/// Default build uses hardware FMA via `f64::mul_add` — one rounded
+/// operation, slightly more precise. With the `deterministic-fp`
+/// feature flag, this expands to a separate multiply and add — two
+/// rounded operations, bit-identical across all hosts and toolchains.
+#[cfg(not(feature = "deterministic-fp"))]
+#[inline]
+#[must_use]
+pub fn fma(a: f64, b: f64, c: f64) -> f64 {
+    a.mul_add(b, c)
+}
+
+/// `deterministic-fp` build of [`fma`]: two rounded operations,
+/// bit-identical across all targets. The `clippy::suboptimal_flops`
+/// allow is the whole point of the feature flag — clippy would
+/// suggest `mul_add`, which is exactly what we're avoiding.
+#[cfg(feature = "deterministic-fp")]
+#[allow(clippy::suboptimal_flops)]
+#[inline]
+#[must_use]
+pub fn fma(a: f64, b: f64, c: f64) -> f64 {
+    (a * b) + c
+}

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -380,6 +380,8 @@ pub mod energy;
 pub mod eta;
 /// Simulation event bus and event types.
 pub mod events;
+/// Floating-point helpers gated by the `deterministic-fp` feature.
+pub(crate) mod fp;
 /// Lifecycle hooks for injecting logic before/after simulation phases.
 pub mod hooks;
 /// Aggregate simulation metrics.

--- a/crates/elevator-core/src/movement.rs
+++ b/crates/elevator-core/src/movement.rs
@@ -70,7 +70,7 @@ pub fn tick_movement(
 
     let new_velocity = if opposing || stopping_distance >= distance_remaining - EPSILON {
         // Decelerate
-        let v = (-safe_decel * dt).mul_add(velocity.signum(), velocity);
+        let v = crate::fp::fma(-safe_decel * dt, velocity.signum(), velocity);
         // Clamp to zero if sign would flip.
         if velocity > 0.0 && v < 0.0 || velocity < 0.0 && v > 0.0 {
             0.0
@@ -79,7 +79,7 @@ pub fn tick_movement(
         }
     } else if speed < max_speed {
         // Accelerate toward target
-        let v = (acceleration * dt).mul_add(sign, velocity);
+        let v = crate::fp::fma(acceleration * dt, sign, velocity);
         // Clamp magnitude to max_speed
         if v.abs() > max_speed {
             sign * max_speed
@@ -91,7 +91,7 @@ pub fn tick_movement(
         sign * max_speed
     };
 
-    let new_pos = new_velocity.mul_add(dt, position);
+    let new_pos = crate::fp::fma(new_velocity, dt, position);
 
     // Overshoot check: did we cross the target?
     let new_displacement = target_position - new_pos;

--- a/crates/elevator-core/src/sim/accessors.rs
+++ b/crates/elevator-core/src/sim/accessors.rs
@@ -73,7 +73,7 @@ impl super::Simulation {
             alpha.clamp(0.0, 1.0)
         };
         let prev = self.world.prev_position(id).map_or(current, |p| p.value);
-        Some((current - prev).mul_add(alpha, prev))
+        Some(crate::fp::fma(current - prev, alpha, prev))
     }
 
     /// Current velocity of an entity along the shaft axis (signed: +up, -down).

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -1100,7 +1100,7 @@ impl Simulation {
         let vel = self.world.velocity(id)?.value;
         let car = self.world.elevator(id)?;
         let dist = crate::movement::braking_distance(vel, car.deceleration.value());
-        Some(vel.signum().mul_add(dist, pos))
+        Some(crate::fp::fma(vel.signum(), dist, pos))
     }
 
     /// Count of elevators currently in the given phase.

--- a/crates/elevator-core/src/systems/movement.rs
+++ b/crates/elevator-core/src/systems/movement.rs
@@ -325,7 +325,7 @@ fn tick_manual(
         vel - dv_max
     };
 
-    let new_pos = new_vel.mul_add(ctx.dt, old_pos);
+    let new_pos = crate::fp::fma(new_vel, ctx.dt, old_pos);
 
     if let Some(p) = world.position_mut(eid) {
         p.value = new_pos;

--- a/crates/elevator-core/src/tests/fp_tests.rs
+++ b/crates/elevator-core/src/tests/fp_tests.rs
@@ -1,0 +1,50 @@
+//! Tests for the `fp` floating-point helpers.
+
+use crate::fp::fma;
+
+#[test]
+fn fma_returns_a_b_plus_c() {
+    // Trivial values where both fused and non-fused agree exactly.
+    assert!((fma(2.0, 3.0, 4.0) - 10.0).abs() < f64::EPSILON);
+    assert!((fma(-1.5, 2.0, 0.5) - (-2.5)).abs() < f64::EPSILON);
+    assert!((fma(0.0, 99.0, 1.0) - 1.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn fma_is_deterministic_across_repeat_calls() {
+    let a = 0.1_f64;
+    let b = 0.2_f64;
+    let c = 0.3_f64;
+    let first = fma(a, b, c);
+    for _ in 0..1000 {
+        assert_eq!(
+            fma(a, b, c),
+            first,
+            "fma must produce identical bits across repeated calls"
+        );
+    }
+}
+
+/// Under the `deterministic-fp` feature, fma must equal `(a * b) + c`
+/// exactly — that's the definition of the flag. The default build
+/// uses `f64::mul_add` which can differ from `(a * b) + c` by one ULP
+/// for some inputs (it's one rounded operation vs two). Both are
+/// internally consistent; the flag picks which one the engine uses.
+#[cfg(feature = "deterministic-fp")]
+#[allow(clippy::suboptimal_flops)]
+#[test]
+fn deterministic_fp_matches_naive_expression() {
+    // Specific value where mul_add and (a*b)+c differ in the last bit.
+    let a = 0.1_f64;
+    let b = 0.2_f64;
+    let c = -(a * b);
+    // (0.1 * 0.2) - (0.1 * 0.2) — naively zero but the rounding of
+    // (a*b) leaves a tiny residue; mul_add eliminates the residue
+    // by fusing. With deterministic-fp on, we keep the residue.
+    let naive = (a * b) + c;
+    assert_eq!(
+        fma(a, b, c),
+        naive,
+        "deterministic-fp build must match (a*b)+c exactly"
+    );
+}

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -60,6 +60,7 @@ mod eta_tests;
 mod etd_age_weight_tests;
 mod etd_mutant_tests;
 mod event_payload_tests;
+mod fp_tests;
 mod hall_call_tests;
 mod idle_with_riders_tests;
 mod invariants_tests;

--- a/crates/elevator-ffi/Cargo.toml
+++ b/crates/elevator-ffi/Cargo.toml
@@ -32,6 +32,11 @@ default = []
 # Mirror elevator-core's `energy` feature so the FFI surfaces
 # `Event::EnergyConsumed` in the drained event stream.
 energy = ["elevator-core/energy"]
+# Mirror elevator-core's `deterministic-fp` feature for consumers
+# (Unity/.NET, .so/.dylib/.dll prebuilt natives) running lockstep
+# across heterogeneous architectures who need byte-exact sim
+# outputs. See elevator-core's docs for the full guarantee.
+deterministic-fp = ["elevator-core/deterministic-fp"]
 
 [dependencies]
 elevator-core = { path = "../elevator-core" }

--- a/crates/elevator-gdext/Cargo.toml
+++ b/crates/elevator-gdext/Cargo.toml
@@ -30,6 +30,13 @@ doc_markdown = "allow"
 option_if_let_else = "allow"
 manual_let_else = "allow"
 
+[features]
+default = []
+# Mirror elevator-core's `deterministic-fp` feature for Godot
+# deployments running lockstep across heterogeneous architectures
+# who need byte-exact sim outputs.
+deterministic-fp = ["elevator-core/deterministic-fp"]
+
 [dependencies]
 elevator-core = { path = "../elevator-core" }
 godot = "0.5"

--- a/crates/elevator-wasm/Cargo.toml
+++ b/crates/elevator-wasm/Cargo.toml
@@ -29,6 +29,13 @@ must_use_candidate = "allow"
 # non-const wrapper), so the lint produces noise across every trivial getter.
 missing_const_for_fn = "allow"
 
+[features]
+default = []
+# Mirror elevator-core's `deterministic-fp` feature for browser/server
+# lockstep consumers (e.g. tower-together) running across V8 builds
+# that may not all expose hardware FMA identically.
+deterministic-fp = ["elevator-core/deterministic-fp"]
+
 [dependencies]
 elevator-core = { path = "../elevator-core", features = ["traffic"] }
 wasm-bindgen = "0.2"


### PR DESCRIPTION
## Summary

Adds a \`deterministic-fp\` feature flag and routes all 16 of the crate's \`f64::mul_add\` call sites through a new \`crate::fp::fma\` helper. Default builds keep the hardware-FMA path (one rounded op, slightly more precise). Builds with \`deterministic-fp\` on fall back to \`(a * b) + c\` (two rounded ops, bit-identical across every target).

## Why

The hardware FMA path on \`wasm32-unknown-unknown\` is already deterministic (lowered to libm fma), so this is mostly defensive for consumers running lockstep across heterogeneous hosts (native + wasm32, multi-arch native fleets, etc.). The flag is opt-in and zero-cost when off.

## Sites swept (16)

- \`movement.rs:73,82,94\` — trapezoidal motion (per-tick hot path)
- \`systems/movement.rs:328\` — position update (per-tick hot path)
- \`eta.rs:45,53\` — closed-form ETA (LOOK dispatch tiebreak)
- \`energy.rs:135\` — feature-gated energy modeling
- \`dispatch/etd.rs:235,244,353-357\` — ETD scoring
- \`dispatch/destination.rs:344\` — Destination dispatch pickup ETA
- \`dispatch/rsr.rs:387\` — RSR scoring
- \`sim/lifecycle.rs:1103\` — projected post-brake position
- \`sim/accessors.rs:76\` — sub-tick interpolated position

## Tests

- New \`fp_tests\` covers basic correctness, intra-process determinism, and (under the flag) that fma matches naive \`(a*b)+c\` exactly.
- All 845 core lib tests pass with both flag states.

## Notes

- \`clippy::suboptimal_flops\` is suppressed in two intentional places: inside the deterministic-fp impl of \`fma\` (the whole point of the flag), and in the test that pins the equivalence.

## Test plan

- [x] \`cargo test -p elevator-core\` (default) — 845 pass
- [x] \`cargo test -p elevator-core --features deterministic-fp\` — 845 pass + new fp test
- [x] \`cargo clippy --workspace --all-features --tests\` — clean
- [x] \`cargo fmt --all\` — clean