### PR TITLE
feat(core): per-elevator home_stop pin overrides reposition strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.29.0"
+version = "15.30.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "cbindgen",
  "elevator-core",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-wasm"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "elevator-core",
  "getrandom 0.4.2",

--- a/bindings.toml
+++ b/bindings.toml
@@ -551,6 +551,27 @@ wasm = "setElevatorRestrictedStops"
 ffi  = "ev_sim_set_elevator_restricted_stops"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
+[[methods]]
+name = "set_elevator_home_stop"
+category = "dispatch"
+wasm = "setElevatorHomeStop"
+ffi  = "ev_sim_set_elevator_home_stop"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+
+[[methods]]
+name = "clear_elevator_home_stop"
+category = "dispatch"
+wasm = "clearElevatorHomeStop"
+ffi  = "ev_sim_clear_elevator_home_stop"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+
+[[methods]]
+name = "elevator_home_stop"
+category = "dispatch"
+wasm = "elevatorHomeStop"
+ffi  = "ev_sim_elevator_home_stop"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+
 # ─── Introspection ────────────────────────────────────────────────────────
 
 [[methods]]

--- a/crates/elevator-core/src/components/elevator.rs
+++ b/crates/elevator-core/src/components/elevator.rs
@@ -190,6 +190,15 @@ pub struct Elevator {
     /// to skip the next stop. `None` disables the bypass.
     #[serde(default)]
     pub(crate) bypass_load_down_pct: Option<f64>,
+    /// Per-elevator home stop. When `Some(stop)`, the reposition phase
+    /// hard-pins this car to that stop: any time the car is idle and
+    /// off-position, it is routed home regardless of the group's
+    /// reposition strategy. Useful for express cars assigned to a
+    /// dedicated lobby or service cars that should park in a
+    /// loading bay between requests. `None` (the default) leaves
+    /// reposition decisions entirely to the group strategy.
+    #[serde(default)]
+    pub(crate) home_stop: Option<EntityId>,
 }
 
 /// Default inspection speed factor (25% of normal speed).
@@ -316,6 +325,16 @@ impl Elevator {
     /// Mutator for the downward full-load bypass threshold.
     pub const fn set_bypass_load_down_pct(&mut self, pct: Option<f64>) {
         self.bypass_load_down_pct = pct;
+    }
+
+    /// Per-elevator hard-pinned home stop. When `Some(stop)`, the
+    /// reposition phase routes this car to `stop` whenever it is
+    /// idle and off-position, regardless of the group's reposition
+    /// strategy. `None` (the default) leaves reposition decisions
+    /// entirely to the group strategy.
+    #[must_use]
+    pub const fn home_stop(&self) -> Option<EntityId> {
+        self.home_stop
     }
 
     /// Whether this car's up-direction indicator lamp is lit.

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -365,6 +365,7 @@ impl Simulation {
                 manual_target_velocity: None,
                 bypass_load_up_pct: ec.bypass_load_up_pct,
                 bypass_load_down_pct: ec.bypass_load_down_pct,
+                home_stop: None,
             },
         );
         #[cfg(feature = "energy")]

--- a/crates/elevator-core/src/sim/runtime.rs
+++ b/crates/elevator-core/src/sim/runtime.rs
@@ -5,8 +5,9 @@
 //! overarching essential-API summary.
 
 use crate::components::{Accel, Speed, Weight};
-use crate::entity::ElevatorId;
+use crate::entity::{ElevatorId, EntityId};
 use crate::error::SimError;
+use crate::stop::StopRef;
 
 impl super::Simulation {
     // ── Runtime elevator upgrades ────────────────────────────────────
@@ -270,5 +271,84 @@ impl super::Simulation {
             crate::events::UpgradeValue::ticks(ticks),
         );
         Ok(())
+    }
+
+    // ── Per-elevator home stop ───────────────────────────────────────
+
+    /// Pin an elevator to a specific home stop. Whenever the car is
+    /// idle and off-position, the reposition phase routes it to
+    /// `home_stop` regardless of the group's reposition strategy. Pass
+    /// any `Into<StopRef>` (e.g. [`StopId`](crate::stop::StopId) or
+    /// [`EntityId`]).
+    ///
+    /// Use [`clear_elevator_home_stop`](Self::clear_elevator_home_stop)
+    /// to remove the pin and let the strategy own the decision again.
+    ///
+    /// # Errors
+    ///
+    /// - [`SimError::NotAnElevator`] if `elevator` is not an elevator
+    ///   entity.
+    /// - [`SimError::StopNotFound`] if the resolved stop does not
+    ///   exist in the building.
+    /// - [`SimError::InvalidConfig`] if the resolved stop is not
+    ///   served by the elevator's line — pinning a car to a stop it
+    ///   physically can't reach is almost always a bug, so we surface
+    ///   it loudly.
+    pub fn set_elevator_home_stop(
+        &mut self,
+        elevator: ElevatorId,
+        home_stop: impl Into<StopRef>,
+    ) -> Result<(), SimError> {
+        let elevator = elevator.entity();
+        let home_stop_eid = self.resolve_stop(home_stop.into())?;
+        // Reject pinning to a stop the elevator's line can't serve.
+        let line = self.require_elevator(elevator)?.line;
+        let line_serves = self
+            .groups
+            .iter()
+            .flat_map(|g| g.lines().iter())
+            .find(|li| li.entity() == line)
+            .is_some_and(|li| li.serves().contains(&home_stop_eid));
+        if !line_serves {
+            return Err(SimError::InvalidConfig {
+                field: "home_stop",
+                reason: "home stop is not served by this elevator's line".into(),
+            });
+        }
+        if let Some(car) = self.world.elevator_mut(elevator) {
+            car.home_stop = Some(home_stop_eid);
+        }
+        Ok(())
+    }
+
+    /// Remove the home-stop pin from an elevator. Reposition decisions
+    /// for this car return to the group's reposition strategy.
+    ///
+    /// Idempotent — calling on an unpinned car is a no-op.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SimError::NotAnElevator`] if `elevator` is not an
+    /// elevator entity.
+    pub fn clear_elevator_home_stop(&mut self, elevator: ElevatorId) -> Result<(), SimError> {
+        let elevator = elevator.entity();
+        self.require_elevator(elevator)?;
+        if let Some(car) = self.world.elevator_mut(elevator) {
+            car.home_stop = None;
+        }
+        Ok(())
+    }
+
+    /// Read the home-stop pin (if any) for an elevator. Returns
+    /// `Ok(None)` when the car has no pin set, `Ok(Some(stop))` when it
+    /// does.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SimError::NotAnElevator`] if `elevator` is not an
+    /// elevator entity.
+    pub fn elevator_home_stop(&self, elevator: ElevatorId) -> Result<Option<EntityId>, SimError> {
+        let elevator = elevator.entity();
+        Ok(self.require_elevator(elevator)?.home_stop)
     }
 }

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -187,6 +187,7 @@ impl Simulation {
                 manual_target_velocity: None,
                 bypass_load_up_pct: params.bypass_load_up_pct,
                 bypass_load_down_pct: params.bypass_load_down_pct,
+                home_stop: None,
             },
         );
         self.world

--- a/crates/elevator-core/src/systems/reposition.rs
+++ b/crates/elevator-core/src/systems/reposition.rs
@@ -162,17 +162,19 @@ fn apply_home_stop_overrides(
 ) -> Vec<(EntityId, f64)> {
     let mut strategy_pool: Vec<(EntityId, f64)> = Vec::with_capacity(idle_elevators.len());
     for &(elev_eid, elev_pos) in idle_elevators {
-        let pinned = world
+        // Fold "is this car pinned?" and "where is the pinned stop?"
+        // into one lookup: if the home stop is missing from
+        // `stop_positions` (e.g. removed since the pin was set), the
+        // car silently falls back to the strategy pool rather than
+        // emitting a dangling decision the rest of the pipeline can't
+        // act on.
+        let pinned: Option<(EntityId, f64)> = world
             .elevator(elev_eid)
             .and_then(crate::components::Elevator::home_stop)
-            .filter(|sid| stop_positions.iter().any(|(s, _)| s == sid));
+            .and_then(|home_eid| stop_positions.iter().find(|(s, _)| *s == home_eid).copied());
 
         match pinned {
-            Some(home_eid) => {
-                let home_pos = stop_positions
-                    .iter()
-                    .find(|(s, _)| *s == home_eid)
-                    .map_or(elev_pos, |(_, p)| *p);
+            Some((home_eid, home_pos)) => {
                 // Only emit a reposition decision if the car isn't
                 // already parked at home — matches `ReturnToLobby`'s
                 // 1e-6 epsilon to avoid a no-op reposition cycle.

--- a/crates/elevator-core/src/systems/reposition.rs
+++ b/crates/elevator-core/src/systems/reposition.rs
@@ -83,7 +83,16 @@ pub fn run(
         }
 
         decisions.clear();
-        strategy.reposition(&idle_elevators, &stop_positions, group, world, decisions);
+
+        // Apply per-elevator home-stop overrides first. Cars with a
+        // hard-pinned home stop are routed there directly and removed
+        // from the pool the strategy sees, so the strategy stays
+        // single-purpose (no per-car override branch in N different
+        // implementations) and a future strategy gets the behavior for
+        // free.
+        let strategy_pool =
+            apply_home_stop_overrides(world, &idle_elevators, &stop_positions, decisions);
+        strategy.reposition(&strategy_pool, &stop_positions, group, world, decisions);
 
         for &(elev_eid, target_stop) in decisions.iter() {
             if let Some(car) = world.elevator_mut(elev_eid) {
@@ -135,4 +144,44 @@ pub fn run(
             }
         }
     }
+}
+
+/// Pull pinned cars out of the idle pool and emit reposition decisions
+/// straight to `decisions` for any pinned car that isn't already at
+/// home. Returns the residual pool for the group's reposition strategy.
+///
+/// A pin is only honored when the home stop is in this group's served
+/// set; a dangling `EntityId` (e.g. from a stop removal) silently falls
+/// back to the strategy rather than emitting a decision the rest of
+/// the pipeline can't act on.
+fn apply_home_stop_overrides(
+    world: &World,
+    idle_elevators: &[(EntityId, f64)],
+    stop_positions: &[(EntityId, f64)],
+    decisions: &mut Vec<(EntityId, EntityId)>,
+) -> Vec<(EntityId, f64)> {
+    let mut strategy_pool: Vec<(EntityId, f64)> = Vec::with_capacity(idle_elevators.len());
+    for &(elev_eid, elev_pos) in idle_elevators {
+        let pinned = world
+            .elevator(elev_eid)
+            .and_then(crate::components::Elevator::home_stop)
+            .filter(|sid| stop_positions.iter().any(|(s, _)| s == sid));
+
+        match pinned {
+            Some(home_eid) => {
+                let home_pos = stop_positions
+                    .iter()
+                    .find(|(s, _)| *s == home_eid)
+                    .map_or(elev_pos, |(_, p)| *p);
+                // Only emit a reposition decision if the car isn't
+                // already parked at home — matches `ReturnToLobby`'s
+                // 1e-6 epsilon to avoid a no-op reposition cycle.
+                if (elev_pos - home_pos).abs() > 1e-6 {
+                    decisions.push((elev_eid, home_eid));
+                }
+            }
+            None => strategy_pool.push((elev_eid, elev_pos)),
+        }
+    }
+    strategy_pool
 }

--- a/crates/elevator-core/src/tests/dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/dispatch_tests.rs
@@ -112,6 +112,7 @@ pub(super) fn spawn_elevator(world: &mut World, position: f64) -> crate::entity:
             manual_target_velocity: None,
             bypass_load_up_pct: None,
             bypass_load_down_pct: None,
+            home_stop: None,
         },
     );
     eid

--- a/crates/elevator-core/src/tests/feature_tests.rs
+++ b/crates/elevator-core/src/tests/feature_tests.rs
@@ -695,6 +695,7 @@ fn despawn_elevator_resets_rider_to_waiting() {
             manual_target_velocity: None,
             bypass_load_up_pct: None,
             bypass_load_down_pct: None,
+            home_stop: None,
         },
     );
 
@@ -784,6 +785,7 @@ fn despawn_rider_mid_transit_removes_from_elevator_load() {
             manual_target_velocity: None,
             bypass_load_up_pct: None,
             bypass_load_down_pct: None,
+            home_stop: None,
         },
     );
 

--- a/crates/elevator-core/src/tests/home_stop_tests.rs
+++ b/crates/elevator-core/src/tests/home_stop_tests.rs
@@ -1,0 +1,452 @@
+//! Per-elevator hard-pinned home stop.
+//!
+//! `set_elevator_home_stop` is a runtime override: when a car has a
+//! pinned home stop, the reposition phase routes it there directly,
+//! bypassing the group's reposition strategy. These tests pin the
+//! contract end-to-end via `Simulation::step` so the override layer in
+//! `systems::reposition::run` is exercised, not just the raw setter.
+
+use crate::components::{Accel, ElevatorPhase, Speed, Weight};
+use crate::config::{
+    BuildingConfig, ElevatorConfig, GroupConfig, LineConfig, PassengerSpawnConfig, SimConfig,
+    SimulationParams,
+};
+use crate::dispatch::reposition::{ReturnToLobby, SpreadEvenly};
+use crate::dispatch::{BuiltinReposition, BuiltinStrategy};
+use crate::entity::{ElevatorId, EntityId};
+use crate::error::SimError;
+use crate::ids::GroupId;
+use crate::sim::Simulation;
+use crate::stop::{StopConfig, StopId};
+use crate::tests::helpers::{default_config, scan};
+
+fn first_elevator(sim: &Simulation) -> ElevatorId {
+    ElevatorId::from(sim.world().iter_elevators().next().unwrap().0)
+}
+
+/// Resolve [`StopId(idx)`] → [`EntityId`] via insertion order. Test
+/// configs in this file always insert stops in id order, so the index
+/// equals the `StopId` numeric value.
+fn stop_entity(sim: &Simulation, id: StopId) -> EntityId {
+    let idx = id.0 as usize;
+    sim.world()
+        .iter_stops()
+        .nth(idx)
+        .expect("stop index out of range")
+        .0
+}
+
+#[test]
+fn set_get_clear_round_trip() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    let elev = first_elevator(&sim);
+
+    assert_eq!(sim.elevator_home_stop(elev).unwrap(), None);
+
+    sim.set_elevator_home_stop(elev, StopId(2)).unwrap();
+    let target = stop_entity(&sim, StopId(2));
+    assert_eq!(sim.elevator_home_stop(elev).unwrap(), Some(target));
+
+    sim.clear_elevator_home_stop(elev).unwrap();
+    assert_eq!(sim.elevator_home_stop(elev).unwrap(), None);
+}
+
+#[test]
+fn clear_is_idempotent_when_no_pin_set() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    let elev = first_elevator(&sim);
+
+    // Two clears in a row, both Ok.
+    sim.clear_elevator_home_stop(elev).unwrap();
+    sim.clear_elevator_home_stop(elev).unwrap();
+    assert_eq!(sim.elevator_home_stop(elev).unwrap(), None);
+}
+
+#[test]
+fn pin_to_unknown_stop_id_returns_stop_not_found() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    let elev = first_elevator(&sim);
+
+    let result = sim.set_elevator_home_stop(elev, StopId(99));
+    assert!(matches!(result, Err(SimError::StopNotFound(_))));
+}
+
+#[test]
+fn elevator_home_stop_errors_on_non_elevator_entity() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    // Use a stop entity id wrapped as an ElevatorId — this is the
+    // exact misuse a buggy adapter could trigger.
+    let stop_eid = stop_entity(&sim, StopId(0));
+    let bogus = ElevatorId::from(stop_eid);
+
+    assert!(matches!(
+        sim.elevator_home_stop(bogus),
+        Err(SimError::NotAnElevator(_))
+    ));
+    assert!(matches!(
+        sim.set_elevator_home_stop(bogus, StopId(0)),
+        Err(SimError::NotAnElevator(_))
+    ));
+    assert!(matches!(
+        sim.clear_elevator_home_stop(bogus),
+        Err(SimError::NotAnElevator(_))
+    ));
+}
+
+#[test]
+fn pin_to_stop_not_served_by_line_returns_invalid_config() {
+    // Two lines: Low (stops 0+1), High (stops 1+2). Pinning the Low
+    // car to stop 2 (High-only) must fail loudly — silently dropping
+    // the request would let a buggy adapter strand cars at stops they
+    // can't physically reach.
+    let config = two_line_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    // L1 is on the Low line; pin it to stop 2 (High-only).
+    let l1 = sim
+        .world()
+        .iter_elevators()
+        .map(|(eid, _, _)| ElevatorId::from(eid))
+        .next()
+        .unwrap();
+
+    let err = sim.set_elevator_home_stop(l1, StopId(2)).unwrap_err();
+    let SimError::InvalidConfig { field, .. } = err else {
+        panic!("expected InvalidConfig, got {err:?}");
+    };
+    assert_eq!(field, "home_stop");
+}
+
+#[test]
+fn pinned_idle_car_routes_home_each_tick() {
+    // 3 stops, 1 car, Span strategy = SpreadEvenly. Without a pin,
+    // SpreadEvenly might park the car at index 1 (middle). Pin it to
+    // stop 2 and run until idle — it must end up there.
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    sim.set_reposition(
+        GroupId(0),
+        Box::new(SpreadEvenly),
+        BuiltinReposition::SpreadEvenly,
+    );
+
+    let elev = first_elevator(&sim);
+    let target = stop_entity(&sim, StopId(2));
+    sim.set_elevator_home_stop(elev, StopId(2)).unwrap();
+
+    // Run enough ticks for the reposition phase to act and the car
+    // to physically reach the home stop. 3-stop demo at 60Hz with
+    // max_speed 2.0 needs roughly 120 ticks for an 8-unit trip.
+    for _ in 0..400 {
+        sim.step();
+    }
+
+    let car_pos = sim
+        .world()
+        .position(elev.entity())
+        .map(|p| p.value)
+        .unwrap();
+    let home_pos = sim.world().stop_position(target).unwrap();
+    assert!(
+        (car_pos - home_pos).abs() < 1e-3,
+        "pinned car should park at home stop ({home_pos}); got {car_pos}"
+    );
+}
+
+#[test]
+fn pin_overrides_strategy_decision() {
+    // ReturnToLobby would send everyone to stop 0; pin the car to
+    // stop 1 and assert the override beats the strategy.
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    sim.set_reposition(
+        GroupId(0),
+        Box::new(ReturnToLobby::new()),
+        BuiltinReposition::ReturnToLobby,
+    );
+
+    let elev = first_elevator(&sim);
+    sim.set_elevator_home_stop(elev, StopId(1)).unwrap();
+
+    for _ in 0..400 {
+        sim.step();
+    }
+
+    let car_pos = sim
+        .world()
+        .position(elev.entity())
+        .map(|p| p.value)
+        .unwrap();
+    let s1 = stop_entity(&sim, StopId(1));
+    let pinned_pos = sim.world().stop_position(s1).unwrap();
+    assert!(
+        (car_pos - pinned_pos).abs() < 1e-3,
+        "pin must beat ReturnToLobby; expected pos {pinned_pos}, got {car_pos}"
+    );
+}
+
+#[test]
+fn clearing_pin_returns_strategy_control() {
+    // With ReturnToLobby and no pin, the car returns to stop 0.
+    // Pin to stop 2, clear, then verify the strategy retakes
+    // control and parks the car at stop 0.
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    sim.set_reposition(
+        GroupId(0),
+        Box::new(ReturnToLobby::new()),
+        BuiltinReposition::ReturnToLobby,
+    );
+
+    let elev = first_elevator(&sim);
+    sim.set_elevator_home_stop(elev, StopId(2)).unwrap();
+    // 400 ticks: enough time for the car to actually reach stop 2.
+    // Clearing the pin mid-flight wouldn't prove the override is
+    // gone — the in-flight reposition continues to its target. We
+    // need the car to settle at home first, then clear, then watch
+    // the strategy retake control.
+    for _ in 0..400 {
+        sim.step();
+    }
+    sim.clear_elevator_home_stop(elev).unwrap();
+    // Now ReturnToLobby kicks in next reposition pass and pulls the
+    // car all the way back to stop 0. 600 more ticks gives plenty of
+    // runway for the round-trip.
+    for _ in 0..600 {
+        sim.step();
+    }
+
+    let car_pos = sim
+        .world()
+        .position(elev.entity())
+        .map(|p| p.value)
+        .unwrap();
+    let s0 = stop_entity(&sim, StopId(0));
+    let lobby_pos = sim.world().stop_position(s0).unwrap();
+    assert!(
+        (car_pos - lobby_pos).abs() < 1e-3,
+        "after clearing pin, ReturnToLobby should retake control; \
+         expected {lobby_pos}, got {car_pos}"
+    );
+}
+
+#[test]
+fn unpinned_cars_still_use_strategy_when_one_car_is_pinned() {
+    // Two cars on one line. Pin one, leave the other under SpreadEvenly.
+    // The unpinned car must still get a strategy decision (otherwise the
+    // override pool surgery accidentally hides the rest of the cars).
+    let config = two_car_one_line_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    // ReturnToLobby is fully deterministic — it will send any
+    // unpinned car to stop 0. So the load-bearing fact is "the
+    // unpinned car still gets routed home by the strategy" while the
+    // pinned car ignores ReturnToLobby and sits at stop 2. Without
+    // the strategy_pool surgery in `systems::reposition::run`, the
+    // unpinned car would either be pinned by accident or never get
+    // a strategy decision.
+    sim.set_reposition(
+        GroupId(0),
+        Box::new(ReturnToLobby::new()),
+        BuiltinReposition::ReturnToLobby,
+    );
+
+    let elev_eids: Vec<EntityId> = sim
+        .world()
+        .iter_elevators()
+        .map(|(eid, _, _)| eid)
+        .collect();
+    let car_a = ElevatorId::from(elev_eids[0]);
+    let car_b = ElevatorId::from(elev_eids[1]);
+
+    sim.set_elevator_home_stop(car_a, StopId(2)).unwrap();
+    let s0 = stop_entity(&sim, StopId(0));
+    let s2 = stop_entity(&sim, StopId(2));
+    let s0_pos = sim.world().stop_position(s0).unwrap();
+    let s2_pos = sim.world().stop_position(s2).unwrap();
+
+    for _ in 0..600 {
+        sim.step();
+    }
+
+    let pos_a = sim.world().position(car_a.entity()).unwrap().value;
+    let pos_b = sim.world().position(car_b.entity()).unwrap().value;
+
+    assert!(
+        (pos_a - s2_pos).abs() < 1e-3,
+        "pinned car A should be at stop 2 ({s2_pos}); got {pos_a}"
+    );
+    assert!(
+        (pos_b - s0_pos).abs() < 1e-3,
+        "unpinned car B should be at the strategy's lobby ({s0_pos}); \
+         got {pos_b}. If this is car A's home (8.0), the override pool \
+         surgery accidentally hid car B from the strategy."
+    );
+}
+
+#[test]
+fn home_stop_survives_snapshot_round_trip() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    let elev = first_elevator(&sim);
+    sim.set_elevator_home_stop(elev, StopId(2)).unwrap();
+    let target = stop_entity(&sim, StopId(2));
+
+    let bytes = sim.snapshot_bytes().expect("snapshot");
+    let restored = Simulation::restore_bytes(&bytes, None).expect("restore");
+
+    assert_eq!(restored.elevator_home_stop(elev).unwrap(), Some(target));
+}
+
+#[test]
+fn already_at_home_does_not_reposition_redundantly() {
+    // Pin a car to stop 0 (its starting stop). The override should
+    // not emit a reposition decision — the car is already there. This
+    // is the 1e-6 epsilon path; without it we'd churn a cycle every
+    // reposition tick.
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    let elev = first_elevator(&sim);
+    sim.set_elevator_home_stop(elev, StopId(0)).unwrap();
+
+    // One reposition pass. After this the car should still be Idle
+    // (not Repositioning), proving no redundant decision was emitted.
+    for _ in 0..30 {
+        sim.step();
+    }
+    let phase = sim.world().elevator(elev.entity()).unwrap().phase();
+    assert_eq!(
+        phase,
+        ElevatorPhase::Idle,
+        "car already at home must not be redirected back; got phase {phase:?}"
+    );
+}
+
+// ── Multi-line config helpers ────────────────────────────────────────
+
+/// Two lines: Low (stops 0+1), High (stops 1+2). One car per line in
+/// distinct dispatch groups. Used to test cross-line pin rejection.
+fn two_line_config() -> SimConfig {
+    SimConfig {
+        building: BuildingConfig {
+            name: "Two Lines".into(),
+            stops: vec![
+                StopConfig {
+                    id: StopId(0),
+                    name: "Ground".into(),
+                    position: 0.0,
+                },
+                StopConfig {
+                    id: StopId(1),
+                    name: "Transfer".into(),
+                    position: 4.0,
+                },
+                StopConfig {
+                    id: StopId(2),
+                    name: "Top".into(),
+                    position: 8.0,
+                },
+            ],
+            lines: Some(vec![
+                LineConfig {
+                    id: 1,
+                    name: "Low".into(),
+                    serves: vec![StopId(0), StopId(1)],
+                    elevators: vec![bare_elevator(1, "L1", StopId(0))],
+                    ..Default::default()
+                },
+                LineConfig {
+                    id: 2,
+                    name: "High".into(),
+                    serves: vec![StopId(1), StopId(2)],
+                    elevators: vec![bare_elevator(2, "H1", StopId(1))],
+                    ..Default::default()
+                },
+            ]),
+            groups: Some(vec![
+                GroupConfig {
+                    id: 0,
+                    name: "Low Rise".into(),
+                    lines: vec![1],
+                    dispatch: BuiltinStrategy::Scan,
+                    reposition: Some(BuiltinReposition::SpreadEvenly),
+                    hall_call_mode: None,
+                    ack_latency_ticks: None,
+                },
+                GroupConfig {
+                    id: 1,
+                    name: "High Rise".into(),
+                    lines: vec![2],
+                    dispatch: BuiltinStrategy::Scan,
+                    reposition: Some(BuiltinReposition::SpreadEvenly),
+                    hall_call_mode: None,
+                    ack_latency_ticks: None,
+                },
+            ]),
+        },
+        elevators: vec![],
+        simulation: SimulationParams {
+            ticks_per_second: 60.0,
+        },
+        passenger_spawning: PassengerSpawnConfig {
+            mean_interval_ticks: 120,
+            weight_range: (50.0, 100.0),
+        },
+    }
+}
+
+/// Three stops on one line, two cars in the same group. Used to test
+/// that the unpinned car still receives a strategy decision when one
+/// car is pinned.
+fn two_car_one_line_config() -> SimConfig {
+    SimConfig {
+        building: BuildingConfig {
+            name: "Two Cars".into(),
+            stops: vec![
+                StopConfig {
+                    id: StopId(0),
+                    name: "Ground".into(),
+                    position: 0.0,
+                },
+                StopConfig {
+                    id: StopId(1),
+                    name: "Mid".into(),
+                    position: 4.0,
+                },
+                StopConfig {
+                    id: StopId(2),
+                    name: "Top".into(),
+                    position: 8.0,
+                },
+            ],
+            lines: None,
+            groups: None,
+        },
+        elevators: vec![
+            bare_elevator(1, "A", StopId(0)),
+            bare_elevator(2, "B", StopId(1)),
+        ],
+        simulation: SimulationParams {
+            ticks_per_second: 60.0,
+        },
+        passenger_spawning: PassengerSpawnConfig {
+            mean_interval_ticks: 120,
+            weight_range: (50.0, 100.0),
+        },
+    }
+}
+
+fn bare_elevator(id: u32, name: &str, starting: StopId) -> ElevatorConfig {
+    ElevatorConfig {
+        id,
+        name: name.into(),
+        max_speed: Speed::from(2.0),
+        acceleration: Accel::from(1.5),
+        deceleration: Accel::from(2.0),
+        weight_capacity: Weight::from(800.0),
+        starting_stop: starting,
+        door_open_ticks: 10,
+        door_transition_ticks: 5,
+        restricted_stops: Vec::new(),
+        #[cfg(feature = "energy")]
+        energy_profile: None,
+        service_mode: None,
+        inspection_speed_factor: 0.25,
+        bypass_load_up_pct: None,
+        bypass_load_down_pct: None,
+    }
+}

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -62,6 +62,7 @@ mod etd_mutant_tests;
 mod event_payload_tests;
 mod fp_tests;
 mod hall_call_tests;
+mod home_stop_tests;
 mod idle_with_riders_tests;
 mod invariants_tests;
 mod manual_mode_tests;

--- a/crates/elevator-core/src/tests/mutation_kills_tests.rs
+++ b/crates/elevator-core/src/tests/mutation_kills_tests.rs
@@ -221,6 +221,7 @@ fn spawn_elev(world: &mut World, pos: f64, n: usize) -> Vec<EntityId> {
                     manual_target_velocity: None,
                     bypass_load_up_pct: None,
                     bypass_load_down_pct: None,
+                    home_stop: None,
                 },
             );
             eid

--- a/crates/elevator-core/src/tests/query_tests.rs
+++ b/crates/elevator-core/src/tests/query_tests.rs
@@ -55,6 +55,7 @@ fn test_world() -> (World, EntityId, EntityId, EntityId) {
             manual_target_velocity: None,
             bypass_load_up_pct: None,
             bypass_load_down_pct: None,
+            home_stop: None,
         },
     );
 

--- a/crates/elevator-core/src/tests/reposition_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_tests.rs
@@ -86,6 +86,7 @@ fn spawn_elevator(world: &mut World, position: f64) -> EntityId {
             manual_target_velocity: None,
             bypass_load_up_pct: None,
             bypass_load_down_pct: None,
+            home_stop: None,
         },
     );
     eid

--- a/crates/elevator-core/src/tests/world_tests.rs
+++ b/crates/elevator-core/src/tests/world_tests.rs
@@ -69,6 +69,7 @@ fn elevator_query_returns_entities_with_both_components() {
             manual_target_velocity: None,
             bypass_load_up_pct: None,
             bypass_load_down_pct: None,
+            home_stop: None,
         },
     );
 
@@ -319,6 +320,7 @@ fn despawn_cleans_up_hall_and_car_calls() {
             manual_target_velocity: None,
             bypass_load_up_pct: None,
             bypass_load_down_pct: None,
+            home_stop: None,
         },
     );
 

--- a/crates/elevator-ffi/include/elevator_ffi.h
+++ b/crates/elevator-ffi/include/elevator_ffi.h
@@ -1706,6 +1706,43 @@ enum EvStatus ev_sim_set_elevator_restricted_stops(struct EvSim *handle,
                                                    uint32_t count);
 
 /**
+ * Pin `elevator_entity_id` to a hard-coded home stop. Whenever the
+ * car is idle and off-position, the reposition phase routes it to
+ * `home_stop_entity_id` regardless of the group's reposition strategy.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_set_elevator_home_stop(struct EvSim *handle,
+                                            uint64_t elevator_entity_id,
+                                            uint64_t home_stop_entity_id);
+
+/**
+ * Remove the home-stop pin from `elevator_entity_id`. Reposition
+ * decisions return to the group's reposition strategy. Idempotent.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+enum EvStatus ev_sim_clear_elevator_home_stop(struct EvSim *handle, uint64_t elevator_entity_id);
+
+/**
+ * Read the home-stop pin for `elevator_entity_id`. Writes the stop
+ * entity id (or `0` for unpinned) into `*out_stop_id` and returns
+ * [`EvStatus::Ok`].
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ * `out_stop_id` must be a valid, writable pointer to a `u64`.
+ */
+enum EvStatus ev_sim_elevator_home_stop(struct EvSim *handle,
+                                        uint64_t elevator_entity_id,
+                                        uint64_t *out_stop_id);
+
+/**
  * Attach `tag` to `entity_id`.
  *
  * # Safety

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -3462,6 +3462,135 @@ pub unsafe extern "C" fn ev_sim_set_elevator_restricted_stops(
     })
 }
 
+/// Pin `elevator_entity_id` to a hard-coded home stop. Whenever the
+/// car is idle and off-position, the reposition phase routes it to
+/// `home_stop_entity_id` regardless of the group's reposition strategy.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_set_elevator_home_stop(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+    home_stop_entity_id: u64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        let Some(stop) = entity_from_u64(home_stop_entity_id) else {
+            set_last_error("home_stop_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev
+            .sim
+            .set_elevator_home_stop(elevator_core::entity::ElevatorId::from(elevator), stop)
+        {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("set_elevator_home_stop: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Remove the home-stop pin from `elevator_entity_id`. Reposition
+/// decisions return to the group's reposition strategy. Idempotent.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_clear_elevator_home_stop(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &mut *handle };
+        match ev
+            .sim
+            .clear_elevator_home_stop(elevator_core::entity::ElevatorId::from(elevator))
+        {
+            Ok(()) => EvStatus::Ok,
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("clear_elevator_home_stop: {e}"));
+                status
+            }
+        }
+    })
+}
+
+/// Read the home-stop pin for `elevator_entity_id`. Writes the stop
+/// entity id (or `0` for unpinned) into `*out_stop_id` and returns
+/// [`EvStatus::Ok`].
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+/// `out_stop_id` must be a valid, writable pointer to a `u64`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_elevator_home_stop(
+    handle: *mut EvSim,
+    elevator_entity_id: u64,
+    out_stop_id: *mut u64,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return EvStatus::NullArg;
+        }
+        if out_stop_id.is_null() {
+            set_last_error("out_stop_id is null");
+            return EvStatus::NullArg;
+        }
+        let Some(elevator) = entity_from_u64(elevator_entity_id) else {
+            set_last_error("elevator_entity_id is invalid");
+            return EvStatus::InvalidArg;
+        };
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        match ev
+            .sim
+            .elevator_home_stop(elevator_core::entity::ElevatorId::from(elevator))
+        {
+            Ok(stop) => {
+                let raw = stop.map_or(0, entity_to_u64);
+                // Safety: caller-provided writable u64 pointer.
+                unsafe { *out_stop_id = raw };
+                EvStatus::Ok
+            }
+            Err(e) => {
+                let status = mode_error_status(&e);
+                set_last_error(format!("elevator_home_stop: {e}"));
+                status
+            }
+        }
+    })
+}
+
 // ── Tagging ──────────────────────────────────────────────────────────────
 //
 // Attach string tags to entities for grouped metrics. Mirrors wasm's
@@ -7387,6 +7516,97 @@ mod tests {
         );
         assert_eq!(
             unsafe { ev_sim_rider_tag(handle, rider_id, std::ptr::null_mut()) },
+            EvStatus::NullArg,
+        );
+
+        unsafe { ev_sim_destroy(handle) };
+    }
+
+    #[test]
+    fn elevator_home_stop_round_trips_and_validates() {
+        // Default 0 (unpinned), set/get round-trips, clear returns
+        // 0, errors propagate from the Rust API for unknown elevators
+        // and unknown stops, and the null-arg gates fire.
+        let handle = create_test_handle();
+        let elevator_id = first_elevator_entity(handle);
+        let (stop_a, _stop_b) = stop_entities(handle);
+
+        // Default is the 0 sentinel — no pin set on a fresh sim.
+        let mut out: u64 = 0xFFFF_FFFF_FFFF_FFFF;
+        assert_eq!(
+            unsafe { ev_sim_elevator_home_stop(handle, elevator_id, &raw mut out) },
+            EvStatus::Ok,
+        );
+        assert_eq!(out, 0, "fresh elevator must default to unpinned (0)");
+
+        // Set + read-back.
+        assert_eq!(
+            unsafe { ev_sim_set_elevator_home_stop(handle, elevator_id, stop_a) },
+            EvStatus::Ok,
+        );
+        let mut roundtrip: u64 = 0;
+        assert_eq!(
+            unsafe { ev_sim_elevator_home_stop(handle, elevator_id, &raw mut roundtrip) },
+            EvStatus::Ok,
+        );
+        assert_eq!(roundtrip, stop_a);
+
+        // Clear → back to 0.
+        assert_eq!(
+            unsafe { ev_sim_clear_elevator_home_stop(handle, elevator_id) },
+            EvStatus::Ok,
+        );
+        let mut after_clear: u64 = 0xFFFF;
+        assert_eq!(
+            unsafe { ev_sim_elevator_home_stop(handle, elevator_id, &raw mut after_clear) },
+            EvStatus::Ok,
+        );
+        assert_eq!(after_clear, 0);
+
+        // Pin to an undecodable stop id — the FFI's `entity_from_u64`
+        // gate rejects this with InvalidArg before reaching the Rust
+        // API. (A *decodable* but stale id would surface NotFound from
+        // the inner `resolve_stop`; that path is exercised by the Rust
+        // `pin_to_unknown_stop_id_returns_stop_not_found` test.)
+        let bogus_stop: u64 = 0;
+        assert_eq!(
+            unsafe { ev_sim_set_elevator_home_stop(handle, elevator_id, bogus_stop) },
+            EvStatus::InvalidArg,
+        );
+
+        // Pin a non-elevator entity — `require_elevator` raises
+        // `NotAnElevator`, which the FFI maps through `mode_error_status`
+        // to NotFound (the same status games already handle for stale
+        // refs).
+        let not_an_elevator = stop_a; // Stop entity, not an elevator.
+        assert_eq!(
+            unsafe { ev_sim_set_elevator_home_stop(handle, not_an_elevator, stop_a) },
+            EvStatus::NotFound,
+        );
+
+        // Null-arg gates — verify each null pointer slot produces
+        // NullArg rather than dereferencing.
+        assert_eq!(
+            unsafe { ev_sim_set_elevator_home_stop(std::ptr::null_mut(), elevator_id, stop_a) },
+            EvStatus::NullArg,
+        );
+        assert_eq!(
+            unsafe { ev_sim_clear_elevator_home_stop(std::ptr::null_mut(), elevator_id) },
+            EvStatus::NullArg,
+        );
+        let mut null_handle_stop: u64 = 0;
+        assert_eq!(
+            unsafe {
+                ev_sim_elevator_home_stop(
+                    std::ptr::null_mut(),
+                    elevator_id,
+                    &raw mut null_handle_stop,
+                )
+            },
+            EvStatus::NullArg,
+        );
+        assert_eq!(
+            unsafe { ev_sim_elevator_home_stop(handle, elevator_id, std::ptr::null_mut()) },
             EvStatus::NullArg,
         );
 

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -853,6 +853,61 @@ impl WasmSim {
             .into()
     }
 
+    /// Pin an elevator to a hard-coded home stop. Whenever the car is
+    /// idle and off-position, the reposition phase routes it to the
+    /// pinned stop regardless of the group's reposition strategy.
+    /// Useful for express cars assigned to a dedicated lobby or
+    /// service cars that should park in a loading bay between
+    /// requests.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the elevator or stop does not exist, or
+    /// if the elevator's line does not serve the requested stop.
+    #[wasm_bindgen(js_name = setElevatorHomeStop)]
+    pub fn set_elevator_home_stop(&mut self, elevator_ref: u64, stop_ref: u64) -> WasmVoidResult {
+        self.inner
+            .set_elevator_home_stop(
+                elevator_core::entity::ElevatorId::from(u64_to_entity(elevator_ref)),
+                u64_to_entity(stop_ref),
+            )
+            .map_err(|e| format!("set_elevator_home_stop: {e}"))
+            .into()
+    }
+
+    /// Remove an elevator's home-stop pin. Reposition decisions return
+    /// to the group's reposition strategy. Idempotent.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the elevator does not exist.
+    #[wasm_bindgen(js_name = clearElevatorHomeStop)]
+    pub fn clear_elevator_home_stop(&mut self, elevator_ref: u64) -> WasmVoidResult {
+        self.inner
+            .clear_elevator_home_stop(elevator_core::entity::ElevatorId::from(u64_to_entity(
+                elevator_ref,
+            )))
+            .map_err(|e| format!("clear_elevator_home_stop: {e}"))
+            .into()
+    }
+
+    /// Read the home-stop pin for an elevator. Returns `0n` when the
+    /// car has no pin set; otherwise the stop entity ref.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if the elevator does not exist.
+    #[wasm_bindgen(js_name = elevatorHomeStop)]
+    pub fn elevator_home_stop(&self, elevator_ref: u64) -> WasmU64Result {
+        self.inner
+            .elevator_home_stop(elevator_core::entity::ElevatorId::from(u64_to_entity(
+                elevator_ref,
+            )))
+            .map(|opt| opt.map_or(0u64, entity_to_u64))
+            .map_err(|e| format!("elevator_home_stop: {e}"))
+            .into()
+    }
+
     /// Replace an elevator's forbidden-stops set. Pass an empty array to
     /// clear all restrictions.
     ///

--- a/crates/elevator-wasm/tests/home_stop.rs
+++ b/crates/elevator-wasm/tests/home_stop.rs
@@ -1,0 +1,97 @@
+//! Tests for `WasmSim::setElevatorHomeStop` / `clearElevatorHomeStop`
+//! / `elevatorHomeStop`.
+//!
+//! Pin persistence and rejection paths are covered exhaustively at the
+//! Rust level in `tests::home_stop_tests`; these tests verify the wasm
+//! shape: ref encoding, the `0n` sentinel for "no pin", and the
+//! WasmU64Result/WasmVoidResult error wrapping.
+
+use elevator_wasm::{WasmSim, WasmU64Result, WasmVoidResult};
+
+const SCENARIO: &str = r#"SimConfig(
+    building: BuildingConfig(
+        name: "Home Stop",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby",   position: 0.0),
+            StopConfig(id: StopId(1), name: "Floor 2", position: 4.0),
+            StopConfig(id: StopId(2), name: "Top",     position: 8.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car 1",
+            max_speed: 2.2, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 90,
+        weight_range: (50.0, 100.0),
+    ),
+)"#;
+
+fn ok_void(r: WasmVoidResult) {
+    match r {
+        WasmVoidResult::Ok {} => {}
+        WasmVoidResult::Err { error } => panic!("void result err: {error}"),
+    }
+}
+
+fn ok_u64(r: WasmU64Result) -> u64 {
+    match r {
+        WasmU64Result::Ok { value } => value,
+        WasmU64Result::Err { error } => panic!("u64 result err: {error}"),
+    }
+}
+
+/// Pull the elevator + stop refs from `world_view()`. The view is the
+/// canonical place game adapters look up entity refs.
+fn refs(sim: &WasmSim) -> (u64, Vec<u64>) {
+    let view = sim.world_view();
+    let elev_ref = view.cars[0].id;
+    let stop_refs: Vec<u64> = view.stops.iter().map(|s| s.entity_id).collect();
+    (elev_ref, stop_refs)
+}
+
+#[test]
+fn defaults_to_zero_for_unpinned_car() {
+    let sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let (elev_ref, _) = refs(&sim);
+
+    assert_eq!(
+        ok_u64(sim.elevator_home_stop(elev_ref)),
+        0,
+        "unpinned car must report 0n (the no-pin sentinel)"
+    );
+}
+
+#[test]
+fn round_trips_set_and_clear() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let (elev_ref, stops) = refs(&sim);
+    let stop2_ref = stops[2];
+
+    ok_void(sim.set_elevator_home_stop(elev_ref, stop2_ref));
+    assert_eq!(ok_u64(sim.elevator_home_stop(elev_ref)), stop2_ref);
+
+    ok_void(sim.clear_elevator_home_stop(elev_ref));
+    assert_eq!(ok_u64(sim.elevator_home_stop(elev_ref)), 0);
+}
+
+#[test]
+fn errors_on_unknown_elevator_ref() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let (_, stops) = refs(&sim);
+
+    // Bogus elevator ref (slot id 999 that never existed).
+    let bogus_elev = 999u64 << 32;
+    let result = sim.set_elevator_home_stop(bogus_elev, stops[0]);
+    assert!(matches!(result, WasmVoidResult::Err { .. }));
+    assert!(matches!(
+        sim.elevator_home_stop(bogus_elev),
+        WasmU64Result::Err { .. }
+    ));
+}


### PR DESCRIPTION
## Summary

Adds \`Simulation::set_elevator_home_stop\` / \`clear_elevator_home_stop\` / \`elevator_home_stop\` plus matching wasm (\`setElevatorHomeStop\` etc.) and FFI (\`ev_sim_set_elevator_home_stop\` etc.) exports. When a car has a pinned home stop, the reposition phase routes it there directly — bypassing the group's reposition strategy — whenever the car is idle and off-position.

## Use case

Express cars assigned to a dedicated lobby and service cars that should park in a loading bay between requests. Previously consumers had to either pick \`ReturnToLobby\` (which pins *every* car in the group to the same stop) or hand-write a custom strategy. A per-car pin is the granularity that actually matches building operations.

## Why the override sits at the phase boundary, not inside strategies

elevator-core has 6 reposition strategies. Threading "if this car has a home_stop, route home" into all 6 would be invasive and easy to forget on the next strategy added. Instead, \`apply_home_stop_overrides\` in \`systems::reposition::run\` extracts pinned cars from the idle pool, emits their reposition decisions directly, and hands the residual pool to the strategy. Strategies stay single-purpose and a future seventh strategy gets the behavior for free.

## Implementation

- \`Elevator.home_stop: Option<EntityId>\` is \`#[serde(default)]\` so legacy snapshots rehydrate cleanly with no pin.
- \`set_elevator_home_stop\` validates the home stop is served by the car's line — pinning a car to a stop it physically can't reach is almost always a bug, surfaced as \`InvalidConfig\`.
- The override applies a 1e-6 epsilon "already at home" check matching \`ReturnToLobby\` so a parked-at-home car doesn't churn a no-op reposition every tick.
- \`bindings.toml\` updated; coverage check in sync (143 methods, 115/28/0 wasm + ffi, 13/130/0 tui).
- \`cbindgen\` regenerated \`elevator_ffi.h\` automatically.

## Test plan

- [x] 11 lib tests in \`tests::home_stop_tests\`: round-trip, idempotent clear, validation paths (unknown stop, non-elevator entity, cross-line stop), pin overrides strategy decision, clearing returns strategy control, unpinned cars in mixed pool still get strategy decisions, snapshot round-trip, no redundant reposition when already at home.
- [x] 3 wasm host tests in \`crates/elevator-wasm/tests/home_stop.rs\`: default \`0n\` sentinel, set/clear round-trip, error wrapping for unknown elevator refs.
- [x] 1 FFI test in \`crates/elevator-ffi/src/lib.rs\`: defaults, round-trip, validation, null-arg gates.
- [x] \`cargo test --workspace\` — 858 + integration green.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean.
- [x] \`cargo fmt --all -- --check\` — clean.
- [x] \`scripts/check-bindings.sh\` — in sync.