### PR TITLE
fix: snapshot/restore byte symmetry — register AssignedCar in Simulation::new

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-wasm"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "elevator-core",
  "getrandom 0.4.2",

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -242,6 +242,18 @@ impl Simulation {
 
         world.insert_resource(crate::tagged_metrics::MetricTags::default());
 
+        // Auto-register dispatch-internal extension types the sim itself
+        // owns. The same registration runs in `from_parts` (the
+        // snapshot-restore path); doing it here too means snapshot bytes
+        // taken from a fresh sim and from a restored sim agree on the
+        // extensions BTreeMap shape (#534's review surfaced this
+        // asymmetry: pre-fix, fresh sims had no `assigned_car` extension
+        // entry while restored sims did, breaking byte-equality of the
+        // snapshot bytes round-trip and the lockstep checksum).
+        world.register_ext::<crate::dispatch::destination::AssignedCar>(
+            crate::dispatch::destination::ASSIGNED_CAR_KEY,
+        );
+
         // Collect line tag info (entity + name + elevator entities) before
         // borrowing world mutably for MetricTags.
         let line_tag_info: Vec<(EntityId, String, Vec<EntityId>)> = groups

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -1028,6 +1028,11 @@ impl crate::sim::Simulation {
     /// computing an independent hash for comparison must use this
     /// method (or run FNV-1a themselves with the same constants).
     ///
+    /// Snapshot/restore is byte-symmetric: a fresh sim and a restored
+    /// sim with the same logical state hash equal. (Earlier code had
+    /// a first-restore asymmetry from the `AssignedCar` extension
+    /// type registering on restore but not `new`; that was fixed.)
+    ///
     /// Designed for divergence detection between runtimes that should
     /// be in lockstep (browser vs server, multi-client multiplayer).
     /// Two sims that have produced bit-identical inputs in bit-identical

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -1038,13 +1038,6 @@ impl crate::sim::Simulation {
     /// Two sims that have produced bit-identical inputs in bit-identical
     /// order must hash to the same value.
     ///
-    /// **Caveat — first-restore asymmetry**: like raw [`Self::snapshot_bytes`],
-    /// this checksum changes after the first `restore_bytes` round-trip
-    /// because the loader materializes default metric-tag rows that a
-    /// fresh sim only allocates lazily. After both sides have gone
-    /// through restore once, the checksum is stable across subsequent
-    /// rounds. Tracked separately for fix.
-    ///
     /// # Errors
     /// Same as [`Self::snapshot_bytes`]: snapshot encoding can fail in
     /// the (unreachable for well-formed sims) postcard error path or

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -470,10 +470,9 @@ impl WasmSim {
     /// loud signal that something has drifted before the next full
     /// snapshot reconciles.
     ///
-    /// Note: like raw `snapshotBytes`, the value is asymmetric on the
-    /// first `fromSnapshotBytes` round-trip (restore materializes
-    /// default metric-tag rows). After both sides have gone through
-    /// restore once, the checksum is stable.
+    /// Snapshot/restore is byte-symmetric: a fresh sim and a restored
+    /// sim with the same logical state hash equal. (Earlier first-
+    /// restore asymmetry was fixed.)
     #[wasm_bindgen(js_name = snapshotChecksum)]
     pub fn snapshot_checksum(&self) -> WasmU64Result {
         match self.inner.snapshot_checksum() {

--- a/crates/elevator-wasm/tests/snapshot_bytes.rs
+++ b/crates/elevator-wasm/tests/snapshot_bytes.rs
@@ -6,16 +6,11 @@
 //! functions, which call into wasm-bindgen imports — those tests must
 //! run under `wasm-pack test`.
 //!
-//! ## Known asymmetry
-//!
-//! `snapshot_bytes(s) == snapshot_bytes(from_snapshot_bytes(snapshot_bytes(s)))`
-//! does *not* hold in general: the restore path materializes default
-//! metric-tag rows (e.g. `assigned_car`) that the original sim only
-//! lazy-allocates on first write. Once a sim has been restored once,
-//! subsequent snapshot/restore round-trips ARE byte-stable. Lockstep
-//! consumers that diff snapshots across runtimes should either both
-//! sides go through restore at least once before diffing, or rely on
-//! a higher-level equivalence (state-checksum API, not byte equality).
+//! Snapshot/restore is byte-symmetric: bytes from a fresh sim equal
+//! bytes from a restored sim with the same logical state. The
+//! earlier first-restore asymmetry (`assigned_car` extension type
+//! materialized on restore but not on `Simulation::new`) was fixed by
+//! registering the type on both paths.
 
 use elevator_wasm::{WasmBytesResult, WasmSim};
 
@@ -52,12 +47,12 @@ fn unwrap_bytes(r: WasmBytesResult) -> Vec<u8> {
     }
 }
 
-/// `snapshot → restore → snapshot → restore → snapshot` is idempotent
-/// after the first restore. The first cycle is asymmetric because
-/// restore materializes default metric-tag rows; once those are present,
-/// further snapshots are byte-stable.
+/// `snapshot → restore → snapshot` is idempotent — the first cycle
+/// (and every cycle) is byte-stable. The earlier asymmetry was
+/// fixed by registering the `AssignedCar` extension type during
+/// `Simulation::new` to match the restore path.
 #[test]
-fn round_trip_is_idempotent_after_first_restore() {
+fn round_trip_is_idempotent_from_the_first_restore() {
     let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
     sim.step_many(500);
 
@@ -67,13 +62,18 @@ fn round_trip_is_idempotent_after_first_restore() {
         WasmSim::from_snapshot_bytes(&initial, "look".to_string(), None).expect("first restore");
     let primed_bytes = unwrap_bytes(primed.snapshot_bytes());
 
+    assert_eq!(
+        initial, primed_bytes,
+        "first-restore byte symmetry: snapshot(restore(snapshot(s))) == snapshot(s)"
+    );
+
     let rebound = WasmSim::from_snapshot_bytes(&primed_bytes, "look".to_string(), None)
         .expect("second restore");
     let rebound_bytes = unwrap_bytes(rebound.snapshot_bytes());
 
     assert_eq!(
         primed_bytes, rebound_bytes,
-        "snapshots taken after the first restore must be byte-stable"
+        "second-restore byte symmetry: still bit-stable after multiple cycles"
     );
 }
 

--- a/crates/elevator-wasm/tests/snapshot_checksum.rs
+++ b/crates/elevator-wasm/tests/snapshot_checksum.rs
@@ -68,14 +68,15 @@ fn checksum_changes_after_step() {
     assert_ne!(before, after, "stepping must change the checksum");
 }
 
-/// The lockstep property: two sims that both went through
-/// `from_snapshot_bytes` from the same source bytes, then took
-/// identical step counts, must hash identically. This is the
-/// scenario that real lockstep deployments encounter — server and
-/// client both restore from the initial checkpoint, then step the
-/// same input batches.
+/// The lockstep property: a fresh sim and two sims that went
+/// through `from_snapshot_bytes` from the same source bytes —
+/// stepped identically — must all hash identically. The fresh-vs-
+/// restored equality is the post-fix property; earlier code had
+/// an asymmetry where restore materialized the `AssignedCar`
+/// extension type that fresh sims didn't, breaking byte equality
+/// of the snapshot bytes round-trip.
 #[test]
-fn parallel_restored_sims_hash_equal_under_identical_steps() {
+fn fresh_and_restored_sims_hash_equal_under_identical_steps() {
     let mut source = WasmSim::new(SCENARIO, "look", None).expect("source");
     source.step_many(100);
     let bytes = unwrap_bytes(source.snapshot_bytes());
@@ -84,37 +85,37 @@ fn parallel_restored_sims_hash_equal_under_identical_steps() {
     let mut b = WasmSim::from_snapshot_bytes(&bytes, "look".to_string(), None).expect("restore b");
 
     for tick in 0..50 {
+        source.step_many(1);
         a.step_many(1);
         b.step_many(1);
+        let h_source = unwrap_u64(source.snapshot_checksum());
+        let h_a = unwrap_u64(a.snapshot_checksum());
+        let h_b = unwrap_u64(b.snapshot_checksum());
+        assert_eq!(h_a, h_b, "two restored sims diverged at tick {tick}");
         assert_eq!(
-            unwrap_u64(a.snapshot_checksum()),
-            unwrap_u64(b.snapshot_checksum()),
-            "checksums diverged at tick {tick} after restore"
+            h_source, h_a,
+            "fresh sim diverged from restored at tick {tick}"
         );
     }
 }
 
-/// Pre-restore checksum and post-restore checksum differ for the
-/// SAME source bytes — this is the documented first-restore
-/// asymmetry. Lockstep consumers should rely on this only after
-/// both sides have been restored at least once. Test pins the
-/// behavior so any future fix surfaces here loudly.
+/// Snapshot/restore is now byte-symmetric: bytes from a fresh sim
+/// equal bytes from a restored sim with the same logical state.
+/// Pinned by this test — earlier code couldn't make this guarantee
+/// because `Simulation::from_parts` registered the `AssignedCar`
+/// extension type while `Simulation::new` didn't, yielding
+/// different `extensions` `BTreeMap` shapes in the snapshot.
 #[test]
-fn first_restore_changes_checksum_documented_asymmetry() {
+fn snapshot_round_trip_is_byte_symmetric() {
     let sim = WasmSim::new(SCENARIO, "look", None).expect("source");
-    let pre_restore = unwrap_u64(sim.snapshot_checksum());
+    let pre_restore_bytes = unwrap_bytes(sim.snapshot_bytes());
 
-    let bytes = unwrap_bytes(sim.snapshot_bytes());
-    let restored = WasmSim::from_snapshot_bytes(&bytes, "look".to_string(), None).expect("restore");
-    let post_restore = unwrap_u64(restored.snapshot_checksum());
+    let restored = WasmSim::from_snapshot_bytes(&pre_restore_bytes, "look".to_string(), None)
+        .expect("restore");
+    let post_restore_bytes = unwrap_bytes(restored.snapshot_bytes());
 
-    // Asymmetry exists today. If/when someone fixes the underlying
-    // metric-tag materialization (mentioned in PR #527's tests),
-    // delete this test and tighten parallel_restored_sims_hash_equal
-    // to also include a freshly-constructed sim alongside two
-    // restored ones.
-    assert_ne!(
-        pre_restore, post_restore,
-        "first-restore asymmetry pinned — see PR #527's restore-tag note"
+    assert_eq!(
+        pre_restore_bytes, post_restore_bytes,
+        "snapshot bytes diverged across the first restore"
     );
 }

--- a/crates/elevator-wasm/tests/snapshot_checksum.rs
+++ b/crates/elevator-wasm/tests/snapshot_checksum.rs
@@ -2,13 +2,12 @@
 //! by lockstep consumers to detect divergence between runtimes that
 //! should be stepping the same state.
 //!
-//! The checksum has the same first-restore asymmetry as raw
-//! `snapshot_bytes` (restore materializes default metric-tag rows
-//! that fresh sims lazy-allocate), so we don't compare two
-//! independently-constructed sims here. The lockstep use case is:
-//! both runtimes start from the same snapshot bytes (initial
-//! checkpoint) and step identically — that's what these tests
-//! validate.
+//! Snapshot/restore is byte-symmetric: a fresh sim and a restored
+//! sim with the same logical state hash equal. (Earlier first-
+//! restore asymmetry was fixed by registering the `AssignedCar`
+//! extension type during `Simulation::new` to match the restore
+//! path.) These tests pin both the same-sim and fresh-vs-restored
+//! equality properties.
 
 use elevator_wasm::{WasmBytesResult, WasmSim, WasmU64Result};
 


### PR DESCRIPTION
## Summary

Closes the first-restore asymmetry that was pinned by tests in PR #530.

\`Simulation::from_parts\` (the snapshot-restore path) was registering the \`AssignedCar\` extension type via \`world.register_ext::<AssignedCar>(ASSIGNED_CAR_KEY)\`, but \`Simulation::new\` was not. Result: the \`extensions\` \`BTreeMap\` in the snapshot had a different shape between fresh and restored sims — restored sims carried an empty \`"assigned_car" → {}\` entry that fresh sims lacked. \`snapshot_bytes\` and \`snapshot_checksum\` diverged by exactly that.

## Fix

Register \`AssignedCar\` in \`Simulation::new\` at the same point where \`MetricTags\` is inserted. Both paths now produce identical \`extensions\` \`BTreeMap\` shapes; \`snapshot(s) == snapshot(restore(snapshot(s)))\` from the first restore.

## Tests

Updated to reflect the new byte-symmetric reality:

- New \`snapshot_round_trip_is_byte_symmetric\` test (replaces the old pinned-asymmetry).
- \`fresh_and_restored_sims_hash_equal_under_identical_steps\` now also asserts the **fresh** sim hashes equal to restored ones across 50 ticks.
- \`round_trip_is_idempotent_from_the_first_restore\` tightened to assert byte equality from the **first** restore.
- Doc comments on \`Simulation::snapshot_checksum\` and \`WasmSim::snapshotChecksum\` updated to drop the asymmetry caveat.

## Test plan

- [x] \`cargo test -p elevator-core\` — 847 lib tests pass
- [x] \`cargo test -p elevator-wasm\` — all integration tests pass
- [x] \`cargo clippy --workspace --all-features --tests\` — clean
- [x] \`cargo fmt\` — clean