### PR TITLE
feat(events): emit Rider.tag on every rider-bearing event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.30.0"
+version = "15.31.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "cbindgen",
  "elevator-core",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-wasm"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "elevator-core",
  "getrandom 0.4.2",

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -88,6 +88,13 @@ pub enum Event {
         origin: EntityId,
         /// The stop the rider wants to reach.
         destination: EntityId,
+        /// Opaque consumer tag attached to the rider at emit time. `0`
+        /// when the rider is untagged. See [`Simulation::set_rider_tag`]
+        /// for the back-pointer pattern this enables.
+        ///
+        /// [`Simulation::set_rider_tag`]: crate::sim::Simulation::set_rider_tag
+        #[serde(default)]
+        tag: u64,
         /// The tick when the rider spawned.
         tick: u64,
     },
@@ -97,6 +104,10 @@ pub enum Event {
         rider: EntityId,
         /// The elevator the rider boarded.
         elevator: EntityId,
+        /// Opaque consumer tag attached to the rider at emit time. `0`
+        /// when the rider is untagged.
+        #[serde(default)]
+        tag: u64,
         /// The tick when boarding occurred.
         tick: u64,
     },
@@ -109,6 +120,12 @@ pub enum Event {
         elevator: EntityId,
         /// The stop where the rider exited.
         stop: EntityId,
+        /// Opaque consumer tag attached to the rider at emit time. `0`
+        /// when the rider is untagged. Sampled before the rider is freed
+        /// so consumers can correlate the exit with external state even
+        /// after the [`RiderId`](crate::entity::RiderId) becomes stale.
+        #[serde(default)]
+        tag: u64,
         /// The tick when exiting occurred.
         tick: u64,
     },
@@ -122,6 +139,10 @@ pub enum Event {
         reason: RejectionReason,
         /// Additional numeric context for the rejection.
         context: Option<RejectionContext>,
+        /// Opaque consumer tag attached to the rider at emit time. `0`
+        /// when the rider is untagged.
+        #[serde(default)]
+        tag: u64,
         /// The tick when rejection occurred.
         tick: u64,
     },
@@ -131,6 +152,10 @@ pub enum Event {
         rider: EntityId,
         /// The stop the rider left.
         stop: EntityId,
+        /// Opaque consumer tag attached to the rider at emit time. `0`
+        /// when the rider is untagged. Sampled before the rider is freed.
+        #[serde(default)]
+        tag: u64,
         /// The tick when abandonment occurred.
         tick: u64,
     },
@@ -145,6 +170,10 @@ pub enum Event {
         elevator: EntityId,
         /// The stop the rider was placed at.
         stop: EntityId,
+        /// Opaque consumer tag attached to the rider at emit time. `0`
+        /// when the rider is untagged.
+        #[serde(default)]
+        tag: u64,
         /// The tick when ejection occurred.
         tick: u64,
     },
@@ -208,6 +237,10 @@ pub enum Event {
         affected_stop: EntityId,
         /// Why the route was invalidated.
         reason: RouteInvalidReason,
+        /// Opaque consumer tag attached to the rider at emit time. `0`
+        /// when the rider is untagged.
+        #[serde(default)]
+        tag: u64,
         /// The tick when invalidation occurred.
         tick: u64,
     },
@@ -217,6 +250,10 @@ pub enum Event {
         rider: EntityId,
         /// The new destination stop.
         new_destination: EntityId,
+        /// Opaque consumer tag attached to the rider at emit time. `0`
+        /// when the rider is untagged.
+        #[serde(default)]
+        tag: u64,
         /// The tick when rerouting occurred.
         tick: u64,
     },
@@ -227,6 +264,10 @@ pub enum Event {
         rider: EntityId,
         /// The stop where the rider settled.
         stop: EntityId,
+        /// Opaque consumer tag attached to the rider at emit time. `0`
+        /// when the rider is untagged.
+        #[serde(default)]
+        tag: u64,
         /// The tick when settlement occurred.
         tick: u64,
     },
@@ -234,6 +275,10 @@ pub enum Event {
     RiderDespawned {
         /// The rider that was removed.
         rider: EntityId,
+        /// Opaque consumer tag attached to the rider at emit time. `0`
+        /// when the rider is untagged. Sampled before the rider is freed.
+        #[serde(default)]
+        tag: u64,
         /// The tick when despawn occurred.
         tick: u64,
     },
@@ -567,6 +612,12 @@ pub enum Event {
         /// for scripted events, player input, or cutscene cues with no
         /// associated rider entity.
         rider: Option<EntityId>,
+        /// Opaque consumer tag attached to the pressing rider, mirroring
+        /// the optionality of [`rider`](Self::CarButtonPressed::rider).
+        /// `Some(0)` for a present-but-untagged rider; `None` for a
+        /// synthetic press with no rider entity.
+        #[serde(default)]
+        tag: Option<u64>,
         /// Tick of the press.
         tick: u64,
     },
@@ -581,6 +632,10 @@ pub enum Event {
         elevator: EntityId,
         /// Stop where the skip happened.
         at_stop: EntityId,
+        /// Opaque consumer tag attached to the rider at emit time. `0`
+        /// when the rider is untagged.
+        #[serde(default)]
+        tag: u64,
         /// Tick of the skip.
         tick: u64,
     },

--- a/crates/elevator-core/src/sim/calls.rs
+++ b/crates/elevator-core/src/sim/calls.rs
@@ -320,10 +320,16 @@ impl super::Simulation {
             queue.push(call);
         }
         if fresh {
+            let tag = rider.map(|rid| {
+                self.world
+                    .rider(rid)
+                    .map_or(0, crate::components::Rider::tag)
+            });
             self.events.emit(Event::CarButtonPressed {
                 car,
                 floor,
                 rider,
+                tag,
                 tick: press_tick,
             });
         }

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -147,9 +147,14 @@ impl Simulation {
         self.world
             .set_route(rider, Route::direct(origin, new_destination, group));
 
+        let tag = self
+            .world
+            .rider(rider)
+            .map_or(0, crate::components::Rider::tag);
         self.events.emit(Event::RiderRerouted {
             rider,
             new_destination,
+            tag,
             tick: self.tick,
         });
 
@@ -213,9 +218,14 @@ impl Simulation {
         }
 
         self.metrics.record_settle();
+        let tag = self
+            .world
+            .rider(id)
+            .map_or(0, crate::components::Rider::tag);
         self.events.emit(Event::RiderSettled {
             rider: id,
             stop,
+            tag,
             tick: self.tick,
         });
         Ok(())
@@ -291,9 +301,14 @@ impl Simulation {
         }
 
         self.metrics.record_reroute();
+        let tag = self
+            .world
+            .rider(id)
+            .map_or(0, crate::components::Rider::tag);
         self.events.emit(Event::RiderRerouted {
             rider: id,
             new_destination,
+            tag,
             tick: self.tick,
         });
         Ok(())
@@ -314,6 +329,7 @@ impl Simulation {
     pub fn despawn_rider(&mut self, id: RiderId) -> Result<(), SimError> {
         let id = id.entity();
         let rider = self.world.rider(id).ok_or(SimError::EntityNotFound(id))?;
+        let tag = rider.tag();
 
         // Targeted index removal based on current phase (O(1) vs O(n) scan).
         if let Some(stop) = rider.current_stop {
@@ -342,6 +358,7 @@ impl Simulation {
 
         self.events.emit(Event::RiderDespawned {
             rider: id,
+            tag,
             tick: self.tick,
         });
         Ok(())
@@ -581,6 +598,10 @@ impl Simulation {
             }
 
             for rid in &rider_ids {
+                let tag = self
+                    .world
+                    .rider(*rid)
+                    .map_or(0, crate::components::Rider::tag);
                 if let Some(r) = self.world.rider_mut(*rid) {
                     r.phase = RiderPhase::Waiting;
                     r.current_stop = nearest_stop;
@@ -592,6 +613,7 @@ impl Simulation {
                         rider: *rid,
                         elevator: id,
                         stop,
+                        tag,
                         tick: self.tick,
                     });
                 }
@@ -669,12 +691,17 @@ impl Simulation {
         for rid in resident_ids {
             self.rider_index.remove_resident(id, rid);
             self.rider_index.insert_abandoned(id, rid);
+            let tag = self
+                .world
+                .rider(rid)
+                .map_or(0, crate::components::Rider::tag);
             if let Some(r) = self.world.rider_mut(rid) {
                 r.phase = RiderPhase::Abandoned;
             }
             self.events.emit(Event::RiderAbandoned {
                 rider: rid,
                 stop: id,
+                tag,
                 tick: self.tick,
             });
         }
@@ -802,10 +829,15 @@ impl Simulation {
         let group = self.group_from_route(self.world.route(rid));
         self.world
             .set_route(rid, Route::direct(origin, alt_stop, group));
+        let tag = self
+            .world
+            .rider(rid)
+            .map_or(0, crate::components::Rider::tag);
         self.events.emit(Event::RouteInvalidated {
             rider: rid,
             affected_stop: disabled_stop,
             reason: reroute_reason,
+            tag,
             tick: self.tick,
         });
         // For in-car riders, the car's target_stop was just nulled by
@@ -842,10 +874,15 @@ impl Simulation {
             .min_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)))
             .map(|(eid, _)| eid);
 
+        let tag = self
+            .world
+            .rider(rid)
+            .map_or(0, crate::components::Rider::tag);
         self.events.emit(Event::RouteInvalidated {
             rider: rid,
             affected_stop: disabled_stop,
             reason: reroute_reason,
+            tag,
             tick: self.tick,
         });
 
@@ -877,6 +914,7 @@ impl Simulation {
                 rider: rid,
                 elevator: car_eid,
                 stop,
+                tag,
                 tick: self.tick,
             });
         } else {
@@ -892,6 +930,7 @@ impl Simulation {
             self.events.emit(Event::RiderAbandoned {
                 rider: rid,
                 stop: disabled_stop,
+                tag,
                 tick: self.tick,
             });
         }
@@ -926,10 +965,15 @@ impl Simulation {
         reroute_reason: crate::events::RouteInvalidReason,
     ) {
         let abandon_stop = rider_current_stop.unwrap_or(disabled_stop);
+        let tag = self
+            .world
+            .rider(rid)
+            .map_or(0, crate::components::Rider::tag);
         self.events.emit(Event::RouteInvalidated {
             rider: rid,
             affected_stop: disabled_stop,
             reason: reroute_reason,
+            tag,
             tick: self.tick,
         });
         if let Some(r) = self.world.rider_mut(rid) {
@@ -946,6 +990,7 @@ impl Simulation {
         self.events.emit(Event::RiderAbandoned {
             rider: rid,
             stop: abandon_stop,
+            tag,
             tick: self.tick,
         });
     }

--- a/crates/elevator-core/src/sim/rider.rs
+++ b/crates/elevator-core/src/sim/rider.rs
@@ -183,6 +183,7 @@ impl super::Simulation {
             rider: eid,
             origin,
             destination,
+            tag: 0,
             tick: self.tick,
         });
 

--- a/crates/elevator-core/src/systems/advance_transient.rs
+++ b/crates/elevator-core/src/systems/advance_transient.rs
@@ -1,6 +1,6 @@
 //! Phase 1: advance transient rider states and tick patience.
 
-use crate::components::{Patience, RiderPhase, Route, TransportMode};
+use crate::components::{Patience, Rider, RiderPhase, Route, TransportMode};
 use crate::entity::EntityId;
 use crate::events::{Event, EventBus};
 use crate::rider_index::RiderIndex;
@@ -109,10 +109,12 @@ fn handle_exit(
         && let Some(dest) = route.current_destination()
         && world.is_disabled(dest)
     {
+        let tag = world.rider(id).map_or(0, Rider::tag);
         events.emit(Event::RouteInvalidated {
             rider: id,
             affected_stop: dest,
             reason: crate::events::RouteInvalidReason::StopDisabled,
+            tag,
             tick: ctx.tick,
         });
     }
@@ -126,6 +128,7 @@ fn handle_exit(
 ///
 /// These transient states last exactly one tick so they're
 /// visible for one frame in the visualization.
+#[allow(clippy::too_many_lines)]
 pub fn run(
     world: &mut World,
     events: &mut EventBus,
@@ -207,6 +210,7 @@ pub fn run(
         events.emit(Event::RiderAbandoned {
             rider: id,
             stop,
+            tag: world.rider(id).map_or(0, Rider::tag),
             tick: ctx.tick,
         });
     }
@@ -249,6 +253,7 @@ pub fn run(
         events.emit(Event::RiderAbandoned {
             rider: id,
             stop,
+            tag: world.rider(id).map_or(0, Rider::tag),
             tick: ctx.tick,
         });
     }

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -356,6 +356,7 @@ fn apply_actions(
                     car.riders.retain(|r| *r != rider);
                     car.current_load -= rider_weight;
                 }
+                let tag = world.rider(rider).map_or(0, crate::components::Rider::tag);
                 if let Some(rd) = world.rider_mut(rider) {
                     rd.phase = RiderPhase::Exiting(elevator);
                     rd.current_stop = Some(stop);
@@ -364,6 +365,7 @@ fn apply_actions(
                     rider,
                     elevator,
                     stop,
+                    tag,
                     tick: ctx.tick,
                 });
                 // Clear the rider from any CarCall's pending list; drop
@@ -405,6 +407,7 @@ fn apply_actions(
                     car.current_load += crate::components::Weight::from(weight);
                     car.riders.push(rider);
                 }
+                let tag = world.rider(rider).map_or(0, crate::components::Rider::tag);
                 if let Some(rd) = world.rider_mut(rider) {
                     rd.phase = RiderPhase::Boarding(elevator);
                     rd.board_tick = Some(ctx.tick);
@@ -413,6 +416,7 @@ fn apply_actions(
                 events.emit(Event::RiderBoarded {
                     rider,
                     elevator,
+                    tag,
                     tick: ctx.tick,
                 });
                 if let Some(car) = world.elevator(elevator) {
@@ -442,11 +446,13 @@ fn apply_actions(
                 reason,
                 context,
             } => {
+                let tag = world.rider(rider).map_or(0, crate::components::Rider::tag);
                 events.emit(Event::RiderRejected {
                     rider,
                     elevator,
                     reason,
                     context,
+                    tag,
                     tick: ctx.tick,
                 });
             }
@@ -458,10 +464,12 @@ fn apply_actions(
                 elevator,
                 at_stop,
             } => {
+                let tag = world.rider(rider).map_or(0, crate::components::Rider::tag);
                 events.emit(Event::RiderSkipped {
                     rider,
                     elevator,
                     at_stop,
+                    tag,
                     tick: ctx.tick,
                 });
                 // Honor `Preferences::abandon_on_full`: the rider doesn't
@@ -482,6 +490,7 @@ fn apply_actions(
                     events.emit(Event::RiderAbandoned {
                         rider,
                         stop: at_stop,
+                        tag,
                         tick: ctx.tick,
                     });
                 }
@@ -517,10 +526,12 @@ fn register_car_call(
     // signal). CarCall latency can be plumbed through later.
     call.acknowledged_at = Some(tick);
     calls.push(call);
+    let tag = world.rider(rider).map_or(0, crate::components::Rider::tag);
     events.emit(Event::CarButtonPressed {
         car,
         floor,
         rider: Some(rider),
+        tag: Some(tag),
         tick,
     });
 }

--- a/crates/elevator-core/src/tests/event_serde_tests.rs
+++ b/crates/elevator-core/src/tests/event_serde_tests.rs
@@ -33,17 +33,20 @@ fn roundtrip_sim_event_ron() {
             rider: e2,
             origin: e1,
             destination: e3,
+            tag: 0,
             tick: 1,
         },
         Event::RiderBoarded {
             rider: e2,
             elevator: e1,
+            tag: 0,
             tick: 15,
         },
         Event::RiderExited {
             rider: e2,
             elevator: e1,
             stop: e3,
+            tag: 0xDEAD_BEEF,
             tick: 30,
         },
         Event::RiderRejected {
@@ -51,11 +54,13 @@ fn roundtrip_sim_event_ron() {
             elevator: e1,
             reason: RejectionReason::OverCapacity,
             context: None,
+            tag: 0,
             tick: 99,
         },
         Event::RiderAbandoned {
             rider: e2,
             stop: e1,
+            tag: 0xCAFE,
             tick: 50,
         },
     ];

--- a/crates/elevator-core/src/tests/event_tag_tests.rs
+++ b/crates/elevator-core/src/tests/event_tag_tests.rs
@@ -1,0 +1,349 @@
+//! Tag propagation through rider-bearing events.
+//!
+//! [`Rider.tag`](crate::components::Rider::tag) is read at emit time and
+//! attached to every rider-bearing [`Event`] variant. Consumers
+//! correlate events with their own object space without an extra lookup
+//! — and crucially without re-querying the rider after `RiderExited` /
+//! `RiderDespawned`, where the [`RiderId`](crate::entity::RiderId) is
+//! freed before the event fires.
+//!
+//! These tests pin the contract per variant: set a distinguishable tag,
+//! drive the sim into the relevant code path, drain events, and assert
+//! the tag came through. `0` is the reserved untagged sentinel for
+//! riders that never had `set_rider_tag` called on them.
+
+use crate::components::Patience;
+use crate::dispatch::scan::ScanDispatch;
+use crate::entity::ElevatorId;
+use crate::events::{Event, RouteInvalidReason};
+use crate::sim::Simulation;
+use crate::stop::StopId;
+use crate::tests::helpers::default_config;
+
+/// A bit pattern obviously distinct from the `0` untagged sentinel and
+/// from any small accidental value the engine might write.
+const SENTINEL: u64 = 0xDEAD_BEEF_CAFE_F00D;
+
+#[test]
+fn rider_spawned_carries_default_zero_tag() {
+    // RiderSpawned fires inside spawn_rider, before the consumer has a
+    // chance to call set_rider_tag. The tag on this event is therefore
+    // always 0; consumers wanting the tag-on-spawn-event signal should
+    // call set_rider_tag *before* the next step that drains.
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let _rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    let events = sim.drain_events();
+    let spawned = events
+        .iter()
+        .find(|e| matches!(e, Event::RiderSpawned { .. }))
+        .expect("RiderSpawned must fire on spawn_rider");
+    let Event::RiderSpawned { tag, .. } = spawned else {
+        unreachable!()
+    };
+    assert_eq!(*tag, 0, "RiderSpawned for an untagged rider must carry 0");
+}
+
+#[test]
+fn rider_boarded_carries_tag() {
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.set_rider_tag(rider, SENTINEL).unwrap();
+    sim.drain_events();
+
+    let mut found = None;
+    for _ in 0..200 {
+        sim.step();
+        for event in sim.drain_events() {
+            if let Event::RiderBoarded { tag, .. } = event {
+                found = Some(tag);
+                break;
+            }
+        }
+        if found.is_some() {
+            break;
+        }
+    }
+    assert_eq!(
+        found,
+        Some(SENTINEL),
+        "RiderBoarded must carry the tag set before boarding"
+    );
+}
+
+#[test]
+fn rider_exited_carries_tag_sampled_before_free() {
+    // The interesting case: by the time a consumer sees RiderExited the
+    // rider's RiderId may have been freed. The event must carry the
+    // tag inline so the consumer can dispatch correctly without re-
+    // querying.
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.set_rider_tag(rider, SENTINEL).unwrap();
+    sim.drain_events();
+
+    let mut found = None;
+    for _ in 0..400 {
+        sim.step();
+        for event in sim.drain_events() {
+            if let Event::RiderExited { tag, .. } = event {
+                found = Some(tag);
+                break;
+            }
+        }
+        if found.is_some() {
+            break;
+        }
+    }
+    assert_eq!(found, Some(SENTINEL));
+}
+
+#[test]
+fn rider_abandoned_carries_tag() {
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.set_rider_tag(rider, SENTINEL).unwrap();
+    // Force abandonment quickly via a 1-tick patience budget.
+    sim.world_mut().set_patience(
+        rider.entity(),
+        Patience {
+            waited_ticks: 0,
+            max_wait_ticks: 1,
+        },
+    );
+    sim.drain_events();
+
+    let mut found = None;
+    for _ in 0..50 {
+        sim.step();
+        for event in sim.drain_events() {
+            if let Event::RiderAbandoned { tag, .. } = event {
+                found = Some(tag);
+                break;
+            }
+        }
+        if found.is_some() {
+            break;
+        }
+    }
+    assert_eq!(found, Some(SENTINEL));
+}
+
+#[test]
+fn rider_despawned_carries_tag_sampled_before_free() {
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.set_rider_tag(rider, SENTINEL).unwrap();
+    sim.drain_events();
+
+    sim.despawn_rider(rider).unwrap();
+    let despawned = sim
+        .drain_events()
+        .into_iter()
+        .find(|e| matches!(e, Event::RiderDespawned { .. }))
+        .expect("RiderDespawned must fire on despawn_rider");
+    let Event::RiderDespawned { tag, .. } = despawned else {
+        unreachable!()
+    };
+    assert_eq!(tag, SENTINEL);
+}
+
+#[test]
+fn rider_settled_carries_tag() {
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.set_rider_tag(rider, SENTINEL).unwrap();
+    for _ in 0..400 {
+        sim.step();
+        if sim
+            .world()
+            .rider(rider.entity())
+            .is_some_and(|r| r.phase == crate::components::RiderPhase::Arrived)
+        {
+            break;
+        }
+    }
+    sim.drain_events();
+    sim.settle_rider(rider).unwrap();
+    let settled = sim
+        .drain_events()
+        .into_iter()
+        .find(|e| matches!(e, Event::RiderSettled { .. }))
+        .expect("RiderSettled must fire after settle_rider");
+    let Event::RiderSettled { tag, .. } = settled else {
+        unreachable!()
+    };
+    assert_eq!(tag, SENTINEL);
+}
+
+#[test]
+fn rider_rerouted_carries_tag() {
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.set_rider_tag(rider, SENTINEL).unwrap();
+    sim.drain_events();
+
+    // Reroute mid-Waiting (rider hasn't boarded yet — they're still at
+    // the origin stop).
+    let stop_1 = sim.stop_entity(StopId(1)).unwrap();
+    sim.reroute(rider, stop_1).unwrap();
+    let rerouted = sim
+        .drain_events()
+        .into_iter()
+        .find(|e| matches!(e, Event::RiderRerouted { .. }))
+        .expect("RiderRerouted must fire after reroute");
+    let Event::RiderRerouted { tag, .. } = rerouted else {
+        unreachable!()
+    };
+    assert_eq!(tag, SENTINEL);
+}
+
+#[test]
+fn route_invalidated_carries_tag() {
+    // Disabling a stop on a rider's route emits RouteInvalidated. The
+    // tag must come through.
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.set_rider_tag(rider, SENTINEL).unwrap();
+    sim.drain_events();
+
+    let dest = sim.stop_entity(StopId(2)).unwrap();
+    sim.disable(dest).unwrap();
+    sim.step();
+    let mut found = None;
+    for event in sim.drain_events() {
+        if let Event::RouteInvalidated { tag, reason, .. } = event {
+            found = Some((tag, reason));
+            break;
+        }
+    }
+    assert!(matches!(
+        found,
+        Some((SENTINEL, RouteInvalidReason::StopDisabled))
+    ));
+}
+
+#[test]
+fn untagged_rider_yields_zero_in_every_event() {
+    // Defensive: a rider that never had set_rider_tag called must
+    // surface tag = 0 in every variant we hit. Combined with the
+    // per-variant tests above, this rules out a bug where the engine
+    // accidentally uses some other rider's tag.
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let _rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+
+    for _ in 0..400 {
+        sim.step();
+        for event in sim.drain_events() {
+            let tag = match event {
+                Event::RiderSpawned { tag, .. }
+                | Event::RiderBoarded { tag, .. }
+                | Event::RiderExited { tag, .. }
+                | Event::RiderRejected { tag, .. }
+                | Event::RiderAbandoned { tag, .. }
+                | Event::RiderEjected { tag, .. }
+                | Event::RiderSettled { tag, .. }
+                | Event::RiderDespawned { tag, .. }
+                | Event::RiderRerouted { tag, .. }
+                | Event::RiderSkipped { tag, .. }
+                | Event::RouteInvalidated { tag, .. } => Some(tag),
+                Event::CarButtonPressed { tag, .. } => tag,
+                _ => None,
+            };
+            if let Some(t) = tag {
+                assert_eq!(t, 0, "untagged rider must surface tag=0 on every event");
+            }
+        }
+    }
+}
+
+#[test]
+fn synthetic_car_button_press_has_none_tag() {
+    // CarButtonPressed for a synthetic press has rider = None, and per
+    // the contract must therefore have tag = None — there is no rider
+    // to read the tag from.
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let car_eid = sim.world().iter_elevators().next().unwrap().0;
+    let car = ElevatorId::from(car_eid);
+    let floor = sim.stop_entity(StopId(2)).unwrap();
+    sim.press_car_button(car, floor).unwrap();
+    let pressed = sim
+        .drain_events()
+        .into_iter()
+        .find(|e| matches!(e, Event::CarButtonPressed { .. }))
+        .expect("synthetic press must emit CarButtonPressed");
+    let Event::CarButtonPressed { rider, tag, .. } = pressed else {
+        unreachable!()
+    };
+    assert!(rider.is_none(), "synthetic press must have rider = None");
+    assert!(
+        tag.is_none(),
+        "synthetic press must have tag = None to mirror the absent rider"
+    );
+}
+
+#[test]
+fn rider_ejected_carries_tag() {
+    // Disabling an elevator with a rider aboard ejects them; the event
+    // must carry the rider's tag.
+    let mut sim = Simulation::new(&default_config(), ScanDispatch::new()).unwrap();
+    let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.set_rider_tag(rider, SENTINEL).unwrap();
+
+    let car_eid = sim.world().iter_elevators().next().unwrap().0;
+    let aboard = (0..200).any(|_| {
+        sim.step();
+        sim.world()
+            .elevator(car_eid)
+            .is_some_and(|c| c.riders.contains(&rider.entity()))
+    });
+    assert!(aboard, "rider should board within 200 ticks");
+    sim.drain_events();
+
+    sim.disable(car_eid).unwrap();
+    let ejected = sim
+        .drain_events()
+        .into_iter()
+        .find(|e| matches!(e, Event::RiderEjected { .. }))
+        .expect("RiderEjected must fire when an occupied car is disabled");
+    let Event::RiderEjected { tag, .. } = ejected else {
+        unreachable!()
+    };
+    assert_eq!(tag, SENTINEL);
+}
+
+#[test]
+fn rider_skipped_or_rejected_carries_tag() {
+    // Force a tagged rider into a Reject/Skip path by capping the car
+    // capacity below two riders' combined weight, then asserting the
+    // tag comes through whichever event fires.
+    let mut config = default_config();
+    config.elevators[0].weight_capacity = crate::components::Weight::from(80.0);
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+    let _filler = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    let blocked = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.set_rider_tag(blocked, SENTINEL).unwrap();
+
+    let mut found_tag = None;
+    for _ in 0..400 {
+        sim.step();
+        for event in sim.drain_events() {
+            match event {
+                Event::RiderRejected { tag, rider, .. }
+                | Event::RiderSkipped { tag, rider, .. }
+                    if rider == blocked.entity() =>
+                {
+                    found_tag = Some(tag);
+                }
+                _ => {}
+            }
+        }
+        if found_tag.is_some() {
+            break;
+        }
+    }
+    assert_eq!(
+        found_tag,
+        Some(SENTINEL),
+        "Reject/Skip for tagged rider must carry the tag"
+    );
+}

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -60,6 +60,7 @@ mod eta_tests;
 mod etd_age_weight_tests;
 mod etd_mutant_tests;
 mod event_payload_tests;
+mod event_tag_tests;
 mod fp_tests;
 mod hall_call_tests;
 mod home_stop_tests;

--- a/crates/elevator-core/src/tests/phase_helpers_tests.rs
+++ b/crates/elevator-core/src/tests/phase_helpers_tests.rs
@@ -104,6 +104,7 @@ fn event_category_classifies_representative_variants() {
         Event::RiderBoarded {
             rider: e,
             elevator: e,
+            tag: 0,
             tick: 0
         }
         .category(),

--- a/crates/elevator-ffi/include/elevator_ffi.h
+++ b/crates/elevator-ffi/include/elevator_ffi.h
@@ -17,11 +17,18 @@
 /**
  * Current ABI version. Bumped for any breaking change to the C layout.
  *
+ * **v5:** [`EvEvent`] gained a `tag` field carrying the opaque
+ * per-rider tag (`Rider.tag`) for every rider-bearing event variant.
+ * Consumers that want the back-pointer pattern this enables (set via
+ * [`ev_sim_set_rider_tag`], read on [`ev_event_kind::RIDER_EXITED`] /
+ * [`ev_event_kind::RIDER_DESPAWNED`] without re-querying a freed
+ * rider) need to rebuild against v5.
+ *
  * **v4** widened [`EvEvent`] from 7 fields to 14 to carry the full
  * payload of every core `Event` variant in a single drain pass. The
  * kind discriminator was extended from 9 known kinds to 49.
  */
-#define EV_ABI_VERSION 4
+#define EV_ABI_VERSION 5
 
 /**
  * `Event::HallButtonPressed`. Fields: `stop`, `direction` (`1` =
@@ -894,6 +901,19 @@ typedef struct EvEvent {
      * kJ) and `CapacityChanged` (capacity).
      */
     double f2;
+    /**
+     * Opaque consumer tag for the rider involved in this event,
+     * mirroring [`Rider::tag()`](elevator_core::components::Rider::tag).
+     * Populated for every rider-bearing variant — `RiderSpawned`,
+     * `RiderBoarded`, `RiderExited`, `RiderRejected`, `RiderAbandoned`,
+     * `RiderEjected`, `RiderSettled`, `RiderDespawned`, `RiderRerouted`,
+     * `RiderSkipped`, `RouteInvalidated`, plus `CarButtonPressed` when
+     * the press came from a real rider. `0` when not applicable
+     * (non-rider event, or rider untagged, or synthetic
+     * [`CarButtonPressed`](ev_event_kind::CAR_BUTTON_PRESSED) with no
+     * associated rider).
+     */
+    uint64_t tag;
 } EvEvent;
 
 /**

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -49,10 +49,17 @@ use slotmap::{Key, KeyData};
 
 /// Current ABI version. Bumped for any breaking change to the C layout.
 ///
+/// **v5:** [`EvEvent`] gained a `tag` field carrying the opaque
+/// per-rider tag (`Rider.tag`) for every rider-bearing event variant.
+/// Consumers that want the back-pointer pattern this enables (set via
+/// [`ev_sim_set_rider_tag`], read on [`ev_event_kind::RIDER_EXITED`] /
+/// [`ev_event_kind::RIDER_DESPAWNED`] without re-querying a freed
+/// rider) need to rebuild against v5.
+///
 /// **v4** widened [`EvEvent`] from 7 fields to 14 to carry the full
 /// payload of every core `Event` variant in a single drain pass. The
 /// kind discriminator was extended from 9 known kinds to 49.
-pub const EV_ABI_VERSION: u32 = 4;
+pub const EV_ABI_VERSION: u32 = 5;
 
 /// Return the ABI version compiled into this shared library.
 #[unsafe(no_mangle)]
@@ -1827,6 +1834,17 @@ pub struct EvEvent {
     /// Secondary float payload. Used by `EnergyConsumed` (regenerated
     /// kJ) and `CapacityChanged` (capacity).
     pub f2: f64,
+    /// Opaque consumer tag for the rider involved in this event,
+    /// mirroring [`Rider::tag()`](elevator_core::components::Rider::tag).
+    /// Populated for every rider-bearing variant — `RiderSpawned`,
+    /// `RiderBoarded`, `RiderExited`, `RiderRejected`, `RiderAbandoned`,
+    /// `RiderEjected`, `RiderSettled`, `RiderDespawned`, `RiderRerouted`,
+    /// `RiderSkipped`, `RouteInvalidated`, plus `CarButtonPressed` when
+    /// the press came from a real rider. `0` when not applicable
+    /// (non-rider event, or rider untagged, or synthetic
+    /// [`CarButtonPressed`](ev_event_kind::CAR_BUTTON_PRESSED) with no
+    /// associated rider).
+    pub tag: u64,
 }
 
 /// Drain pending events into `out`.
@@ -1977,12 +1995,14 @@ fn refill_pending_events(ev: &mut EvSim) {
                 car,
                 floor,
                 rider,
+                tag,
                 tick,
             } => {
                 let mut e = ev_event_skeleton(ev_event_kind::CAR_BUTTON_PRESSED, tick);
                 e.car = entity_to_u64(car);
                 e.rider = rider.map_or(0, entity_to_u64);
                 e.floor = entity_to_u64(floor);
+                e.tag = tag.unwrap_or(0);
                 e
             }
             // ── Rider lifecycle ──────────────────────────────────────
@@ -1990,64 +2010,80 @@ fn refill_pending_events(ev: &mut EvSim) {
                 rider,
                 elevator,
                 at_stop,
+                tag,
                 tick,
             } => {
                 let mut e = ev_event_skeleton(ev_event_kind::RIDER_SKIPPED, tick);
                 e.stop = entity_to_u64(at_stop);
                 e.car = entity_to_u64(elevator);
                 e.rider = entity_to_u64(rider);
+                e.tag = tag;
                 e
             }
             Event::RiderSpawned {
                 rider,
                 origin,
                 destination,
+                tag,
                 tick,
             } => {
                 let mut e = ev_event_skeleton(ev_event_kind::RIDER_SPAWNED, tick);
                 e.stop = entity_to_u64(origin);
                 e.rider = entity_to_u64(rider);
                 e.floor = entity_to_u64(destination);
+                e.tag = tag;
                 e
             }
             Event::RiderBoarded {
                 rider,
                 elevator,
+                tag,
                 tick,
             } => {
                 let mut e = ev_event_skeleton(ev_event_kind::RIDER_BOARDED, tick);
                 e.car = entity_to_u64(elevator);
                 e.rider = entity_to_u64(rider);
+                e.tag = tag;
                 e
             }
             Event::RiderExited {
                 rider,
                 elevator,
                 stop,
+                tag,
                 tick,
             } => {
                 let mut e = ev_event_skeleton(ev_event_kind::RIDER_EXITED, tick);
                 e.stop = entity_to_u64(stop);
                 e.car = entity_to_u64(elevator);
                 e.rider = entity_to_u64(rider);
+                e.tag = tag;
                 e
             }
-            Event::RiderAbandoned { rider, stop, tick } => {
+            Event::RiderAbandoned {
+                rider,
+                stop,
+                tag,
+                tick,
+            } => {
                 let mut e = ev_event_skeleton(ev_event_kind::RIDER_ABANDONED, tick);
                 e.stop = entity_to_u64(stop);
                 e.rider = entity_to_u64(rider);
+                e.tag = tag;
                 e
             }
             Event::RiderEjected {
                 rider,
                 elevator,
                 stop,
+                tag,
                 tick,
             } => {
                 let mut e = ev_event_skeleton(ev_event_kind::RIDER_EJECTED, tick);
                 e.stop = entity_to_u64(stop);
                 e.car = entity_to_u64(elevator);
                 e.rider = entity_to_u64(rider);
+                e.tag = tag;
                 e
             }
             Event::RiderRejected {
@@ -2055,6 +2091,7 @@ fn refill_pending_events(ev: &mut EvSim) {
                 elevator,
                 reason,
                 context,
+                tag,
                 tick,
             } => {
                 let mut e = ev_event_skeleton(ev_event_kind::RIDER_REJECTED, tick);
@@ -2070,39 +2107,51 @@ fn refill_pending_events(ev: &mut EvSim) {
                 });
                 e.f1 = attempted;
                 e.f2 = load;
+                e.tag = tag;
                 e
             }
             Event::RiderRerouted {
                 rider,
                 new_destination,
+                tag,
                 tick,
             } => {
                 let mut e = ev_event_skeleton(ev_event_kind::RIDER_REROUTED, tick);
                 e.rider = entity_to_u64(rider);
                 e.floor = entity_to_u64(new_destination);
+                e.tag = tag;
                 e
             }
-            Event::RiderSettled { rider, stop, tick } => {
+            Event::RiderSettled {
+                rider,
+                stop,
+                tag,
+                tick,
+            } => {
                 let mut e = ev_event_skeleton(ev_event_kind::RIDER_SETTLED, tick);
                 e.stop = entity_to_u64(stop);
                 e.rider = entity_to_u64(rider);
+                e.tag = tag;
                 e
             }
-            Event::RiderDespawned { rider, tick } => {
+            Event::RiderDespawned { rider, tag, tick } => {
                 let mut e = ev_event_skeleton(ev_event_kind::RIDER_DESPAWNED, tick);
                 e.rider = entity_to_u64(rider);
+                e.tag = tag;
                 e
             }
             Event::RouteInvalidated {
                 rider,
                 affected_stop,
                 reason,
+                tag,
                 tick,
             } => {
                 let mut e = ev_event_skeleton(ev_event_kind::ROUTE_INVALIDATED, tick);
                 e.rider = entity_to_u64(rider);
                 e.stop = entity_to_u64(affected_stop);
                 e.code1 = encode_route_invalid_reason(reason);
+                e.tag = tag;
                 e
             }
             // ── Elevator motion ──────────────────────────────────────
@@ -2729,6 +2778,7 @@ const fn ev_event_skeleton(kind: u8, tick: u64) -> EvEvent {
         count: 0,
         f1: 0.0,
         f2: 0.0,
+        tag: 0,
     }
 }
 
@@ -6866,7 +6916,7 @@ mod tests {
     #[test]
     fn abi_version_matches_constant() {
         assert_eq!(ev_abi_version(), EV_ABI_VERSION);
-        assert_eq!(EV_ABI_VERSION, 4);
+        assert_eq!(EV_ABI_VERSION, 5);
     }
 
     #[test]
@@ -7064,6 +7114,7 @@ mod tests {
                 count: 0,
                 f1: 0.0,
                 f2: 0.0,
+                tag: 0,
             }; 64];
             let mut written: u32 = 0;
             let status = unsafe {
@@ -7136,6 +7187,7 @@ mod tests {
             count: 0,
             f1: 0.0,
             f2: 0.0,
+            tag: 0,
         }; 2];
         let mut first_written: u32 = 0;
         assert_eq!(
@@ -7169,6 +7221,7 @@ mod tests {
                 count: 0,
                 f1: 0.0,
                 f2: 0.0,
+                tag: 0,
             };
             (still_pending + 8) as usize
         ];
@@ -7286,6 +7339,7 @@ mod tests {
                 count: 0,
                 f1: 0.0,
                 f2: 0.0,
+                tag: 0,
             }; 128];
             let mut written: u32 = 0;
             assert_eq!(
@@ -7655,6 +7709,59 @@ mod tests {
                 .iter()
                 .any(|e| e.kind == ev_event_kind::RIDER_EXITED && e.rider == rider_id),
             "should see RIDER_EXITED",
+        );
+
+        unsafe { ev_sim_destroy(handle) };
+    }
+
+    /// `EvEvent.tag` (ABI v5) carries `Rider.tag` for every rider event,
+    /// sampled before the rider's slot is freed. Pin the contract from
+    /// the C side: set a tag, drain across a full lifecycle, assert it
+    /// shows up on every rider-bearing event we observe.
+    #[test]
+    fn drained_events_carry_rider_tag() {
+        const SENTINEL: u64 = 0xCAFE_F00D;
+
+        let handle = create_test_handle();
+        let (origin, dest) = stop_entities(handle);
+
+        let mut rider_id: u64 = 0;
+        assert_eq!(
+            unsafe { ev_sim_spawn_rider(handle, origin, dest, 80.0, &raw mut rider_id) },
+            EvStatus::Ok,
+        );
+
+        // Tag *after* spawn — RiderSpawned fired with tag = 0; every
+        // subsequent rider-bearing event must surface SENTINEL.
+        assert_eq!(
+            unsafe { ev_sim_set_rider_tag(handle, rider_id, SENTINEL) },
+            EvStatus::Ok,
+        );
+
+        for _ in 0..3000 {
+            assert_eq!(unsafe { ev_sim_step(handle) }, EvStatus::Ok);
+        }
+        let events = drain_all_events(handle);
+
+        let rider_kinds = [
+            ev_event_kind::RIDER_BOARDED,
+            ev_event_kind::RIDER_EXITED,
+            ev_event_kind::CAR_BUTTON_PRESSED,
+        ];
+        let mut saw_any_with_tag = false;
+        for event in &events {
+            if event.rider == rider_id && rider_kinds.contains(&event.kind) {
+                assert_eq!(
+                    event.tag, SENTINEL,
+                    "rider-bearing event kind {} for our rider must carry the sentinel tag",
+                    event.kind,
+                );
+                saw_any_with_tag = true;
+            }
+        }
+        assert!(
+            saw_any_with_tag,
+            "should observe at least one rider-bearing event for our rider",
         );
 
         unsafe { ev_sim_destroy(handle) };

--- a/crates/elevator-gdext/src/sim_node.rs
+++ b/crates/elevator-gdext/src/sim_node.rs
@@ -487,6 +487,7 @@ impl ElevatorSim {
                     rider,
                     origin,
                     destination,
+                    tag,
                     tick,
                 } => dict! {
                     "kind" => "RiderSpawned",
@@ -494,21 +495,25 @@ impl ElevatorSim {
                     "rider" => rider.data().as_ffi() as i64,
                     "stop" => origin.data().as_ffi() as i64,
                     "destination" => destination.data().as_ffi() as i64,
+                    "tag" => tag as i64,
                 },
                 Event::RiderBoarded {
                     rider,
                     elevator,
+                    tag,
                     tick,
                 } => dict! {
                     "kind" => "RiderBoarded",
                     "tick" => tick as i64,
                     "rider" => rider.data().as_ffi() as i64,
                     "elevator" => elevator.data().as_ffi() as i64,
+                    "tag" => tag as i64,
                 },
                 Event::RiderExited {
                     rider,
                     elevator,
                     stop,
+                    tag,
                     tick,
                 } => dict! {
                     "kind" => "RiderExited",
@@ -516,17 +521,25 @@ impl ElevatorSim {
                     "rider" => rider.data().as_ffi() as i64,
                     "elevator" => elevator.data().as_ffi() as i64,
                     "stop" => stop.data().as_ffi() as i64,
+                    "tag" => tag as i64,
                 },
-                Event::RiderAbandoned { rider, stop, tick } => dict! {
+                Event::RiderAbandoned {
+                    rider,
+                    stop,
+                    tag,
+                    tick,
+                } => dict! {
                     "kind" => "RiderAbandoned",
                     "tick" => tick as i64,
                     "rider" => rider.data().as_ffi() as i64,
                     "stop" => stop.data().as_ffi() as i64,
+                    "tag" => tag as i64,
                 },
                 Event::RiderSkipped {
                     rider,
                     elevator,
                     at_stop,
+                    tag,
                     tick,
                 } => dict! {
                     "kind" => "RiderSkipped",
@@ -534,6 +547,7 @@ impl ElevatorSim {
                     "rider" => rider.data().as_ffi() as i64,
                     "elevator" => elevator.data().as_ffi() as i64,
                     "stop" => at_stop.data().as_ffi() as i64,
+                    "tag" => tag as i64,
                 },
                 Event::HallButtonPressed { stop, tick, .. } => dict! {
                     "kind" => "HallButtonPressed",

--- a/crates/elevator-wasm/src/dto.rs
+++ b/crates/elevator-wasm/src/dto.rs
@@ -443,73 +443,102 @@ impl From<&elevator_core::components::CarCall> for CarCallDto {
 #[serde(tag = "kind", rename_all = "kebab-case")]
 pub enum EventDto {
     // ── Rider lifecycle ─────────────────────────────────────────────
+    /// `tag` mirrors the rider's opaque consumer tag at emit time. `0`
+    /// means untagged. Set via [`WasmSim::set_rider_tag`] —
+    /// see that method for the back-pointer pattern this enables.
     RiderSpawned {
         tick: u64,
         rider: u32,
         origin: u32,
         destination: u32,
+        tag: u64,
     },
+    /// `tag` mirrors the rider's opaque consumer tag at emit time. `0`
+    /// means untagged.
     RiderBoarded {
         tick: u64,
         rider: u32,
         elevator: u32,
+        tag: u64,
     },
+    /// `tag` mirrors the rider's opaque consumer tag, sampled before the
+    /// rider is freed so consumers can correlate the exit with external
+    /// state. `0` means untagged.
     RiderExited {
         tick: u64,
         rider: u32,
         elevator: u32,
         stop: u32,
+        tag: u64,
     },
     /// A rider was rejected from boarding (e.g., over capacity, access
     /// denied). `reason` is a kebab-case label drawn from
-    /// [`elevator_core::error::RejectionReason`].
+    /// [`elevator_core::error::RejectionReason`]. `tag` mirrors the
+    /// rider's opaque consumer tag; `0` means untagged.
     RiderRejected {
         tick: u64,
         rider: u32,
         elevator: u32,
         reason: String,
+        tag: u64,
     },
+    /// `tag` mirrors the rider's opaque consumer tag, sampled before the
+    /// rider is freed. `0` means untagged.
     RiderAbandoned {
         tick: u64,
         rider: u32,
         stop: u32,
+        tag: u64,
     },
-    /// A rider was ejected from a disabled / removed elevator.
+    /// A rider was ejected from a disabled / removed elevator. `tag`
+    /// mirrors the rider's opaque consumer tag; `0` means untagged.
     RiderEjected {
         tick: u64,
         rider: u32,
         elevator: u32,
         stop: u32,
+        tag: u64,
     },
+    /// `tag` mirrors the rider's opaque consumer tag; `0` means untagged.
     RiderSettled {
         tick: u64,
         rider: u32,
         stop: u32,
+        tag: u64,
     },
+    /// `tag` mirrors the rider's opaque consumer tag, sampled before the
+    /// rider is freed. `0` means untagged.
     RiderDespawned {
         tick: u64,
         rider: u32,
+        tag: u64,
     },
     /// A rider was rerouted via `sim.reroute()` or `sim.reroute_rider()`.
+    /// `tag` mirrors the rider's opaque consumer tag; `0` means untagged.
     RiderRerouted {
         tick: u64,
         rider: u32,
         new_destination: u32,
+        tag: u64,
     },
-    /// A rider skipped a car they considered too crowded.
+    /// A rider skipped a car they considered too crowded. `tag` mirrors
+    /// the rider's opaque consumer tag; `0` means untagged.
     RiderSkipped {
         tick: u64,
         rider: u32,
         elevator: u32,
         at_stop: u32,
+        tag: u64,
     },
     /// A rider's route was invalidated by topology change. `reason` is
-    /// `"stop-disabled"`, `"stop-removed"`, or `"no-alternative"`.
+    /// `"stop-disabled"`, `"stop-removed"`, or `"no-alternative"`. `tag`
+    /// mirrors the rider's opaque consumer tag; `0` means untagged.
     RouteInvalidated {
         tick: u64,
         rider: u32,
         affected_stop: u32,
         reason: String,
+        tag: u64,
     },
 
     // ── Elevator motion + doors ─────────────────────────────────────
@@ -590,11 +619,15 @@ pub enum EventDto {
         car: u32,
     },
     /// `rider` is `None` when the press is synthetic (scripted).
+    /// `tag` mirrors the pressing rider's opaque consumer tag and is
+    /// `None` whenever `rider` is `None`. `Some(0)` means a present but
+    /// untagged rider.
     CarButtonPressed {
         tick: u64,
         car: u32,
         floor: u32,
         rider: Option<u32>,
+        tag: Option<u64>,
     },
     DestinationQueued {
         tick: u64,
@@ -778,99 +811,128 @@ impl From<Event> for EventDto {
                 rider,
                 origin,
                 destination,
+                tag,
             } => Self::RiderSpawned {
                 tick,
                 rider: entity_to_u32(rider),
                 origin: entity_to_u32(origin),
                 destination: entity_to_u32(destination),
+                tag,
             },
             Event::RiderBoarded {
                 tick,
                 rider,
                 elevator,
+                tag,
             } => Self::RiderBoarded {
                 tick,
                 rider: entity_to_u32(rider),
                 elevator: entity_to_u32(elevator),
+                tag,
             },
             Event::RiderExited {
                 tick,
                 rider,
                 elevator,
                 stop,
+                tag,
             } => Self::RiderExited {
                 tick,
                 rider: entity_to_u32(rider),
                 elevator: entity_to_u32(elevator),
                 stop: entity_to_u32(stop),
+                tag,
             },
             Event::RiderRejected {
                 tick,
                 rider,
                 elevator,
                 reason,
+                tag,
                 ..
             } => Self::RiderRejected {
                 tick,
                 rider: entity_to_u32(rider),
                 elevator: entity_to_u32(elevator),
                 reason: rejection_label(reason).to_string(),
+                tag,
             },
-            Event::RiderAbandoned { tick, rider, stop } => Self::RiderAbandoned {
+            Event::RiderAbandoned {
+                tick,
+                rider,
+                stop,
+                tag,
+            } => Self::RiderAbandoned {
                 tick,
                 rider: entity_to_u32(rider),
                 stop: entity_to_u32(stop),
+                tag,
             },
             Event::RiderEjected {
                 tick,
                 rider,
                 elevator,
                 stop,
+                tag,
             } => Self::RiderEjected {
                 tick,
                 rider: entity_to_u32(rider),
                 elevator: entity_to_u32(elevator),
                 stop: entity_to_u32(stop),
+                tag,
             },
-            Event::RiderSettled { tick, rider, stop } => Self::RiderSettled {
+            Event::RiderSettled {
+                tick,
+                rider,
+                stop,
+                tag,
+            } => Self::RiderSettled {
                 tick,
                 rider: entity_to_u32(rider),
                 stop: entity_to_u32(stop),
+                tag,
             },
-            Event::RiderDespawned { tick, rider } => Self::RiderDespawned {
+            Event::RiderDespawned { tick, rider, tag } => Self::RiderDespawned {
                 tick,
                 rider: entity_to_u32(rider),
+                tag,
             },
             Event::RiderRerouted {
                 tick,
                 rider,
                 new_destination,
+                tag,
             } => Self::RiderRerouted {
                 tick,
                 rider: entity_to_u32(rider),
                 new_destination: entity_to_u32(new_destination),
+                tag,
             },
             Event::RiderSkipped {
                 tick,
                 rider,
                 elevator,
                 at_stop,
+                tag,
             } => Self::RiderSkipped {
                 tick,
                 rider: entity_to_u32(rider),
                 elevator: entity_to_u32(elevator),
                 at_stop: entity_to_u32(at_stop),
+                tag,
             },
             Event::RouteInvalidated {
                 tick,
                 rider,
                 affected_stop,
                 reason,
+                tag,
             } => Self::RouteInvalidated {
                 tick,
                 rider: entity_to_u32(rider),
                 affected_stop: entity_to_u32(affected_stop),
                 reason: route_invalid_label(reason).to_string(),
+                tag,
             },
 
             // ── Elevator motion + doors ─────────────────────────────
@@ -992,11 +1054,13 @@ impl From<Event> for EventDto {
                 car,
                 floor,
                 rider,
+                tag,
             } => Self::CarButtonPressed {
                 tick,
                 car: entity_to_u32(car),
                 floor: entity_to_u32(floor),
                 rider: rider.map(entity_to_u32),
+                tag,
             },
             Event::DestinationQueued {
                 tick,

--- a/crates/elevator-wasm/src/dto.rs
+++ b/crates/elevator-wasm/src/dto.rs
@@ -434,204 +434,314 @@ impl From<&elevator_core::components::CarCall> for CarCallDto {
     }
 }
 
-/// Flattened event DTO. Every variant includes a `kind` discriminator and the
-/// engine tick at which it was emitted; the remaining fields vary by kind.
-/// Unknown variants (added to core later) fall back to `{ kind: "unknown" }`
+/// Flattened event DTO.
+///
+/// Every variant includes a `kind` discriminator and the engine tick at
+/// which it was emitted; the remaining fields vary by kind. Unknown
+/// variants (added to core later) fall back to `{ kind: "unknown" }`
 /// so the UI stays forward-compatible.
 #[derive(Serialize, Tsify)]
 #[tsify(into_wasm_abi)]
 #[serde(tag = "kind", rename_all = "kebab-case")]
 pub enum EventDto {
     // ── Rider lifecycle ─────────────────────────────────────────────
-    /// `tag` mirrors the rider's opaque consumer tag at emit time. `0`
-    /// means untagged. Set via [`WasmSim::set_rider_tag`] —
-    /// see that method for the back-pointer pattern this enables.
+    /// A new rider appeared at a stop. `tag` mirrors the rider's opaque
+    /// consumer tag at emit time (`0` means untagged); set via
+    /// [`WasmSim::set_rider_tag`] for the back-pointer pattern.
     RiderSpawned {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the rider entity.
         rider: u32,
+        /// Slotmap slot id of the origin stop.
         origin: u32,
+        /// Slotmap slot id of the destination stop.
         destination: u32,
+        /// Opaque consumer tag carried by the rider; `0` if untagged.
         tag: u64,
     },
-    /// `tag` mirrors the rider's opaque consumer tag at emit time. `0`
-    /// means untagged.
+    /// A rider boarded an elevator. `tag` mirrors the rider's opaque
+    /// consumer tag; `0` means untagged.
     RiderBoarded {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the rider entity.
         rider: u32,
+        /// Slotmap slot id of the elevator boarded.
         elevator: u32,
+        /// Opaque consumer tag carried by the rider; `0` if untagged.
         tag: u64,
     },
-    /// `tag` mirrors the rider's opaque consumer tag, sampled before the
-    /// rider is freed so consumers can correlate the exit with external
-    /// state. `0` means untagged.
+    /// A rider exited an elevator at their destination. `tag` is
+    /// sampled before the rider is freed so consumers can correlate
+    /// the exit with external state; `0` means untagged.
     RiderExited {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the rider entity (now stale).
         rider: u32,
+        /// Slotmap slot id of the elevator the rider exited.
         elevator: u32,
+        /// Slotmap slot id of the stop the rider exited at.
         stop: u32,
+        /// Opaque consumer tag carried by the rider; `0` if untagged.
         tag: u64,
     },
     /// A rider was rejected from boarding (e.g., over capacity, access
-    /// denied). `reason` is a kebab-case label drawn from
-    /// [`elevator_core::error::RejectionReason`]. `tag` mirrors the
-    /// rider's opaque consumer tag; `0` means untagged.
+    /// denied). `tag` mirrors the rider's opaque consumer tag; `0`
+    /// means untagged.
     RiderRejected {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the rider entity.
         rider: u32,
+        /// Slotmap slot id of the elevator that rejected the rider.
         elevator: u32,
+        /// Kebab-case label drawn from
+        /// [`elevator_core::error::RejectionReason`].
         reason: String,
+        /// Opaque consumer tag carried by the rider; `0` if untagged.
         tag: u64,
     },
-    /// `tag` mirrors the rider's opaque consumer tag, sampled before the
-    /// rider is freed. `0` means untagged.
+    /// A rider gave up waiting and left the stop. `tag` is sampled
+    /// before the rider is freed; `0` means untagged.
     RiderAbandoned {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the rider entity (now stale).
         rider: u32,
+        /// Slotmap slot id of the stop the rider abandoned.
         stop: u32,
+        /// Opaque consumer tag carried by the rider; `0` if untagged.
         tag: u64,
     },
     /// A rider was ejected from a disabled / removed elevator. `tag`
     /// mirrors the rider's opaque consumer tag; `0` means untagged.
     RiderEjected {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the rider entity.
         rider: u32,
+        /// Slotmap slot id of the elevator the rider was ejected from.
         elevator: u32,
+        /// Slotmap slot id of the stop the rider was placed at.
         stop: u32,
+        /// Opaque consumer tag carried by the rider; `0` if untagged.
         tag: u64,
     },
-    /// `tag` mirrors the rider's opaque consumer tag; `0` means untagged.
+    /// A rider settled at a stop, becoming a resident. `tag` mirrors
+    /// the rider's opaque consumer tag; `0` means untagged.
     RiderSettled {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the rider entity.
         rider: u32,
+        /// Slotmap slot id of the stop the rider settled at.
         stop: u32,
+        /// Opaque consumer tag carried by the rider; `0` if untagged.
         tag: u64,
     },
-    /// `tag` mirrors the rider's opaque consumer tag, sampled before the
-    /// rider is freed. `0` means untagged.
+    /// A rider was removed from the simulation. `tag` is sampled
+    /// before the rider is freed; `0` means untagged.
     RiderDespawned {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the rider entity (now stale).
         rider: u32,
+        /// Opaque consumer tag carried by the rider; `0` if untagged.
         tag: u64,
     },
     /// A rider was rerouted via `sim.reroute()` or `sim.reroute_rider()`.
     /// `tag` mirrors the rider's opaque consumer tag; `0` means untagged.
     RiderRerouted {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the rider entity.
         rider: u32,
+        /// Slotmap slot id of the new destination stop.
         new_destination: u32,
+        /// Opaque consumer tag carried by the rider; `0` if untagged.
         tag: u64,
     },
-    /// A rider skipped a car they considered too crowded. `tag` mirrors
-    /// the rider's opaque consumer tag; `0` means untagged.
+    /// A rider skipped a car they considered too crowded. `tag`
+    /// mirrors the rider's opaque consumer tag; `0` means untagged.
     RiderSkipped {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the rider entity.
         rider: u32,
+        /// Slotmap slot id of the elevator they declined to board.
         elevator: u32,
+        /// Slotmap slot id of the stop where the skip happened.
         at_stop: u32,
+        /// Opaque consumer tag carried by the rider; `0` if untagged.
         tag: u64,
     },
-    /// A rider's route was invalidated by topology change. `reason` is
-    /// `"stop-disabled"`, `"stop-removed"`, or `"no-alternative"`. `tag`
+    /// A rider's route was invalidated by topology change. `tag`
     /// mirrors the rider's opaque consumer tag; `0` means untagged.
     RouteInvalidated {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the affected rider.
         rider: u32,
+        /// Slotmap slot id of the stop that caused the invalidation.
         affected_stop: u32,
+        /// One of `"stop-disabled"`, `"stop-removed"`, or
+        /// `"no-alternative"`.
         reason: String,
+        /// Opaque consumer tag carried by the rider; `0` if untagged.
         tag: u64,
     },
 
     // ── Elevator motion + doors ─────────────────────────────────────
+    /// An elevator arrived at a stop.
     ElevatorArrived {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator that arrived.
         elevator: u32,
+        /// Slotmap slot id of the stop arrived at.
         stop: u32,
     },
+    /// An elevator departed from a stop.
     ElevatorDeparted {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator that departed.
         elevator: u32,
+        /// Slotmap slot id of the stop departed from.
         stop: u32,
     },
+    /// An elevator's doors finished opening.
     DoorOpened {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator whose doors opened.
         elevator: u32,
     },
+    /// An elevator's doors finished closing.
     DoorClosed {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator whose doors closed.
         elevator: u32,
     },
-    /// `command` is one of `"open"`, `"close"`, `"hold-open"`,
-    /// `"cancel-hold"` (kebab-case from
-    /// [`elevator_core::door::DoorCommand`]).
+    /// A manual door-control command was queued for later application.
     DoorCommandQueued {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator targeted by the command.
         elevator: u32,
+        /// One of `"open"`, `"close"`, `"hold-open"`, `"cancel-hold"`
+        /// (kebab-case from [`elevator_core::door::DoorCommand`]).
         command: String,
     },
-    /// Same `command` set as [`EventDto::DoorCommandQueued`].
+    /// A queued door-control command actually took effect.
     DoorCommandApplied {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator the command applied to.
         elevator: u32,
+        /// Same label set as [`EventDto::DoorCommandQueued::command`].
         command: String,
     },
-    /// An elevator passes a stop without stopping.
+    /// An elevator passed a stop without stopping.
     PassingFloor {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator passing by.
         elevator: u32,
+        /// Slotmap slot id of the stop being passed.
         stop: u32,
+        /// `true` = moving up, `false` = moving down.
         moving_up: bool,
     },
     /// An in-flight movement was aborted; the car decelerates to
     /// `brake_target`.
     MovementAborted {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator whose trip was aborted.
         elevator: u32,
+        /// Slotmap slot id of the stop the car will brake to.
         brake_target: u32,
     },
+    /// An elevator became idle (no assignments or repositioning).
     ElevatorIdle {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator that became idle.
         elevator: u32,
-        /// `None` if the car is not currently parked at a stop.
+        /// Slotmap slot id of the stop the car is parked at, or `None`
+        /// if it is not currently parked at a stop.
         at_stop: Option<u32>,
     },
 
     // ── Dispatch / calls ────────────────────────────────────────────
+    /// An elevator was assigned to serve a stop by the dispatcher.
     ElevatorAssigned {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator assigned.
         elevator: u32,
+        /// Slotmap slot id of the stop it was assigned to serve.
         stop: u32,
     },
-    /// `direction` is `"up"` or `"down"`.
+    /// A hall button was pressed.
     HallButtonPressed {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the stop where the press occurred.
         stop: u32,
+        /// `"up"` or `"down"`.
         direction: String,
     },
+    /// A hall call passed its ack-latency window and is now visible to
+    /// dispatch.
     HallCallAcknowledged {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the stop the call was placed at.
         stop: u32,
+        /// `"up"` or `"down"`.
         direction: String,
     },
+    /// A hall call was cleared by an arriving car.
     HallCallCleared {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the stop whose call was cleared.
         stop: u32,
+        /// `"up"` or `"down"`.
         direction: String,
+        /// Slotmap slot id of the car that cleared the call.
         car: u32,
     },
-    /// `rider` is `None` when the press is synthetic (scripted).
-    /// `tag` mirrors the pressing rider's opaque consumer tag and is
-    /// `None` whenever `rider` is `None`. `Some(0)` means a present but
-    /// untagged rider.
+    /// A floor button was pressed inside a car. `rider` is `None` when
+    /// the press is synthetic (scripted); `tag` mirrors the pressing
+    /// rider's opaque consumer tag and is `None` whenever `rider` is
+    /// `None`. `Some(0)` means a present but untagged rider.
     CarButtonPressed {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator the button was pressed in.
         car: u32,
+        /// Slotmap slot id of the floor the rider requested.
         floor: u32,
+        /// Slotmap slot id of the rider who pressed, or `None` for a
+        /// synthetic press.
         rider: Option<u32>,
+        /// Opaque consumer tag of the pressing rider, mirroring the
+        /// optionality of `rider`.
         tag: Option<u64>,
     },
+    /// A stop was queued as a destination for an elevator.
     DestinationQueued {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator whose queue was updated.
         elevator: u32,
+        /// Slotmap slot id of the stop that was queued.
         stop: u32,
     },
 
@@ -639,83 +749,135 @@ pub enum EventDto {
     /// Idle elevator has been sent to a new parking position by the
     /// group's reposition strategy.
     ElevatorRepositioning {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator being repositioned.
         elevator: u32,
+        /// Slotmap slot id of the stop it is being sent to.
         stop: u32,
     },
     /// An elevator completed repositioning at its target stop.
     ElevatorRepositioned {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator that finished repositioning.
         elevator: u32,
+        /// Slotmap slot id of the stop it arrived at.
         stop: u32,
     },
     /// The elevator was recalled to a stop via `sim.recall_to()`.
     ElevatorRecalled {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator that was recalled.
         elevator: u32,
+        /// Slotmap slot id of the stop the elevator is being sent to.
         to_stop: u32,
     },
 
     // ── Topology lifecycle ──────────────────────────────────────────
+    /// A new stop was added to the simulation at runtime.
     StopAdded {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the new stop entity.
         stop: u32,
+        /// Slotmap slot id of the line the stop was added to.
         line: u32,
+        /// Group id the stop was added to.
         group: u32,
     },
+    /// A stop was permanently removed from the simulation.
     StopRemoved {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the stop that was removed.
         stop: u32,
     },
+    /// A new elevator was added to the simulation at runtime.
     ElevatorAdded {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the new elevator entity.
         elevator: u32,
+        /// Slotmap slot id of the line the elevator was added to.
         line: u32,
+        /// Group id the elevator was added to.
         group: u32,
     },
+    /// An elevator was permanently removed from the simulation.
     ElevatorRemoved {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator that was removed.
         elevator: u32,
+        /// Slotmap slot id of the line it belonged to.
         line: u32,
+        /// Group id it belonged to.
         group: u32,
     },
+    /// A line was added to the simulation.
     LineAdded {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the new line entity.
         line: u32,
+        /// Group id the line was added to.
         group: u32,
     },
+    /// A line was removed from the simulation.
     LineRemoved {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the removed line entity.
         line: u32,
+        /// Group id the line belonged to.
         group: u32,
     },
+    /// A line was reassigned to a different group.
     LineReassigned {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the line entity that was reassigned.
         line: u32,
+        /// Group id the line was previously in.
         old_group: u32,
+        /// Group id the line was moved to.
         new_group: u32,
     },
+    /// An elevator was reassigned to a different line.
     ElevatorReassigned {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator that was reassigned.
         elevator: u32,
+        /// Slotmap slot id of the line the elevator was previously on.
         old_line: u32,
+        /// Slotmap slot id of the line the elevator was moved to.
         new_line: u32,
     },
+    /// An entity was disabled.
     EntityDisabled {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the entity that was disabled.
         entity: u32,
     },
+    /// An entity was re-enabled.
     EntityEnabled {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the entity that was re-enabled.
         entity: u32,
     },
     /// A stop was removed while resident riders were still attached;
     /// the consumer must relocate or despawn them.
     ResidentsAtRemovedStop {
-        /// `tick` is `0` for this variant (it is not carried by the
-        /// underlying core event).
+        /// `0` for this variant — the underlying core event carries no tick.
         tick: u64,
+        /// Slotmap slot id of the removed stop.
         stop: u32,
+        /// Slotmap slot ids of the riders that were resident at the stop.
         residents: Vec<u32>,
     },
 
@@ -724,69 +886,102 @@ pub enum EventDto {
     /// `"normal"`, `"independent"`, `"inspection"`, `"manual"`,
     /// `"out-of-service"`.
     ServiceModeChanged {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator whose mode changed.
         elevator: u32,
+        /// Previous service mode (kebab-case label).
         from: String,
+        /// New service mode (kebab-case label).
         to: String,
     },
     /// A velocity command on a Manual-mode elevator. `target_velocity`
     /// is `null` when the command clears the target (emergency stop).
     ManualVelocityCommanded {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator targeted.
         elevator: u32,
+        /// Target velocity clamped to `[-max_speed, max_speed]`, or
+        /// `None` to clear the target.
         target_velocity: Option<f64>,
     },
+    /// An elevator's load changed (rider boarded or exited).
     CapacityChanged {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator whose load changed.
         elevator: u32,
+        /// Total weight aboard after the change.
         current_load: f64,
+        /// Maximum weight capacity of the elevator.
         capacity: f64,
     },
+    /// An elevator's direction indicator lamps changed state.
     DirectionIndicatorChanged {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator whose lamps changed.
         elevator: u32,
+        /// New state of the up-direction lamp.
         going_up: bool,
+        /// New state of the down-direction lamp.
         going_down: bool,
     },
     /// An elevator parameter was upgraded at runtime. `field` is one of
     /// `"max-speed"`, `"acceleration"`, `"deceleration"`,
     /// `"weight-capacity"`, `"door-transition-ticks"`,
-    /// `"door-open-ticks"`. `old`/`new` are the value as f64 (tick
+    /// `"door-open-ticks"`. `old`/`new` are the value as `f64` (tick
     /// counts cast losslessly into the ~2^53 safe range).
     ElevatorUpgraded {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator whose parameter changed.
         elevator: u32,
+        /// Kebab-case label of the field that changed.
         field: String,
+        /// Previous value as `f64`.
         old: f64,
+        /// New value as `f64`.
         new: f64,
     },
     /// Energy consumed/regenerated this tick. Only emitted with the
     /// `energy` feature on core; absent otherwise.
     EnergyConsumed {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Slotmap slot id of the elevator the reading is for.
         elevator: u32,
+        /// Energy consumed this tick.
         consumed: f64,
+        /// Energy regenerated this tick.
         regenerated: f64,
     },
     /// Snapshot restore encountered an entity reference that could not
     /// be remapped — signals snapshot corruption.
     SnapshotDanglingReference {
+        /// Engine tick from the snapshot at restore time.
         tick: u64,
+        /// The entity slot id from the snapshot that had no mapping.
         stale_id: u32,
     },
     /// Snapshot restore could not re-instantiate the reposition
     /// strategy for a group.
     RepositionStrategyNotRestored {
-        /// Always `0` — the underlying event carries no tick.
+        /// `0` for this variant — the underlying core event carries no tick.
         tick: u64,
+        /// Group id whose strategy was lost.
         group: u32,
     },
     /// Snapshot restore failed to replay tunable dispatch config; the
     /// strategy runs with its default weights.
     DispatchConfigNotRestored {
-        /// Always `0` — the underlying event carries no tick.
+        /// `0` for this variant — the underlying core event carries no tick.
         tick: u64,
+        /// Group id whose dispatcher ran with defaults.
         group: u32,
+        /// Parse error from
+        /// [`DispatchStrategy::restore_config`](elevator_core::dispatch::DispatchStrategy::restore_config).
         reason: String,
     },
 
@@ -796,7 +991,9 @@ pub enum EventDto {
     /// Consumers should treat this as "event was emitted but the shape
     /// is unknown" — `label` carries the variant name.
     Unknown {
+        /// Engine tick the event was emitted on.
         tick: u64,
+        /// Variant name from the core `Event` enum.
         label: String,
     },
 }

--- a/crates/elevator-wasm/src/dto.rs
+++ b/crates/elevator-wasm/src/dto.rs
@@ -447,7 +447,7 @@ pub enum EventDto {
     // ── Rider lifecycle ─────────────────────────────────────────────
     /// A new rider appeared at a stop. `tag` mirrors the rider's opaque
     /// consumer tag at emit time (`0` means untagged); set via
-    /// [`WasmSim::set_rider_tag`] for the back-pointer pattern.
+    /// [`crate::WasmSim::set_rider_tag`] for the back-pointer pattern.
     RiderSpawned {
         /// Engine tick the event was emitted on.
         tick: u64,

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -29,6 +29,7 @@ mod dto;
 mod result;
 mod world_view;
 
+pub use dto::EventDto;
 pub use result::{WasmBytesResult, WasmU32Result, WasmU64Result, WasmVoidResult};
 
 /// Encode an `EntityId` for the JS boundary as a `u64` (`BigInt` in JS).

--- a/crates/elevator-wasm/tests/event_tag.rs
+++ b/crates/elevator-wasm/tests/event_tag.rs
@@ -1,0 +1,133 @@
+//! Tag-on-events smoke tests for the wasm DTO surface.
+//!
+//! Pins the contract that the `tag` field added to every rider-bearing
+//! [`EventDto`] variant carries the value last set via `setRiderTag`.
+//! The contract for in-process callers is exercised by
+//! `elevator-core/src/tests/event_tag_tests.rs`; these tests cover the
+//! second hop — DTO conversion — that wasm consumers see.
+
+use elevator_wasm::{EventDto, WasmSim, WasmU64Result, WasmVoidResult};
+
+const SCENARIO: &str = r#"SimConfig(
+    building: BuildingConfig(
+        name: "Tag Events",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby",   position: 0.0),
+            StopConfig(id: StopId(1), name: "Floor 2", position: 4.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car 1",
+            max_speed: 2.2, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 90,
+        weight_range: (50.0, 100.0),
+    ),
+)"#;
+
+const SENTINEL: u64 = 0xCAFE_F00D;
+
+fn ok_u64(r: WasmU64Result) -> u64 {
+    match r {
+        WasmU64Result::Ok { value } => value,
+        WasmU64Result::Err { error } => panic!("u64 result err: {error}"),
+    }
+}
+
+fn ok_void(r: WasmVoidResult) {
+    match r {
+        WasmVoidResult::Ok {} => {}
+        WasmVoidResult::Err { error } => panic!("void result err: {error}"),
+    }
+}
+
+#[test]
+fn rider_boarded_dto_carries_tag() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let rider = ok_u64(sim.spawn_rider(0, 1, 75.0, None));
+    ok_void(sim.set_rider_tag(rider, SENTINEL));
+    sim.drain_events();
+
+    let mut found = None;
+    for _ in 0..400 {
+        sim.step_many(1);
+        for event in sim.drain_events() {
+            if let EventDto::RiderBoarded { tag, .. } = event {
+                found = Some(tag);
+                break;
+            }
+        }
+        if found.is_some() {
+            break;
+        }
+    }
+    assert_eq!(
+        found,
+        Some(SENTINEL),
+        "RiderBoarded DTO must carry the tag set before boarding"
+    );
+}
+
+#[test]
+fn rider_exited_dto_carries_tag() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let rider = ok_u64(sim.spawn_rider(0, 1, 75.0, None));
+    ok_void(sim.set_rider_tag(rider, SENTINEL));
+    sim.drain_events();
+
+    let mut found = None;
+    for _ in 0..600 {
+        sim.step_many(1);
+        for event in sim.drain_events() {
+            if let EventDto::RiderExited { tag, .. } = event {
+                found = Some(tag);
+                break;
+            }
+        }
+        if found.is_some() {
+            break;
+        }
+    }
+    assert_eq!(
+        found,
+        Some(SENTINEL),
+        "RiderExited DTO must carry the rider's tag, sampled before free"
+    );
+}
+
+#[test]
+fn untagged_rider_dto_yields_zero() {
+    let mut sim = WasmSim::new(SCENARIO, "look", None).expect("construct sim");
+    let _rider = ok_u64(sim.spawn_rider(0, 1, 75.0, None));
+
+    for _ in 0..600 {
+        sim.step_many(1);
+        for event in sim.drain_events() {
+            let tag = match event {
+                EventDto::RiderSpawned { tag, .. }
+                | EventDto::RiderBoarded { tag, .. }
+                | EventDto::RiderExited { tag, .. }
+                | EventDto::RiderRejected { tag, .. }
+                | EventDto::RiderAbandoned { tag, .. }
+                | EventDto::RiderEjected { tag, .. }
+                | EventDto::RiderSettled { tag, .. }
+                | EventDto::RiderDespawned { tag, .. }
+                | EventDto::RiderRerouted { tag, .. }
+                | EventDto::RiderSkipped { tag, .. }
+                | EventDto::RouteInvalidated { tag, .. } => Some(tag),
+                EventDto::CarButtonPressed { tag, .. } => tag,
+                _ => None,
+            };
+            if let Some(t) = tag {
+                assert_eq!(t, 0, "untagged rider must surface tag=0 on every DTO");
+            }
+        }
+    }
+}

--- a/docs/src/error-handling.md
+++ b/docs/src/error-handling.md
@@ -157,7 +157,7 @@ Rider rejections are not Rust errors -- they are events. The simulation continue
 sim.step();
 
 for event in sim.drain_events() {
-    if let Event::RiderRejected { rider, elevator, reason, context, tick } = event {
+    if let Event::RiderRejected { rider, elevator, reason, context, tick, .. } = event {
         match reason {
             RejectionReason::OverCapacity => {
                 // Show "elevator full" indicator in game UI.

--- a/docs/src/events-metrics.md
+++ b/docs/src/events-metrics.md
@@ -31,16 +31,18 @@ Every significant moment in the simulation -- a rider boarding, an elevator arri
 
 | Event | When it fires |
 |---|---|
-| `RiderSpawned { rider, origin, destination, tick }` | A new rider appears at a stop |
-| `RiderBoarded { rider, elevator, tick }` | A rider enters an elevator |
-| `RiderExited { rider, elevator, stop, tick }` | A rider exits at their destination |
-| `RiderRejected { rider, elevator, reason, context, tick }` | A rider was refused boarding |
-| `RiderAbandoned { rider, stop, tick }` | A rider gave up waiting |
-| `RiderSkipped { rider, elevator, at_stop, tick }` | A rider skipped a crowded car (may still board the next) |
-| `RiderEjected { rider, elevator, stop, tick }` | A rider was ejected (elevator disabled) |
-| `RiderSettled { rider, stop, tick }` | A rider settled as a resident |
-| `RiderDespawned { rider, tick }` | A rider was removed from the simulation |
-| `RiderRerouted { rider, new_destination, tick }` | A rider was rerouted to a new destination |
+| `RiderSpawned { rider, origin, destination, tag, tick }` | A new rider appears at a stop |
+| `RiderBoarded { rider, elevator, tag, tick }` | A rider enters an elevator |
+| `RiderExited { rider, elevator, stop, tag, tick }` | A rider exits at their destination |
+| `RiderRejected { rider, elevator, reason, context, tag, tick }` | A rider was refused boarding |
+| `RiderAbandoned { rider, stop, tag, tick }` | A rider gave up waiting |
+| `RiderSkipped { rider, elevator, at_stop, tag, tick }` | A rider skipped a crowded car (may still board the next) |
+| `RiderEjected { rider, elevator, stop, tag, tick }` | A rider was ejected (elevator disabled) |
+| `RiderSettled { rider, stop, tag, tick }` | A rider settled as a resident |
+| `RiderDespawned { rider, tag, tick }` | A rider was removed from the simulation |
+| `RiderRerouted { rider, new_destination, tag, tick }` | A rider was rerouted to a new destination |
+
+Every rider-bearing variant carries a `tag: u64` that mirrors the rider's opaque consumer tag at emit time (see `set_rider_tag`). It is `0` for untagged riders and is sampled before the rider is freed on `RiderExited` / `RiderDespawned`, so consumers can correlate the event with their own object space without an extra lookup.
 
 ### Topology events
 
@@ -50,7 +52,7 @@ Every significant moment in the simulation -- a rider boarding, an elevator arri
 | `ElevatorAdded { elevator, line, group, tick }` | An elevator was added at runtime |
 | `EntityDisabled { entity, tick }` | An entity was disabled |
 | `EntityEnabled { entity, tick }` | An entity was re-enabled |
-| `RouteInvalidated { rider, affected_stop, reason, tick }` | A rider's route was broken by a topology change |
+| `RouteInvalidated { rider, affected_stop, reason, tag, tick }` | A rider's route was broken by a topology change |
 | `LineAdded { line, group, tick }` | A line was added |
 | `LineRemoved { line, group, tick }` | A line was removed |
 | `LineReassigned { line, old_group, new_group, tick }` | A line moved between groups |
@@ -65,7 +67,7 @@ Every significant moment in the simulation -- a rider boarding, an elevator arri
 | `HallButtonPressed { stop, direction, tick }` | First press per (stop, direction) |
 | `HallCallAcknowledged { stop, direction, tick }` | Ack-latency window elapsed |
 | `HallCallCleared { stop, direction, car, tick }` | Assigned car opened doors at stop |
-| `CarButtonPressed { car, floor, rider: Option, tick }` | Floor button pressed inside a car |
+| `CarButtonPressed { car, floor, rider: Option, tag: Option, tick }` | Floor button pressed inside a car |
 
 ## Draining events
 
@@ -78,7 +80,7 @@ sim.step();
 
 for event in sim.drain_events() {
     match event {
-        Event::RiderBoarded { rider, elevator, tick } => {
+        Event::RiderBoarded { rider, elevator, tick, .. } => {
             println!("[{tick}] {rider:?} boarded {elevator:?}");
         }
         Event::ElevatorArrived { elevator, at_stop, tick } => {

--- a/docs/src/quick-start.md
+++ b/docs/src/quick-start.md
@@ -94,7 +94,7 @@ while !arrived {
 
     for event in sim.drain_events() {
         match event {
-            Event::RiderBoarded { rider, elevator, tick } => {
+            Event::RiderBoarded { rider, elevator, tick, .. } => {
                 println!("Tick {tick}: rider {rider:?} boarded elevator {elevator:?}");
             }
             Event::ElevatorArrived { elevator, at_stop, tick } => {
@@ -144,7 +144,7 @@ fn main() -> Result<(), SimError> {
 
         for event in sim.drain_events() {
             match event {
-                Event::RiderBoarded { rider, elevator, tick } => {
+                Event::RiderBoarded { rider, elevator, tick, .. } => {
                     println!("Tick {tick}: rider {rider:?} boarded elevator {elevator:?}");
                 }
                 Event::ElevatorArrived { elevator, at_stop, tick } => {

--- a/examples/csharp-harness/Program.cs
+++ b/examples/csharp-harness/Program.cs
@@ -116,14 +116,18 @@ internal static class Native
     public const byte EV_RIDER_EXITED = 8;
     public const byte EV_RIDER_ABANDONED = 9;
 
-    // Explicit layout mirrors the Rust #[repr(C)] EvEvent at ABI v4
-    // (80 bytes). The first 8 bytes pack four single-byte fields and
-    // a u32 group id; bytes 8..80 are eight u64/f64 slots in their
+    // Explicit layout mirrors the Rust #[repr(C)] EvEvent at ABI v5
+    // (88 bytes). The first 8 bytes pack four single-byte fields and
+    // a u32 group id; bytes 8..88 are nine u64/f64 slots in their
     // natural order. Relying on the CLR's default Sequential packing
     // could match by coincidence on one platform but skew on
     // another, so explicit FieldOffsets are spelled out for every
     // platform target.
-    [StructLayout(LayoutKind.Explicit, Size = 80)]
+    //
+    // ABI v5 added the `tag` field (offset 80) carrying `Rider.tag`
+    // for every rider-bearing variant; consumers that don't use the
+    // tag can simply ignore the new slot.
+    [StructLayout(LayoutKind.Explicit, Size = 88)]
     public struct EvEvent
     {
         [FieldOffset(0)] public byte kind;
@@ -140,6 +144,7 @@ internal static class Native
         [FieldOffset(56)] public ulong count;
         [FieldOffset(64)] public double f1;
         [FieldOffset(72)] public double f2;
+        [FieldOffset(80)] public ulong tag;
     }
 
     [DllImport(Lib)] public static extern uint ev_abi_version();
@@ -180,7 +185,7 @@ internal static class Native
 internal static class Program
 {
     private const int TICKS = 600;
-    private const uint EXPECTED_ABI = 4;
+    private const uint EXPECTED_ABI = 5;
 
     private static int Main(string[] args)
     {


### PR DESCRIPTION
## Summary

Completes the back-pointer pattern from #541. Consumers can now read the opaque per-rider tag inline from each rider-bearing event variant — no extra lookup needed. This is the missing half for `RiderExited` / `RiderDespawned`, where the rider is freed before the event fires and `rider_tag(id)` would error out.

The motivating downstream is the tower-together adapter (3 simulations across 2 clients + 1 worker, lockstep). Without tag-on-events, that adapter has to maintain a parallel `Map<RiderId, simId>` solely to dispatch arrivals on freed riders. With this PR, the engine carries the back-pointer the consumer needs.

## Changes

- `Event` enum: `tag: u64` added to `RiderSpawned`, `RiderBoarded`, `RiderExited`, `RiderRejected`, `RiderAbandoned`, `RiderEjected`, `RiderSettled`, `RiderDespawned`, `RiderRerouted`, `RiderSkipped`, `RouteInvalidated`. `CarButtonPressed` gets `tag: Option<u64>` to mirror its `rider: Option<EntityId>`. All new fields are `#[serde(default)]` so legacy snapshots/JSON without the field decode to ` tag = 0` (the reserved untagged sentinel).
- Every emit site reads `Rider.tag` before phase mutation / despawn so the value survives `RiderExited` and `RiderDespawned`.
- `EventDto` (wasm): `tag: u64` / `Option<u64>` mirrored across every variant; `From<Event>` populates them. `EventDto` is now re-exported at the wasm crate root for integration-test access.
- FFI `EvEvent` (ABI v4 → v5): new `tag: u64` field, populated for every rider-bearing kind. Bumped `EV_ABI_VERSION`; cbindgen header regenerated.
- gdext: rider-bearing dict variants gain a `"tag"` key (i64).
- Docs and quick-start example updated for the new field.

## Compatibility

| Layer | Impact |
|---|---|
| Rust core | `#[non_exhaustive] enum`, `#[serde(default)]` fields → not breaking per project conventions |
| wasm/JS | New optional field on tagged-union variants → TS-additive, not breaking |
| FFI/C | `EvEvent` struct widened by 8 bytes → ABI v4 → v5; consumers must rebuild and check `EV_ABI_VERSION` |
| Snapshots | Legacy postcards round-trip cleanly (`tag = 0` default) |

## Test plan

- [x] `crates/elevator-core/src/tests/event_tag_tests.rs` — 12 tests, one per variant + an untagged/zero contract test + a synthetic `CarButtonPressed { tag: None }` test. Covers the read-before-free property for `RiderExited` and `RiderDespawned` explicitly.
- [x] `crates/elevator-wasm/tests/event_tag.rs` — 3 tests: DTO carries tag for boarded / exited / untagged rider.
- [x] FFI: `drained_events_carry_rider_tag` smoke test pinning the v5 `EvEvent.tag` contract from the C side.
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p elevator-core --all-features -- -D warnings` — clean
- [x] `cargo test -p elevator-core --all-features` — 885 lib tests + doctests + integration scenarios green
- [x] `cargo test --workspace --all-features` — green across core / ffi / wasm / gdext / bevy / tui
- [x] `cargo check --workspace --all-features --all-targets` — green
- [x] `scripts/check-bindings.sh` — in sync (145 methods)
- [x] `scripts/lint-docs.sh --quick` — clean