### PR TITLE
fix(playground): split worker lockdown loop into two passes

### DIFF
--- a/playground/src/features/quest/worker.ts
+++ b/playground/src/features/quest/worker.ts
@@ -165,9 +165,29 @@ function lockdownWorkerGlobals(): void {
     "importScripts",
     "XMLHttpRequest",
   ];
+  // Two passes so a throw on a non-writable prototype property
+  // doesn't bail the loop and leave later names with their instance
+  // shadow uncleared. Each property override is wrapped in its own
+  // try/catch — best-effort rather than all-or-nothing — because in
+  // strict mode some prototype slots are non-configurable in older
+  // runtimes. Worst case: one banned name stays accessible; the
+  // other seven are still locked. The guarantees aren't perfect,
+  // but they degrade gracefully instead of cliffing.
   for (const name of banned) {
-    g[name] = undefined;
-    if (protoBag) protoBag[name] = undefined;
+    try {
+      g[name] = undefined;
+    } catch {
+      /* property is non-writable on the instance — best-effort */
+    }
+  }
+  if (protoBag) {
+    for (const name of banned) {
+      try {
+        protoBag[name] = undefined;
+      } catch {
+        /* property is non-writable on the prototype — best-effort */
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Greptile P1 from PR #573: \`lockdownWorkerGlobals\` interleaved instance + prototype writes per banned name. If a prototype write threw mid-loop (non-writable slot in strict mode), the rest of the names never had their instance shadow set — leaving banned globals like \`fetch\` and \`WebSocket\` accessible.

Two-pass loop with per-name try/catch: instance overrides first, prototype overrides second. Worst case: one prototype slot stays accessible; the instance shadow for every other name still lands. Degrades gracefully instead of cliffing.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 169 tests pass
- [x] Pre-commit hook ran on commit