### PR TITLE
fix(playground): drain quest event buffer every tick + simplify passFn hint

### DIFF
--- a/playground/src/features/quest/stage-runner.ts
+++ b/playground/src/features/quest/stage-runner.ts
@@ -109,7 +109,9 @@ export async function runStage(
       // guard so the type narrows below.
       throw new Error("runStage: maxTicks must be positive");
     }
-    return finalize(stage, makeGrade(lastMetrics, endTick), null);
+    // Loop exited because every tested batch's `passFn` returned
+    // `false` — pass that through so `finalize` doesn't re-evaluate.
+    return finalize(stage, makeGrade(lastMetrics, endTick), false);
   } finally {
     sim.dispose();
   }
@@ -125,13 +127,12 @@ function makeGrade(metrics: MetricsDto, endTick: number): GradeInputs {
 }
 
 /**
- * Build the final `StageResult` from a grade. `passedHint` lets the
- * caller skip a redundant `passFn` call when it already knows the
- * outcome (the early-exit path in `runStage` does); pass `null` to
- * have `finalize` evaluate `passFn` itself.
+ * Build the final `StageResult` from a grade. `passed` is supplied by
+ * the caller — both call sites in `runStage` already know it (one
+ * from the early-exit `passFn(grade)` branch, the other from the
+ * loop's exit condition), so `finalize` doesn't re-evaluate.
  */
-function finalize(stage: Stage, grade: GradeInputs, passedHint: boolean | null): StageResult {
-  const passed = passedHint ?? stage.passFn(grade);
+function finalize(stage: Stage, grade: GradeInputs, passed: boolean): StageResult {
   if (!passed) {
     return { passed: false, stars: 0, grade };
   }

--- a/playground/src/features/quest/worker.ts
+++ b/playground/src/features/quest/worker.ts
@@ -85,10 +85,16 @@ function handleTick(id: number, ticks: number, wantVisuals: boolean): void {
     sim.stepMany(ticks);
     const tick = Number(sim.currentTick());
     const metrics = sim.metrics();
+    // Always drain so the wasm `EventBus` (an unbounded `Vec<Event>`)
+    // doesn't grow for the lifetime of the worker. The per-batch
+    // serialization cost stays, but the saved postMessage bandwidth
+    // (and the snapshot serialization, which is the bigger win)
+    // still come back when wantVisuals is false.
+    const events = sim.drainEvents();
     // exactOptionalPropertyTypes rejects an explicit `undefined` on
     // optional fields, so build the result with two literal shapes.
     const result: TickResultPayload = wantVisuals
-      ? { tick, metrics, snapshot: sim.snapshot(), events: sim.drainEvents() }
+      ? { tick, metrics, snapshot: sim.snapshot(), events }
       : { tick, metrics };
     post({ kind: "tick-result", id, result });
   } catch (err) {


### PR DESCRIPTION
## Summary

Two greptile P2s from #594.

## Changes

- **Always drain the wasm event buffer.** The wasm `EventBus` is `Vec<Event>` (unbounded) — the previous skip in the headless path meant events accumulated for the worker's entire lifetime. Now `drainEvents()` fires every batch; the result is still excluded from the postMessage payload when `wantVisuals` is false, so the snapshot-serialization win (the bigger cost) survives. Per-batch event serialization stays, but the buffer is bounded.
- **Pass `false` to `finalize` on the timeout path.** The loop only exits when every batch's `passFn` returned `false`, so passing `null` and forcing a redundant evaluation defeats the whole point of the `passedHint`. Collapses the parameter to `passed: boolean` since both call sites already know.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 215 pass
- [x] Pre-commit hook clean