### PR TITLE
feat(playground): quest stages 4-7

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -546,15 +546,25 @@
         </div>
         <p id="quest-stage-brief" class="text-content-secondary text-[13px] m-0"></p>
       </header>
-      <pre
-        id="quest-starter-code"
-        class="m-0 px-3 py-3 bg-surface-elevated border border-stroke-subtle rounded-md text-[12.5px] leading-snug font-mono whitespace-pre overflow-x-auto"
-      ></pre>
-      <p class="text-content-tertiary text-[11px] m-0">
-        The editor and run button mount here in the next iteration. For now this banner is the proof
-        that <code class="font-mono">?m=quest</code> is wired through the permalink and the stage
-        registry.
-      </p>
+      <div
+        id="quest-editor"
+        class="min-h-[260px] bg-surface-elevated border border-stroke-subtle rounded-md overflow-hidden"
+        aria-label="Quest controller editor"
+      ></div>
+      <div class="flex items-center gap-3">
+        <button
+          type="button"
+          id="quest-run"
+          class="inline-flex items-center px-3 py-1.5 rounded-sm bg-accent text-surface text-[12.5px] font-semibold tracking-[0.01em] cursor-pointer transition-opacity duration-fast hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Run
+        </button>
+        <span
+          id="quest-result"
+          class="text-content-secondary text-[12.5px] tracking-[0.01em]"
+          aria-live="polite"
+        ></span>
+      </div>
     </section>
 
     <div

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -1,16 +1,18 @@
 /**
  * Mount the Quest mode UI shell.
  *
- * Q-09 ships the smallest possible visible signal that
- * `?m=quest` is wired end-to-end: a stage banner with title, brief,
- * and starter code. The Monaco editor mount, run button, and
- * results modal land in follow-up PRs that build on this anchor.
+ * Q-09 added the visible banner; Q-10 swaps the static starter-code
+ * `<pre>` for a Monaco editor and wires the Run button to
+ * `runStage`. Result text lands in `#quest-result` so screen readers
+ * pick up the pass/star outcome via `aria-live`.
  *
  * The function is intentionally idempotent and side-effect-light so
  * the shell can call it from `boot.ts` without coordinating with the
  * existing compare-mode render loop.
  */
 
+import { mountQuestEditor, type QuestEditor } from "./editor";
+import { runStage } from "./stage-runner";
 import { STAGES } from "./stages";
 import type { Stage } from "./stages";
 
@@ -18,7 +20,9 @@ export interface QuestPaneHandles {
   readonly root: HTMLElement;
   readonly title: HTMLElement;
   readonly brief: HTMLElement;
-  readonly starter: HTMLElement;
+  readonly editorHost: HTMLElement;
+  readonly runBtn: HTMLButtonElement;
+  readonly result: HTMLElement;
 }
 
 /**
@@ -31,18 +35,26 @@ export function wireQuestPane(): QuestPaneHandles {
   if (!root) throw new Error("quest-pane: missing #quest-pane");
   const title = document.getElementById("quest-stage-title");
   const brief = document.getElementById("quest-stage-brief");
-  const starter = document.getElementById("quest-starter-code");
-  if (!title || !brief || !starter) {
+  const editorHost = document.getElementById("quest-editor");
+  const runBtn = document.getElementById("quest-run");
+  const result = document.getElementById("quest-result");
+  if (!title || !brief || !editorHost || !runBtn || !result) {
     throw new Error("quest-pane: missing stage banner elements");
   }
-  return { root, title, brief, starter };
+  return {
+    root,
+    title,
+    brief,
+    editorHost,
+    runBtn: runBtn as HTMLButtonElement,
+    result,
+  };
 }
 
-/** Render a stage's banner content into the wired pane. */
+/** Render the static parts of a stage (title, brief). */
 export function renderStage(handles: QuestPaneHandles, stage: Stage): void {
   handles.title.textContent = stage.title;
   handles.brief.textContent = stage.brief;
-  handles.starter.textContent = stage.starterCode;
 }
 
 /**
@@ -70,11 +82,55 @@ export function hideQuestPane(handles: QuestPaneHandles): void {
 }
 
 /**
- * Boot the Quest pane: wire DOM, render the first stage, swap the
- * visible layout. Returns the handles so future iterations can keep
- * a reference for re-rendering on stage navigation.
+ * Wire the Run button to execute the editor's current text against
+ * the supplied stage. While a run is in flight the button is
+ * disabled and the result panel shows "Running…"; on completion it
+ * shows pass/fail + star count, or the error message on throw.
  */
-export function bootQuestPane(): QuestPaneHandles {
+function attachRunButton(handles: QuestPaneHandles, editor: QuestEditor, stage: Stage): void {
+  handles.runBtn.addEventListener("click", () => {
+    void executeRun(handles, editor, stage);
+  });
+}
+
+async function executeRun(
+  handles: QuestPaneHandles,
+  editor: QuestEditor,
+  stage: Stage,
+): Promise<void> {
+  handles.runBtn.disabled = true;
+  handles.result.textContent = "Running…";
+  try {
+    // Cap the controller's initial run at one second — long enough
+    // for honest setup work, short enough that an infinite loop
+    // bubbles up as a timeout instead of blocking indefinitely.
+    const result = await runStage(stage, editor.getValue(), { timeoutMs: 1000 });
+    if (result.passed) {
+      const stars = "★".repeat(result.stars) + "☆".repeat(3 - result.stars);
+      handles.result.textContent = `Passed — ${stars} (${result.grade.delivered} delivered, tick ${result.grade.endTick})`;
+    } else {
+      handles.result.textContent = `Did not pass — ${result.grade.delivered} delivered, ${result.grade.abandoned} abandoned`;
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    handles.result.textContent = `Error: ${msg}`;
+  } finally {
+    handles.runBtn.disabled = false;
+  }
+}
+
+/**
+ * Boot the Quest pane: wire DOM, render the first stage, mount the
+ * editor with the stage's starter code, attach the run button.
+ *
+ * Returns the handles plus the editor handle so future iterations
+ * can re-render on stage navigation. The mount is async because
+ * Monaco loads lazily.
+ */
+export async function bootQuestPane(): Promise<{
+  handles: QuestPaneHandles;
+  editor: QuestEditor;
+}> {
   const handles = wireQuestPane();
   // Stage selection by permalink is a Q-12 concern; for now Stage 1
   // is the default. The registry ordering is the canonical
@@ -85,5 +141,18 @@ export function bootQuestPane(): QuestPaneHandles {
   }
   renderStage(handles, firstStage);
   showQuestPane(handles);
-  return handles;
+  // Disable Run while the Monaco bundle loads so a click before
+  // mount completes doesn't run against an undefined editor. The
+  // attachRunButton path re-enables it after each run.
+  handles.runBtn.disabled = true;
+  handles.result.textContent = "Loading editor…";
+  const editor = await mountQuestEditor({
+    container: handles.editorHost,
+    initialValue: firstStage.starterCode,
+    language: "typescript",
+  });
+  handles.runBtn.disabled = false;
+  handles.result.textContent = "";
+  attachRunButton(handles, editor, firstStage);
+  return { handles, editor };
 }

--- a/playground/src/features/quest/stages/stage-04-builtin.ts
+++ b/playground/src/features/quest/stages/stage-04-builtin.ts
@@ -1,0 +1,80 @@
+import type { Stage } from "./types";
+
+/**
+ * Stage 4 — Stand on Shoulders.
+ *
+ * Two cars and eight stops, lunchtime traffic. Introduces
+ * `setStrategy(name)`: instead of queuing destinations one by one,
+ * the controller delegates routing to a built-in dispatcher. The
+ * curriculum's first taste of "let the engine do the work."
+ */
+const STAGE_04_RON = `SimConfig(
+    building: BuildingConfig(
+        name: "Quest 4",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby", position: 0.0),
+            StopConfig(id: StopId(1), name: "F2", position: 4.0),
+            StopConfig(id: StopId(2), name: "F3", position: 8.0),
+            StopConfig(id: StopId(3), name: "F4", position: 12.0),
+            StopConfig(id: StopId(4), name: "F5", position: 16.0),
+            StopConfig(id: StopId(5), name: "F6", position: 20.0),
+            StopConfig(id: StopId(6), name: "F7", position: 24.0),
+            StopConfig(id: StopId(7), name: "F8", position: 28.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car 1",
+            max_speed: 2.5, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+        ElevatorConfig(
+            id: 1, name: "Car 2",
+            max_speed: 2.5, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 30,
+        weight_range: (50.0, 100.0),
+    ),
+)`;
+
+export const STAGE_04_BUILTIN: Stage = {
+  id: "builtin",
+  title: "Stand on Shoulders",
+  brief: "Two cars, eight stops, lunchtime rush. Pick a built-in dispatch strategy.",
+  configRon: STAGE_04_RON,
+  unlockedApi: ["setStrategy"],
+  baseline: "scan",
+  passFn: ({ delivered }) => delivered >= 25,
+  starFns: [
+    // 2★ — beat the SCAN baseline on average wait.
+    ({ delivered, metrics }) => delivered >= 25 && metrics.avg_wait_s < 25,
+    // 3★ — sub-18s average; LOOK or NearestCar usually edges this
+    // out under steady traffic.
+    ({ delivered, metrics }) => delivered >= 25 && metrics.avg_wait_s < 18,
+  ],
+  starterCode: `// Stage 4 — Stand on Shoulders
+//
+// elevator-core ships built-in dispatch strategies: scan, look,
+// nearest, etd, destination, rsr. Try them out:
+//
+//   sim.setStrategy("look");
+//
+// returns true on success, false if the name isn't a built-in.
+// The default for this stage is SCAN — see if you can beat it.
+
+sim.setStrategy("look");
+`,
+  hints: [
+    "`scan` sweeps end-to-end; `look` stops at the last request and reverses; `nearest` picks the closest idle car; `etd` minimises estimated time-to-destination.",
+    "Look at `metrics.avg_wait_s` to judge: lower is better. Try each strategy in turn — the deltas are small but visible.",
+    "3★ requires sub-18s average wait. ETD typically wins on heavy traffic; LOOK is competitive at lower spawn rates.",
+  ],
+};

--- a/playground/src/features/quest/stages/stage-05-choose.ts
+++ b/playground/src/features/quest/stages/stage-05-choose.ts
@@ -1,0 +1,76 @@
+import type { Stage } from "./types";
+
+/**
+ * Stage 5 — Choose Wisely.
+ *
+ * Same surface as Stage 4 but with asymmetric traffic — heavily
+ * lobby-biased origins and short-distance destinations. Strategy
+ * choice matters more here. Baseline is `nearest`, the controller
+ * has to beat it.
+ */
+const STAGE_05_RON = `SimConfig(
+    building: BuildingConfig(
+        name: "Quest 5",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby", position: 0.0),
+            StopConfig(id: StopId(1), name: "F2", position: 4.0),
+            StopConfig(id: StopId(2), name: "F3", position: 8.0),
+            StopConfig(id: StopId(3), name: "F4", position: 12.0),
+            StopConfig(id: StopId(4), name: "F5", position: 16.0),
+            StopConfig(id: StopId(5), name: "F6", position: 20.0),
+            StopConfig(id: StopId(6), name: "F7", position: 24.0),
+            StopConfig(id: StopId(7), name: "F8", position: 28.0),
+            StopConfig(id: StopId(8), name: "F9", position: 32.0),
+            StopConfig(id: StopId(9), name: "F10", position: 36.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car 1",
+            max_speed: 2.5, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+        ElevatorConfig(
+            id: 1, name: "Car 2",
+            max_speed: 2.5, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 25,
+        weight_range: (50.0, 100.0),
+    ),
+)`;
+
+export const STAGE_05_CHOOSE: Stage = {
+  id: "choose",
+  title: "Choose Wisely",
+  brief: "Asymmetric morning rush. Pick the strategy that handles up-peak best.",
+  configRon: STAGE_05_RON,
+  unlockedApi: ["setStrategy"],
+  baseline: "nearest",
+  passFn: ({ delivered }) => delivered >= 30,
+  starFns: [
+    // 2★ — beat nearest by a meaningful margin.
+    ({ delivered, metrics }) => delivered >= 30 && metrics.avg_wait_s < 22,
+    // 3★ — ETD or RSR territory.
+    ({ delivered, metrics }) => delivered >= 30 && metrics.avg_wait_s < 16,
+  ],
+  starterCode: `// Stage 5 — Choose Wisely
+//
+// Up-peak traffic: most riders board at the lobby, all heading up.
+// Some strategies handle this better than others. Try a few.
+
+sim.setStrategy("etd");
+`,
+  hints: [
+    "Up-peak is exactly the case ETD was designed for: it minimises estimated time-to-destination across the assignment.",
+    "RSR (Relative System Response) factors direction and load-share into the cost; try it under heavier traffic.",
+    "3★ requires under 16s average wait. The choice between ETD and RSR is the closest call here.",
+  ],
+};

--- a/playground/src/features/quest/stages/stage-06-rank-first.ts
+++ b/playground/src/features/quest/stages/stage-06-rank-first.ts
@@ -1,0 +1,84 @@
+import type { Stage } from "./types";
+
+/**
+ * Stage 6 — Your First rank().
+ *
+ * The trait unlock. Introduces `setStrategyJs(name, rankFn)`: the
+ * controller registers a JS function that elevator-core calls for
+ * every (car, stop) candidate during dispatch. Returning a number
+ * scores the pair (lower is better); returning `null` excludes it.
+ *
+ * Implement nearest-car-style ranking. The starter code is the
+ * canonical "distance from car to stop" implementation; the player
+ * can match (or beat) the built-in `nearest` baseline.
+ */
+const STAGE_06_RON = `SimConfig(
+    building: BuildingConfig(
+        name: "Quest 6",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby", position: 0.0),
+            StopConfig(id: StopId(1), name: "F2", position: 4.0),
+            StopConfig(id: StopId(2), name: "F3", position: 8.0),
+            StopConfig(id: StopId(3), name: "F4", position: 12.0),
+            StopConfig(id: StopId(4), name: "F5", position: 16.0),
+            StopConfig(id: StopId(5), name: "F6", position: 20.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car 1",
+            max_speed: 2.5, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+        ElevatorConfig(
+            id: 1, name: "Car 2",
+            max_speed: 2.5, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 40,
+        weight_range: (50.0, 100.0),
+    ),
+)`;
+
+const STAGE_06_STARTER = `// Stage 6 — Your First rank()
+//
+// sim.setStrategyJs(name, rank) registers a JS function as the
+// dispatch strategy. rank({ car, carPosition, stop, stopPosition })
+// returns a number (lower = better) or null to exclude the pair.
+//
+// Implement nearest-car ranking: distance between car and stop.
+
+sim.setStrategyJs("my-rank", (ctx) => {
+  return Math.abs(ctx.carPosition - ctx.stopPosition);
+});
+`;
+
+export const STAGE_06_RANK_FIRST: Stage = {
+  id: "rank-first",
+  title: "Your First rank()",
+  brief: "Implement dispatch as a function. Score each (car, stop) pair.",
+  configRon: STAGE_06_RON,
+  unlockedApi: ["setStrategyJs"],
+  baseline: "nearest",
+  passFn: ({ delivered }) => delivered >= 20,
+  starFns: [
+    // 2★ — within 10% of nearest's average wait.
+    ({ delivered, metrics }) => delivered >= 20 && metrics.avg_wait_s < 28,
+    // 3★ — beat nearest. Tightening the rank function — e.g.
+    // breaking ties by direction — wins this.
+    ({ delivered, metrics }) => delivered >= 20 && metrics.avg_wait_s < 22,
+  ],
+  starterCode: STAGE_06_STARTER,
+  hints: [
+    "The context object has `car` and `stop` (entity refs as bigints), and `carPosition` and `stopPosition` (numbers, in metres).",
+    "Returning `null` excludes the pair from assignment — useful for capacity limits or wrong-direction stops once you unlock those.",
+    "3★ requires beating the nearest baseline. Try penalising backward moves: add a constant if `car` would have to reverse direction to reach `stop`.",
+  ],
+};

--- a/playground/src/features/quest/stages/stage-07-beat-etd.ts
+++ b/playground/src/features/quest/stages/stage-07-beat-etd.ts
@@ -1,0 +1,94 @@
+import type { Stage } from "./types";
+
+/**
+ * Stage 7 — Beat ETD.
+ *
+ * Three cars, ten stops, mixed traffic. The baseline is the built-in
+ * ETD strategy — the strongest classical dispatcher elevator-core
+ * ships with. The player has to write a `rank()` that meets it on
+ * its own ground.
+ *
+ * Pass: deliver under heavy load. 2★/3★: beat ETD by 5%/15%.
+ */
+const STAGE_07_RON = `SimConfig(
+    building: BuildingConfig(
+        name: "Quest 7",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby", position: 0.0),
+            StopConfig(id: StopId(1), name: "F2", position: 4.0),
+            StopConfig(id: StopId(2), name: "F3", position: 8.0),
+            StopConfig(id: StopId(3), name: "F4", position: 12.0),
+            StopConfig(id: StopId(4), name: "F5", position: 16.0),
+            StopConfig(id: StopId(5), name: "F6", position: 20.0),
+            StopConfig(id: StopId(6), name: "F7", position: 24.0),
+            StopConfig(id: StopId(7), name: "F8", position: 28.0),
+            StopConfig(id: StopId(8), name: "F9", position: 32.0),
+            StopConfig(id: StopId(9), name: "F10", position: 36.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car 1",
+            max_speed: 2.5, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+        ElevatorConfig(
+            id: 1, name: "Car 2",
+            max_speed: 2.5, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+        ElevatorConfig(
+            id: 2, name: "Car 3",
+            max_speed: 2.5, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 20,
+        weight_range: (50.0, 100.0),
+    ),
+)`;
+
+export const STAGE_07_BEAT_ETD: Stage = {
+  id: "beat-etd",
+  title: "Beat ETD",
+  brief: "Three cars, mixed traffic. The strongest built-in is your baseline.",
+  configRon: STAGE_07_RON,
+  unlockedApi: ["setStrategyJs"],
+  baseline: "etd",
+  passFn: ({ delivered }) => delivered >= 40,
+  starFns: [
+    // 2★ — match ETD within 5%.
+    ({ delivered, metrics }) => delivered >= 40 && metrics.avg_wait_s < 24,
+    // 3★ — beat ETD by ~15%. Requires factoring in car load and
+    // direction, not just distance.
+    ({ delivered, metrics }) => delivered >= 40 && metrics.avg_wait_s < 20,
+  ],
+  starterCode: `// Stage 7 — Beat ETD
+//
+// ETD minimises estimated time-to-destination. To match or beat
+// it, your rank() needs to factor in:
+//   - distance between car and stop (Stage 6)
+//   - car direction (penalise reversals)
+//   - car load (avoid sending a full car to a hall call)
+//
+// Start with distance, layer the rest in.
+
+sim.setStrategyJs("rival-etd", (ctx) => {
+  const dist = Math.abs(ctx.carPosition - ctx.stopPosition);
+  return dist;
+});
+`,
+  hints: [
+    "Direction penalty: if the car is heading up but the stop is below it, add a constant cost — preferring to keep the sweep going.",
+    "Load awareness needs more context than this surface exposes today. Distance + direction is enough to land 2★; future curriculum stages add load and pending-call context.",
+    "ETD is not invincible — its weakness is uniform-cost ties on lightly-loaded cars. Find that and you'll edge it.",
+  ],
+};

--- a/playground/src/shell/boot.ts
+++ b/playground/src/shell/boot.ts
@@ -89,9 +89,10 @@ export async function boot(): Promise<void> {
   state.ready = true;
   loop(state, ui);
   // Quest mode swaps the compare layout for the curriculum banner.
-  // The handle is held only for future re-renders; nothing in this
-  // PR drives stage navigation yet, so we drop it after mount.
+  // `bootQuestPane` lazy-loads Monaco, so the await is genuine —
+  // the controls bar stays interactive in the meantime because boot
+  // already completed the synchronous wiring above.
   if (state.permalink.mode === "quest") {
-    bootQuestPane();
+    await bootQuestPane();
   }
 }


### PR DESCRIPTION
## Summary

Q-11: stages 4-7 appended to the curriculum registry. Mid-arc of the API tour.

- **Stage 4 — Stand on Shoulders**: \`setStrategy\` unlock. Two cars, eight stops, lunchtime traffic. Try the built-ins.
- **Stage 5 — Choose Wisely**: asymmetric up-peak. Beat \`nearest\`.
- **Stage 6 — Your First rank()**: the trait unlock. \`setStrategyJs\` introduced. Player implements distance-based ranking.
- **Stage 7 — Beat ETD**: three cars, mixed traffic, baseline = ETD. Direction-aware ranking required for 3★.

Each starter is paste-and-run for pass; star tiers are the puzzle.

Stacked on #571 (stage runner), #572 (stages 2-3), #573 (UI shell), #574 (editor mount). Will rebase as the stack lands.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 162 tests pass; existing stage-registry tests cover the new entries
- [x] Pre-commit hook ran on commit