### PR TITLE
feat(wasm): spawnRider returns the rider ref (matches spawnRiderByRef)

### DIFF
--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -374,12 +374,16 @@ impl WasmSim {
     /// abandonment for this rider — preserves the pre-patience
     /// behavior for scenarios that want bounded queues.
     ///
+    /// Returns the spawned rider's entity ref on success so consumers
+    /// can correlate with subsequent `rider-*` events. Symmetric with
+    /// [`Self::spawn_rider_by_ref`].
+    ///
     /// # Errors
     ///
-    /// Returns a Result-shaped object: `{ kind: "ok" }` on success, or
-    /// `{ kind: "err", error: "..." }` if either stop id is unknown,
-    /// the rider is rejected by the sim, or the `(origin, destination)`
-    /// route can't be auto-detected.
+    /// Returns a Result-shaped object: `{ kind: "ok", value: bigint }`
+    /// on success, or `{ kind: "err", error: "..." }` if either stop
+    /// id is unknown, the rider is rejected by the sim, or the
+    /// `(origin, destination)` route can't be auto-detected.
     #[wasm_bindgen(js_name = spawnRider)]
     pub fn spawn_rider(
         &mut self,
@@ -387,8 +391,8 @@ impl WasmSim {
         destination: u32,
         weight: f64,
         patience_ticks: Option<u32>,
-    ) -> WasmVoidResult {
-        (|| -> Result<(), String> {
+    ) -> WasmU64Result {
+        (|| -> Result<u64, String> {
             let mut builder = self
                 .inner
                 .build_rider(StopId(origin), StopId(destination))
@@ -397,10 +401,8 @@ impl WasmSim {
             if let Some(ticks) = patience_ticks.filter(|&t| t > 0) {
                 builder = builder.patience(u64::from(ticks));
             }
-            builder
-                .spawn()
-                .map(|_| ())
-                .map_err(|e| format!("spawn: {e}"))
+            let rider = builder.spawn().map_err(|e| format!("spawn: {e}"))?;
+            Ok(entity_to_u64(rider.entity()))
         })()
         .into()
     }

--- a/crates/elevator-wasm/tests/spawn_rider_ref.rs
+++ b/crates/elevator-wasm/tests/spawn_rider_ref.rs
@@ -1,0 +1,65 @@
+//! Tests for `WasmSim::spawnRider` returning the rider ref.
+//!
+//! Earlier versions returned `WasmVoidResult` and discarded the ref.
+//! The signature change to `WasmU64Result` (matching
+//! `spawnRiderByRef`) lets consumers correlate the spawn with
+//! subsequent `rider-*` events without a separate by-ref call.
+
+use elevator_wasm::{WasmSim, WasmU64Result};
+
+const SCENARIO: &str = r#"SimConfig(
+    building: BuildingConfig(
+        name: "Spawn Ref",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby",   position: 0.0),
+            StopConfig(id: StopId(1), name: "Floor 2", position: 4.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car 1",
+            max_speed: 2.2, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 90,
+        weight_range: (50.0, 100.0),
+    ),
+)"#;
+
+#[test]
+fn spawn_rider_returns_ref_on_success() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let result = sim.spawn_rider(0, 1, 75.0, None);
+    match result {
+        WasmU64Result::Ok { value } => {
+            // Slot id is non-zero (slotmap reserves 0 as a null sentinel)
+            // — exact value depends on insertion order, just assert
+            // we got something we can despawn.
+            assert!(value != 0, "rider ref must be non-null");
+            // Round-trip: despawn by the same ref.
+            let despawn = sim.despawn_rider(value);
+            assert!(matches!(despawn, elevator_wasm::WasmVoidResult::Ok {}));
+        }
+        WasmU64Result::Err { error } => panic!("spawn failed: {error}"),
+    }
+}
+
+#[test]
+fn spawn_rider_returns_err_for_unknown_stop() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    // Stop id 99 doesn't exist in the scenario.
+    let result = sim.spawn_rider(0, 99, 75.0, None);
+    assert!(matches!(result, WasmU64Result::Err { .. }));
+}
+
+#[test]
+fn spawn_rider_with_patience_succeeds() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let result = sim.spawn_rider(0, 1, 75.0, Some(600));
+    assert!(matches!(result, WasmU64Result::Ok { .. }));
+}

--- a/playground/src/sim/sim.ts
+++ b/playground/src/sim/sim.ts
@@ -5,7 +5,7 @@ import type {
   Snapshot,
   StrategyName,
   TrafficMode,
-  WasmVoidResult,
+  WasmU64Result,
 } from "../types";
 
 // Thin TS wrapper around `WasmSim`. The wasm-bindgen generated class
@@ -35,7 +35,7 @@ interface WasmSimInstance {
     destination: number,
     weight: number,
     patienceTicks?: number,
-  ): WasmVoidResult;
+  ): WasmU64Result;
   setTrafficRate(ridersPerMinute: number): void;
   trafficRate(): number;
   snapshot(): Snapshot;
@@ -125,7 +125,7 @@ export class Sim {
     destination: number,
     weight: number,
     patienceTicks?: number,
-  ): WasmVoidResult {
+  ): WasmU64Result {
     return this.#inner.spawnRider(origin, destination, weight, patienceTicks);
   }
 


### PR DESCRIPTION
## Summary

\`spawnRider\` previously returned \`WasmVoidResult\` and discarded the spawned rider's entity ref via \`.map(|_| ())\`. Switched to \`WasmU64Result\` so consumers can correlate the spawn with subsequent \`rider-*\` events without an extra \`spawnRiderByRef\` detour.

API parity with the sibling \`spawnRiderByRef\` (which already returns \`WasmU64Result\`).

## Compatibility

Runtime-compatible with existing callers that only inspect \`result.kind === "ok" / "err"\` (e.g. the playground's seed loop in \`shell/reset.ts\`): both old and new types share the same \`kind\` discriminator and \`err\` shape; the \`value\` field on \`Ok\` is purely additive.

TypeScript callers that explicitly destructured to expect a void-shaped \`Ok\` would see a type error — none in this repo do.

## Tests

- Success returns a non-null ref that round-trips through \`despawnRider\`.
- Unknown stop id returns \`err\`.
- Patience-budgeted spawn returns the ref (patience param doesn't affect return shape).

## Test plan

- [x] \`cargo test -p elevator-wasm\` — all pass including the new 3
- [x] \`cargo clippy --workspace --all-features --tests\` — clean
- [x] \`cargo fmt\` — clean