### PR TITLE
feat(wasm): per-elevator setters for door/speed/capacity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.28.0"
+version = "15.29.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "cbindgen",
  "elevator-core",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-wasm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "elevator-core",
  "getrandom 0.4.2",

--- a/bindings.toml
+++ b/bindings.toml
@@ -899,7 +899,10 @@ tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 [[methods]]
 name = "set_max_speed"
 category = "parameters"
-wasm = "setMaxSpeedAll"
+# Wasm exposes both per-elevator (`setMaxSpeed`) and bulk
+# (`setMaxSpeedAll`); the per-elevator mapping is the canonical
+# 1:1 with Rust's per-elevator signature.
+wasm = "setMaxSpeed"
 ffi  = "ev_sim_set_max_speed"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
@@ -920,21 +923,25 @@ tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 [[methods]]
 name = "set_door_open_ticks"
 category = "parameters"
-wasm = "setDoorOpenTicksAll"
+# Per-elevator (`setDoorOpenTicks`) is the 1:1 mapping;
+# `setDoorOpenTicksAll` is also exposed as a bulk convenience.
+wasm = "setDoorOpenTicks"
 ffi  = "ev_sim_set_door_open_ticks"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "set_door_transition_ticks"
 category = "parameters"
-wasm = "setDoorTransitionTicksAll"
+# Per-elevator + bulk wasm exports; per-elevator is canonical.
+wasm = "setDoorTransitionTicks"
 ffi  = "ev_sim_set_door_transition_ticks"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
 name = "set_weight_capacity"
 category = "parameters"
-wasm = "setWeightCapacityAll"
+# Per-elevator + bulk wasm exports; per-elevator is canonical.
+wasm = "setWeightCapacity"
 ffi  = "ev_sim_set_weight_capacity"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -2262,6 +2262,78 @@ impl WasmSim {
         .into()
     }
 
+    /// Set `door_open_ticks` (dwell duration) on a single elevator.
+    ///
+    /// Takes effect on the **next** door cycle — an in-progress dwell
+    /// completes its original timing to avoid visual glitches. See
+    /// [`Simulation::set_door_open_ticks`](elevator_core::sim::Simulation::set_door_open_ticks).
+    ///
+    /// # Errors
+    ///
+    /// Surfaces the underlying `SimError` if `elevator_ref` is unknown
+    /// or the value is invalid (zero `ticks`).
+    #[wasm_bindgen(js_name = setDoorOpenTicks)]
+    pub fn set_door_open_ticks(&mut self, elevator_ref: u64, ticks: u32) -> WasmVoidResult {
+        self.inner
+            .set_door_open_ticks(
+                elevator_core::entity::ElevatorId::from(u64_to_entity(elevator_ref)),
+                ticks,
+            )
+            .into()
+    }
+
+    /// Set `door_transition_ticks` (open/close transition duration) on
+    /// a single elevator. Takes effect on the next door cycle.
+    ///
+    /// # Errors
+    ///
+    /// Surfaces the underlying `SimError` if `elevator_ref` is unknown
+    /// or the value is invalid (zero `ticks`).
+    #[wasm_bindgen(js_name = setDoorTransitionTicks)]
+    pub fn set_door_transition_ticks(&mut self, elevator_ref: u64, ticks: u32) -> WasmVoidResult {
+        self.inner
+            .set_door_transition_ticks(
+                elevator_core::entity::ElevatorId::from(u64_to_entity(elevator_ref)),
+                ticks,
+            )
+            .into()
+    }
+
+    /// Set `max_speed` (m/s) on a single elevator. Applied immediately.
+    ///
+    /// # Errors
+    ///
+    /// Surfaces the underlying `SimError` if `elevator_ref` is unknown
+    /// or `speed` is non-positive / non-finite.
+    #[wasm_bindgen(js_name = setMaxSpeed)]
+    pub fn set_max_speed(&mut self, elevator_ref: u64, speed: f64) -> WasmVoidResult {
+        self.inner
+            .set_max_speed(
+                elevator_core::entity::ElevatorId::from(u64_to_entity(elevator_ref)),
+                speed,
+            )
+            .into()
+    }
+
+    /// Set `weight_capacity` (kg) on a single elevator. A new cap
+    /// below `current_load` leaves the car temporarily overweight
+    /// (no riders ejected); subsequent boarding rejects further
+    /// additions.
+    ///
+    /// # Errors
+    ///
+    /// Surfaces the underlying `SimError` if `elevator_ref` is unknown
+    /// or `capacity` is non-positive / non-finite.
+    #[wasm_bindgen(js_name = setWeightCapacity)]
+    pub fn set_weight_capacity(&mut self, elevator_ref: u64, capacity: f64) -> WasmVoidResult {
+        self.inner
+            .set_weight_capacity(
+                elevator_core::entity::ElevatorId::from(u64_to_entity(elevator_ref)),
+                capacity,
+            )
+            .into()
+    }
+
     /// Set `door_open_ticks` (dwell duration) on every elevator.
     ///
     /// Takes effect on the **next** door cycle — an in-progress dwell

--- a/crates/elevator-wasm/tests/per_elevator_setters.rs
+++ b/crates/elevator-wasm/tests/per_elevator_setters.rs
@@ -1,0 +1,108 @@
+//! Tests for per-elevator runtime setters: setDoorOpenTicks,
+//! setDoorTransitionTicks, setMaxSpeed, setWeightCapacity.
+//!
+//! These are the per-entity counterparts to the existing
+//! setMaxSpeedAll / setDoorOpenTicksAll bulk setters. Consumers
+//! tuning a specific shaft (e.g. tower-together's "set elevator
+//! dwell delay" command, scoped per-shaft per-daypart) need
+//! per-elevator granularity.
+
+use elevator_wasm::{WasmSim, WasmVoidResult};
+
+const SCENARIO: &str = r#"SimConfig(
+    building: BuildingConfig(
+        name: "Per-Elevator Setters",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby",   position: 0.0),
+            StopConfig(id: StopId(1), name: "Floor 2", position: 4.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car 1",
+            max_speed: 2.2, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 90,
+        weight_range: (50.0, 100.0),
+    ),
+)"#;
+
+fn elevator_ref(sim: &WasmSim) -> u64 {
+    sim.all_lines()
+        .into_iter()
+        .flat_map(|line| sim.elevators_on_line(line))
+        .next()
+        .expect("scenario has one elevator")
+}
+
+fn assert_ok(label: &str, r: WasmVoidResult) {
+    match r {
+        WasmVoidResult::Ok {} => {}
+        WasmVoidResult::Err { error } => panic!("{label}: {error}"),
+    }
+}
+
+#[test]
+fn set_door_open_ticks_per_elevator_succeeds() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let r = elevator_ref(&sim);
+    assert_ok("setDoorOpenTicks", sim.set_door_open_ticks(r, 90));
+    // Stepping doesn't panic — config change took effect.
+    sim.step_many(10);
+}
+
+#[test]
+fn set_door_transition_ticks_per_elevator_succeeds() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let r = elevator_ref(&sim);
+    assert_ok(
+        "setDoorTransitionTicks",
+        sim.set_door_transition_ticks(r, 20),
+    );
+    sim.step_many(10);
+}
+
+#[test]
+fn set_max_speed_per_elevator_succeeds() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let r = elevator_ref(&sim);
+    assert_ok("setMaxSpeed", sim.set_max_speed(r, 4.5));
+    sim.step_many(10);
+}
+
+#[test]
+fn set_weight_capacity_per_elevator_succeeds() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let r = elevator_ref(&sim);
+    assert_ok("setWeightCapacity", sim.set_weight_capacity(r, 1200.0));
+    sim.step_many(10);
+}
+
+#[test]
+fn unknown_elevator_ref_returns_err() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let bogus = 0xdead_beef_dead_beef;
+    let result = sim.set_door_open_ticks(bogus, 90);
+    match result {
+        WasmVoidResult::Err { .. } => {}
+        WasmVoidResult::Ok {} => panic!("bogus ref should have failed"),
+    }
+}
+
+#[test]
+fn invalid_value_returns_err() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let r = elevator_ref(&sim);
+    // Zero ticks rejected by the underlying Simulation::set_door_open_ticks.
+    let result = sim.set_door_open_ticks(r, 0);
+    match result {
+        WasmVoidResult::Err { .. } => {}
+        WasmVoidResult::Ok {} => panic!("zero ticks should have failed"),
+    }
+}

--- a/crates/elevator-wasm/tests/per_elevator_setters.rs
+++ b/crates/elevator-wasm/tests/per_elevator_setters.rs
@@ -106,3 +106,27 @@ fn invalid_value_returns_err() {
         WasmVoidResult::Ok {} => panic!("zero ticks should have failed"),
     }
 }
+
+#[test]
+fn set_max_speed_rejects_non_positive() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let r = elevator_ref(&sim);
+    for bad in [0.0_f64, -1.0, f64::NAN, f64::INFINITY] {
+        match sim.set_max_speed(r, bad) {
+            WasmVoidResult::Err { .. } => {}
+            WasmVoidResult::Ok {} => panic!("speed={bad} should have failed"),
+        }
+    }
+}
+
+#[test]
+fn set_weight_capacity_rejects_non_positive() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let r = elevator_ref(&sim);
+    for bad in [0.0_f64, -1.0, f64::NAN, f64::INFINITY] {
+        match sim.set_weight_capacity(r, bad) {
+            WasmVoidResult::Err { .. } => {}
+            WasmVoidResult::Ok {} => panic!("capacity={bad} should have failed"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds \`setDoorOpenTicks\`, \`setDoorTransitionTicks\`, \`setMaxSpeed\`, and \`setWeightCapacity\` as per-elevator counterparts to the existing \`*All\` bulk setters.

Each takes a \`u64\` \`elevator_ref\` and forwards to the matching \`Simulation::set_*\` method (which already exists in core; only the wasm exposure was missing).

## Why

Bulk setters can't model per-shaft tuning. tower-together's \`handleSetElevatorDwellDelay\` is scoped per-shaft (and historically per-daypart × calendar phase) — \`setDoorOpenTicksAll\` would change every shaft in the tower instead of just the one the player is configuring.

## Tests

- Each setter succeeds with a valid ref + value.
- Unknown elevator_ref returns Err cleanly.
- Invalid values (e.g. zero door ticks) propagate \`Simulation\`'s validation as Err.

## Test plan

- [x] \`cargo test -p elevator-wasm\` — all pass including the new 6 cases
- [x] \`cargo clippy --all-features --tests\` — clean
- [x] \`cargo fmt\` — clean