### PR TITLE
feat(playground): add `mode` field to permalink for Quest

### DIFF
--- a/playground/src/__tests__/permalink.test.ts
+++ b/playground/src/__tests__/permalink.test.ts
@@ -17,7 +17,30 @@ describe("permalink: core knobs", () => {
     expect(decoded.scenario).toBe(DEFAULT_STATE.scenario);
     expect(decoded.strategyA).toBe(DEFAULT_STATE.strategyA);
     expect(decoded.compare).toBe(DEFAULT_STATE.compare);
+    expect(decoded.mode).toBe(DEFAULT_STATE.mode);
     expect(decoded.overrides).toEqual({});
+  });
+
+  it("omits `m` from the URL when mode is the default (compare)", () => {
+    // Cold-boot URLs stay short — only Quest mode's explicit opt-in
+    // emits the key.
+    const qs = encodePermalink(DEFAULT_STATE);
+    expect(qs).not.toMatch(/(^|&|\?)m=/);
+  });
+
+  it("emits and round-trips mode=quest", () => {
+    const qs = encodePermalink({ ...DEFAULT_STATE, mode: "quest" });
+    expect(qs).toMatch(/(^|&|\?)m=quest(&|$)/);
+    const decoded = decodePermalink(qs);
+    expect(decoded.mode).toBe("quest");
+  });
+
+  it("falls back to default mode for unrecognised values", () => {
+    // Stale or hand-edited URLs with unknown modes shouldn't crash —
+    // they land on the default. Compare-mode URLs that recipients
+    // tweak by accident keep working.
+    expect(decodePermalink("?m=blah").mode).toBe(DEFAULT_STATE.mode);
+    expect(decodePermalink("?m=").mode).toBe(DEFAULT_STATE.mode);
   });
 
   it("honors an explicit c=0 over the default", () => {

--- a/playground/src/domain/permalink/index.ts
+++ b/playground/src/domain/permalink/index.ts
@@ -5,4 +5,5 @@ export {
   hashSeedWord,
   syncPermalinkUrl,
   type PermalinkState,
+  type PlaygroundMode,
 } from "./permalink";

--- a/playground/src/domain/permalink/permalink.ts
+++ b/playground/src/domain/permalink/permalink.ts
@@ -5,7 +5,18 @@ import type { RepositionStrategyName, StrategyName } from "../../types";
 // URL state encoding. Keeps the sim reproducible: sharing the URL replays
 // exactly what the sender saw. Only knobs that affect behavior go here.
 
+/**
+ * Top-level playground modes. `compare` is the long-standing
+ * side-by-side strategy view; `quest` is the curriculum mode that
+ * lands across the Quest series (Q-04+ wires the editor + worker
+ * integration). Encoded compactly so unused defaults don't bloat the
+ * URL — `compare` is omitted entirely from the query string.
+ */
+export type PlaygroundMode = "compare" | "quest";
+
 export interface PermalinkState {
+  /** Top-level playground mode. */
+  mode: PlaygroundMode;
   scenario: string;
   strategyA: StrategyName;
   strategyB: StrategyName;
@@ -55,6 +66,9 @@ const OVERRIDE_KEYS: Record<ParamKey, string> = {
 };
 
 export const DEFAULT_STATE: PermalinkState = {
+  // Cold-boot mode: compare. The Quest curriculum mode lights up via
+  // an explicit `?m=quest` until its UI shell lands (Q-04+).
+  mode: "compare",
   // First-impression tuning: skyscraper is the visually richest
   // scenario (3 cars, 12 floors, bypass feature firing during morning
   // rush). Unknown scenario ids still resolve through
@@ -135,8 +149,21 @@ export function syncPermalinkUrl(state: PermalinkState): void {
   window.history.replaceState(null, "", qs);
 }
 
+function parseMode(raw: string | null, fallback: PlaygroundMode): PlaygroundMode {
+  // Anything other than the two known modes silently falls back to
+  // the default. Keeps recipients of malformed URLs landing on
+  // something usable rather than throwing.
+  return raw === "compare" || raw === "quest" ? raw : fallback;
+}
+
 export function encodePermalink(state: PermalinkState): string {
   const p = new URLSearchParams();
+  // Only emit `m` when the mode is non-default. Compare-mode URLs
+  // stay short, and the existing share-link reader keeps producing
+  // identical canonical query strings for unchanged state.
+  if (state.mode !== DEFAULT_STATE.mode) {
+    p.set("m", state.mode);
+  }
   p.set("s", state.scenario);
   p.set("a", state.strategyA);
   // Always persist `b` so a shared non-compare URL still remembers the B
@@ -188,6 +215,7 @@ export function decodePermalink(search: string): PermalinkState {
     if (Number.isFinite(n)) overrides[k] = n;
   }
   return {
+    mode: parseMode(p.get("m"), DEFAULT_STATE.mode),
     scenario: p.get("s") ?? DEFAULT_STATE.scenario,
     strategyA: parseStrategy(p.get("a") ?? p.get("d"), DEFAULT_STATE.strategyA),
     strategyB: parseStrategy(p.get("b"), DEFAULT_STATE.strategyB),


### PR DESCRIPTION
## Summary

- **Q-03** of the Quest curriculum: the routing primitive. Adds `mode: \"compare\" | \"quest\"` to `PermalinkState` and a matching `?m=` URL key.
- Default \`compare\` is omitted from the encoded URL so cold-boot share-links stay short and existing canonical query strings are byte-identical to before.
- Nothing reads the field yet. Hand-edited \`?m=quest\` URLs decode cleanly today; the UI shell that hides Compare-specific controls and shows the Quest banner lands in Q-04 alongside Monaco.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean (boundaries-plugin migration warnings are pre-existing)
- [x] \`pnpm test\` — 148 tests pass, including 4 new in \`permalink.test.ts\` for the mode field
- [x] \`pnpm format:check\` clean
- [x] Pre-commit hook ran on commit