### PR TITLE
feat(playground): results modal for graded quest runs

### DIFF
--- a/playground/src/features/quest/index.ts
+++ b/playground/src/features/quest/index.ts
@@ -20,3 +20,9 @@ export {
   wireQuestPane,
   type QuestPaneHandles,
 } from "./quest-pane";
+export {
+  hideResults,
+  showResults,
+  wireResultsModal,
+  type ResultsModalHandles,
+} from "./results-modal";

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -13,6 +13,7 @@
  */
 
 import { mountQuestEditor, type QuestEditor } from "./editor";
+import { showResults, wireResultsModal, type ResultsModalHandles } from "./results-modal";
 import { runStage } from "./stage-runner";
 import { STAGES, stageById } from "./stages";
 import type { Stage } from "./stages";
@@ -109,18 +110,22 @@ export function hideQuestPane(handles: QuestPaneHandles): void {
  */
 function attachRunButton(
   handles: QuestPaneHandles,
+  modal: ResultsModalHandles,
   editor: QuestEditor,
   getStage: () => Stage,
 ): void {
-  handles.runBtn.addEventListener("click", () => {
-    void executeRun(handles, editor, getStage());
-  });
+  const runOnce = (): void => {
+    void executeRun(handles, modal, editor, getStage(), runOnce);
+  };
+  handles.runBtn.addEventListener("click", runOnce);
 }
 
 async function executeRun(
   handles: QuestPaneHandles,
+  modal: ResultsModalHandles,
   editor: QuestEditor,
   stage: Stage,
+  retry: () => void,
 ): Promise<void> {
   handles.runBtn.disabled = true;
   handles.result.textContent = "Running…";
@@ -129,14 +134,13 @@ async function executeRun(
     // for honest setup work, short enough that an infinite loop
     // bubbles up as a timeout instead of blocking indefinitely.
     const result = await runStage(stage, editor.getValue(), { timeoutMs: 1000 });
-    if (result.passed) {
-      const stars = "★".repeat(result.stars) + "☆".repeat(3 - result.stars);
-      handles.result.textContent = `Passed — ${stars} (${result.grade.delivered} delivered, tick ${result.grade.endTick})`;
-    } else {
-      handles.result.textContent = `Did not pass — ${result.grade.delivered} delivered, ${result.grade.abandoned} abandoned`;
-    }
+    handles.result.textContent = "";
+    showResults(modal, result, retry);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    // Errors stay inline — the modal is for graded outcomes.
+    // A controller throw is a code bug the player needs to see in
+    // place, not a result to celebrate or retry.
     handles.result.textContent = `Error: ${msg}`;
   } finally {
     handles.runBtn.disabled = false;
@@ -179,7 +183,8 @@ export async function bootQuestPane(opts: {
   });
   handles.runBtn.disabled = false;
   handles.result.textContent = "";
-  attachRunButton(handles, editor, () => activeStage);
+  const modal = wireResultsModal();
+  attachRunButton(handles, modal, editor, () => activeStage);
 
   // Stage navigator: rewrite the editor's contents to the new
   // stage's starter and clear the result panel. A user mid-edit

--- a/playground/src/features/quest/results-modal.ts
+++ b/playground/src/features/quest/results-modal.ts
@@ -1,0 +1,92 @@
+/**
+ * Results modal — shown after a `runStage` settles.
+ *
+ * Replaces the inline result text with a focused dialog so the
+ * pass/fail outcome can't be missed under a long editor or hidden
+ * behind a results-pending state. The inline `<span>` from the
+ * Run row stays as a status hint while the modal is closed (the
+ * "Loading editor…" affordance still uses it), so the modal is
+ * additive — it appears on settle and dismisses on close or retry.
+ */
+
+import type { GradeInputs } from "./stages";
+import type { StageResult } from "./stage-runner";
+
+export interface ResultsModalHandles {
+  readonly root: HTMLElement;
+  readonly title: HTMLElement;
+  readonly stars: HTMLElement;
+  readonly detail: HTMLElement;
+  readonly close: HTMLButtonElement;
+  readonly retry: HTMLButtonElement;
+}
+
+export function wireResultsModal(): ResultsModalHandles {
+  const root = document.getElementById("quest-results-modal");
+  const title = document.getElementById("quest-results-title");
+  const stars = document.getElementById("quest-results-stars");
+  const detail = document.getElementById("quest-results-detail");
+  const close = document.getElementById("quest-results-close");
+  const retry = document.getElementById("quest-results-retry");
+  if (!root || !title || !stars || !detail || !close || !retry) {
+    throw new Error("results-modal: missing DOM anchors");
+  }
+  return {
+    root,
+    title,
+    stars,
+    detail,
+    close: close as HTMLButtonElement,
+    retry: retry as HTMLButtonElement,
+  };
+}
+
+/**
+ * Show the modal with a graded `StageResult` payload. The retry
+ * button's behaviour is wired by the caller via `onRetry` so the
+ * modal stays decoupled from the run mechanics.
+ */
+export function showResults(
+  handles: ResultsModalHandles,
+  result: StageResult,
+  onRetry: () => void,
+): void {
+  if (result.passed) {
+    handles.title.textContent = result.stars === 3 ? "Mastered!" : "Passed";
+    handles.stars.textContent = "★".repeat(result.stars) + "☆".repeat(3 - result.stars);
+  } else {
+    handles.title.textContent = "Did not pass";
+    handles.stars.textContent = "";
+  }
+  handles.detail.textContent = formatDetail(result.grade, result.passed);
+
+  // Bind a fresh retry handler each show so a previous run's
+  // closure doesn't leak. Same for close — `addEventListener` with
+  // `{ once: true }` keeps us from accumulating listeners across
+  // many runs.
+  handles.retry.onclick = () => {
+    hideResults(handles);
+    onRetry();
+  };
+  handles.close.onclick = () => {
+    hideResults(handles);
+  };
+
+  handles.root.classList.add("show");
+  // Focus the close button so keyboard users can dismiss without
+  // hunting for the dialog's tabbable surface.
+  handles.close.focus();
+}
+
+export function hideResults(handles: ResultsModalHandles): void {
+  handles.root.classList.remove("show");
+}
+
+function formatDetail(grade: GradeInputs, passed: boolean): string {
+  const ticks = `tick ${grade.endTick}`;
+  const counts = `${grade.delivered} delivered, ${grade.abandoned} abandoned`;
+  if (passed) {
+    return `${counts} · finished by ${ticks}.`;
+  }
+  return `${counts}. The pass condition wasn't met within the run budget.`;
+}


### PR DESCRIPTION
Q-19 replaces the inline result text with a focused dialog for pass/fail/star outcomes. Errors stay inline (they're code bugs to see in place); the modal is for graded outcomes only. Adds Run-again button so the player can iterate without hunting for the Run button.