### PR TITLE
docs: bound README example loop with tick budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,24 @@ fn main() -> Result<(), SimError> {
 
     sim.spawn_rider(StopId(0), StopId(2), 75.0)?;
 
-    loop {
+    for _ in 0..1000 {
         sim.step();
         for event in sim.drain_events() {
-            if let Event::RiderExited { rider, tick, .. } = event {
-                println!("Tick {tick}: rider {rider:?} delivered!");
-                return Ok(());
+            match event {
+                Event::RiderExited { rider, tick, .. } => {
+                    println!("Tick {tick}: rider {rider:?} delivered!");
+                    return Ok(());
+                }
+                Event::RiderAbandoned { rider, stop, tick, .. } => {
+                    eprintln!("Tick {tick}: rider {rider:?} abandoned at {stop:?}");
+                    return Ok(());
+                }
+                _ => {}
             }
         }
     }
+    eprintln!("timed out after 1000 ticks");
+    Ok(())
 }
 ```
 


### PR DESCRIPTION
## Summary
- The previous `loop {}` in the README quick-start exited only on `RiderExited`. A reader copy-pasting it would silently hang the moment the rider abandoned (patience exhaustion, full car, no path).
- Wraps the loop in a 1000-tick budget and matches `RiderAbandoned` as a terminal event, so the example demonstrates both lifecycle outcomes and never blocks indefinitely.
- Doubles as documentation: the tick budget shows readers that `step()` is the unit of progress.

## Test plan
- [x] `cargo test --doc -p elevator-core` — all 159 doc tests pass (the README is wired in via `crates/elevator-core/src/doctests.rs:16`)
- [x] Pre-commit hook (fmt, clippy, core tests, doc tests, `cargo check --workspace`, doc lint) green