### PR TITLE
docs: add playground demo gif to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Plug it into Bevy, Unity, your own renderer, or run headless.
 
 </div>
 
-<!-- Drop a GIF of the Bevy demo here when you have one -->
+<p align="center">
+  <img src="https://raw.githubusercontent.com/andymai/elevator-core/main/media/demo.gif" alt="elevator-core web playground: two dispatch strategies racing on identical traffic" width="720" />
+</p>
 
 ## What it does
 


### PR DESCRIPTION
## Summary
- Replaces the placeholder comment in the README hero with a centered `<img>` of `media/demo.gif` (web playground showing two dispatch strategies racing on identical traffic).
- Uses an absolute `raw.githubusercontent.com/.../main/media/demo.gif` URL so the demo also renders on crates.io (the workspace-root `media/` directory isn't packaged with the published crate).
- GIF is 9.2MB (1300×988, 20s @ 22fps) — under GitHub's 10MB decimal-MB embed limit. Display width capped at 720px so it doesn't dominate on desktop while still serving full-res for retina.

## Test plan
- [ ] README renders correctly on GitHub once `main` updates (image resolves via raw.githubusercontent CDN — may take a few minutes after merge).
- [ ] Visual check: GIF is centered, sized appropriately, and sits between the playground link and "What it does".
- [ ] crates.io preview (next publish) shows the image via the absolute URL.