### PR TITLE
feat(playground): visible quest mode shell

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -531,6 +531,32 @@
       </div>
     </div>
 
+    <section
+      id="quest-pane"
+      class="hidden flex-col gap-4 px-5 pt-3.5 pb-[calc(var(--controls-bar-h,52px)+16px)] flex-1 max-md:px-[calc(14px+env(safe-area-inset-left))] max-md:pr-[calc(14px+env(safe-area-inset-right))] max-md:pt-2.5 max-md:pb-[calc(var(--controls-bar-h,52px)+12px+env(safe-area-inset-bottom))]"
+      aria-label="Quest mode"
+    >
+      <header class="flex flex-col gap-1.5">
+        <div class="flex items-baseline gap-2">
+          <span
+            class="inline-flex items-center px-1.5 py-0.5 rounded-sm bg-accent/15 text-accent text-[10px] font-bold tracking-[0.08em] uppercase"
+            >Quest</span
+          >
+          <h1 id="quest-stage-title" class="text-content text-base font-semibold m-0">Loading…</h1>
+        </div>
+        <p id="quest-stage-brief" class="text-content-secondary text-[13px] m-0"></p>
+      </header>
+      <pre
+        id="quest-starter-code"
+        class="m-0 px-3 py-3 bg-surface-elevated border border-stroke-subtle rounded-md text-[12.5px] leading-snug font-mono whitespace-pre overflow-x-auto"
+      ></pre>
+      <p class="text-content-tertiary text-[11px] m-0">
+        The editor and run button mount here in the next iteration. For now this banner is the proof
+        that <code class="font-mono">?m=quest</code> is wired through the permalink and the stage
+        registry.
+      </p>
+    </section>
+
     <div
       id="loader"
       class="loader show fixed inset-0 grid place-items-center gap-3 bg-[color-mix(in_srgb,var(--bg-primary)_85%,transparent)] backdrop-blur-[2px] z-[60] opacity-0 pointer-events-none transition-opacity duration-slow [&.show]:opacity-100 [&.show]:pointer-events-auto"

--- a/playground/src/features/quest/index.ts
+++ b/playground/src/features/quest/index.ts
@@ -12,3 +12,11 @@ export {
   type UnlockedApi,
 } from "./stages";
 export { runStage, type StageResult, type RunStageOptions, type StarCount } from "./stage-runner";
+export {
+  bootQuestPane,
+  hideQuestPane,
+  renderStage,
+  showQuestPane,
+  wireQuestPane,
+  type QuestPaneHandles,
+} from "./quest-pane";

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -1,0 +1,89 @@
+/**
+ * Mount the Quest mode UI shell.
+ *
+ * Q-09 ships the smallest possible visible signal that
+ * `?m=quest` is wired end-to-end: a stage banner with title, brief,
+ * and starter code. The Monaco editor mount, run button, and
+ * results modal land in follow-up PRs that build on this anchor.
+ *
+ * The function is intentionally idempotent and side-effect-light so
+ * the shell can call it from `boot.ts` without coordinating with the
+ * existing compare-mode render loop.
+ */
+
+import { STAGES } from "./stages";
+import type { Stage } from "./stages";
+
+export interface QuestPaneHandles {
+  readonly root: HTMLElement;
+  readonly title: HTMLElement;
+  readonly brief: HTMLElement;
+  readonly starter: HTMLElement;
+}
+
+/**
+ * Wire the Quest pane DOM. Throws if the expected anchor isn't in
+ * the document — the caller should only invoke this when in Quest
+ * mode (the index.html ships the section hidden by default).
+ */
+export function wireQuestPane(): QuestPaneHandles {
+  const root = document.getElementById("quest-pane");
+  if (!root) throw new Error("quest-pane: missing #quest-pane");
+  const title = document.getElementById("quest-stage-title");
+  const brief = document.getElementById("quest-stage-brief");
+  const starter = document.getElementById("quest-starter-code");
+  if (!title || !brief || !starter) {
+    throw new Error("quest-pane: missing stage banner elements");
+  }
+  return { root, title, brief, starter };
+}
+
+/** Render a stage's banner content into the wired pane. */
+export function renderStage(handles: QuestPaneHandles, stage: Stage): void {
+  handles.title.textContent = stage.title;
+  handles.brief.textContent = stage.brief;
+  handles.starter.textContent = stage.starterCode;
+}
+
+/**
+ * Show the Quest pane and hide the existing compare layout.
+ *
+ * Compare mode keeps its DOM intact — we toggle visibility rather
+ * than tear it down so the user can flip back via permalink without
+ * a remount cost. The bottom controls bar stays visible because it
+ * carries the seed and speed inputs which Quest will eventually
+ * read too.
+ */
+export function showQuestPane(handles: QuestPaneHandles): void {
+  const layout = document.getElementById("layout");
+  if (layout) layout.classList.add("hidden");
+  handles.root.classList.remove("hidden");
+  handles.root.classList.add("flex");
+}
+
+/** Inverse of `showQuestPane`. */
+export function hideQuestPane(handles: QuestPaneHandles): void {
+  handles.root.classList.add("hidden");
+  handles.root.classList.remove("flex");
+  const layout = document.getElementById("layout");
+  if (layout) layout.classList.remove("hidden");
+}
+
+/**
+ * Boot the Quest pane: wire DOM, render the first stage, swap the
+ * visible layout. Returns the handles so future iterations can keep
+ * a reference for re-rendering on stage navigation.
+ */
+export function bootQuestPane(): QuestPaneHandles {
+  const handles = wireQuestPane();
+  // Stage selection by permalink is a Q-12 concern; for now Stage 1
+  // is the default. The registry ordering is the canonical
+  // curriculum sequence.
+  const firstStage = STAGES[0];
+  if (!firstStage) {
+    throw new Error("quest-pane: stage registry is empty");
+  }
+  renderStage(handles, firstStage);
+  showQuestPane(handles);
+  return handles;
+}

--- a/playground/src/shell/boot.ts
+++ b/playground/src/shell/boot.ts
@@ -1,4 +1,5 @@
 import { reconcileStrategyWithScenario } from "../features/scenario-picker";
+import { bootQuestPane } from "../features/quest";
 import {
   DEFAULT_STATE,
   compactOverrides,
@@ -87,4 +88,10 @@ export async function boot(): Promise<void> {
   await resetAll(state, ui);
   state.ready = true;
   loop(state, ui);
+  // Quest mode swaps the compare layout for the curriculum banner.
+  // The handle is held only for future re-renders; nothing in this
+  // PR drives stage navigation yet, so we drop it after mount.
+  if (state.permalink.mode === "quest") {
+    bootQuestPane();
+  }
 }


### PR DESCRIPTION
## Summary

- **Q-09** of the Quest curriculum: the smallest possible visible signal that \`?m=quest\` is wired end-to-end. Adds a Quest pane that swaps in for the compare layout when \`mode === \"quest\"\`, showing the active stage's title, brief, and starter code.
- New module \`features/quest/quest-pane.ts\` with a tiny composable API (\`wireQuestPane\` / \`renderStage\` / \`showQuestPane\` / \`hideQuestPane\` / \`bootQuestPane\`).
- DOM toggle preserves the existing compare layout, so a permalink flip back doesn't pay a remount cost.

## Why this PR exists

Until now \`?m=quest\` decoded cleanly through the permalink but produced no visible difference. This PR delivers the routing primitive's first user-visible payoff. The editor mount, run button, and results modal are deliberately deferred to follow-up PRs that hang off this anchor.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 162 tests pass; existing stage-registry tests cover the data the pane renders
- [x] Pre-commit hook ran on commit
- [ ] DOM smoke test against \`?m=quest\` in a real browser — covered when the editor mount lands and we have something more interactive to drive end-to-end

Stacked on #570 (stage schema), #571 (stage runner), #572 (stages 2-3). Will rebase onto main as those merge.