### PR TITLE
feat(playground): quest stages 13-15

### DIFF
--- a/playground/src/features/quest/api-reference.ts
+++ b/playground/src/features/quest/api-reference.ts
@@ -90,6 +90,39 @@ export const API_REFERENCE: readonly ApiEntry[] = [
     signature: "reroute(riderRef, route): boolean",
     description: "Replace a rider's route. Useful when a stop on their route was removed.",
   },
+  {
+    name: "transferPoints",
+    signature: "transferPoints(): number[]",
+    description:
+      "Stops that bridge two lines — useful when ranking trips that may need a transfer.",
+  },
+  {
+    name: "reachableStopsFrom",
+    signature: "reachableStopsFrom(stop): number[]",
+    description: "Every stop reachable without changing lines.",
+  },
+  {
+    name: "addStop",
+    signature: "addStop(name, position): bigint",
+    description:
+      "Create a new stop. Returns the new stop's ref. Add to a line before dispatch will use it.",
+  },
+  {
+    name: "addStopToLine",
+    signature: "addStopToLine(lineRef, stopRef): void",
+    description: "Register a stop on a line so dispatch routes to it.",
+  },
+  {
+    name: "assignLineToGroup",
+    signature: "assignLineToGroup(lineRef, groupRef): void",
+    description:
+      "Put a line under a group's dispatcher. Two groups means two independent dispatch passes.",
+  },
+  {
+    name: "reassignElevatorToLine",
+    signature: "reassignElevatorToLine(carRef, lineRef): void",
+    description: "Move a car to a different line. Useful for duty-banding when one zone is busier.",
+  },
 ];
 
 const API_BY_NAME = new Map<string, ApiEntry>(API_REFERENCE.map((e) => [e.name, e]));

--- a/playground/src/features/quest/stages/index.ts
+++ b/playground/src/features/quest/stages/index.ts
@@ -20,6 +20,9 @@ import { STAGE_09_MANUAL } from "./stage-09-manual";
 import { STAGE_10_HOLD_DOORS } from "./stage-10-hold-doors";
 import { STAGE_11_FIRE_ALARM } from "./stage-11-fire-alarm";
 import { STAGE_12_ROUTES } from "./stage-12-routes";
+import { STAGE_13_TRANSFERS } from "./stage-13-transfers";
+import { STAGE_14_BUILD_FLOOR } from "./stage-14-build-floor";
+import { STAGE_15_SKY_LOBBY } from "./stage-15-sky-lobby";
 
 export const STAGES: readonly Stage[] = [
   STAGE_01_FIRST_FLOOR,
@@ -34,6 +37,9 @@ export const STAGES: readonly Stage[] = [
   STAGE_10_HOLD_DOORS,
   STAGE_11_FIRE_ALARM,
   STAGE_12_ROUTES,
+  STAGE_13_TRANSFERS,
+  STAGE_14_BUILD_FLOOR,
+  STAGE_15_SKY_LOBBY,
 ];
 
 /** Look up a stage by id. Returns `undefined` if no match. */

--- a/playground/src/features/quest/stages/stage-13-transfers.ts
+++ b/playground/src/features/quest/stages/stage-13-transfers.ts
@@ -1,0 +1,84 @@
+import type { Stage } from "./types";
+
+/**
+ * Stage 13 — Transfer Points.
+ *
+ * The first multi-line stage. The building has two lines (low-rise
+ * and high-rise) that share a transfer floor. Riders going from
+ * lobby to a high floor must change cars at the transfer point.
+ * Introduces transferPoints + reachableStopsFrom.
+ *
+ * Routes are auto-built by the engine; the curriculum's job here
+ * is to make the player aware of the topology query surface so
+ * later stages (sky-lobby dispatch, dynamic re-routing) feel
+ * natural.
+ */
+const STAGE_13_RON = `SimConfig(
+    building: BuildingConfig(
+        name: "Quest 13",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby", position: 0.0),
+            StopConfig(id: StopId(1), name: "L2", position: 4.0),
+            StopConfig(id: StopId(2), name: "L3", position: 8.0),
+            StopConfig(id: StopId(3), name: "Transfer", position: 12.0),
+            StopConfig(id: StopId(4), name: "H1", position: 16.0),
+            StopConfig(id: StopId(5), name: "H2", position: 20.0),
+            StopConfig(id: StopId(6), name: "H3", position: 24.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Low",
+            max_speed: 2.5, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+        ElevatorConfig(
+            id: 1, name: "High",
+            max_speed: 3.0, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(3),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 50,
+        weight_range: (50.0, 100.0),
+    ),
+)`;
+
+const STAGE_13_STARTER = `// Stage 13 — Transfer Points
+//
+// Two cars on two lines that meet at the Transfer floor. Riders
+// going lobby->H2 ride the Low car to Transfer, change to the
+// High car, then ride to H2. The engine handles the change
+// automatically when riders carry routes — your job here is just
+// to keep dispatch healthy on both lines.
+//
+// transferPoints() and reachableStopsFrom(stop) tell you the
+// topology, but you don't need them for the pass condition.
+
+sim.setStrategy("etd");
+`;
+
+export const STAGE_13_TRANSFERS: Stage = {
+  id: "transfers",
+  title: "Transfer Points",
+  brief: "Two lines that share a transfer floor. Keep both halves moving.",
+  configRon: STAGE_13_RON,
+  unlockedApi: ["setStrategy", "transferPoints", "reachableStopsFrom", "shortestRoute"],
+  baseline: "scan",
+  passFn: ({ delivered }) => delivered >= 18,
+  starFns: [
+    ({ delivered, metrics }) => delivered >= 18 && metrics.avg_wait_s < 30,
+    ({ delivered, metrics }) => delivered >= 18 && metrics.avg_wait_s < 22,
+  ],
+  starterCode: STAGE_13_STARTER,
+  hints: [
+    "`sim.transferPoints()` returns the stops that bridge two lines. Useful when you're building a custom rank() that wants to penalise crossings.",
+    "`sim.reachableStopsFrom(stop)` returns every stop reachable without a transfer. Multi-line ranks use it to prefer same-line trips.",
+    "3★ requires sub-22s average wait. ETD or RSR plus a custom rank() that biases toward whichever car can finish the trip without a transfer wins it.",
+  ],
+};

--- a/playground/src/features/quest/stages/stage-14-build-floor.ts
+++ b/playground/src/features/quest/stages/stage-14-build-floor.ts
@@ -1,0 +1,76 @@
+import type { Stage } from "./types";
+
+/**
+ * Stage 14 — Build a Floor.
+ *
+ * Mid-run topology mutation. The building starts at five floors;
+ * a few minutes in, "construction completes" and the controller
+ * needs to add a sixth stop to the line so dispatch starts serving
+ * the new floor. Introduces addStop + addStopToLine.
+ *
+ * This stage is intentionally low-traffic so the player can focus
+ * on the topology change rather than fighting throughput. Pass is
+ * lenient; star tiers reward acting on the construction signal
+ * promptly (riders waiting on the unfinished floor would abandon
+ * if it isn't activated).
+ */
+const STAGE_14_RON = `SimConfig(
+    building: BuildingConfig(
+        name: "Quest 14",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby", position: 0.0),
+            StopConfig(id: StopId(1), name: "F2", position: 4.0),
+            StopConfig(id: StopId(2), name: "F3", position: 8.0),
+            StopConfig(id: StopId(3), name: "F4", position: 12.0),
+            StopConfig(id: StopId(4), name: "F5", position: 16.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Car 1",
+            max_speed: 2.5, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 80,
+        weight_range: (50.0, 100.0),
+    ),
+)`;
+
+const STAGE_14_STARTER = `// Stage 14 — Build a Floor
+//
+// The building starts five stops tall. Construction "finishes" a
+// few minutes in and the player adds the sixth floor:
+//
+//   const newStop = sim.addStop("F6", 20.0);
+//   sim.addStopToLine(line, newStop);
+//
+// Standard dispatch otherwise.
+
+sim.setStrategy("etd");
+`;
+
+export const STAGE_14_BUILD_FLOOR: Stage = {
+  id: "build-floor",
+  title: "Build a Floor",
+  brief: "Add a stop mid-run. The new floor must join the line dispatch sees.",
+  configRon: STAGE_14_RON,
+  unlockedApi: ["setStrategy", "addStop", "addStopToLine"],
+  baseline: "none",
+  passFn: ({ delivered }) => delivered >= 8,
+  starFns: [
+    ({ delivered, abandoned }) => delivered >= 10 && abandoned === 0,
+    ({ delivered, abandoned, metrics }) =>
+      delivered >= 12 && abandoned === 0 && metrics.avg_wait_s < 25,
+  ],
+  starterCode: STAGE_14_STARTER,
+  hints: [
+    "`sim.addStop(name, position)` returns the new stop's ref. The stop is created but not yet part of any line — riders won't go there until you add it to a line.",
+    "`sim.addStopToLine(lineRef, stopRef)` registers the new stop on the line so dispatch can route to it. Call it once construction is done.",
+    "3★ requires sub-25s average wait with no abandons — react quickly to the construction-complete event so waiting riders don't time out.",
+  ],
+};

--- a/playground/src/features/quest/stages/stage-15-sky-lobby.ts
+++ b/playground/src/features/quest/stages/stage-15-sky-lobby.ts
@@ -1,0 +1,94 @@
+import type { Stage } from "./types";
+
+/**
+ * Stage 15 — Sky Lobby.
+ *
+ * Two dispatch groups (low-rise and high-rise) sharing a sky-lobby
+ * floor. Reads like a small skyscraper: lobby + low floors are
+ * one group, sky-lobby + high floors are another, and a transfer
+ * at the sky lobby connects them. Introduces assignLineToGroup
+ * and reassignElevatorToLine.
+ *
+ * The starter code keeps everything on the default group; star
+ * tiers reward splitting the cars into low/high duty bands so
+ * the high-rise car never wastes time on lobby calls.
+ */
+const STAGE_15_RON = `SimConfig(
+    building: BuildingConfig(
+        name: "Quest 15",
+        stops: [
+            StopConfig(id: StopId(0), name: "Lobby", position: 0.0),
+            StopConfig(id: StopId(1), name: "L2", position: 4.0),
+            StopConfig(id: StopId(2), name: "L3", position: 8.0),
+            StopConfig(id: StopId(3), name: "L4", position: 12.0),
+            StopConfig(id: StopId(4), name: "Sky", position: 16.0),
+            StopConfig(id: StopId(5), name: "H1", position: 20.0),
+            StopConfig(id: StopId(6), name: "H2", position: 24.0),
+            StopConfig(id: StopId(7), name: "H3", position: 28.0),
+            StopConfig(id: StopId(8), name: "H4", position: 32.0),
+        ],
+    ),
+    elevators: [
+        ElevatorConfig(
+            id: 0, name: "Low",
+            max_speed: 2.5, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+        ElevatorConfig(
+            id: 1, name: "High",
+            max_speed: 3.0, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(4),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+        ElevatorConfig(
+            id: 2, name: "Floater",
+            max_speed: 2.5, acceleration: 1.5, deceleration: 2.0,
+            weight_capacity: 800.0,
+            starting_stop: StopId(0),
+            door_open_ticks: 55, door_transition_ticks: 14,
+        ),
+    ],
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 30,
+        weight_range: (50.0, 100.0),
+    ),
+)`;
+
+const STAGE_15_STARTER = `// Stage 15 — Sky Lobby
+//
+// Three cars over nine stops. The Sky stop bridges the low and
+// high halves of the building. A natural split: Low car serves
+// the bottom half, High car serves the top half, Floater fills in.
+//
+// assignLineToGroup(lineRef, groupRef) puts a line under a group's
+// dispatcher; reassignElevatorToLine(carRef, lineRef) moves a car.
+//
+// The default config has everything on one group. ETD does fine.
+// Beating 22s average wait needs an explicit group split.
+
+sim.setStrategy("etd");
+`;
+
+export const STAGE_15_SKY_LOBBY: Stage = {
+  id: "sky-lobby",
+  title: "Sky Lobby",
+  brief: "Three cars, two zones, one sky lobby. Split duty for sub-22s.",
+  configRon: STAGE_15_RON,
+  unlockedApi: ["setStrategy", "assignLineToGroup", "reassignElevatorToLine"],
+  baseline: "etd",
+  passFn: ({ delivered }) => delivered >= 30,
+  starFns: [
+    ({ delivered, metrics }) => delivered >= 30 && metrics.avg_wait_s < 28,
+    ({ delivered, metrics }) => delivered >= 30 && metrics.avg_wait_s < 22,
+  ],
+  starterCode: STAGE_15_STARTER,
+  hints: [
+    "`sim.assignLineToGroup(lineRef, groupRef)` puts a line under a group's dispatcher. Two groups means two independent dispatch decisions.",
+    "`sim.reassignElevatorToLine(carRef, lineRef)` moves a car between lines without rebuilding the topology. Useful when a duty band is over- or under-loaded.",
+    "3★ requires sub-22s average wait. The Floater is the lever: park it on whichever side has the bigger queue and let the dedicated cars handle their bands.",
+  ],
+};


### PR DESCRIPTION
Q-20: stages 13-15. Multi-line topology arc — transfer points, mid-run addStop, sky-lobby duty-banding. Stacked on Q-17 (api reference) once that lands; the new methods need API_REFERENCE entries to satisfy the curriculum-completeness test.