### PR TITLE
perf(loading): fold rider tag read into existing borrows

### DIFF
--- a/crates/elevator-core/src/systems/advance_transient.rs
+++ b/crates/elevator-core/src/systems/advance_transient.rs
@@ -198,9 +198,12 @@ pub fn run(
 
     // Apply abandonments.
     for &(id, stop) in &abandon {
-        if let Some(r) = world.rider_mut(id) {
+        // Read the tag from the same mutable borrow we use to flip the
+        // phase, instead of doing a second arena lookup at emit time.
+        let tag = world.rider_mut(id).map_or(0, |r| {
             r.phase = RiderPhase::Abandoned;
-        }
+            r.tag()
+        });
         // An abandoned rider is not a waiter any more; leaving their
         // ID in `pending_riders` would spuriously hold car calls open
         // and count them in mode-detection `is_empty()` checks.
@@ -210,7 +213,7 @@ pub fn run(
         events.emit(Event::RiderAbandoned {
             rider: id,
             stop,
-            tag: world.rider(id).map_or(0, Rider::tag),
+            tag,
             tick: ctx.tick,
         });
     }
@@ -244,16 +247,17 @@ pub fn run(
         })
         .collect();
     for (id, stop) in time_abandon {
-        if let Some(r) = world.rider_mut(id) {
+        let tag = world.rider_mut(id).map_or(0, |r| {
             r.phase = RiderPhase::Abandoned;
-        }
+            r.tag()
+        });
         world.scrub_rider_from_pending_calls(id);
         rider_index.remove_waiting(stop, id);
         rider_index.insert_abandoned(stop, id);
         events.emit(Event::RiderAbandoned {
             rider: id,
             stop,
-            tag: world.rider(id).map_or(0, Rider::tag),
+            tag,
             tick: ctx.tick,
         });
     }

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -343,20 +343,17 @@ fn apply_actions(
             } => {
                 // Guard: skip if rider is no longer Riding this elevator (another
                 // elevator may have already exited them in an earlier action).
-                if world
-                    .rider(rider)
-                    .is_none_or(|r| r.phase != RiderPhase::Riding(elevator))
-                {
-                    continue;
-                }
-                let rider_weight = world
-                    .rider(rider)
-                    .map_or(crate::components::Weight::ZERO, |rd| rd.weight);
+                // Fold the phase guard, weight read, and tag read into a single
+                // arena lookup — emitted per rider per exit, so the `SecondaryMap`
+                // traversals compound on rider-heavy ticks.
+                let (rider_weight, tag) = match world.rider(rider) {
+                    Some(r) if r.phase == RiderPhase::Riding(elevator) => (r.weight, r.tag()),
+                    _ => continue,
+                };
                 if let Some(car) = world.elevator_mut(elevator) {
                     car.riders.retain(|r| *r != rider);
                     car.current_load -= rider_weight;
                 }
-                let tag = world.rider(rider).map_or(0, crate::components::Rider::tag);
                 if let Some(rd) = world.rider_mut(rider) {
                     rd.phase = RiderPhase::Exiting(elevator);
                     rd.current_stop = Some(stop);
@@ -392,22 +389,20 @@ fn apply_actions(
             } => {
                 // Guard: skip if rider is no longer Waiting (another elevator at
                 // the same stop may have already boarded them in an earlier action).
-                let boarding_stop = world.rider(rider).and_then(|r| {
-                    if r.phase == RiderPhase::Waiting {
-                        r.current_stop
-                    } else {
-                        None
-                    }
-                });
-                let Some(stop) = boarding_stop else {
-                    continue;
+                // Fold the phase guard, current_stop read, and tag read into a
+                // single arena lookup.
+                let (stop, tag) = match world.rider(rider) {
+                    Some(r) if r.phase == RiderPhase::Waiting => match r.current_stop {
+                        Some(s) => (s, r.tag()),
+                        None => continue,
+                    },
+                    _ => continue,
                 };
                 rider_index.remove_waiting(stop, rider);
                 if let Some(car) = world.elevator_mut(elevator) {
                     car.current_load += crate::components::Weight::from(weight);
                     car.riders.push(rider);
                 }
-                let tag = world.rider(rider).map_or(0, crate::components::Rider::tag);
                 if let Some(rd) = world.rider_mut(rider) {
                     rd.phase = RiderPhase::Boarding(elevator);
                     rd.board_tick = Some(ctx.tick);
@@ -437,7 +432,7 @@ fn apply_actions(
                     .route(rider)
                     .and_then(crate::components::Route::current_destination)
                 {
-                    register_car_call(world, events, elevator, dest, rider, ctx.tick);
+                    register_car_call(world, events, elevator, dest, rider, tag, ctx.tick);
                 }
             }
             LoadAction::Reject {
@@ -464,7 +459,11 @@ fn apply_actions(
                 elevator,
                 at_stop,
             } => {
-                let tag = world.rider(rider).map_or(0, crate::components::Rider::tag);
+                // Fold the tag read and the abandon-eligibility phase guard
+                // into a single arena lookup.
+                let (tag, phase_is_waiting) = world
+                    .rider(rider)
+                    .map_or((0, false), |r| (r.tag(), r.phase == RiderPhase::Waiting));
                 events.emit(Event::RiderSkipped {
                     rider,
                     elevator,
@@ -474,13 +473,10 @@ fn apply_actions(
                 });
                 // Honor `Preferences::abandon_on_full`: the rider doesn't
                 // wait for another car — they abandon immediately.
-                let escalate = world
-                    .preferences(rider)
-                    .is_some_and(Preferences::abandon_on_full);
-                if escalate
+                if phase_is_waiting
                     && world
-                        .rider(rider)
-                        .is_some_and(|r| r.phase == RiderPhase::Waiting)
+                        .preferences(rider)
+                        .is_some_and(Preferences::abandon_on_full)
                 {
                     if let Some(r) = world.rider_mut(rider) {
                         r.phase = RiderPhase::Abandoned;
@@ -507,6 +503,7 @@ fn register_car_call(
     car: EntityId,
     floor: EntityId,
     rider: EntityId,
+    rider_tag: u64,
     tick: u64,
 ) {
     let Some(calls) = world.car_calls_mut(car) else {
@@ -526,12 +523,11 @@ fn register_car_call(
     // signal). CarCall latency can be plumbed through later.
     call.acknowledged_at = Some(tick);
     calls.push(call);
-    let tag = world.rider(rider).map_or(0, crate::components::Rider::tag);
     events.emit(Event::CarButtonPressed {
         car,
         floor,
         rider: Some(rider),
-        tag: Some(tag),
+        tag: Some(rider_tag),
         tick,
     });
 }


### PR DESCRIPTION
## Summary

- Combines the tag read with the existing rider borrow in the four hot-path emit sites added by #545: `LoadAction::Exit`, `LoadAction::Board`, `LoadAction::Skip` (in `loading::apply_actions`), and the patience- and time-triggered abandon loops in `advance_transient::run`.
- Threads `tag` through `register_car_call` so the per-Board car-button emit doesn't re-lookup the rider it was just spawned from.
- No semantic change — every event still carries the same tag value, every guard still rejects the same actions.

## Motivation

Closes ref. #547 — nightly bench flagged 5–15 % regressions across rider-heavy scenarios (`scaling_realistic`, `scaling_extreme`, `scaling_shanghai_tower/stress`, `multi_group_step`). All within the diff window since the prior locked baseline; the only feature commit between baseline and benched SHA is #545.

The PR added per-event `world.rider(id).map_or(0, Rider::tag)` reads — each one a `SecondaryMap::get` — placed *next to* an existing `world.rider(id)` or `world.rider_mut(id)` borrow:

| arm | rider lookups before | after |
|---|---|---|
| `Exit` | 4 (phase guard + weight + tag + mut) | **2** (one combined match + mut) |
| `Board` | 3 (boarding-stop guard + tag + mut) | **2** (one combined match + mut) |
| `Skip` | 3 (tag + escalate phase guard + mut) | **2** (combined tag+phase, mut) |
| `register_car_call` | 1 (tag) | **0** (passed in) |
| `advance_transient` abandon × 2 | 2 each (mut + tag) | **1 each** (combined) |

## What this PR does *not* fix

The wider `Event` enum (64 → 72 bytes after #545's `tag: u64`) is intrinsic to the feature and remains. That is structural and I'd expect a portion of #547's regression to persist for that reason — the next nightly will tell us how much. Local benches on my machine (faster CPU than the GH runner) show the affected scenarios within noise both before and after; on the runner I'd expect a partial recovery.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p elevator-core --all-features --all-targets -- -D warnings` clean
- [x] `cargo test -p elevator-core --all-features` — 885 lib + 159 doctests + integration scenarios green
- [x] `cargo check --workspace --all-features --all-targets` green across core / ffi / wasm / gdext / bevy / tui
- [ ] Nightly bench (run on next schedule) — confirms recovery vs locked baseline