### PR TITLE
feat(playground): persist best-stars per stage in navigator

### DIFF
--- a/playground/src/__tests__/quest-storage.test.ts
+++ b/playground/src/__tests__/quest-storage.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { clearCode, loadCode, saveCode } from "../features/quest";
+import {
+  clearBestStars,
+  clearCode,
+  loadBestStars,
+  loadCode,
+  saveBestStars,
+  saveCode,
+} from "../features/quest";
 
 // Vitest runs in node by default, so `localStorage` isn't a global.
 // Install a minimal in-memory shim on `globalThis` and tear it down
@@ -123,6 +130,71 @@ describe("quest: storage", () => {
     delete (globalThis as unknown as LocalStorageHolder).localStorage;
     expect(() => {
       saveCode("first-floor", "code");
+    }).not.toThrow();
+  });
+});
+
+describe("quest: bestStars", () => {
+  it("loadBestStars returns 0 for an unset stage", () => {
+    expect(loadBestStars("first-floor")).toBe(0);
+  });
+
+  it("saveBestStars then loadBestStars round-trips for each tier", () => {
+    saveBestStars("a", 1);
+    expect(loadBestStars("a")).toBe(1);
+    saveBestStars("b", 2);
+    expect(loadBestStars("b")).toBe(2);
+    saveBestStars("c", 3);
+    expect(loadBestStars("c")).toBe(3);
+  });
+
+  it("entries are namespaced under quest:bestStars:v1:", () => {
+    saveBestStars("listen-up", 2);
+    expect(mem.getItem("quest:bestStars:v1:listen-up")).toBe("2");
+  });
+
+  it("never regresses a higher score with a lower one", () => {
+    saveBestStars("x", 3);
+    saveBestStars("x", 1);
+    expect(loadBestStars("x")).toBe(3);
+  });
+
+  it("equal score is a no-op (storage write is skipped)", () => {
+    saveBestStars("x", 2);
+    const setSpy = vi.spyOn(mem, "setItem");
+    saveBestStars("x", 2);
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it("clearBestStars removes the stored entry", () => {
+    saveBestStars("x", 3);
+    clearBestStars("x");
+    expect(loadBestStars("x")).toBe(0);
+  });
+
+  it("malformed entries read as 0", () => {
+    mem.setItem("quest:bestStars:v1:bad", "not-a-number");
+    expect(loadBestStars("bad")).toBe(0);
+  });
+
+  it("out-of-range entries read as 0", () => {
+    mem.setItem("quest:bestStars:v1:bad", "9");
+    expect(loadBestStars("bad")).toBe(0);
+    mem.setItem("quest:bestStars:v1:bad", "-1");
+    expect(loadBestStars("bad")).toBe(0);
+  });
+
+  it("loadBestStars returns 0 when localStorage is unavailable", () => {
+    delete (globalThis as unknown as LocalStorageHolder).localStorage;
+    expect(loadBestStars("any")).toBe(0);
+  });
+
+  it("saveBestStars swallows setItem errors", () => {
+    vi.spyOn(mem, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    expect(() => {
+      saveBestStars("any", 3);
     }).not.toThrow();
   });
 });

--- a/playground/src/features/quest/index.ts
+++ b/playground/src/features/quest/index.ts
@@ -8,10 +8,11 @@ export {
   type GradeInputs,
   type PassFn,
   type Stage,
+  type StarCount,
   type StarFn,
   type UnlockedApi,
 } from "./stages";
-export { runStage, type StageResult, type RunStageOptions, type StarCount } from "./stage-runner";
+export { runStage, type StageResult, type RunStageOptions } from "./stage-runner";
 export {
   bootQuestPane,
   hideQuestPane,
@@ -28,4 +29,11 @@ export {
 } from "./results-modal";
 export { API_REFERENCE, apiEntry, unlockedEntries, type ApiEntry } from "./api-reference";
 export { renderHints, wireHintsDrawer, type HintsDrawerHandles } from "./hints-drawer";
-export { clearCode, loadCode, saveCode } from "./storage";
+export {
+  clearBestStars,
+  clearCode,
+  loadBestStars,
+  loadCode,
+  saveBestStars,
+  saveCode,
+} from "./storage";

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -17,10 +17,10 @@ import { mountQuestEditor, type QuestEditor } from "./editor";
 import { renderHints, wireHintsDrawer, type HintsDrawerHandles } from "./hints-drawer";
 import { showResults, wireResultsModal, type ResultsModalHandles } from "./results-modal";
 import { renderSnippets, wireSnippetPicker, type SnippetPickerHandles } from "./snippet-picker";
-import { runStage } from "./stage-runner";
+import { runStage, type StageResult } from "./stage-runner";
 import { STAGES, stageById } from "./stages";
-import type { Stage } from "./stages";
-import { clearCode, loadCode, saveCode } from "./storage";
+import type { StarCount, Stage } from "./stages";
+import { clearCode, loadBestStars, loadCode, saveBestStars, saveCode } from "./storage";
 
 export interface QuestPaneHandles {
   readonly root: HTMLElement;
@@ -82,9 +82,20 @@ export function populateStageSelect(handles: QuestPaneHandles): void {
   STAGES.forEach((stage, index) => {
     const opt = document.createElement("option");
     opt.value = stage.id;
-    opt.textContent = `${String(index + 1).padStart(2, "0")} · ${stage.title}`;
+    opt.textContent = stageOptionLabel(stage, index, loadBestStars(stage.id));
     handles.select.appendChild(opt);
   });
+}
+
+/**
+ * Build the option label for a stage. Earned stars (1–3) are appended
+ * as filled glyphs; unstarred stages keep the bare title to avoid
+ * cluttering the picker before the player has scored anything.
+ */
+function stageOptionLabel(stage: Stage, index: number, stars: StarCount): string {
+  const ordinal = String(index + 1).padStart(2, "0");
+  const head = `${ordinal} · ${stage.title}`;
+  return stars === 0 ? head : `${head} ${"★".repeat(stars)}`;
 }
 
 /**
@@ -120,9 +131,10 @@ function attachRunButton(
   modal: ResultsModalHandles,
   editor: QuestEditor,
   getStage: () => Stage,
+  onGraded: (stage: Stage, result: StageResult) => void,
 ): void {
   const runOnce = (): void => {
-    void executeRun(handles, modal, editor, getStage(), runOnce);
+    void executeRun(handles, modal, editor, getStage(), runOnce, onGraded);
   };
   handles.runBtn.addEventListener("click", runOnce);
 }
@@ -133,6 +145,7 @@ async function executeRun(
   editor: QuestEditor,
   stage: Stage,
   retry: () => void,
+  onGraded: (stage: Stage, result: StageResult) => void,
 ): Promise<void> {
   handles.runBtn.disabled = true;
   handles.result.textContent = "Running…";
@@ -142,6 +155,7 @@ async function executeRun(
     // bubbles up as a timeout instead of blocking indefinitely.
     const result = await runStage(stage, editor.getValue(), { timeoutMs: 1000 });
     handles.result.textContent = "";
+    onGraded(stage, result);
     showResults(modal, result, retry);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -202,7 +216,26 @@ export async function bootQuestPane(opts: {
   handles.resetBtn.disabled = false;
   handles.result.textContent = "";
   const modal = wireResultsModal();
-  attachRunButton(handles, modal, editor, () => activeStage);
+  attachRunButton(
+    handles,
+    modal,
+    editor,
+    () => activeStage,
+    (stage, result) => {
+      // Persist a new high score and refresh the picker labels so the
+      // ★ glyphs reflect the win without waiting for a remount. The
+      // saved selection has to be restored after `populateStageSelect`
+      // since it rebuilds the option list and resets the value.
+      if (result.passed) {
+        const previous = loadBestStars(stage.id);
+        if (result.stars > previous) {
+          saveBestStars(stage.id, result.stars);
+          populateStageSelect(handles);
+          handles.select.value = stage.id;
+        }
+      }
+    },
+  );
 
   // Persist edits per stage so refresh / stage-swap don't wipe the
   // player's work. Monaco's onDidChange fires for every content

--- a/playground/src/features/quest/stage-runner.ts
+++ b/playground/src/features/quest/stage-runner.ts
@@ -18,11 +18,8 @@
  */
 
 import { createWorkerSim } from "./worker-sim";
-import type { GradeInputs, Stage } from "./stages";
+import type { GradeInputs, StarCount, Stage } from "./stages";
 import type { MetricsDto } from "../../types";
-
-/** Star count awarded for a run. 0 = failed pass condition. */
-export type StarCount = 0 | 1 | 2 | 3;
 
 export interface StageResult {
   /** `true` iff the stage's `passFn` returned `true` for the final grade. */

--- a/playground/src/features/quest/stages/index.ts
+++ b/playground/src/features/quest/stages/index.ts
@@ -47,4 +47,4 @@ export function stageById(id: string): Stage | undefined {
   return STAGES.find((s) => s.id === id);
 }
 
-export type { Stage, Baseline, UnlockedApi, GradeInputs, PassFn, StarFn } from "./types";
+export type { Stage, Baseline, StarCount, UnlockedApi, GradeInputs, PassFn, StarFn } from "./types";

--- a/playground/src/features/quest/stages/types.ts
+++ b/playground/src/features/quest/stages/types.ts
@@ -54,6 +54,9 @@ export type PassFn = (inputs: GradeInputs) => boolean;
  */
 export type StarFn = (inputs: GradeInputs) => boolean;
 
+/** Star count earned on a stage. 0 = not passed; 1–3 = grade tiers. */
+export type StarCount = 0 | 1 | 2 | 3;
+
 export interface Stage {
   /** Stable URL-safe slug; permalinks key off this. */
   readonly id: string;

--- a/playground/src/features/quest/storage.ts
+++ b/playground/src/features/quest/storage.ts
@@ -1,18 +1,20 @@
 /**
- * Persistence for Quest editor state.
+ * Persistence for Quest editor state and progression.
  *
  * Saves the player's in-flight code per stage so a refresh, a stage
- * swap, or a tab-restore doesn't wipe their work. Best-stars and
- * unlocked-stages live alongside this module in follow-up PRs; the
- * key prefix and helper shape are designed to extend.
+ * swap, or a tab-restore doesn't wipe their work, and tracks the
+ * best star count per stage so the navigator can show progress.
  *
  * All localStorage access is wrapped in try/catch — Safari private
  * mode throws on `setItem`, Brave's shim can null the global, and
  * quota-exceeded surfaces as a thrown `QuotaExceededError`. The
  * editor must keep working even when persistence quietly fails, so
- * load returns `null` and save/clear are no-ops on any error.
+ * load returns `null` / 0 and save/clear are no-ops on any error.
  */
-const KEY_PREFIX = "quest:code:v1:";
+import type { StarCount } from "./stages";
+
+const CODE_PREFIX = "quest:code:v1:";
+const STARS_PREFIX = "quest:bestStars:v1:";
 
 /**
  * Hard cap per saved entry, measured in `String.length` (UTF-16 code
@@ -43,7 +45,7 @@ export function loadCode(stageId: string): string | null {
   const s = storage();
   if (!s) return null;
   try {
-    return s.getItem(KEY_PREFIX + stageId);
+    return s.getItem(CODE_PREFIX + stageId);
   } catch {
     return null;
   }
@@ -58,7 +60,7 @@ export function saveCode(stageId: string, code: string): void {
   const s = storage();
   if (!s) return;
   try {
-    s.setItem(KEY_PREFIX + stageId, code);
+    s.setItem(CODE_PREFIX + stageId, code);
   } catch {
     // Quota / private mode — drop the write rather than surface to
     // the editor. The next save attempt will retry.
@@ -70,7 +72,57 @@ export function clearCode(stageId: string): void {
   const s = storage();
   if (!s) return;
   try {
-    s.removeItem(KEY_PREFIX + stageId);
+    s.removeItem(CODE_PREFIX + stageId);
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Read the best star count earned on a stage, or `0` if no entry, the
+ * stored value is malformed, or storage is unavailable. Stars are
+ * stored as a single decimal digit ("0"–"3") rather than JSON so a
+ * corrupted entry parses cleanly to a sentinel rather than throwing.
+ */
+export function loadBestStars(stageId: string): StarCount {
+  const s = storage();
+  if (!s) return 0;
+  let raw: string | null;
+  try {
+    raw = s.getItem(STARS_PREFIX + stageId);
+  } catch {
+    return 0;
+  }
+  if (raw === null) return 0;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n) || n < 0 || n > 3) return 0;
+  return n as StarCount;
+}
+
+/**
+ * Write the best star count for a stage, but only if `stars` is
+ * higher than the current entry. A graded run that scored fewer
+ * stars than the player's previous attempt should not regress the
+ * persisted score.
+ */
+export function saveBestStars(stageId: string, stars: StarCount): void {
+  const current = loadBestStars(stageId);
+  if (stars <= current) return;
+  const s = storage();
+  if (!s) return;
+  try {
+    s.setItem(STARS_PREFIX + stageId, String(stars));
+  } catch {
+    // Quota / private mode — drop the write.
+  }
+}
+
+/** Remove the best-stars entry for a stage. Mostly useful for tests. */
+export function clearBestStars(stageId: string): void {
+  const s = storage();
+  if (!s) return;
+  try {
+    s.removeItem(STARS_PREFIX + stageId);
   } catch {
     // ignore
   }


### PR DESCRIPTION
## Summary

- Tracks the highest star count earned per quest stage in `localStorage` and surfaces it in the navigator option labels (e.g. `01 · First Floor ★★`). Builds on the storage seam landed in #587.
- After a graded `runStage` resolves, the run hook saves the score (only on improvement — a 1★ run can't regress a previously earned 3★) and re-renders the picker so the new ★s show up before the player closes the results modal.
- Consolidates `StarCount` into `stages/types.ts` so storage and stage-runner share one canonical definition; the public barrel re-exports from `./stages` instead of `./stage-runner`.

## Implementation notes

- Stars stored as a single decimal digit (`"0"`–`"3"`) under `quest:bestStars:v1:<stageId>`, not JSON. Malformed or out-of-range entries (manual edit, schema drift, future regression) parse to 0 instead of throwing.
- `saveBestStars` short-circuits when the new score is `<= current`, so the load-then-write path doesn't need an outer guard at every call site.
- `populateStageSelect` rebuilds option text from `loadBestStars`; calling it after a save refreshes labels in place. The active selection is restored after rebuild since the rebuild resets `<select>.value`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (only pre-existing boundaries warnings)
- [x] `pnpm test` — 194 pass, 10 new in `quest-storage.test.ts` covering round-trip, regression-block, malformed/out-of-range parsing, missing storage, error swallowing
- [x] Pre-commit hook clean
- [ ] Manual: pass a stage with 1★, verify `01 · First Floor ★` appears in navigator
- [ ] Manual: pass the same stage with 3★, verify upgrade to `★★★`
- [ ] Manual: drop to 1★ on a stage with stored 3★, verify navigator unchanged
- [ ] Manual: refresh, verify stars survive