### PR TITLE
perf(playground): drop dead-weight from quest tick payload + small wins

### DIFF
--- a/playground/src/features/quest/editor.ts
+++ b/playground/src/features/quest/editor.ts
@@ -30,8 +30,13 @@ export interface QuestEditor {
   getValue(): string;
   /** Replace the editor's text. */
   setValue(text: string): void;
-  /** Subscribe to text changes. Returns an unsubscribe handle. */
-  onDidChange(listener: (value: string) => void): { dispose(): void };
+  /**
+   * Subscribe to text changes. The listener is called with no
+   * argument to avoid a `getValue()` allocation on every keystroke;
+   * call `getValue()` from the listener if the current text is
+   * actually needed.
+   */
+  onDidChange(listener: () => void): { dispose(): void };
   /** Insert `text` at the current cursor position and focus the editor. */
   insertAtCursor(text: string): void;
   /** Tear down the editor and free its DOM/worker resources. */
@@ -117,7 +122,7 @@ export async function mountQuestEditor(opts: EditorMountOptions): Promise<QuestE
     },
     onDidChange(listener) {
       const sub = editor.onDidChangeModelContent(() => {
-        listener(editor.getValue());
+        listener();
       });
       return {
         dispose: () => {

--- a/playground/src/features/quest/protocol.ts
+++ b/playground/src/features/quest/protocol.ts
@@ -31,12 +31,20 @@ export interface InitPayload {
   readonly wasmBgUrl: string;
 }
 
-/** Snapshot bundle returned after a `tick` request. */
+/**
+ * Snapshot bundle returned after a `tick` request.
+ *
+ * `snapshot` and `events` are only populated when the host requested
+ * visuals (`wantVisuals: true` on the `TickRequest`). In the headless
+ * grading path they're undefined — the worker skips both wasm calls
+ * entirely so we don't pay for snapshot serialization or event drain
+ * on every batch when only `metrics` + `tick` are read.
+ */
 export interface TickResultPayload {
-  readonly snapshot: Snapshot;
   readonly tick: number;
-  readonly events: readonly EventDto[];
   readonly metrics: MetricsDto;
+  readonly snapshot?: Snapshot;
+  readonly events?: readonly EventDto[];
 }
 
 // ─── Host → Worker ──────────────────────────────────────────────────
@@ -51,6 +59,13 @@ export interface TickRequest {
   readonly kind: "tick";
   readonly id: number;
   readonly ticks: number;
+  /**
+   * Set true when the host needs the snapshot + event bundle for a
+   * visualizer or replay. Default false — saves a wasm `snapshot()`
+   * and a wasm `drainEvents()` per batch in the headless grading
+   * path, which on stage-15-scale configs is a measurable win.
+   */
+  readonly wantVisuals?: boolean;
 }
 
 export interface SpawnRiderRequest {

--- a/playground/src/features/quest/stage-runner.ts
+++ b/playground/src/features/quest/stage-runner.ts
@@ -100,7 +100,7 @@ export async function runStage(
       endTick = result.tick;
       const grade = makeGrade(lastMetrics, endTick);
       if (stage.passFn(grade)) {
-        return finalize(stage, grade);
+        return finalize(stage, grade, true);
       }
     }
 
@@ -109,7 +109,7 @@ export async function runStage(
       // guard so the type narrows below.
       throw new Error("runStage: maxTicks must be positive");
     }
-    return finalize(stage, makeGrade(lastMetrics, endTick));
+    return finalize(stage, makeGrade(lastMetrics, endTick), null);
   } finally {
     sim.dispose();
   }
@@ -124,8 +124,14 @@ function makeGrade(metrics: MetricsDto, endTick: number): GradeInputs {
   };
 }
 
-function finalize(stage: Stage, grade: GradeInputs): StageResult {
-  const passed = stage.passFn(grade);
+/**
+ * Build the final `StageResult` from a grade. `passedHint` lets the
+ * caller skip a redundant `passFn` call when it already knows the
+ * outcome (the early-exit path in `runStage` does); pass `null` to
+ * have `finalize` evaluate `passFn` itself.
+ */
+function finalize(stage: Stage, grade: GradeInputs, passedHint: boolean | null): StageResult {
+  const passed = passedHint ?? stage.passFn(grade);
   if (!passed) {
     return { passed: false, stars: 0, grade };
   }

--- a/playground/src/features/quest/worker-sim.ts
+++ b/playground/src/features/quest/worker-sim.ts
@@ -58,11 +58,21 @@ export class WorkerSim {
     });
   }
 
-  async tick(ticks: number): Promise<TickResultPayload> {
+  /**
+   * Step the sim by `ticks` ticks and return the post-step bundle.
+   *
+   * `wantVisuals` defaults to `false` — the worker skips the wasm
+   * `snapshot()` and `drainEvents()` calls when nobody on the host
+   * will read them. Visualizers / replay UIs pass `true` to receive
+   * the full bundle.
+   */
+  async tick(ticks: number, options?: { wantVisuals?: boolean }): Promise<TickResultPayload> {
+    const wantVisuals = options?.wantVisuals ?? false;
     return this.#request<TickResultPayload>({
       kind: "tick",
       id: this.#takeId(),
       ticks,
+      ...(wantVisuals ? { wantVisuals: true } : {}),
     });
   }
 

--- a/playground/src/features/quest/worker.ts
+++ b/playground/src/features/quest/worker.ts
@@ -11,6 +11,7 @@
  */
 declare const self: DedicatedWorkerGlobalScope;
 
+import type { EventDto, MetricsDto, Snapshot } from "../../types";
 import type { HostToWorker, InitPayload, TickResultPayload, WorkerToHost } from "./protocol";
 
 interface WasmModule {
@@ -32,9 +33,9 @@ interface WasmSimInstance {
     weight: number,
     patienceTicks?: number,
   ): { kind: "ok"; value: bigint } | { kind: "err"; error: string };
-  snapshot(): TickResultPayload["snapshot"];
-  drainEvents(): TickResultPayload["events"][number][];
-  metrics(): TickResultPayload["metrics"];
+  snapshot(): Snapshot;
+  drainEvents(): EventDto[];
+  metrics(): MetricsDto;
   free(): void;
 }
 
@@ -75,19 +76,20 @@ async function handleInit(id: number, payload: InitPayload): Promise<void> {
   }
 }
 
-function handleTick(id: number, ticks: number): void {
+function handleTick(id: number, ticks: number, wantVisuals: boolean): void {
   if (!sim) {
     post({ kind: "error", id, message: "tick before init" });
     return;
   }
   try {
     sim.stepMany(ticks);
-    const result: TickResultPayload = {
-      snapshot: sim.snapshot(),
-      tick: Number(sim.currentTick()),
-      events: sim.drainEvents(),
-      metrics: sim.metrics(),
-    };
+    const tick = Number(sim.currentTick());
+    const metrics = sim.metrics();
+    // exactOptionalPropertyTypes rejects an explicit `undefined` on
+    // optional fields, so build the result with two literal shapes.
+    const result: TickResultPayload = wantVisuals
+      ? { tick, metrics, snapshot: sim.snapshot(), events: sim.drainEvents() }
+      : { tick, metrics };
     post({ kind: "tick-result", id, result });
   } catch (err) {
     post({ kind: "error", id, message: errorMessage(err) });
@@ -281,7 +283,7 @@ self.addEventListener("message", (event: MessageEvent<HostToWorker>) => {
       void handleInit(msg.id, msg.payload);
       return;
     case "tick":
-      handleTick(msg.id, msg.ticks);
+      handleTick(msg.id, msg.ticks, msg.wantVisuals === true);
       return;
     case "spawn-rider":
       handleSpawnRider(msg.id, msg.origin, msg.destination, msg.weight, msg.patienceTicks);


### PR DESCRIPTION
## Summary

Optimizer audit found the headless grading path serializing `snapshot()` + `drainEvents()` across the worker boundary on every tick batch but `runStage` reads only `metrics` + `tick`. On a stage-15 nine-stop / three-car config that's ~25 batches × the full DTO tree per batch, all of it discarded.

## Changes

- **`TickRequest.wantVisuals`** (optional, default false) controls whether the worker computes the snapshot bundle. `WorkerSim.tick(N, { wantVisuals: true })` opts in for visualizers / replay UIs that actually need it. Headless callers (the existing `stage-runner` is the only one) now skip both wasm calls — saves snapshot serialization, event-buffer drain, and structured-clone cost on every batch.
- **`TickResultPayload.snapshot` and `events`** are now optional. Consumers that need them must check or pass `wantVisuals: true`.
- **`finalize` accepts a `passedHint`** so the early-exit path in `runStage` doesn't pay for a redundant `passFn` call (was called twice on every passing batch).
- **`editor.onDidChange` listener is now `() => void`** — the previous shape called `editor.getValue()` on every keystroke and the only consumer (autosave debounce) ignored the value. Drops a piece-tree string allocation per keystroke.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 215 pass
- [x] Pre-commit hook clean
- [ ] Manual: run a stage end-to-end, verify it grades correctly without the snapshot bundle
- [ ] Manual: trace a worker postMessage payload size before/after — expect 90%+ reduction on tick replies