### PR TITLE
feat(playground): persist quest editor code per stage

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -569,6 +569,14 @@
         >
           Run
         </button>
+        <button
+          type="button"
+          id="quest-reset"
+          class="inline-flex items-center px-2.5 py-1.5 rounded-sm bg-surface-elevated border border-stroke-subtle text-content-secondary text-[12px] tracking-[0.01em] cursor-pointer transition-colors duration-fast hover:text-content hover:border-stroke disabled:opacity-50 disabled:cursor-not-allowed"
+          title="Replace your code with the stage's starter"
+        >
+          Reset
+        </button>
         <span
           id="quest-result"
           class="text-content-secondary text-[12.5px] tracking-[0.01em]"

--- a/playground/src/__tests__/quest-storage.test.ts
+++ b/playground/src/__tests__/quest-storage.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearCode, loadCode, saveCode } from "../features/quest";
+
+// Vitest runs in node by default, so `localStorage` isn't a global.
+// Install a minimal in-memory shim on `globalThis` and tear it down
+// after each test — matches the storage module's `globalThis.localStorage`
+// lookup path without pulling in a full DOM (jsdom / happy-dom).
+
+type MutableStorage = Storage;
+
+function makeMemStorage(): MutableStorage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => {
+      map.clear();
+    },
+    getItem: (k: string) => (map.has(k) ? (map.get(k) as string) : null),
+    setItem: (k: string, v: string) => {
+      map.set(k, v);
+    },
+    removeItem: (k: string) => {
+      map.delete(k);
+    },
+    key: (i: number) => Array.from(map.keys())[i] ?? null,
+  };
+}
+
+const KEY_PREFIX = "quest:code:v1:";
+
+// DOM lib types declare `localStorage` as always defined on the global
+// scope; cast through `unknown` so we can install / delete it cleanly
+// for the unavailable-storage tests without redeclaring the global.
+type LocalStorageHolder = { localStorage?: Storage };
+
+let mem: MutableStorage;
+
+beforeEach(() => {
+  mem = makeMemStorage();
+  (globalThis as unknown as LocalStorageHolder).localStorage = mem;
+});
+
+afterEach(() => {
+  delete (globalThis as unknown as LocalStorageHolder).localStorage;
+  vi.restoreAllMocks();
+});
+
+describe("quest: storage", () => {
+  it("loadCode returns null for an unset stage", () => {
+    expect(loadCode("first-floor")).toBeNull();
+  });
+
+  it("saveCode then loadCode round-trips", () => {
+    saveCode("first-floor", "sim.pushDestination(0, 1);");
+    expect(loadCode("first-floor")).toBe("sim.pushDestination(0, 1);");
+  });
+
+  it("clearCode removes a saved entry", () => {
+    saveCode("first-floor", "x");
+    clearCode("first-floor");
+    expect(loadCode("first-floor")).toBeNull();
+  });
+
+  it("entries are namespaced under quest:code:v1:", () => {
+    saveCode("listen-up", "abc");
+    expect(mem.getItem(`${KEY_PREFIX}listen-up`)).toBe("abc");
+  });
+
+  it("different stage ids do not collide", () => {
+    saveCode("a", "alpha");
+    saveCode("b", "beta");
+    expect(loadCode("a")).toBe("alpha");
+    expect(loadCode("b")).toBe("beta");
+  });
+
+  it("rejects entries larger than the per-stage cap", () => {
+    // Cap is 50KB; a 60KB string must not write.
+    const huge = "x".repeat(60_000);
+    saveCode("big", huge);
+    expect(loadCode("big")).toBeNull();
+  });
+
+  it("accepts entries up to the per-stage cap", () => {
+    const big = "y".repeat(50_000);
+    saveCode("ok", big);
+    expect(loadCode("ok")).toBe(big);
+  });
+
+  it("saveCode swallows setItem errors (private mode / quota)", () => {
+    const setSpy = vi.spyOn(mem, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    expect(() => {
+      saveCode("first-floor", "code");
+    }).not.toThrow();
+    expect(setSpy).toHaveBeenCalled();
+  });
+
+  it("loadCode swallows getItem errors", () => {
+    vi.spyOn(mem, "getItem").mockImplementation(() => {
+      throw new Error("storage disabled");
+    });
+    expect(loadCode("first-floor")).toBeNull();
+  });
+
+  it("clearCode swallows removeItem errors", () => {
+    vi.spyOn(mem, "removeItem").mockImplementation(() => {
+      throw new Error("storage disabled");
+    });
+    expect(() => {
+      clearCode("first-floor");
+    }).not.toThrow();
+  });
+
+  it("loadCode returns null when localStorage is unavailable", () => {
+    delete (globalThis as unknown as LocalStorageHolder).localStorage;
+    expect(loadCode("first-floor")).toBeNull();
+  });
+
+  it("saveCode is a no-op when localStorage is unavailable", () => {
+    delete (globalThis as unknown as LocalStorageHolder).localStorage;
+    expect(() => {
+      saveCode("first-floor", "code");
+    }).not.toThrow();
+  });
+});

--- a/playground/src/features/quest/index.ts
+++ b/playground/src/features/quest/index.ts
@@ -28,3 +28,4 @@ export {
 } from "./results-modal";
 export { API_REFERENCE, apiEntry, unlockedEntries, type ApiEntry } from "./api-reference";
 export { renderHints, wireHintsDrawer, type HintsDrawerHandles } from "./hints-drawer";
+export { clearCode, loadCode, saveCode } from "./storage";

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -20,6 +20,7 @@ import { renderSnippets, wireSnippetPicker, type SnippetPickerHandles } from "./
 import { runStage } from "./stage-runner";
 import { STAGES, stageById } from "./stages";
 import type { Stage } from "./stages";
+import { clearCode, loadCode, saveCode } from "./storage";
 
 export interface QuestPaneHandles {
   readonly root: HTMLElement;
@@ -28,6 +29,7 @@ export interface QuestPaneHandles {
   readonly select: HTMLSelectElement;
   readonly editorHost: HTMLElement;
   readonly runBtn: HTMLButtonElement;
+  readonly resetBtn: HTMLButtonElement;
   readonly result: HTMLElement;
 }
 
@@ -44,8 +46,9 @@ export function wireQuestPane(): QuestPaneHandles {
   const select = document.getElementById("quest-stage-select");
   const editorHost = document.getElementById("quest-editor");
   const runBtn = document.getElementById("quest-run");
+  const resetBtn = document.getElementById("quest-reset");
   const result = document.getElementById("quest-result");
-  if (!title || !brief || !select || !editorHost || !runBtn || !result) {
+  if (!title || !brief || !select || !editorHost || !runBtn || !resetBtn || !result) {
     throw new Error("quest-pane: missing stage banner elements");
   }
   return {
@@ -55,6 +58,7 @@ export function wireQuestPane(): QuestPaneHandles {
     select: select as HTMLSelectElement,
     editorHost,
     runBtn: runBtn as HTMLButtonElement,
+    resetBtn: resetBtn as HTMLButtonElement,
     result,
   };
 }
@@ -187,16 +191,42 @@ export async function bootQuestPane(opts: {
   // Disable Run while the Monaco bundle loads so a click before
   // mount completes doesn't run against an undefined editor.
   handles.runBtn.disabled = true;
+  handles.resetBtn.disabled = true;
   handles.result.textContent = "Loading editor…";
   const editor = await mountQuestEditor({
     container: handles.editorHost,
-    initialValue: activeStage.starterCode,
+    initialValue: loadCode(activeStage.id) ?? activeStage.starterCode,
     language: "typescript",
   });
   handles.runBtn.disabled = false;
+  handles.resetBtn.disabled = false;
   handles.result.textContent = "";
   const modal = wireResultsModal();
   attachRunButton(handles, modal, editor, () => activeStage);
+
+  // Persist edits per stage so refresh / stage-swap don't wipe the
+  // player's work. Debounced because Monaco fires a change on every
+  // keystroke; ~300ms is below the perceptible "I edited then it
+  // saved" gap and well under the time it takes to lift the finger
+  // and reach for refresh.
+  const SAVE_DEBOUNCE_MS = 300;
+  let saveTimer: ReturnType<typeof setTimeout> | null = null;
+  const scheduleSave = (): void => {
+    if (saveTimer !== null) clearTimeout(saveTimer);
+    saveTimer = setTimeout(() => {
+      saveCode(activeStage.id, editor.getValue());
+      saveTimer = null;
+    }, SAVE_DEBOUNCE_MS);
+  };
+  const flushSave = (): void => {
+    if (saveTimer === null) return;
+    clearTimeout(saveTimer);
+    saveTimer = null;
+    saveCode(activeStage.id, editor.getValue());
+  };
+  editor.onDidChange(() => {
+    scheduleSave();
+  });
 
   // Snippet picker — chips paste pre-built API calls into the
   // editor at the cursor. Wired here (after editor mount) so the
@@ -204,18 +234,31 @@ export async function bootQuestPane(opts: {
   const snippets: SnippetPickerHandles = wireSnippetPicker();
   renderSnippets(snippets, activeStage, editor);
 
-  // Stage navigator: rewrite the editor's contents to the new
-  // stage's starter and clear the result panel. A user mid-edit
-  // loses their work — by design for v1; a "discard your code?"
-  // confirm is a follow-up nicety.
+  // Reset: drop the saved entry and rehydrate the starter. Confirm
+  // first because it's destructive — the player's only undo is
+  // Monaco's edit history, which doesn't survive a refresh.
+  handles.resetBtn.addEventListener("click", () => {
+    const ok = window.confirm(`Reset ${activeStage.title} to its starter code?`);
+    if (!ok) return;
+    clearCode(activeStage.id);
+    editor.setValue(activeStage.starterCode);
+    handles.result.textContent = "";
+  });
+
+  // Stage navigator: save the outgoing stage's edits, then rehydrate
+  // the next stage from its saved entry (or starter on first visit).
+  // Saving on swap covers the "user edited then immediately picked a
+  // different stage" race that would otherwise lose the last <300ms
+  // of typing to the debounce.
   handles.select.addEventListener("change", () => {
+    flushSave();
     const next = resolveStage(handles.select.value);
     activeStage = next;
     renderStage(handles, next);
     renderApiPanel(apiPanel, next);
     renderHints(hints, next);
     renderSnippets(snippets, next, editor);
-    editor.setValue(next.starterCode);
+    editor.setValue(loadCode(next.id) ?? next.starterCode);
     handles.result.textContent = "";
     opts.onStageChange?.(next.id);
   });

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -205,13 +205,16 @@ export async function bootQuestPane(opts: {
   attachRunButton(handles, modal, editor, () => activeStage);
 
   // Persist edits per stage so refresh / stage-swap don't wipe the
-  // player's work. Debounced because Monaco fires a change on every
-  // keystroke; ~300ms is below the perceptible "I edited then it
-  // saved" gap and well under the time it takes to lift the finger
-  // and reach for refresh.
+  // player's work. Monaco's onDidChange fires for every content
+  // change including programmatic `setValue`, so a `suppressSave`
+  // flag gates the debounce while we rehydrate from storage —
+  // otherwise stage-swap and Reset would silently re-save the
+  // starter code 300ms later, defeating the clear.
   const SAVE_DEBOUNCE_MS = 300;
   let saveTimer: ReturnType<typeof setTimeout> | null = null;
+  let suppressSave = false;
   const scheduleSave = (): void => {
+    if (suppressSave) return;
     if (saveTimer !== null) clearTimeout(saveTimer);
     saveTimer = setTimeout(() => {
       saveCode(activeStage.id, editor.getValue());
@@ -223,6 +226,14 @@ export async function bootQuestPane(opts: {
     clearTimeout(saveTimer);
     saveTimer = null;
     saveCode(activeStage.id, editor.getValue());
+  };
+  const setEditorSilently = (text: string): void => {
+    suppressSave = true;
+    try {
+      editor.setValue(text);
+    } finally {
+      suppressSave = false;
+    }
   };
   editor.onDidChange(() => {
     scheduleSave();
@@ -241,7 +252,7 @@ export async function bootQuestPane(opts: {
     const ok = window.confirm(`Reset ${activeStage.title} to its starter code?`);
     if (!ok) return;
     clearCode(activeStage.id);
-    editor.setValue(activeStage.starterCode);
+    setEditorSilently(activeStage.starterCode);
     handles.result.textContent = "";
   });
 
@@ -258,7 +269,7 @@ export async function bootQuestPane(opts: {
     renderApiPanel(apiPanel, next);
     renderHints(hints, next);
     renderSnippets(snippets, next, editor);
-    editor.setValue(loadCode(next.id) ?? next.starterCode);
+    setEditorSilently(loadCode(next.id) ?? next.starterCode);
     handles.result.textContent = "";
     opts.onStageChange?.(next.id);
   });

--- a/playground/src/features/quest/storage.ts
+++ b/playground/src/features/quest/storage.ts
@@ -15,12 +15,14 @@
 const KEY_PREFIX = "quest:code:v1:";
 
 /**
- * Hard cap per saved entry. The localStorage origin quota is ~5MB on
- * most browsers; capping each stage at 50KB keeps the curriculum's
- * worst case (one entry per stage × ~20 stages) well under 1MB and
- * prevents a single runaway paste from starving every other slot.
+ * Hard cap per saved entry, measured in `String.length` (UTF-16 code
+ * units, ≈ ASCII chars). The localStorage origin quota is ~5MB on
+ * most browsers; capping each stage at 50_000 chars keeps the
+ * curriculum's worst case (one entry per stage × ~20 stages) well
+ * under 1MB and prevents a single runaway paste from starving every
+ * other slot.
  */
-const MAX_CODE_BYTES = 50_000;
+const MAX_CODE_LENGTH = 50_000;
 
 function storage(): Storage | null {
   // `globalThis.localStorage` is the safe access path: in jsdom it's
@@ -52,7 +54,7 @@ export function loadCode(stageId: string): string | null {
  * exceeds the per-stage size cap or storage rejects the write.
  */
 export function saveCode(stageId: string, code: string): void {
-  if (code.length > MAX_CODE_BYTES) return;
+  if (code.length > MAX_CODE_LENGTH) return;
   const s = storage();
   if (!s) return;
   try {

--- a/playground/src/features/quest/storage.ts
+++ b/playground/src/features/quest/storage.ts
@@ -1,0 +1,75 @@
+/**
+ * Persistence for Quest editor state.
+ *
+ * Saves the player's in-flight code per stage so a refresh, a stage
+ * swap, or a tab-restore doesn't wipe their work. Best-stars and
+ * unlocked-stages live alongside this module in follow-up PRs; the
+ * key prefix and helper shape are designed to extend.
+ *
+ * All localStorage access is wrapped in try/catch — Safari private
+ * mode throws on `setItem`, Brave's shim can null the global, and
+ * quota-exceeded surfaces as a thrown `QuotaExceededError`. The
+ * editor must keep working even when persistence quietly fails, so
+ * load returns `null` and save/clear are no-ops on any error.
+ */
+const KEY_PREFIX = "quest:code:v1:";
+
+/**
+ * Hard cap per saved entry. The localStorage origin quota is ~5MB on
+ * most browsers; capping each stage at 50KB keeps the curriculum's
+ * worst case (one entry per stage × ~20 stages) well under 1MB and
+ * prevents a single runaway paste from starving every other slot.
+ */
+const MAX_CODE_BYTES = 50_000;
+
+function storage(): Storage | null {
+  // `globalThis.localStorage` is the safe access path: in jsdom it's
+  // the same object as `window.localStorage`, and on platforms where
+  // the shim is absent or throws on access it's catchable here once
+  // instead of at every call site. Cast through `unknown` so the
+  // null-check isn't elided by the DOM lib's "always defined" type.
+  try {
+    const ls = (globalThis as unknown as { localStorage?: Storage }).localStorage;
+    return ls ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Read saved code for a stage, or `null` if no entry / unavailable. */
+export function loadCode(stageId: string): string | null {
+  const s = storage();
+  if (!s) return null;
+  try {
+    return s.getItem(KEY_PREFIX + stageId);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write the player's code for a stage. Silently no-ops if the entry
+ * exceeds the per-stage size cap or storage rejects the write.
+ */
+export function saveCode(stageId: string, code: string): void {
+  if (code.length > MAX_CODE_BYTES) return;
+  const s = storage();
+  if (!s) return;
+  try {
+    s.setItem(KEY_PREFIX + stageId, code);
+  } catch {
+    // Quota / private mode — drop the write rather than surface to
+    // the editor. The next save attempt will retry.
+  }
+}
+
+/** Remove the saved entry for a stage. Useful for "reset to starter". */
+export function clearCode(stageId: string): void {
+  const s = storage();
+  if (!s) return;
+  try {
+    s.removeItem(KEY_PREFIX + stageId);
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## Summary

- Player edits in Quest mode now survive page refresh, tab restore, and stage swap. Stored per-stage in `localStorage` under the namespaced key `quest:code:v1:<stageId>`.
- Adds a Reset button next to Run that drops the saved entry and rehydrates the stage's starter code (with a confirm — the only undo would be Monaco's edit history, which doesn't survive a refresh).
- New `storage.ts` helper module is the seam for follow-up persistence work (best-stars, unlocked-stages, code-blob permalink — design decision 12).

## Implementation notes

- All `localStorage` access is wrapped in try/catch. Safari private mode throws on `setItem`; Brave's shim can null the global; `QuotaExceededError` surfaces on writes. The editor must keep working even when persistence quietly fails — load returns `null`, save/clear are no-ops.
- 50KB cap per entry. Origin quota is ~5MB on most browsers; capping ensures one runaway paste can't starve every other stage's slot.
- Save is debounced (300ms). Stage-swap and a future-flush helper guarantee the outgoing stage's edits flush before the next stage rehydrates, covering the "type-then-immediately-pick-next" race.
- Tests stub `globalThis.localStorage` directly rather than pulling in jsdom / happy-dom — keeps the test in node env and matches the storage module's lookup path exactly.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (only pre-existing boundaries plugin warnings)
- [x] `pnpm test` — 184 tests pass, 12 new in `quest-storage.test.ts`
- [x] Pre-commit hook clean (lint-staged + typecheck + vitest)
- [ ] Manual: edit code, refresh browser → edits persist
- [ ] Manual: edit on stage A, switch to stage B, switch back → A's edits restored
- [ ] Manual: click Reset → confirm → starter code shown
- [ ] Manual: portrait + landscape mobile (P0 gate)