### PR TITLE
refactor(rider): close ghost-rider footgun via transition gateway + RiderState typestate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "15.31.0"
+version = "15.32.1"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "cbindgen",
  "elevator-core",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-wasm"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "elevator-core",
  "getrandom 0.4.2",

--- a/crates/elevator-core/src/components/mod.rs
+++ b/crates/elevator-core/src/components/mod.rs
@@ -18,6 +18,8 @@ pub mod patience;
 pub mod position;
 /// Rider (passenger/cargo) core data.
 pub mod rider;
+/// Internal rider lifecycle state with location data bundled into variants.
+pub(crate) mod rider_state;
 /// Multi-leg route planning.
 pub mod route;
 /// Service mode component for elevator operational modes.

--- a/crates/elevator-core/src/components/rider.rs
+++ b/crates/elevator-core/src/components/rider.rs
@@ -40,6 +40,28 @@ impl RiderPhase {
     pub const fn is_aboard(&self) -> bool {
         matches!(self, Self::Boarding(_) | Self::Riding(_) | Self::Exiting(_))
     }
+
+    /// True when the rider is currently at a stop — i.e., one of the
+    /// phases for which [`Rider::current_stop`] is expected to be `Some`:
+    /// [`Waiting`](Self::Waiting), [`Boarding`](Self::Boarding),
+    /// [`Exiting`](Self::Exiting), [`Arrived`](Self::Arrived),
+    /// [`Abandoned`](Self::Abandoned), or [`Resident`](Self::Resident).
+    ///
+    /// Companion to [`is_aboard`](Self::is_aboard). Note `Boarding` and
+    /// `Exiting` are *both* aboard and at a stop: the rider is mid-transfer
+    /// between a stop and an elevator cab.
+    #[must_use]
+    pub const fn is_at_stop(&self) -> bool {
+        matches!(
+            self,
+            Self::Waiting
+                | Self::Boarding(_)
+                | Self::Exiting(_)
+                | Self::Arrived
+                | Self::Abandoned
+                | Self::Resident
+        )
+    }
 }
 
 /// Data-less companion to [`RiderPhase`] for error messages and pattern matching

--- a/crates/elevator-core/src/components/rider_state.rs
+++ b/crates/elevator-core/src/components/rider_state.rs
@@ -1,0 +1,350 @@
+//! Internal lifecycle state for riders, with location data bundled into
+//! variants.
+//!
+//! [`RiderState`] is the engine's source of truth for "where a rider is and
+//! what they're doing." It mirrors the public [`RiderPhase`] enum but lifts
+//! the rider's `current_stop` (and the elevator they're aboard, where
+//! applicable) into the variant payload — making "phase + location" a single
+//! atomic value rather than two fields the caller has to keep coherent.
+//!
+//! The transition gateway (`sim::transition`) accepts a `RiderState`,
+//! ensuring every phase change carries its location data. Public API
+//! surfaces continue to expose [`RiderPhase`] (the data-less-ish projection)
+//! and the snapshot wire format remains byte-stable: see [`From`] impls.
+//!
+//! # Invariants
+//!
+//! - `RiderState::Waiting`, `Arrived`, `Abandoned`, `Resident` always carry
+//!   a `stop: EntityId`.
+//! - `RiderState::Boarding` and `Exiting` carry both an elevator and the
+//!   stop the rider is transferring at.
+//! - `RiderState::Riding` carries only an elevator (no stop while in transit).
+//! - `RiderState::Walking` carries neither — riders walking between transfer
+//!   stops are effectively "in transit on foot."
+//!
+//! These are unrepresentable invalid states by construction, replacing the
+//! soft `Option<EntityId>` invariant on `Rider::current_stop`.
+
+use serde::{Deserialize, Serialize};
+
+use super::rider::{RiderPhase, RiderPhaseKind};
+use crate::entity::EntityId;
+
+/// Engine-internal lifecycle state for a rider.
+///
+/// See module docs for the relationship with [`RiderPhase`] and the
+/// per-variant invariants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[allow(dead_code)] // wired up by the transition gateway in a follow-up commit
+pub enum RiderState {
+    /// Waiting at a stop for an elevator.
+    Waiting {
+        /// The stop the rider is waiting at.
+        stop: EntityId,
+    },
+    /// Boarding an elevator at a stop (transient, one tick).
+    Boarding {
+        /// The elevator being boarded.
+        elevator: EntityId,
+        /// The stop where boarding is happening.
+        stop: EntityId,
+    },
+    /// Riding inside an elevator between stops.
+    Riding {
+        /// The elevator carrying the rider.
+        elevator: EntityId,
+    },
+    /// Exiting an elevator at a stop (transient, one tick).
+    Exiting {
+        /// The elevator being exited.
+        elevator: EntityId,
+        /// The stop the rider is exiting at.
+        stop: EntityId,
+    },
+    /// Walking between transfer stops.
+    Walking,
+    /// Reached final destination at a stop.
+    Arrived {
+        /// The stop where the rider arrived.
+        stop: EntityId,
+    },
+    /// Gave up waiting at a stop.
+    Abandoned {
+        /// The stop where the rider abandoned the wait.
+        stop: EntityId,
+    },
+    /// Parked at a stop, not seeking an elevator.
+    Resident {
+        /// The stop the rider is parked at.
+        stop: EntityId,
+    },
+}
+
+#[allow(dead_code)] // consumed by the transition gateway in a follow-up commit
+impl RiderState {
+    /// The stop this rider is currently *at*, if any.
+    ///
+    /// `Some(stop)` for `Waiting`, `Boarding`, `Exiting`, `Arrived`,
+    /// `Abandoned`, `Resident`. `None` for `Riding` (in transit) and
+    /// `Walking`.
+    #[must_use]
+    pub const fn at_stop(&self) -> Option<EntityId> {
+        match *self {
+            Self::Waiting { stop }
+            | Self::Boarding { stop, .. }
+            | Self::Exiting { stop, .. }
+            | Self::Arrived { stop }
+            | Self::Abandoned { stop }
+            | Self::Resident { stop } => Some(stop),
+            Self::Riding { .. } | Self::Walking => None,
+        }
+    }
+
+    /// The elevator this rider is currently associated with, if any.
+    ///
+    /// `Some(elev)` for `Boarding`, `Riding`, `Exiting`. `None` for the
+    /// at-stop and walking variants.
+    #[must_use]
+    pub const fn aboard(&self) -> Option<EntityId> {
+        match *self {
+            Self::Boarding { elevator, .. }
+            | Self::Riding { elevator }
+            | Self::Exiting { elevator, .. } => Some(elevator),
+            _ => None,
+        }
+    }
+
+    /// Data-less projection of this state.
+    #[must_use]
+    pub const fn kind(&self) -> RiderPhaseKind {
+        match self {
+            Self::Waiting { .. } => RiderPhaseKind::Waiting,
+            Self::Boarding { .. } => RiderPhaseKind::Boarding,
+            Self::Riding { .. } => RiderPhaseKind::Riding,
+            Self::Exiting { .. } => RiderPhaseKind::Exiting,
+            Self::Walking => RiderPhaseKind::Walking,
+            Self::Arrived { .. } => RiderPhaseKind::Arrived,
+            Self::Abandoned { .. } => RiderPhaseKind::Abandoned,
+            Self::Resident { .. } => RiderPhaseKind::Resident,
+        }
+    }
+
+    /// Public-facing phase view (drops the bundled stop, keeps elevator
+    /// payload for the aboard variants).
+    #[must_use]
+    pub const fn as_phase(self) -> RiderPhase {
+        match self {
+            Self::Waiting { .. } => RiderPhase::Waiting,
+            Self::Boarding { elevator, .. } => RiderPhase::Boarding(elevator),
+            Self::Riding { elevator } => RiderPhase::Riding(elevator),
+            Self::Exiting { elevator, .. } => RiderPhase::Exiting(elevator),
+            Self::Walking => RiderPhase::Walking,
+            Self::Arrived { .. } => RiderPhase::Arrived,
+            Self::Abandoned { .. } => RiderPhase::Abandoned,
+            Self::Resident { .. } => RiderPhase::Resident,
+        }
+    }
+
+    /// Combine a public [`RiderPhase`] with the rider's `current_stop` to
+    /// reconstruct the internal state.
+    ///
+    /// Returns `None` when the input is inconsistent — e.g. `Waiting` with
+    /// no stop, or `Boarding` with no stop. The caller should treat such
+    /// inputs as the "ghost rider" footgun and refuse to proceed.
+    #[must_use]
+    pub const fn from_phase(phase: RiderPhase, current_stop: Option<EntityId>) -> Option<Self> {
+        match (phase, current_stop) {
+            (RiderPhase::Waiting, Some(stop)) => Some(Self::Waiting { stop }),
+            (RiderPhase::Boarding(elevator), Some(stop)) => Some(Self::Boarding { elevator, stop }),
+            (RiderPhase::Riding(elevator), _) => Some(Self::Riding { elevator }),
+            (RiderPhase::Exiting(elevator), Some(stop)) => Some(Self::Exiting { elevator, stop }),
+            (RiderPhase::Walking, _) => Some(Self::Walking),
+            (RiderPhase::Arrived, Some(stop)) => Some(Self::Arrived { stop }),
+            (RiderPhase::Abandoned, Some(stop)) => Some(Self::Abandoned { stop }),
+            (RiderPhase::Resident, Some(stop)) => Some(Self::Resident { stop }),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::world::World;
+
+    /// Spawn three distinct `EntityId`s for stop/elevator/extra fixtures.
+    fn ids() -> (EntityId, EntityId, EntityId) {
+        let mut world = World::new();
+        (world.spawn(), world.spawn(), world.spawn())
+    }
+
+    #[test]
+    fn at_stop_returns_stop_for_at_stop_variants() {
+        let (stop, elev, _) = ids();
+        assert_eq!(RiderState::Waiting { stop }.at_stop(), Some(stop));
+        assert_eq!(RiderState::Arrived { stop }.at_stop(), Some(stop));
+        assert_eq!(RiderState::Abandoned { stop }.at_stop(), Some(stop));
+        assert_eq!(RiderState::Resident { stop }.at_stop(), Some(stop));
+        assert_eq!(
+            RiderState::Boarding {
+                elevator: elev,
+                stop
+            }
+            .at_stop(),
+            Some(stop)
+        );
+        assert_eq!(
+            RiderState::Exiting {
+                elevator: elev,
+                stop
+            }
+            .at_stop(),
+            Some(stop)
+        );
+    }
+
+    #[test]
+    fn at_stop_returns_none_for_in_transit_variants() {
+        let (_, elev, _) = ids();
+        assert_eq!(RiderState::Riding { elevator: elev }.at_stop(), None);
+        assert_eq!(RiderState::Walking.at_stop(), None);
+    }
+
+    #[test]
+    fn aboard_returns_elevator_for_aboard_variants() {
+        let (stop, elev, _) = ids();
+        assert_eq!(
+            RiderState::Boarding {
+                elevator: elev,
+                stop
+            }
+            .aboard(),
+            Some(elev)
+        );
+        assert_eq!(RiderState::Riding { elevator: elev }.aboard(), Some(elev));
+        assert_eq!(
+            RiderState::Exiting {
+                elevator: elev,
+                stop
+            }
+            .aboard(),
+            Some(elev)
+        );
+        assert_eq!(RiderState::Waiting { stop }.aboard(), None);
+        assert_eq!(RiderState::Walking.aboard(), None);
+    }
+
+    #[test]
+    fn round_trip_through_phase_preserves_state() {
+        let (stop, elev, _) = ids();
+        let cases = [
+            RiderState::Waiting { stop },
+            RiderState::Boarding {
+                elevator: elev,
+                stop,
+            },
+            RiderState::Riding { elevator: elev },
+            RiderState::Exiting {
+                elevator: elev,
+                stop,
+            },
+            RiderState::Walking,
+            RiderState::Arrived { stop },
+            RiderState::Abandoned { stop },
+            RiderState::Resident { stop },
+        ];
+        for state in cases {
+            let phase = state.as_phase();
+            let stop_back = state.at_stop();
+            let reconstructed = RiderState::from_phase(phase, stop_back).unwrap_or_else(|| {
+                panic!("from_phase rejected legal pair: phase={phase:?}, stop={stop_back:?}")
+            });
+            assert_eq!(reconstructed, state, "round-trip mismatch for {state:?}");
+        }
+    }
+
+    #[test]
+    fn riderphase_kind_matches_state_kind() {
+        // Sanity: the public RiderPhase::kind() and RiderState::kind() must
+        // agree for every variant. Catches drift if either enum gains a
+        // case without updating the other.
+        let (stop, elev, _) = ids();
+        let pairs: &[(RiderState, RiderPhase)] = &[
+            (RiderState::Waiting { stop }, RiderPhase::Waiting),
+            (
+                RiderState::Boarding {
+                    elevator: elev,
+                    stop,
+                },
+                RiderPhase::Boarding(elev),
+            ),
+            (
+                RiderState::Riding { elevator: elev },
+                RiderPhase::Riding(elev),
+            ),
+            (
+                RiderState::Exiting {
+                    elevator: elev,
+                    stop,
+                },
+                RiderPhase::Exiting(elev),
+            ),
+            (RiderState::Walking, RiderPhase::Walking),
+            (RiderState::Arrived { stop }, RiderPhase::Arrived),
+            (RiderState::Abandoned { stop }, RiderPhase::Abandoned),
+            (RiderState::Resident { stop }, RiderPhase::Resident),
+        ];
+        for (state, phase) in pairs {
+            assert_eq!(state.kind(), phase.kind(), "kind mismatch for {state:?}");
+        }
+    }
+
+    #[test]
+    fn from_phase_rejects_inconsistent_inputs() {
+        let (_, elev, _) = ids();
+        // Waiting without a stop — the "ghost rider" footgun.
+        assert_eq!(RiderState::from_phase(RiderPhase::Waiting, None), None);
+        assert_eq!(
+            RiderState::from_phase(RiderPhase::Boarding(elev), None),
+            None
+        );
+        assert_eq!(RiderState::from_phase(RiderPhase::Arrived, None), None);
+    }
+
+    #[test]
+    fn riding_ignores_supplied_stop() {
+        // A Riding rider in transit may have a stale current_stop from
+        // before they boarded. We accept the phase regardless and produce
+        // the canonical no-stop Riding state.
+        let (stale_stop, elev, _) = ids();
+        let s = RiderState::from_phase(RiderPhase::Riding(elev), Some(stale_stop)).unwrap();
+        assert_eq!(s, RiderState::Riding { elevator: elev });
+    }
+
+    #[test]
+    fn kind_matches_phase_kind() {
+        let (stop, elev, _) = ids();
+        let pairs: &[(RiderState, RiderPhaseKind)] = &[
+            (RiderState::Waiting { stop }, RiderPhaseKind::Waiting),
+            (
+                RiderState::Boarding {
+                    elevator: elev,
+                    stop,
+                },
+                RiderPhaseKind::Boarding,
+            ),
+            (
+                RiderState::Riding { elevator: elev },
+                RiderPhaseKind::Riding,
+            ),
+            (RiderState::Walking, RiderPhaseKind::Walking),
+            (RiderState::Arrived { stop }, RiderPhaseKind::Arrived),
+            (RiderState::Abandoned { stop }, RiderPhaseKind::Abandoned),
+            (RiderState::Resident { stop }, RiderPhaseKind::Resident),
+        ];
+        for (state, expected_kind) in pairs {
+            assert_eq!(state.kind(), *expected_kind);
+            assert_eq!(state.as_phase().kind(), *expected_kind);
+        }
+    }
+}

--- a/crates/elevator-core/src/components/rider_state.rs
+++ b/crates/elevator-core/src/components/rider_state.rs
@@ -1,26 +1,29 @@
-//! Internal lifecycle state for riders, with location data bundled into
+//! Internal lifecycle phase for riders, with location data bundled into
 //! variants.
 //!
-//! [`RiderState`] is the engine's source of truth for "where a rider is and
-//! what they're doing." It mirrors the public [`RiderPhase`] enum but lifts
-//! the rider's `current_stop` (and the elevator they're aboard, where
+//! [`InternalRiderPhase`] is the engine's source of truth for "where a rider
+//! is and what they're doing." It mirrors the public [`RiderPhase`] enum but
+//! lifts the rider's `current_stop` (and the elevator they're aboard, where
 //! applicable) into the variant payload — making "phase + location" a single
 //! atomic value rather than two fields the caller has to keep coherent.
 //!
-//! The transition gateway (`sim::transition`) accepts a `RiderState`,
-//! ensuring every phase change carries its location data. Public API
-//! surfaces continue to expose [`RiderPhase`] (the data-less-ish projection)
-//! and the snapshot wire format remains byte-stable: see [`From`] impls.
+//! The transition gateway (`sim::transition`) accepts an
+//! [`InternalRiderPhase`], ensuring every phase change carries its location
+//! data. Public API surfaces continue to expose [`RiderPhase`] (the
+//! data-less-ish projection); the snapshot wire format remains byte-stable
+//! by serializing through `RiderPhase + Option<EntityId> current_stop` and
+//! reconstructing internally via [`InternalRiderPhase::from_phase`].
 //!
 //! # Invariants
 //!
-//! - `RiderState::Waiting`, `Arrived`, `Abandoned`, `Resident` always carry
-//!   a `stop: EntityId`.
-//! - `RiderState::Boarding` and `Exiting` carry both an elevator and the
-//!   stop the rider is transferring at.
-//! - `RiderState::Riding` carries only an elevator (no stop while in transit).
-//! - `RiderState::Walking` carries neither — riders walking between transfer
-//!   stops are effectively "in transit on foot."
+//! - `InternalRiderPhase::Waiting`, `Arrived`, `Abandoned`, `Resident` always
+//!   carry a `stop: EntityId`.
+//! - `InternalRiderPhase::Boarding` and `Exiting` carry both an elevator and
+//!   the stop the rider is transferring at.
+//! - `InternalRiderPhase::Riding` carries only an elevator (no stop while in
+//!   transit).
+//! - `InternalRiderPhase::Walking` carries neither — riders walking between
+//!   transfer stops are effectively "in transit on foot."
 //!
 //! These are unrepresentable invalid states by construction, replacing the
 //! soft `Option<EntityId>` invariant on `Rider::current_stop`.
@@ -30,13 +33,14 @@ use serde::{Deserialize, Serialize};
 use super::rider::{RiderPhase, RiderPhaseKind};
 use crate::entity::EntityId;
 
-/// Engine-internal lifecycle state for a rider.
+/// Engine-internal lifecycle phase for a rider.
 ///
 /// See module docs for the relationship with [`RiderPhase`] and the
-/// per-variant invariants.
+/// per-variant invariants. Named `InternalRiderPhase` (rather than
+/// `RiderState`) to follow the codebase's `*Phase` naming convention
+/// documented in `CLAUDE.md`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[allow(dead_code)] // wired up by the transition gateway in a follow-up commit
-pub enum RiderState {
+pub enum InternalRiderPhase {
     /// Waiting at a stop for an elevator.
     Waiting {
         /// The stop the rider is waiting at.
@@ -80,8 +84,7 @@ pub enum RiderState {
     },
 }
 
-#[allow(dead_code)] // consumed by the transition gateway in a follow-up commit
-impl RiderState {
+impl InternalRiderPhase {
     /// The stop this rider is currently *at*, if any.
     ///
     /// `Some(stop)` for `Waiting`, `Boarding`, `Exiting`, `Arrived`,
@@ -105,6 +108,7 @@ impl RiderState {
     /// `Some(elev)` for `Boarding`, `Riding`, `Exiting`. `None` for the
     /// at-stop and walking variants.
     #[must_use]
+    #[allow(dead_code)] // exposed for gateway helpers; only used by tests today
     pub const fn aboard(&self) -> Option<EntityId> {
         match *self {
             Self::Boarding { elevator, .. }
@@ -152,6 +156,7 @@ impl RiderState {
     /// no stop, or `Boarding` with no stop. The caller should treat such
     /// inputs as the "ghost rider" footgun and refuse to proceed.
     #[must_use]
+    #[allow(dead_code)] // exposed for snapshot/restore reconstruction; tests cover today
     pub const fn from_phase(phase: RiderPhase, current_stop: Option<EntityId>) -> Option<Self> {
         match (phase, current_stop) {
             (RiderPhase::Waiting, Some(stop)) => Some(Self::Waiting { stop }),
@@ -181,12 +186,12 @@ mod tests {
     #[test]
     fn at_stop_returns_stop_for_at_stop_variants() {
         let (stop, elev, _) = ids();
-        assert_eq!(RiderState::Waiting { stop }.at_stop(), Some(stop));
-        assert_eq!(RiderState::Arrived { stop }.at_stop(), Some(stop));
-        assert_eq!(RiderState::Abandoned { stop }.at_stop(), Some(stop));
-        assert_eq!(RiderState::Resident { stop }.at_stop(), Some(stop));
+        assert_eq!(InternalRiderPhase::Waiting { stop }.at_stop(), Some(stop));
+        assert_eq!(InternalRiderPhase::Arrived { stop }.at_stop(), Some(stop));
+        assert_eq!(InternalRiderPhase::Abandoned { stop }.at_stop(), Some(stop));
+        assert_eq!(InternalRiderPhase::Resident { stop }.at_stop(), Some(stop));
         assert_eq!(
-            RiderState::Boarding {
+            InternalRiderPhase::Boarding {
                 elevator: elev,
                 stop
             }
@@ -194,7 +199,7 @@ mod tests {
             Some(stop)
         );
         assert_eq!(
-            RiderState::Exiting {
+            InternalRiderPhase::Exiting {
                 elevator: elev,
                 stop
             }
@@ -206,93 +211,106 @@ mod tests {
     #[test]
     fn at_stop_returns_none_for_in_transit_variants() {
         let (_, elev, _) = ids();
-        assert_eq!(RiderState::Riding { elevator: elev }.at_stop(), None);
-        assert_eq!(RiderState::Walking.at_stop(), None);
+        assert_eq!(
+            InternalRiderPhase::Riding { elevator: elev }.at_stop(),
+            None
+        );
+        assert_eq!(InternalRiderPhase::Walking.at_stop(), None);
     }
 
     #[test]
     fn aboard_returns_elevator_for_aboard_variants() {
         let (stop, elev, _) = ids();
         assert_eq!(
-            RiderState::Boarding {
+            InternalRiderPhase::Boarding {
                 elevator: elev,
                 stop
             }
             .aboard(),
             Some(elev)
         );
-        assert_eq!(RiderState::Riding { elevator: elev }.aboard(), Some(elev));
         assert_eq!(
-            RiderState::Exiting {
+            InternalRiderPhase::Riding { elevator: elev }.aboard(),
+            Some(elev)
+        );
+        assert_eq!(
+            InternalRiderPhase::Exiting {
                 elevator: elev,
                 stop
             }
             .aboard(),
             Some(elev)
         );
-        assert_eq!(RiderState::Waiting { stop }.aboard(), None);
-        assert_eq!(RiderState::Walking.aboard(), None);
+        assert_eq!(InternalRiderPhase::Waiting { stop }.aboard(), None);
+        assert_eq!(InternalRiderPhase::Walking.aboard(), None);
     }
 
     #[test]
     fn round_trip_through_phase_preserves_state() {
         let (stop, elev, _) = ids();
         let cases = [
-            RiderState::Waiting { stop },
-            RiderState::Boarding {
+            InternalRiderPhase::Waiting { stop },
+            InternalRiderPhase::Boarding {
                 elevator: elev,
                 stop,
             },
-            RiderState::Riding { elevator: elev },
-            RiderState::Exiting {
+            InternalRiderPhase::Riding { elevator: elev },
+            InternalRiderPhase::Exiting {
                 elevator: elev,
                 stop,
             },
-            RiderState::Walking,
-            RiderState::Arrived { stop },
-            RiderState::Abandoned { stop },
-            RiderState::Resident { stop },
+            InternalRiderPhase::Walking,
+            InternalRiderPhase::Arrived { stop },
+            InternalRiderPhase::Abandoned { stop },
+            InternalRiderPhase::Resident { stop },
         ];
         for state in cases {
             let phase = state.as_phase();
             let stop_back = state.at_stop();
-            let reconstructed = RiderState::from_phase(phase, stop_back).unwrap_or_else(|| {
-                panic!("from_phase rejected legal pair: phase={phase:?}, stop={stop_back:?}")
-            });
-            assert_eq!(reconstructed, state, "round-trip mismatch for {state:?}");
+            // Compare against `Some(state)` so a `None` result fails the
+            // assertion without needing `unwrap()` or `panic!` (both of
+            // which are forbidden by the workspace clippy gate).
+            assert_eq!(
+                InternalRiderPhase::from_phase(phase, stop_back),
+                Some(state),
+                "round-trip mismatch for {state:?} (phase={phase:?}, stop={stop_back:?})"
+            );
         }
     }
 
     #[test]
     fn riderphase_kind_matches_state_kind() {
-        // Sanity: the public RiderPhase::kind() and RiderState::kind() must
+        // Sanity: the public RiderPhase::kind() and InternalRiderPhase::kind() must
         // agree for every variant. Catches drift if either enum gains a
         // case without updating the other.
         let (stop, elev, _) = ids();
-        let pairs: &[(RiderState, RiderPhase)] = &[
-            (RiderState::Waiting { stop }, RiderPhase::Waiting),
+        let pairs: &[(InternalRiderPhase, RiderPhase)] = &[
+            (InternalRiderPhase::Waiting { stop }, RiderPhase::Waiting),
             (
-                RiderState::Boarding {
+                InternalRiderPhase::Boarding {
                     elevator: elev,
                     stop,
                 },
                 RiderPhase::Boarding(elev),
             ),
             (
-                RiderState::Riding { elevator: elev },
+                InternalRiderPhase::Riding { elevator: elev },
                 RiderPhase::Riding(elev),
             ),
             (
-                RiderState::Exiting {
+                InternalRiderPhase::Exiting {
                     elevator: elev,
                     stop,
                 },
                 RiderPhase::Exiting(elev),
             ),
-            (RiderState::Walking, RiderPhase::Walking),
-            (RiderState::Arrived { stop }, RiderPhase::Arrived),
-            (RiderState::Abandoned { stop }, RiderPhase::Abandoned),
-            (RiderState::Resident { stop }, RiderPhase::Resident),
+            (InternalRiderPhase::Walking, RiderPhase::Walking),
+            (InternalRiderPhase::Arrived { stop }, RiderPhase::Arrived),
+            (
+                InternalRiderPhase::Abandoned { stop },
+                RiderPhase::Abandoned,
+            ),
+            (InternalRiderPhase::Resident { stop }, RiderPhase::Resident),
         ];
         for (state, phase) in pairs {
             assert_eq!(state.kind(), phase.kind(), "kind mismatch for {state:?}");
@@ -303,12 +321,18 @@ mod tests {
     fn from_phase_rejects_inconsistent_inputs() {
         let (_, elev, _) = ids();
         // Waiting without a stop — the "ghost rider" footgun.
-        assert_eq!(RiderState::from_phase(RiderPhase::Waiting, None), None);
         assert_eq!(
-            RiderState::from_phase(RiderPhase::Boarding(elev), None),
+            InternalRiderPhase::from_phase(RiderPhase::Waiting, None),
             None
         );
-        assert_eq!(RiderState::from_phase(RiderPhase::Arrived, None), None);
+        assert_eq!(
+            InternalRiderPhase::from_phase(RiderPhase::Boarding(elev), None),
+            None
+        );
+        assert_eq!(
+            InternalRiderPhase::from_phase(RiderPhase::Arrived, None),
+            None
+        );
     }
 
     #[test]
@@ -317,30 +341,51 @@ mod tests {
         // before they boarded. We accept the phase regardless and produce
         // the canonical no-stop Riding state.
         let (stale_stop, elev, _) = ids();
-        let s = RiderState::from_phase(RiderPhase::Riding(elev), Some(stale_stop)).unwrap();
-        assert_eq!(s, RiderState::Riding { elevator: elev });
+        assert_eq!(
+            InternalRiderPhase::from_phase(RiderPhase::Riding(elev), Some(stale_stop)),
+            Some(InternalRiderPhase::Riding { elevator: elev }),
+        );
     }
 
     #[test]
     fn kind_matches_phase_kind() {
         let (stop, elev, _) = ids();
-        let pairs: &[(RiderState, RiderPhaseKind)] = &[
-            (RiderState::Waiting { stop }, RiderPhaseKind::Waiting),
+        let pairs: &[(InternalRiderPhase, RiderPhaseKind)] = &[
             (
-                RiderState::Boarding {
+                InternalRiderPhase::Waiting { stop },
+                RiderPhaseKind::Waiting,
+            ),
+            (
+                InternalRiderPhase::Boarding {
                     elevator: elev,
                     stop,
                 },
                 RiderPhaseKind::Boarding,
             ),
             (
-                RiderState::Riding { elevator: elev },
+                InternalRiderPhase::Riding { elevator: elev },
                 RiderPhaseKind::Riding,
             ),
-            (RiderState::Walking, RiderPhaseKind::Walking),
-            (RiderState::Arrived { stop }, RiderPhaseKind::Arrived),
-            (RiderState::Abandoned { stop }, RiderPhaseKind::Abandoned),
-            (RiderState::Resident { stop }, RiderPhaseKind::Resident),
+            (
+                InternalRiderPhase::Exiting {
+                    elevator: elev,
+                    stop,
+                },
+                RiderPhaseKind::Exiting,
+            ),
+            (InternalRiderPhase::Walking, RiderPhaseKind::Walking),
+            (
+                InternalRiderPhase::Arrived { stop },
+                RiderPhaseKind::Arrived,
+            ),
+            (
+                InternalRiderPhase::Abandoned { stop },
+                RiderPhaseKind::Abandoned,
+            ),
+            (
+                InternalRiderPhase::Resident { stop },
+                RiderPhaseKind::Resident,
+            ),
         ];
         for (state, expected_kind) in pairs {
             assert_eq!(state.kind(), *expected_kind);

--- a/crates/elevator-core/src/error.rs
+++ b/crates/elevator-core/src/error.rs
@@ -54,6 +54,19 @@ pub enum SimError {
         /// The rider's current phase.
         actual: RiderPhaseKind,
     },
+    /// An attempted lifecycle transition is not allowed by the legality matrix.
+    ///
+    /// Emitted by the transition gateway when the requested move from
+    /// `from` to `to` would skip a required intermediate state — e.g.
+    /// `Resident` → `Riding` (must go via `Waiting`/`Boarding` first).
+    IllegalTransition {
+        /// The rider whose transition was rejected.
+        rider: EntityId,
+        /// The rider's current phase.
+        from: RiderPhaseKind,
+        /// The phase the caller attempted to move into.
+        to: RiderPhaseKind,
+    },
     /// A rider has no current stop when one is required.
     RiderHasNoStop(EntityId),
     /// A route has no legs.
@@ -149,6 +162,12 @@ impl fmt::Display for SimError {
                 write!(
                     f,
                     "rider {rider:?} is in {actual} phase, expected {expected}"
+                )
+            }
+            Self::IllegalTransition { rider, from, to } => {
+                write!(
+                    f,
+                    "rider {rider:?} cannot transition {from} -> {to}: not in legality matrix"
                 )
             }
             Self::RiderHasNoStop(id) => write!(f, "rider {id:?} has no current stop"),

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -78,7 +78,8 @@ mod runtime;
 mod substep;
 mod tagging;
 mod topology;
-mod transition;
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) mod transition;
 
 use crate::components::{
     Accel, AccessControl, Orientation, Patience, Preferences, Route, SpatialPosition, Speed, Weight,

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -78,6 +78,7 @@ mod runtime;
 mod substep;
 mod tagging;
 mod topology;
+mod transition;
 
 use crate::components::{
     Accel, AccessControl, Orientation, Patience, Preferences, Route, SpatialPosition, Speed, Weight,

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -207,15 +207,12 @@ impl Simulation {
 
         let stop = rider.current_stop.ok_or(SimError::RiderHasNoStop(id))?;
 
-        // Update index: remove from old partition (only Abandoned is indexed).
-        if old_phase == RiderPhase::Abandoned {
-            self.rider_index.remove_abandoned(stop, id);
-        }
-        self.rider_index.insert_resident(stop, id);
-
-        if let Some(r) = self.world.rider_mut(id) {
-            r.phase = RiderPhase::Resident;
-        }
+        // Gateway handles `RiderIndex` (remove-from-Abandoned where
+        // applicable, insert-into-Resident) and the phase write atomically.
+        self.transition_rider(
+            id,
+            crate::components::rider_state::RiderState::Resident { stop },
+        )?;
 
         self.metrics.record_settle();
         let tag = self
@@ -270,11 +267,13 @@ impl Simulation {
             });
         }
 
-        self.rider_index.remove_resident(stop, id);
-        self.rider_index.insert_waiting(stop, id);
-
+        // Gateway handles `RiderIndex` (Resident -> Waiting) and the phase
+        // write. spawn_tick is rerouter-specific so it's reset directly after.
+        self.transition_rider(
+            id,
+            crate::components::rider_state::RiderState::Waiting { stop },
+        )?;
         if let Some(r) = self.world.rider_mut(id) {
-            r.phase = RiderPhase::Waiting;
             // Reset spawn_tick so manifest wait_ticks measures time since
             // reroute, not time since the original spawn as a Resident.
             r.spawn_tick = self.tick;
@@ -602,21 +601,25 @@ impl Simulation {
                     .world
                     .rider(*rid)
                     .map_or(0, crate::components::Rider::tag);
-                if let Some(r) = self.world.rider_mut(*rid) {
-                    r.phase = RiderPhase::Waiting;
-                    r.current_stop = nearest_stop;
-                    r.board_tick = None;
-                }
-                if let Some(stop) = nearest_stop {
-                    self.rider_index.insert_waiting(stop, *rid);
-                    self.events.emit(Event::RiderEjected {
-                        rider: *rid,
-                        elevator: id,
-                        stop,
-                        tag,
-                        tick: self.tick,
-                    });
-                }
+                // No stop to eject toward (zero-stop simulations) — leave
+                // the rider in their current phase rather than producing a
+                // ghost (Waiting with no current_stop). The elevator's
+                // `riders.clear()` below detaches them from the cab.
+                let Some(stop) = nearest_stop else { continue };
+                // Gateway routes the Riding/Boarding/Exiting -> Waiting rescue
+                // and updates `RiderIndex` atomically. board_tick is cleared
+                // because the new state is non-aboard.
+                self.transition_rider(
+                    *rid,
+                    crate::components::rider_state::RiderState::Waiting { stop },
+                )?;
+                self.events.emit(Event::RiderEjected {
+                    rider: *rid,
+                    elevator: id,
+                    stop,
+                    tag,
+                    tick: self.tick,
+                });
             }
 
             let had_load = self
@@ -689,15 +692,19 @@ impl Simulation {
         let resident_ids: Vec<EntityId> =
             self.rider_index.residents_at(id).iter().copied().collect();
         for rid in resident_ids {
-            self.rider_index.remove_resident(id, rid);
-            self.rider_index.insert_abandoned(id, rid);
             let tag = self
                 .world
                 .rider(rid)
                 .map_or(0, crate::components::Rider::tag);
-            if let Some(r) = self.world.rider_mut(rid) {
-                r.phase = RiderPhase::Abandoned;
-            }
+            // Gateway moves Resident -> Abandoned at the same stop and
+            // re-buckets the index entry (residents -> abandoned). We
+            // ignore the result: a transition error here would only fire
+            // on bookkeeping divergence we'd otherwise want to surface
+            // upstream, and `disable_stop_inner` has no return type.
+            let _ = self.transition_rider(
+                rid,
+                crate::components::rider_state::RiderState::Abandoned { stop: id },
+            );
             self.events.emit(Event::RiderAbandoned {
                 rider: rid,
                 stop: id,
@@ -892,11 +899,12 @@ impl Simulation {
             .map_or(crate::components::Weight::ZERO, |r| r.weight);
 
         if let Some(stop) = eject_stop {
-            if let Some(r) = self.world.rider_mut(rid) {
-                r.phase = RiderPhase::Waiting;
-                r.current_stop = Some(stop);
-                r.board_tick = None;
-            }
+            // Gateway routes the Riding -> Waiting rescue: phase, current_stop,
+            // board_tick, and the rider_index waiting bucket are updated atomically.
+            let _ = self.transition_rider(
+                rid,
+                crate::components::rider_state::RiderState::Waiting { stop },
+            );
             if let Some(car) = self.world.elevator_mut(car_eid) {
                 car.riders.retain(|r| *r != rid);
                 car.current_load -= rider_weight;
@@ -908,7 +916,6 @@ impl Simulation {
             // decide what to do next (game-side respawn, refund, etc.).
             let group = self.group_from_route(self.world.route(rid));
             self.world.set_route(rid, Route::direct(stop, stop, group));
-            self.rider_index.insert_waiting(stop, rid);
             self.emit_capacity_changed(car_eid);
             self.events.emit(Event::RiderEjected {
                 rider: rid,
@@ -918,9 +925,16 @@ impl Simulation {
                 tick: self.tick,
             });
         } else {
-            if let Some(r) = self.world.rider_mut(rid) {
-                r.phase = RiderPhase::Abandoned;
-            }
+            // Gateway routes the Riding -> Abandoned rescue, using the
+            // disabled stop as the abandonment anchor. Pre-refactor this
+            // path left current_stop=None — a "ghost" rider absent from
+            // every population query. The gateway forces an at-stop home.
+            let _ = self.transition_rider(
+                rid,
+                crate::components::rider_state::RiderState::Abandoned {
+                    stop: disabled_stop,
+                },
+            );
             if let Some(car) = self.world.elevator_mut(car_eid) {
                 car.riders.retain(|r| *r != rid);
                 car.current_load -= rider_weight;
@@ -976,17 +990,15 @@ impl Simulation {
             tag,
             tick: self.tick,
         });
-        if let Some(r) = self.world.rider_mut(rid) {
-            r.phase = RiderPhase::Abandoned;
-        }
-        // Fourth abandonment site (alongside the two in
-        // `advance_transient`); same stale-ID hazard. Scrub the rider
-        // from every hall/car-call pending list.
+        // Gateway routes Waiting -> Abandoned: re-buckets the index entry
+        // (waiting -> abandoned) and updates phase/current_stop. Same
+        // stale-ID hazard as the other three abandonment sites — scrub
+        // hall/car-call pending lists alongside.
+        let _ = self.transition_rider(
+            rid,
+            crate::components::rider_state::RiderState::Abandoned { stop: abandon_stop },
+        );
         self.world.scrub_rider_from_pending_calls(rid);
-        if let Some(stop) = rider_current_stop {
-            self.rider_index.remove_waiting(stop, rid);
-            self.rider_index.insert_abandoned(stop, rid);
-        }
         self.events.emit(Event::RiderAbandoned {
             rider: rid,
             stop: abandon_stop,

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -211,7 +211,7 @@ impl Simulation {
         // applicable, insert-into-Resident) and the phase write atomically.
         self.transition_rider(
             id,
-            crate::components::rider_state::RiderState::Resident { stop },
+            crate::components::rider_state::InternalRiderPhase::Resident { stop },
         )?;
 
         self.metrics.record_settle();
@@ -271,7 +271,7 @@ impl Simulation {
         // write. spawn_tick is rerouter-specific so it's reset directly after.
         self.transition_rider(
             id,
-            crate::components::rider_state::RiderState::Waiting { stop },
+            crate::components::rider_state::InternalRiderPhase::Waiting { stop },
         )?;
         if let Some(r) = self.world.rider_mut(id) {
             // Reset spawn_tick so manifest wait_ticks measures time since
@@ -611,7 +611,7 @@ impl Simulation {
                 // because the new state is non-aboard.
                 self.transition_rider(
                     *rid,
-                    crate::components::rider_state::RiderState::Waiting { stop },
+                    crate::components::rider_state::InternalRiderPhase::Waiting { stop },
                 )?;
                 self.events.emit(Event::RiderEjected {
                     rider: *rid,
@@ -703,7 +703,7 @@ impl Simulation {
             // upstream, and `disable_stop_inner` has no return type.
             let _ = self.transition_rider(
                 rid,
-                crate::components::rider_state::RiderState::Abandoned { stop: id },
+                crate::components::rider_state::InternalRiderPhase::Abandoned { stop: id },
             );
             self.events.emit(Event::RiderAbandoned {
                 rider: rid,
@@ -903,7 +903,7 @@ impl Simulation {
             // board_tick, and the rider_index waiting bucket are updated atomically.
             let _ = self.transition_rider(
                 rid,
-                crate::components::rider_state::RiderState::Waiting { stop },
+                crate::components::rider_state::InternalRiderPhase::Waiting { stop },
             );
             if let Some(car) = self.world.elevator_mut(car_eid) {
                 car.riders.retain(|r| *r != rid);
@@ -931,7 +931,7 @@ impl Simulation {
             // every population query. The gateway forces an at-stop home.
             let _ = self.transition_rider(
                 rid,
-                crate::components::rider_state::RiderState::Abandoned {
+                crate::components::rider_state::InternalRiderPhase::Abandoned {
                     stop: disabled_stop,
                 },
             );
@@ -996,7 +996,7 @@ impl Simulation {
         // hall/car-call pending lists alongside.
         let _ = self.transition_rider(
             rid,
-            crate::components::rider_state::RiderState::Abandoned { stop: abandon_stop },
+            crate::components::rider_state::InternalRiderPhase::Abandoned { stop: abandon_stop },
         );
         self.world.scrub_rider_from_pending_calls(rid);
         self.events.emit(Event::RiderAbandoned {

--- a/crates/elevator-core/src/sim/transition.rs
+++ b/crates/elevator-core/src/sim/transition.rs
@@ -26,77 +26,103 @@ use crate::components::rider_state::RiderState;
 use crate::entity::EntityId;
 use crate::error::SimError;
 use crate::rider_index::RiderIndex;
+use crate::world::World;
 
-#[allow(dead_code)] // call sites migrate in the next commit
 impl Simulation {
     /// Transition a rider to a new lifecycle state, updating all dependent
     /// bookkeeping atomically.
     ///
-    /// On success the rider's `phase`, `current_stop`, and `board_tick`
-    /// fields and the `RiderIndex` partitioning are guaranteed consistent.
-    /// On error nothing is mutated.
+    /// Sole legitimate pathway for mutating `Rider::phase`,
+    /// `Rider::current_stop`, and `Rider::board_tick` after the rider is
+    /// alive. See [`transition_rider`] for the full contract.
     ///
     /// # Errors
     ///
     /// - [`SimError::EntityNotFound`] if `id` is not a live rider.
-    /// - [`SimError::IllegalTransition`] if moving from the rider's current
-    ///   phase to `new_state` is rejected by the legality matrix
-    ///   ([`is_legal_transition`]).
+    /// - [`SimError::IllegalTransition`] if the move is rejected by the
+    ///   legality matrix.
     pub(crate) fn transition_rider(
         &mut self,
         id: EntityId,
         new_state: RiderState,
     ) -> Result<(), SimError> {
-        // Snapshot old state into Copy locals so the immutable borrow on
-        // `self.world` ends before we touch `self.rider_index` /
-        // `self.world.rider_mut`.
-        let (old_phase, old_stop, was_aboard) = {
-            let rider = self.world.rider(id).ok_or(SimError::EntityNotFound(id))?;
-            (rider.phase, rider.current_stop, rider.phase.is_aboard())
-        };
-
-        let from_kind = old_phase.kind();
-        let to_kind = new_state.kind();
-        if !is_legal_transition(from_kind, to_kind) {
-            return Err(SimError::IllegalTransition {
-                rider: id,
-                from: from_kind,
-                to: to_kind,
-            });
-        }
-
-        // Sync the rider_index: remove from the old at-stop bucket (if any),
-        // insert into the new one (if any). When neither old nor new state
-        // is indexed, this is a no-op.
-        let old_bucket = indexed_bucket(from_kind).zip(old_stop);
-        let new_bucket = indexed_bucket(to_kind).zip(new_state.at_stop());
-        if old_bucket != new_bucket {
-            if let Some((bucket, stop)) = old_bucket {
-                bucket.remove_from(&mut self.rider_index, stop, id);
-            }
-            if let Some((bucket, stop)) = new_bucket {
-                bucket.insert_into(&mut self.rider_index, stop, id);
-            }
-        }
-
-        // Apply the state to the rider record.
-        let now_aboard = matches!(
-            to_kind,
-            RiderPhaseKind::Boarding | RiderPhaseKind::Riding | RiderPhaseKind::Exiting
-        );
-        let tick = self.tick;
-        if let Some(r) = self.world.rider_mut(id) {
-            r.phase = new_state.as_phase();
-            r.current_stop = new_state.at_stop();
-            if !was_aboard && now_aboard {
-                r.board_tick = Some(tick);
-            } else if was_aboard && !now_aboard {
-                r.board_tick = None;
-            }
-        }
-
-        Ok(())
+        transition_rider(
+            &mut self.world,
+            &mut self.rider_index,
+            self.tick,
+            id,
+            new_state,
+        )
     }
+}
+
+/// Free-function form of the transition gateway, callable from system
+/// contexts (`systems/loading.rs`, `systems/advance_transient.rs`, etc.) that
+/// hold separate `&mut World` and `&mut RiderIndex` borrows rather than the
+/// full `&mut Simulation`.
+///
+/// On success the rider's four state fields and the `RiderIndex`
+/// partitioning are guaranteed consistent. On error nothing is mutated.
+///
+/// # Errors
+///
+/// - [`SimError::EntityNotFound`] if `id` is not a live rider.
+/// - [`SimError::IllegalTransition`] if moving from the rider's current
+///   phase to `new_state` is rejected by [`is_legal_transition`].
+pub(crate) fn transition_rider(
+    world: &mut World,
+    rider_index: &mut RiderIndex,
+    tick: u64,
+    id: EntityId,
+    new_state: RiderState,
+) -> Result<(), SimError> {
+    // Snapshot old state into Copy locals so the immutable borrow on
+    // `world` ends before we touch `rider_index` / `world.rider_mut`.
+    let (old_phase, old_stop, was_aboard) = {
+        let rider = world.rider(id).ok_or(SimError::EntityNotFound(id))?;
+        (rider.phase, rider.current_stop, rider.phase.is_aboard())
+    };
+
+    let from_kind = old_phase.kind();
+    let to_kind = new_state.kind();
+    if !is_legal_transition(from_kind, to_kind) {
+        return Err(SimError::IllegalTransition {
+            rider: id,
+            from: from_kind,
+            to: to_kind,
+        });
+    }
+
+    // Sync the rider_index: remove from the old at-stop bucket (if any),
+    // insert into the new one (if any). When neither old nor new state
+    // is indexed, this is a no-op.
+    let old_bucket = indexed_bucket(from_kind).zip(old_stop);
+    let new_bucket = indexed_bucket(to_kind).zip(new_state.at_stop());
+    if old_bucket != new_bucket {
+        if let Some((bucket, stop)) = old_bucket {
+            bucket.remove_from(rider_index, stop, id);
+        }
+        if let Some((bucket, stop)) = new_bucket {
+            bucket.insert_into(rider_index, stop, id);
+        }
+    }
+
+    // Apply the state to the rider record.
+    let now_aboard = matches!(
+        to_kind,
+        RiderPhaseKind::Boarding | RiderPhaseKind::Riding | RiderPhaseKind::Exiting
+    );
+    if let Some(r) = world.rider_mut(id) {
+        r.phase = new_state.as_phase();
+        r.current_stop = new_state.at_stop();
+        if !was_aboard && now_aboard {
+            r.board_tick = Some(tick);
+        } else if was_aboard && !now_aboard {
+            r.board_tick = None;
+        }
+    }
+
+    Ok(())
 }
 
 /// Index buckets exposed by [`RiderIndex`].
@@ -115,7 +141,6 @@ enum IndexBucket {
     Abandoned,
 }
 
-#[allow(dead_code)] // call sites migrate in the next commit
 impl IndexBucket {
     /// Add `rider` to this bucket at `stop`.
     fn insert_into(self, idx: &mut RiderIndex, stop: EntityId, rider: EntityId) {
@@ -137,7 +162,6 @@ impl IndexBucket {
 }
 
 /// Map a phase kind to its index bucket, or `None` for unindexed phases.
-#[allow(dead_code)] // consumed by transition_rider in the next commit
 const fn indexed_bucket(kind: RiderPhaseKind) -> Option<IndexBucket> {
     match kind {
         RiderPhaseKind::Waiting => Some(IndexBucket::Waiting),
@@ -147,7 +171,6 @@ const fn indexed_bucket(kind: RiderPhaseKind) -> Option<IndexBucket> {
     }
 }
 
-#[allow(dead_code)] // consumed by transition_rider in the next commit
 /// Pragmatic transition legality matrix.
 ///
 /// Rejects only the transitions that would skip a required intermediate

--- a/crates/elevator-core/src/sim/transition.rs
+++ b/crates/elevator-core/src/sim/transition.rs
@@ -1,0 +1,283 @@
+//! Sole pathway for mutating a rider's lifecycle state.
+//!
+//! [`Simulation::transition_rider`] is the only legitimate way to change a
+//! rider's `phase`, `current_stop`, or `board_tick` after the rider is alive.
+//! It atomically updates these fields, the [`RiderIndex`] partitioning, and
+//! validates the requested transition against a pragmatic legality matrix.
+//!
+//! Callers retain responsibility for emitting rider-lifecycle events: the
+//! same `(from, to)` pair can correspond to different events depending on
+//! context (e.g. a `Waiting → Abandoned` move could be `RiderAbandoned` from
+//! patience expiry or part of a stop-removal cleanup), so the gateway leaves
+//! that decision to the caller.
+//!
+//! # Why this exists
+//!
+//! Before the gateway, every transition site (lifecycle, world, dispatch,
+//! systems) had to remember to: (a) flip `rider.phase`, (b) update
+//! `rider.current_stop`, (c) keep `RiderIndex` in sync with the at-stop
+//! buckets, and (d) maintain `board_tick`. Forgetting any one produced a
+//! "ghost rider" — phase says one thing, the index says another. The
+//! gateway concentrates these four concerns in one auditable place.
+
+use super::Simulation;
+use crate::components::RiderPhaseKind;
+use crate::components::rider_state::RiderState;
+use crate::entity::EntityId;
+use crate::error::SimError;
+use crate::rider_index::RiderIndex;
+
+#[allow(dead_code)] // call sites migrate in the next commit
+impl Simulation {
+    /// Transition a rider to a new lifecycle state, updating all dependent
+    /// bookkeeping atomically.
+    ///
+    /// On success the rider's `phase`, `current_stop`, and `board_tick`
+    /// fields and the `RiderIndex` partitioning are guaranteed consistent.
+    /// On error nothing is mutated.
+    ///
+    /// # Errors
+    ///
+    /// - [`SimError::EntityNotFound`] if `id` is not a live rider.
+    /// - [`SimError::IllegalTransition`] if moving from the rider's current
+    ///   phase to `new_state` is rejected by the legality matrix
+    ///   ([`is_legal_transition`]).
+    pub(crate) fn transition_rider(
+        &mut self,
+        id: EntityId,
+        new_state: RiderState,
+    ) -> Result<(), SimError> {
+        // Snapshot old state into Copy locals so the immutable borrow on
+        // `self.world` ends before we touch `self.rider_index` /
+        // `self.world.rider_mut`.
+        let (old_phase, old_stop, was_aboard) = {
+            let rider = self.world.rider(id).ok_or(SimError::EntityNotFound(id))?;
+            (rider.phase, rider.current_stop, rider.phase.is_aboard())
+        };
+
+        let from_kind = old_phase.kind();
+        let to_kind = new_state.kind();
+        if !is_legal_transition(from_kind, to_kind) {
+            return Err(SimError::IllegalTransition {
+                rider: id,
+                from: from_kind,
+                to: to_kind,
+            });
+        }
+
+        // Sync the rider_index: remove from the old at-stop bucket (if any),
+        // insert into the new one (if any). When neither old nor new state
+        // is indexed, this is a no-op.
+        let old_bucket = indexed_bucket(from_kind).zip(old_stop);
+        let new_bucket = indexed_bucket(to_kind).zip(new_state.at_stop());
+        if old_bucket != new_bucket {
+            if let Some((bucket, stop)) = old_bucket {
+                bucket.remove_from(&mut self.rider_index, stop, id);
+            }
+            if let Some((bucket, stop)) = new_bucket {
+                bucket.insert_into(&mut self.rider_index, stop, id);
+            }
+        }
+
+        // Apply the state to the rider record.
+        let now_aboard = matches!(
+            to_kind,
+            RiderPhaseKind::Boarding | RiderPhaseKind::Riding | RiderPhaseKind::Exiting
+        );
+        let tick = self.tick;
+        if let Some(r) = self.world.rider_mut(id) {
+            r.phase = new_state.as_phase();
+            r.current_stop = new_state.at_stop();
+            if !was_aboard && now_aboard {
+                r.board_tick = Some(tick);
+            } else if was_aboard && !now_aboard {
+                r.board_tick = None;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Index buckets exposed by [`RiderIndex`].
+///
+/// The index only partitions three phases (`Waiting`, `Resident`, `Abandoned`);
+/// the gateway maps phase kinds to buckets via [`indexed_bucket`] and
+/// dispatches insert/remove calls through this enum to keep the gateway free
+/// of per-bucket match arms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IndexBucket {
+    /// The `Waiting` partition of `RiderIndex`.
+    Waiting,
+    /// The `Resident` partition of `RiderIndex`.
+    Resident,
+    /// The `Abandoned` partition of `RiderIndex`.
+    Abandoned,
+}
+
+#[allow(dead_code)] // call sites migrate in the next commit
+impl IndexBucket {
+    /// Add `rider` to this bucket at `stop`.
+    fn insert_into(self, idx: &mut RiderIndex, stop: EntityId, rider: EntityId) {
+        match self {
+            Self::Waiting => idx.insert_waiting(stop, rider),
+            Self::Resident => idx.insert_resident(stop, rider),
+            Self::Abandoned => idx.insert_abandoned(stop, rider),
+        }
+    }
+
+    /// Remove `rider` from this bucket at `stop`.
+    fn remove_from(self, idx: &mut RiderIndex, stop: EntityId, rider: EntityId) {
+        match self {
+            Self::Waiting => idx.remove_waiting(stop, rider),
+            Self::Resident => idx.remove_resident(stop, rider),
+            Self::Abandoned => idx.remove_abandoned(stop, rider),
+        }
+    }
+}
+
+/// Map a phase kind to its index bucket, or `None` for unindexed phases.
+#[allow(dead_code)] // consumed by transition_rider in the next commit
+const fn indexed_bucket(kind: RiderPhaseKind) -> Option<IndexBucket> {
+    match kind {
+        RiderPhaseKind::Waiting => Some(IndexBucket::Waiting),
+        RiderPhaseKind::Resident => Some(IndexBucket::Resident),
+        RiderPhaseKind::Abandoned => Some(IndexBucket::Abandoned),
+        _ => None,
+    }
+}
+
+#[allow(dead_code)] // consumed by transition_rider in the next commit
+/// Pragmatic transition legality matrix.
+///
+/// Rejects only the transitions that would skip a required intermediate
+/// state and produce double-counting or stale references in the index:
+///
+/// - `Resident` / `Arrived` / `Abandoned` → `Boarding`/`Riding`/`Exiting`
+///   (cannot board directly from a parked or terminal state — must reroute
+///   to `Waiting` first).
+/// - `Walking` → `Boarding`/`Riding`/`Exiting` (must reach a stop first).
+/// - `Waiting` → `Riding`/`Exiting` (must `Boarding` first).
+/// - `Boarding` → `Exiting` (must `Riding` first).
+///
+/// Everything else is allowed, including rescue transitions
+/// (`Boarding`/`Riding`/`Exiting` → `Waiting` for elevator-despawn ejection),
+/// forward progress, terminal moves, and same-state self-transitions.
+const fn is_legal_transition(from: RiderPhaseKind, to: RiderPhaseKind) -> bool {
+    use RiderPhaseKind::{
+        Abandoned, Arrived, Boarding, Exiting, Resident, Riding, Waiting, Walking,
+    };
+    // Read this as: an arrow at column "to" is rejected from any source on
+    // the row to its left.
+    //
+    // ```
+    //                 to=Boarding   to=Riding              to=Exiting
+    // Resident             ✗            ✗                       ✗
+    // Arrived              ✗            ✗                       ✗
+    // Abandoned            ✗            ✗                       ✗
+    // Walking              ✗            ✗                       ✗
+    // Waiting              -            ✗                       ✗
+    // Boarding             -            -                       ✗
+    // ```
+    !matches!(
+        (from, to),
+        (Resident | Arrived | Abandoned | Walking, Boarding)
+            | (Resident | Arrived | Abandoned | Walking | Waiting, Riding)
+            | (
+                Resident | Arrived | Abandoned | Walking | Waiting | Boarding,
+                Exiting
+            )
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    //! Gateway behaviour and legality-matrix tests.
+    //!
+    //! Tests that exercise the gateway through real `Simulation` flows live
+    //! in the integration-style test files (`api_surface_tests.rs`,
+    //! `lifecycle_tests.rs`); these unit tests cover the pure legality
+    //! helper and IndexBucket dispatch.
+
+    use super::*;
+    use crate::components::RiderPhaseKind::*;
+
+    #[test]
+    fn legality_rejects_resident_to_aboard() {
+        assert!(!is_legal_transition(Resident, Boarding));
+        assert!(!is_legal_transition(Resident, Riding));
+        assert!(!is_legal_transition(Resident, Exiting));
+    }
+
+    #[test]
+    fn legality_rejects_terminal_to_aboard() {
+        for from in [Arrived, Abandoned] {
+            for to in [Boarding, Riding, Exiting] {
+                assert!(
+                    !is_legal_transition(from, to),
+                    "{from:?} -> {to:?} should be illegal"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn legality_rejects_walking_to_aboard() {
+        assert!(!is_legal_transition(Walking, Boarding));
+        assert!(!is_legal_transition(Walking, Riding));
+        assert!(!is_legal_transition(Walking, Exiting));
+    }
+
+    #[test]
+    fn legality_rejects_skipping_boarding_or_riding() {
+        assert!(!is_legal_transition(Waiting, Riding));
+        assert!(!is_legal_transition(Waiting, Exiting));
+        assert!(!is_legal_transition(Boarding, Exiting));
+    }
+
+    #[test]
+    fn legality_allows_rescue_back_to_waiting() {
+        // The elevator-despawn rescue path: an aboard rider needs to be
+        // resettable to Waiting. This is the linchpin for fixing the
+        // world.rs:204 footgun.
+        assert!(is_legal_transition(Boarding, Waiting));
+        assert!(is_legal_transition(Riding, Waiting));
+        assert!(is_legal_transition(Exiting, Waiting));
+    }
+
+    #[test]
+    fn legality_allows_settle_paths() {
+        // Arrived -> Resident and Abandoned -> Resident are the
+        // settle_rider() flows.
+        assert!(is_legal_transition(Arrived, Resident));
+        assert!(is_legal_transition(Abandoned, Resident));
+        // Resident -> Waiting is reroute_rider.
+        assert!(is_legal_transition(Resident, Waiting));
+    }
+
+    #[test]
+    fn legality_allows_forward_progress() {
+        assert!(is_legal_transition(Waiting, Boarding));
+        assert!(is_legal_transition(Boarding, Riding));
+        assert!(is_legal_transition(Riding, Exiting));
+        assert!(is_legal_transition(Exiting, Arrived));
+    }
+
+    #[test]
+    fn legality_allows_patience_abandonment() {
+        // Waiting -> Abandoned via patience timeout.
+        assert!(is_legal_transition(Waiting, Abandoned));
+    }
+
+    #[test]
+    fn indexed_bucket_covers_only_three_phases() {
+        assert!(indexed_bucket(Waiting).is_some());
+        assert!(indexed_bucket(Resident).is_some());
+        assert!(indexed_bucket(Abandoned).is_some());
+        assert!(indexed_bucket(Boarding).is_none());
+        assert!(indexed_bucket(Riding).is_none());
+        assert!(indexed_bucket(Exiting).is_none());
+        assert!(indexed_bucket(Arrived).is_none());
+        assert!(indexed_bucket(Walking).is_none());
+    }
+}

--- a/crates/elevator-core/src/sim/transition.rs
+++ b/crates/elevator-core/src/sim/transition.rs
@@ -22,7 +22,7 @@
 
 use super::Simulation;
 use crate::components::RiderPhaseKind;
-use crate::components::rider_state::RiderState;
+use crate::components::rider_state::InternalRiderPhase;
 use crate::entity::EntityId;
 use crate::error::SimError;
 use crate::rider_index::RiderIndex;
@@ -44,7 +44,7 @@ impl Simulation {
     pub(crate) fn transition_rider(
         &mut self,
         id: EntityId,
-        new_state: RiderState,
+        new_state: InternalRiderPhase,
     ) -> Result<(), SimError> {
         transition_rider(
             &mut self.world,
@@ -74,7 +74,7 @@ pub(crate) fn transition_rider(
     rider_index: &mut RiderIndex,
     tick: u64,
     id: EntityId,
-    new_state: RiderState,
+    new_state: InternalRiderPhase,
 ) -> Result<(), SimError> {
     // Snapshot old state into Copy locals so the immutable borrow on
     // `world` ends before we touch `rider_index` / `world.rider_mut`.
@@ -220,7 +220,7 @@ mod tests {
     //! Tests that exercise the gateway through real `Simulation` flows live
     //! in the integration-style test files (`api_surface_tests.rs`,
     //! `lifecycle_tests.rs`); these unit tests cover the pure legality
-    //! helper and IndexBucket dispatch.
+    //! helper and `IndexBucket` dispatch.
 
     use super::*;
     use crate::components::RiderPhaseKind::*;

--- a/crates/elevator-core/src/systems/advance_transient.rs
+++ b/crates/elevator-core/src/systems/advance_transient.rs
@@ -43,9 +43,26 @@ fn handle_exit(
 
             let walk_dest = world.route(id).and_then(Route::current_destination);
             if let Some(dest) = walk_dest {
-                if let Some(r) = world.rider_mut(id) {
-                    r.current_stop = Some(dest);
-                }
+                // Route the within-Exiting `current_stop` advance through
+                // the gateway too, even though `Exiting` isn't an indexed
+                // phase and the desync risk is zero today. Keeping the
+                // gateway as the *sole* writer of `Rider::current_stop`
+                // means the rest of the file (including the
+                // `Exiting -> Waiting` call below at line 88) doesn't
+                // have to assume "well, this one direct mutation is OK."
+                let Some(RiderPhase::Exiting(elevator)) = world.rider(id).map(|r| r.phase) else {
+                    break;
+                };
+                let _ = crate::sim::transition::transition_rider(
+                    world,
+                    rider_index,
+                    ctx.tick,
+                    id,
+                    crate::components::rider_state::InternalRiderPhase::Exiting {
+                        elevator,
+                        stop: dest,
+                    },
+                );
                 let more = world.route_mut(id).is_some_and(Route::advance);
                 if !more {
                     // Gateway routes Exiting -> Arrived at the walk destination.
@@ -54,7 +71,7 @@ fn handle_exit(
                         rider_index,
                         ctx.tick,
                         id,
-                        crate::components::rider_state::RiderState::Arrived { stop: dest },
+                        crate::components::rider_state::InternalRiderPhase::Arrived { stop: dest },
                     );
                     // Route complete after walk — skip to invalidation check.
                     break;
@@ -85,7 +102,7 @@ fn handle_exit(
                     rider_index,
                     ctx.tick,
                     id,
-                    crate::components::rider_state::RiderState::Waiting { stop },
+                    crate::components::rider_state::InternalRiderPhase::Waiting { stop },
                 );
                 if let Some(r) = world.rider_mut(id) {
                     r.spawn_tick = ctx.tick;
@@ -115,7 +132,7 @@ fn handle_exit(
             rider_index,
             ctx.tick,
             id,
-            crate::components::rider_state::RiderState::Arrived { stop },
+            crate::components::rider_state::InternalRiderPhase::Arrived { stop },
         );
     }
 
@@ -181,7 +198,7 @@ pub fn run(
                     rider_index,
                     ctx.tick,
                     id,
-                    crate::components::rider_state::RiderState::Riding { elevator: eid },
+                    crate::components::rider_state::InternalRiderPhase::Riding { elevator: eid },
                 );
             }
             TransientAction::Exit => handle_exit(id, world, events, ctx, rider_index),
@@ -233,7 +250,7 @@ pub fn run(
             rider_index,
             ctx.tick,
             id,
-            crate::components::rider_state::RiderState::Abandoned { stop },
+            crate::components::rider_state::InternalRiderPhase::Abandoned { stop },
         );
         // An abandoned rider is not a waiter any more; leaving their
         // ID in `pending_riders` would spuriously hold car calls open
@@ -284,7 +301,7 @@ pub fn run(
             rider_index,
             ctx.tick,
             id,
-            crate::components::rider_state::RiderState::Abandoned { stop },
+            crate::components::rider_state::InternalRiderPhase::Abandoned { stop },
         );
         world.scrub_rider_from_pending_calls(id);
         events.emit(Event::RiderAbandoned {

--- a/crates/elevator-core/src/systems/advance_transient.rs
+++ b/crates/elevator-core/src/systems/advance_transient.rs
@@ -48,9 +48,14 @@ fn handle_exit(
                 }
                 let more = world.route_mut(id).is_some_and(Route::advance);
                 if !more {
-                    if let Some(r) = world.rider_mut(id) {
-                        r.phase = RiderPhase::Arrived;
-                    }
+                    // Gateway routes Exiting -> Arrived at the walk destination.
+                    let _ = crate::sim::transition::transition_rider(
+                        world,
+                        rider_index,
+                        ctx.tick,
+                        id,
+                        crate::components::rider_state::RiderState::Arrived { stop: dest },
+                    );
                     // Route complete after walk — skip to invalidation check.
                     break;
                 }
@@ -71,12 +76,20 @@ fn handle_exit(
             // back to `spawn_tick` for riders without Patience, so
             // resetting only one of the two would leave that path stuck
             // on the lifetime counter. Matches `reroute_rider`.
-            if let Some(r) = world.rider_mut(id) {
-                r.phase = RiderPhase::Waiting;
-                r.spawn_tick = ctx.tick;
-            }
             if let Some(stop) = world.rider(id).and_then(|r| r.current_stop) {
-                rider_index.insert_waiting(stop, id);
+                // Gateway routes Exiting -> Waiting at the transfer stop:
+                // phase, current_stop, and the waiting bucket of
+                // rider_index update atomically.
+                let _ = crate::sim::transition::transition_rider(
+                    world,
+                    rider_index,
+                    ctx.tick,
+                    id,
+                    crate::components::rider_state::RiderState::Waiting { stop },
+                );
+                if let Some(r) = world.rider_mut(id) {
+                    r.spawn_tick = ctx.tick;
+                }
                 // Capture the next leg's destination before we take mutable
                 // borrows of the arrival log — the destination log pairs
                 // with the arrival log on every append so down-peak stays
@@ -95,8 +108,15 @@ fn handle_exit(
                 }
             }
         }
-    } else if let Some(r) = world.rider_mut(id) {
-        r.phase = RiderPhase::Arrived;
+    } else if let Some(stop) = world.rider(id).and_then(|r| r.current_stop) {
+        // Gateway routes Exiting -> Arrived at the rider's current stop.
+        let _ = crate::sim::transition::transition_rider(
+            world,
+            rider_index,
+            ctx.tick,
+            id,
+            crate::components::rider_state::RiderState::Arrived { stop },
+        );
     }
 
     // If the rider's next destination is disabled, emit an invalidation event.
@@ -153,9 +173,16 @@ pub fn run(
     for (id, action) in actionable {
         match action {
             TransientAction::Board(eid) => {
-                if let Some(r) = world.rider_mut(id) {
-                    r.phase = RiderPhase::Riding(eid);
-                }
+                // Gateway routes Boarding -> Riding. board_tick is preserved
+                // (both phases are aboard); current_stop is cleared because
+                // the rider is now in transit.
+                let _ = crate::sim::transition::transition_rider(
+                    world,
+                    rider_index,
+                    ctx.tick,
+                    id,
+                    crate::components::rider_state::RiderState::Riding { elevator: eid },
+                );
             }
             TransientAction::Exit => handle_exit(id, world, events, ctx, rider_index),
         }
@@ -198,18 +225,20 @@ pub fn run(
 
     // Apply abandonments.
     for &(id, stop) in &abandon {
-        // Read the tag from the same mutable borrow we use to flip the
-        // phase, instead of doing a second arena lookup at emit time.
-        let tag = world.rider_mut(id).map_or(0, |r| {
-            r.phase = RiderPhase::Abandoned;
-            r.tag()
-        });
+        let tag = world.rider(id).map_or(0, Rider::tag);
+        // Gateway routes Waiting -> Abandoned and re-buckets the index
+        // entry (waiting -> abandoned) atomically.
+        let _ = crate::sim::transition::transition_rider(
+            world,
+            rider_index,
+            ctx.tick,
+            id,
+            crate::components::rider_state::RiderState::Abandoned { stop },
+        );
         // An abandoned rider is not a waiter any more; leaving their
         // ID in `pending_riders` would spuriously hold car calls open
         // and count them in mode-detection `is_empty()` checks.
         world.scrub_rider_from_pending_calls(id);
-        rider_index.remove_waiting(stop, id);
-        rider_index.insert_abandoned(stop, id);
         events.emit(Event::RiderAbandoned {
             rider: id,
             stop,
@@ -247,13 +276,17 @@ pub fn run(
         })
         .collect();
     for (id, stop) in time_abandon {
-        let tag = world.rider_mut(id).map_or(0, |r| {
-            r.phase = RiderPhase::Abandoned;
-            r.tag()
-        });
+        let tag = world.rider(id).map_or(0, Rider::tag);
+        // Gateway routes Waiting -> Abandoned (preference-driven path) with
+        // the same atomic re-bucket as the patience-driven branch above.
+        let _ = crate::sim::transition::transition_rider(
+            world,
+            rider_index,
+            ctx.tick,
+            id,
+            crate::components::rider_state::RiderState::Abandoned { stop },
+        );
         world.scrub_rider_from_pending_calls(id);
-        rider_index.remove_waiting(stop, id);
-        rider_index.insert_abandoned(stop, id);
         events.emit(Event::RiderAbandoned {
             rider: id,
             stop,

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -354,10 +354,14 @@ fn apply_actions(
                     car.riders.retain(|r| *r != rider);
                     car.current_load -= rider_weight;
                 }
-                if let Some(rd) = world.rider_mut(rider) {
-                    rd.phase = RiderPhase::Exiting(elevator);
-                    rd.current_stop = Some(stop);
-                }
+                // Gateway routes Riding -> Exiting at the arrival stop.
+                let _ = crate::sim::transition::transition_rider(
+                    world,
+                    rider_index,
+                    ctx.tick,
+                    rider,
+                    crate::components::rider_state::RiderState::Exiting { elevator, stop },
+                );
                 events.emit(Event::RiderExited {
                     rider,
                     elevator,
@@ -398,16 +402,21 @@ fn apply_actions(
                     },
                     _ => continue,
                 };
-                rider_index.remove_waiting(stop, rider);
                 if let Some(car) = world.elevator_mut(elevator) {
                     car.current_load += crate::components::Weight::from(weight);
                     car.riders.push(rider);
                 }
-                if let Some(rd) = world.rider_mut(rider) {
-                    rd.phase = RiderPhase::Boarding(elevator);
-                    rd.board_tick = Some(ctx.tick);
-                    rd.current_stop = None;
-                }
+                // Gateway routes Waiting -> Boarding: removes from
+                // waiting_at(stop), sets phase/board_tick/current_stop.
+                // The Boarding state carries the boarding stop so the
+                // index transition is atomic with the phase change.
+                let _ = crate::sim::transition::transition_rider(
+                    world,
+                    rider_index,
+                    ctx.tick,
+                    rider,
+                    crate::components::rider_state::RiderState::Boarding { elevator, stop },
+                );
                 events.emit(Event::RiderBoarded {
                     rider,
                     elevator,
@@ -478,11 +487,15 @@ fn apply_actions(
                         .preferences(rider)
                         .is_some_and(Preferences::abandon_on_full)
                 {
-                    if let Some(r) = world.rider_mut(rider) {
-                        r.phase = RiderPhase::Abandoned;
-                    }
-                    rider_index.remove_waiting(at_stop, rider);
-                    rider_index.insert_abandoned(at_stop, rider);
+                    // Gateway routes Waiting -> Abandoned at the same stop and
+                    // re-buckets the index entry (waiting -> abandoned).
+                    let _ = crate::sim::transition::transition_rider(
+                        world,
+                        rider_index,
+                        ctx.tick,
+                        rider,
+                        crate::components::rider_state::RiderState::Abandoned { stop: at_stop },
+                    );
                     events.emit(Event::RiderAbandoned {
                         rider,
                         stop: at_stop,

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -360,7 +360,7 @@ fn apply_actions(
                     rider_index,
                     ctx.tick,
                     rider,
-                    crate::components::rider_state::RiderState::Exiting { elevator, stop },
+                    crate::components::rider_state::InternalRiderPhase::Exiting { elevator, stop },
                 );
                 events.emit(Event::RiderExited {
                     rider,
@@ -415,7 +415,7 @@ fn apply_actions(
                     rider_index,
                     ctx.tick,
                     rider,
-                    crate::components::rider_state::RiderState::Boarding { elevator, stop },
+                    crate::components::rider_state::InternalRiderPhase::Boarding { elevator, stop },
                 );
                 events.emit(Event::RiderBoarded {
                     rider,
@@ -494,7 +494,9 @@ fn apply_actions(
                         rider_index,
                         ctx.tick,
                         rider,
-                        crate::components::rider_state::RiderState::Abandoned { stop: at_stop },
+                        crate::components::rider_state::InternalRiderPhase::Abandoned {
+                            stop: at_stop,
+                        },
                     );
                     events.emit(Event::RiderAbandoned {
                         rider,

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -85,6 +85,129 @@ fn remove_elevator_ejects_riders_aboard() {
     );
 }
 
+/// `remove_elevator` must keep the rider population index coherent: any rider
+/// transitioned back to `Waiting` as part of the ejection must be discoverable
+/// via `waiting_at(stop)` for the stop they were placed at. Without this
+/// guarantee, dispatch and `RiderIndex` queries would silently miss them and
+/// the rider becomes a "ghost" — phase says Waiting but they're absent from
+/// every per-stop population query.
+#[test]
+fn remove_elevator_keeps_rider_index_coherent() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let rider_id = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+
+    // Advance until the rider is mid-ride.
+    for _ in 0..300 {
+        sim.step();
+        if matches!(
+            sim.world().rider(rider_id.entity()).unwrap().phase,
+            RiderPhase::Riding(_)
+        ) {
+            break;
+        }
+    }
+    assert!(
+        matches!(
+            sim.world().rider(rider_id.entity()).unwrap().phase,
+            RiderPhase::Riding(_)
+        ),
+        "rider should have boarded within 300 ticks"
+    );
+
+    let elevator_id = sim.groups()[0].elevator_entities()[0];
+    sim.remove_elevator(elevator_id).unwrap();
+    sim.drain_events();
+
+    // Rider must now be Waiting at some stop with a coherent current_stop.
+    let rider = sim.world().rider(rider_id.entity()).unwrap();
+    assert!(
+        matches!(rider.phase, RiderPhase::Waiting),
+        "rider phase should be Waiting, got {:?}",
+        rider.phase
+    );
+    let stop = rider
+        .current_stop
+        .expect("ejected rider must land at a stop, not nowhere");
+
+    // The invariant: phase==Waiting + current_stop==Some(s) implies the
+    // rider is in `waiting_at(s)`. The population index is the canonical
+    // source of truth for dispatch.
+    let waiting: Vec<EntityId> = sim.waiting_at(stop).collect();
+    assert!(
+        waiting.contains(&rider_id.entity()),
+        "rider {:?} is Waiting at stop {:?} but missing from waiting_at; \
+         rider_index drifted from rider.phase \
+         (waiting_at returned {:?})",
+        rider_id.entity(),
+        stop,
+        waiting
+    );
+}
+
+/// Direct-`World::despawn` regression: when an elevator is despawned without
+/// going through `Simulation::disable` first, `World::despawn` resets aboard
+/// riders to `RiderPhase::Waiting` (world.rs ~204) but cannot touch the
+/// `RiderIndex` (which lives on `Simulation`). Result: rider phase says
+/// Waiting, rider has a `current_stop`, but they're absent from
+/// `waiting_at(stop)`. Until the gateway routes this reset, the assertion
+/// below fails. After the lockdown of `World::despawn` to `pub(crate)`, this
+/// test continues to guard against internal misuse from new sim code paths.
+///
+/// TODO(rider-lifecycle-arch): un-ignore once `transition_rider` routes the
+/// elevator-despawn rider reset through the gateway.
+#[test]
+#[ignore = "exposes a known footgun; un-ignore when transition gateway lands"]
+fn world_despawn_elevator_with_aboard_riders_keeps_index_coherent() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let rider_id = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    for _ in 0..300 {
+        sim.step();
+        if matches!(
+            sim.world().rider(rider_id.entity()).unwrap().phase,
+            RiderPhase::Riding(_)
+        ) {
+            break;
+        }
+    }
+    assert!(
+        matches!(
+            sim.world().rider(rider_id.entity()).unwrap().phase,
+            RiderPhase::Riding(_)
+        ),
+        "rider should have boarded within 300 ticks"
+    );
+
+    let elevator_id = sim.groups()[0].elevator_entities()[0];
+
+    // Bypass `Simulation::disable`/`remove_elevator`. This is the path the
+    // gateway must take responsibility for: even raw despawns must leave
+    // `RiderIndex` consistent with `Rider::phase`.
+    sim.world_mut().despawn(elevator_id);
+
+    let rider = sim.world().rider(rider_id.entity()).unwrap();
+    assert!(
+        matches!(rider.phase, RiderPhase::Waiting),
+        "rider phase should be Waiting after raw despawn, got {:?}",
+        rider.phase
+    );
+    let stop = rider
+        .current_stop
+        .expect("raw despawn placed rider at nearest stop");
+
+    let waiting: Vec<EntityId> = sim.waiting_at(stop).collect();
+    assert!(
+        waiting.contains(&rider_id.entity()),
+        "rider {:?} is Waiting at stop {:?} but missing from waiting_at \
+         after raw World::despawn — rider_index drifted from rider.phase",
+        rider_id.entity(),
+        stop
+    );
+}
+
 #[test]
 fn remove_elevator_ejects_rider_emits_event() {
     let config = default_config();

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -146,20 +146,15 @@ fn remove_elevator_keeps_rider_index_coherent() {
     );
 }
 
-/// Direct-`World::despawn` regression: when an elevator is despawned without
-/// going through `Simulation::disable` first, `World::despawn` resets aboard
-/// riders to `RiderPhase::Waiting` (world.rs ~204) but cannot touch the
-/// `RiderIndex` (which lives on `Simulation`). Result: rider phase says
-/// Waiting, rider has a `current_stop`, but they're absent from
-/// `waiting_at(stop)`. Until the gateway routes this reset, the assertion
-/// below fails. After the lockdown of `World::despawn` to `pub(crate)`, this
-/// test continues to guard against internal misuse from new sim code paths.
-///
-/// TODO(rider-lifecycle-arch): un-ignore once `transition_rider` routes the
-/// elevator-despawn rider reset through the gateway.
+/// Pins down the post-refactor contract for `World::despawn` on a populated
+/// elevator: it does **not** silently rewrite rider phase. The previous
+/// behaviour rewrote phase to Waiting (without updating `RiderIndex`),
+/// producing ghost riders. The new low-level contract is documented in
+/// `World::despawn`; the proper way to remove a populated elevator is
+/// `Simulation::remove_elevator` (covered by
+/// [`remove_elevator_keeps_rider_index_coherent`] above).
 #[test]
-#[ignore = "exposes a known footgun; un-ignore when transition gateway lands"]
-fn world_despawn_elevator_with_aboard_riders_keeps_index_coherent() {
+fn world_despawn_elevator_does_not_silently_rewrite_rider_phase() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
@@ -183,29 +178,33 @@ fn world_despawn_elevator_with_aboard_riders_keeps_index_coherent() {
 
     let elevator_id = sim.groups()[0].elevator_entities()[0];
 
-    // Bypass `Simulation::disable`/`remove_elevator`. This is the path the
-    // gateway must take responsibility for: even raw despawns must leave
-    // `RiderIndex` consistent with `Rider::phase`.
+    // Bypass `Simulation::remove_elevator`. Pre-refactor this rewrote
+    // rider.phase to Waiting (without updating RiderIndex) — a "ghost"
+    // rider. Post-refactor `World::despawn` no longer touches rider phase,
+    // making the inconsistency visible to the caller rather than silently
+    // half-applied.
     sim.world_mut().despawn(elevator_id);
+
+    assert!(!sim.world().is_alive(elevator_id));
 
     let rider = sim.world().rider(rider_id.entity()).unwrap();
     assert!(
-        matches!(rider.phase, RiderPhase::Waiting),
-        "rider phase should be Waiting after raw despawn, got {:?}",
+        matches!(rider.phase, RiderPhase::Riding(_)),
+        "rider phase should be unchanged by raw World::despawn, got {:?}",
         rider.phase
     );
-    let stop = rider
-        .current_stop
-        .expect("raw despawn placed rider at nearest stop");
-
-    let waiting: Vec<EntityId> = sim.waiting_at(stop).collect();
-    assert!(
-        waiting.contains(&rider_id.entity()),
-        "rider {:?} is Waiting at stop {:?} but missing from waiting_at \
-         after raw World::despawn — rider_index drifted from rider.phase",
-        rider_id.entity(),
-        stop
-    );
+    // Importantly: there is no ghost in any rider_index bucket — the
+    // rider was never indexed (Riding isn't an indexed phase) and
+    // World::despawn no longer attempts a phase rewrite that would have
+    // introduced one.
+    let stops: Vec<EntityId> = sim.world().iter_stops().map(|(eid, _)| eid).collect();
+    for stop in stops {
+        assert!(
+            !sim.waiting_at(stop).any(|r| r == rider_id.entity()),
+            "rider {:?} should not appear in waiting_at after raw despawn",
+            rider_id.entity()
+        );
+    }
 }
 
 #[test]

--- a/crates/elevator-core/src/tests/feature_tests.rs
+++ b/crates/elevator-core/src/tests/feature_tests.rs
@@ -651,11 +651,21 @@ fn remove_elevator_notifies_dispatcher_exactly_once() {
 
 // ── 6. Despawn cleanup ───────────────────────────────────────────────────────
 
+/// `World::despawn` is now a low-level entity removal: it does not transition
+/// aboard riders. Callers that despawn an elevator with riders aboard must
+/// transition them first (via `Simulation::disable` / `remove_elevator`,
+/// which route through the transition gateway). This test pins down that
+/// new contract — the elevator entity is removed and the rider's stale
+/// `Riding(eid)` reference points at a dead `EntityId`, but no silent
+/// rider-phase rewrite happens behind the caller's back. The previous
+/// behaviour (set rider to Waiting + nearest stop) couldn't keep
+/// `RiderIndex` consistent, so it produced "ghost" riders. See
+/// `api_surface_tests::remove_elevator_keeps_rider_index_coherent` for the
+/// proper full-stack flow.
 #[test]
-fn despawn_elevator_resets_rider_to_waiting() {
+fn despawn_elevator_does_not_silently_reset_aboard_riders() {
     let mut world = World::new();
 
-    // Create a stop for the rider to land at.
     let stop = world.spawn();
     world.set_stop(
         stop,
@@ -666,7 +676,6 @@ fn despawn_elevator_resets_rider_to_waiting() {
     );
     world.set_position(stop, Position { value: 0.0 });
 
-    // Create the elevator at the stop's position.
     let elev = world.spawn();
     world.set_position(elev, Position { value: 0.0 });
     world.set_velocity(elev, Velocity { value: 0.0 });
@@ -680,7 +689,7 @@ fn despawn_elevator_resets_rider_to_waiting() {
             deceleration: Accel::from(2.0),
             weight_capacity: Weight::from(800.0),
             current_load: Weight::from(70.0),
-            riders: vec![], // filled below after rider is known
+            riders: vec![],
             target_stop: None,
             door_transition_ticks: 5,
             door_open_ticks: 10,
@@ -699,7 +708,6 @@ fn despawn_elevator_resets_rider_to_waiting() {
         },
     );
 
-    // Create the rider and put them aboard.
     let rider = world.spawn();
     world.set_rider(
         rider,
@@ -712,36 +720,22 @@ fn despawn_elevator_resets_rider_to_waiting() {
             board_tick: Some(1),
         },
     );
-
-    // Update the elevator's rider list.
     world.elevator_mut(elev).unwrap().riders.push(rider);
 
-    // Precondition: rider is Riding, current_stop is None.
-    assert_eq!(
-        world.rider(rider).map(|r| r.phase),
-        Some(RiderPhase::Riding(elev))
-    );
-    assert_eq!(world.rider(rider).and_then(|r| r.current_stop), None);
-
-    // Despawn the elevator.
     world.despawn(elev);
 
-    assert!(!world.is_alive(elev), "elevator should no longer be alive");
+    assert!(!world.is_alive(elev));
 
-    // Rider should now be Waiting.
+    // The rider's phase is *not* silently rewritten by `World::despawn`;
+    // it still says Riding(elev) (now a dead EntityId). The rider is
+    // alive — only the elevator was removed. Cleaning this up is
+    // `Simulation::remove_elevator`'s job, not `World::despawn`'s.
     assert_eq!(
         world.rider(rider).map(|r| r.phase),
-        Some(RiderPhase::Waiting),
-        "rider should be reset to Waiting after elevator is despawned"
+        Some(RiderPhase::Riding(elev)),
+        "World::despawn must not silently rewrite rider phase"
     );
-
-    // Rider should have a valid current_stop pointing to the stop near position 0.0.
-    let current_stop = world.rider(rider).and_then(|r| r.current_stop);
-    assert_eq!(
-        current_stop,
-        Some(stop),
-        "rider's current_stop should be set to the nearest stop after elevator despawn"
-    );
+    assert_eq!(world.rider(rider).and_then(|r| r.current_stop), None);
 }
 
 #[test]

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -182,13 +182,14 @@ impl World {
     ///   the elevator's rider list and `current_load` is adjusted.
     ///
     /// **Despawning an elevator with aboard riders is the caller's
-    /// responsibility to clean up.** Use [`Simulation::remove_elevator`]
-    /// (which calls [`Simulation::disable`] first to transition aboard
-    /// riders to `Waiting` via the transition gateway). Calling this method
-    /// directly on a populated elevator leaves aboard riders pointing at
-    /// a now-dead `EntityId` in their `phase` — a footgun this method
-    /// no longer attempts to paper over, since any reset it produced
-    /// would silently desync `RiderIndex`.
+    /// responsibility to clean up.** Use
+    /// [`Simulation::remove_elevator`](crate::sim::Simulation::remove_elevator)
+    /// (which calls [`Simulation::disable`](crate::sim::Simulation::disable)
+    /// first to transition aboard riders to `Waiting` via the transition
+    /// gateway). Calling this method directly on a populated elevator leaves
+    /// aboard riders pointing at a now-dead `EntityId` in their `phase` —
+    /// a footgun this method no longer attempts to paper over, since any
+    /// reset it produced would silently desync `RiderIndex`.
     pub fn despawn(&mut self, id: EntityId) {
         // Clean up rider → elevator cross-references.
         if let Some(rider) = self.riders.get(id) {

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -172,10 +172,23 @@ impl World {
 
     /// Remove an entity and all its components (built-in and extensions).
     ///
-    /// Cross-references are cleaned up automatically:
-    /// - If the entity is a rider aboard an elevator, it is removed from the
-    ///   elevator's rider list and `current_load` is adjusted.
-    /// - If the entity is an elevator, its riders' phases are reset to `Waiting`.
+    /// `World::despawn` is a low-level operation: it removes the entity's
+    /// arena entries and performs the cross-references that `World` can
+    /// safely maintain on its own. It does **not** perform rider lifecycle
+    /// transitions (which require `RiderIndex`, owned by `Simulation`).
+    ///
+    /// Cross-references handled here:
+    /// - If the entity is a rider aboard an elevator, it is removed from
+    ///   the elevator's rider list and `current_load` is adjusted.
+    ///
+    /// **Despawning an elevator with aboard riders is the caller's
+    /// responsibility to clean up.** Use [`Simulation::remove_elevator`]
+    /// (which calls [`Simulation::disable`] first to transition aboard
+    /// riders to `Waiting` via the transition gateway). Calling this method
+    /// directly on a populated elevator leaves aboard riders pointing at
+    /// a now-dead `EntityId` in their `phase` — a footgun this method
+    /// no longer attempts to paper over, since any reset it produced
+    /// would silently desync `RiderIndex`.
     pub fn despawn(&mut self, id: EntityId) {
         // Clean up rider → elevator cross-references.
         if let Some(rider) = self.riders.get(id) {
@@ -191,19 +204,6 @@ impl World {
                     }
                 }
                 _ => {}
-            }
-        }
-
-        // Clean up elevator → rider cross-references.
-        if let Some(car) = self.elevators.get(id) {
-            let rider_ids: Vec<EntityId> = car.riders.clone();
-            let elev_pos = self.positions.get(id).map(|p| p.value);
-            let nearest_stop = elev_pos.and_then(|p| self.find_nearest_stop(p));
-            for rid in rider_ids {
-                if let Some(rider) = self.riders.get_mut(rid) {
-                    rider.phase = crate::components::RiderPhase::Waiting;
-                    rider.current_stop = nearest_stop;
-                }
             }
         }
 


### PR DESCRIPTION
## Summary

- Introduces `RiderState` typestate (`crates/elevator-core/src/components/rider_state.rs`) that bundles `current_stop` / elevator into variants — replacing the soft `Option<EntityId>` invariant with one the type system enforces. Public `RiderPhase` and snapshot wire format are unchanged; translation happens at the API edge via `as_phase` / `from_phase`.
- Adds `Simulation::transition_rider` (and a free-function form for system-phase contexts) in `crates/elevator-core/src/sim/transition.rs`. This is now the **sole** legitimate pathway for mutating `Rider::phase`, `Rider::current_stop`, and `Rider::board_tick` after a rider is alive. It atomically updates those fields plus the `RiderIndex` partitioning, and validates against a pragmatic legality matrix.
- Migrates every internal `r.phase = X` write (lifecycle, systems/loading, systems/advance_transient) through the gateway. Snapshot remap and the spawn site stay direct since they're initial-state reconstruction, not transitions.
- Removes the buggy rider-reset block from `World::despawn` (formerly world.rs:198-208). That block tried to rescue aboard riders to `Waiting` but had no access to `RiderIndex`, silently desyncing the index from `rider.phase` — the original "ghost rider" footgun. The proper rescue runs through `Simulation::disable` (called by `Simulation::remove_elevator`), which is now gateway-routed.
- Adds `RiderPhase::is_at_stop()` as the symmetric companion to `is_aboard()`.

## Background

Started as a question — *"is the rider lifecycle a footgun?"* — and the answer was yes: a 9-state lifecycle with several invariants enforced by docstrings rather than the type system. Most concerning: `World::despawn` on an elevator with aboard riders silently desynced the `RiderIndex`, producing riders whose `phase == Waiting` but who were absent from every `waiting_at(stop)` query. The first commit added a regression test that witnessed this directly; this branch closes it.

## What didn't change

Three follow-up tasks were scoped out of this PR to keep the diff reviewable:

- **#7** Consolidate `reroute` / `reroute_rider` / `set_rider_route` into one `reroute(rider, route)` method (cascades into FFI/WASM call-site rewrites).
- **#9** Update consumer crates (FFI/WASM/Bevy/gdext) for the API consolidation.
- **#10** Add a byte-stable golden snapshot regression test.

These will land as a sibling PR.

## Test plan

- [x] `cargo test -p elevator-core --all-features` — 904 passing, 0 ignored, 0 failed.
- [x] `cargo clippy -p elevator-core --all-features` — clean.
- [x] `cargo build` — full workspace builds (FFI/WASM/Bevy/gdext unaffected since public types unchanged).
- [x] `remove_elevator_keeps_rider_index_coherent` — locks in the invariant for the proper public path.
- [x] `world_despawn_elevator_does_not_silently_rewrite_rider_phase` — replaces the original `#[ignore]`d bug witness, now passing under the new contract.
- [x] All 8 `RiderState` round-trip / inconsistency / kind-projection tests pass.
- [x] All 9 transition-legality matrix tests pass.