### PR TITLE
perf(transition): fold rider arena lookups into a single mut borrow

### DIFF
--- a/crates/elevator-core/src/sim/transition.rs
+++ b/crates/elevator-core/src/sim/transition.rs
@@ -76,12 +76,10 @@ pub(crate) fn transition_rider(
     id: EntityId,
     new_state: InternalRiderPhase,
 ) -> Result<(), SimError> {
-    // Snapshot old state into Copy locals so the immutable borrow on
-    // `world` ends before we touch `rider_index` / `world.rider_mut`.
-    let (old_phase, old_stop, was_aboard) = {
-        let rider = world.rider(id).ok_or(SimError::EntityNotFound(id))?;
-        (rider.phase, rider.current_stop, rider.phase.is_aboard())
-    };
+    let r = world.rider_mut(id).ok_or(SimError::EntityNotFound(id))?;
+    let old_phase = r.phase;
+    let old_stop = r.current_stop;
+    let was_aboard = old_phase.is_aboard();
 
     let from_kind = old_phase.kind();
     let to_kind = new_state.kind();
@@ -91,6 +89,18 @@ pub(crate) fn transition_rider(
             from: from_kind,
             to: to_kind,
         });
+    }
+
+    let now_aboard = matches!(
+        to_kind,
+        RiderPhaseKind::Boarding | RiderPhaseKind::Riding | RiderPhaseKind::Exiting
+    );
+    r.phase = new_state.as_phase();
+    r.current_stop = new_state.at_stop();
+    if !was_aboard && now_aboard {
+        r.board_tick = Some(tick);
+    } else if was_aboard && !now_aboard {
+        r.board_tick = None;
     }
 
     // Sync the rider_index: remove from the old at-stop bucket (if any),
@@ -104,21 +114,6 @@ pub(crate) fn transition_rider(
         }
         if let Some((bucket, stop)) = new_bucket {
             bucket.insert_into(rider_index, stop, id);
-        }
-    }
-
-    // Apply the state to the rider record.
-    let now_aboard = matches!(
-        to_kind,
-        RiderPhaseKind::Boarding | RiderPhaseKind::Riding | RiderPhaseKind::Exiting
-    );
-    if let Some(r) = world.rider_mut(id) {
-        r.phase = new_state.as_phase();
-        r.current_stop = new_state.at_stop();
-        if !was_aboard && now_aboard {
-            r.board_tick = Some(tick);
-        } else if was_aboard && !now_aboard {
-            r.board_tick = None;
         }
     }
 


### PR DESCRIPTION
## Summary

Closes the regression flagged in #557. The transition gateway introduced in #550 was doing **two `SecondaryMap` traversals per call** — one immutable lookup to snapshot the old phase/stop, then a mutable lookup to write the new fields. Pre-#550 the loading hot path did one rider lookup per Board/Exit; post-#550 it does two. Across `step/*`, `dispatch_comparison/*`, and `cross_group_routing/*` the doubling was visible at 5–15% on the nightly runner.

This collapses the gateway to a single `world.rider_mut()`:

1. Borrow mutably, snapshot `phase`/`current_stop`/`is_aboard()` into Copy locals.
2. Run the legality matrix on the snapshot — early-return on illegal transitions before any write.
3. Apply the new state to the rider record in place.
4. Sync `rider_index` after the mutable borrow on `world` is released (`rider_index` is a disjoint argument, so the borrow checker is fine).

## Correctness

- The legality check still runs **before** any field is mutated (the snapshot is read first; writes happen below the bail).
- On the error path nothing is mutated — same as before.
- The atomicity contract (rider record + rider_index always consistent on `Ok`) is preserved: the index sync runs unconditionally after the rider write, both inside the same function with no early returns between them.
- Snapshot semantics for `was_aboard` are unchanged — read once from the original phase, used after the mutable write.

## Test plan

- [x] `cargo test -p elevator-core --all-features` — 907 unit + 159 doc tests pass.
- [x] `cargo clippy -p elevator-core --all-features` — clean.
- [x] Pre-commit hook passes (fmt, clippy, core tests, doc tests, workspace check).
- [ ] Tomorrow's nightly bench compares against today's locked baseline; expect rider-heavy benches to recover.

Local benches show the change as within-noise on my hardware (~1% point estimates on the win side, p > 0.05) — same runner-sensitivity pattern noted in the diagnosis comment on #547.