### PR TITLE
fix(playground): restore quest mode boot — add missing modal/snippet DOM

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -561,6 +561,7 @@
         class="min-h-[260px] bg-surface-elevated border border-stroke-subtle rounded-md overflow-hidden"
         aria-label="Quest controller editor"
       ></div>
+      <div id="quest-snippets" class="flex flex-wrap gap-1.5" aria-label="Insert API call"></div>
       <div class="flex items-center gap-3">
         <button
           type="button"
@@ -624,6 +625,50 @@
       class="toast fixed bottom-[calc(var(--controls-bar-h,52px)+16px)] left-1/2 -translate-x-1/2 translate-y-2.5 scale-95 px-3.5 py-2 bg-surface-elevated border border-stroke rounded-lg shadow-lg text-content text-[12.5px] font-medium tracking-[0.01em] pointer-events-none z-[55] opacity-0 transition-all duration-normal ease-spring [&.show]:opacity-100 [&.show]:translate-y-0 [&.show]:scale-100"
       role="status"
     ></div>
+
+    <div
+      id="quest-results-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="quest-results-title"
+      class="fixed inset-0 hidden items-center justify-center bg-[color-mix(in_srgb,var(--bg-primary)_70%,transparent)] backdrop-blur-[4px] backdrop-saturate-[120%] z-[95] [&.show]:flex"
+    >
+      <div
+        class="w-[min(420px,90vw)] bg-gradient-to-b from-surface-hover to-surface-secondary border border-stroke rounded-lg shadow-lg p-[18px_20px_20px] text-content-secondary"
+      >
+        <header class="flex flex-col gap-1 mb-4">
+          <h2
+            id="quest-results-title"
+            class="m-0 text-content text-base font-semibold tracking-[0.01em]"
+          ></h2>
+          <div
+            id="quest-results-stars"
+            class="text-accent text-xl tracking-[0.18em] leading-none"
+            aria-live="polite"
+          ></div>
+        </header>
+        <p
+          id="quest-results-detail"
+          class="m-0 text-[12.5px] text-content-tertiary tracking-[0.01em]"
+        ></p>
+        <div class="flex items-center justify-end gap-2 mt-5">
+          <button
+            type="button"
+            id="quest-results-close"
+            class="inline-flex items-center px-2.5 py-1.5 rounded-sm bg-surface-elevated border border-stroke-subtle text-content-secondary text-[12px] tracking-[0.01em] cursor-pointer transition-colors duration-fast hover:text-content hover:border-stroke"
+          >
+            Close
+          </button>
+          <button
+            type="button"
+            id="quest-results-retry"
+            class="inline-flex items-center px-3 py-1.5 rounded-sm bg-accent text-surface text-[12.5px] font-semibold tracking-[0.01em] cursor-pointer transition-opacity duration-fast hover:opacity-90"
+          >
+            Run again
+          </button>
+        </div>
+      </div>
+    </div>
 
     <div
       id="shortcut-sheet"

--- a/playground/src/__tests__/quest-dom-guard.test.ts
+++ b/playground/src/__tests__/quest-dom-guard.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Static guard: every `document.getElementById("quest-…")` call in the
+// quest feature module must have a matching `id="…"` in index.html.
+// Without this, a missing anchor causes Quest mode to throw on boot —
+// invisible in unit tests because vitest doesn't run the page DOM.
+const root = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const featureFiles = [
+  "src/features/quest/quest-pane.ts",
+  "src/features/quest/api-panel.ts",
+  "src/features/quest/hints-drawer.ts",
+  "src/features/quest/results-modal.ts",
+  "src/features/quest/snippet-picker.ts",
+];
+const html = readFileSync(join(root, "index.html"), "utf8");
+
+const idRefRe = /document\.getElementById\("(quest-[^"]+)"\)/g;
+const referencedIds = new Set<string>();
+for (const file of featureFiles) {
+  const src = readFileSync(join(root, file), "utf8");
+  for (const m of src.matchAll(idRefRe)) {
+    referencedIds.add(m[1]);
+  }
+}
+
+describe("quest: DOM anchors", () => {
+  it("scans more than one referenced id (sanity)", () => {
+    expect(referencedIds.size).toBeGreaterThan(5);
+  });
+
+  for (const id of [...referencedIds].sort()) {
+    it(`index.html has #${id}`, () => {
+      expect(html).toContain(`id="${id}"`);
+    });
+  }
+});

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -154,15 +154,24 @@ async function executeRun(
     // for honest setup work, short enough that an infinite loop
     // bubbles up as a timeout instead of blocking indefinitely.
     const result = await runStage(stage, editor.getValue(), { timeoutMs: 1000 });
-    handles.result.textContent = "";
+    // Always grade — a passed run earns its stars even if the player
+    // navigated to a different stage during the run window. Only
+    // surface the modal/inline status if the player is still looking
+    // at the same stage; otherwise hijacking their context with an
+    // old result is more confusing than silently banking the score.
     onGraded(stage, result);
-    showResults(modal, result, retry);
+    if (handles.select.value === stage.id) {
+      handles.result.textContent = "";
+      showResults(modal, result, retry);
+    }
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    // Errors stay inline — the modal is for graded outcomes.
-    // A controller throw is a code bug the player needs to see in
-    // place, not a result to celebrate or retry.
-    handles.result.textContent = `Error: ${msg}`;
+    if (handles.select.value === stage.id) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // Errors stay inline — the modal is for graded outcomes.
+      // A controller throw is a code bug the player needs to see in
+      // place, not a result to celebrate or retry.
+      handles.result.textContent = `Error: ${msg}`;
+    }
   } finally {
     handles.runBtn.disabled = false;
   }
@@ -223,15 +232,16 @@ export async function bootQuestPane(opts: {
     () => activeStage,
     (stage, result) => {
       // Persist a new high score and refresh the picker labels so the
-      // ★ glyphs reflect the win without waiting for a remount. The
-      // saved selection has to be restored after `populateStageSelect`
-      // since it rebuilds the option list and resets the value.
+      // ★ glyphs reflect the win without waiting for a remount. After
+      // rebuilding the options we restore `activeStage.id` (not the
+      // graded stage's id) — if the player navigated mid-run, the
+      // dropdown should track wherever they landed, not snap back.
       if (result.passed) {
         const previous = loadBestStars(stage.id);
         if (result.stars > previous) {
           saveBestStars(stage.id, result.stars);
           populateStageSelect(handles);
-          handles.select.value = stage.id;
+          handles.select.value = activeStage.id;
         }
       }
     },


### PR DESCRIPTION
## Summary

Quest mode was crashing on boot the moment a user navigated to `?m=quest`. Two earlier feature PRs (#584 results modal, #586 snippet picker) shipped wireup that calls `document.getElementById` on anchors that were never added to `index.html`.

## Why

`wireResultsModal` (`results-modal.ts:24-33`) needs `#quest-results-{modal,title,stars,detail,close,retry}`. `wireSnippetPicker` (`snippet-picker.ts:60-64`) needs `#quest-snippets`. Neither existed. `bootQuestPane` calls both eagerly, so the first `await mountQuestEditor(...)` returns and the next call throws "missing DOM anchors" before any UI renders.

## Changes

- `index.html` — add `#quest-snippets` chip-row container between editor and run row, and full `#quest-results-modal` markup styled to match the existing shortcut-sheet overlay pattern.
- `quest-pane.ts` — fix the in-flight-run vs stage-swap race. A graded result still saves stars (the run is legitimate for the original stage) but only surfaces the modal/inline status if the player hasn't navigated away. After re-rendering the picker, `select.value` follows `activeStage.id` so the dropdown tracks the player, not the run. Closes the [P2 greptile finding on #588](https://github.com/andymai/elevator-core/pull/588#discussion_r…).
- `quest-dom-guard.test.ts` — static guard parses every `getElementById("quest-…")` reference out of the feature modules and asserts each id exists in `index.html`. The next missing anchor will fail at test time instead of in production.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 214 tests pass (20 new from the per-id guard)
- [ ] Manual: open `?m=quest`, verify editor + chips + Run row + api panel + hints all render
- [ ] Manual: hit Run, verify results modal appears with stars + detail + close + retry
- [ ] Manual: click Run, immediately navigate to a different stage, verify the dropdown stays on the new stage and no stale modal appears