### PR TITLE
fix(playground): harden quest worker sandbox and protocol

### DIFF
--- a/playground/src/__tests__/quest-storage.test.ts
+++ b/playground/src/__tests__/quest-storage.test.ts
@@ -95,6 +95,19 @@ describe("quest: storage", () => {
     expect(loadCode("ok")).toBe(big);
   });
 
+  it("loadCode evicts and returns null on an oversized stored entry", () => {
+    // Plant an entry that bypasses saveCode's cap (e.g. another tab,
+    // a manual devtools poke, or a future cap change). loadCode must
+    // not return it — the editor would load a value that subsequent
+    // saves silently refuse.
+    // 50_001 chars — one over the storage module's MAX_CODE_LENGTH.
+    const huge = "z".repeat(50_001);
+    mem.setItem(`${KEY_PREFIX}poke`, huge);
+    expect(loadCode("poke")).toBeNull();
+    // Eviction is implicit: the stale entry should be gone.
+    expect(mem.getItem(`${KEY_PREFIX}poke`)).toBeNull();
+  });
+
   it("saveCode swallows setItem errors (private mode / quota)", () => {
     const setSpy = vi.spyOn(mem, "setItem").mockImplementation(() => {
       throw new Error("QuotaExceededError");

--- a/playground/src/features/quest/storage.ts
+++ b/playground/src/features/quest/storage.ts
@@ -40,12 +40,30 @@ function storage(): Storage | null {
   }
 }
 
-/** Read saved code for a stage, or `null` if no entry / unavailable. */
+/**
+ * Read saved code for a stage, or `null` if no entry / unavailable.
+ *
+ * Mirrors the `MAX_CODE_LENGTH` cap on the read path: if storage
+ * holds an oversized entry (a different tab, a manual devtools poke,
+ * or a future cap change), evict it and return `null`. Otherwise the
+ * editor would load a value that subsequent saves silently refuse,
+ * making edits *appear* to persist while every refresh reverts them.
+ */
 export function loadCode(stageId: string): string | null {
   const s = storage();
   if (!s) return null;
   try {
-    return s.getItem(CODE_PREFIX + stageId);
+    const raw = s.getItem(CODE_PREFIX + stageId);
+    if (raw === null) return null;
+    if (raw.length > MAX_CODE_LENGTH) {
+      try {
+        s.removeItem(CODE_PREFIX + stageId);
+      } catch {
+        /* eviction is best-effort */
+      }
+      return null;
+    }
+    return raw;
   } catch {
     return null;
   }

--- a/playground/src/features/quest/worker-sim.ts
+++ b/playground/src/features/quest/worker-sim.ts
@@ -244,6 +244,14 @@ export class WorkerSim {
       case "error":
         resolver.reject(new Error(msg.message));
         return;
+      default: {
+        // An unknown `kind` from a future worker version would silently
+        // leave the host promise unresolved — reject loudly instead so
+        // the caller surfaces a debuggable error.
+        const kind = (msg as { kind?: unknown }).kind;
+        resolver.reject(new Error(`WorkerSim: unknown reply kind "${String(kind)}"`));
+        return;
+      }
     }
   };
 }

--- a/playground/src/features/quest/worker.ts
+++ b/playground/src/features/quest/worker.ts
@@ -144,17 +144,18 @@ function handleSetStrategy(id: number, strategy: string): void {
  * script. wasm is already loaded by the time we get here — none of
  * these are needed for sim operations afterwards.
  *
- * We override on both the instance (`self`) and the prototype
- * (`WorkerGlobalScope.prototype`). Without the prototype hop a hostile
- * controller could sidestep the instance shadowing via
- * `Object.getPrototypeOf(self).fetch.call(self, ...)`. Idempotent
- * across calls because subsequent overrides set the same `undefined`.
+ * We override on `self` *and on every prototype up the chain*. The
+ * banned globals (`fetch`, `WebSocket`, etc.) live on
+ * `WorkerGlobalScope.prototype`, which is two hops above
+ * `DedicatedWorkerGlobalScope`. Shadowing only the first level still
+ * lets a hostile controller reach the original via
+ * `Object.getPrototypeOf(Object.getPrototypeOf(self)).fetch.call(self, …)`.
+ * Walking until `null` covers the chain regardless of how vendors
+ * structure it. Each override is wrapped in try/catch — best-effort
+ * rather than all-or-nothing — since some prototype slots are
+ * non-configurable.
  */
 function lockdownWorkerGlobals(): void {
-  const g = self as unknown as Record<string, unknown>;
-  const proto: unknown = Object.getPrototypeOf(self);
-  const protoBag =
-    proto !== null && typeof proto === "object" ? (proto as Record<string, unknown>) : null;
   const banned = [
     "fetch",
     "WebSocket",
@@ -165,29 +166,32 @@ function lockdownWorkerGlobals(): void {
     "importScripts",
     "XMLHttpRequest",
   ];
-  // Two passes so a throw on a non-writable prototype property
-  // doesn't bail the loop and leave later names with their instance
-  // shadow uncleared. Each property override is wrapped in its own
-  // try/catch — best-effort rather than all-or-nothing — because in
-  // strict mode some prototype slots are non-configurable in older
-  // runtimes. Worst case: one banned name stays accessible; the
-  // other seven are still locked. The guarantees aren't perfect,
-  // but they degrade gracefully instead of cliffing.
+  // Always shadow on the instance so direct `self.fetch` resolves to
+  // `undefined`. Then walk the prototype chain and clear at every
+  // level that owns the name — but stop short of `Object.prototype`
+  // so we don't pollute every plain object in the worker. In
+  // practice the banned names are own properties of either
+  // `WorkerGlobalScope.prototype` or its dedicated subclass.
+  const instance = self as unknown as Record<string, unknown>;
   for (const name of banned) {
     try {
-      g[name] = undefined;
+      instance[name] = undefined;
     } catch {
-      /* property is non-writable on the instance — best-effort */
+      /* non-writable on the instance — best-effort */
     }
   }
-  if (protoBag) {
+  let level: unknown = Object.getPrototypeOf(self);
+  while (level !== null && level !== Object.prototype) {
+    const bag = level as Record<string, unknown>;
     for (const name of banned) {
+      if (!Object.prototype.hasOwnProperty.call(bag, name)) continue;
       try {
-        protoBag[name] = undefined;
+        bag[name] = undefined;
       } catch {
-        /* property is non-writable on the prototype — best-effort */
+        /* non-writable / non-configurable — best-effort */
       }
     }
+    level = Object.getPrototypeOf(level);
   }
 }
 
@@ -280,5 +284,20 @@ self.addEventListener("message", (event: MessageEvent<HostToWorker>) => {
     case "load-controller":
       handleLoadController(msg.id, msg.source, msg.unlockedApi);
       return;
+    default: {
+      // Reply with an error on the request id so the host's pending
+      // promise rejects instead of hanging forever. Casting to silence
+      // the exhaustive-switch narrowing — by definition we're here
+      // because the protocol added a kind the worker doesn't handle.
+      const unknown = msg as { id?: number; kind?: string };
+      if (typeof unknown.id === "number") {
+        post({
+          kind: "error",
+          id: unknown.id,
+          message: `worker: unknown message kind "${String(unknown.kind)}"`,
+        });
+      }
+      return;
+    }
   }
 });


### PR DESCRIPTION
## Summary

Three hardenings caught by audit. None blocks ship today, but each closes a class of latent bug that's hard to debug when it eventually fires.

## Changes

1. **Lockdown walks the full prototype chain.** `fetch`, `WebSocket`, `BroadcastChannel`, etc. are own properties of `WorkerGlobalScope.prototype`, two hops above `DedicatedWorkerGlobalScope`. The previous one-level walk left them reachable via `Object.getPrototypeOf(Object.getPrototypeOf(self)).fetch.call(self, …)`. Walks until just before `Object.prototype` and only overrides at levels that own the banned name, so plain objects in the worker aren't polluted.

2. **Default arms on both message switches.** `WorkerSim.#onMessage` and the worker's `addEventListener` both lacked `default`. An unknown `kind` from a future protocol version would `delete` the pending entry on the host but never resolve/reject — caller hangs forever. Now: host rejects with a debuggable error; worker posts an `error` reply on the request id.

3. **`loadCode` enforces `MAX_CODE_LENGTH` on read.** Without this an entry planted by another tab / future cap change / manual devtools edit loads into the editor but every subsequent save silently refuses; edits appear to persist until refresh wipes them. Now: oversized entries are evicted on first read.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 195 pass (1 new oversized-eviction test)
- [x] Pre-commit hook clean