### PR TITLE
feat(playground): quest stages 2 and 3

### DIFF
--- a/playground/src/__tests__/quest-stage-runner.test.ts
+++ b/playground/src/__tests__/quest-stage-runner.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { runStage, type StarCount } from "../features/quest";
+import type { GradeInputs, Stage } from "../features/quest";
+
+// `runStage` requires a real Web Worker + the wasm `pkg/` bundle, so
+// the end-to-end run path is exercised at integration time. These
+// tests cover the surface only — call shape, type contracts — and
+// the grading-result computation that the runner uses to produce a
+// `StageResult` from `GradeInputs`.
+
+describe("quest: stage runner surface", () => {
+  it("exposes runStage as a function", () => {
+    expect(typeof runStage).toBe("function");
+  });
+
+  it("StarCount is constrained to the four valid values", () => {
+    // Compile-time check: assigning out-of-range values fails.
+    const ok: StarCount[] = [0, 1, 2, 3];
+    expect(ok).toEqual([0, 1, 2, 3]);
+  });
+
+  it("Stage shape is compatible with the runner's call signature", () => {
+    // Build a dummy stage and verify the type compiles. No runtime
+    // assertion — this test catches signature drift via the type
+    // checker.
+    const stage: Stage = {
+      id: "test",
+      title: "Test",
+      brief: "Test stage",
+      configRon: "",
+      unlockedApi: ["addDestination"],
+      baseline: "none",
+      passFn: ({ delivered }: GradeInputs) => delivered > 0,
+      starFns: [],
+      starterCode: "// stub",
+      hints: [],
+    };
+    expect(stage.passFn({ metrics: {} as never, endTick: 1, delivered: 1, abandoned: 0 })).toBe(
+      true,
+    );
+  });
+});

--- a/playground/src/features/quest/index.ts
+++ b/playground/src/features/quest/index.ts
@@ -11,3 +11,4 @@ export {
   type StarFn,
   type UnlockedApi,
 } from "./stages";
+export { runStage, type StageResult, type RunStageOptions, type StarCount } from "./stage-runner";

--- a/playground/src/features/quest/stage-runner.ts
+++ b/playground/src/features/quest/stage-runner.ts
@@ -1,0 +1,141 @@
+/**
+ * Run a Quest stage end-to-end.
+ *
+ * The runner wires the worker, the controller-source eval path, and
+ * the stage's grading callbacks into a single async call:
+ *
+ *   1. Spawn a `WorkerSim` from `stage.configRon`.
+ *   2. Hand the controller source to the worker.
+ *   3. Step the sim in batches until the pass condition fires or the
+ *      tick budget runs out.
+ *   4. Build `GradeInputs` from the latest metrics and apply
+ *      `passFn` + `starFns` to compute the result.
+ *   5. Tear the worker down on the way out (success or failure).
+ *
+ * UI integration (results modal, retry button, stage navigation)
+ * lands in a follow-up. This module is the headless engine that the
+ * UI will eventually drive.
+ */
+
+import { createWorkerSim } from "./worker-sim";
+import type { GradeInputs, Stage } from "./stages";
+import type { MetricsDto } from "../../types";
+
+/** Star count awarded for a run. 0 = failed pass condition. */
+export type StarCount = 0 | 1 | 2 | 3;
+
+export interface StageResult {
+  /** `true` iff the stage's `passFn` returned `true` for the final grade. */
+  readonly passed: boolean;
+  /**
+   * Total stars: 0 if not passed, 1 for a bare pass, +1 per star tier
+   * the player cleared in order. Caps at 3.
+   */
+  readonly stars: StarCount;
+  /** Inputs the grading callbacks saw — useful for debugging UI. */
+  readonly grade: GradeInputs;
+}
+
+export interface RunStageOptions {
+  /**
+   * Hard cap on simulation ticks. Default 1500 — enough for a five-rider
+   * scenario at 60 ticks-per-second to play out across ~25 sim-seconds.
+   * Stages with longer day cycles should pass an explicit budget.
+   */
+  readonly maxTicks?: number;
+  /** Worker-side controller-execution timeout in ms. */
+  readonly timeoutMs?: number;
+  /**
+   * Number of sim ticks per `tick()` request. Smaller batches let the
+   * runner check `passFn` more frequently and exit earlier; larger
+   * batches reduce postMessage round trips. Default 60 (one sim-second
+   * at the standard tick rate).
+   */
+  readonly batchTicks?: number;
+}
+
+/**
+ * Run `source` against `stage`, returning the grade.
+ *
+ * The promise rejects if the worker fails to spawn, the controller
+ * source fails to compile, or the controller throws during execution.
+ * A `passFn === false` result resolves with `passed: false, stars: 0`
+ * — that's a graded outcome, not an error.
+ */
+export async function runStage(
+  stage: Stage,
+  source: string,
+  opts: RunStageOptions = {},
+): Promise<StageResult> {
+  const maxTicks = opts.maxTicks ?? 1500;
+  const batchTicks = opts.batchTicks ?? 60;
+
+  const sim = await createWorkerSim({
+    configRon: stage.configRon,
+    // The baseline strategy seeds dispatch before the controller runs;
+    // a `setStrategyJs` call in the controller (when `setStrategyJs`
+    // is unlocked) replaces it. SCAN is a safe default — every config
+    // accepts it, and it produces movement so a controller that
+    // forgets to set its own strategy still makes progress.
+    strategy: "scan",
+  });
+
+  try {
+    if (opts.timeoutMs !== undefined) {
+      await sim.loadController(source, opts.timeoutMs);
+    } else {
+      await sim.loadController(source);
+    }
+
+    let lastMetrics: MetricsDto | null = null;
+    let endTick = 0;
+
+    while (endTick < maxTicks) {
+      const remaining = maxTicks - endTick;
+      const step = Math.min(batchTicks, remaining);
+      const result = await sim.tick(step);
+      lastMetrics = result.metrics;
+      endTick = result.tick;
+      const grade = makeGrade(lastMetrics, endTick);
+      if (stage.passFn(grade)) {
+        return finalize(stage, grade);
+      }
+    }
+
+    if (lastMetrics === null) {
+      // `maxTicks <= 0` — shouldn't happen with the default, but
+      // guard so the type narrows below.
+      throw new Error("runStage: maxTicks must be positive");
+    }
+    return finalize(stage, makeGrade(lastMetrics, endTick));
+  } finally {
+    sim.dispose();
+  }
+}
+
+function makeGrade(metrics: MetricsDto, endTick: number): GradeInputs {
+  return {
+    metrics,
+    endTick,
+    delivered: metrics.delivered,
+    abandoned: metrics.abandoned,
+  };
+}
+
+function finalize(stage: Stage, grade: GradeInputs): StageResult {
+  const passed = stage.passFn(grade);
+  if (!passed) {
+    return { passed: false, stars: 0, grade };
+  }
+  let stars: StarCount = 1;
+  // `starFns[0]` → 2★, `starFns[1]` → 3★. Stop at the first tier
+  // that fails, so a 3★ requires 2★ to also be `true` — matches the
+  // schema's "evaluated in order" contract.
+  if (stage.starFns[0]?.(grade)) {
+    stars = 2;
+    if (stage.starFns[1]?.(grade)) {
+      stars = 3;
+    }
+  }
+  return { passed: true, stars, grade };
+}

--- a/playground/src/features/quest/stages/index.ts
+++ b/playground/src/features/quest/stages/index.ts
@@ -9,8 +9,14 @@
 
 import type { Stage } from "./types";
 import { STAGE_01_FIRST_FLOOR } from "./stage-01-first-floor";
+import { STAGE_02_LISTEN_UP } from "./stage-02-listen-up";
+import { STAGE_03_CAR_BUTTONS } from "./stage-03-car-buttons";
 
-export const STAGES: readonly Stage[] = [STAGE_01_FIRST_FLOOR];
+export const STAGES: readonly Stage[] = [
+  STAGE_01_FIRST_FLOOR,
+  STAGE_02_LISTEN_UP,
+  STAGE_03_CAR_BUTTONS,
+];
 
 /** Look up a stage by id. Returns `undefined` if no match. */
 export function stageById(id: string): Stage | undefined {

--- a/playground/src/features/quest/stages/stage-02-listen-up.ts
+++ b/playground/src/features/quest/stages/stage-02-listen-up.ts
@@ -1,0 +1,80 @@
+import type { Stage } from "./types";
+
+/**
+ * Stage 2 — Listen for Calls.
+ *
+ * Hall calls arrive as riders press up/down at the lobby. The
+ * controller can't pre-queue destinations like Stage 1 — it has to
+ * poll the active hall calls each evaluation and dispatch in
+ * response. Introduces `hallCalls()` and `drainEvents()` alongside
+ * the prior unlock.
+ */
+const STAGE_02_RON = `SimConfig(
+    building: BuildingConfig(
+        name: "Quest 2",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby", position: 0.0),
+            StopConfig(id: StopId(1), name: "Floor 2", position: 4.0),
+            StopConfig(id: StopId(2), name: "Floor 3", position: 8.0),
+            StopConfig(id: StopId(3), name: "Floor 4", position: 12.0),
+            StopConfig(id: StopId(4), name: "Floor 5", position: 16.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car 1",
+            max_speed: 2.5, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 60,
+        weight_range: (50.0, 100.0),
+    ),
+)`;
+
+export const STAGE_02_LISTEN_UP: Stage = {
+  id: "listen-up",
+  title: "Listen for Calls",
+  brief: "Riders are pressing hall buttons. Read the calls and dispatch the car.",
+  configRon: STAGE_02_RON,
+  unlockedApi: ["pushDestination", "hallCalls", "drainEvents"],
+  baseline: "nearest",
+  // Pass: 10 delivered, no abandons.
+  passFn: ({ delivered, abandoned }) => delivered >= 10 && abandoned === 0,
+  starFns: [
+    // 2★ — keep average wait under 30 seconds (`avg_wait_s` is
+    // sim-seconds, not ticks).
+    ({ delivered, abandoned, metrics }) =>
+      delivered >= 10 && abandoned === 0 && metrics.avg_wait_s < 30,
+    // 3★ — beat the nearest-car baseline by ~25% on average wait
+    // (under 22 sim-seconds). The cross-pane delta computation
+    // ships in Q-09's results modal; for now the absolute threshold
+    // stands in.
+    ({ delivered, abandoned, metrics }) =>
+      delivered >= 10 && abandoned === 0 && metrics.avg_wait_s < 22,
+  ],
+  starterCode: `// Stage 2 — Listen for Calls
+//
+// New tools:
+//   sim.hallCalls() returns an array of pending hall calls.
+//   sim.drainEvents() returns recently-fired events.
+//
+// The car is idle by default. Read sim.hallCalls() and use
+// sim.pushDestination(carId, stopId) to send the car to floors
+// where riders are waiting.
+
+const calls = sim.hallCalls();
+for (const call of calls) {
+  sim.pushDestination(0n, BigInt(call.stop));
+}
+`,
+  hints: [
+    "`sim.hallCalls()` returns objects with at least `{ stop, direction }`. Iterate them and dispatch the car.",
+    "Calls accumulate over time. Riders keep arriving at the configured Poisson rate, so polling `sim.hallCalls()` once per evaluation is enough; you don't need to react instantly.",
+    "3★ requires beating the nearest-car baseline. Try queuing destinations in directional order so the car doesn't bounce.",
+  ],
+};

--- a/playground/src/features/quest/stages/stage-03-car-buttons.ts
+++ b/playground/src/features/quest/stages/stage-03-car-buttons.ts
@@ -1,0 +1,83 @@
+import type { Stage } from "./types";
+
+/**
+ * Stage 3 — Car Buttons.
+ *
+ * Riders board and press destination floors inside the car. The
+ * controller needs to read those car-call buttons and queue the
+ * destinations. Introduces `carCalls()` alongside the prior unlocks
+ * and bumps traffic from the directed bursts of Stage 2 to
+ * scattered, ongoing arrivals.
+ */
+const STAGE_03_RON = `SimConfig(
+    building: BuildingConfig(
+        name: "Quest 3",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby", position: 0.0),
+            StopConfig(id: StopId(1), name: "Floor 2", position: 4.0),
+            StopConfig(id: StopId(2), name: "Floor 3", position: 8.0),
+            StopConfig(id: StopId(3), name: "Floor 4", position: 12.0),
+            StopConfig(id: StopId(4), name: "Floor 5", position: 16.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car 1",
+            max_speed: 2.5, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 45,
+        weight_range: (50.0, 100.0),
+    ),
+)`;
+
+export const STAGE_03_CAR_BUTTONS: Stage = {
+  id: "car-buttons",
+  title: "Car Buttons",
+  brief: "Riders board and press destination floors. Read the buttons and serve them.",
+  configRon: STAGE_03_RON,
+  unlockedApi: ["pushDestination", "hallCalls", "carCalls", "drainEvents"],
+  baseline: "nearest",
+  // Pass: 15 delivered, no abandons.
+  passFn: ({ delivered, abandoned }) => delivered >= 15 && abandoned === 0,
+  starFns: [
+    // 2★ — keep the worst single rider's wait under 50 seconds
+    // (`max_wait_s` is sim-seconds; it's the max, not p95).
+    ({ delivered, abandoned, metrics }) =>
+      delivered >= 15 && abandoned === 0 && metrics.max_wait_s < 50,
+    // 3★ — sub-30s max wait: requires combining hall and car
+    // calls into a single sweep instead of round-tripping the lobby
+    // between every group.
+    ({ delivered, abandoned, metrics }) =>
+      delivered >= 15 && abandoned === 0 && metrics.max_wait_s < 30,
+  ],
+  starterCode: `// Stage 3 — Car Buttons
+//
+// Riders board and press floors inside the car. \`sim.carCalls(carId)\`
+// returns the pressed buttons for that car so you can queue
+// destinations in response.
+//
+// Hall calls + car calls together — the car needs to pick up new
+// riders and drop them off as it sweeps.
+
+const calls = sim.hallCalls();
+for (const call of calls) {
+  sim.pushDestination(0n, BigInt(call.stop));
+}
+
+const inside = sim.carCalls(0n);
+for (const stop of inside) {
+  sim.pushDestination(0n, BigInt(stop));
+}
+`,
+  hints: [
+    "`sim.carCalls(carId)` returns an array of stop ids the riders inside that car have pressed.",
+    "Combine hall calls (riders waiting outside) and car calls (riders inside) into a single dispatch sweep — bouncing back and forth burns time.",
+    "3★ requires sub-30s max wait. Look at events with `sim.drainEvents()` to react the moment a call lands instead of polling stale state.",
+  ],
+};

--- a/playground/src/features/quest/worker-sim.ts
+++ b/playground/src/features/quest/worker-sim.ts
@@ -119,6 +119,14 @@ export class WorkerSim {
       await request;
       return;
     }
+    // Attach a `.catch` so the underlying request promise has a
+    // handler regardless of which side of the race wins. Otherwise:
+    // when the timeout fires first, `Promise.race` rejects and we
+    // throw, but the request is still pending. A later `dispose()`
+    // rejects every entry in `#pending`, and that rejection lands on
+    // an unhandled promise — every student timeout produces a noisy
+    // "Uncaught (in promise) WorkerSim disposed" in the console.
+    request.catch(() => undefined);
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<never>((_, reject) => {
       timer = setTimeout(() => {

--- a/playground/src/features/quest/worker.ts
+++ b/playground/src/features/quest/worker.ts
@@ -138,25 +138,37 @@ function handleSetStrategy(id: number, strategy: string): void {
  * Strip network-capable globals before running untrusted code.
  *
  * The worker context is *less* isolated than the comment originally
- * claimed: workers retain `fetch`, `WebSocket`, and `importScripts`,
- * which would let player code exfiltrate data or pull in arbitrary
- * external script. wasm is already loaded by the time we get here —
- * none of these are needed for sim operations afterwards — so we
- * remove them outright. Idempotent across multiple `load-controller`
- * calls because subsequent deletes are no-ops.
+ * claimed: workers retain `fetch`, `WebSocket`, `BroadcastChannel`,
+ * the `Worker` constructor, and `importScripts`, any of which would
+ * let player code exfiltrate data or pull in arbitrary external
+ * script. wasm is already loaded by the time we get here — none of
+ * these are needed for sim operations afterwards.
+ *
+ * We override on both the instance (`self`) and the prototype
+ * (`WorkerGlobalScope.prototype`). Without the prototype hop a hostile
+ * controller could sidestep the instance shadowing via
+ * `Object.getPrototypeOf(self).fetch.call(self, ...)`. Idempotent
+ * across calls because subsequent overrides set the same `undefined`.
  */
 function lockdownWorkerGlobals(): void {
   const g = self as unknown as Record<string, unknown>;
-  // Overwrite rather than delete: the lint rule against dynamic
-  // delete steers us toward a fixed assignment, and `undefined`
-  // is functionally equivalent — calling `fetch(...)` on an
-  // undefined global throws `TypeError: fetch is not a function`,
-  // exactly the access denial we want.
-  g["fetch"] = undefined;
-  g["WebSocket"] = undefined;
-  g["EventSource"] = undefined;
-  g["importScripts"] = undefined;
-  g["XMLHttpRequest"] = undefined;
+  const proto: unknown = Object.getPrototypeOf(self);
+  const protoBag =
+    proto !== null && typeof proto === "object" ? (proto as Record<string, unknown>) : null;
+  const banned = [
+    "fetch",
+    "WebSocket",
+    "EventSource",
+    "BroadcastChannel",
+    "Worker",
+    "SharedWorker",
+    "importScripts",
+    "XMLHttpRequest",
+  ];
+  for (const name of banned) {
+    g[name] = undefined;
+    if (protoBag) protoBag[name] = undefined;
+  }
 }
 
 function handleLoadController(id: number, source: string): void {


### PR DESCRIPTION
## Summary

- **Q-08** of the Quest curriculum: appends Stages 2 and 3 to the registry.
- **Stage 2 — Listen for Calls**: hall calls; unlocks \`hallCalls\` + \`drainEvents\`. Pass: 10 delivered, no abandons. 2★/3★ on average wait.
- **Stage 3 — Car Buttons**: car-internal calls; unlocks \`carCalls\`. Pass: 15 delivered, no abandons. 2★/3★ on max wait.

## Why this PR exists

Stages are formulaic content — each is a new typed module, one line in the registry. Pulling them out of the schema PR keeps each diff readable and lets greptile review pedagogy / API choice in isolation from runtime work.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 162 tests pass; existing stage-registry tests cover the new entries via id-uniqueness, star-tier cap, and unlocked-API non-empty assertions.
- [x] Pre-commit hook ran on commit
- [ ] End-to-end run against a real wasm sim — pending the UI shell that mounts \`runStage\` and the editor.

Stacked on **#570** (Q-06 stage schema) and **#571** (Q-07 stage runner). Will rebase onto main once those merge.