### PR TITLE
feat(playground): compare/quest mode toggle

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -31,26 +31,24 @@
 
         <div
           id="mode-toggle"
-          role="tablist"
+          role="group"
           aria-label="Playground mode"
           class="md:order-1 inline-flex items-center gap-0 rounded-md bg-surface-secondary border border-stroke-subtle p-0.5 shrink-0"
         >
           <button
             type="button"
-            role="tab"
             data-mode="compare"
             data-active="true"
-            aria-selected="true"
+            aria-pressed="true"
             class="px-2.5 py-1 rounded-sm bg-transparent border-0 text-[11.5px] font-semibold tracking-[0.02em] cursor-pointer transition-colors duration-fast text-content-tertiary hover:text-content data-[active=true]:text-content data-[active=true]:bg-surface-elevated focus-visible:outline-none focus-visible:text-content"
           >
             Compare
           </button>
           <button
             type="button"
-            role="tab"
             data-mode="quest"
             data-active="false"
-            aria-selected="false"
+            aria-pressed="false"
             class="px-2.5 py-1 rounded-sm bg-transparent border-0 text-[11.5px] font-semibold tracking-[0.02em] cursor-pointer transition-colors duration-fast text-content-tertiary hover:text-content data-[active=true]:text-content data-[active=true]:bg-surface-elevated focus-visible:outline-none focus-visible:text-content"
           >
             Quest

--- a/playground/index.html
+++ b/playground/index.html
@@ -29,6 +29,34 @@
           >
         </h1>
 
+        <div
+          id="mode-toggle"
+          role="tablist"
+          aria-label="Playground mode"
+          class="md:order-1 inline-flex items-center gap-0 rounded-md bg-surface-secondary border border-stroke-subtle p-0.5 shrink-0"
+        >
+          <button
+            type="button"
+            role="tab"
+            data-mode="compare"
+            data-active="true"
+            aria-selected="true"
+            class="px-2.5 py-1 rounded-sm bg-transparent border-0 text-[11.5px] font-semibold tracking-[0.02em] cursor-pointer transition-colors duration-fast text-content-tertiary hover:text-content data-[active=true]:text-content data-[active=true]:bg-surface-elevated focus-visible:outline-none focus-visible:text-content"
+          >
+            Compare
+          </button>
+          <button
+            type="button"
+            role="tab"
+            data-mode="quest"
+            data-active="false"
+            aria-selected="false"
+            class="px-2.5 py-1 rounded-sm bg-transparent border-0 text-[11.5px] font-semibold tracking-[0.02em] cursor-pointer transition-colors duration-fast text-content-tertiary hover:text-content data-[active=true]:text-content data-[active=true]:bg-surface-elevated focus-visible:outline-none focus-visible:text-content"
+          >
+            Quest
+          </button>
+        </div>
+
         <nav
           class="ml-auto md:order-3 flex items-center gap-4 shrink-0 max-md:gap-3"
           aria-label="External links"
@@ -55,6 +83,7 @@
         </nav>
 
         <div
+          id="cabin-legend"
           class="md:order-2 flex max-lg:hidden items-center gap-x-3 gap-y-1 flex-wrap text-[10.5px] text-content-tertiary min-w-0"
           aria-label="Cabin color legend"
         >
@@ -80,6 +109,7 @@
     </header>
 
     <section
+      id="scenario-picker"
       aria-label="Scenario picker"
       class="scenario-cards flex flex-row items-center gap-3 px-5 py-1.5 border-b border-stroke-subtle max-md:gap-2 max-md:px-3.5 max-md:py-1.5"
     >

--- a/playground/src/domain/index.ts
+++ b/playground/src/domain/index.ts
@@ -5,6 +5,7 @@ export {
   hashSeedWord,
   syncPermalinkUrl,
   type PermalinkState,
+  type PlaygroundMode,
 } from "./permalink";
 export {
   PARAM_KEYS,

--- a/playground/src/features/mode-toggle.ts
+++ b/playground/src/features/mode-toggle.ts
@@ -1,0 +1,86 @@
+/**
+ * Header-level Compare ⇆ Quest toggle.
+ *
+ * Two responsibilities:
+ *
+ * 1. `applyPlaygroundMode` — reflect the active mode in the DOM by
+ *    hiding the chrome that doesn't belong to the active surface.
+ *    Compare mode owns the layout panes, scenario picker, controls
+ *    bar, and cabin-color legend; Quest mode owns the curriculum
+ *    pane. Called from boot before first paint so a Quest deep-link
+ *    doesn't flash the compare-mode chrome on cold load.
+ *
+ * 2. `wireModeToggle` — sync the toggle's pressed state to the
+ *    current mode and turn clicks into a permalink-preserving
+ *    navigation. We deliberately reload rather than swap modes in
+ *    place: Monaco's lazy mount, the compare render loop, and the
+ *    wasm sim's lifecycle all assume a single mode for the page's
+ *    lifetime, and a hard reload is far simpler than threading
+ *    teardown for each.
+ */
+import type { PlaygroundMode } from "../domain";
+
+/** Elements that exist for compare mode and have no Quest meaning. */
+const COMPARE_CHROME_IDS = ["layout", "scenario-picker", "controls-bar", "cabin-legend"] as const;
+
+/** Elements that exist for Quest mode only. */
+const QUEST_CHROME_IDS = ["quest-pane"] as const;
+
+/**
+ * Apply the active playground mode to the DOM. Idempotent — safe to
+ * call repeatedly. Quest pane uses `flex` as its visible display so we
+ * pair the `hidden` toggle with `flex` rather than relying on Tailwind's
+ * default block.
+ */
+export function applyPlaygroundMode(mode: PlaygroundMode): void {
+  const isQuest = mode === "quest";
+  for (const id of COMPARE_CHROME_IDS) {
+    const el = document.getElementById(id);
+    if (el) el.classList.toggle("hidden", isQuest);
+  }
+  for (const id of QUEST_CHROME_IDS) {
+    const el = document.getElementById(id);
+    if (!el) continue;
+    el.classList.toggle("hidden", !isQuest);
+    el.classList.toggle("flex", isQuest);
+  }
+}
+
+/**
+ * Wire the Compare ⇆ Quest segmented toggle.
+ *
+ * Reflects the active mode via `data-active` (Tailwind's
+ * `data-[active=true]:*` variants render the pressed chip) and
+ * `aria-selected`. Clicks rewrite the URL to swap modes and reload —
+ * the new mode flows through `boot()` cleanly, including Monaco's
+ * lazy-load on first Quest entry.
+ */
+export function wireModeToggle(currentMode: PlaygroundMode): void {
+  const root = document.getElementById("mode-toggle");
+  if (!root) return;
+  const buttons = root.querySelectorAll<HTMLButtonElement>("button[data-mode]");
+  for (const btn of buttons) {
+    const isActive = btn.dataset["mode"] === currentMode;
+    btn.dataset["active"] = String(isActive);
+    btn.setAttribute("aria-selected", String(isActive));
+  }
+  root.addEventListener("click", (ev) => {
+    const target = ev.target;
+    if (!(target instanceof HTMLElement)) return;
+    const btn = target.closest<HTMLButtonElement>("button[data-mode]");
+    if (!btn) return;
+    const next = btn.dataset["mode"];
+    if (next !== "compare" && next !== "quest") return;
+    if (next === currentMode) return;
+    const url = new URL(window.location.href);
+    if (next === "compare") {
+      // `qs` is a Quest-only key; drop it so a returning compare-mode
+      // URL stays clean.
+      url.searchParams.delete("m");
+      url.searchParams.delete("qs");
+    } else {
+      url.searchParams.set("m", next);
+    }
+    window.location.assign(url.toString());
+  });
+}

--- a/playground/src/features/mode-toggle.ts
+++ b/playground/src/features/mode-toggle.ts
@@ -51,9 +51,13 @@ export function applyPlaygroundMode(mode: PlaygroundMode): void {
  *
  * Reflects the active mode via `data-active` (Tailwind's
  * `data-[active=true]:*` variants render the pressed chip) and
- * `aria-selected`. Clicks rewrite the URL to swap modes and reload —
- * the new mode flows through `boot()` cleanly, including Monaco's
- * lazy-load on first Quest entry.
+ * `aria-pressed`. The toggle is a `role="group"` of plain buttons
+ * rather than a `role="tablist"` because activation navigates (a
+ * full reload) instead of swapping panels in the same view — plain
+ * Tab/Shift+Tab is the right keyboard model, no roving tabindex /
+ * arrow-key contract to honor. Clicks rewrite the URL to swap modes
+ * and reload; the new mode flows through `boot()` cleanly, including
+ * Monaco's lazy-load on first Quest entry.
  */
 export function wireModeToggle(currentMode: PlaygroundMode): void {
   const root = document.getElementById("mode-toggle");
@@ -62,7 +66,7 @@ export function wireModeToggle(currentMode: PlaygroundMode): void {
   for (const btn of buttons) {
     const isActive = btn.dataset["mode"] === currentMode;
     btn.dataset["active"] = String(isActive);
-    btn.setAttribute("aria-selected", String(isActive));
+    btn.setAttribute("aria-pressed", String(isActive));
   }
   root.addEventListener("click", (ev) => {
     const target = ev.target;

--- a/playground/src/features/quest/index.ts
+++ b/playground/src/features/quest/index.ts
@@ -13,14 +13,7 @@ export {
   type UnlockedApi,
 } from "./stages";
 export { runStage, type StageResult, type RunStageOptions } from "./stage-runner";
-export {
-  bootQuestPane,
-  hideQuestPane,
-  renderStage,
-  showQuestPane,
-  wireQuestPane,
-  type QuestPaneHandles,
-} from "./quest-pane";
+export { bootQuestPane, renderStage, wireQuestPane, type QuestPaneHandles } from "./quest-pane";
 export {
   hideResults,
   showResults,

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -81,25 +81,21 @@ function stageOptionLabel(stage: Stage, index: number, stars: StarCount): string
 }
 
 /**
- * Show the Quest pane and hide the existing compare layout.
- *
- * Compare mode keeps its DOM intact — we toggle visibility rather
- * than tear it down so the user can flip back via permalink without
- * a remount cost.
+ * Show / hide the Quest pane only — the compare-mode chrome (layout,
+ * scenario picker, controls bar, cabin legend) is owned by
+ * `applyPlaygroundMode` in `mode-toggle.ts`, which boot calls before
+ * first paint. These helpers stay around so callers that want to flip
+ * the Quest pane independently still can, but the cross-mode chrome
+ * concerns live in one place.
  */
 export function showQuestPane(handles: QuestPaneHandles): void {
-  const layout = document.getElementById("layout");
-  if (layout) layout.classList.add("hidden");
   handles.root.classList.remove("hidden");
   handles.root.classList.add("flex");
 }
 
-/** Inverse of `showQuestPane`. */
 export function hideQuestPane(handles: QuestPaneHandles): void {
   handles.root.classList.add("hidden");
   handles.root.classList.remove("flex");
-  const layout = document.getElementById("layout");
-  if (layout) layout.classList.remove("hidden");
 }
 
 /**

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -81,24 +81,6 @@ function stageOptionLabel(stage: Stage, index: number, stars: StarCount): string
 }
 
 /**
- * Show / hide the Quest pane only — the compare-mode chrome (layout,
- * scenario picker, controls bar, cabin legend) is owned by
- * `applyPlaygroundMode` in `mode-toggle.ts`, which boot calls before
- * first paint. These helpers stay around so callers that want to flip
- * the Quest pane independently still can, but the cross-mode chrome
- * concerns live in one place.
- */
-export function showQuestPane(handles: QuestPaneHandles): void {
-  handles.root.classList.remove("hidden");
-  handles.root.classList.add("flex");
-}
-
-export function hideQuestPane(handles: QuestPaneHandles): void {
-  handles.root.classList.add("hidden");
-  handles.root.classList.remove("flex");
-}
-
-/**
  * Wire the Run button to execute the editor's current text against
  * the active stage. The stage is read via the supplied getter on
  * each click so a navigation between Run presses pulls the new
@@ -178,7 +160,6 @@ export async function bootQuestPane(opts: {
 
   let activeStage = resolveStage(opts.initialStageId);
   renderStage(handles, activeStage);
-  showQuestPane(handles);
 
   // Side panel: list the methods unlocked at the active stage.
   // Re-renders on stage change so the player always sees what

--- a/playground/src/shell/boot.ts
+++ b/playground/src/shell/boot.ts
@@ -1,4 +1,5 @@
 import { reconcileStrategyWithScenario } from "../features/scenario-picker";
+import { applyPlaygroundMode, wireModeToggle } from "../features/mode-toggle";
 import { bootQuestPane } from "../features/quest";
 import {
   DEFAULT_STATE,
@@ -72,6 +73,11 @@ export async function boot(): Promise<void> {
   // is the decode-side counterpart, done once at boot rather than in
   // every subsequent write path.
   permalink.overrides = compactOverrides(scenario, permalink.overrides);
+  // Apply mode-derived visibility before any paint: a `?m=quest`
+  // deep-link should never flash the compare-mode chrome. Wiring the
+  // toggle here also avoids a second pass over the same DOM nodes.
+  applyPlaygroundMode(permalink.mode);
+  wireModeToggle(permalink.mode);
   applyPermalinkToUi(permalink, ui);
   const state: State = {
     running: true,


### PR DESCRIPTION
## Summary

Quest mode was unreachable without typing `?m=quest` directly into the URL bar — flagged in the UX assessment as the single highest-impact gap. This PR adds a segmented Compare ⇆ Quest toggle in the header and centralizes mode-derived chrome visibility so the compare-mode chrome (scenario picker, controls bar, cabin legend) stops leaking through into Quest's UI.

## Changes

- **`playground/src/features/mode-toggle.ts`** — new feature module with two exports: `applyPlaygroundMode(mode)` toggles visibility of compare-only and quest-only DOM nodes, `wireModeToggle(currentMode)` reflects the active mode in the toggle and turns clicks into a permalink-preserving reload.
- **`playground/index.html`** — header gains a segmented toggle (`#mode-toggle`) right after the title with `Compare` / `Quest` segments. Adds `id` attributes to `#scenario-picker` and `#cabin-legend` so the chrome helper can find them.
- **`playground/src/shell/boot.ts`** — calls `applyPlaygroundMode(permalink.mode)` and `wireModeToggle(permalink.mode)` before `applyPermalinkToUi` and any await — so a `?m=quest` deep-link doesn't flash the compare chrome on cold load.
- **`playground/src/features/quest/quest-pane.ts`** — `showQuestPane` / `hideQuestPane` no longer touch `#layout`; that's now `applyPlaygroundMode`'s job. Helpers retained for completeness, narrowed to just the Quest pane root.
- **`playground/src/domain/index.ts`** — re-exports `PlaygroundMode` so `mode-toggle.ts` doesn't have to reach into the permalink subtree.

## Design notes

**Hard reload, not in-place swap.** Monaco's lazy mount, the compare render loop, and the wasm sim's lifecycle all assume a single mode for the page's lifetime. Threading teardown for each into a live mode swap would be substantially more code than letting `boot()` run again with the new mode in the URL — and a reload is genuinely faster than re-mounting Monaco anyway.

**Visibility helper owns the cross-mode concerns.** Previously `showQuestPane` reached out and grabbed `#layout` — fine when there was one element, awkward as soon as the chrome list grew. `applyPlaygroundMode` now owns the whole list (`#layout`, `#scenario-picker`, `#controls-bar`, `#cabin-legend` for compare; `#quest-pane` for Quest), so future chrome additions are one-line edits.

## Out of scope

The UX assessment listed several other Quest fixes (live execution feedback, results modal "next stage" CTA, stage-grid navigator, reference-solution unlock, failure-message specificity, Monaco theme alignment). Those land in follow-up PRs; this one is intentionally narrow so the discoverability fix lands fast.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (no new warnings)
- [x] `pnpm test` — 215 pass
- [x] `pnpm build` succeeds
- [x] Pre-commit hook clean
- [ ] Manual: load `/` → toggle reads `Compare` active, `Quest` inactive
- [ ] Manual: click `Quest` → URL gains `?m=quest`, page reloads into curriculum, scenario row + controls bar + cabin legend hidden
- [ ] Manual: click `Compare` → URL drops `m`+`qs`, page reloads into compare, all chrome restored
- [ ] Manual: deep-link `?m=quest` → no flash of compare chrome on cold boot
- [ ] Manual mobile: toggle visible in header on portrait + landscape (P0)