### PR TITLE
feat(playground): tap-to-insert snippet picker

### DIFF
--- a/playground/src/features/quest/editor.ts
+++ b/playground/src/features/quest/editor.ts
@@ -33,6 +33,8 @@ export interface QuestEditor {
   setValue(text: string): void;
   /** Subscribe to text changes. Returns an unsubscribe handle. */
   onDidChange(listener: (value: string) => void): { dispose(): void };
+  /** Insert `text` at the current cursor position and focus the editor. */
+  insertAtCursor(text: string): void;
   /** Tear down the editor and free its DOM/worker resources. */
   dispose(): void;
 }
@@ -123,6 +125,21 @@ export async function mountQuestEditor(opts: EditorMountOptions): Promise<QuestE
           sub.dispose();
         },
       };
+    },
+    insertAtCursor(text: string) {
+      // executeEdits drives the same undo stack as keyboard input,
+      // so a player can ⌘Z away a snippet they didn't mean to insert.
+      // Without a selection range Monaco needs an explicit one — use
+      // the current cursor position, collapsed.
+      const selection = editor.getSelection();
+      const range = selection ?? {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 1,
+      };
+      editor.executeEdits("quest-snippet", [{ range, text, forceMoveMarkers: true }]);
+      editor.focus();
     },
     dispose: () => {
       // Dispose the backing model first — `editor.dispose()` releases

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -16,6 +16,7 @@ import { renderApiPanel, wireApiPanel, type ApiPanelHandles } from "./api-panel"
 import { mountQuestEditor, type QuestEditor } from "./editor";
 import { renderHints, wireHintsDrawer, type HintsDrawerHandles } from "./hints-drawer";
 import { showResults, wireResultsModal, type ResultsModalHandles } from "./results-modal";
+import { renderSnippets, wireSnippetPicker, type SnippetPickerHandles } from "./snippet-picker";
 import { runStage } from "./stage-runner";
 import { STAGES, stageById } from "./stages";
 import type { Stage } from "./stages";
@@ -197,6 +198,12 @@ export async function bootQuestPane(opts: {
   const modal = wireResultsModal();
   attachRunButton(handles, modal, editor, () => activeStage);
 
+  // Snippet picker — chips paste pre-built API calls into the
+  // editor at the cursor. Wired here (after editor mount) so the
+  // chip click handlers have a real editor to insert into.
+  const snippets: SnippetPickerHandles = wireSnippetPicker();
+  renderSnippets(snippets, activeStage, editor);
+
   // Stage navigator: rewrite the editor's contents to the new
   // stage's starter and clear the result panel. A user mid-edit
   // loses their work — by design for v1; a "discard your code?"
@@ -207,6 +214,7 @@ export async function bootQuestPane(opts: {
     renderStage(handles, next);
     renderApiPanel(apiPanel, next);
     renderHints(hints, next);
+    renderSnippets(snippets, next, editor);
     editor.setValue(next.starterCode);
     handles.result.textContent = "";
     opts.onStageChange?.(next.id);

--- a/playground/src/features/quest/snippet-picker.ts
+++ b/playground/src/features/quest/snippet-picker.ts
@@ -1,0 +1,89 @@
+/**
+ * Tap-to-insert chips beneath the editor.
+ *
+ * Each unlocked-API entry maps to a snippet — a paste-ready
+ * one-liner the player can drop into the editor with a single
+ * click/tap. On mobile the chip row is the primary input affordance
+ * for adding code; on desktop it's a faster path than typing the
+ * full call.
+ *
+ * The chip row re-renders on stage navigation: locked methods
+ * disappear, freshly-unlocked methods appear with a subtle accent
+ * the first time they show up. (Actually we render every time
+ * without the "fresh" treatment for v1; the per-stage-novelty
+ * highlight is a follow-up.)
+ */
+
+import { unlockedEntries } from "./api-reference";
+import type { QuestEditor } from "./editor";
+import type { Stage } from "./stages";
+
+export interface SnippetPickerHandles {
+  readonly root: HTMLElement;
+}
+
+/**
+ * Curated insert templates per wasm method. Mirrors API_REFERENCE
+ * entries (the registry-completeness test should eventually pin
+ * snippets to the reference too — for v1 the lookup falls back to
+ * a generic `sim.{name}();` template, which is good enough for
+ * methods I haven't hand-tuned yet).
+ */
+const SNIPPETS: Record<string, string> = {
+  pushDestination: "sim.pushDestination(0n, 2n);",
+  hallCalls: "const calls = sim.hallCalls();",
+  carCalls: "const inside = sim.carCalls(0n);",
+  drainEvents: "const events = sim.drainEvents();",
+  setStrategy: 'sim.setStrategy("etd");',
+  setStrategyJs: `sim.setStrategyJs("my-rank", (ctx) => {
+  return Math.abs(ctx.carPosition - ctx.stopPosition);
+});`,
+  setServiceMode: 'sim.setServiceMode(0n, "manual");',
+  setTargetVelocity: "sim.setTargetVelocity(0n, 2.0);",
+  holdDoor: "sim.holdDoor(0n);",
+  cancelDoorHold: "sim.cancelDoorHold(0n);",
+  emergencyStop: "sim.emergencyStop(0n);",
+  shortestRoute: "const route = sim.shortestRoute(0n, 4n);",
+  reroute: "sim.reroute(riderRef, [0n, 4n]);",
+  transferPoints: "const transfers = sim.transferPoints();",
+  reachableStopsFrom: "const reachable = sim.reachableStopsFrom(0n);",
+  addStop: 'const newStop = sim.addStop("F6", 20.0);',
+  addStopToLine: "sim.addStopToLine(lineRef, newStop);",
+  assignLineToGroup: "sim.assignLineToGroup(lineRef, groupRef);",
+  reassignElevatorToLine: "sim.reassignElevatorToLine(0n, lineRef);",
+};
+
+function snippetFor(name: string): string {
+  return SNIPPETS[name] ?? `sim.${name}();`;
+}
+
+export function wireSnippetPicker(): SnippetPickerHandles {
+  const root = document.getElementById("quest-snippets");
+  if (!root) throw new Error("snippet-picker: missing #quest-snippets");
+  return { root };
+}
+
+export function renderSnippets(
+  handles: SnippetPickerHandles,
+  stage: Stage,
+  editor: QuestEditor,
+): void {
+  while (handles.root.firstChild) {
+    handles.root.removeChild(handles.root.firstChild);
+  }
+  const entries = unlockedEntries(stage.unlockedApi);
+  if (entries.length === 0) return;
+
+  for (const entry of entries) {
+    const chip = document.createElement("button");
+    chip.type = "button";
+    chip.className =
+      "inline-flex items-center px-2 py-0.5 rounded-sm bg-surface-elevated border border-stroke-subtle text-content text-[11.5px] font-mono cursor-pointer transition-colors duration-fast hover:bg-surface-hover hover:border-stroke";
+    chip.textContent = entry.name;
+    chip.title = `Insert: ${snippetFor(entry.name)}`;
+    chip.addEventListener("click", () => {
+      editor.insertAtCursor(snippetFor(entry.name));
+    });
+    handles.root.appendChild(chip);
+  }
+}

--- a/playground/src/features/quest/snippet-picker.ts
+++ b/playground/src/features/quest/snippet-picker.ts
@@ -44,13 +44,13 @@ const SNIPPETS: Record<string, string> = {
   cancelDoorHold: "sim.cancelDoorHold(0n);",
   emergencyStop: "sim.emergencyStop(0n);",
   shortestRoute: "const route = sim.shortestRoute(0n, 4n);",
-  reroute: "sim.reroute(riderRef, [0n, 4n]);",
+  reroute: "sim.reroute(/* riderRef */, [0n, 4n]);",
   transferPoints: "const transfers = sim.transferPoints();",
   reachableStopsFrom: "const reachable = sim.reachableStopsFrom(0n);",
   addStop: 'const newStop = sim.addStop("F6", 20.0);',
-  addStopToLine: "sim.addStopToLine(lineRef, newStop);",
-  assignLineToGroup: "sim.assignLineToGroup(lineRef, groupRef);",
-  reassignElevatorToLine: "sim.reassignElevatorToLine(0n, lineRef);",
+  addStopToLine: "sim.addStopToLine(/* lineRef */, /* stopRef */);",
+  assignLineToGroup: "sim.assignLineToGroup(/* lineRef */, /* groupRef */);",
+  reassignElevatorToLine: "sim.reassignElevatorToLine(0n, /* lineRef */);",
 };
 
 function snippetFor(name: string): string {


### PR DESCRIPTION
Q-21: chip row beneath the editor maps every unlocked-API method to a paste-ready snippet. Click/tap inserts at cursor. Helps mobile (typing is slow) and desktop (one-click paste of common calls). QuestEditor gains insertAtCursor; the chips re-render on stage navigation so locked methods don't appear.