### PR TITLE
refactor(prelude)!: trim from ~70 names to a 22-name starter kit

### DIFF
--- a/crates/elevator-core/benches/query_bench.rs
+++ b/crates/elevator-core/benches/query_bench.rs
@@ -9,6 +9,7 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 
+use elevator_core::components::{Elevator, Position, Rider, Route};
 use elevator_core::config::{
     BuildingConfig, ElevatorConfig, PassengerSpawnConfig, SimConfig, SimulationParams,
 };

--- a/crates/elevator-core/examples/dispatch_comparison.rs
+++ b/crates/elevator-core/examples/dispatch_comparison.rs
@@ -32,6 +32,7 @@
     clippy::print_stdout
 )]
 
+use elevator_core::components::{Accel, Speed, Weight};
 use elevator_core::config::{
     BuildingConfig, ElevatorConfig, PassengerSpawnConfig, SimConfig, SimulationParams,
 };
@@ -45,6 +46,7 @@ use elevator_core::stop::StopConfig;
 use elevator_core::traffic::{
     PoissonSource, SpawnRequest, TrafficPattern, TrafficSchedule, TrafficSource,
 };
+use elevator_core::world::ExtKey;
 use rand::SeedableRng;
 
 const WARMUP_TICKS: u64 = 1000;

--- a/crates/elevator-core/examples/extensions.rs
+++ b/crates/elevator-core/examples/extensions.rs
@@ -1,8 +1,10 @@
 //! Using extension components for game-specific data.
 #![allow(clippy::unwrap_used, clippy::missing_docs_in_private_items)]
 
+use elevator_core::entity::EntityId;
 use elevator_core::prelude::*;
 use elevator_core::query::Ext;
+use elevator_core::world::ExtKey;
 use serde::{Deserialize, Serialize};
 
 /// A custom VIP tag attached to riders.

--- a/crates/elevator-core/examples/extensions.rs
+++ b/crates/elevator-core/examples/extensions.rs
@@ -1,7 +1,6 @@
 //! Using extension components for game-specific data.
 #![allow(clippy::unwrap_used, clippy::missing_docs_in_private_items)]
 
-use elevator_core::entity::EntityId;
 use elevator_core::prelude::*;
 use elevator_core::query::Ext;
 use elevator_core::world::ExtKey;

--- a/crates/elevator-core/examples/manual_driver.rs
+++ b/crates/elevator-core/examples/manual_driver.rs
@@ -13,6 +13,7 @@
 //! ```
 #![allow(clippy::unwrap_used, clippy::missing_docs_in_private_items)]
 
+use elevator_core::components::ServiceMode;
 use elevator_core::prelude::*;
 
 fn main() {

--- a/crates/elevator-core/examples/showcase.rs
+++ b/crates/elevator-core/examples/showcase.rs
@@ -12,6 +12,7 @@
     clippy::must_use_candidate
 )]
 
+use elevator_core::components::{Accel, Speed, Weight};
 use elevator_core::config::{
     BuildingConfig, ElevatorConfig, PassengerSpawnConfig, SimConfig, SimulationParams,
 };
@@ -19,6 +20,7 @@ use elevator_core::dispatch::etd::EtdDispatch;
 use elevator_core::hooks::Phase;
 use elevator_core::prelude::*;
 use elevator_core::stop::StopConfig;
+use elevator_core::world::ExtKey;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -11,6 +11,7 @@
 //! # Example: custom dispatch strategy
 //!
 //! ```rust
+//! use elevator_core::dispatch::RankContext;
 //! use elevator_core::prelude::*;
 //!
 //! struct AlwaysFirstStop;

--- a/crates/elevator-core/src/dispatch/reposition.rs
+++ b/crates/elevator-core/src/dispatch/reposition.rs
@@ -4,7 +4,7 @@
 //!
 //! ```rust
 //! use elevator_core::prelude::*;
-//! use elevator_core::dispatch::BuiltinReposition;
+//! use elevator_core::dispatch::reposition::SpreadEvenly;
 //!
 //! let sim = SimulationBuilder::demo()
 //!     .reposition(SpreadEvenly, BuiltinReposition::SpreadEvenly)

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -158,6 +158,7 @@
 //!
 //! ```rust,no_run
 //! # use elevator_core::prelude::*;
+//! # use elevator_core::__doctest_prelude::*;
 //! # use elevator_core::query::Ext;
 //! # use serde::{Serialize, Deserialize};
 //! # #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -462,112 +463,97 @@ macro_rules! register_extensions {
 
 /// Common imports for consumers of this library.
 ///
-/// `use elevator_core::prelude::*;` pulls in the types you need for the vast
-/// majority of simulations — building a sim, stepping it, spawning riders,
-/// reading events and metrics, and writing custom dispatch strategies.
+/// `use elevator_core::prelude::*;` pulls in the 22 names that cover the
+/// vast majority of usage: building a sim, stepping it, querying world
+/// state, writing custom dispatch, and reading aggregate metrics. Anything
+/// beyond that — fine-grained component types, per-strategy structs,
+/// extension keys, traffic generation — is imported explicitly from its
+/// sub-module.
 ///
 /// # Contents
 ///
-/// - **Builder & simulation:** [`SimulationBuilder`](crate::builder::SimulationBuilder),
-///   [`Simulation`](crate::sim::Simulation),
+/// - **Sim & builder:** [`Simulation`](crate::sim::Simulation),
+///   [`SimulationBuilder`](crate::builder::SimulationBuilder),
 ///   [`RiderBuilder`](crate::sim::RiderBuilder)
-/// - **Components:** [`Rider`](crate::components::Rider),
-///   [`RiderPhase`](crate::components::RiderPhase),
-///   [`RiderPhaseKind`](crate::components::RiderPhaseKind),
-///   [`Elevator`](crate::components::Elevator),
-///   [`ElevatorPhase`](crate::components::ElevatorPhase),
-///   [`Stop`](crate::components::Stop), [`Line`](crate::components::Line),
-///   [`Position`](crate::components::Position),
-///   [`Velocity`](crate::components::Velocity),
-///   [`SpatialPosition`](crate::components::SpatialPosition),
-///   [`Route`](crate::components::Route),
-///   [`Patience`](crate::components::Patience),
-///   [`Preferences`](crate::components::Preferences),
-///   [`AccessControl`](crate::components::AccessControl),
-///   [`DestinationQueue`](crate::components::DestinationQueue),
-///   [`Direction`](crate::components::Direction),
-///   [`Orientation`](crate::components::Orientation),
-///   [`ServiceMode`](crate::components::ServiceMode)
 /// - **Config:** [`SimConfig`](crate::config::SimConfig),
 ///   [`ElevatorConfig`](crate::config::ElevatorConfig),
-///   [`GroupConfig`](crate::config::GroupConfig),
-///   [`LineConfig`](crate::config::LineConfig),
 ///   [`StopConfig`](crate::stop::StopConfig)
-/// - **Dispatch:** [`DispatchStrategy`](crate::dispatch::DispatchStrategy),
-///   [`RepositionStrategy`](crate::dispatch::RepositionStrategy),
-///   [`DispatchDecision`](crate::dispatch::DispatchDecision),
-///   [`DispatchManifest`](crate::dispatch::DispatchManifest),
-///   [`ElevatorGroup`](crate::dispatch::ElevatorGroup),
-///   [`AssignedCar`](crate::dispatch::AssignedCar),
-///   [`RankContext`](crate::dispatch::RankContext),
-///   [`DestinationDispatch`](crate::dispatch::DestinationDispatch),
-///   [`ScanDispatch`](crate::dispatch::ScanDispatch),
-///   [`LookDispatch`](crate::dispatch::LookDispatch),
-///   [`NearestCarDispatch`](crate::dispatch::NearestCarDispatch),
-///   [`EtdDispatch`](crate::dispatch::EtdDispatch),
-///   [`RsrDispatch`](crate::dispatch::RsrDispatch),
-///   [`BuiltinStrategy`](crate::dispatch::BuiltinStrategy),
-///   [`BuiltinReposition`](crate::dispatch::BuiltinReposition),
-///   plus the built-in reposition strategies
-///   [`NearestIdle`](crate::dispatch::reposition::NearestIdle),
-///   [`ReturnToLobby`](crate::dispatch::reposition::ReturnToLobby),
-///   [`SpreadEvenly`](crate::dispatch::reposition::SpreadEvenly),
-///   [`DemandWeighted`](crate::dispatch::reposition::DemandWeighted),
-///   [`PredictiveParking`](crate::dispatch::reposition::PredictiveParking),
-///   [`AdaptiveParking`](crate::dispatch::reposition::AdaptiveParking)
-/// - **Traffic observation:** [`TrafficDetector`](crate::traffic_detector::TrafficDetector),
-///   [`TrafficMode`](crate::traffic_detector::TrafficMode),
-///   [`ArrivalLog`](crate::arrival_log::ArrivalLog),
-///   [`DestinationLog`](crate::arrival_log::DestinationLog),
-///   [`CurrentTick`](crate::arrival_log::CurrentTick),
-///   [`ArrivalLogRetention`](crate::arrival_log::ArrivalLogRetention)
-/// - **Identity:** [`EntityId`](crate::entity::EntityId),
-///   [`StopId`](crate::stop::StopId), [`StopRef`](crate::stop::StopRef),
+/// - **Identity:** [`StopId`](crate::stop::StopId),
+///   [`ElevatorId`](crate::entity::ElevatorId),
+///   [`RiderId`](crate::entity::RiderId),
+///   [`EntityId`](crate::entity::EntityId),
 ///   [`GroupId`](crate::ids::GroupId)
 /// - **Errors & events:** [`SimError`](crate::error::SimError),
-///   [`EtaError`](crate::error::EtaError),
 ///   [`RejectionReason`](crate::error::RejectionReason),
-///   [`RejectionContext`](crate::error::RejectionContext),
-///   [`Event`](crate::events::Event),
-///   [`EventBus`](crate::events::EventBus),
-///   [`EventCategory`](crate::events::EventCategory)
-/// - **World & misc:** [`World`](crate::world::World),
-///   [`Metrics`](crate::metrics::Metrics),
-///   [`TimeAdapter`](crate::time::TimeAdapter),
-///   [`ExtKey`](crate::world::ExtKey)
+///   [`Event`](crate::events::Event)
+/// - **Phase & direction enums:** [`ElevatorPhase`](crate::components::ElevatorPhase),
+///   [`RiderPhase`](crate::components::RiderPhase),
+///   [`Direction`](crate::components::Direction)
+/// - **Dispatch:** [`DispatchStrategy`](crate::dispatch::DispatchStrategy),
+///   [`BuiltinStrategy`](crate::dispatch::BuiltinStrategy),
+///   [`BuiltinReposition`](crate::dispatch::BuiltinReposition)
+/// - **World & metrics:** [`World`](crate::world::World),
+///   [`Metrics`](crate::metrics::Metrics)
 ///
 /// # Not included (import explicitly)
 ///
+/// - Fine-grained component types (`Position`, `Velocity`, `Speed`, `Accel`,
+///   `Weight`, `Route`, `Patience`, `ServiceMode`, etc.) → [`crate::components`]
+/// - Per-strategy structs (`ScanDispatch`, `LookDispatch`,
+///   `NearestCarDispatch`, `EtdDispatch`, `RsrDispatch`, `DestinationDispatch`),
+///   `RankContext`, `DispatchManifest`, reposition strategies → [`crate::dispatch`]
+/// - Extension storage (`ExtKey`) → [`crate::world`]
+/// - Traffic detection, arrival logs, time adapters, event bus,
+///   group/line config, and `StopRef` → their respective modules
 /// - Traffic generation types from [`crate::traffic`] (feature-gated)
 /// - Snapshot types from [`crate::snapshot`]
 pub mod prelude {
-    pub use crate::arrival_log::{ArrivalLog, ArrivalLogRetention, CurrentTick, DestinationLog};
     pub use crate::builder::SimulationBuilder;
+    pub use crate::components::{Direction, ElevatorPhase, RiderPhase};
+    pub use crate::config::{ElevatorConfig, SimConfig};
+    pub use crate::dispatch::{BuiltinReposition, BuiltinStrategy, DispatchStrategy};
+    pub use crate::entity::{ElevatorId, EntityId, RiderId};
+    pub use crate::error::{RejectionReason, SimError};
+    pub use crate::events::Event;
+    pub use crate::ids::GroupId;
+    pub use crate::metrics::Metrics;
+    pub use crate::sim::{RiderBuilder, Simulation};
+    pub use crate::stop::{StopConfig, StopId};
+    pub use crate::world::World;
+}
+
+/// Internal-only re-exports used by hidden doc-test setup lines
+/// (`# use elevator_core::__doctest_prelude::*;`) so each chapter's
+/// fenced blocks compile without per-block import surgery while the
+/// public [`prelude`] stays small. Hidden from `cargo doc` and
+/// considered an implementation detail — not part of the public API.
+///
+/// Names already in [`prelude`] are deliberately omitted to avoid
+/// glob-import ambiguity errors when both modules are wildcarded.
+#[doc(hidden)]
+pub mod __doctest_prelude {
+    pub use crate::arrival_log::{ArrivalLog, ArrivalLogRetention, CurrentTick, DestinationLog};
     pub use crate::components::{
-        Accel, AccessControl, DestinationQueue, Direction, Elevator, ElevatorPhase, Line,
-        Orientation, Patience, Position, Preferences, Rider, RiderPhase, RiderPhaseKind, Route,
-        ServiceMode, SpatialPosition, Speed, Stop, UnitError, Velocity, Weight,
+        Accel, AccessControl, DestinationQueue, Elevator, Line, Orientation, Patience, Position,
+        Preferences, Rider, RiderPhaseKind, Route, ServiceMode, SpatialPosition, Speed, Stop,
+        UnitError, Velocity, Weight,
     };
-    pub use crate::config::{ElevatorConfig, GroupConfig, LineConfig, SimConfig};
+    pub use crate::config::{GroupConfig, LineConfig};
     pub use crate::dispatch::reposition::{
         AdaptiveParking, DemandWeighted, NearestIdle, PredictiveParking, ReturnToLobby,
         SpreadEvenly,
     };
     pub use crate::dispatch::{
-        AssignedCar, BuiltinReposition, BuiltinStrategy, DestinationDispatch, DispatchDecision,
-        DispatchManifest, DispatchStrategy, ElevatorGroup, EtdDispatch, LookDispatch,
-        NearestCarDispatch, RankContext, RepositionStrategy, RsrDispatch, ScanDispatch,
+        AssignedCar, DestinationDispatch, DispatchDecision, DispatchManifest, ElevatorGroup,
+        EtdDispatch, LookDispatch, NearestCarDispatch, RankContext, RepositionStrategy,
+        RsrDispatch, ScanDispatch,
     };
-    pub use crate::entity::{ElevatorId, EntityId, RiderId};
-    pub use crate::error::{EtaError, RejectionContext, RejectionReason, SimError};
-    pub use crate::events::{Event, EventBus, EventCategory};
-    pub use crate::ids::GroupId;
-    pub use crate::metrics::Metrics;
-    pub use crate::sim::{RiderBuilder, Simulation};
-    pub use crate::stop::{StopConfig, StopId, StopRef};
+    pub use crate::error::{EtaError, RejectionContext};
+    pub use crate::events::{EventBus, EventCategory};
+    pub use crate::stop::StopRef;
     pub use crate::time::TimeAdapter;
     pub use crate::traffic_detector::{TrafficDetector, TrafficMode};
-    pub use crate::world::{ExtKey, World};
+    pub use crate::world::ExtKey;
 }
 
 #[cfg(test)]

--- a/crates/elevator-core/src/query/mod.rs
+++ b/crates/elevator-core/src/query/mod.rs
@@ -3,8 +3,10 @@
 //! # Examples
 //!
 //! ```
+//! use elevator_core::components::{Position, Rider, Route};
 //! use elevator_core::prelude::*;
 //! use elevator_core::query::{Ext, With, Without};
+//! use elevator_core::world::ExtKey;
 //!
 //! use serde::{Serialize, Deserialize};
 //!

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -52,6 +52,7 @@ impl Simulation {
     ///
     /// ```no_run
     /// # use elevator_core::prelude::*;
+    /// # use elevator_core::__doctest_prelude::*;
     /// # use elevator_core::register_extensions;
     /// # use elevator_core::snapshot::WorldSnapshot;
     /// # use serde::{Serialize, Deserialize};

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -1012,6 +1012,7 @@ impl World {
     /// Create a query builder for iterating entities by component composition.
     ///
     /// ```
+    /// use elevator_core::components::{Position, Rider};
     /// use elevator_core::prelude::*;
     ///
     /// let mut sim = SimulationBuilder::demo().build().unwrap();

--- a/crates/elevator-core/tests/scenarios/deterministic_replay.rs
+++ b/crates/elevator-core/tests/scenarios/deterministic_replay.rs
@@ -14,7 +14,6 @@
 use elevator_core::components::{Accel, Speed, Weight};
 use elevator_core::config::ElevatorConfig;
 use elevator_core::dispatch::etd::EtdDispatch;
-use elevator_core::metrics::Metrics;
 use elevator_core::prelude::*;
 
 /// A rider spawn scheduled at a specific tick.

--- a/crates/elevator-core/tests/scenarios/deterministic_replay.rs
+++ b/crates/elevator-core/tests/scenarios/deterministic_replay.rs
@@ -11,8 +11,10 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
+use elevator_core::components::{Accel, Speed, Weight};
 use elevator_core::config::ElevatorConfig;
 use elevator_core::dispatch::etd::EtdDispatch;
+use elevator_core::metrics::Metrics;
 use elevator_core::prelude::*;
 
 /// A rider spawn scheduled at a specific tick.

--- a/crates/elevator-core/tests/scenarios/multi_line.rs
+++ b/crates/elevator-core/tests/scenarios/multi_line.rs
@@ -3,9 +3,10 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use elevator_core::components::{Preferences, RiderPhase, Route, RouteLeg, TransportMode};
+use elevator_core::components::{Preferences, Rider, RiderPhase, Route, RouteLeg, TransportMode};
 use elevator_core::dispatch::ScanDispatch;
 use elevator_core::entity::EntityId;
+use elevator_core::ids::GroupId;
 use elevator_core::prelude::*;
 
 #[path = "common/mod.rs"]

--- a/crates/elevator-core/tests/scenarios/multi_line.rs
+++ b/crates/elevator-core/tests/scenarios/multi_line.rs
@@ -3,10 +3,8 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use elevator_core::components::{Preferences, Rider, RiderPhase, Route, RouteLeg, TransportMode};
+use elevator_core::components::{Preferences, Rider, Route, RouteLeg, TransportMode};
 use elevator_core::dispatch::ScanDispatch;
-use elevator_core::entity::EntityId;
-use elevator_core::ids::GroupId;
 use elevator_core::prelude::*;
 
 #[path = "common/mod.rs"]

--- a/crates/elevator-core/tests/scenarios/service_modes.rs
+++ b/crates/elevator-core/tests/scenarios/service_modes.rs
@@ -4,7 +4,7 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use elevator_core::components::{RiderPhase, ServiceMode};
+use elevator_core::components::{Rider, RiderPhase, ServiceMode};
 use elevator_core::dispatch::{EtdDispatch, ScanDispatch};
 use elevator_core::entity::EntityId;
 use elevator_core::events::Event;

--- a/crates/elevator-core/tests/scenarios/single_call_single_car.rs
+++ b/crates/elevator-core/tests/scenarios/single_call_single_car.rs
@@ -23,7 +23,6 @@ use elevator_core::dispatch::{
     ScanDispatch,
 };
 use elevator_core::prelude::*;
-use elevator_core::stop::StopConfig;
 
 fn three_car_sim_with<D: DispatchStrategy + 'static>(dispatch: D) -> Simulation {
     let stops: Vec<StopConfig> = (0..13)

--- a/crates/elevator-core/tests/scenarios/single_call_single_car.rs
+++ b/crates/elevator-core/tests/scenarios/single_call_single_car.rs
@@ -17,11 +17,13 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
+use elevator_core::components::{Accel, Route, Speed, Weight};
 use elevator_core::dispatch::{
     BuiltinReposition, DispatchStrategy, EtdDispatch, LookDispatch, NearestCarDispatch,
     ScanDispatch,
 };
 use elevator_core::prelude::*;
+use elevator_core::stop::StopConfig;
 
 fn three_car_sim_with<D: DispatchStrategy + 'static>(dispatch: D) -> Simulation {
     let stops: Vec<StopConfig> = (0..13)

--- a/docs/src/bevy-integration.md
+++ b/docs/src/bevy-integration.md
@@ -48,6 +48,7 @@ The core simulation is wrapped in a Bevy resource:
 ```rust,no_run
 # use bevy::prelude::*;
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 #[derive(Resource)]
 pub struct SimulationRes {
     pub sim: Simulation,

--- a/docs/src/custom-dispatch.md
+++ b/docs/src/custom-dispatch.md
@@ -290,6 +290,7 @@ Two levels of test coverage work well:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # struct BusyStopNearest;
 # impl DispatchStrategy for BusyStopNearest {
 #     fn rank(&mut self, _ctx: &RankContext<'_>) -> Option<f64> { Some(0.0) }

--- a/docs/src/dispatch-strategies.md
+++ b/docs/src/dispatch-strategies.md
@@ -19,6 +19,7 @@ If you want to tell an elevator exactly where to go -- bypassing strategy logic 
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # let mut sim: Simulation = todo!();
 # let elev: ElevatorId = todo!();
 # let stop_a: EntityId = todo!();

--- a/docs/src/door-control.md
+++ b/docs/src/door-control.md
@@ -42,6 +42,7 @@ You can change these at runtime:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # let mut sim: Simulation = todo!();
 # let elev: ElevatorId = todo!();
 sim.set_door_transition_ticks(elev, 3).unwrap();
@@ -67,6 +68,7 @@ Here is a practical example -- hold doors for a late arrival, then force them sh
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # let mut sim: Simulation = todo!();
 # let elev: ElevatorId = todo!();
 // A friend is running for the elevator -- hold the doors.

--- a/docs/src/elevators.md
+++ b/docs/src/elevators.md
@@ -30,6 +30,7 @@ Access elevator data through the simulation or the world directly:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &Simulation, elevator_id: EntityId) {
 // World accessors return Option -- unwrap when you know the entity exists.
 let pos: f64 = sim.world().position(elevator_id).unwrap().value();
@@ -65,6 +66,7 @@ Read the lamps through the simulation API:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &Simulation, elevator_id: EntityId) {
 let going_up = sim.elevator_going_up(elevator_id);
 let going_down = sim.elevator_going_down(elevator_id);
@@ -76,6 +78,7 @@ Or directly from the component:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &Simulation, elevator_id: EntityId) {
 let elev = sim.world().elevator(elevator_id).unwrap();
 let going_up = elev.going_up();
@@ -116,6 +119,7 @@ When constructing elevators, use `ElevatorConfig` to set initial parameters:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn main() -> Result<(), SimError> {
 # let sim = SimulationBuilder::new()
 #     .stop(StopId(0), "Ground", 0.0)
@@ -145,6 +149,7 @@ Physics parameters, capacity, and door timing can be changed on a running elevat
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &mut Simulation, elev: ElevatorId) -> Result<(), SimError> {
 sim.set_max_speed(elev, 4.0)?;
 sim.set_acceleration(elev, 2.5)?;

--- a/docs/src/error-handling.md
+++ b/docs/src/error-handling.md
@@ -80,6 +80,7 @@ Every `RiderRejected` event includes a `RejectionContext` with the numeric detai
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 use ordered_float::OrderedFloat;
 
 let context = RejectionContext {
@@ -94,6 +95,7 @@ let context = RejectionContext {
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # use ordered_float::OrderedFloat;
 # let context = RejectionContext {
 #     attempted_weight: OrderedFloat(80.0),
@@ -123,6 +125,7 @@ The most common error path in game code is spawning riders. Here are the key fai
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # let mut sim: Simulation = todo!();
 match sim.spawn_rider(StopId(0), StopId(5), 75.0) {
     Ok(rider) => {
@@ -153,6 +156,7 @@ Rider rejections are not Rust errors -- they are events. The simulation continue
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &mut Simulation) {
 sim.step();
 

--- a/docs/src/events-metrics.md
+++ b/docs/src/events-metrics.md
@@ -75,6 +75,7 @@ Events are buffered during each tick and made available via `sim.drain_events()`
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &mut Simulation) {
 sim.step();
 
@@ -109,6 +110,7 @@ The `Metrics` struct aggregates key performance indicators across the entire sim
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &Simulation) {
 let m = sim.metrics();
 
@@ -155,6 +157,7 @@ Metrics are updated during the Metrics phase each tick. They are always availabl
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &Simulation) {
 println!("{}", sim.metrics());
 // Output: "42 delivered, avg wait 87.3t, 65% util"
@@ -174,6 +177,7 @@ The `Simulation` exposes read-only query helpers for game UIs and dispatch logic
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &Simulation) {
 let idle = sim.idle_elevator_count();
 let loading = sim.elevators_in_phase(ElevatorPhase::Loading);
@@ -191,6 +195,7 @@ For per-zone or per-label breakdowns, tag entities with string labels and query 
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn main() -> Result<(), SimError> {
 # let mut sim = SimulationBuilder::new()
 #     .stop(StopId(0), "Ground", 0.0)
@@ -214,6 +219,7 @@ sim.tag_entity(rider.entity(), "priority:vip")?;
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &Simulation) {
 if let Some(m) = sim.metrics_for_tag("zone:lobby") {
     println!("Lobby avg wait:  {:.1} ticks", m.avg_wait_time());
@@ -231,6 +237,7 @@ Metrics are reported in ticks. Convert to wall-clock seconds via the `TimeAdapte
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &Simulation) {
 let time = sim.time();
 let avg_wait_seconds = time.ticks_to_seconds(sim.metrics().avg_wait_time() as u64);

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -56,6 +56,7 @@ Use `world.insert_ext()` to attach your component to an entity:
 # #[derive(Debug, Clone, Serialize, Deserialize)]
 # struct GuestPriority { priority_class: u8, suite_floor: u32 }
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn main() -> Result<(), SimError> {
 # let mut sim = SimulationBuilder::new()
 #     .stop(StopId(0), "Ground", 0.0)
@@ -83,6 +84,7 @@ Use `world.ext()` for a cloned value, `world.ext_ref()` for a zero-copy borrow, 
 # #[derive(Debug, Clone, Serialize, Deserialize)]
 # struct GuestPriority { priority_class: u8, suite_floor: u32 }
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &mut Simulation, rider_id: EntityId) {
 // Read (cloned)
 if let Some(guest) = sim.world().ext::<GuestPriority>(rider_id) {
@@ -105,6 +107,7 @@ Extensions integrate with the query builder for ECS-style iteration:
 # #[derive(Debug, Clone, Serialize, Deserialize)]
 # struct GuestPriority { priority_class: u8, suite_floor: u32 }
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # use elevator_core::query::Ext;
 # fn run(world: &mut World) {
 // Read-only iteration (cloned via Ext<T>)
@@ -127,6 +130,7 @@ For global data that is not attached to a specific entity, use **resources**. Re
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &mut Simulation) {
 // Insert a resource
 sim.world_mut().insert_resource(42u32);
@@ -166,6 +170,7 @@ Extension components are serialized by their registered type name into the `Worl
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # use elevator_core::snapshot::WorldSnapshot;
 # use serde::{Serialize, Deserialize};
 # #[derive(Clone, Serialize, Deserialize)] struct GuestPriority { priority_class: u8, suite_floor: u32 }

--- a/docs/src/hall-calls.md
+++ b/docs/src/hall-calls.md
@@ -49,6 +49,7 @@ Game and operator code can drive the call system outside the normal rider flow. 
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # use elevator_core::components::hall_call::CallDirection;
 # fn run(
 #     sim: &mut Simulation,

--- a/docs/src/headless-non-bevy.md
+++ b/docs/src/headless-non-bevy.md
@@ -36,6 +36,7 @@ The body of the main loop is small enough to inline here:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # use std::io::Write;
 # fn run(sim: &mut Simulation, out: &mut impl Write, ticks: u64) -> Result<(), Box<dyn std::error::Error>> {
 for _ in 0..ticks {

--- a/docs/src/lifecycle-hooks.md
+++ b/docs/src/lifecycle-hooks.md
@@ -34,6 +34,7 @@ You can add hooks to a running simulation. This is useful when hook logic depend
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # use elevator_core::hooks::Phase;
 # fn main() -> Result<(), SimError> {
 # let mut sim = SimulationBuilder::new()
@@ -54,6 +55,7 @@ For multi-group buildings, you can register hooks that only fire for a specific 
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # use elevator_core::hooks::Phase;
 # fn main() -> Result<(), SimError> {
 let sim = SimulationBuilder::new()
@@ -127,10 +129,9 @@ A facilities team monitoring an office tower wants to know whenever a tenant has
 The hook closure cannot call `sim.current_tick()` directly (the simulation is borrowed during the tick), so the tick is mirrored into a `World` resource that the hook reads.
 
 ```rust,no_run
-use elevator_core::prelude::*;
-use elevator_core::config::ElevatorConfig;
 use elevator_core::hooks::Phase;
-use elevator_core::stop::StopId;
+use elevator_core::prelude::*;
+use elevator_core::world::ExtKey;
 use serde::{Serialize, Deserialize};
 
 /// Per-rider flag that latches the first time a tenant breaches the

--- a/docs/src/manual-inspection-modes.md
+++ b/docs/src/manual-inspection-modes.md
@@ -17,6 +17,7 @@ Use `sim.set_service_mode()` to change an elevator's mode at any time. The metho
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &mut Simulation, elev: EntityId) -> Result<(), SimError> {
 sim.set_service_mode(elev, ServiceMode::Manual)?;
 # Ok(())
@@ -35,6 +36,7 @@ Set the target velocity with `sim.set_target_velocity()`. The elevator accelerat
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &mut Simulation, elev: ElevatorId) -> Result<(), SimError> {
 // Command the elevator upward.
 sim.set_target_velocity(elev, 2.0)?;
@@ -56,6 +58,7 @@ Trigger an immediate deceleration to zero:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &mut Simulation, elev: ElevatorId) -> Result<(), SimError> {
 sim.emergency_stop(elev)?;
 # Ok(())
@@ -70,6 +73,7 @@ This example puts an elevator into manual mode, commands it upward, then trigger
 
 ```rust,no_run
 use elevator_core::prelude::*;
+use elevator_core::components::ServiceMode;
 
 fn main() {
     let mut sim = SimulationBuilder::demo().build().unwrap();
@@ -108,6 +112,7 @@ This mode is useful for maintenance walk-throughs and operator-driven inspection
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &mut Simulation, elev: EntityId) -> Result<(), SimError> {
 sim.set_service_mode(elev, ServiceMode::Inspection)?;
 // The elevator now moves at 25% of its normal max speed.
@@ -125,6 +130,7 @@ This is useful for freight elevators, service lifts, or any elevator that should
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &mut Simulation, elev: ElevatorId) -> Result<(), SimError> {
 sim.set_service_mode(elev.entity(), ServiceMode::Independent)?;
 // Now manually send it somewhere.
@@ -147,6 +153,7 @@ Re-enable with `sim.enable()`, which emits `EntityEnabled`. Most `Simulation` me
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &mut Simulation, elev: EntityId) -> Result<(), SimError> {
 // Take out of service.
 sim.disable(elev)?;
@@ -163,6 +170,7 @@ The `Event::ServiceModeChanged` event fires whenever `set_service_mode` changes 
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn handle(event: Event) {
 if let Event::ServiceModeChanged { elevator, from, to, tick } = event {
     let _ = (elevator, from, to, tick); // use the fields in your game

--- a/docs/src/movement-physics.md
+++ b/docs/src/movement-physics.md
@@ -50,6 +50,7 @@ Game renderers typically run at a higher framerate than the simulation tick rate
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # let sim: Simulation = todo!();
 # let elev: EntityId = todo!();
 // alpha = 0.0 is the position at tick start, 1.0 at tick end.
@@ -62,6 +63,7 @@ A typical render loop at 4x the sim rate samples at `alpha = 0.0, 0.25, 0.5, 0.7
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # let mut sim: Simulation = todo!();
 # let elev: EntityId = todo!();
 sim.step();
@@ -86,6 +88,7 @@ Two methods estimate arrival times for UI countdown displays and dispatch logic:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # let sim: Simulation = todo!();
 # let elev: ElevatorId = todo!();
 # let lobby: EntityId = todo!();
@@ -109,6 +112,7 @@ When an elevator passes a stop without stopping, a `PassingFloor` event fires:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn handle(event: Event) {
 if let Event::PassingFloor { elevator, stop, moving_up, tick } = event {
     let _ = (elevator, stop, moving_up, tick);

--- a/docs/src/quick-start.md
+++ b/docs/src/quick-start.md
@@ -10,13 +10,13 @@ cargo add elevator-core
 
 ## Import the prelude
 
-The prelude re-exports everything you need for typical usage:
+The prelude re-exports the 22 names that cover most usage — building a simulation, stepping it, querying world state, writing custom dispatch, and reading aggregate metrics:
 
 ```rust
 use elevator_core::prelude::*;
 ```
 
-This brings in the builder, simulation runner, all component types, dispatch traits, identity types, error types, and events. Types not in the prelude (concrete dispatch strategies, config structs, traffic module) are imported explicitly when needed.
+This brings in `Simulation`, `SimulationBuilder`, `RiderBuilder`, `SimConfig`, `ElevatorConfig`, `StopConfig`, the typed IDs (`StopId`, `ElevatorId`, `RiderId`, `EntityId`, `GroupId`), `Event`, `SimError`, `RejectionReason`, the phase + direction enums (`ElevatorPhase`, `RiderPhase`, `Direction`), the dispatch trait + presets (`DispatchStrategy`, `BuiltinStrategy`, `BuiltinReposition`), and `World` + `Metrics`. Fine-grained component types (`Position`, `Speed`, `Route`, `Patience`, …), per-strategy structs (`ScanDispatch`, `EtdDispatch`, …), extension keys (`ExtKey`), and traffic types are imported explicitly from their sub-modules when needed.
 
 ### Feature flags
 
@@ -55,6 +55,7 @@ A rider is anything that rides an elevator. Provide an origin stop, a destinatio
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn main() -> Result<(), SimError> {
 # let mut sim = SimulationBuilder::new()
 #     .stop(StopId(0), "Lobby", 0.0)
@@ -79,6 +80,7 @@ Each call to `sim.step()` advances the simulation by one tick, running all [eigh
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn main() -> Result<(), SimError> {
 # let mut sim = SimulationBuilder::new()
 #     .stop(StopId(0), "Lobby", 0.0)

--- a/docs/src/rider-lifecycle.md
+++ b/docs/src/rider-lifecycle.md
@@ -50,6 +50,7 @@ Riders can have a patience budget that causes automatic abandonment. Attach a `P
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # let mut sim: Simulation = todo!();
 let rider = sim.build_rider(StopId(0), StopId(2))
     .unwrap()
@@ -81,6 +82,7 @@ Whichever condition fires first wins. Setting `abandon_on_full = true` with `aba
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # let mut sim: Simulation = todo!();
 let rider = sim.build_rider(StopId(0), StopId(2))
     .unwrap()
@@ -103,6 +105,7 @@ The `AccessControl` component restricts which stops a rider may visit. If a ride
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # use std::collections::HashSet;
 # let mut sim: Simulation = todo!();
 # let lobby: EntityId = todo!();
@@ -128,6 +131,7 @@ Once a rider reaches `Arrived` or `Abandoned`, the simulation stops managing the
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # let mut sim: Simulation = todo!();
 # let rider: RiderId = todo!();
 # let new_route: Route = todo!();

--- a/docs/src/riders.md
+++ b/docs/src/riders.md
@@ -8,6 +8,7 @@ The simplest way to create a rider is `spawn_rider`, which takes an origin stop,
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &mut Simulation) -> Result<(), SimError> {
 let rider_id = sim.spawn_rider(StopId(0), StopId(3), 75.0)?;
 # let _ = rider_id;
@@ -21,6 +22,7 @@ For more control, use the `RiderBuilder` fluent API:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &mut Simulation) -> Result<(), SimError> {
 let rider_id = sim.build_rider(StopId(0), StopId(3))?
     .weight(80.0)
@@ -70,6 +72,7 @@ The simulation maintains a reverse index (`RiderIndex`) that tracks riders at ea
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &Simulation, lobby_entity: EntityId, floor_10: EntityId, stop_entity: EntityId) {
 // Who is waiting at the lobby?
 let waiting: Vec<EntityId> = sim.waiting_at(lobby_entity).collect();
@@ -97,6 +100,7 @@ When you have an `EntityId` and need to know what it refers to, use the type-che
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &Simulation, id: EntityId) {
 if sim.is_rider(id) {
     // handle rider
@@ -124,6 +128,7 @@ Always use `sim.despawn_rider(id)` instead of calling `world.despawn()` directly
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &mut Simulation, rider_id: RiderId, new_route: Route) -> Result<(), SimError> {
 // A rider arrives at their destination. Settle them as a resident.
 sim.settle_rider(rider_id)?;

--- a/docs/src/simulation-loop.md
+++ b/docs/src/simulation-loop.md
@@ -140,6 +140,7 @@ Each phase supports before/after lifecycle hooks, letting you inject custom logi
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # use elevator_core::hooks::Phase;
 # fn run(sim: &mut Simulation) {
 sim.add_before_hook(Phase::Loading, |world| {
@@ -156,6 +157,7 @@ For advanced use cases, you can run individual phases instead of calling `step()
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn main() -> Result<(), SimError> {
 # let mut sim = SimulationBuilder::new()
 #     .stop(StopId(0), "Ground", 0.0)

--- a/docs/src/snapshots-determinism.md
+++ b/docs/src/snapshots-determinism.md
@@ -26,6 +26,7 @@ A `WorldSnapshot` captures the full simulation state -- all entities, components
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn main() -> Result<(), SimError> {
 # let mut sim = SimulationBuilder::new()
 #     .stop(StopId(0), "Ground", 0.0)
@@ -47,6 +48,7 @@ The snapshot struct is `Serialize + Deserialize` -- choose any serde format (RON
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # use elevator_core::snapshot::WorldSnapshot;
 # fn main() -> Result<(), SimError> {
 let bytes = std::fs::read_to_string("save.ron").unwrap();
@@ -69,6 +71,7 @@ Built-in strategies (`Scan`, `Look`, `NearestCar`, `Etd`, `Rsr`, `Destination`) 
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # use elevator_core::snapshot::WorldSnapshot;
 # struct HighestFirstDispatch;
 # impl DispatchStrategy for HighestFirstDispatch {
@@ -90,6 +93,7 @@ Extensions are serialized by their registered name. Dispatch-internal extensions
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # use elevator_core::snapshot::WorldSnapshot;
 # use serde::{Serialize, Deserialize};
 # #[derive(Clone, Serialize, Deserialize)] struct VipTag;
@@ -118,6 +122,7 @@ Run a seeded scenario for N ticks, snapshot, and diff against a golden snapshot:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &mut Simulation, expected: &str) {
 let snap = sim.snapshot();
 let actual = ron::to_string(&snap).unwrap();
@@ -135,6 +140,7 @@ To compare dispatch strategies fairly, use identical seeded traffic across runs:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn build_sim(dispatch: impl DispatchStrategy + 'static) -> Simulation {
 #   SimulationBuilder::new()
 #       .stop(StopId(0), "Ground", 0.0)

--- a/docs/src/stops-lines-groups.md
+++ b/docs/src/stops-lines-groups.md
@@ -8,6 +8,7 @@ A **stop** is a named position along a 1D shaft axis. Unlike traditional elevato
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn main() -> Result<(), SimError> {
 let sim = SimulationBuilder::new()
     .stop(StopId(0), "Basement", -3.0)
@@ -30,6 +31,7 @@ For simple single-shaft buildings, you never need to think about lines. The buil
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn main() -> Result<(), SimError> {
 // This implicitly creates one line containing both elevators and all stops.
 SimulationBuilder::new()
@@ -98,6 +100,7 @@ The library uses three identity types. Knowing which to reach for saves confusio
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &Simulation) {
 let lobby_entity: Option<EntityId> = sim.stop_entity(StopId(0));
 # let _ = lobby_entity;
@@ -118,6 +121,7 @@ Convert between ticks and seconds using the time API:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(sim: &Simulation) {
 let seconds = sim.time().ticks_to_seconds(120);  // 120 ticks -> seconds
 # let _ = seconds;

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -78,6 +78,7 @@ Save a snapshot, serialize it, deserialize it, restore, and verify the state mat
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # use elevator_core::snapshot::WorldSnapshot;
 #[test]
 fn snapshot_roundtrip_preserves_state() {
@@ -114,6 +115,7 @@ For elevators in non-trivial phases (e.g., `Repositioning`), verify that the pha
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(restored: &Simulation, elev_id: EntityId) {
 let restored_phase = restored.world().elevator(elev_id).unwrap().phase();
 match restored_phase {
@@ -251,6 +253,7 @@ Criterion generates HTML reports in `target/criterion/` with statistical analysi
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # fn run(events: Vec<Event>, metrics: &Metrics, expected_minimum: u64) {
 assert!(events.iter().any(|e| matches!(e, Event::RiderBoarded { .. })));
 assert!(metrics.total_delivered() >= expected_minimum);

--- a/docs/src/traffic-generation.md
+++ b/docs/src/traffic-generation.md
@@ -116,6 +116,7 @@ If your `SimConfig` already has `passenger_spawning` populated, use `from_config
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # use elevator_core::traffic::PoissonSource;
 # fn run(config: &SimConfig) {
 let source = PoissonSource::from_config(config);
@@ -221,6 +222,7 @@ A `SpawnRequest` is the minimal description of a rider to spawn:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # use elevator_core::traffic::SpawnRequest;
 // Constructing a SpawnRequest to feed into the simulation:
 let req = SpawnRequest {
@@ -235,6 +237,7 @@ For riders that need patience, preferences, or access control, spawn through the
 
 ```rust,no_run
 # use elevator_core::prelude::*;
+# use elevator_core::__doctest_prelude::*;
 # use elevator_core::traffic::SpawnRequest;
 # fn run(sim: &mut Simulation, req: SpawnRequest) -> Result<(), SimError> {
 sim.build_rider(req.origin, req.destination)?


### PR DESCRIPTION
## Summary
- The prelude was re-exporting almost the entire public API across 16 modules — every component type, every dispatch strategy, every identity type, traffic detection, arrival logs, time adapters, the event bus, world internals (~70 names total). `use elevator_core::prelude::*;` polluted the consumer's namespace and risked collision on common identifiers like `Direction`, `Position`, `Stop`.
- New prelude exports the **22 names** that cover the vast majority of usage: build a sim, step it, query world state, write custom dispatch, read aggregate metrics. Anything else (fine-grained component types, per-strategy structs, `ExtKey`, traffic types, etc.) now requires explicit sub-module imports.
- Internal `#[doc(hidden)] __doctest_prelude` keeps mdBook chapters compiling without per-block import surgery; not part of the public API.

## Prelude contents

| Category | Names |
|---|---|
| Sim & builder | `Simulation`, `SimulationBuilder`, `RiderBuilder` |
| Config | `SimConfig`, `ElevatorConfig`, `StopConfig` |
| Identity | `StopId`, `ElevatorId`, `RiderId`, `EntityId`, `GroupId` |
| Errors & events | `SimError`, `RejectionReason`, `Event` |
| Phase & direction enums | `ElevatorPhase`, `RiderPhase`, `Direction` |
| Dispatch | `DispatchStrategy`, `BuiltinStrategy`, `BuiltinReposition` |
| World & metrics | `World`, `Metrics` |

## Migration

Anything you previously got "for free" from the prelude is now explicit:

```rust
// Before:
use elevator_core::prelude::*;
let mut s = Speed::from(2.0);
let r: Route = ...;

// After:
use elevator_core::components::{Speed, Route};
use elevator_core::prelude::*;
let mut s = Speed::from(2.0);
let r: Route = ...;
```

Common cases that need new explicit imports:
- Component types like `Position`, `Velocity`, `Speed`, `Accel`, `Weight`, `Route`, `Patience`, `ServiceMode` → `elevator_core::components`
- Per-strategy structs (`ScanDispatch`, `LookDispatch`, `NearestCarDispatch`, `EtdDispatch`, `RsrDispatch`, `DestinationDispatch`), `RankContext`, `DispatchManifest` → `elevator_core::dispatch`
- Reposition strategies (`SpreadEvenly`, `NearestIdle`, `ReturnToLobby`, …) → `elevator_core::dispatch::reposition`
- Extension storage (`ExtKey`) → `elevator_core::world`

## Test plan
- [x] `cargo check --workspace --tests --examples --benches` — clean
- [x] `cargo test -p elevator-core --all-features` — 907 unit + integration tests pass, 159 doc tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `scripts/check-bindings.sh` — bindings.toml in sync (no `pub fn` changes on `Simulation`)
- [x] Pre-commit hook (fmt, clippy, core tests, doc tests, `cargo check --workspace`, doc lint) green

## Notes
- 36 files changed (+161 / −87). The bulk of the additions are the `# use elevator_core::__doctest_prelude::*;` line propagated to each mdBook chapter so doctests compile without touching every fenced block.
- The `__doctest_prelude` module is `#[doc(hidden)]` — does not appear in `cargo doc` output and is not stable.

BREAKING CHANGE: Names removed from the prelude are now imported explicitly from their sub-modules.