### PR TITLE
refactor(dispatch)!: merge pair_can_do_work into pair_is_useful

### DIFF
--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -32,7 +32,7 @@ use crate::components::{DestinationQueue, Direction, ElevatorPhase};
 use crate::entity::EntityId;
 use crate::world::{ExtKey, World};
 
-use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext, pair_can_do_work};
+use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext, pair_is_useful};
 
 /// Sticky rider → car assignment produced by [`DestinationDispatch`].
 ///
@@ -262,7 +262,7 @@ impl DispatchStrategy for DestinationDispatch {
         // car, so the Hungarian assignment reduces to the identity match
         // between each car and the stop it has already committed to.
         //
-        // The `pair_can_do_work` gate guards against the same full-car
+        // The `pair_is_useful` gate guards against the same full-car
         // self-assign stall the other built-ins close: a sticky DCS
         // assignment whose car has filled up with earlier riders and
         // whose queue front is still the *pickup* for an un-boarded
@@ -272,7 +272,7 @@ impl DispatchStrategy for DestinationDispatch {
             .world
             .destination_queue(ctx.car)
             .and_then(DestinationQueue::front)?;
-        if front == ctx.stop && pair_can_do_work(ctx) {
+        if front == ctx.stop && pair_is_useful(ctx, false) {
             Some(0.0)
         } else {
             None

--- a/crates/elevator-core/src/dispatch/etd.rs
+++ b/crates/elevator-core/src/dispatch/etd.rs
@@ -12,7 +12,7 @@ use crate::components::{ElevatorPhase, Route};
 use crate::entity::EntityId;
 use crate::world::World;
 
-use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext, pair_can_do_work};
+use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext, pair_is_useful};
 
 /// Estimated Time to Destination (ETD) dispatch algorithm.
 ///
@@ -218,7 +218,7 @@ impl DispatchStrategy for EtdDispatch {
         // the car is already at the stop). Dispatch then re-selects that
         // stop every tick — doors cycle open, reject, close, repeat — and
         // the aboard riders are never carried to their destinations.
-        if !pair_can_do_work(ctx) {
+        if !pair_is_useful(ctx, false) {
             return None;
         }
         let mut cost = self.compute_cost(ctx.car, ctx.car_position, ctx.stop_position, ctx.world);

--- a/crates/elevator-core/src/dispatch/look.rs
+++ b/crates/elevator-core/src/dispatch/look.rs
@@ -16,7 +16,7 @@ use crate::entity::EntityId;
 use crate::world::World;
 
 use super::sweep::{self, SweepDirection, SweepMode};
-use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext, pair_can_do_work};
+use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext, pair_is_useful};
 
 /// Elevator dispatch using the LOOK algorithm. See module docs.
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -86,7 +86,7 @@ impl DispatchStrategy for LookDispatch {
         // Same guard as SCAN: deny un-servable pairs so an over-capacity
         // waiting rider at the car's own stop can't pull the car into a
         // cost-0 self-assignment during the Lenient reversal tick.
-        if !pair_can_do_work(ctx) {
+        if !pair_is_useful(ctx, false) {
             return None;
         }
         sweep::rank(

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -66,21 +66,36 @@ use crate::ids::GroupId;
 use crate::world::World;
 use std::collections::{BTreeMap, HashSet};
 
-/// Whether assigning `ctx.car` to `ctx.stop` can perform useful work.
+/// Whether assigning `ctx.car` to `ctx.stop` is worth ranking.
 ///
-/// "Useful" here means one of: exit an aboard rider, board a waiting
-/// rider that fits, or answer a rider-less hall call with at least some
-/// spare capacity. A pair that can do none of those is a no-op move —
-/// and worse, a zero-cost one when the car is already parked at the
-/// stop — which dispatch strategies must exclude to avoid door-cycle
-/// stalls against unservable demand.
+/// Combines two checks every dispatch strategy needs at the top of its
+/// `rank` implementation:
 ///
-/// Built-in strategies use this as a universal floor; delivery-safety
-/// guarantees are only as strong as this guard. Custom strategies
-/// should call it at the top of their `rank` implementations when
-/// capacity-based stalls are a concern.
+/// 1. **Servability** — capacity, full-load bypass, and the loading-phase
+///    boarding filter. A pair that can't exit an aboard rider, board a
+///    waiter, or answer a rider-less hall call is a no-op move (and a
+///    zero-cost one when the car is already parked there) which would
+///    otherwise stall doors against unservable demand.
+/// 2. **Path discipline** (only when `respect_aboard_path` is `true`) —
+///    refuses pickups that would pull a car carrying routed riders off
+///    the direct path to every aboard rider's destination. Without it, a
+///    stream of closer-destination hall calls can indefinitely preempt a
+///    farther aboard rider's delivery (the "never reaches the
+///    passenger's desired stop" loop).
+///
+/// Strategies with their own direction discipline (SCAN, LOOK, ETD,
+/// Destination) pass `respect_aboard_path: false` because their
+/// sweep/direction terms already rule out backtracks. Strategies without
+/// it (`NearestCar`, RSR) pass `respect_aboard_path: true`. Custom
+/// strategies should pass `true` unless they enforce direction
+/// discipline themselves.
+///
+/// Aboard riders without a published route (game-managed manual riders)
+/// don't constrain the path — any pickup is trivially on-the-way for
+/// them, so the path check trivially passes when no aboard rider has a
+/// `Route::current_destination`.
 #[must_use]
-pub fn pair_can_do_work(ctx: &RankContext<'_>) -> bool {
+pub fn pair_is_useful(ctx: &RankContext<'_>, respect_aboard_path: bool) -> bool {
     let Some(car) = ctx.world.elevator(ctx.car) else {
         return false;
     };
@@ -106,66 +121,39 @@ pub fn pair_can_do_work(ctx: &RankContext<'_>) -> bool {
         return false;
     }
     let waiting = ctx.manifest.waiting_riders_at(ctx.stop);
-    if !waiting.is_empty() {
-        return waiting
+    let servable = if waiting.is_empty() {
+        // No waiters at the stop, and no aboard rider of ours exits here
+        // (the `can_exit_here` short-circuit ruled that out above).
+        // Demand must therefore come from either another car's
+        // `riding_to_stop` (not work this car can perform) or a
+        // rider-less hall call (someone pressed a button with no rider
+        // attached yet — a press from `press_hall_button` or one whose
+        // riders have since been fulfilled or abandoned). Only the
+        // latter is actionable; without this filter an idle car parked
+        // at the stop collapses to cost 0, the Hungarian picks the
+        // self-pair every tick, and doors cycle open/close indefinitely
+        // while the other car finishes its trip.
+        ctx.manifest
+            .hall_calls_at_stop
+            .get(&ctx.stop)
+            .is_some_and(|calls| calls.iter().any(|c| c.pending_riders.is_empty()))
+    } else {
+        waiting
             .iter()
-            .any(|r| rider_can_board(r, car, ctx, remaining_capacity));
-    }
-    // No waiters at the stop, and no aboard rider of ours exits here
-    // (the `can_exit_here` short-circuit ruled that out above). Demand
-    // must therefore come from either another car's `riding_to_stop`
-    // (not work this car can perform) or a rider-less hall call
-    // (someone pressed a button with no rider attached yet — a press
-    // from `press_hall_button` or one whose riders have since been
-    // fulfilled or abandoned). Only the latter is actionable; without
-    // this filter an idle car parked at the stop collapses to cost 0,
-    // the Hungarian picks the self-pair every tick, and doors cycle
-    // open/close indefinitely while the other car finishes its trip.
-    ctx.manifest
-        .hall_calls_at_stop
-        .get(&ctx.stop)
-        .is_some_and(|calls| calls.iter().any(|c| c.pending_riders.is_empty()))
-}
-
-/// Stronger servability predicate: [`pair_can_do_work`] *plus* a path
-/// check guaranteeing the pickup doesn't strand aboard riders.
-///
-/// A car carrying riders with committed destinations refuses pickups
-/// that would pull it off the path to every aboard rider's destination.
-/// Without this guard, a stream of closer-destination hall calls can
-/// indefinitely preempt a farther aboard rider's delivery — the
-/// "never reaches the passenger's desired stop" loop. `NearestCar` and
-/// `Rsr` both call this at the top of `rank`; strategies with their
-/// own direction discipline (SCAN/LOOK/ETD) use [`pair_can_do_work`]
-/// because their sweep/direction terms already rule out backtracks.
-///
-/// Aboard riders without a published route (game-managed manual
-/// riders) don't constrain the path — any pickup is trivially
-/// on-the-way for them, so the predicate falls back to the base
-/// [`pair_can_do_work`] check.
-#[must_use]
-pub fn pair_is_useful(ctx: &RankContext<'_>) -> bool {
-    if !pair_can_do_work(ctx) {
-        return false;
-    }
-
-    let Some(car) = ctx.world.elevator(ctx.car) else {
-        return false;
+            .any(|r| rider_can_board(r, car, ctx, remaining_capacity))
     };
-    // Exiting an aboard rider is always on-the-way for that rider.
-    let can_exit_here = car
-        .riders()
-        .iter()
-        .any(|&rid| ctx.world.route(rid).and_then(Route::current_destination) == Some(ctx.stop));
-    if can_exit_here || car.riders().is_empty() {
+    if !servable {
+        return false;
+    }
+    if !respect_aboard_path || car.riders().is_empty() {
         return true;
     }
 
     // Route-less aboard riders (game-managed manual riders) don't
     // publish a destination, so there's no committed path to protect.
-    // Any pickup is trivially on-the-way — fall back to the raw
-    // servability check. Otherwise we'd refuse every pickup the moment
-    // the car carried its first manually-managed passenger.
+    // Any pickup is trivially on-the-way — let it through. Otherwise
+    // we'd refuse every pickup the moment the car carried its first
+    // manually-managed passenger.
     let has_routed_rider = car.riders().iter().any(|&rid| {
         ctx.world
             .route(rid)
@@ -193,7 +181,7 @@ pub fn pair_is_useful(ctx: &RankContext<'_>) -> bool {
 }
 
 /// Whether a waiting rider could actually board this car, matching the
-/// same filters the loading phase applies. Prevents `pair_can_do_work`
+/// same filters the loading phase applies. Prevents `pair_is_useful`
 /// from approving a pickup whose only demand is direction-filtered or
 /// over-capacity — the loading phase would reject the rider, doors
 /// would cycle, and dispatch would re-pick the zero-cost self-pair.

--- a/crates/elevator-core/src/dispatch/nearest_car.rs
+++ b/crates/elevator-core/src/dispatch/nearest_car.rs
@@ -38,7 +38,7 @@ impl Default for NearestCarDispatch {
 
 impl DispatchStrategy for NearestCarDispatch {
     fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
-        if !pair_is_useful(ctx) {
+        if !pair_is_useful(ctx, true) {
             return None;
         }
         Some((ctx.car_position - ctx.stop_position).abs())

--- a/crates/elevator-core/src/dispatch/rsr.rs
+++ b/crates/elevator-core/src/dispatch/rsr.rs
@@ -77,7 +77,7 @@ pub struct RsrDispatch {
     /// (`load_penalty_coeff · load_ratio`).
     ///
     /// Fires for partially loaded cars below the `bypass_load_*_pct`
-    /// threshold enforced by [`pair_is_useful`](super::pair_is_useful);
+    /// threshold enforced by [`pair_is_useful`];
     /// lets you prefer emptier cars for new pickups without an on/off cliff.
     /// Default `0.0`.
     pub load_penalty_coeff: f64,

--- a/crates/elevator-core/src/dispatch/rsr.rs
+++ b/crates/elevator-core/src/dispatch/rsr.rs
@@ -77,7 +77,7 @@ pub struct RsrDispatch {
     /// (`load_penalty_coeff · load_ratio`).
     ///
     /// Fires for partially loaded cars below the `bypass_load_*_pct`
-    /// threshold enforced by [`pair_can_do_work`](super::pair_can_do_work);
+    /// threshold enforced by [`pair_is_useful`](super::pair_is_useful);
     /// lets you prefer emptier cars for new pickups without an on/off cliff.
     /// Default `0.0`.
     pub load_penalty_coeff: f64,
@@ -305,14 +305,15 @@ impl Default for RsrDispatch {
 
 impl DispatchStrategy for RsrDispatch {
     fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
-        // `pair_is_useful` subsumes `pair_can_do_work` and adds the
-        // aboard-rider path guard. Without it, a loaded RSR car gets
-        // pulled off the path to its aboard riders' destinations by
-        // closer pickups — the same "never reaches the passenger's
-        // desired stop" loop that NearestCar specifically fixes. RSR's
-        // `wrong_direction_penalty` can mitigate this when configured,
-        // but the guard is a correctness floor independent of tuning.
-        if !pair_is_useful(ctx) {
+        // `pair_is_useful(ctx, true)` enables the aboard-rider path
+        // guard on top of the servability check. Without it, a loaded
+        // RSR car gets pulled off the path to its aboard riders'
+        // destinations by closer pickups — the same "never reaches
+        // the passenger's desired stop" loop that NearestCar
+        // specifically fixes. RSR's `wrong_direction_penalty` can
+        // mitigate this when configured, but the guard is a
+        // correctness floor independent of tuning.
+        if !pair_is_useful(ctx, true) {
             return None;
         }
         let car = ctx.world.elevator(ctx.car)?;
@@ -361,7 +362,7 @@ impl DispatchStrategy for RsrDispatch {
             cost -= self.coincident_car_call_bonus;
         }
 
-        // Smooth load-fraction penalty. `pair_can_do_work` has already
+        // Smooth load-fraction penalty. `pair_is_useful` has already
         // filtered over-capacity and bypass-threshold cases; this term
         // shapes preference among the survivors so emptier cars win
         // pickups when all else is equal. Idle cars contribute zero.

--- a/crates/elevator-core/src/dispatch/scan.rs
+++ b/crates/elevator-core/src/dispatch/scan.rs
@@ -11,7 +11,7 @@ use crate::entity::EntityId;
 use crate::world::World;
 
 use super::sweep::{self, SweepDirection, SweepMode};
-use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext, pair_can_do_work};
+use super::{DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext, pair_is_useful};
 
 /// Elevator dispatch using the SCAN (elevator) algorithm.
 ///
@@ -92,7 +92,7 @@ impl DispatchStrategy for ScanDispatch {
         // it out of the self-stop within one tick (strict-ahead excludes
         // the current position), but the Lenient transition tick would
         // still rank the self-pair at cost 0 without this guard.
-        if !pair_can_do_work(ctx) {
+        if !pair_is_useful(ctx, false) {
             return None;
         }
         sweep::rank(

--- a/crates/elevator-core/src/systems/doors.rs
+++ b/crates/elevator-core/src/systems/doors.rs
@@ -67,7 +67,7 @@ pub fn run(
                 // car is at a stop and free for reassignment. Also
                 // reset direction lamps so any stale state from the
                 // just-finished leg (e.g., `going_up=false` after a
-                // down-trip) doesn't make `pair_can_do_work` reject
+                // down-trip) doesn't make `pair_is_useful` reject
                 // opposite-direction pickup in the next dispatch tick.
                 // Without this, a car that dropped a down-bound rider
                 // at the lobby sits idle while an up-bound rider

--- a/crates/elevator-core/src/systems/movement.rs
+++ b/crates/elevator-core/src/systems/movement.rs
@@ -223,7 +223,7 @@ pub fn run(
                 // advance_queue), but once the car is parked with no
                 // committed work the lamps should read "both" — otherwise
                 // the next dispatch tick rejects opposite-direction hall
-                // calls at this stop via `pair_can_do_work`, and the
+                // calls at this stop via `pair_is_useful`, and the
                 // Hungarian picks a different, farther car to serve
                 // them while this one sits there.
                 let indicators_dirty = !(car.going_up && car.going_down);

--- a/crates/elevator-core/src/tests/canonical_benchmarks.rs
+++ b/crates/elevator-core/src/tests/canonical_benchmarks.rs
@@ -102,7 +102,7 @@ fn down_peak_8_floor_2_car_delivers_within_budget() {
 /// 20 riders at the lobby, all heading to the top floor, with a
 /// single under-capacity car. Forces at least three round-trips.
 /// Exercises the full-load self-assign guard (see
-/// [`crate::dispatch::pair_can_do_work`]); regression here was
+/// [`crate::dispatch::pair_is_useful`]); regression here was
 /// previously a doors-cycle-forever bug (#317).
 #[test]
 fn full_load_cycle_delivers_all_in_bounded_trips() {

--- a/crates/elevator-core/src/tests/direction_indicator_tests.rs
+++ b/crates/elevator-core/src/tests/direction_indicator_tests.rs
@@ -73,7 +73,7 @@ fn dispatch_downward_sets_going_down_only() {
 
 /// Regression: a car that just delivered a down-bound rider and
 /// closed its doors must have both indicators lit *before* the next
-/// dispatch tick runs. Without this, `pair_can_do_work` rejects a
+/// dispatch tick runs. Without this, `pair_is_useful` rejects a
 /// fresh up-bound rider at that same stop on direction mismatch, and
 /// Hungarian picks a farther car to serve them while the just-
 /// delivered car sits idle (the lobby-idle bug).
@@ -114,7 +114,7 @@ fn indicators_reset_at_door_close_not_at_next_dispatch() {
     // On the very tick the doors closed, indicators must read both-lit.
     // Without the fix, `going_up` would still be `false` from the
     // delivery trip and a subsequent up-bound rider at this stop would
-    // be rejected by `pair_can_do_work`.
+    // be rejected by `pair_is_useful`.
     assert_eq!(sim.elevator_going_up(elev.entity()), Some(true));
     assert_eq!(sim.elevator_going_down(elev.entity()), Some(true));
 }

--- a/crates/elevator-core/src/tests/direction_stall_tests.rs
+++ b/crates/elevator-core/src/tests/direction_stall_tests.rs
@@ -3,7 +3,7 @@
 //! A car carrying riders with downward destinations has direction
 //! indicator Down. At a waypoint where a waiting rider wants Up, the
 //! loading phase silently direction-filters the rider and no boarding
-//! happens. Pre-fix, `pair_can_do_work` looked only at weight fit and
+//! happens. Pre-fix, `pair_is_useful` looked only at weight fit and
 //! approved the pair — cost collapsed to 0 at the self-pair, the
 //! Hungarian picked it every tick, doors cycled open → filter →
 //! close forever, and aboard riders never reached their destinations.
@@ -74,7 +74,7 @@ fn etd_skips_pickup_whose_riders_are_all_direction_filtered() {
     );
 }
 
-/// Same scenario on `NearestCar` — the `pair_can_do_work` guard is
+/// Same scenario on `NearestCar` — the `pair_is_useful` guard is
 /// shared, so the fix must apply uniformly.
 #[test]
 fn nearest_car_skips_pickup_whose_riders_are_all_direction_filtered() {
@@ -285,7 +285,7 @@ fn etd_approves_self_pair_for_riderless_hall_call() {
 }
 
 /// Cross-car stall mirrored onto `NearestCar` — the fix lives in
-/// shared `pair_can_do_work`, so it applies uniformly across every
+/// shared `pair_is_useful`, so it applies uniformly across every
 /// built-in strategy that uses the guard. This test is an explicit
 /// regression for that contract, matching the paired-strategy
 /// pattern the direction-filter stall tests (above) already follow.
@@ -326,7 +326,7 @@ fn nearest_car_skips_self_pair_when_only_demand_is_another_cars_riding() {
     assert_eq!(
         decisions[0].1,
         DispatchDecision::Idle,
-        "NearestCar must honor the cross-car stall fix — pair_can_do_work is \
+        "NearestCar must honor the cross-car stall fix — pair_is_useful is \
          shared, so regressions here would surface in both strategies"
     );
 }

--- a/crates/elevator-core/src/tests/dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/dispatch_tests.rs
@@ -204,7 +204,7 @@ fn scan_serves_rider_destination() {
     // earlier form of this test faked aboard demand by only populating
     // `riding_to_stop` — a fixture that can't occur in production since
     // `build_manifest` derives `riding_to_stop` from each group car's
-    // `riders` list. Once `pair_can_do_work` started rejecting
+    // `riders` list. Once `pair_is_useful` started rejecting
     // unservable self-pairs (to close the cross-car stall), the faked
     // form became unreachable and the test asserted on a Hungarian
     // fallback. Boarding the rider on this car restores the intent:

--- a/crates/elevator-core/src/tests/rsr_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/rsr_dispatch_tests.rs
@@ -652,12 +652,13 @@ fn peak_direction_multiplier_tolerates_missing_detector() {
 // ── Aboard-rider path guard ─────────────────────────────────────────
 //
 // These two tests lock in the correctness fix routing RSR through
-// `pair_is_useful` (the shared NearestCar path guard). With only
-// `pair_can_do_work`, an unconfigured RSR (all weights at their
-// `new()` defaults — i.e. effectively NearestCar) would be pulled off
-// its aboard riders' path by closer pickups, indefinitely deferring
-// delivery. Tests mirror `nearest_car_*` regression tests so any
-// future drift shows up on both strategies simultaneously.
+// `pair_is_useful(ctx, true)` (the same path guard NearestCar uses).
+// Without `respect_aboard_path: true`, an unconfigured RSR (all
+// weights at their `new()` defaults — i.e. effectively NearestCar)
+// would be pulled off its aboard riders' path by closer pickups,
+// indefinitely deferring delivery. Tests mirror `nearest_car_*`
+// regression tests so any future drift shows up on both strategies
+// simultaneously.
 
 /// Full-car self-pair: a saturated RSR car parked at a pickup stop
 /// whose only waiter it cannot board must still be dispatched to its


### PR DESCRIPTION
## Summary
- The dispatch module exposed two near-identical public predicates: `pair_can_do_work` (capacity / full-load bypass / loading filter) and `pair_is_useful` (the same checks plus an aboard-rider path-discipline guard). The doc comments spent ~30 lines justifying when to call each — the comment block defending the split was longer than either function.
- Merge into a single `pair_is_useful(ctx: &RankContext<'_>, respect_aboard_path: bool)`. The bool parameter names the distinction the old API tried to encode in two function names. SCAN/LOOK/ETD/Destination call `pair_is_useful(ctx, false)`; NearestCar/RSR call `pair_is_useful(ctx, true)`.
- The merged body computes the elevator fetch and `can_exit_here` exactly once on the `respect_aboard_path: true` path. Previously `pair_is_useful` called `pair_can_do_work` and then re-did both — minor perf win in addition to the API cleanup.

## Call-site changes

| Strategy | Before | After |
|---|---|---|
| ScanDispatch | pair_can_do_work(ctx) | pair_is_useful(ctx, false) |
| LookDispatch | pair_can_do_work(ctx) | pair_is_useful(ctx, false) |
| EtdDispatch | pair_can_do_work(ctx) | pair_is_useful(ctx, false) |
| DestinationDispatch | pair_can_do_work(ctx) | pair_is_useful(ctx, false) |
| NearestCarDispatch | pair_is_useful(ctx) | pair_is_useful(ctx, true) |
| RsrDispatch | pair_is_useful(ctx) | pair_is_useful(ctx, true) |

## Migration

Custom dispatch strategies that called pair_can_do_work should call:
- pair_is_useful(ctx, false) if the strategy enforces direction discipline itself (SCAN-like sweep terms, etc.),
- pair_is_useful(ctx, true) if it needs the aboard-rider path guard (the safe default).

## Test plan
- [x] cargo test -p elevator-core --all-features — 907 unit + integration tests pass, 159 doc tests pass
- [x] cargo clippy --workspace --all-targets -- -D warnings — clean
- [x] cargo check --workspace --tests --examples --benches — clean
- [x] scripts/check-bindings.sh — bindings.toml in sync (no pub fn changes on Simulation)
- [x] Pre-commit hook (fmt, clippy, core tests, doc tests, cargo check --workspace) green
- [x] Existing regression tests for the cross-car stall (direction_stall_tests) and the aboard-rider path guard (rsr_dispatch_tests::aboard_rider_path_*) still pass — locking in that the merged predicate enforces both fixes.

## Notes
- 14 files changed (+91 / −101), net −10 lines. The dispatch/mod.rs doc comment shrinks substantially; comment / doc-link references to pair_can_do_work across adjacent systems and tests are updated to the unified name.

BREAKING CHANGE: pair_can_do_work is removed.