### PR TITLE
feat(playground): quest stages 11-12

### DIFF
--- a/playground/src/features/quest/stages/index.ts
+++ b/playground/src/features/quest/stages/index.ts
@@ -18,6 +18,8 @@ import { STAGE_07_BEAT_ETD } from "./stage-07-beat-etd";
 import { STAGE_08_EVENTS } from "./stage-08-events";
 import { STAGE_09_MANUAL } from "./stage-09-manual";
 import { STAGE_10_HOLD_DOORS } from "./stage-10-hold-doors";
+import { STAGE_11_FIRE_ALARM } from "./stage-11-fire-alarm";
+import { STAGE_12_ROUTES } from "./stage-12-routes";
 
 export const STAGES: readonly Stage[] = [
   STAGE_01_FIRST_FLOOR,
@@ -30,6 +32,8 @@ export const STAGES: readonly Stage[] = [
   STAGE_08_EVENTS,
   STAGE_09_MANUAL,
   STAGE_10_HOLD_DOORS,
+  STAGE_11_FIRE_ALARM,
+  STAGE_12_ROUTES,
 ];
 
 /** Look up a stage by id. Returns `undefined` if no match. */

--- a/playground/src/features/quest/stages/stage-11-fire-alarm.ts
+++ b/playground/src/features/quest/stages/stage-11-fire-alarm.ts
@@ -1,0 +1,83 @@
+import type { Stage } from "./types";
+
+/**
+ * Stage 11 — Fire Alarm.
+ *
+ * Mid-run a fire-alarm scenario fires. The controller has to call
+ * emergencyStop on every car within a tight tick budget. Standard
+ * dispatch otherwise — but a controller that ignores the alarm
+ * fails the stage outright (riders abandon as the sim fills with
+ * stuck cars).
+ *
+ * In the real building, fire-service mode is mandatory. In the
+ * curriculum it teaches you that emergencyStop exists and how to
+ * react quickly to a sim event.
+ */
+const STAGE_11_RON = `SimConfig(
+    building: BuildingConfig(
+        name: "Quest 11",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby", position: 0.0),
+            StopConfig(id: StopId(1), name: "F2", position: 4.0),
+            StopConfig(id: StopId(2), name: "F3", position: 8.0),
+            StopConfig(id: StopId(3), name: "F4", position: 12.0),
+            StopConfig(id: StopId(4), name: "F5", position: 16.0),
+            StopConfig(id: StopId(5), name: "F6", position: 20.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car 1",
+            max_speed: 2.5, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+        ElevatorConfig(
+            id: 1, name: "Car 2",
+            max_speed: 2.5, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 50,
+        weight_range: (50.0, 100.0),
+    ),
+)`;
+
+const STAGE_11_STARTER = `// Stage 11 — Fire Alarm
+//
+// emergencyStop(carRef) brings a car to a halt regardless of
+// dispatch state. Combined with setServiceMode(carRef,
+// "out-of-service"), it takes the car off the dispatcher's
+// hands so it doesn't try to resume a queued destination.
+//
+// For the simplest reliable response, just route normally and
+// trust the sim's emergency-stop primitive when needed.
+
+sim.setStrategy("nearest");
+`;
+
+export const STAGE_11_FIRE_ALARM: Stage = {
+  id: "fire-alarm",
+  title: "Fire Alarm",
+  brief: "Halt every car cleanly when an alarm fires. Standard dispatch otherwise.",
+  configRon: STAGE_11_RON,
+  unlockedApi: ["setStrategy", "drainEvents", "emergencyStop", "setServiceMode"],
+  baseline: "scan",
+  passFn: ({ delivered, abandoned }) => delivered >= 12 && abandoned <= 2,
+  starFns: [
+    ({ delivered, abandoned }) => delivered >= 15 && abandoned <= 1,
+    ({ delivered, abandoned, metrics }) =>
+      delivered >= 18 && abandoned === 0 && metrics.avg_wait_s < 28,
+  ],
+  starterCode: STAGE_11_STARTER,
+  hints: [
+    "`emergencyStop(carRef)` halts a car immediately — no door-cycle phase, no queue drain.",
+    'Pair it with `setServiceMode(carRef, "out-of-service")` so dispatch doesn\'t immediately re-queue work for the stopped car.',
+    "3★ requires sub-28s average wait and zero abandons — meaning you reset the cars cleanly to service after the alarm clears.",
+  ],
+};

--- a/playground/src/features/quest/stages/stage-12-routes.ts
+++ b/playground/src/features/quest/stages/stage-12-routes.ts
@@ -1,0 +1,81 @@
+import type { Stage } from "./types";
+
+/**
+ * Stage 12 — Routes.
+ *
+ * Riders carry an explicit route — origin → ... → destination. The
+ * controller can read the shortest route via shortestRoute and
+ * reroute riders if their original route is no longer valid (e.g.
+ * a stop has been removed mid-run). Lighter introduction to the
+ * routes API; multi-line transfer-point handling lands in a later
+ * stage.
+ */
+const STAGE_12_RON = `SimConfig(
+    building: BuildingConfig(
+        name: "Quest 12",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby", position: 0.0),
+            StopConfig(id: StopId(1), name: "F2", position: 4.0),
+            StopConfig(id: StopId(2), name: "F3", position: 8.0),
+            StopConfig(id: StopId(3), name: "F4", position: 12.0),
+            StopConfig(id: StopId(4), name: "F5", position: 16.0),
+            StopConfig(id: StopId(5), name: "F6", position: 20.0),
+            StopConfig(id: StopId(6), name: "F7", position: 24.0),
+            StopConfig(id: StopId(7), name: "F8", position: 28.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car 1",
+            max_speed: 2.5, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+        ElevatorConfig(
+            id: 1, name: "Car 2",
+            max_speed: 2.5, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 35,
+        weight_range: (50.0, 100.0),
+    ),
+)`;
+
+const STAGE_12_STARTER = `// Stage 12 — Routes
+//
+// Riders have explicit routes between origin and destination. The
+// controller can inspect them with shortestRoute(originStop,
+// destinationStop) and reroute(rider, newRoute) when needed.
+//
+// Most stages don't need this directly — riders are auto-routed at
+// spawn. But understanding routes is the foundation for the
+// multi-line topology stages later.
+
+sim.setStrategy("etd");
+`;
+
+export const STAGE_12_ROUTES: Stage = {
+  id: "routes",
+  title: "Routes & Reroutes",
+  brief: "Explicit per-rider routes. Read them; understand them.",
+  configRon: STAGE_12_RON,
+  unlockedApi: ["setStrategy", "shortestRoute", "reroute"],
+  baseline: "scan",
+  passFn: ({ delivered }) => delivered >= 25,
+  starFns: [
+    ({ delivered, metrics }) => delivered >= 25 && metrics.avg_wait_s < 22,
+    ({ delivered, metrics }) => delivered >= 25 && metrics.avg_wait_s < 16,
+  ],
+  starterCode: STAGE_12_STARTER,
+  hints: [
+    "`sim.shortestRoute(originStop, destinationStop)` returns the canonical route as an array of stop refs. The first entry is the origin, the last is the destination.",
+    "`sim.reroute(riderRef, newRoute)` replaces a rider's route — useful when a stop on their route has been disabled or removed mid-run.",
+    "3★ requires sub-16s average wait. ETD or RSR usually wins this; the route API is here so you understand what's available, not because you need it for the optimization.",
+  ],
+};


### PR DESCRIPTION
## Summary

Q-14: stages 11-12.

- **Stage 11 — Fire Alarm**: \`emergencyStop\` unlock. Halt cars cleanly under an alarm.
- **Stage 12 — Routes**: \`shortestRoute\` / \`reroute\` introduction.

Stacked on #577 (Q-13). Will rebase as the stack lands.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 169 tests pass