### PR TITLE
feat(playground): quest stage navigator

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -537,12 +537,22 @@
       aria-label="Quest mode"
     >
       <header class="flex flex-col gap-1.5">
-        <div class="flex items-baseline gap-2">
+        <div class="flex items-baseline gap-2 flex-wrap">
           <span
             class="inline-flex items-center px-1.5 py-0.5 rounded-sm bg-accent/15 text-accent text-[10px] font-bold tracking-[0.08em] uppercase"
             >Quest</span
           >
           <h1 id="quest-stage-title" class="text-content text-base font-semibold m-0">Loading…</h1>
+          <label
+            class="ml-auto inline-flex items-center gap-1.5 text-[11.5px] text-content-tertiary"
+          >
+            Stage
+            <select
+              id="quest-stage-select"
+              class="bg-surface-elevated border border-stroke-subtle rounded-sm px-1.5 py-0.5 text-[12px] text-content cursor-pointer focus-visible:outline-none focus-visible:border-accent"
+              aria-label="Choose a quest stage"
+            ></select>
+          </label>
         </div>
         <p id="quest-stage-brief" class="text-content-secondary text-[13px] m-0"></p>
       </header>

--- a/playground/src/__tests__/permalink.test.ts
+++ b/playground/src/__tests__/permalink.test.ts
@@ -43,6 +43,33 @@ describe("permalink: core knobs", () => {
     expect(decodePermalink("?m=").mode).toBe(DEFAULT_STATE.mode);
   });
 
+  it("emits qs= only in quest mode and only when non-default", () => {
+    // Compare-mode URLs stay clean — questStage on default never
+    // leaks into the URL even if the user briefly dipped into quest
+    // mode and back.
+    const compareDefault = encodePermalink(DEFAULT_STATE);
+    expect(compareDefault).not.toMatch(/(^|&|\?)qs=/);
+
+    const compareWithStage = encodePermalink({ ...DEFAULT_STATE, questStage: "beat-etd" });
+    expect(compareWithStage).not.toMatch(/(^|&|\?)qs=/);
+
+    const questDefault = encodePermalink({ ...DEFAULT_STATE, mode: "quest" });
+    expect(questDefault).not.toMatch(/(^|&|\?)qs=/);
+
+    const questWithStage = encodePermalink({
+      ...DEFAULT_STATE,
+      mode: "quest",
+      questStage: "beat-etd",
+    });
+    expect(questWithStage).toMatch(/(^|&|\?)qs=beat-etd(&|$)/);
+  });
+
+  it("decodes questStage and falls back when absent", () => {
+    expect(decodePermalink("?m=quest&qs=rank-first").questStage).toBe("rank-first");
+    expect(decodePermalink("?m=quest").questStage).toBe(DEFAULT_STATE.questStage);
+    expect(decodePermalink("").questStage).toBe(DEFAULT_STATE.questStage);
+  });
+
   it("honors an explicit c=0 over the default", () => {
     // Guards against regressions where a recipient's bare URL inherits
     // the default even when the sender explicitly opted out.

--- a/playground/src/domain/permalink/permalink.ts
+++ b/playground/src/domain/permalink/permalink.ts
@@ -17,6 +17,14 @@ export type PlaygroundMode = "compare" | "quest";
 export interface PermalinkState {
   /** Top-level playground mode. */
   mode: PlaygroundMode;
+  /**
+   * Active Quest stage id. Ignored in compare mode. Encoded as `?qs=`
+   * because `s` is already taken by the scenario picker. Unknown
+   * stage ids fall back to the first stage in the registry — keeps
+   * stale share-links loading cleanly when the curriculum's id set
+   * shifts.
+   */
+  questStage: string;
   scenario: string;
   strategyA: StrategyName;
   strategyB: StrategyName;
@@ -69,6 +77,10 @@ export const DEFAULT_STATE: PermalinkState = {
   // Cold-boot mode: compare. The Quest curriculum mode lights up via
   // an explicit `?m=quest` until its UI shell lands (Q-04+).
   mode: "compare",
+  // Cold-boot Quest stage: the curriculum's first entry. The
+  // `?qs=` URL key only emits when this differs from the default,
+  // so compare-mode share-links don't carry a stale Quest stage id.
+  questStage: "first-floor",
   // First-impression tuning: skyscraper is the visually richest
   // scenario (3 cars, 12 floors, bypass feature firing during morning
   // rush). Unknown scenario ids still resolve through
@@ -164,6 +176,11 @@ export function encodePermalink(state: PermalinkState): string {
   if (state.mode !== DEFAULT_STATE.mode) {
     p.set("m", state.mode);
   }
+  // Quest stage id — only emit when not default and only meaningful
+  // in quest mode. Compare-mode URLs stay clean.
+  if (state.mode === "quest" && state.questStage !== DEFAULT_STATE.questStage) {
+    p.set("qs", state.questStage);
+  }
   p.set("s", state.scenario);
   p.set("a", state.strategyA);
   // Always persist `b` so a shared non-compare URL still remembers the B
@@ -216,6 +233,10 @@ export function decodePermalink(search: string): PermalinkState {
   }
   return {
     mode: parseMode(p.get("m"), DEFAULT_STATE.mode),
+    // Stage id is freeform — the registry validates it at lookup
+    // time. An unknown id round-trips here but the consumer should
+    // fall back when `stageById` returns `undefined`.
+    questStage: (p.get("qs") ?? "").trim() || DEFAULT_STATE.questStage,
     scenario: p.get("s") ?? DEFAULT_STATE.scenario,
     strategyA: parseStrategy(p.get("a") ?? p.get("d"), DEFAULT_STATE.strategyA),
     strategyB: parseStrategy(p.get("b"), DEFAULT_STATE.strategyB),

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -3,8 +3,9 @@
  *
  * Q-09 added the visible banner; Q-10 swaps the static starter-code
  * `<pre>` for a Monaco editor and wires the Run button to
- * `runStage`. Result text lands in `#quest-result` so screen readers
- * pick up the pass/star outcome via `aria-live`.
+ * `runStage`. Q-15 adds the stage navigator: a `<select>` lets the
+ * player switch between every stage in the registry, and the chosen
+ * stage round-trips through the permalink as `?qs=`.
  *
  * The function is intentionally idempotent and side-effect-light so
  * the shell can call it from `boot.ts` without coordinating with the
@@ -13,13 +14,14 @@
 
 import { mountQuestEditor, type QuestEditor } from "./editor";
 import { runStage } from "./stage-runner";
-import { STAGES } from "./stages";
+import { STAGES, stageById } from "./stages";
 import type { Stage } from "./stages";
 
 export interface QuestPaneHandles {
   readonly root: HTMLElement;
   readonly title: HTMLElement;
   readonly brief: HTMLElement;
+  readonly select: HTMLSelectElement;
   readonly editorHost: HTMLElement;
   readonly runBtn: HTMLButtonElement;
   readonly result: HTMLElement;
@@ -35,26 +37,46 @@ export function wireQuestPane(): QuestPaneHandles {
   if (!root) throw new Error("quest-pane: missing #quest-pane");
   const title = document.getElementById("quest-stage-title");
   const brief = document.getElementById("quest-stage-brief");
+  const select = document.getElementById("quest-stage-select");
   const editorHost = document.getElementById("quest-editor");
   const runBtn = document.getElementById("quest-run");
   const result = document.getElementById("quest-result");
-  if (!title || !brief || !editorHost || !runBtn || !result) {
+  if (!title || !brief || !select || !editorHost || !runBtn || !result) {
     throw new Error("quest-pane: missing stage banner elements");
   }
   return {
     root,
     title,
     brief,
+    select: select as HTMLSelectElement,
     editorHost,
     runBtn: runBtn as HTMLButtonElement,
     result,
   };
 }
 
-/** Render the static parts of a stage (title, brief). */
+/** Render the static parts of a stage (title, brief, picker selection). */
 export function renderStage(handles: QuestPaneHandles, stage: Stage): void {
   handles.title.textContent = stage.title;
   handles.brief.textContent = stage.brief;
+  if (handles.select.value !== stage.id) {
+    handles.select.value = stage.id;
+  }
+}
+
+/** Populate the stage picker from the registry. Idempotent. */
+export function populateStageSelect(handles: QuestPaneHandles): void {
+  // Clear in case of re-entry — `populateStageSelect` is called on
+  // every Quest mount and the registry is the source of truth.
+  while (handles.select.firstChild) {
+    handles.select.removeChild(handles.select.firstChild);
+  }
+  STAGES.forEach((stage, index) => {
+    const opt = document.createElement("option");
+    opt.value = stage.id;
+    opt.textContent = `${String(index + 1).padStart(2, "0")} · ${stage.title}`;
+    handles.select.appendChild(opt);
+  });
 }
 
 /**
@@ -62,9 +84,7 @@ export function renderStage(handles: QuestPaneHandles, stage: Stage): void {
  *
  * Compare mode keeps its DOM intact — we toggle visibility rather
  * than tear it down so the user can flip back via permalink without
- * a remount cost. The bottom controls bar stays visible because it
- * carries the seed and speed inputs which Quest will eventually
- * read too.
+ * a remount cost.
  */
 export function showQuestPane(handles: QuestPaneHandles): void {
   const layout = document.getElementById("layout");
@@ -83,13 +103,17 @@ export function hideQuestPane(handles: QuestPaneHandles): void {
 
 /**
  * Wire the Run button to execute the editor's current text against
- * the supplied stage. While a run is in flight the button is
- * disabled and the result panel shows "Running…"; on completion it
- * shows pass/fail + star count, or the error message on throw.
+ * the active stage. The stage is read via the supplied getter on
+ * each click so a navigation between Run presses pulls the new
+ * stage cleanly.
  */
-function attachRunButton(handles: QuestPaneHandles, editor: QuestEditor, stage: Stage): void {
+function attachRunButton(
+  handles: QuestPaneHandles,
+  editor: QuestEditor,
+  getStage: () => Stage,
+): void {
   handles.runBtn.addEventListener("click", () => {
-    void executeRun(handles, editor, stage);
+    void executeRun(handles, editor, getStage());
   });
 }
 
@@ -120,39 +144,55 @@ async function executeRun(
 }
 
 /**
- * Boot the Quest pane: wire DOM, render the first stage, mount the
- * editor with the stage's starter code, attach the run button.
- *
- * Returns the handles plus the editor handle so future iterations
- * can re-render on stage navigation. The mount is async because
- * Monaco loads lazily.
+ * Boot the Quest pane: wire DOM, render the requested stage, mount
+ * the editor with the stage's starter code, attach the run button
+ * and stage navigator. The `onStageChange` callback notifies the
+ * caller (boot.ts) so the permalink can sync.
  */
-export async function bootQuestPane(): Promise<{
-  handles: QuestPaneHandles;
-  editor: QuestEditor;
-}> {
+export async function bootQuestPane(opts: {
+  initialStageId: string;
+  onStageChange?: (stageId: string) => void;
+}): Promise<{ handles: QuestPaneHandles; editor: QuestEditor }> {
   const handles = wireQuestPane();
-  // Stage selection by permalink is a Q-12 concern; for now Stage 1
-  // is the default. The registry ordering is the canonical
-  // curriculum sequence.
-  const firstStage = STAGES[0];
-  if (!firstStage) {
-    throw new Error("quest-pane: stage registry is empty");
-  }
-  renderStage(handles, firstStage);
+  populateStageSelect(handles);
+
+  const resolveStage = (id: string): Stage => {
+    const found = stageById(id);
+    if (found) return found;
+    const fallback = STAGES[0];
+    if (!fallback) throw new Error("quest-pane: stage registry is empty");
+    return fallback;
+  };
+
+  let activeStage = resolveStage(opts.initialStageId);
+  renderStage(handles, activeStage);
   showQuestPane(handles);
+
   // Disable Run while the Monaco bundle loads so a click before
-  // mount completes doesn't run against an undefined editor. The
-  // attachRunButton path re-enables it after each run.
+  // mount completes doesn't run against an undefined editor.
   handles.runBtn.disabled = true;
   handles.result.textContent = "Loading editor…";
   const editor = await mountQuestEditor({
     container: handles.editorHost,
-    initialValue: firstStage.starterCode,
+    initialValue: activeStage.starterCode,
     language: "typescript",
   });
   handles.runBtn.disabled = false;
   handles.result.textContent = "";
-  attachRunButton(handles, editor, firstStage);
+  attachRunButton(handles, editor, () => activeStage);
+
+  // Stage navigator: rewrite the editor's contents to the new
+  // stage's starter and clear the result panel. A user mid-edit
+  // loses their work — by design for v1; a "discard your code?"
+  // confirm is a follow-up nicety.
+  handles.select.addEventListener("change", () => {
+    const next = resolveStage(handles.select.value);
+    activeStage = next;
+    renderStage(handles, next);
+    editor.setValue(next.starterCode);
+    handles.result.textContent = "";
+    opts.onStageChange?.(next.id);
+  });
+
   return { handles, editor };
 }

--- a/playground/src/shell/boot.ts
+++ b/playground/src/shell/boot.ts
@@ -93,6 +93,18 @@ export async function boot(): Promise<void> {
   // the controls bar stays interactive in the meantime because boot
   // already completed the synchronous wiring above.
   if (state.permalink.mode === "quest") {
-    await bootQuestPane();
+    await bootQuestPane({
+      initialStageId: state.permalink.questStage,
+      onStageChange: (stageId) => {
+        state.permalink.questStage = stageId;
+        const url = new URL(window.location.href);
+        if (stageId === DEFAULT_STATE.questStage) {
+          url.searchParams.delete("qs");
+        } else {
+          url.searchParams.set("qs", stageId);
+        }
+        window.history.replaceState(null, "", url.toString());
+      },
+    });
   }
 }


### PR DESCRIPTION
## Summary

**Q-15** unlocks the curriculum. The 11 stages that landed in Q-08, Q-11, Q-13, and Q-14 were invisible because the Quest pane hardcoded Stage 1. This PR adds a \`<select>\` in the banner header so the player can switch between every stage in the registry, and the choice round-trips through the permalink as \`?qs=\`.

- New permalink field \`questStage\`. URL key \`?qs=\` is only emitted when the mode is \`quest\` AND the stage differs from the default — compare-mode share-links stay byte-identical.
- \`bootQuestPane\` now takes \`initialStageId\` + an \`onStageChange\` callback so the shell can sync the URL on selection.
- Picker rewrites the editor to the new stage's starter and clears the result panel.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 171 tests pass; 2 new for the \`questStage\` permalink field
- [x] Pre-commit hook ran on commit