### PR TITLE
feat(playground): live progress while a quest stage runs

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -590,7 +590,7 @@
         aria-label="Quest controller editor"
       ></div>
       <div id="quest-snippets" class="flex flex-wrap gap-1.5" aria-label="Insert API call"></div>
-      <div class="flex items-center gap-3">
+      <div class="flex flex-wrap items-center gap-x-3 gap-y-1.5">
         <button
           type="button"
           id="quest-run"
@@ -610,6 +610,11 @@
           id="quest-result"
           class="text-content-secondary text-[12.5px] tracking-[0.01em]"
           aria-live="polite"
+        ></span>
+        <span
+          id="quest-progress"
+          class="text-content-tertiary text-[11.5px] tabular-nums tracking-[0.01em] ml-auto"
+          aria-hidden="true"
         ></span>
       </div>
       <aside

--- a/playground/src/__tests__/quest-stage-progress.test.ts
+++ b/playground/src/__tests__/quest-stage-progress.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { formatProgress, type GradeInputs } from "../features/quest";
+import type { MetricsDto } from "../types";
+
+// `formatProgress` shapes the live "Tick X · Y delivered · Zs avg wait"
+// readout that runs beneath the Run button while a stage is executing.
+// The cases below pin the elision rules so a future tweak to the format
+// can't silently drop the early-batch "waiting…" message or paint
+// `0.0s avg wait` before the first rider has been delivered.
+
+function metrics(over: Partial<MetricsDto> = {}): MetricsDto {
+  return {
+    delivered: 0,
+    abandoned: 0,
+    spawned: 0,
+    settled: 0,
+    rerouted: 0,
+    throughput: 0,
+    avg_wait_s: 0,
+    max_wait_s: 0,
+    avg_ride_s: 0,
+    utilization: 0,
+    abandonment_rate: 0,
+    total_distance: 0,
+    total_moves: 0,
+    ...over,
+  };
+}
+
+function grade(over: Partial<GradeInputs> = {}): GradeInputs {
+  return {
+    metrics: metrics(),
+    endTick: 60,
+    delivered: 0,
+    abandoned: 0,
+    ...over,
+  };
+}
+
+describe("quest: formatProgress", () => {
+  it("shows waiting… on the first batch with no riders moved", () => {
+    expect(formatProgress(grade({ endTick: 60 }))).toBe("Tick 60 · waiting…");
+  });
+
+  it("includes delivered count once any rider has arrived", () => {
+    expect(formatProgress(grade({ endTick: 240, delivered: 3 }))).toBe("Tick 240 · 3 delivered");
+  });
+
+  it("renders avg wait once samples exist, to one decimal place", () => {
+    const out = formatProgress(
+      grade({
+        endTick: 600,
+        delivered: 5,
+        metrics: metrics({ delivered: 5, avg_wait_s: 12.345 }),
+      }),
+    );
+    expect(out).toBe("Tick 600 · 5 delivered · 12.3s avg wait");
+  });
+
+  it("includes abandons clause only when non-zero", () => {
+    const withAbandons = formatProgress(grade({ endTick: 480, delivered: 4, abandoned: 1 }));
+    expect(withAbandons).toBe("Tick 480 · 4 delivered · 1 abandoned");
+    const clean = formatProgress(grade({ endTick: 480, delivered: 4, abandoned: 0 }));
+    expect(clean).toBe("Tick 480 · 4 delivered");
+  });
+
+  it("omits avg wait when the metric is zero or non-finite", () => {
+    const zero = formatProgress(
+      grade({ endTick: 120, delivered: 1, metrics: metrics({ delivered: 1, avg_wait_s: 0 }) }),
+    );
+    expect(zero).toBe("Tick 120 · 1 delivered");
+    const nan = formatProgress(
+      grade({ endTick: 120, delivered: 1, metrics: metrics({ delivered: 1, avg_wait_s: NaN }) }),
+    );
+    expect(nan).toBe("Tick 120 · 1 delivered");
+  });
+});

--- a/playground/src/features/quest/index.ts
+++ b/playground/src/features/quest/index.ts
@@ -13,6 +13,7 @@ export {
   type UnlockedApi,
 } from "./stages";
 export { runStage, type StageResult, type RunStageOptions } from "./stage-runner";
+export { formatProgress } from "./stage-progress";
 export { bootQuestPane, renderStage, wireQuestPane, type QuestPaneHandles } from "./quest-pane";
 export {
   hideResults,

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -294,6 +294,12 @@ export async function bootQuestPane(opts: {
     renderSnippets(snippets, next, editor);
     setEditorSilently(loadCode(next.id) ?? next.starterCode);
     handles.result.textContent = "";
+    // If a run is in flight, its `onProgress` and the success / error
+    // cleanup paths all gate on `select.value === stage.id` — none of
+    // them will fire for the outgoing stage now that the value has
+    // changed. Without this clear, the last "Tick X · N delivered"
+    // readout from the orphaned run sticks on the new stage's UI.
+    handles.progress.textContent = "";
     opts.onStageChange?.(next.id);
   });
 

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -14,6 +14,7 @@ import { mountQuestEditor, type QuestEditor } from "./editor";
 import { renderHints, wireHintsDrawer, type HintsDrawerHandles } from "./hints-drawer";
 import { showResults, wireResultsModal, type ResultsModalHandles } from "./results-modal";
 import { renderSnippets, wireSnippetPicker, type SnippetPickerHandles } from "./snippet-picker";
+import { formatProgress } from "./stage-progress";
 import { runStage, type StageResult } from "./stage-runner";
 import { STAGES, stageById } from "./stages";
 import type { StarCount, Stage } from "./stages";
@@ -28,6 +29,13 @@ export interface QuestPaneHandles {
   readonly runBtn: HTMLButtonElement;
   readonly resetBtn: HTMLButtonElement;
   readonly result: HTMLElement;
+  /**
+   * Live tick/delivered/avg-wait readout shown beside the Run row
+   * while a stage is running. Distinct from `result` so screen
+   * readers (which announce `result` via `aria-live`) don't get
+   * spammed by the per-batch update stream.
+   */
+  readonly progress: HTMLElement;
 }
 
 /**
@@ -46,6 +54,7 @@ export function wireQuestPane(): QuestPaneHandles {
     runBtn: requireElement("quest-run", m) as HTMLButtonElement,
     resetBtn: requireElement("quest-reset", m) as HTMLButtonElement,
     result: requireElement("quest-result", m),
+    progress: requireElement("quest-progress", m),
   };
 }
 
@@ -109,11 +118,21 @@ async function executeRun(
 ): Promise<void> {
   handles.runBtn.disabled = true;
   handles.result.textContent = "Running…";
+  handles.progress.textContent = "";
   try {
     // Cap the controller's initial run at one second — long enough
     // for honest setup work, short enough that an infinite loop
     // bubbles up as a timeout instead of blocking indefinitely.
-    const result = await runStage(stage, editor.getValue(), { timeoutMs: 1000 });
+    const result = await runStage(stage, editor.getValue(), {
+      timeoutMs: 1000,
+      onProgress: (grade) => {
+        // Drop progress updates if the player navigated away mid-run;
+        // matches the modal-suppression policy below so the next
+        // stage's fresh state isn't overwritten by stale text.
+        if (handles.select.value !== stage.id) return;
+        handles.progress.textContent = formatProgress(grade);
+      },
+    });
     // Always grade — a passed run earns its stars even if the player
     // navigated to a different stage during the run window. Only
     // surface the modal/inline status if the player is still looking
@@ -122,6 +141,7 @@ async function executeRun(
     onGraded(stage, result);
     if (handles.select.value === stage.id) {
       handles.result.textContent = "";
+      handles.progress.textContent = "";
       showResults(modal, result, retry);
     }
   } catch (err) {
@@ -131,6 +151,7 @@ async function executeRun(
       // A controller throw is a code bug the player needs to see in
       // place, not a result to celebrate or retry.
       handles.result.textContent = `Error: ${msg}`;
+      handles.progress.textContent = "";
     }
   } finally {
     handles.runBtn.disabled = false;

--- a/playground/src/features/quest/stage-progress.ts
+++ b/playground/src/features/quest/stage-progress.ts
@@ -1,0 +1,25 @@
+/**
+ * Format a per-batch grade as a one-line progress readout for the
+ * Quest run row.
+ *
+ * Avg wait is omitted on the very first batch (when `delivered === 0`)
+ * because the underlying metric has no samples yet and would render
+ * as "0.0s avg wait" — misleading for both screen-reading and casual
+ * scanning. Likewise the abandons clause only appears when at least
+ * one rider has abandoned, so a clean run keeps the text short.
+ */
+import type { GradeInputs } from "./stages";
+
+export function formatProgress(grade: GradeInputs): string {
+  const head = `Tick ${grade.endTick}`;
+  if (grade.delivered === 0 && grade.abandoned === 0) {
+    return `${head} · waiting…`;
+  }
+  const parts = [head, `${grade.delivered} delivered`];
+  if (grade.abandoned > 0) parts.push(`${grade.abandoned} abandoned`);
+  const avg = grade.metrics.avg_wait_s;
+  if (grade.delivered > 0 && Number.isFinite(avg) && avg > 0) {
+    parts.push(`${avg.toFixed(1)}s avg wait`);
+  }
+  return parts.join(" · ");
+}

--- a/playground/src/features/quest/stage-runner.ts
+++ b/playground/src/features/quest/stage-runner.ts
@@ -49,6 +49,12 @@ export interface RunStageOptions {
    * at the standard tick rate).
    */
   readonly batchTicks?: number;
+  /**
+   * Called after each batch with the latest grade. Lets the host paint
+   * tick-by-tick progress while the sim runs. Throws are caught — a
+   * UI update error must not abort an in-flight run.
+   */
+  readonly onProgress?: (grade: GradeInputs) => void;
 }
 
 /**
@@ -99,6 +105,13 @@ export async function runStage(
       lastMetrics = result.metrics;
       endTick = result.tick;
       const grade = makeGrade(lastMetrics, endTick);
+      if (opts.onProgress) {
+        try {
+          opts.onProgress(grade);
+        } catch {
+          // A UI bug in the progress renderer must not abort the run.
+        }
+      }
       if (stage.passFn(grade)) {
         return finalize(stage, grade, true);
       }


### PR DESCRIPTION
## Summary

Closes the second gap from the UX assessment: clicking **Run** in Quest used to look like nothing happened until a results modal appeared hundreds of ms later. This PR replaces the silent gap with a per-batch readout — \`Tick 240 · 4 delivered · 12.3s avg wait\` — beneath the Run row.

## Implementation

- **\`stage-runner.ts\`** — \`RunStageOptions\` gains \`onProgress?: (grade: GradeInputs) => void\`, called after each batch. The runner already gets a \`{ tick, metrics }\` bundle per \`sim.tick(step)\`, so this is a one-call addition with no protocol or wasm change. Throws from the callback are swallowed — a UI bug must not abort an in-flight run.
- **\`stage-progress.ts\`** — new module with the \`formatProgress(grade)\` helper. Pulled out so it's directly testable without standing up a worker.
- **\`quest-pane.ts\`** — passes \`onProgress\` to \`runStage\` and renders the result into a new \`#quest-progress\` span. Skips updates when the player has navigated to a different stage mid-run (matches the existing modal-suppression policy).
- **\`index.html\`** — adds \`#quest-progress\` next to (not replacing) \`#quest-result\` so the live update stream doesn't spam \`#quest-result\`'s \`aria-live=\"polite\"\`. Screen readers hear start/end states only; sighted users see the per-batch ticker. The Run row also gains \`flex-wrap\` so the progress text doesn't shove the buttons off-screen on narrow widths.

## Format-rule design

\`formatProgress\` elides aggressively so the readout doesn't lie:

- Very first batch → \`Tick 60 · waiting…\` (delivered + abandoned both 0)
- Once a rider arrives → adds \`N delivered\`
- Abandons clause appears only if at least one rider abandoned
- Avg wait appears only after \`delivered > 0\` and \`avg_wait_s\` is finite & > 0 — otherwise the metric reads \`0.0s avg wait\` before any sample exists, which scans as \"my code is fast\" instead of \"no data yet\"

Six unit tests pin these rules.

## Out of scope

The \"Right\" version of this fix from the UX assessment — wiring the worker's \`Snapshot\` to a live shaft canvas inside the Quest pane so the player sees the cars moving — is intentionally a follow-up PR. This one ships the cheap version that lands the UX delta with no rendering-infrastructure churn.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean (no new warnings)
- [x] \`pnpm test\` — 221 pass (was 215)
- [x] Pre-commit hook clean
- [ ] Manual: Quest stage 1, click Run → \`Tick X · waiting…\` appears in <1s, transitions to \`Tick X · N delivered\` once cars start arriving, ends with results modal
- [ ] Manual: Quest stage with controller error (e.g. \`sim.totallyNotAMethod()\`) → progress stays empty, error lands in result span as before
- [ ] Manual mobile: progress text wraps cleanly under the Run row on narrow widths (P0)