### PR TITLE
refactor(rider)!: unify reroute / reroute_rider / set_rider_route into one method

### DIFF
--- a/bindings.toml
+++ b/bindings.toml
@@ -394,26 +394,22 @@ tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 [[methods]]
 name = "reroute"
 category = "routes"
+# Unified API: dispatches on phase (Waiting -> set route in place;
+# Resident -> transition to Waiting + set route). The previous trio
+# (`reroute(RiderId, EntityId)` / `reroute_rider(EntityId, Route)` /
+# `set_rider_route(EntityId, Route)`) was collapsed into this single
+# method. The bindings expose multiple convenience overloads for the
+# common single-leg/shortest-path patterns:
+#   - WASM: `reroute` (single-leg from current_stop), `setRiderRouteDirect`,
+#     `setRiderRouteShortest`, `rerouteRiderDirect`, `rerouteRiderShortest`.
+#   - FFI: `ev_sim_reroute`, `ev_sim_set_rider_route_direct`,
+#     `ev_sim_set_rider_route_shortest`, `ev_sim_reroute_rider_direct`,
+#     `ev_sim_reroute_rider_shortest`.
+# The canonical names below are the simplest variants; the others are
+# convenience wrappers that build a `Route` and forward to the same
+# underlying `Simulation::reroute`.
 wasm = "reroute"
 ffi  = "ev_sim_reroute"
-tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
-
-[[methods]]
-name = "reroute_rider"
-category = "routes"
-# Two convenience overloads per binding. The bindings file lists the
-# Shortest variant as the canonical name; Direct (single-leg via a named
-# group) ships alongside as `rerouteRiderDirect` / `ev_sim_reroute_rider_direct`.
-wasm = "rerouteRiderShortest"
-ffi  = "ev_sim_reroute_rider_shortest"
-tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
-
-[[methods]]
-name = "set_rider_route"
-category = "routes"
-# Two convenience overloads per binding. See `reroute_rider` above.
-wasm = "setRiderRouteShortest"
-ffi  = "ev_sim_set_rider_route_shortest"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
 
 [[methods]]

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -244,7 +244,7 @@ pub enum Event {
         /// The tick when invalidation occurred.
         tick: u64,
     },
-    /// A rider was manually rerouted via `sim.reroute()` or `sim.reroute_rider()`.
+    /// A rider was manually rerouted via `sim.reroute()`.
     RiderRerouted {
         /// The rerouted rider.
         rider: EntityId,

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -230,7 +230,7 @@ impl Simulation {
     ///
     /// Resident riders are parked — invisible to dispatch and loading, but
     /// queryable via [`residents_at()`](Self::residents_at). They can later
-    /// be given a new route via [`reroute_rider()`](Self::reroute_rider).
+    /// be given a new route via [`reroute()`](Self::reroute).
     ///
     /// # Errors
     ///

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -112,65 +112,114 @@ impl Simulation {
 
     // ── Re-routing ───────────────────────────────────────────────────
 
-    /// Change a rider's destination mid-route.
+    /// Replace a rider's remaining route, transitioning Resident → Waiting if
+    /// needed.
     ///
-    /// Replaces remaining route legs with a single direct leg to `new_destination`,
-    /// keeping the rider's current stop as origin.
+    /// Dispatches on the rider's current phase:
+    /// - **`Waiting`**: the route is replaced in place; the rider stays
+    ///   `Waiting` at the same stop.
+    /// - **`Resident`**: the rider transitions Resident → Waiting via the
+    ///   transition gateway, the route is set, `spawn_tick` and
+    ///   `Patience::waited_ticks` are reset, and arrival/destination logs
+    ///   are recorded so dispatch sees the rider as fresh demand.
+    /// - **Any other phase**: returns [`SimError::WrongRiderPhase`].
     ///
-    /// Returns `Err` if the rider does not exist or is not in `Waiting` phase
-    /// (riding/boarding riders cannot be rerouted until they exit).
+    /// Replaces the prior `reroute(RiderId, EntityId)` /
+    /// `reroute_rider(EntityId, Route)` / `set_rider_route(EntityId, Route)`
+    /// trio. Callers that previously passed only a destination should
+    /// construct a `Route::direct(rider_current_stop, destination, group)`.
     ///
     /// # Errors
     ///
-    /// Returns [`SimError::EntityNotFound`] if `rider` does not exist.
-    /// Returns [`SimError::WrongRiderPhase`] if the rider is not in
-    /// [`RiderPhase::Waiting`], or [`SimError::RiderHasNoStop`] if the
-    /// rider has no current stop.
-    pub fn reroute(&mut self, rider: RiderId, new_destination: EntityId) -> Result<(), SimError> {
-        let rider = rider.entity();
-        let r = self
-            .world
-            .rider(rider)
-            .ok_or(SimError::EntityNotFound(rider))?;
+    /// - [`SimError::EntityNotFound`] if `rider` does not exist.
+    /// - [`SimError::WrongRiderPhase`] if the rider is not `Waiting` or
+    ///   `Resident`.
+    /// - [`SimError::RiderHasNoStop`] if the rider has no current stop.
+    /// - [`SimError::EmptyRoute`] if `route` has no legs.
+    /// - [`SimError::RouteOriginMismatch`] if the route's first leg origin
+    ///   does not match the rider's current stop.
+    pub fn reroute(&mut self, rider: RiderId, route: Route) -> Result<(), SimError> {
+        let id = rider.entity();
+        let r = self.world.rider(id).ok_or(SimError::EntityNotFound(id))?;
+        let phase = r.phase;
 
-        if r.phase != RiderPhase::Waiting {
-            return Err(SimError::WrongRiderPhase {
-                rider,
-                expected: RiderPhaseKind::Waiting,
-                actual: r.phase.kind(),
+        // Phase precondition takes priority over the missing-stop check —
+        // a non-Waiting/Resident rider is the more actionable error for
+        // callers, and `Riding` riders intentionally carry
+        // `current_stop = None`.
+        let was_resident = match phase {
+            RiderPhase::Waiting => false,
+            RiderPhase::Resident => true,
+            _ => {
+                return Err(SimError::WrongRiderPhase {
+                    rider: id,
+                    expected: RiderPhaseKind::Waiting,
+                    actual: phase.kind(),
+                });
+            }
+        };
+
+        let stop = r.current_stop.ok_or(SimError::RiderHasNoStop(id))?;
+
+        let new_destination = route.final_destination().ok_or(SimError::EmptyRoute)?;
+
+        // Validate that the route departs from the rider's current stop.
+        if let Some(leg) = route.current()
+            && leg.from != stop
+        {
+            return Err(SimError::RouteOriginMismatch {
+                expected_origin: stop,
+                route_origin: leg.from,
             });
         }
 
-        let origin = r.current_stop.ok_or(SimError::RiderHasNoStop(rider))?;
+        if was_resident {
+            // Gateway moves Resident -> Waiting and re-buckets the index
+            // entry (residents -> waiting) atomically.
+            self.transition_rider(
+                id,
+                crate::components::rider_state::InternalRiderPhase::Waiting { stop },
+            )?;
+            // spawn_tick is reroute-specific so it lives outside the
+            // gateway. Resetting it ensures manifest wait_ticks measures
+            // time since the reroute, not the original spawn-as-Resident.
+            if let Some(r) = self.world.rider_mut(id) {
+                r.spawn_tick = self.tick;
+            }
+        }
 
-        let group = self.group_from_route(self.world.route(rider));
-        self.world
-            .set_route(rider, Route::direct(origin, new_destination, group));
+        self.world.set_route(id, route);
+
+        if was_resident {
+            // A rerouted resident is indistinguishable from a fresh arrival
+            // — record it so predictive parking and `arrivals_at` see the
+            // demand. Mirror into the destination log so down-peak
+            // classification stays coherent for multi-leg riders.
+            if let Some(p) = self.world.patience_mut(id) {
+                p.waited_ticks = 0;
+            }
+            if let Some(log) = self.world.resource_mut::<crate::arrival_log::ArrivalLog>() {
+                log.record(self.tick, stop);
+            }
+            if let Some(log) = self
+                .world
+                .resource_mut::<crate::arrival_log::DestinationLog>()
+            {
+                log.record(self.tick, new_destination);
+            }
+            self.metrics.record_reroute();
+        }
 
         let tag = self
             .world
-            .rider(rider)
+            .rider(id)
             .map_or(0, crate::components::Rider::tag);
         self.events.emit(Event::RiderRerouted {
-            rider,
+            rider: id,
             new_destination,
             tag,
             tick: self.tick,
         });
-
-        Ok(())
-    }
-
-    /// Replace a rider's entire remaining route.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SimError::EntityNotFound`] if `rider` does not exist.
-    pub fn set_rider_route(&mut self, rider: EntityId, route: Route) -> Result<(), SimError> {
-        if self.world.rider(rider).is_none() {
-            return Err(SimError::EntityNotFound(rider));
-        }
-        self.world.set_route(rider, route);
         Ok(())
     }
 
@@ -222,91 +271,6 @@ impl Simulation {
         self.events.emit(Event::RiderSettled {
             rider: id,
             stop,
-            tag,
-            tick: self.tick,
-        });
-        Ok(())
-    }
-
-    /// Give a `Resident` rider a new route, transitioning them to `Waiting`.
-    ///
-    /// The rider begins waiting at their current stop for an elevator
-    /// matching the route's transport mode. If the rider has a
-    /// [`Patience`](crate::components::Patience) component, its
-    /// `waited_ticks` is reset to zero.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SimError::EntityNotFound`] if `id` does not exist.
-    /// Returns [`SimError::WrongRiderPhase`] if the rider is not in `Resident`
-    /// phase, [`SimError::EmptyRoute`] if the route has no legs, or
-    /// [`SimError::RouteOriginMismatch`] if the route's first leg origin does
-    /// not match the rider's current stop.
-    pub fn reroute_rider(&mut self, id: EntityId, route: Route) -> Result<(), SimError> {
-        let rider = self.world.rider(id).ok_or(SimError::EntityNotFound(id))?;
-
-        if rider.phase != RiderPhase::Resident {
-            return Err(SimError::WrongRiderPhase {
-                rider: id,
-                expected: RiderPhaseKind::Resident,
-                actual: rider.phase.kind(),
-            });
-        }
-
-        let stop = rider.current_stop.ok_or(SimError::RiderHasNoStop(id))?;
-
-        let new_destination = route.final_destination().ok_or(SimError::EmptyRoute)?;
-
-        // Validate that the route departs from the rider's current stop.
-        if let Some(leg) = route.current()
-            && leg.from != stop
-        {
-            return Err(SimError::RouteOriginMismatch {
-                expected_origin: stop,
-                route_origin: leg.from,
-            });
-        }
-
-        // Gateway handles `RiderIndex` (Resident -> Waiting) and the phase
-        // write. spawn_tick is rerouter-specific so it's reset directly after.
-        self.transition_rider(
-            id,
-            crate::components::rider_state::InternalRiderPhase::Waiting { stop },
-        )?;
-        if let Some(r) = self.world.rider_mut(id) {
-            // Reset spawn_tick so manifest wait_ticks measures time since
-            // reroute, not time since the original spawn as a Resident.
-            r.spawn_tick = self.tick;
-        }
-        self.world.set_route(id, route);
-
-        // Reset patience if present.
-        if let Some(p) = self.world.patience_mut(id) {
-            p.waited_ticks = 0;
-        }
-
-        // A rerouted resident is indistinguishable from a fresh arrival —
-        // record it so predictive parking and `arrivals_at` see the demand.
-        // Mirror into the destination log so down-peak classification stays
-        // coherent for multi-leg riders.
-        if let Some(log) = self.world.resource_mut::<crate::arrival_log::ArrivalLog>() {
-            log.record(self.tick, stop);
-        }
-        if let Some(log) = self
-            .world
-            .resource_mut::<crate::arrival_log::DestinationLog>()
-        {
-            log.record(self.tick, new_destination);
-        }
-
-        self.metrics.record_reroute();
-        let tag = self
-            .world
-            .rider(id)
-            .map_or(0, crate::components::Rider::tag);
-        self.events.emit(Event::RiderRerouted {
-            rider: id,
-            new_destination,
             tag,
             tick: self.tick,
         });

--- a/crates/elevator-core/src/tests/arrival_log_tests.rs
+++ b/crates/elevator-core/src/tests/arrival_log_tests.rs
@@ -180,7 +180,7 @@ fn reroute_records_arrival_and_resets_spawn_tick() {
 
     // Reroute: head back down to StopId(0).
     let route = Route::direct(stop2, stop0, GroupId(0));
-    sim.reroute_rider(rider.entity(), route).unwrap();
+    sim.reroute(rider, route).unwrap();
 
     // ArrivalLog must have a fresh entry at StopId(2) — this is where
     // the rider "appeared" as waiting demand.

--- a/crates/elevator-core/src/tests/event_tag_tests.rs
+++ b/crates/elevator-core/src/tests/event_tag_tests.rs
@@ -12,10 +12,11 @@
 //! the tag came through. `0` is the reserved untagged sentinel for
 //! riders that never had `set_rider_tag` called on them.
 
-use crate::components::Patience;
+use crate::components::{Patience, Route};
 use crate::dispatch::scan::ScanDispatch;
 use crate::entity::ElevatorId;
 use crate::events::{Event, RouteInvalidReason};
+use crate::ids::GroupId;
 use crate::sim::Simulation;
 use crate::stop::StopId;
 use crate::tests::helpers::default_config;
@@ -184,8 +185,10 @@ fn rider_rerouted_carries_tag() {
 
     // Reroute mid-Waiting (rider hasn't boarded yet — they're still at
     // the origin stop).
+    let stop_0 = sim.stop_entity(StopId(0)).unwrap();
     let stop_1 = sim.stop_entity(StopId(1)).unwrap();
-    sim.reroute(rider, stop_1).unwrap();
+    sim.reroute(rider, Route::direct(stop_0, stop_1, GroupId(0)))
+        .unwrap();
     let rerouted = sim
         .drain_events()
         .into_iter()

--- a/crates/elevator-core/src/tests/reroute_tests.rs
+++ b/crates/elevator-core/src/tests/reroute_tests.rs
@@ -1,5 +1,5 @@
 use crate::components::RiderPhase;
-use crate::components::{Accel, Speed, Weight};
+use crate::components::{Accel, Route, Speed, Weight};
 use crate::config::{
     BuildingConfig, ElevatorConfig, PassengerSpawnConfig, SimConfig, SimulationParams,
 };
@@ -7,6 +7,7 @@ use crate::dispatch::scan::ScanDispatch;
 use crate::entity::RiderId;
 use crate::error::SimError;
 use crate::events::{Event, RouteInvalidReason};
+use crate::ids::GroupId;
 use crate::sim::Simulation;
 use crate::stop::{StopConfig, StopId};
 
@@ -73,8 +74,10 @@ fn reroute_changes_rider_destination() {
     let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     // Reroute to stop 1 instead.
+    let stop0 = sim.stop_entity(StopId(0)).unwrap();
     let stop1 = sim.stop_entity(StopId(1)).unwrap();
-    sim.reroute(rider, stop1).unwrap();
+    sim.reroute(rider, Route::direct(stop0, stop1, GroupId(0)))
+        .unwrap();
 
     let route = sim.world().route(rider.entity()).unwrap();
     assert_eq!(route.current_destination(), Some(stop1));
@@ -256,7 +259,7 @@ fn set_rider_route_replaces_route() {
         ],
         current_leg: 0,
     };
-    sim.set_rider_route(rider.entity(), route).unwrap();
+    sim.reroute(rider, route).unwrap();
 
     let r = sim.world().route(rider.entity()).unwrap();
     assert_eq!(r.legs.len(), 2);
@@ -279,8 +282,9 @@ fn reroute_rejects_non_waiting_rider() {
         }
     }
 
+    let stop0 = sim.stop_entity(StopId(0)).unwrap();
     let stop1 = sim.stop_entity(StopId(1)).unwrap();
-    let result = sim.reroute(rider, stop1);
+    let result = sim.reroute(rider, Route::direct(stop0, stop1, GroupId(0)));
 
     // Should fail if rider is not Waiting.
     let phase = sim.world().rider(rider.entity()).unwrap().phase;
@@ -298,9 +302,13 @@ fn reroute_nonexistent_rider_returns_error() {
     let config = three_stop_config();
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
+    let stop0 = sim.stop_entity(StopId(0)).unwrap();
     let stop1 = sim.stop_entity(StopId(1)).unwrap();
     // Use a stop entity as a fake rider — it's a valid EntityId but not a rider.
-    let result = sim.reroute(RiderId::from(stop1), stop1);
+    let result = sim.reroute(
+        RiderId::from(stop1),
+        Route::direct(stop0, stop1, GroupId(0)),
+    );
     assert!(result.is_err());
 }
 

--- a/crates/elevator-core/src/tests/resident_tests.rs
+++ b/crates/elevator-core/src/tests/resident_tests.rs
@@ -121,7 +121,7 @@ fn reroute_resident_to_waiting() {
     // Resolve StopId(0) to EntityId for the route.
     let dest = sim.stop_entity(StopId(0)).unwrap();
     let route = Route::direct(stop, dest, GroupId(0));
-    sim.reroute_rider(rider.entity(), route).unwrap();
+    sim.reroute(rider, route).unwrap();
 
     let r = sim.world().rider(rider.entity()).unwrap();
     assert_eq!(r.phase(), RiderPhase::Waiting);
@@ -139,19 +139,47 @@ fn reroute_resident_to_waiting() {
     );
 }
 
+/// `reroute` accepts both `Waiting` and `Resident` riders by design (it
+/// dispatches on phase). Phases that aren't either of those return
+/// `WrongRiderPhase`. Pin both the success path on Waiting and the
+/// rejection on a non-Waiting/non-Resident phase.
 #[test]
-fn reroute_wrong_phase_returns_error() {
+fn reroute_rejects_aboard_phases() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
     let rider = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
 
     let dest = sim.stop_entity(StopId(2)).unwrap();
     let origin = sim.stop_entity(StopId(0)).unwrap();
-    let route = Route::direct(origin, dest, GroupId(0));
 
-    // Rider is Waiting — should fail.
-    let result = sim.reroute_rider(rider.entity(), route);
-    assert!(matches!(result, Err(SimError::WrongRiderPhase { .. })));
+    // Waiting -> reroute is allowed under the unified API; the route is
+    // replaced in place. (Pre-refactor `reroute_rider` rejected this.)
+    let route = Route::direct(origin, dest, GroupId(0));
+    sim.reroute(rider, route).unwrap();
+
+    // Drive the rider into Riding so we can hit the rejection path.
+    for _ in 0..500 {
+        sim.step();
+        if matches!(
+            sim.world().rider(rider.entity()).unwrap().phase,
+            crate::components::RiderPhase::Riding(_)
+        ) {
+            break;
+        }
+    }
+
+    let route = Route::direct(origin, dest, GroupId(0));
+    let result = sim.reroute(rider, route);
+    let phase = sim.world().rider(rider.entity()).unwrap().phase;
+    if !matches!(
+        phase,
+        crate::components::RiderPhase::Waiting | crate::components::RiderPhase::Resident
+    ) {
+        assert!(
+            matches!(result, Err(SimError::WrongRiderPhase { .. })),
+            "expected WrongRiderPhase, got {result:?}"
+        );
+    }
 }
 
 #[test]
@@ -257,7 +285,7 @@ fn full_lifecycle_spawn_ride_settle_reroute_ride_despawn() {
     // Reroute back to Ground.
     let ground = sim.stop_entity(StopId(0)).unwrap();
     let route = Route::direct(floor3, ground, GroupId(0));
-    sim.reroute_rider(rider.entity(), route).unwrap();
+    sim.reroute(rider, route).unwrap();
     assert_eq!(sim.metrics().total_rerouted(), 1);
 
     assert!(sim.waiting_at(floor3).any(|id| id == rider.entity()));
@@ -343,7 +371,7 @@ fn patience_reset_on_reroute() {
         .unwrap();
     let dest = sim.stop_entity(StopId(0)).unwrap();
     let route = Route::direct(stop, dest, GroupId(0));
-    sim.reroute_rider(rider.entity(), route).unwrap();
+    sim.reroute(rider, route).unwrap();
 
     // Patience should be reset.
     let patience = sim.world().patience(rider.entity()).unwrap();

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -3764,7 +3764,20 @@ pub unsafe extern "C" fn ev_sim_reroute(
         };
         // Safety: validity guaranteed by caller.
         let ev = unsafe { &mut *handle };
-        match ev.sim.reroute(RiderId::from(rider), dest) {
+        // The unified `reroute` takes a `Route`; construct a single-leg
+        // direct route from the rider's current stop to the new destination.
+        // Mirrors the prior `reroute(RiderId, EntityId)` semantics.
+        let Some(origin) = ev
+            .sim
+            .world()
+            .rider(rider)
+            .and_then(elevator_core::components::Rider::current_stop)
+        else {
+            set_last_error("rider has no current stop");
+            return EvStatus::NotFound;
+        };
+        let route = elevator_core::components::Route::direct(origin, dest, GroupId(0));
+        match ev.sim.reroute(RiderId::from(rider), route) {
             Ok(()) => EvStatus::Ok,
             Err(e) => {
                 let status = mode_error_status(&e);
@@ -3922,7 +3935,7 @@ pub unsafe extern "C" fn ev_sim_set_rider_route_direct(
         let route = elevator_core::components::Route::direct(from, to, GroupId(group_id));
         // Safety: validity guaranteed by caller.
         let ev = unsafe { &mut *handle };
-        match ev.sim.set_rider_route(rider, route) {
+        match ev.sim.reroute(RiderId::from(rider), route) {
             Ok(()) => EvStatus::Ok,
             Err(e) => {
                 let status = mode_error_status(&e);
@@ -3977,7 +3990,7 @@ pub unsafe extern "C" fn ev_sim_set_rider_route_shortest(
             set_last_error("no route between rider's stop and to_stop");
             return EvStatus::NotFound;
         };
-        match ev.sim.set_rider_route(rider, route) {
+        match ev.sim.reroute(RiderId::from(rider), route) {
             Ok(()) => EvStatus::Ok,
             Err(e) => {
                 let status = mode_error_status(&e);
@@ -4024,7 +4037,7 @@ pub unsafe extern "C" fn ev_sim_reroute_rider_direct(
         let route = elevator_core::components::Route::direct(from, to, GroupId(group_id));
         // Safety: validity guaranteed by caller.
         let ev = unsafe { &mut *handle };
-        match ev.sim.reroute_rider(rider, route) {
+        match ev.sim.reroute(RiderId::from(rider), route) {
             Ok(()) => EvStatus::Ok,
             Err(e) => {
                 let status = mode_error_status(&e);
@@ -4080,7 +4093,7 @@ pub unsafe extern "C" fn ev_sim_reroute_rider_shortest(
             set_last_error("no route between rider's stop and to_stop");
             return EvStatus::NotFound;
         };
-        match ev.sim.reroute_rider(rider, route) {
+        match ev.sim.reroute(RiderId::from(rider), route) {
             Ok(()) => EvStatus::Ok,
             Err(e) => {
                 let status = mode_error_status(&e);

--- a/crates/elevator-wasm/src/dto.rs
+++ b/crates/elevator-wasm/src/dto.rs
@@ -551,7 +551,7 @@ pub enum EventDto {
         /// Opaque consumer tag carried by the rider; `0` if untagged.
         tag: u64,
     },
-    /// A rider was rerouted via `sim.reroute()` or `sim.reroute_rider()`.
+    /// A rider was rerouted via `sim.reroute()`.
     /// `tag` mirrors the rider's opaque consumer tag; `0` means untagged.
     RiderRerouted {
         /// Engine tick the event was emitted on.

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -1936,11 +1936,25 @@ impl WasmSim {
     /// Returns a JS error if the rider or destination does not exist.
     #[wasm_bindgen(js_name = reroute)]
     pub fn reroute(&mut self, rider_ref: u64, new_destination_ref: u64) -> WasmVoidResult {
+        let rider_eid = u64_to_entity(rider_ref);
+        // The unified `Simulation::reroute` takes a `Route`; build a
+        // single-leg direct route from the rider's current stop. The
+        // multi-leg variants are exposed separately (see below).
+        let Some(origin) = self
+            .inner
+            .world()
+            .rider(rider_eid)
+            .and_then(elevator_core::components::Rider::current_stop)
+        else {
+            return Err("reroute: rider has no current stop".to_string()).into();
+        };
+        let route = elevator_core::components::Route::direct(
+            origin,
+            u64_to_entity(new_destination_ref),
+            elevator_core::ids::GroupId(0),
+        );
         self.inner
-            .reroute(
-                elevator_core::entity::RiderId::from(u64_to_entity(rider_ref)),
-                u64_to_entity(new_destination_ref),
-            )
+            .reroute(elevator_core::entity::RiderId::from(rider_eid), route)
             .map_err(|e| format!("reroute: {e}"))
             .into()
     }
@@ -2044,7 +2058,10 @@ impl WasmSim {
                 elevator_core::ids::GroupId(group_id),
             );
             self.inner
-                .set_rider_route(u64_to_entity(rider_ref), route)
+                .reroute(
+                    elevator_core::entity::RiderId::from(u64_to_entity(rider_ref)),
+                    route,
+                )
                 .map_err(|e| format!("set_rider_route_direct: {e}"))
         })()
         .into()
@@ -2073,7 +2090,7 @@ impl WasmSim {
                 "set_rider_route_shortest: no route between rider's stop and to_stop".to_owned()
             })?;
             self.inner
-                .set_rider_route(rider_eid, route)
+                .reroute(elevator_core::entity::RiderId::from(rider_eid), route)
                 .map_err(|e| format!("set_rider_route_shortest: {e}"))
         })()
         .into()
@@ -2104,7 +2121,10 @@ impl WasmSim {
                 elevator_core::ids::GroupId(group_id),
             );
             self.inner
-                .reroute_rider(u64_to_entity(rider_ref), route)
+                .reroute(
+                    elevator_core::entity::RiderId::from(u64_to_entity(rider_ref)),
+                    route,
+                )
                 .map_err(|e| format!("reroute_rider_direct: {e}"))
         })()
         .into()
@@ -2133,7 +2153,7 @@ impl WasmSim {
                 "reroute_rider_shortest: no route between rider's stop and to_stop".to_owned()
             })?;
             self.inner
-                .reroute_rider(rider_eid, route)
+                .reroute(elevator_core::entity::RiderId::from(rider_eid), route)
                 .map_err(|e| format!("reroute_rider_shortest: {e}"))
         })()
         .into()

--- a/docs/src/rider-lifecycle.md
+++ b/docs/src/rider-lifecycle.md
@@ -122,9 +122,7 @@ Once a rider reaches `Arrived` or `Abandoned`, the simulation stops managing the
 
 **`sim.settle_rider(id)`** -- transitions an `Arrived` or `Abandoned` rider to `Resident`. Residents are parked at a stop, tracked by the population index, and invisible to dispatch. Use this for occupants who live or work on a floor between elevator trips: a tenant in their office, a hotel guest in their room, a patient on a ward.
 
-**`sim.reroute_rider(id, route)`** -- sends a `Resident` rider back to `Waiting` with a new multi-leg route. Use this when a settled occupant has a new destination -- a tenant heading to lunch, a guest checking out.
-
-**`sim.reroute(id, new_destination)`** -- changes a `Waiting` rider's destination. The rider stays at their stop and waits for an elevator serving the new route. Useful for mid-wait plan changes.
+**`sim.reroute(id, route)`** -- replaces the rider's route. Dispatches on phase: a `Waiting` rider gets the new route in place; a `Resident` rider is transitioned back to `Waiting` and the route is set. Use this for mid-wait plan changes (Waiting riders) or for settled occupants who have a new destination -- a tenant heading to lunch, a guest checking out (Resident riders).
 
 **`sim.despawn_rider(id)`** -- removes the rider from the simulation entirely. Always use this instead of `world.despawn()` directly -- it keeps the stop index consistent.
 
@@ -137,9 +135,9 @@ Once a rider reaches `Arrived` or `Abandoned`, the simulation stops managing the
 // at the stop without re-entering the dispatch queue.
 sim.settle_rider(rider).unwrap();
 
-// Later, the same tenant heads back down. reroute_rider takes a full
-// Route and only works on Resident riders.
-sim.reroute_rider(rider.entity(), new_route).unwrap();
+// Later, the same tenant heads back down. `reroute` accepts a full
+// Route and works for both Waiting and Resident riders.
+sim.reroute(rider, new_route).unwrap();
 ```
 
 ## Population tracking

--- a/docs/src/riders.md
+++ b/docs/src/riders.md
@@ -117,7 +117,7 @@ Three methods manage rider state transitions after arrival or abandonment:
 | Method | Effect |
 |---|---|
 | `sim.settle_rider(id)` | Transitions an `Arrived` or `Abandoned` rider to `Resident` at their current stop |
-| `sim.reroute_rider(id, route)` | Sends a `Resident` rider back to `Waiting` with a new route |
+| `sim.reroute(id, route)` | Replaces a `Waiting` or `Resident` rider's route (Resident -> Waiting transition included) |
 | `sim.despawn_rider(id)` | Removes the rider entity and updates all indexes |
 
 Always use `sim.despawn_rider(id)` instead of calling `world.despawn()` directly -- it keeps the population index consistent and emits a `RiderDespawned` event.
@@ -128,9 +128,10 @@ Always use `sim.despawn_rider(id)` instead of calling `world.despawn()` directly
 // A rider arrives at their destination. Settle them as a resident.
 sim.settle_rider(rider_id)?;
 
-// Later, they want to go back down. Reroute them.
-// (`reroute_rider` takes an `EntityId`; the sibling calls take `RiderId`.)
-sim.reroute_rider(rider_id.entity(), new_route)?;
+// Later, they want to go back down. Reroute them with a new route —
+// the gateway dispatches on phase: Waiting riders get the route in
+// place; Resident riders transition back to Waiting first.
+sim.reroute(rider_id, new_route)?;
 
 // Or remove them entirely.
 sim.despawn_rider(rider_id)?;


### PR DESCRIPTION
## Summary

Follow-up to #550 (rider-lifecycle architecture refactor). Collapses the three rerouting methods on `Simulation` into a single phase-dispatching API.

**Before:**
- `reroute(rider: RiderId, dest: EntityId)` — Waiting only, destination-based.
- `reroute_rider(id: EntityId, route: Route)` — Resident only.
- `set_rider_route(id: EntityId, route: Route)` — any phase, no validation.

**After:**
- `reroute(rider: RiderId, route: Route)` — dispatches on phase: Waiting → set route in place; Resident → transition to Waiting via the gateway and set route; other phases return `WrongRiderPhase`.

The two siblings are removed. Net: 145 → 143 public Simulation methods.

## Why

The three methods overlapped semantically and differed mostly in their phase preconditions. `set_rider_route` accepted any phase with no validation — a soft footgun that the new gateway-routed `reroute` rejects with `WrongRiderPhase` for non-Waiting/non-Resident callers. Phase precondition is now checked before the missing-stop check so callers get the more actionable error (Riding riders deliberately carry `current_stop = None`).

## Consumer-crate updates

- **FFI** (`elevator-ffi`): `ev_sim_reroute` now constructs a `Route::direct` from the rider's current stop. The four C-ABI overloads (`ev_sim_reroute_rider_direct/_shortest`, `ev_sim_set_rider_route_direct/_shortest`) forward to `Simulation::reroute` internally; their C signatures are unchanged.
- **WASM** (`elevator-wasm`): same pattern. `reroute`, `setRiderRouteDirect/Shortest`, `rerouteRiderDirect/Shortest` are unchanged at the JS API level.
- **bindings.toml**: collapse three `[[methods]]` entries into one. `scripts/check-bindings.sh` confirms 143 public Simulation methods are in sync.

## Migration

```rust
// before
sim.reroute(rider, dest)
// after — caller builds the Route from current_stop + dest + group
let stop = sim.world().rider(rider.entity()).and_then(|r| r.current_stop).unwrap();
sim.reroute(rider, Route::direct(stop, dest, group))

// before
sim.reroute_rider(eid, route) / sim.set_rider_route(eid, route)
// after
sim.reroute(RiderId::from(eid), route)
```

## Test plan

- [x] `cargo test -p elevator-core --all-features` — 904 + doctests + binding tests pass.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo build --workspace` — full workspace builds (FFI/WASM/Bevy/gdext/TUI).
- [x] `scripts/check-bindings.sh` — bindings.toml in sync.
- [x] `tests/resident_tests::reroute_rejects_aboard_phases` — pins the new dispatch contract: Waiting reroute succeeds, Riding reroute returns `WrongRiderPhase`.
- [x] mdBook docs (`riders.md`, `rider-lifecycle.md`) updated; doctests pass.

BREAKING CHANGE flagged in the commit message — release-please will major-bump on merge.