### PR TITLE
feat(playground): add Quest worker host scaffolding

### DIFF
--- a/playground/src/__tests__/quest-protocol.test.ts
+++ b/playground/src/__tests__/quest-protocol.test.ts
@@ -94,6 +94,39 @@ describe("quest: protocol shape", () => {
     expect(typeof createWorkerSim).toBe("function");
   });
 
+  it("WorkerSim rejects pending requests when the worker errors", async () => {
+    // Mock Worker that captures listeners so we can fire `error`
+    // ourselves. Without `onerror` wiring, an unhandled worker
+    // exception would leave every pending promise hanging forever.
+    const listeners = new Map<string, EventListener>();
+    const mock = {
+      addEventListener(type: string, fn: EventListener) {
+        listeners.set(type, fn);
+      },
+      removeEventListener(type: string, _fn: EventListener) {
+        listeners.delete(type);
+      },
+      postMessage(_msg: unknown) {},
+      terminate() {},
+    } as unknown as Worker;
+
+    const sim = new WorkerSim(mock);
+    const pending = sim.tick(1);
+
+    // Synthesize a worker error. The listener duck-types `.message`
+    // rather than checking `instanceof ErrorEvent`, so a plain object
+    // shaped like an `ErrorEvent` is enough to drive the path.
+    const errorListener = listeners.get("error");
+    expect(errorListener).toBeDefined();
+    errorListener!({ message: "wasm panic" } as unknown as Event);
+
+    await expect(pending).rejects.toThrow(/wasm panic/);
+
+    // After an error, future requests reject immediately because the
+    // handle marks itself disposed.
+    await expect(sim.tick(1)).rejects.toThrow(/disposed/);
+  });
+
   it("spawn-result encodes success with riderId and failure with error", () => {
     const success: WorkerToHost = {
       kind: "spawn-result",

--- a/playground/src/__tests__/quest-protocol.test.ts
+++ b/playground/src/__tests__/quest-protocol.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  WorkerSim,
+  createWorkerSim,
+  type HostToWorker,
+  type InitPayload,
+  type TickResultPayload,
+  type WorkerToHost,
+} from "../features/quest";
+
+// These tests verify the protocol's shape and discriminated-union
+// exhaustiveness — there's no Worker spinning up here. The actual
+// host↔worker round-trip is exercised when the Quest mode shell wires
+// it into the playground in a follow-up PR; jsdom (vitest's default)
+// has no Web Workers, and instantiating the worker requires the wasm
+// pkg/ bundle which the dev pipeline already covers.
+
+describe("quest: protocol shape", () => {
+  it("HostToWorker covers all five command kinds", () => {
+    const initPayload: InitPayload = {
+      configRon: "",
+      strategy: "scan",
+      wasmJsUrl: "https://example.test/pkg/elevator_wasm.js",
+      wasmBgUrl: "https://example.test/pkg/elevator_wasm_bg.wasm",
+    };
+    const messages: HostToWorker[] = [
+      { kind: "init", id: 1, payload: initPayload },
+      { kind: "tick", id: 2, ticks: 5 },
+      { kind: "spawn-rider", id: 3, origin: 0, destination: 2, weight: 75 },
+      { kind: "set-strategy", id: 4, strategy: "etd" },
+      { kind: "reset", id: 5, payload: initPayload },
+    ];
+    expect(messages.map((m) => m.kind)).toEqual([
+      "init",
+      "tick",
+      "spawn-rider",
+      "set-strategy",
+      "reset",
+    ]);
+  });
+
+  it("WorkerToHost covers the four response kinds", () => {
+    const tickResult: TickResultPayload = {
+      snapshot: { tick: 0n, cars: [], stops: [], assignments: [] } as never,
+      tick: 0,
+      events: [],
+      metrics: {} as never,
+    };
+    const messages: WorkerToHost[] = [
+      { kind: "ok", id: 1 },
+      { kind: "tick-result", id: 2, result: tickResult },
+      { kind: "spawn-result", id: 3, riderId: 42n, error: null },
+      { kind: "spawn-result", id: 4, riderId: null, error: "nope" },
+      { kind: "error", id: 5, message: "boom" },
+    ];
+    expect(messages.map((m) => m.kind)).toEqual([
+      "ok",
+      "tick-result",
+      "spawn-result",
+      "spawn-result",
+      "error",
+    ]);
+  });
+
+  it("init payload optional reposition is omitted, not undefined", () => {
+    // exactOptionalPropertyTypes compatibility: omitting the field
+    // is the supported shape; setting it to undefined would fail to
+    // type-check at the call site.
+    const a: InitPayload = {
+      configRon: "",
+      strategy: "scan",
+      wasmJsUrl: "",
+      wasmBgUrl: "",
+    };
+    expect(Object.hasOwn(a, "reposition")).toBe(false);
+
+    const b: InitPayload = {
+      configRon: "",
+      strategy: "scan",
+      reposition: "predictive",
+      wasmJsUrl: "",
+      wasmBgUrl: "",
+    };
+    expect(b.reposition).toBe("predictive");
+  });
+
+  it("public surface re-exports WorkerSim and createWorkerSim", () => {
+    // Smoke check: keeps the runtime entry points reachable from a
+    // test entry while the Quest mode shell is still being wired up.
+    // Constructing a real WorkerSim requires Web Workers + the wasm
+    // pkg/ bundle, neither of which is available in jsdom; that path
+    // gets exercised once the shell integration lands.
+    expect(typeof WorkerSim).toBe("function");
+    expect(typeof createWorkerSim).toBe("function");
+  });
+
+  it("spawn-result encodes success with riderId and failure with error", () => {
+    const success: WorkerToHost = {
+      kind: "spawn-result",
+      id: 1,
+      riderId: 1n,
+      error: null,
+    };
+    const failure: WorkerToHost = {
+      kind: "spawn-result",
+      id: 2,
+      riderId: null,
+      error: "no such stop",
+    };
+    expect(success.kind === "spawn-result" && success.riderId).toBe(1n);
+    expect(failure.kind === "spawn-result" && failure.error).toBe("no such stop");
+  });
+});

--- a/playground/src/features/quest/index.ts
+++ b/playground/src/features/quest/index.ts
@@ -1,0 +1,2 @@
+export type { HostToWorker, InitPayload, TickResultPayload, WorkerToHost } from "./protocol";
+export { WorkerSim, createWorkerSim, type WorkerSimOptions } from "./worker-sim";

--- a/playground/src/features/quest/protocol.ts
+++ b/playground/src/features/quest/protocol.ts
@@ -1,0 +1,110 @@
+/**
+ * Wire format for the Quest worker.
+ *
+ * The worker owns a `WasmSim` and runs every operation against it on the
+ * worker thread. The main thread keeps a `WorkerSim` handle that wraps
+ * `postMessage` in a promise-based API.
+ *
+ * Each request carries a numeric `id` so the host can correlate the
+ * matching response — the worker replies in order today, but pinning
+ * that as a contract via `id` lets us add concurrent requests later
+ * without breaking callers.
+ */
+
+import type { EventDto, MetricsDto, Snapshot, StrategyName } from "../../types";
+
+/** Init payload sent by the host before any tick request. */
+export interface InitPayload {
+  /** RON-encoded `SimConfig`. */
+  readonly configRon: string;
+  /** Built-in dispatch strategy name. */
+  readonly strategy: StrategyName;
+  /** Reposition strategy name; omit to use the scenario default. */
+  readonly reposition?: string;
+  /**
+   * URL of `pkg/elevator_wasm.js`, resolved on the host against
+   * `document.baseURI`. Workers don't have `document`, so the host
+   * resolves the deploy-aware path once and forwards it.
+   */
+  readonly wasmJsUrl: string;
+  /** URL of `pkg/elevator_wasm_bg.wasm`, resolved the same way. */
+  readonly wasmBgUrl: string;
+}
+
+/** Snapshot bundle returned after a `tick` request. */
+export interface TickResultPayload {
+  readonly snapshot: Snapshot;
+  readonly tick: number;
+  readonly events: readonly EventDto[];
+  readonly metrics: MetricsDto;
+}
+
+// ─── Host → Worker ──────────────────────────────────────────────────
+
+export interface InitRequest {
+  readonly kind: "init";
+  readonly id: number;
+  readonly payload: InitPayload;
+}
+
+export interface TickRequest {
+  readonly kind: "tick";
+  readonly id: number;
+  readonly ticks: number;
+}
+
+export interface SpawnRiderRequest {
+  readonly kind: "spawn-rider";
+  readonly id: number;
+  readonly origin: number;
+  readonly destination: number;
+  readonly weight: number;
+  readonly patienceTicks?: number;
+}
+
+export interface SetStrategyRequest {
+  readonly kind: "set-strategy";
+  readonly id: number;
+  readonly strategy: StrategyName;
+}
+
+export interface ResetRequest {
+  readonly kind: "reset";
+  readonly id: number;
+  readonly payload: InitPayload;
+}
+
+export type HostToWorker =
+  | InitRequest
+  | TickRequest
+  | SpawnRiderRequest
+  | SetStrategyRequest
+  | ResetRequest;
+
+// ─── Worker → Host ──────────────────────────────────────────────────
+
+export interface OkResponse {
+  readonly kind: "ok";
+  readonly id: number;
+}
+
+export interface TickResponse {
+  readonly kind: "tick-result";
+  readonly id: number;
+  readonly result: TickResultPayload;
+}
+
+export interface SpawnResponse {
+  readonly kind: "spawn-result";
+  readonly id: number;
+  readonly riderId: bigint | null;
+  readonly error: string | null;
+}
+
+export interface ErrorResponse {
+  readonly kind: "error";
+  readonly id: number;
+  readonly message: string;
+}
+
+export type WorkerToHost = OkResponse | TickResponse | SpawnResponse | ErrorResponse;

--- a/playground/src/features/quest/worker-sim.ts
+++ b/playground/src/features/quest/worker-sim.ts
@@ -41,6 +41,13 @@ export class WorkerSim {
   constructor(worker: Worker) {
     this.#worker = worker;
     this.#worker.addEventListener("message", this.#onMessage);
+    // A wasm panic or unhandled worker exception fires `error` /
+    // `messageerror` on the `Worker` object itself, not `message`. Without
+    // these listeners every pending promise hangs forever instead of
+    // rejecting — and the next request silently posts into a worker
+    // that's already dead.
+    this.#worker.addEventListener("error", this.#onWorkerError);
+    this.#worker.addEventListener("messageerror", this.#onWorkerError);
   }
 
   async init(opts: WorkerSimOptions): Promise<void> {
@@ -98,10 +105,15 @@ export class WorkerSim {
     if (this.#disposed) return;
     this.#disposed = true;
     this.#worker.removeEventListener("message", this.#onMessage);
+    this.#worker.removeEventListener("error", this.#onWorkerError);
+    this.#worker.removeEventListener("messageerror", this.#onWorkerError);
     this.#worker.terminate();
-    const err = new Error("WorkerSim disposed");
+    this.#rejectAllPending(new Error("WorkerSim disposed"));
+  }
+
+  #rejectAllPending(reason: Error): void {
     for (const resolver of this.#pending.values()) {
-      resolver.reject(err);
+      resolver.reject(reason);
     }
     this.#pending.clear();
   }
@@ -138,6 +150,21 @@ export class WorkerSim {
       this.#worker.postMessage(msg);
     });
   }
+
+  readonly #onWorkerError = (event: Event): void => {
+    // `ErrorEvent.message` is the most useful detail. Duck-type the
+    // property instead of `instanceof ErrorEvent` so the same code
+    // path works in node-based test envs that don't ship the DOM
+    // class as a global.
+    const candidate: unknown = (event as { message?: unknown }).message;
+    const message =
+      typeof candidate === "string" && candidate.length > 0
+        ? candidate
+        : "worker errored before responding";
+    this.#disposed = true;
+    this.#worker.terminate();
+    this.#rejectAllPending(new Error(message));
+  };
 
   readonly #onMessage = (event: MessageEvent<WorkerToHost>): void => {
     const msg = event.data;

--- a/playground/src/features/quest/worker-sim.ts
+++ b/playground/src/features/quest/worker-sim.ts
@@ -1,0 +1,170 @@
+/**
+ * Main-thread handle for the Quest worker.
+ *
+ * Wraps the typed `postMessage` protocol in a promise-based API. Each
+ * outbound request gets a unique numeric id; the matching response
+ * resolves a pending promise stored in the `pending` map.
+ */
+
+import type { RepositionStrategyName, StrategyName } from "../../types";
+import type { HostToWorker, InitPayload, TickResultPayload, WorkerToHost } from "./protocol";
+
+interface PendingResolver {
+  resolve: (value: unknown) => void;
+  reject: (reason: Error) => void;
+}
+
+export interface WorkerSimOptions {
+  readonly configRon: string;
+  readonly strategy: StrategyName;
+  readonly reposition?: RepositionStrategyName;
+}
+
+/** Instantiate a Quest worker and complete its `init` handshake. */
+export async function createWorkerSim(opts: WorkerSimOptions): Promise<WorkerSim> {
+  // Vite bundles `?worker` imports as a separate chunk and produces a
+  // constructor that builds a fresh Worker per call. The `module`
+  // type lets the worker use ESM `import` for protocol types.
+  const QuestWorker = (await import("./worker.ts?worker")).default;
+  const worker = new QuestWorker();
+  const handle = new WorkerSim(worker);
+  await handle.init(opts);
+  return handle;
+}
+
+export class WorkerSim {
+  readonly #worker: Worker;
+  readonly #pending = new Map<number, PendingResolver>();
+  #nextId = 1;
+  #disposed = false;
+
+  constructor(worker: Worker) {
+    this.#worker = worker;
+    this.#worker.addEventListener("message", this.#onMessage);
+  }
+
+  async init(opts: WorkerSimOptions): Promise<void> {
+    await this.#request<undefined>({
+      kind: "init",
+      id: this.#takeId(),
+      payload: this.#payload(opts),
+    });
+  }
+
+  async tick(ticks: number): Promise<TickResultPayload> {
+    return this.#request<TickResultPayload>({
+      kind: "tick",
+      id: this.#takeId(),
+      ticks,
+    });
+  }
+
+  async spawnRider(
+    origin: number,
+    destination: number,
+    weight: number,
+    patienceTicks?: number,
+  ): Promise<bigint> {
+    return this.#request<bigint>({
+      kind: "spawn-rider",
+      id: this.#takeId(),
+      origin,
+      destination,
+      weight,
+      // `exactOptionalPropertyTypes` rejects an explicit `undefined` on
+      // an optional field — spread when present so the request shape
+      // matches the protocol type literally.
+      ...(patienceTicks !== undefined ? { patienceTicks } : {}),
+    });
+  }
+
+  async setStrategy(strategy: StrategyName): Promise<void> {
+    await this.#request<undefined>({
+      kind: "set-strategy",
+      id: this.#takeId(),
+      strategy,
+    });
+  }
+
+  async reset(opts: WorkerSimOptions): Promise<void> {
+    await this.#request<undefined>({
+      kind: "reset",
+      id: this.#takeId(),
+      payload: this.#payload(opts),
+    });
+  }
+
+  dispose(): void {
+    if (this.#disposed) return;
+    this.#disposed = true;
+    this.#worker.removeEventListener("message", this.#onMessage);
+    this.#worker.terminate();
+    const err = new Error("WorkerSim disposed");
+    for (const resolver of this.#pending.values()) {
+      resolver.reject(err);
+    }
+    this.#pending.clear();
+  }
+
+  #takeId(): number {
+    return this.#nextId++;
+  }
+
+  #payload(opts: WorkerSimOptions): InitPayload {
+    // `document.baseURI` resolves the deploy-aware path so a
+    // GitHub-Pages subpath deploy (`/elevator-core/playground/`) ends
+    // up with the right wasm URL. Workers don't have `document`, so we
+    // resolve once on the host and forward the absolute URL.
+    const wasmJsUrl = new URL("pkg/elevator_wasm.js", document.baseURI).href;
+    const wasmBgUrl = new URL("pkg/elevator_wasm_bg.wasm", document.baseURI).href;
+    return {
+      configRon: opts.configRon,
+      strategy: opts.strategy,
+      wasmJsUrl,
+      wasmBgUrl,
+      ...(opts.reposition !== undefined ? { reposition: opts.reposition } : {}),
+    };
+  }
+
+  async #request<T>(msg: HostToWorker): Promise<T> {
+    if (this.#disposed) {
+      throw new Error("WorkerSim disposed");
+    }
+    return new Promise<T>((resolve, reject) => {
+      this.#pending.set(msg.id, {
+        resolve: resolve as (value: unknown) => void,
+        reject,
+      });
+      this.#worker.postMessage(msg);
+    });
+  }
+
+  readonly #onMessage = (event: MessageEvent<WorkerToHost>): void => {
+    const msg = event.data;
+    const resolver = this.#pending.get(msg.id);
+    if (!resolver) {
+      // Late reply for an already-disposed request, or a bug. Either
+      // way it's not actionable here.
+      return;
+    }
+    this.#pending.delete(msg.id);
+    switch (msg.kind) {
+      case "ok":
+        resolver.resolve(undefined);
+        return;
+      case "tick-result":
+        resolver.resolve(msg.result);
+        return;
+      case "spawn-result":
+        if (msg.error !== null) {
+          resolver.reject(new Error(msg.error));
+        } else {
+          resolver.resolve(msg.riderId);
+        }
+        return;
+      case "error":
+        resolver.reject(new Error(msg.message));
+        return;
+    }
+  };
+}

--- a/playground/src/features/quest/worker.ts
+++ b/playground/src/features/quest/worker.ts
@@ -122,11 +122,15 @@ function handleSetStrategy(id: number, strategy: string): void {
     post({ kind: "error", id, message: "set-strategy before init" });
     return;
   }
-  const ok = sim.setStrategy(strategy);
-  if (ok) {
-    post({ kind: "ok", id });
-  } else {
-    post({ kind: "error", id, message: `unknown strategy: ${strategy}` });
+  try {
+    const ok = sim.setStrategy(strategy);
+    if (ok) {
+      post({ kind: "ok", id });
+    } else {
+      post({ kind: "error", id, message: `unknown strategy: ${strategy}` });
+    }
+  } catch (err) {
+    post({ kind: "error", id, message: errorMessage(err) });
   }
 }
 

--- a/playground/src/features/quest/worker.ts
+++ b/playground/src/features/quest/worker.ts
@@ -1,0 +1,152 @@
+/// <reference lib="webworker" />
+/**
+ * Quest worker entry. Owns a `WasmSim` and answers requests from the
+ * host. Each response carries the request's `id` so the host can match
+ * it against a pending promise.
+ *
+ * The worker doesn't drive its own loop — the host pulls ticks via
+ * `tick` requests at the cadence it wants. Keeping that pull-model
+ * here matches the existing playground's main-thread pattern where
+ * `requestAnimationFrame` decides when to step.
+ */
+declare const self: DedicatedWorkerGlobalScope;
+
+import type { HostToWorker, InitPayload, TickResultPayload, WorkerToHost } from "./protocol";
+
+interface WasmModule {
+  default: (input: string) => Promise<unknown>;
+  WasmSim: WasmSimCtor;
+}
+
+interface WasmSimCtor {
+  new (configRon: string, strategy: string, reposition?: string): WasmSimInstance;
+}
+
+interface WasmSimInstance {
+  stepMany(n: number): void;
+  currentTick(): bigint;
+  setStrategy(name: string): boolean;
+  spawnRider(
+    origin: number,
+    destination: number,
+    weight: number,
+    patienceTicks?: number,
+  ): { kind: "ok"; value: bigint } | { kind: "err"; error: string };
+  snapshot(): TickResultPayload["snapshot"];
+  drainEvents(): TickResultPayload["events"][number][];
+  metrics(): TickResultPayload["metrics"];
+  free(): void;
+}
+
+let sim: WasmSimInstance | null = null;
+
+function post(msg: WorkerToHost): void {
+  self.postMessage(msg);
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+async function loadAndConstruct(payload: InitPayload): Promise<WasmSimInstance> {
+  // `@vite-ignore` keeps Vite from trying to bundle the URL — at
+  // runtime it's whatever path the host resolved against
+  // `document.baseURI`, and that path doesn't exist relative to the
+  // worker bundle. The worker just imports it raw.
+  const mod = (await import(/* @vite-ignore */ payload.wasmJsUrl)) as WasmModule;
+  await mod.default(payload.wasmBgUrl);
+  return new mod.WasmSim(payload.configRon, payload.strategy, payload.reposition);
+}
+
+async function handleInit(id: number, payload: InitPayload): Promise<void> {
+  try {
+    sim?.free();
+    sim = await loadAndConstruct(payload);
+    post({ kind: "ok", id });
+  } catch (err) {
+    sim = null;
+    post({ kind: "error", id, message: errorMessage(err) });
+  }
+}
+
+function handleTick(id: number, ticks: number): void {
+  if (!sim) {
+    post({ kind: "error", id, message: "tick before init" });
+    return;
+  }
+  try {
+    sim.stepMany(ticks);
+    const result: TickResultPayload = {
+      snapshot: sim.snapshot(),
+      tick: Number(sim.currentTick()),
+      events: sim.drainEvents(),
+      metrics: sim.metrics(),
+    };
+    post({ kind: "tick-result", id, result });
+  } catch (err) {
+    post({ kind: "error", id, message: errorMessage(err) });
+  }
+}
+
+function handleSpawnRider(
+  id: number,
+  origin: number,
+  destination: number,
+  weight: number,
+  patienceTicks: number | undefined,
+): void {
+  if (!sim) {
+    post({ kind: "error", id, message: "spawn-rider before init" });
+    return;
+  }
+  try {
+    const r = sim.spawnRider(origin, destination, weight, patienceTicks);
+    if (r.kind === "ok") {
+      post({ kind: "spawn-result", id, riderId: r.value, error: null });
+    } else {
+      post({ kind: "spawn-result", id, riderId: null, error: r.error });
+    }
+  } catch (err) {
+    post({ kind: "error", id, message: errorMessage(err) });
+  }
+}
+
+function handleSetStrategy(id: number, strategy: string): void {
+  if (!sim) {
+    post({ kind: "error", id, message: "set-strategy before init" });
+    return;
+  }
+  const ok = sim.setStrategy(strategy);
+  if (ok) {
+    post({ kind: "ok", id });
+  } else {
+    post({ kind: "error", id, message: `unknown strategy: ${strategy}` });
+  }
+}
+
+self.addEventListener("message", (event: MessageEvent<HostToWorker>) => {
+  const msg = event.data;
+  switch (msg.kind) {
+    case "init":
+      void handleInit(msg.id, msg.payload);
+      return;
+    case "reset":
+      void handleInit(msg.id, msg.payload);
+      return;
+    case "tick":
+      handleTick(msg.id, msg.ticks);
+      return;
+    case "spawn-rider":
+      handleSpawnRider(msg.id, msg.origin, msg.destination, msg.weight, msg.patienceTicks);
+      return;
+    case "set-strategy":
+      handleSetStrategy(msg.id, msg.strategy);
+      return;
+  }
+});


### PR DESCRIPTION
## Summary

- **Q-02** of the Quest curriculum: the postMessage transport so a Web Worker can own the wasm sim while the main thread renders. Pull-model — host requests ticks, worker steps and replies with the snapshot.
- Five new files under `playground/src/features/quest/`: typed protocol, worker entry, host-side `WorkerSim` handle, barrel, plus a vitest covering the protocol's discriminated-union shape.
- No UI integration yet. Nothing imports the worker outside the test. Q-03 adds the mode toggle, Q-04 adds Monaco, Q-05 adds player-code execution and the `setStrategyJs` bridge from #562.

## Design notes

- **Pull-model, not push** — the worker doesn't run its own `setInterval`; it ticks only when the host asks. Matches the existing playground's `requestAnimationFrame`-driven cadence in `shell/loop.ts` and avoids races between the worker's tick rate and the renderer's frame rate.
- **Request `id` correlation** — every host request carries a numeric `id`; worker replies with the same `id`. Pinning that as a contract today lets us add concurrent requests later without breaking the wire format.
- **Wasm URLs forwarded by the host** — workers don't have `document.baseURI`. The host resolves `pkg/elevator_wasm.js` once against the page URL (so GitHub-Pages subpath deploys keep working) and ships the absolute URLs in the `init` payload.
- **Reset = re-init** — `reset` reuses `handleInit`. Previous sim's wasm memory is freed first via `sim?.free()` before the new sim constructs.
- **`exactOptionalPropertyTypes` discipline** — optional fields are spread when present rather than passed as `undefined`, so request shapes match the protocol type literally.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (existing boundaries-plugin migration warnings are pre-existing on main, not new)
- [x] `pnpm test` — 147 tests pass, including 5 new in `quest-protocol.test.ts`
- [x] `pnpm format:check` clean
- [x] `pnpm knip` — no new unused-files entries from this PR; the two pre-existing `Unused exports` warnings (`resolveStopName`, `METRIC_DEFS`) are on main, not introduced here
- [x] Pre-commit hook ran (lint-staged + typecheck + vitest) on commit
- [ ] End-to-end host↔worker round-trip — exercised when Q-03 wires the worker into the Quest mode shell. jsdom has no `Worker`, and the worker needs the wasm `pkg/` bundle to construct, so this can't run under vitest.