### PR TITLE
fix(playground): correct addStopToLine arg order and tighten lockdown

### DIFF
--- a/playground/src/features/quest/api-reference.ts
+++ b/playground/src/features/quest/api-reference.ts
@@ -111,7 +111,7 @@ export const API_REFERENCE: readonly ApiEntry[] = [
   },
   {
     name: "addStopToLine",
-    signature: "addStopToLine(lineRef, stopRef): void",
+    signature: "addStopToLine(stopRef, lineRef): void",
     description: "Register a stop on a line so dispatch routes to it.",
   },
   {

--- a/playground/src/features/quest/snippet-picker.ts
+++ b/playground/src/features/quest/snippet-picker.ts
@@ -48,7 +48,7 @@ const SNIPPETS: Record<string, string> = {
   transferPoints: "const transfers = sim.transferPoints();",
   reachableStopsFrom: "const reachable = sim.reachableStopsFrom(0n);",
   addStop: 'const newStop = sim.addStop(/* lineRef */, "F6", 20.0);',
-  addStopToLine: "sim.addStopToLine(/* lineRef */, /* stopRef */);",
+  addStopToLine: "sim.addStopToLine(/* stopRef */, /* lineRef */);",
   assignLineToGroup: "sim.assignLineToGroup(/* lineRef */, /* groupId */ 1);",
   reassignElevatorToLine: "sim.reassignElevatorToLine(0n, /* lineRef */);",
 };

--- a/playground/src/features/quest/stages/stage-14-build-floor.ts
+++ b/playground/src/features/quest/stages/stage-14-build-floor.ts
@@ -48,7 +48,7 @@ const STAGE_14_STARTER = `// Stage 14 — Build a Floor
 //
 //   const lineRef = /* the line you want to add the stop to */;
 //   const newStop = sim.addStop(lineRef, "F6", 20.0);
-//   sim.addStopToLine(lineRef, newStop);
+//   sim.addStopToLine(newStop, lineRef);  // (stopRef, lineRef)
 //
 // Standard dispatch otherwise.
 
@@ -71,7 +71,7 @@ export const STAGE_14_BUILD_FLOOR: Stage = {
   starterCode: STAGE_14_STARTER,
   hints: [
     "`sim.addStop(lineRef, name, position)` creates a stop on the supplied line and returns its ref. Once it's added, the line knows about it but dispatch may need a reassign or rebuild before serving it actively.",
-    "`sim.addStopToLine(lineRef, stopRef)` is what binds an *existing* stop to a line — useful when you've created a stop with `addStop` on a different line and want it shared.",
+    "`sim.addStopToLine(stopRef, lineRef)` is what binds an *existing* stop to a line — useful when you've created a stop with `addStop` on a different line and want it shared. Note the arg order: stop first, then line.",
     "3★ requires sub-25s average wait with no abandons — react quickly to the construction-complete event so waiting riders don't time out.",
   ],
 };

--- a/playground/src/features/quest/worker.ts
+++ b/playground/src/features/quest/worker.ts
@@ -172,26 +172,34 @@ function lockdownWorkerGlobals(): void {
   // so we don't pollute every plain object in the worker. In
   // practice the banned names are own properties of either
   // `WorkerGlobalScope.prototype` or its dedicated subclass.
-  const instance = self as unknown as Record<string, unknown>;
-  for (const name of banned) {
-    try {
-      instance[name] = undefined;
-    } catch {
-      /* non-writable on the instance — best-effort */
-    }
-  }
+  //
+  // `Object.defineProperty` instead of plain assignment because some
+  // platforms expose the banned names as getter-only accessors —
+  // `bag.fetch = undefined` throws TypeError in strict mode for those,
+  // even when the descriptor is `configurable: true`. defineProperty
+  // replaces the accessor with a data property cleanly.
+  silence(self as unknown as Record<string, unknown>, banned);
   let level: unknown = Object.getPrototypeOf(self);
   while (level !== null && level !== Object.prototype) {
     const bag = level as Record<string, unknown>;
-    for (const name of banned) {
-      if (!Object.prototype.hasOwnProperty.call(bag, name)) continue;
-      try {
-        bag[name] = undefined;
-      } catch {
-        /* non-writable / non-configurable — best-effort */
-      }
-    }
+    silence(bag, banned, /* ownOnly */ true);
     level = Object.getPrototypeOf(level);
+  }
+}
+
+function silence(bag: Record<string, unknown>, names: readonly string[], ownOnly = false): void {
+  for (const name of names) {
+    if (ownOnly && !Object.prototype.hasOwnProperty.call(bag, name)) continue;
+    try {
+      Object.defineProperty(bag, name, {
+        value: undefined,
+        writable: true,
+        configurable: true,
+        enumerable: false,
+      });
+    } catch {
+      /* non-configurable property — best-effort */
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Two greptile findings from #590/#591:

- **`addStopToLine` arg order** (P1, missed in #591). Wasm signature is `add_stop_to_line(stop_ref, line_ref)` — Quest had `(lineRef, stopRef)` in the API reference, the snippet, and Stage 14's starter + hint. Players using Stage 14 would silently miswire the topology. Stage 14 hint now calls out the order explicitly so it doesn't drift again.
- **Worker lockdown getter-only handling** (P2). `bag[name] = undefined` throws `TypeError` in strict mode for getter-only prototype properties — so on platforms that expose `fetch`/`WebSocket`/etc. as accessors, the lockdown silently failed. Replaces plain assignment with `Object.defineProperty(..., { value: undefined, writable: true, configurable: true })`, which replaces accessor slots cleanly. No behavior change for writable data properties.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 215 pass
- [x] Pre-commit hook clean