### PR TITLE
feat(playground): mount monaco editor + run button in quest pane

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -546,15 +546,25 @@
         </div>
         <p id="quest-stage-brief" class="text-content-secondary text-[13px] m-0"></p>
       </header>
-      <pre
-        id="quest-starter-code"
-        class="m-0 px-3 py-3 bg-surface-elevated border border-stroke-subtle rounded-md text-[12.5px] leading-snug font-mono whitespace-pre overflow-x-auto"
-      ></pre>
-      <p class="text-content-tertiary text-[11px] m-0">
-        The editor and run button mount here in the next iteration. For now this banner is the proof
-        that <code class="font-mono">?m=quest</code> is wired through the permalink and the stage
-        registry.
-      </p>
+      <div
+        id="quest-editor"
+        class="min-h-[260px] bg-surface-elevated border border-stroke-subtle rounded-md overflow-hidden"
+        aria-label="Quest controller editor"
+      ></div>
+      <div class="flex items-center gap-3">
+        <button
+          type="button"
+          id="quest-run"
+          class="inline-flex items-center px-3 py-1.5 rounded-sm bg-accent text-surface text-[12.5px] font-semibold tracking-[0.01em] cursor-pointer transition-opacity duration-fast hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Run
+        </button>
+        <span
+          id="quest-result"
+          class="text-content-secondary text-[12.5px] tracking-[0.01em]"
+          aria-live="polite"
+        ></span>
+      </div>
     </section>
 
     <div

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -1,16 +1,18 @@
 /**
  * Mount the Quest mode UI shell.
  *
- * Q-09 ships the smallest possible visible signal that
- * `?m=quest` is wired end-to-end: a stage banner with title, brief,
- * and starter code. The Monaco editor mount, run button, and
- * results modal land in follow-up PRs that build on this anchor.
+ * Q-09 added the visible banner; Q-10 swaps the static starter-code
+ * `<pre>` for a Monaco editor and wires the Run button to
+ * `runStage`. Result text lands in `#quest-result` so screen readers
+ * pick up the pass/star outcome via `aria-live`.
  *
  * The function is intentionally idempotent and side-effect-light so
  * the shell can call it from `boot.ts` without coordinating with the
  * existing compare-mode render loop.
  */
 
+import { mountQuestEditor, type QuestEditor } from "./editor";
+import { runStage } from "./stage-runner";
 import { STAGES } from "./stages";
 import type { Stage } from "./stages";
 
@@ -18,7 +20,9 @@ export interface QuestPaneHandles {
   readonly root: HTMLElement;
   readonly title: HTMLElement;
   readonly brief: HTMLElement;
-  readonly starter: HTMLElement;
+  readonly editorHost: HTMLElement;
+  readonly runBtn: HTMLButtonElement;
+  readonly result: HTMLElement;
 }
 
 /**
@@ -31,18 +35,26 @@ export function wireQuestPane(): QuestPaneHandles {
   if (!root) throw new Error("quest-pane: missing #quest-pane");
   const title = document.getElementById("quest-stage-title");
   const brief = document.getElementById("quest-stage-brief");
-  const starter = document.getElementById("quest-starter-code");
-  if (!title || !brief || !starter) {
+  const editorHost = document.getElementById("quest-editor");
+  const runBtn = document.getElementById("quest-run");
+  const result = document.getElementById("quest-result");
+  if (!title || !brief || !editorHost || !runBtn || !result) {
     throw new Error("quest-pane: missing stage banner elements");
   }
-  return { root, title, brief, starter };
+  return {
+    root,
+    title,
+    brief,
+    editorHost,
+    runBtn: runBtn as HTMLButtonElement,
+    result,
+  };
 }
 
-/** Render a stage's banner content into the wired pane. */
+/** Render the static parts of a stage (title, brief). */
 export function renderStage(handles: QuestPaneHandles, stage: Stage): void {
   handles.title.textContent = stage.title;
   handles.brief.textContent = stage.brief;
-  handles.starter.textContent = stage.starterCode;
 }
 
 /**
@@ -70,11 +82,55 @@ export function hideQuestPane(handles: QuestPaneHandles): void {
 }
 
 /**
- * Boot the Quest pane: wire DOM, render the first stage, swap the
- * visible layout. Returns the handles so future iterations can keep
- * a reference for re-rendering on stage navigation.
+ * Wire the Run button to execute the editor's current text against
+ * the supplied stage. While a run is in flight the button is
+ * disabled and the result panel shows "Running…"; on completion it
+ * shows pass/fail + star count, or the error message on throw.
  */
-export function bootQuestPane(): QuestPaneHandles {
+function attachRunButton(handles: QuestPaneHandles, editor: QuestEditor, stage: Stage): void {
+  handles.runBtn.addEventListener("click", () => {
+    void executeRun(handles, editor, stage);
+  });
+}
+
+async function executeRun(
+  handles: QuestPaneHandles,
+  editor: QuestEditor,
+  stage: Stage,
+): Promise<void> {
+  handles.runBtn.disabled = true;
+  handles.result.textContent = "Running…";
+  try {
+    // Cap the controller's initial run at one second — long enough
+    // for honest setup work, short enough that an infinite loop
+    // bubbles up as a timeout instead of blocking indefinitely.
+    const result = await runStage(stage, editor.getValue(), { timeoutMs: 1000 });
+    if (result.passed) {
+      const stars = "★".repeat(result.stars) + "☆".repeat(3 - result.stars);
+      handles.result.textContent = `Passed — ${stars} (${result.grade.delivered} delivered, tick ${result.grade.endTick})`;
+    } else {
+      handles.result.textContent = `Did not pass — ${result.grade.delivered} delivered, ${result.grade.abandoned} abandoned`;
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    handles.result.textContent = `Error: ${msg}`;
+  } finally {
+    handles.runBtn.disabled = false;
+  }
+}
+
+/**
+ * Boot the Quest pane: wire DOM, render the first stage, mount the
+ * editor with the stage's starter code, attach the run button.
+ *
+ * Returns the handles plus the editor handle so future iterations
+ * can re-render on stage navigation. The mount is async because
+ * Monaco loads lazily.
+ */
+export async function bootQuestPane(): Promise<{
+  handles: QuestPaneHandles;
+  editor: QuestEditor;
+}> {
   const handles = wireQuestPane();
   // Stage selection by permalink is a Q-12 concern; for now Stage 1
   // is the default. The registry ordering is the canonical
@@ -85,5 +141,18 @@ export function bootQuestPane(): QuestPaneHandles {
   }
   renderStage(handles, firstStage);
   showQuestPane(handles);
-  return handles;
+  // Disable Run while the Monaco bundle loads so a click before
+  // mount completes doesn't run against an undefined editor. The
+  // attachRunButton path re-enables it after each run.
+  handles.runBtn.disabled = true;
+  handles.result.textContent = "Loading editor…";
+  const editor = await mountQuestEditor({
+    container: handles.editorHost,
+    initialValue: firstStage.starterCode,
+    language: "typescript",
+  });
+  handles.runBtn.disabled = false;
+  handles.result.textContent = "";
+  attachRunButton(handles, editor, firstStage);
+  return { handles, editor };
 }

--- a/playground/src/shell/boot.ts
+++ b/playground/src/shell/boot.ts
@@ -89,9 +89,10 @@ export async function boot(): Promise<void> {
   state.ready = true;
   loop(state, ui);
   // Quest mode swaps the compare layout for the curriculum banner.
-  // The handle is held only for future re-renders; nothing in this
-  // PR drives stage navigation yet, so we drop it after mount.
+  // `bootQuestPane` lazy-loads Monaco, so the await is genuine —
+  // the controls bar stays interactive in the meantime because boot
+  // already completed the synchronous wiring above.
   if (state.permalink.mode === "quest") {
-    bootQuestPane();
+    await bootQuestPane();
   }
 }


### PR DESCRIPTION
## Summary

- **Q-10** of the Quest curriculum: the Quest banner from Q-09 becomes interactive. Replaces the static starter-code \`<pre>\` with a lazy-loaded Monaco editor and wires a Run button to \`runStage\`.
- Result panel renders pass/star outcome inline (no modal yet — that lands as a polish PR).
- 1000 ms timeout on the controller's initial run keeps an infinite loop from hanging the page; surfaces back as a visible "Error: …".

## Why this PR exists

Q-09 made \`?m=quest\` visibly different. This PR makes it *useful* — a player can edit the starter code and click Run to see what happens. The first end-to-end interactive Quest moment.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 162 tests pass; existing tests cover the runner, schema, and editor surface
- [x] Pre-commit hook ran on commit

Stacked on **#570** (stage schema), **#571** (stage runner), **#572** (stages 2-3), **#573** (UI shell). The Monaco editor was copied from main (Q-04 is already merged) plus the \`monaco-editor\` dep added explicitly to make the diff self-contained relative to the stack base; the rebase will fold cleanly once the upstream PRs land.