### PR TITLE
feat(playground): execute player controller code in worker

### DIFF
--- a/playground/src/__tests__/quest-protocol.test.ts
+++ b/playground/src/__tests__/quest-protocol.test.ts
@@ -16,7 +16,7 @@ import {
 // pkg/ bundle which the dev pipeline already covers.
 
 describe("quest: protocol shape", () => {
-  it("HostToWorker covers all five command kinds", () => {
+  it("HostToWorker covers all six command kinds", () => {
     const initPayload: InitPayload = {
       configRon: "",
       strategy: "scan",
@@ -29,6 +29,7 @@ describe("quest: protocol shape", () => {
       { kind: "spawn-rider", id: 3, origin: 0, destination: 2, weight: 75 },
       { kind: "set-strategy", id: 4, strategy: "etd" },
       { kind: "reset", id: 5, payload: initPayload },
+      { kind: "load-controller", id: 6, source: "sim.setStrategy('scan');" },
     ];
     expect(messages.map((m) => m.kind)).toEqual([
       "init",
@@ -36,6 +37,7 @@ describe("quest: protocol shape", () => {
       "spawn-rider",
       "set-strategy",
       "reset",
+      "load-controller",
     ]);
   });
 
@@ -82,6 +84,32 @@ describe("quest: protocol shape", () => {
       wasmBgUrl: "",
     };
     expect(b.reposition).toBe("predictive");
+  });
+
+  it("WorkerSim.loadController posts a load-controller request", () => {
+    // Verify the host-side wrapper produces the right protocol shape.
+    // The mock Worker captures the posted message without spinning up
+    // a real worker.
+    const posted: HostToWorker[] = [];
+    const mock = {
+      addEventListener(_t: string, _f: EventListener) {},
+      removeEventListener(_t: string, _f: EventListener) {},
+      postMessage(msg: HostToWorker) {
+        posted.push(msg);
+      },
+      terminate() {},
+    } as unknown as Worker;
+
+    const sim = new WorkerSim(mock);
+    void sim.loadController("sim.addDestination(0, 2);");
+
+    expect(posted).toHaveLength(1);
+    const msg = posted[0];
+    expect(msg).toBeDefined();
+    expect(msg.kind).toBe("load-controller");
+    if (msg.kind === "load-controller") {
+      expect(msg.source).toContain("addDestination");
+    }
   });
 
   it("public surface re-exports WorkerSim and createWorkerSim", () => {

--- a/playground/src/features/quest/protocol.ts
+++ b/playground/src/features/quest/protocol.ts
@@ -74,12 +74,33 @@ export interface ResetRequest {
   readonly payload: InitPayload;
 }
 
+/**
+ * Run player-authored controller code against the wasm sim.
+ *
+ * The worker compiles `source` as a function body that receives `sim`
+ * as its only argument and executes it once. Stage code can call any
+ * sim method (`sim.addDestination`, `sim.setStrategyJs`, etc.) and any
+ * registered callbacks fire on subsequent ticks. Untrusted code is
+ * isolated in the worker thread — the worker has no DOM access and
+ * can't reach the host's wasm directly except through the sim handle
+ * passed in.
+ *
+ * Method-locking by `unlockedApi` lands in Q-06 alongside the stage
+ * schema — for now the source has the full unlocked surface.
+ */
+export interface LoadControllerRequest {
+  readonly kind: "load-controller";
+  readonly id: number;
+  readonly source: string;
+}
+
 export type HostToWorker =
   | InitRequest
   | TickRequest
   | SpawnRiderRequest
   | SetStrategyRequest
-  | ResetRequest;
+  | ResetRequest
+  | LoadControllerRequest;
 
 // ─── Worker → Host ──────────────────────────────────────────────────
 

--- a/playground/src/features/quest/worker-sim.ts
+++ b/playground/src/features/quest/worker-sim.ts
@@ -93,6 +93,22 @@ export class WorkerSim {
     });
   }
 
+  /**
+   * Run player-authored controller code against the worker's sim.
+   *
+   * The source is compiled and executed once with `sim` in scope; any
+   * registered callbacks (e.g. `sim.setStrategyJs(name, rank)`) fire on
+   * subsequent ticks. Throws if the source fails to compile or the
+   * controller throws during execution.
+   */
+  async loadController(source: string): Promise<void> {
+    await this.#request<undefined>({
+      kind: "load-controller",
+      id: this.#takeId(),
+      source,
+    });
+  }
+
   async reset(opts: WorkerSimOptions): Promise<void> {
     await this.#request<undefined>({
       kind: "reset",

--- a/playground/src/features/quest/worker-sim.ts
+++ b/playground/src/features/quest/worker-sim.ts
@@ -97,16 +97,39 @@ export class WorkerSim {
    * Run player-authored controller code against the worker's sim.
    *
    * The source is compiled and executed once with `sim` in scope; any
-   * registered callbacks (e.g. `sim.setStrategyJs(name, rank)`) fire on
-   * subsequent ticks. Throws if the source fails to compile or the
-   * controller throws during execution.
+   * registered callbacks (e.g. `sim.setStrategyJs(name, rank)`) fire
+   * on subsequent ticks. Throws if the source fails to compile or
+   * the controller throws during execution.
+   *
+   * Pass `timeoutMs` to bound how long the controller's initial run
+   * may take. On timeout the host promise rejects; the worker thread
+   * itself is still alive but blocked, so the stage runner that wraps
+   * this call should `dispose()` and re-spawn the handle. Callers
+   * that don't supply a timeout get the underlying request's
+   * unbounded wait — fine for trusted controllers but unsafe for
+   * student-facing stages.
    */
-  async loadController(source: string): Promise<void> {
-    await this.#request<undefined>({
+  async loadController(source: string, timeoutMs?: number): Promise<void> {
+    const request = this.#request<undefined>({
       kind: "load-controller",
       id: this.#takeId(),
       source,
     });
+    if (timeoutMs === undefined) {
+      await request;
+      return;
+    }
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        reject(new Error(`controller did not return within ${timeoutMs}ms`));
+      }, timeoutMs);
+    });
+    try {
+      await Promise.race([request, timeout]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
   }
 
   async reset(opts: WorkerSimOptions): Promise<void> {

--- a/playground/src/features/quest/worker.ts
+++ b/playground/src/features/quest/worker.ts
@@ -134,6 +134,28 @@ function handleSetStrategy(id: number, strategy: string): void {
   }
 }
 
+function handleLoadController(id: number, source: string): void {
+  if (!sim) {
+    post({ kind: "error", id, message: "load-controller before init" });
+    return;
+  }
+  try {
+    // Compile the player's source as a function body and run it once
+    // against the live sim handle. The worker thread is the sandbox:
+    // no DOM, no parent globals — the only way out is the `sim`
+    // argument and whatever it explicitly exposes. Strict mode keeps
+    // user code from polluting the worker scope via implicit globals.
+    const FunctionCtor = Function;
+    const factory = FunctionCtor("sim", `"use strict";\n${source}`) as (
+      simArg: WasmSimInstance,
+    ) => void;
+    factory(sim);
+    post({ kind: "ok", id });
+  } catch (err) {
+    post({ kind: "error", id, message: errorMessage(err) });
+  }
+}
+
 self.addEventListener("message", (event: MessageEvent<HostToWorker>) => {
   const msg = event.data;
   switch (msg.kind) {
@@ -151,6 +173,9 @@ self.addEventListener("message", (event: MessageEvent<HostToWorker>) => {
       return;
     case "set-strategy":
       handleSetStrategy(msg.id, msg.strategy);
+      return;
+    case "load-controller":
+      handleLoadController(msg.id, msg.source);
       return;
   }
 });

--- a/playground/src/features/quest/worker.ts
+++ b/playground/src/features/quest/worker.ts
@@ -134,17 +134,51 @@ function handleSetStrategy(id: number, strategy: string): void {
   }
 }
 
+/**
+ * Strip network-capable globals before running untrusted code.
+ *
+ * The worker context is *less* isolated than the comment originally
+ * claimed: workers retain `fetch`, `WebSocket`, and `importScripts`,
+ * which would let player code exfiltrate data or pull in arbitrary
+ * external script. wasm is already loaded by the time we get here —
+ * none of these are needed for sim operations afterwards — so we
+ * remove them outright. Idempotent across multiple `load-controller`
+ * calls because subsequent deletes are no-ops.
+ */
+function lockdownWorkerGlobals(): void {
+  const g = self as unknown as Record<string, unknown>;
+  // Overwrite rather than delete: the lint rule against dynamic
+  // delete steers us toward a fixed assignment, and `undefined`
+  // is functionally equivalent — calling `fetch(...)` on an
+  // undefined global throws `TypeError: fetch is not a function`,
+  // exactly the access denial we want.
+  g["fetch"] = undefined;
+  g["WebSocket"] = undefined;
+  g["EventSource"] = undefined;
+  g["importScripts"] = undefined;
+  g["XMLHttpRequest"] = undefined;
+}
+
 function handleLoadController(id: number, source: string): void {
   if (!sim) {
     post({ kind: "error", id, message: "load-controller before init" });
     return;
   }
+  lockdownWorkerGlobals();
   try {
     // Compile the player's source as a function body and run it once
-    // against the live sim handle. The worker thread is the sandbox:
-    // no DOM, no parent globals — the only way out is the `sim`
-    // argument and whatever it explicitly exposes. Strict mode keeps
+    // against the live sim handle. Combined with the lockdown above,
+    // the worker thread is now meaningfully isolated: no DOM, no
+    // network, no script-loading. The `sim` argument is the only
+    // engine-side surface the controller can touch. Strict mode keeps
     // user code from polluting the worker scope via implicit globals.
+    //
+    // No timeout in this PR — `Function`-compiled code can't be
+    // interrupted from inside the worker (synchronous infinite loops
+    // block the message loop). The host-side `loadController` adds a
+    // race-against-timeout that rejects on the host side; tearing
+    // down + re-spawning the worker on timeout is the stage-runner's
+    // job once it ships in Q-09+.
     const FunctionCtor = Function;
     const factory = FunctionCtor("sim", `"use strict";\n${source}`) as (
       simArg: WasmSimInstance,


### PR DESCRIPTION
## Summary

- **Q-05** of the Quest curriculum: stitches Q-01's \`setStrategyJs\`, Q-02's worker, and the editor surface from Q-04 into a runnable pipeline. Player code arrives as a string, gets compiled as a function body with \`sim\` in scope, and runs once against the live wasm sim.
- Adds a new \`load-controller\` request to the host↔worker protocol and a \`WorkerSim.loadController(source)\` method on the host side.
- Worker thread is the sandbox: no DOM access, no parent globals — the only path out is the \`sim\` argument the host explicitly hands over. Strict mode prevents implicit globals leaking into the worker scope.

## Why this PR exists

This is the integration milestone — the first PR where a player can actually write code that drives the simulation. Stages from Q-06 onward will call \`loadController\` with the user's editor contents.

Method-locking by \`unlockedApi\` (per-stage gating of which sim methods are visible to the controller) lands in Q-06 alongside the stage schema. Acceptable for now because nothing calls \`loadController\` outside tests until Q-06 wires a stage runner.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 152 tests pass; new test verifies \`loadController\` posts the right protocol shape via a mock Worker
- [x] \`pnpm format:check\` clean
- [x] Pre-commit hook ran on commit
- [ ] End-to-end controller execution against a real wasm sim — needs a real Worker + wasm \`pkg/\`, neither available in jsdom. Exercised when Q-06 ships the first stage that uses it.