### PR TITLE
chore(playground): quest cleanup — dom-utils, drop metacomments, drop dead exports

### DIFF
--- a/playground/src/__tests__/quest-dom-guard.test.ts
+++ b/playground/src/__tests__/quest-dom-guard.test.ts
@@ -3,10 +3,14 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-// Static guard: every `document.getElementById("quest-…")` call in the
-// quest feature module must have a matching `id="…"` in index.html.
-// Without this, a missing anchor causes Quest mode to throw on boot —
-// invisible in unit tests because vitest doesn't run the page DOM.
+// Static guard: every `quest-…` id referenced by the quest feature
+// modules must have a matching `id="…"` in index.html. Missing
+// anchors cause Quest mode to throw on boot — invisible in unit
+// tests because vitest doesn't run the page DOM.
+//
+// Scans both `document.getElementById("…")` (legacy direct lookups)
+// and `requireElement("…", …)` (the dom-utils helper). New panel
+// modules go in `featureFiles`.
 const root = join(dirname(fileURLToPath(import.meta.url)), "../..");
 const featureFiles = [
   "src/features/quest/quest-pane.ts",
@@ -17,12 +21,17 @@ const featureFiles = [
 ];
 const html = readFileSync(join(root, "index.html"), "utf8");
 
-const idRefRe = /document\.getElementById\("(quest-[^"]+)"\)/g;
+const idRefRes = [
+  /document\.getElementById\("(quest-[^"]+)"\)/g,
+  /requireElement\("(quest-[^"]+)"/g,
+];
 const referencedIds = new Set<string>();
 for (const file of featureFiles) {
   const src = readFileSync(join(root, file), "utf8");
-  for (const m of src.matchAll(idRefRe)) {
-    referencedIds.add(m[1]);
+  for (const re of idRefRes) {
+    for (const m of src.matchAll(re)) {
+      referencedIds.add(m[1]);
+    }
   }
 }
 

--- a/playground/src/__tests__/quest-editor.test.ts
+++ b/playground/src/__tests__/quest-editor.test.ts
@@ -3,14 +3,11 @@ import { loadMonaco, mountQuestEditor } from "../features/quest";
 
 // These tests verify the public surface of the lazy Monaco loader.
 // Actually mounting Monaco requires a real DOM with a layout engine
-// and Web Workers — vitest's node env has neither, so the mount path
-// is exercised once the Quest mode shell wires the editor into the
-// playground in a follow-up PR.
+// and Web Workers; vitest's node env has neither, so the mount path
+// is exercised in browser only.
 
 describe("quest: editor", () => {
   it("exposes loadMonaco and mountQuestEditor", () => {
-    // Smoke check: keeps the runtime entry points reachable from a
-    // test entry while the editor isn't yet mounted by any feature.
     expect(typeof loadMonaco).toBe("function");
     expect(typeof mountQuestEditor).toBe("function");
   });

--- a/playground/src/__tests__/quest-protocol.test.ts
+++ b/playground/src/__tests__/quest-protocol.test.ts
@@ -9,11 +9,9 @@ import {
 } from "../features/quest";
 
 // These tests verify the protocol's shape and discriminated-union
-// exhaustiveness — there's no Worker spinning up here. The actual
-// host↔worker round-trip is exercised when the Quest mode shell wires
-// it into the playground in a follow-up PR; jsdom (vitest's default)
-// has no Web Workers, and instantiating the worker requires the wasm
-// pkg/ bundle which the dev pipeline already covers.
+// exhaustiveness without spinning up a real Worker. jsdom has no
+// `Worker`, and instantiating the wasm sim requires the pkg/ bundle
+// — the live host↔worker round-trip is exercised in browser only.
 
 describe("quest: protocol shape", () => {
   it("HostToWorker covers all six command kinds", () => {

--- a/playground/src/__tests__/quest-stages.test.ts
+++ b/playground/src/__tests__/quest-stages.test.ts
@@ -23,8 +23,7 @@ describe("quest: stage registry", () => {
 
   it("each stage has at most two star tiers", () => {
     // 1★ comes from `passFn`; `starFns` covers the 2★ and 3★ bonus
-    // tiers only. Anything beyond that would be invisible to the
-    // player — the grading UX (Q-09) renders 1–3 stars total.
+    // tiers only. The results modal renders at most 3 stars total.
     for (const stage of STAGES) {
       expect(stage.starFns.length).toBeLessThanOrEqual(2);
     }
@@ -45,8 +44,8 @@ describe("quest: stage registry", () => {
   });
 
   it("stage 1 (first-floor) is the curriculum entry point", () => {
-    // Stage 1 must exist and unlock `pushDestination`. Removing it
-    // would break onboarding from Q-12+.
+    // Stage 1 must exist and unlock `pushDestination` — removing it
+    // would break onboarding for every new player.
     const stage1 = stageById("first-floor");
     expect(stage1).toBeDefined();
     expect(stage1?.unlockedApi).toContain("pushDestination");

--- a/playground/src/features/quest/api-panel.ts
+++ b/playground/src/features/quest/api-panel.ts
@@ -9,6 +9,7 @@
  */
 
 import { unlockedEntries } from "./api-reference";
+import { clearChildren, requireElement } from "./dom-utils";
 import type { Stage } from "./stages";
 
 export interface ApiPanelHandles {
@@ -16,16 +17,11 @@ export interface ApiPanelHandles {
 }
 
 export function wireApiPanel(): ApiPanelHandles {
-  const root = document.getElementById("quest-api-panel");
-  if (!root) throw new Error("api-panel: missing #quest-api-panel");
-  return { root };
+  return { root: requireElement("quest-api-panel", "api-panel") };
 }
 
 export function renderApiPanel(handles: ApiPanelHandles, stage: Stage): void {
-  // Clear via removeChild so we don't trip the no-innerHTML rule.
-  while (handles.root.firstChild) {
-    handles.root.removeChild(handles.root.firstChild);
-  }
+  clearChildren(handles.root);
   const entries = unlockedEntries(stage.unlockedApi);
   if (entries.length === 0) {
     const empty = document.createElement("p");

--- a/playground/src/features/quest/dom-utils.ts
+++ b/playground/src/features/quest/dom-utils.ts
@@ -1,0 +1,27 @@
+/**
+ * Tiny DOM helpers shared across quest panel modules.
+ *
+ * Each panel previously rolled its own `getElementById` + null-check
+ * + cast pattern and its own loop to clear children (we avoid
+ * `innerHTML = ""` so the project's no-innerHTML rule doesn't get
+ * tripped). Centralising the patterns trims ~30 LOC of boilerplate
+ * and keeps the "missing anchor" error messages consistent for the
+ * `quest-dom-guard` test to scrape.
+ */
+
+/**
+ * Resolve a DOM anchor by id or throw a descriptive error. The
+ * thrown message is the test-guard's parse target, so keep the
+ * `<module>: missing #<id>` shape stable. Callers needing a more
+ * specific subtype (e.g. `HTMLButtonElement`) cast at the use site.
+ */
+export function requireElement(id: string, module: string): HTMLElement {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`${module}: missing #${id}`);
+  return el;
+}
+
+/** Remove every child node of `root`. */
+export function clearChildren(root: Node): void {
+  while (root.firstChild) root.removeChild(root.firstChild);
+}

--- a/playground/src/features/quest/editor.ts
+++ b/playground/src/features/quest/editor.ts
@@ -1,11 +1,10 @@
 /**
  * Lazy-loaded Monaco editor for Quest mode.
  *
- * Exposes a small handle so callers (Q-05's player-code execution) can
- * mount an editor, read/write the code, and dispose it without
- * importing Monaco directly. The Monaco bundle (~3MB) only loads when
- * `mountQuestEditor` is first called — Compare-mode users never pay
- * the cost.
+ * Exposes a small handle so callers can mount an editor, read/write
+ * the code, and dispose it without importing Monaco directly. The
+ * Monaco bundle (~3MB) only loads when `mountQuestEditor` is first
+ * called — Compare-mode users never pay the cost.
  *
  * The editor's web workers (TS language service + the generic editor
  * worker) are configured via `MonacoEnvironment` on first mount so

--- a/playground/src/features/quest/hints-drawer.ts
+++ b/playground/src/features/quest/hints-drawer.ts
@@ -14,6 +14,7 @@
  * while letting confident ones ignore the panel entirely.
  */
 
+import { clearChildren, requireElement } from "./dom-utils";
 import type { Stage } from "./stages";
 
 export interface HintsDrawerHandles {
@@ -23,23 +24,15 @@ export interface HintsDrawerHandles {
 }
 
 export function wireHintsDrawer(): HintsDrawerHandles {
-  const root = document.getElementById("quest-hints");
-  const count = document.getElementById("quest-hints-count");
-  const list = document.getElementById("quest-hints-list");
-  if (!root || !count || !list) {
-    throw new Error("hints-drawer: missing DOM anchors");
-  }
   return {
-    root: root as HTMLDetailsElement,
-    count,
-    list: list as HTMLOListElement,
+    root: requireElement("quest-hints", "hints-drawer") as HTMLDetailsElement,
+    count: requireElement("quest-hints-count", "hints-drawer"),
+    list: requireElement("quest-hints-list", "hints-drawer") as HTMLOListElement,
   };
 }
 
 export function renderHints(handles: HintsDrawerHandles, stage: Stage): void {
-  while (handles.list.firstChild) {
-    handles.list.removeChild(handles.list.firstChild);
-  }
+  clearChildren(handles.list);
   const total = stage.hints.length;
   if (total === 0) {
     handles.count.textContent = "(none for this stage)";

--- a/playground/src/features/quest/protocol.ts
+++ b/playground/src/features/quest/protocol.ts
@@ -86,7 +86,7 @@ export interface ResetRequest {
  *
  * Pass an empty `unlockedApi` to lock everything (mostly useful for
  * tests). Pass `null` to disable gating entirely — the controller
- * sees the full sim surface, matching the pre-Q-16 behaviour.
+ * sees the full sim surface.
  */
 export interface LoadControllerRequest {
   readonly kind: "load-controller";

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -1,18 +1,15 @@
 /**
  * Mount the Quest mode UI shell.
  *
- * Q-09 added the visible banner; Q-10 swaps the static starter-code
- * `<pre>` for a Monaco editor and wires the Run button to
- * `runStage`. Q-15 adds the stage navigator: a `<select>` lets the
- * player switch between every stage in the registry, and the chosen
- * stage round-trips through the permalink as `?qs=`.
- *
- * The function is intentionally idempotent and side-effect-light so
+ * Renders the stage banner, mounts the Monaco editor, wires the
+ * Run/Reset buttons and stage navigator, and hosts per-stage
+ * persistence. The function is idempotent and side-effect-light so
  * the shell can call it from `boot.ts` without coordinating with the
  * existing compare-mode render loop.
  */
 
 import { renderApiPanel, wireApiPanel, type ApiPanelHandles } from "./api-panel";
+import { clearChildren, requireElement } from "./dom-utils";
 import { mountQuestEditor, type QuestEditor } from "./editor";
 import { renderHints, wireHintsDrawer, type HintsDrawerHandles } from "./hints-drawer";
 import { showResults, wireResultsModal, type ResultsModalHandles } from "./results-modal";
@@ -34,32 +31,21 @@ export interface QuestPaneHandles {
 }
 
 /**
- * Wire the Quest pane DOM. Throws if the expected anchor isn't in
- * the document — the caller should only invoke this when in Quest
- * mode (the index.html ships the section hidden by default).
+ * Wire the Quest pane DOM. Throws if any expected anchor is missing —
+ * the caller should only invoke this when in Quest mode (the
+ * index.html ships the section hidden by default).
  */
 export function wireQuestPane(): QuestPaneHandles {
-  const root = document.getElementById("quest-pane");
-  if (!root) throw new Error("quest-pane: missing #quest-pane");
-  const title = document.getElementById("quest-stage-title");
-  const brief = document.getElementById("quest-stage-brief");
-  const select = document.getElementById("quest-stage-select");
-  const editorHost = document.getElementById("quest-editor");
-  const runBtn = document.getElementById("quest-run");
-  const resetBtn = document.getElementById("quest-reset");
-  const result = document.getElementById("quest-result");
-  if (!title || !brief || !select || !editorHost || !runBtn || !resetBtn || !result) {
-    throw new Error("quest-pane: missing stage banner elements");
-  }
+  const m = "quest-pane";
   return {
-    root,
-    title,
-    brief,
-    select: select as HTMLSelectElement,
-    editorHost,
-    runBtn: runBtn as HTMLButtonElement,
-    resetBtn: resetBtn as HTMLButtonElement,
-    result,
+    root: requireElement("quest-pane", m),
+    title: requireElement("quest-stage-title", m),
+    brief: requireElement("quest-stage-brief", m),
+    select: requireElement("quest-stage-select", m) as HTMLSelectElement,
+    editorHost: requireElement("quest-editor", m),
+    runBtn: requireElement("quest-run", m) as HTMLButtonElement,
+    resetBtn: requireElement("quest-reset", m) as HTMLButtonElement,
+    result: requireElement("quest-result", m),
   };
 }
 
@@ -73,12 +59,8 @@ export function renderStage(handles: QuestPaneHandles, stage: Stage): void {
 }
 
 /** Populate the stage picker from the registry. Idempotent. */
-export function populateStageSelect(handles: QuestPaneHandles): void {
-  // Clear in case of re-entry — `populateStageSelect` is called on
-  // every Quest mount and the registry is the source of truth.
-  while (handles.select.firstChild) {
-    handles.select.removeChild(handles.select.firstChild);
-  }
+function populateStageSelect(handles: QuestPaneHandles): void {
+  clearChildren(handles.select);
   STAGES.forEach((stage, index) => {
     const opt = document.createElement("option");
     opt.value = stage.id;

--- a/playground/src/features/quest/results-modal.ts
+++ b/playground/src/features/quest/results-modal.ts
@@ -9,6 +9,7 @@
  * additive — it appears on settle and dismisses on close or retry.
  */
 
+import { requireElement } from "./dom-utils";
 import type { GradeInputs } from "./stages";
 import type { StageResult } from "./stage-runner";
 
@@ -22,22 +23,14 @@ export interface ResultsModalHandles {
 }
 
 export function wireResultsModal(): ResultsModalHandles {
-  const root = document.getElementById("quest-results-modal");
-  const title = document.getElementById("quest-results-title");
-  const stars = document.getElementById("quest-results-stars");
-  const detail = document.getElementById("quest-results-detail");
-  const close = document.getElementById("quest-results-close");
-  const retry = document.getElementById("quest-results-retry");
-  if (!root || !title || !stars || !detail || !close || !retry) {
-    throw new Error("results-modal: missing DOM anchors");
-  }
+  const m = "results-modal";
   return {
-    root,
-    title,
-    stars,
-    detail,
-    close: close as HTMLButtonElement,
-    retry: retry as HTMLButtonElement,
+    root: requireElement("quest-results-modal", m),
+    title: requireElement("quest-results-title", m),
+    stars: requireElement("quest-results-stars", m),
+    detail: requireElement("quest-results-detail", m),
+    close: requireElement("quest-results-close", m) as HTMLButtonElement,
+    retry: requireElement("quest-results-retry", m) as HTMLButtonElement,
   };
 }
 

--- a/playground/src/features/quest/snippet-picker.ts
+++ b/playground/src/features/quest/snippet-picker.ts
@@ -6,15 +6,10 @@
  * click/tap. On mobile the chip row is the primary input affordance
  * for adding code; on desktop it's a faster path than typing the
  * full call.
- *
- * The chip row re-renders on stage navigation: locked methods
- * disappear, freshly-unlocked methods appear with a subtle accent
- * the first time they show up. (Actually we render every time
- * without the "fresh" treatment for v1; the per-stage-novelty
- * highlight is a follow-up.)
  */
 
 import { unlockedEntries } from "./api-reference";
+import { clearChildren, requireElement } from "./dom-utils";
 import type { QuestEditor } from "./editor";
 import type { Stage } from "./stages";
 
@@ -24,10 +19,7 @@ export interface SnippetPickerHandles {
 
 /**
  * Curated insert templates per wasm method. Mirrors API_REFERENCE
- * entries (the registry-completeness test should eventually pin
- * snippets to the reference too — for v1 the lookup falls back to
- * a generic `sim.{name}();` template, which is good enough for
- * methods I haven't hand-tuned yet).
+ * entries; missing names fall through to a generic `sim.{name}();`.
  */
 const SNIPPETS: Record<string, string> = {
   pushDestination: "sim.pushDestination(0n, 2n);",
@@ -58,9 +50,7 @@ function snippetFor(name: string): string {
 }
 
 export function wireSnippetPicker(): SnippetPickerHandles {
-  const root = document.getElementById("quest-snippets");
-  if (!root) throw new Error("snippet-picker: missing #quest-snippets");
-  return { root };
+  return { root: requireElement("quest-snippets", "snippet-picker") };
 }
 
 export function renderSnippets(
@@ -68,9 +58,7 @@ export function renderSnippets(
   stage: Stage,
   editor: QuestEditor,
 ): void {
-  while (handles.root.firstChild) {
-    handles.root.removeChild(handles.root.firstChild);
-  }
+  clearChildren(handles.root);
   const entries = unlockedEntries(stage.unlockedApi);
   if (entries.length === 0) return;
 

--- a/playground/src/features/quest/stage-runner.ts
+++ b/playground/src/features/quest/stage-runner.ts
@@ -12,9 +12,9 @@
  *      `passFn` + `starFns` to compute the result.
  *   5. Tear the worker down on the way out (success or failure).
  *
- * UI integration (results modal, retry button, stage navigation)
- * lands in a follow-up. This module is the headless engine that the
- * UI will eventually drive.
+ * The runner is intentionally headless — `quest-pane` drives the UI
+ * (results modal, retry, navigation) on top of the resolved
+ * `StageResult`.
  */
 
 import { createWorkerSim } from "./worker-sim";

--- a/playground/src/features/quest/stages/index.ts
+++ b/playground/src/features/quest/stages/index.ts
@@ -1,10 +1,10 @@
 /**
  * Quest stage registry.
  *
- * Stages are listed in display order. The registry is intentionally a
- * simple array so the picker UI (Q-12+) can iterate it directly. New
- * stages add an export from a `stage-NN-slug.ts` module and append it
- * here — no central type wrangling required.
+ * Stages are listed in display order. The registry is a simple
+ * array so the picker UI can iterate it directly. New stages export
+ * from a `stage-NN-slug.ts` module and append it here — no central
+ * type wrangling required.
  */
 
 import type { Stage } from "./types";

--- a/playground/src/features/quest/stages/stage-02-listen-up.ts
+++ b/playground/src/features/quest/stages/stage-02-listen-up.ts
@@ -51,9 +51,7 @@ export const STAGE_02_LISTEN_UP: Stage = {
     ({ delivered, abandoned, metrics }) =>
       delivered >= 10 && abandoned === 0 && metrics.avg_wait_s < 30,
     // 3★ — beat the nearest-car baseline by ~25% on average wait
-    // (under 22 sim-seconds). The cross-pane delta computation
-    // ships in Q-09's results modal; for now the absolute threshold
-    // stands in.
+    // (under 22 sim-seconds).
     ({ delivered, abandoned, metrics }) =>
       delivered >= 10 && abandoned === 0 && metrics.avg_wait_s < 22,
   ],

--- a/playground/src/features/quest/stages/types.ts
+++ b/playground/src/features/quest/stages/types.ts
@@ -3,9 +3,7 @@
  *
  * Each stage is its own typed module under `stages/`. The fields are
  * intentionally small and serializable so the registry can be loaded
- * incrementally as the curriculum grows. Q-09 grafts richer grading
- * (`starFns`, results modal); Q-10 adds the reference solution
- * gating; for v1 the schema covers what stages 1–3 need.
+ * incrementally as the curriculum grows.
  */
 
 import type { MetricsDto } from "../../../types";
@@ -78,6 +76,6 @@ export interface Stage {
   readonly starterCode: string;
   /** Progressive hints, revealed one at a time on demand. */
   readonly hints: readonly string[];
-  /** Reference solution — unlocked after a 1★ pass (Q-10). */
+  /** Reference solution — unlocked after a 1★ pass. */
   readonly referenceSolution?: string;
 }

--- a/playground/src/features/quest/worker.ts
+++ b/playground/src/features/quest/worker.ts
@@ -202,7 +202,7 @@ function lockdownWorkerGlobals(): void {
  * that doesn't exist on the underlying sim falls through unchanged
  * (typo'd properties read as `undefined`, matching the bare wasm
  * surface). `null` skips gating entirely — the controller sees the
- * full sim, matching pre-Q-16 behaviour.
+ * full sim.
  */
 function gatedSim(
   realSim: WasmSimInstance,


### PR DESCRIPTION
## Summary

Audit cleanup pass. Pure refactor — no behavior change.

## Changes

- **`dom-utils.ts`** new helpers: `requireElement(id, module)` and `clearChildren(node)`. Five panel modules (`api-panel`, `hints-drawer`, `results-modal`, `snippet-picker`, `quest-pane`) refactored onto them, removing ~30 LOC of `getElementById` + null-check + cast boilerplate plus four copies of the `while (root.firstChild) root.removeChild(...)` clear loop.
- **Metacomments stripped** per the project's "no metacomments" rule (don't narrate change history in code; that lives in PR descriptions). Touches doc headers in `editor.ts`, `protocol.ts`, `worker.ts`, `stage-runner.ts`, `stages/index.ts`, `stages/types.ts`, and inline comments in `stage-02-listen-up.ts`, the editor test, the protocol test, and the stages test.
- **`populateStageSelect`** no longer exported (was unused outside its module); reads cleaner via `clearChildren`.
- **`quest-dom-guard` test** extended to also scan `requireElement("…", …)` callsites so the static "every referenced id exists in index.html" check survives the refactor.

Net diff: -128 / +105 LOC; 215 tests still pass.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 215 pass
- [x] Pre-commit hook clean