### PR TITLE
feat(core): per-rider opaque tag for consumer back-pointers

### DIFF
--- a/bindings.toml
+++ b/bindings.toml
@@ -424,6 +424,20 @@ ffi  = "ev_sim_set_rider_access"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]
+name = "set_rider_tag"
+category = "riders"
+wasm = "setRiderTag"
+ffi  = "ev_sim_set_rider_tag"
+tui  = "skip:opaque consumer-attached id — TUI viewer has no concept of an external tag space"
+
+[[methods]]
+name = "rider_tag"
+category = "riders"
+wasm = "riderTag"
+ffi  = "ev_sim_rider_tag"
+tui  = "skip:opaque consumer-attached id — TUI viewer has no concept of an external tag space"
+
+[[methods]]
 name = "shortest_route"
 category = "routes"
 wasm = "shortestRoute"

--- a/crates/elevator-core/src/components/rider.rs
+++ b/crates/elevator-core/src/components/rider.rs
@@ -130,6 +130,14 @@ pub struct Rider {
     pub(crate) spawn_tick: u64,
     /// Tick when this rider boarded (for ride-time metrics).
     pub(crate) board_tick: Option<u64>,
+    /// Opaque consumer-attached tag. The engine doesn't interpret
+    /// this value — it survives snapshot round-trip so consumers
+    /// can correlate riders with external identifiers (e.g. a
+    /// game-side sim id, a player id, a freight-shipment id) without
+    /// maintaining a parallel map keyed by `RiderId`. Defaults to 0
+    /// (no tag); `0` is reserved by convention for "untagged."
+    #[serde(default)]
+    pub(crate) tag: u64,
 }
 
 impl Rider {
@@ -161,5 +169,15 @@ impl Rider {
     #[must_use]
     pub const fn board_tick(&self) -> Option<u64> {
         self.board_tick
+    }
+
+    /// Opaque consumer-attached tag. The engine doesn't interpret this
+    /// value; consumers use it to correlate riders with external
+    /// identifiers (e.g. a game-side sim id, a player id, a freight
+    /// shipment id) without maintaining a parallel `RiderId → u64` map.
+    /// Defaults to `0`, which is reserved by convention for "untagged."
+    #[must_use]
+    pub const fn tag(&self) -> u64 {
+        self.tag
     }
 }

--- a/crates/elevator-core/src/sim/rider.rs
+++ b/crates/elevator-core/src/sim/rider.rs
@@ -165,6 +165,7 @@ impl super::Simulation {
                 current_stop: Some(origin),
                 spawn_tick: self.tick,
                 board_tick: None,
+                tag: 0,
             },
         );
         self.world.set_route(eid, route);
@@ -281,6 +282,49 @@ impl super::Simulation {
         }
         self.pending_output = remaining;
         matched
+    }
+
+    // ── Rider tag (opaque consumer-attached id) ──────────────────────
+
+    /// Read the opaque tag attached to a rider.
+    ///
+    /// Consumers use [`set_rider_tag`](Self::set_rider_tag) to stash an
+    /// external identifier on the rider (a game-side sim id, a player
+    /// id, a freight shipment id) and read it back here without keeping
+    /// a parallel `RiderId → u64` map. The engine never interprets the
+    /// value; it survives snapshot round-trip.
+    ///
+    /// Returns `0` for the default "untagged" state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SimError::EntityNotFound`] if `id` does not correspond
+    /// to a live rider.
+    pub fn rider_tag(&self, id: RiderId) -> Result<u64, SimError> {
+        let eid = id.entity();
+        self.world
+            .rider(eid)
+            .map(Rider::tag)
+            .ok_or(SimError::EntityNotFound(eid))
+    }
+
+    /// Attach an opaque tag to a rider. The engine doesn't interpret the
+    /// value — pick whatever encoding your consumer needs (e.g. a 32-bit
+    /// external id zero-extended to `u64`, or two 32-bit half-words).
+    /// Pass `0` to clear the tag (the reserved "untagged" sentinel).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SimError::EntityNotFound`] if `id` does not correspond
+    /// to a live rider.
+    pub fn set_rider_tag(&mut self, id: RiderId, tag: u64) -> Result<(), SimError> {
+        let eid = id.entity();
+        let rider = self
+            .world
+            .rider_mut(eid)
+            .ok_or(SimError::EntityNotFound(eid))?;
+        rider.tag = tag;
+        Ok(())
     }
 
     /// Register (or aggregate) a hall call on behalf of a specific

--- a/crates/elevator-core/src/tests/dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/dispatch_tests.rs
@@ -216,6 +216,7 @@ fn scan_serves_rider_destination() {
             phase: RiderPhase::Riding(elev),
             current_stop: None,
             spawn_tick: 0,
+            tag: 0,
             board_tick: Some(0),
         },
     );

--- a/crates/elevator-core/src/tests/feature_tests.rs
+++ b/crates/elevator-core/src/tests/feature_tests.rs
@@ -707,6 +707,7 @@ fn despawn_elevator_resets_rider_to_waiting() {
             phase: RiderPhase::Riding(elev),
             current_stop: None,
             spawn_tick: 0,
+            tag: 0,
             board_tick: Some(1),
         },
     );
@@ -794,6 +795,7 @@ fn despawn_rider_mid_transit_removes_from_elevator_load() {
             phase: RiderPhase::Riding(elev),
             current_stop: None,
             spawn_tick: 0,
+            tag: 0,
             board_tick: Some(1),
         },
     );
@@ -846,6 +848,7 @@ fn route_direct_current_returns_single_leg() {
             phase: RiderPhase::Waiting,
             current_stop: Some(from),
             spawn_tick: 0,
+            tag: 0,
             board_tick: None,
         },
     );

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -76,6 +76,7 @@ mod query_event_tests;
 mod reposition_tests;
 mod resident_tests;
 mod rider_index_tests;
+mod rider_tag_tests;
 mod rsr_dispatch_tests;
 mod runtime_upgrades_tests;
 mod service_mode_tests;

--- a/crates/elevator-core/src/tests/mutation_kills_tests.rs
+++ b/crates/elevator-core/src/tests/mutation_kills_tests.rs
@@ -154,6 +154,7 @@ fn dispatch_manifest_wait_ticks_grows_with_time() {
             phase: RiderPhase::Waiting,
             current_stop: Some(stops[1]),
             spawn_tick: 0,
+            tag: 0,
             board_tick: None,
         },
     );

--- a/crates/elevator-core/src/tests/query_tests.rs
+++ b/crates/elevator-core/src/tests/query_tests.rs
@@ -20,6 +20,7 @@ fn test_world() -> (World, EntityId, EntityId, EntityId) {
             phase: RiderPhase::Waiting,
             current_stop: None,
             spawn_tick: 0,
+            tag: 0,
             board_tick: None,
         },
     );

--- a/crates/elevator-core/src/tests/reposition_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_tests.rs
@@ -998,6 +998,7 @@ fn etd_rider_delay_penalizes() {
             weight: Weight::from(70.0),
             current_stop: None,
             spawn_tick: 0,
+            tag: 0,
             board_tick: Some(0),
         },
     );
@@ -1080,6 +1081,7 @@ fn etd_custom_weights() {
             weight: Weight::from(70.0),
             current_stop: None,
             spawn_tick: 0,
+            tag: 0,
             board_tick: Some(0),
         },
     );

--- a/crates/elevator-core/src/tests/rider_index_tests.rs
+++ b/crates/elevator-core/src/tests/rider_index_tests.rs
@@ -35,6 +35,7 @@ fn rider_in_phase(world: &mut World, at: EntityId, phase: RiderPhase) -> EntityI
             phase,
             current_stop: Some(at),
             spawn_tick: 0,
+            tag: 0,
             board_tick: None,
         },
     );

--- a/crates/elevator-core/src/tests/rider_tag_tests.rs
+++ b/crates/elevator-core/src/tests/rider_tag_tests.rs
@@ -98,22 +98,6 @@ fn round_trips_through_snapshot_bytes() {
 }
 
 #[test]
-fn legacy_snapshot_without_tag_field_defaults_to_zero() {
-    // `Rider.tag` is `#[serde(default)]`. A simulation snapshotted
-    // before the field existed must still rehydrate cleanly — we can
-    // simulate that by snapshotting now (tag = 0) and confirming the
-    // field-absence default semantics line up with "untagged."
-    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
-    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
-    // Don't touch the tag — it's the legacy "absent" case.
-
-    let bytes = sim.snapshot_bytes().expect("snapshot");
-    let restored = Simulation::restore_bytes(&bytes, None).expect("restore from bytes");
-
-    assert_eq!(restored.rider_tag(rider).unwrap(), 0);
-}
-
-#[test]
 fn returns_entity_not_found_for_despawned_rider() {
     let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
     let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();

--- a/crates/elevator-core/src/tests/rider_tag_tests.rs
+++ b/crates/elevator-core/src/tests/rider_tag_tests.rs
@@ -1,0 +1,154 @@
+//! Per-rider opaque tag accessors.
+//!
+//! The tag is a `u64` payload the engine never interprets. Consumers
+//! (e.g. the tower-together adapter) stash an external id on each
+//! rider so they can correlate `RiderId` with their own object space
+//! without maintaining a parallel `Map<RiderId, u32>`. The tests below
+//! pin the contract: the value round-trips, persists across snapshot,
+//! never escapes the rider it was set on, and missing-rider errors
+//! cleanly.
+
+use crate::dispatch::scan::ScanDispatch;
+use crate::error::SimError;
+use crate::sim::Simulation;
+use crate::stop::StopId;
+use crate::tests::helpers::default_config;
+
+#[test]
+fn defaults_to_zero_for_a_fresh_rider() {
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    assert_eq!(
+        sim.rider_tag(rider).unwrap(),
+        0,
+        "fresh rider must default to the reserved untagged sentinel (0)"
+    );
+}
+
+#[test]
+fn round_trips_through_set_and_get() {
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+
+    sim.set_rider_tag(rider, 0xDEAD_BEEF_CAFE_F00D).unwrap();
+    assert_eq!(sim.rider_tag(rider).unwrap(), 0xDEAD_BEEF_CAFE_F00D);
+
+    // Re-setting overwrites cleanly.
+    sim.set_rider_tag(rider, 1).unwrap();
+    assert_eq!(sim.rider_tag(rider).unwrap(), 1);
+
+    // Clearing back to the untagged sentinel works.
+    sim.set_rider_tag(rider, 0).unwrap();
+    assert_eq!(sim.rider_tag(rider).unwrap(), 0);
+}
+
+#[test]
+fn tags_are_per_rider_and_do_not_leak_across_riders() {
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let a = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    let b = sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
+    let c = sim.spawn_rider(StopId(2), StopId(0), 70.0).unwrap();
+
+    sim.set_rider_tag(a, 100).unwrap();
+    sim.set_rider_tag(b, 200).unwrap();
+    // c intentionally left untagged.
+
+    assert_eq!(sim.rider_tag(a).unwrap(), 100);
+    assert_eq!(sim.rider_tag(b).unwrap(), 200);
+    assert_eq!(sim.rider_tag(c).unwrap(), 0);
+}
+
+#[test]
+fn survives_phase_transitions_during_a_full_trip() {
+    // The tag is data, not lifecycle state — Waiting → Boarding →
+    // Riding → Exiting → Arrived must not perturb it.
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.set_rider_tag(rider, 0xABCD_1234).unwrap();
+
+    // 200 ticks is comfortably long enough for the demo config to
+    // dispatch and complete a 2-stop trip; the assertion is on the
+    // tag, not on the trip outcome.
+    for _ in 0..200 {
+        sim.step();
+        // Tag must remain intact every tick the rider exists.
+        if let Ok(t) = sim.rider_tag(rider) {
+            assert_eq!(t, 0xABCD_1234, "tag must survive every phase transition");
+        } else {
+            // Rider arrived/despawned — done.
+            break;
+        }
+    }
+}
+
+#[test]
+fn round_trips_through_snapshot_bytes() {
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.set_rider_tag(rider, 0x1122_3344_5566_7788).unwrap();
+
+    let bytes = sim.snapshot_bytes().expect("snapshot");
+    let restored = Simulation::restore_bytes(&bytes, None).expect("restore from bytes");
+
+    assert_eq!(
+        restored.rider_tag(rider).unwrap(),
+        0x1122_3344_5566_7788,
+        "tag must survive postcard snapshot round-trip"
+    );
+}
+
+#[test]
+fn legacy_snapshot_without_tag_field_defaults_to_zero() {
+    // `Rider.tag` is `#[serde(default)]`. A simulation snapshotted
+    // before the field existed must still rehydrate cleanly — we can
+    // simulate that by snapshotting now (tag = 0) and confirming the
+    // field-absence default semantics line up with "untagged."
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    // Don't touch the tag — it's the legacy "absent" case.
+
+    let bytes = sim.snapshot_bytes().expect("snapshot");
+    let restored = Simulation::restore_bytes(&bytes, None).expect("restore from bytes");
+
+    assert_eq!(restored.rider_tag(rider).unwrap(), 0);
+}
+
+#[test]
+fn returns_entity_not_found_for_despawned_rider() {
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.despawn_rider(rider).unwrap();
+
+    // Rider id is now stale — both accessors must fail with
+    // EntityNotFound rather than silently returning 0 / silently
+    // tagging a freed slot.
+    let read = sim.rider_tag(rider);
+    assert!(matches!(read, Err(SimError::EntityNotFound(_))));
+
+    let write = sim.set_rider_tag(rider, 42);
+    assert!(matches!(write, Err(SimError::EntityNotFound(_))));
+}
+
+#[test]
+fn tag_is_independent_of_metric_tags() {
+    // Metric tags (`MetricTags::tag`) and the opaque rider tag share
+    // the word "tag" but live in unrelated storage. Setting the rider
+    // tag must not appear in metric-tag queries, and vice versa.
+    use crate::tagged_metrics::MetricTags;
+
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.set_rider_tag(rider, 999).unwrap();
+
+    // The metric-tag space is unaffected — we only see the auto stop
+    // tag added during spawn ("stop:<name>"), never the integer 999.
+    let metric_tags = sim
+        .world()
+        .resource::<MetricTags>()
+        .expect("MetricTags resource present");
+    let entity_metric_tags = metric_tags.tags_for(rider.entity());
+    assert!(
+        entity_metric_tags.iter().all(|t| t != "999"),
+        "rider opaque tag must not leak into MetricTags"
+    );
+}

--- a/crates/elevator-core/src/tests/world_tests.rs
+++ b/crates/elevator-core/src/tests/world_tests.rs
@@ -95,6 +95,7 @@ fn rider_query() {
             phase: RiderPhase::Waiting,
             current_stop: Some(origin),
             spawn_tick: 0,
+            tag: 0,
             board_tick: None,
         },
     );

--- a/crates/elevator-ffi/include/elevator_ffi.h
+++ b/crates/elevator-ffi/include/elevator_ffi.h
@@ -1747,6 +1747,29 @@ enum EvStatus ev_sim_reroute(struct EvSim *handle,
 enum EvStatus ev_sim_settle_rider(struct EvSim *handle, uint64_t rider_entity_id);
 
 /**
+ * Attach an opaque tag to a rider. Stored verbatim — the engine never
+ * interprets the value. Pass `0` to clear (the reserved "untagged"
+ * sentinel). Survives snapshot round-trip.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_set_rider_tag(struct EvSim *handle, uint64_t rider_entity_id, uint64_t tag);
+
+/**
+ * Read the opaque tag attached to a rider. Writes the value into
+ * `*out_tag` and returns [`EvStatus::Ok`]. Returns `0` for the default
+ * "untagged" state.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ * `out_tag` must be a valid, writable pointer to a `u64`.
+ */
+enum EvStatus ev_sim_rider_tag(struct EvSim *handle, uint64_t rider_entity_id, uint64_t *out_tag);
+
+/**
  * Replace a rider's remaining route with a single-leg route via
  * `group_id`. Convenience wrapper for the common "send this rider via
  * this group" case.

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -3626,6 +3626,87 @@ pub unsafe extern "C" fn ev_sim_settle_rider(handle: *mut EvSim, rider_entity_id
     })
 }
 
+/// Attach an opaque tag to a rider. Stored verbatim — the engine never
+/// interprets the value. Pass `0` to clear (the reserved "untagged"
+/// sentinel). Survives snapshot round-trip.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_set_rider_tag(
+    handle: *mut EvSim,
+    rider_entity_id: u64,
+    tag: u64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(rider) = entity_from_u64(rider_entity_id) else {
+            set_last_error("rider_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev.sim.set_rider_tag(RiderId::from(rider), tag) {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("set_rider_tag: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Read the opaque tag attached to a rider. Writes the value into
+/// `*out_tag` and returns [`EvStatus::Ok`]. Returns `0` for the default
+/// "untagged" state.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+/// `out_tag` must be a valid, writable pointer to a `u64`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_rider_tag(
+    handle: *mut EvSim,
+    rider_entity_id: u64,
+    out_tag: *mut u64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        if out_tag.is_null() {
+            set_last_error("out_tag is null");
+            return EvStatus::NullArg;
+        }
+        let Some(rider) = entity_from_u64(rider_entity_id) else {
+            set_last_error("rider_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        match ev.sim.rider_tag(RiderId::from(rider)) {
+            Ok(tag) => {
+                // Safety: caller-provided writable u64 pointer.
+                unsafe { *out_tag = tag };
+                EvStatus::Ok
+            }
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("rider_tag: {e}"));
+                status
+            }
+        }
+    })
+}
+
 /// Replace a rider's remaining route with a single-leg route via
 /// `group_id`. Convenience wrapper for the common "send this rider via
 /// this group" case.
@@ -7242,6 +7323,66 @@ mod tests {
         assert_eq!(
             unsafe { ev_sim_despawn_rider(handle, rider_id) },
             EvStatus::NotFound,
+        );
+
+        unsafe { ev_sim_destroy(handle) };
+    }
+
+    #[test]
+    fn rider_tag_round_trips_and_errors_on_stale_id() {
+        // Default 0, set/get round-trips, despawned id returns
+        // NotFound. The 6-line null-arg checks exercise the safety
+        // gates without needing a live sim.
+        let handle = create_test_handle();
+        let (origin, dest) = stop_entities(handle);
+
+        let mut rider_id: u64 = 0;
+        assert_eq!(
+            unsafe { ev_sim_spawn_rider(handle, origin, dest, 80.0, &raw mut rider_id) },
+            EvStatus::Ok,
+        );
+
+        let mut tag: u64 = 0xFFFF_FFFF_FFFF_FFFF;
+        assert_eq!(
+            unsafe { ev_sim_rider_tag(handle, rider_id, &raw mut tag) },
+            EvStatus::Ok,
+        );
+        assert_eq!(tag, 0, "fresh rider must default to untagged sentinel");
+
+        assert_eq!(
+            unsafe { ev_sim_set_rider_tag(handle, rider_id, 0xDEAD_BEEF) },
+            EvStatus::Ok,
+        );
+        let mut roundtrip: u64 = 0;
+        assert_eq!(
+            unsafe { ev_sim_rider_tag(handle, rider_id, &raw mut roundtrip) },
+            EvStatus::Ok,
+        );
+        assert_eq!(roundtrip, 0xDEAD_BEEF);
+
+        // Stale id after despawn — both accessors must return NotFound.
+        assert_eq!(
+            unsafe { ev_sim_despawn_rider(handle, rider_id) },
+            EvStatus::Ok,
+        );
+        assert_eq!(
+            unsafe { ev_sim_set_rider_tag(handle, rider_id, 1) },
+            EvStatus::NotFound,
+        );
+        let mut after_despawn: u64 = 0;
+        assert_eq!(
+            unsafe { ev_sim_rider_tag(handle, rider_id, &raw mut after_despawn) },
+            EvStatus::NotFound,
+        );
+
+        // Null-arg gates.
+        assert_eq!(
+            unsafe { ev_sim_set_rider_tag(std::ptr::null_mut(), rider_id, 1) },
+            EvStatus::NullArg,
+        );
+        assert_eq!(
+            unsafe { ev_sim_rider_tag(handle, rider_id, std::ptr::null_mut()) },
+            EvStatus::NullArg,
         );
 
         unsafe { ev_sim_destroy(handle) };

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -7380,6 +7380,11 @@ mod tests {
             unsafe { ev_sim_set_rider_tag(std::ptr::null_mut(), rider_id, 1) },
             EvStatus::NullArg,
         );
+        let mut null_handle_tag: u64 = 0;
+        assert_eq!(
+            unsafe { ev_sim_rider_tag(std::ptr::null_mut(), rider_id, &raw mut null_handle_tag) },
+            EvStatus::NullArg,
+        );
         assert_eq!(
             unsafe { ev_sim_rider_tag(handle, rider_id, std::ptr::null_mut()) },
             EvStatus::NullArg,

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -1800,6 +1800,42 @@ impl WasmSim {
             .into()
     }
 
+    /// Attach an opaque tag to a rider. The engine doesn't interpret
+    /// the value — JS consumers use it to correlate a `RiderId` with an
+    /// external id (e.g. a game-side sim id) without maintaining a
+    /// parallel `Map<RiderId, u32>`. Pass `0n` to clear (`0` is the
+    /// reserved "untagged" sentinel).
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if `rider_ref` is not a rider entity.
+    #[wasm_bindgen(js_name = setRiderTag)]
+    pub fn set_rider_tag(&mut self, rider_ref: u64, tag: u64) -> WasmVoidResult {
+        self.inner
+            .set_rider_tag(
+                elevator_core::entity::RiderId::from(u64_to_entity(rider_ref)),
+                tag,
+            )
+            .map_err(|e| format!("set_rider_tag: {e}"))
+            .into()
+    }
+
+    /// Read the opaque tag attached to a rider. Returns `0n` for the
+    /// default "untagged" state.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if `rider_ref` is not a rider entity.
+    #[wasm_bindgen(js_name = riderTag)]
+    pub fn rider_tag(&self, rider_ref: u64) -> WasmU64Result {
+        self.inner
+            .rider_tag(elevator_core::entity::RiderId::from(u64_to_entity(
+                rider_ref,
+            )))
+            .map_err(|e| format!("rider_tag: {e}"))
+            .into()
+    }
+
     /// Step the simulation forward up to `max_ticks` ticks, stopping
     /// early if the world becomes "quiet" (no in-flight riders, no
     /// pending hall calls, all cars idle). Returns the number of ticks

--- a/crates/elevator-wasm/tests/rider_tag.rs
+++ b/crates/elevator-wasm/tests/rider_tag.rs
@@ -1,0 +1,97 @@
+//! Tests for `WasmSim::setRiderTag` / `WasmSim::riderTag`.
+//!
+//! The opaque rider tag is the engine-side back-pointer for consumers
+//! that already key on `RiderId` (e.g. the tower-together adapter
+//! correlating a rider with a game-side `simId`). These tests pin the
+//! contract: default 0, round-trips, errors on stale refs, survives
+//! `restoreBytes`.
+
+use elevator_wasm::{WasmBytesResult, WasmSim, WasmU64Result, WasmVoidResult};
+
+const SCENARIO: &str = r#"SimConfig(
+    building: BuildingConfig(
+        name: "Tag",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby",   position: 0.0),
+            StopConfig(id: StopId(1), name: "Floor 2", position: 4.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car 1",
+            max_speed: 2.2, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 90,
+        weight_range: (50.0, 100.0),
+    ),
+)"#;
+
+fn ok_u64(r: WasmU64Result) -> u64 {
+    match r {
+        WasmU64Result::Ok { value } => value,
+        WasmU64Result::Err { error } => panic!("u64 result err: {error}"),
+    }
+}
+
+fn ok_void(r: WasmVoidResult) {
+    match r {
+        WasmVoidResult::Ok {} => {}
+        WasmVoidResult::Err { error } => panic!("void result err: {error}"),
+    }
+}
+
+#[test]
+fn defaults_to_zero_for_a_fresh_rider() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let rider = ok_u64(sim.spawn_rider(0, 1, 75.0, None));
+    assert_eq!(ok_u64(sim.rider_tag(rider)), 0);
+}
+
+#[test]
+fn round_trips_through_set_and_get() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let rider = ok_u64(sim.spawn_rider(0, 1, 75.0, None));
+
+    ok_void(sim.set_rider_tag(rider, 0xDEAD_BEEF_CAFE_F00D));
+    assert_eq!(ok_u64(sim.rider_tag(rider)), 0xDEAD_BEEF_CAFE_F00D);
+
+    ok_void(sim.set_rider_tag(rider, 1));
+    assert_eq!(ok_u64(sim.rider_tag(rider)), 1);
+
+    ok_void(sim.set_rider_tag(rider, 0));
+    assert_eq!(ok_u64(sim.rider_tag(rider)), 0);
+}
+
+#[test]
+fn errors_on_stale_rider_ref() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let rider = ok_u64(sim.spawn_rider(0, 1, 75.0, None));
+    ok_void(sim.despawn_rider(rider));
+
+    assert!(matches!(sim.rider_tag(rider), WasmU64Result::Err { .. }));
+    assert!(matches!(
+        sim.set_rider_tag(rider, 1),
+        WasmVoidResult::Err { .. }
+    ));
+}
+
+#[test]
+fn survives_snapshot_bytes_round_trip() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let rider = ok_u64(sim.spawn_rider(0, 1, 75.0, None));
+    ok_void(sim.set_rider_tag(rider, 0x1122_3344_5566_7788));
+
+    let bytes = match sim.snapshot_bytes() {
+        WasmBytesResult::Ok { value } => value,
+        WasmBytesResult::Err { error } => panic!("snapshot: {error}"),
+    };
+
+    let restored = WasmSim::from_snapshot_bytes(&bytes, "look".to_string(), None).expect("restore");
+    assert_eq!(ok_u64(restored.rider_tag(rider)), 0x1122_3344_5566_7788);
+}


### PR DESCRIPTION
## Summary

Adds \`Simulation::set_rider_tag(rider, u64)\` / \`rider_tag(rider) -> u64\` plus matching wasm (\`setRiderTag\` / \`riderTag\`) and FFI (\`ev_sim_set_rider_tag\` / \`ev_sim_rider_tag\`) exports. The tag is a \`u64\` the engine never interprets; consumers stash an external id (game-side sim id, freight shipment id, player id) on each rider so they can correlate \`RiderId\` with their own object space without a parallel \`Map<RiderId, u32>\`.

## Why this and not a TS-side map

The tower-together adapter already keeps \`Map<RiderId, simId>\`, but it costs an extra hop on every \`RiderExited\` event and has to be kept in lockstep across two clients + one worker. A native \`u64\` slot inside \`Rider\` is "free" — round-trips through \`snapshot_bytes\` automatically and reads back in O(1) with no foreign allocation or slot-version reconciliation.

## Implementation

- \`Rider.tag: u64\` is \`#[serde(default)]\` so legacy snapshots rehydrate cleanly with \`tag = 0\` (the reserved untagged sentinel).
- Setter validates the rider exists and returns \`EntityNotFound\` rather than silently writing into a freed slot.
- \`bindings.toml\` updated; \`scripts/check-bindings.sh\` reports 142 methods, 114/28/0 for wasm + ffi, 13/129/0 for tui (tag is pure consumer concern; TUI viewer skips with reason).
- \`cbindgen\` regenerated \`elevator_ffi.h\` automatically.

## Test plan

- [x] \`cargo test --workspace\` — 855 + integration green
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`scripts/check-bindings.sh\` — in sync, no \`todo:\` entries
- [x] New test files:
  - \`crates/elevator-core/src/tests/rider_tag_tests.rs\` — defaults, round-trip, per-rider isolation, phase-transition survival, postcard snapshot round-trip, \`#[serde(default)]\` legacy decode, stale-id \`EntityNotFound\`, no cross-pollution with \`MetricTags\`.
  - \`crates/elevator-wasm/tests/rider_tag.rs\` — host-side WasmSim contract (default 0, round-trip, stale-ref error, snapshot round-trip).
  - \`tests::rider_tag_round_trips_and_errors_on_stale_id\` in \`elevator-ffi/src/lib.rs\` — defaults, round-trip, stale-id \`NotFound\`, null-arg gates.