### PR TITLE
fix(playground): use vite ?worker imports for monaco workers

### DIFF
--- a/playground/src/features/quest/editor.ts
+++ b/playground/src/features/quest/editor.ts
@@ -48,7 +48,7 @@ export async function loadMonaco(): Promise<typeof Monaco> {
   if (monacoModule) return monacoModule;
   if (monacoLoading) return monacoLoading;
   monacoLoading = (async () => {
-    configureWorkerEnvironment();
+    await configureWorkerEnvironment();
     const mod = await import("monaco-editor");
     monacoModule = mod;
     return mod;
@@ -65,24 +65,32 @@ export async function loadMonaco(): Promise<typeof Monaco> {
 }
 
 /** Configure Monaco's `getWorker` to use Vite's `?worker` imports. */
-function configureWorkerEnvironment(): void {
+async function configureWorkerEnvironment(): Promise<void> {
   // `MonacoEnvironment` is a global Monaco reads on init. Without
   // wiring up the workers, every keystroke drops a "could not
   // create web worker" warning and language services degrade
-  // silently. Vite resolves the URL refs at build time and bundles
-  // each worker into its own chunk.
+  // silently.
+  //
+  // The earlier `new URL("monaco-editor/...", import.meta.url)`
+  // pattern works in dev (where Vite's middleware resolves bare
+  // module specifiers) but breaks the production build: Vite's
+  // `worker-import-meta-url` plugin treats the first arg as a
+  // path relative to the importing file, so it tries to resolve
+  // `src/features/quest/monaco-editor/...` and fails. The `?worker`
+  // suffix is the documented escape hatch — Vite emits each worker
+  // into its own chunk via Rollup, no relative-path heuristics
+  // involved.
+  const [{ default: TsWorker }, { default: EditorWorker }] = await Promise.all([
+    import("monaco-editor/esm/vs/language/typescript/ts.worker?worker"),
+    import("monaco-editor/esm/vs/editor/editor.worker?worker"),
+  ]);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (globalThis as any).MonacoEnvironment = {
     getWorker(_workerId: string, label: string): Worker {
       if (label === "typescript" || label === "javascript") {
-        return new Worker(
-          new URL("monaco-editor/esm/vs/language/typescript/ts.worker", import.meta.url),
-          { type: "module" },
-        );
+        return new TsWorker();
       }
-      return new Worker(new URL("monaco-editor/esm/vs/editor/editor.worker", import.meta.url), {
-        type: "module",
-      });
+      return new EditorWorker();
     },
   };
 }


### PR DESCRIPTION
## Summary

**Production build on main is failing.** Reproduced locally and fixed.

The Docs job fails with:
\`\`\`
[vite:worker-import-meta-url] Could not resolve entry module
\"src/features/quest/monaco-editor/esm/vs/language/typescript/ts.worker\"
\`\`\`

The \`new URL(\"monaco-editor/...\", import.meta.url)\` pattern works under \`vite dev\` (the middleware resolves bare module specifiers) but the production build's \`worker-import-meta-url\` plugin treats the first arg as relative to the importing file — it prepends \`src/features/quest/\` and tries to resolve as if Monaco lived in our source tree.

The \`?worker\` query string is the documented escape hatch. Vite emits each worker into its own chunk via Rollup with no relative-path heuristics involved.

\`configureWorkerEnvironment\` becomes async because the worker constructors come back via dynamic imports, but \`loadMonaco\` already awaits the underlying chain so the user-visible mount path is unchanged.

## Verification

- [x] \`pnpm build\` locally — succeeds, emits separate chunks for ts and editor workers
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean