### PR TITLE
feat(playground): unlocked api reference panel

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -575,6 +575,11 @@
           aria-live="polite"
         ></span>
       </div>
+      <aside
+        id="quest-api-panel"
+        class="flex flex-col gap-1 px-3 py-2.5 bg-surface-secondary border border-stroke-subtle rounded-md"
+        aria-label="Unlocked API reference"
+      ></aside>
     </section>
 
     <div

--- a/playground/src/__tests__/quest-api-reference.test.ts
+++ b/playground/src/__tests__/quest-api-reference.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { API_REFERENCE, STAGES, apiEntry, unlockedEntries, type ApiEntry } from "../features/quest";
+
+describe("quest: api reference", () => {
+  it("entries are unique by name", () => {
+    const names = API_REFERENCE.map((e: ApiEntry) => e.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("apiEntry round-trips by name", () => {
+    for (const entry of API_REFERENCE) {
+      expect(apiEntry(entry.name)?.signature).toBe(entry.signature);
+    }
+    expect(apiEntry("does-not-exist")).toBeUndefined();
+  });
+
+  it("every stage's unlockedApi has a reference entry", () => {
+    // The api panel skips unknown names, so a stage that unlocks
+    // a method without a reference entry would silently render an
+    // incomplete panel. Pin the curriculum to the reference here.
+    const known = new Set(API_REFERENCE.map((e: ApiEntry) => e.name));
+    for (const stage of STAGES) {
+      for (const method of stage.unlockedApi) {
+        expect(
+          known,
+          `stage "${stage.id}" unlocks "${method}" — add it to API_REFERENCE`,
+        ).toContain(method);
+      }
+    }
+  });
+
+  it("unlockedEntries preserves API_REFERENCE ordering", () => {
+    const filtered = unlockedEntries(["pushDestination", "drainEvents", "hallCalls"]);
+    const referenceOrder = API_REFERENCE.map((e: ApiEntry) => e.name);
+    const filteredOrder = filtered.map((e: ApiEntry) => e.name);
+    const reconstructed = referenceOrder.filter((n: string) => filteredOrder.includes(n));
+    expect(filteredOrder).toEqual(reconstructed);
+  });
+
+  it("unlockedEntries silently drops unknown names", () => {
+    const filtered = unlockedEntries(["pushDestination", "absolutely-not-a-method"]);
+    expect(filtered.map((e: ApiEntry) => e.name)).toEqual(["pushDestination"]);
+  });
+});

--- a/playground/src/features/quest/api-panel.ts
+++ b/playground/src/features/quest/api-panel.ts
@@ -1,0 +1,64 @@
+/**
+ * Render the unlocked-API reference panel for a stage.
+ *
+ * The panel sits beneath the editor and re-renders on stage
+ * navigation to reflect that stage's `unlockedApi`. It deliberately
+ * shows only what's unlocked — locked methods don't render at all,
+ * so the panel doubles as a quiet hint about the curriculum's
+ * progression.
+ */
+
+import { unlockedEntries } from "./api-reference";
+import type { Stage } from "./stages";
+
+export interface ApiPanelHandles {
+  readonly root: HTMLElement;
+}
+
+export function wireApiPanel(): ApiPanelHandles {
+  const root = document.getElementById("quest-api-panel");
+  if (!root) throw new Error("api-panel: missing #quest-api-panel");
+  return { root };
+}
+
+export function renderApiPanel(handles: ApiPanelHandles, stage: Stage): void {
+  // Clear via removeChild so we don't trip the no-innerHTML rule.
+  while (handles.root.firstChild) {
+    handles.root.removeChild(handles.root.firstChild);
+  }
+  const entries = unlockedEntries(stage.unlockedApi);
+  if (entries.length === 0) {
+    const empty = document.createElement("p");
+    empty.className = "text-content-tertiary text-[11px] m-0";
+    empty.textContent = "No methods unlocked at this stage.";
+    handles.root.appendChild(empty);
+    return;
+  }
+
+  const heading = document.createElement("p");
+  heading.className =
+    "m-0 text-[10.5px] uppercase tracking-[0.08em] text-content-tertiary font-medium";
+  heading.textContent = `Unlocked at this stage (${entries.length})`;
+  handles.root.appendChild(heading);
+
+  const list = document.createElement("ul");
+  list.className =
+    "m-0 mt-1.5 p-0 list-none flex flex-col gap-1 text-[12px] leading-snug max-h-[200px] overflow-y-auto";
+  for (const entry of entries) {
+    const item = document.createElement("li");
+    item.className = "px-2 py-1 rounded-sm bg-surface-elevated border border-stroke-subtle/50";
+
+    const sig = document.createElement("code");
+    sig.className = "block font-mono text-[12px] text-content";
+    sig.textContent = entry.signature;
+    item.appendChild(sig);
+
+    const desc = document.createElement("p");
+    desc.className = "m-0 mt-0.5 text-[11.5px] text-content-secondary";
+    desc.textContent = entry.description;
+    item.appendChild(desc);
+
+    list.appendChild(item);
+  }
+  handles.root.appendChild(list);
+}

--- a/playground/src/features/quest/api-reference.ts
+++ b/playground/src/features/quest/api-reference.ts
@@ -1,0 +1,111 @@
+/**
+ * Curated one-line descriptions for the elevator-core wasm methods
+ * the curriculum exposes through `Stage.unlockedApi`.
+ *
+ * These descriptions are hand-authored rather than extracted from the
+ * wasm `.d.ts` JSDoc because (a) the JSDoc strings are written for
+ * library consumers rather than learners, (b) extracting at build
+ * time adds a tooling step we don't otherwise need, and (c) the
+ * curriculum already hand-tunes how each method is introduced. The
+ * tradeoff is that this file falls behind the wasm surface unless
+ * authors update it; the test below pins the curriculum's
+ * `unlockedApi` lists to entries here, so adding a new unlock
+ * without an entry breaks the build.
+ */
+
+export interface ApiEntry {
+  /** Wasm method name (matches `Stage.unlockedApi` strings). */
+  readonly name: string;
+  /** Function signature shown alongside the name. */
+  readonly signature: string;
+  /** One-line description in plain language. */
+  readonly description: string;
+}
+
+export const API_REFERENCE: readonly ApiEntry[] = [
+  {
+    name: "pushDestination",
+    signature: "pushDestination(carRef, stopRef): void",
+    description: "Append a stop to the back of the car's destination queue.",
+  },
+  {
+    name: "hallCalls",
+    signature: "hallCalls(): { stop, direction }[]",
+    description: "Pending hall calls — riders waiting at floors.",
+  },
+  {
+    name: "carCalls",
+    signature: "carCalls(carRef): number[]",
+    description: "Stop ids the riders inside the car have pressed.",
+  },
+  {
+    name: "drainEvents",
+    signature: "drainEvents(): EventDto[]",
+    description: "Take the events fired since the last drain (rider, elevator, door, …).",
+  },
+  {
+    name: "setStrategy",
+    signature: "setStrategy(name): boolean",
+    description:
+      "Swap to a built-in dispatch strategy by name (scan / look / nearest / etd / rsr).",
+  },
+  {
+    name: "setStrategyJs",
+    signature: "setStrategyJs(name, rank): boolean",
+    description:
+      "Register your own ranking function as the dispatcher. Return a number per (car, stop) pair; null excludes.",
+  },
+  {
+    name: "setServiceMode",
+    signature: "setServiceMode(carRef, mode): void",
+    description: "Switch a car between normal / manual / out-of-service modes.",
+  },
+  {
+    name: "setTargetVelocity",
+    signature: "setTargetVelocity(carRef, vMps): void",
+    description: "Drive a manual-mode car directly. Positive is up, negative is down.",
+  },
+  {
+    name: "holdDoor",
+    signature: "holdDoor(carRef): void",
+    description: "Keep the car's doors open past the configured cycle until cancelDoorHold.",
+  },
+  {
+    name: "cancelDoorHold",
+    signature: "cancelDoorHold(carRef): void",
+    description: "Release a holdDoor; doors close on the next loading-complete tick.",
+  },
+  {
+    name: "emergencyStop",
+    signature: "emergencyStop(carRef): void",
+    description: "Halt a car immediately — no door cycle, no queue drain.",
+  },
+  {
+    name: "shortestRoute",
+    signature: "shortestRoute(originStop, destStop): number[]",
+    description: "Canonical route between two stops. First entry is origin, last is destination.",
+  },
+  {
+    name: "reroute",
+    signature: "reroute(riderRef, route): boolean",
+    description: "Replace a rider's route. Useful when a stop on their route was removed.",
+  },
+];
+
+const API_BY_NAME = new Map<string, ApiEntry>(API_REFERENCE.map((e) => [e.name, e]));
+
+/** Look up an API entry by method name. */
+export function apiEntry(name: string): ApiEntry | undefined {
+  return API_BY_NAME.get(name);
+}
+
+/**
+ * Return the entries that match the supplied unlocked-API list,
+ * preserving the registry's original ordering. Unknown names are
+ * skipped — they're flagged by the curriculum-completeness test
+ * rather than rendered as broken rows.
+ */
+export function unlockedEntries(unlockedApi: readonly string[]): readonly ApiEntry[] {
+  const allowed = new Set(unlockedApi);
+  return API_REFERENCE.filter((e) => allowed.has(e.name));
+}

--- a/playground/src/features/quest/index.ts
+++ b/playground/src/features/quest/index.ts
@@ -26,3 +26,4 @@ export {
   wireResultsModal,
   type ResultsModalHandles,
 } from "./results-modal";
+export { API_REFERENCE, apiEntry, unlockedEntries, type ApiEntry } from "./api-reference";

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -12,6 +12,7 @@
  * existing compare-mode render loop.
  */
 
+import { renderApiPanel, wireApiPanel, type ApiPanelHandles } from "./api-panel";
 import { mountQuestEditor, type QuestEditor } from "./editor";
 import { showResults, wireResultsModal, type ResultsModalHandles } from "./results-modal";
 import { runStage } from "./stage-runner";
@@ -172,6 +173,12 @@ export async function bootQuestPane(opts: {
   renderStage(handles, activeStage);
   showQuestPane(handles);
 
+  // Side panel: list the methods unlocked at the active stage.
+  // Re-renders on stage change so the player always sees what
+  // `sim.*` is currently allowed to call.
+  const apiPanel: ApiPanelHandles = wireApiPanel();
+  renderApiPanel(apiPanel, activeStage);
+
   // Disable Run while the Monaco bundle loads so a click before
   // mount completes doesn't run against an undefined editor.
   handles.runBtn.disabled = true;
@@ -194,6 +201,7 @@ export async function bootQuestPane(opts: {
     const next = resolveStage(handles.select.value);
     activeStage = next;
     renderStage(handles, next);
+    renderApiPanel(apiPanel, next);
     editor.setValue(next.starterCode);
     handles.result.textContent = "";
     opts.onStageChange?.(next.id);


### PR DESCRIPTION
Q-17: side panel beneath the editor listing every unlocked method with signature + one-line description. Pinned by a curriculum-completeness test that breaks the build if a stage unlocks something without a reference entry. Stacked on #580 (method locking).