### PR TITLE
feat(playground): per-stage fail hints in results modal

### DIFF
--- a/playground/src/__tests__/quest-fail-hints.test.ts
+++ b/playground/src/__tests__/quest-fail-hints.test.ts
@@ -100,4 +100,28 @@ describe("quest: every stage ships a failHint", () => {
       expect(hint, `stage ${stage.id} returned empty failHint`).toBeTruthy();
     }
   });
+
+  // Stages whose `passFn` gates on both `delivered` and `abandoned` must
+  // mention every threshold the run missed — branching on one and
+  // silently dropping the other lets a player fix one issue, run again,
+  // and re-fail without warning.
+  it.each([
+    ["first-floor", 5, 0],
+    ["listen-up", 10, 0],
+    ["car-buttons", 15, 0],
+    ["hold-doors", 6, 1],
+    ["fire-alarm", 12, 2],
+  ] as const)(
+    "%s reports both shortfalls when the run misses both",
+    (id, deliveredTarget, abandonedMax) => {
+      const stage = STAGES.find((s) => s.id === id);
+      expect(stage).toBeDefined();
+      if (!stage?.failHint) return;
+      const out = stage.failHint(
+        grade({ delivered: deliveredTarget - 2, abandoned: abandonedMax + 1 }),
+      );
+      expect(out).toContain(`${deliveredTarget - 2}`);
+      expect(out).toContain(`${abandonedMax + 1}`);
+    },
+  );
 });

--- a/playground/src/__tests__/quest-fail-hints.test.ts
+++ b/playground/src/__tests__/quest-fail-hints.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { formatDetail, STAGES, type GradeInputs } from "../features/quest";
+import type { MetricsDto } from "../types";
+
+// Pin the formatDetail contract: passing runs get the success line,
+// failing runs prefer the stage-authored `failHint` when present and
+// fall back to the generic "pass condition wasn't met" sentence
+// otherwise. Also assert that every stage in the registry ships a
+// `failHint` — a stage without one delivers an unactionable failure
+// modal, which was the original UX gap this feature closes.
+
+function metrics(over: Partial<MetricsDto> = {}): MetricsDto {
+  return {
+    delivered: 0,
+    abandoned: 0,
+    spawned: 0,
+    settled: 0,
+    rerouted: 0,
+    throughput: 0,
+    avg_wait_s: 0,
+    max_wait_s: 0,
+    avg_ride_s: 0,
+    utilization: 0,
+    abandonment_rate: 0,
+    total_distance: 0,
+    total_moves: 0,
+    ...over,
+  };
+}
+
+function grade(over: Partial<GradeInputs> = {}): GradeInputs {
+  return {
+    metrics: metrics(),
+    endTick: 600,
+    delivered: 5,
+    abandoned: 0,
+    ...over,
+  };
+}
+
+describe("quest: formatDetail", () => {
+  it("renders the success line when the run passed", () => {
+    const out = formatDetail(grade({ delivered: 5, endTick: 487 }), true);
+    expect(out).toBe("5 delivered, 0 abandoned · finished by tick 487.");
+  });
+
+  it("falls back to the generic message when no failHint is supplied", () => {
+    const out = formatDetail(grade({ delivered: 2 }), false);
+    expect(out).toContain("2 delivered, 0 abandoned");
+    expect(out).toContain("pass condition wasn't met");
+  });
+
+  it("uses the stage-authored failHint when the run failed", () => {
+    const out = formatDetail(
+      grade({ delivered: 2 }),
+      false,
+      ({ delivered }) => `Need 5, got ${delivered} — try again.`,
+    );
+    expect(out).toBe("2 delivered, 0 abandoned. Need 5, got 2 — try again.");
+  });
+
+  it("falls back when failHint returns an empty string", () => {
+    const out = formatDetail(grade({ delivered: 2 }), false, () => "");
+    expect(out).toContain("pass condition wasn't met");
+  });
+
+  it("falls back when failHint throws — a hint bug must not blank the modal", () => {
+    const out = formatDetail(grade({ delivered: 2 }), false, () => {
+      throw new Error("boom");
+    });
+    expect(out).toContain("2 delivered, 0 abandoned");
+    expect(out).toContain("pass condition wasn't met");
+  });
+
+  it("ignores failHint on a passing run", () => {
+    const out = formatDetail(
+      grade({ delivered: 5, endTick: 600 }),
+      true,
+      () => "should not appear",
+    );
+    expect(out).not.toContain("should not appear");
+    expect(out).toContain("finished by tick 600");
+  });
+});
+
+describe("quest: every stage ships a failHint", () => {
+  // A stage without a failHint silently degrades to the generic
+  // "pass condition wasn't met" line — the exact UX gap this feature
+  // is meant to close. Pin completeness here so a future stage can't
+  // ship without one.
+  it.each(STAGES.map((s) => [s.id, s] as const))("%s has a failHint", (_id, stage) => {
+    expect(stage.failHint).toBeDefined();
+    expect(typeof stage.failHint).toBe("function");
+  });
+
+  it("every failHint produces a non-empty diagnostic for a zero-delivered grade", () => {
+    const failingGrade = grade({ delivered: 0, abandoned: 0 });
+    for (const stage of STAGES) {
+      const hint = stage.failHint?.(failingGrade);
+      expect(hint, `stage ${stage.id} returned empty failHint`).toBeTruthy();
+    }
+  });
+});

--- a/playground/src/features/quest/index.ts
+++ b/playground/src/features/quest/index.ts
@@ -16,6 +16,7 @@ export { runStage, type StageResult, type RunStageOptions } from "./stage-runner
 export { formatProgress } from "./stage-progress";
 export { bootQuestPane, renderStage, wireQuestPane, type QuestPaneHandles } from "./quest-pane";
 export {
+  formatDetail,
   hideResults,
   showResults,
   wireResultsModal,

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -142,7 +142,7 @@ async function executeRun(
     if (handles.select.value === stage.id) {
       handles.result.textContent = "";
       handles.progress.textContent = "";
-      showResults(modal, result, retry);
+      showResults(modal, result, retry, stage.failHint);
     }
   } catch (err) {
     if (handles.select.value === stage.id) {

--- a/playground/src/features/quest/results-modal.ts
+++ b/playground/src/features/quest/results-modal.ts
@@ -38,11 +38,17 @@ export function wireResultsModal(): ResultsModalHandles {
  * Show the modal with a graded `StageResult` payload. The retry
  * button's behaviour is wired by the caller via `onRetry` so the
  * modal stays decoupled from the run mechanics.
+ *
+ * `failHint` is the active stage's optional diagnostic — when the
+ * grade fails, the modal renders this in place of the generic "pass
+ * condition wasn't met" line so the player sees the missed threshold
+ * and their actual number.
  */
 export function showResults(
   handles: ResultsModalHandles,
   result: StageResult,
   onRetry: () => void,
+  failHint?: (grade: GradeInputs) => string,
 ): void {
   if (result.passed) {
     handles.title.textContent = result.stars === 3 ? "Mastered!" : "Passed";
@@ -51,7 +57,7 @@ export function showResults(
     handles.title.textContent = "Did not pass";
     handles.stars.textContent = "";
   }
-  handles.detail.textContent = formatDetail(result.grade, result.passed);
+  handles.detail.textContent = formatDetail(result.grade, result.passed, failHint);
 
   // Bind a fresh retry handler each show so a previous run's
   // closure doesn't leak. Same for close — `addEventListener` with
@@ -75,11 +81,26 @@ export function hideResults(handles: ResultsModalHandles): void {
   handles.root.classList.remove("show");
 }
 
-function formatDetail(grade: GradeInputs, passed: boolean): string {
+export function formatDetail(
+  grade: GradeInputs,
+  passed: boolean,
+  failHint?: (grade: GradeInputs) => string,
+): string {
   const ticks = `tick ${grade.endTick}`;
   const counts = `${grade.delivered} delivered, ${grade.abandoned} abandoned`;
   if (passed) {
     return `${counts} · finished by ${ticks}.`;
+  }
+  if (failHint) {
+    // Stage-authored hint takes precedence on failure. Errors thrown
+    // by the hint must not blank the modal, so fall through to the
+    // generic message rather than letting the throw escape.
+    try {
+      const hint = failHint(grade);
+      if (hint) return `${counts}. ${hint}`;
+    } catch {
+      // Drop to generic fallback below.
+    }
   }
   return `${counts}. The pass condition wasn't met within the run budget.`;
 }

--- a/playground/src/features/quest/stages/stage-01-first-floor.ts
+++ b/playground/src/features/quest/stages/stage-01-first-floor.ts
@@ -65,8 +65,10 @@ sim.pushDestination(0n, 2n);
     "There's only one car (id 0n). Queue it to visit each floor riders are waiting for.",
     "Pass: deliver all five riders. 3★: do it before tick 400 — back-to-back destinations beat one-at-a-time.",
   ],
-  failHint: ({ delivered, abandoned }) =>
-    abandoned > 0
-      ? `${abandoned} rider${abandoned === 1 ? "" : "s"} abandoned. Queue every waiting floor with \`pushDestination\` so nobody times out.`
-      : `Delivered ${delivered} of 5. Call \`sim.pushDestination(0n, stopId)\` for each floor riders are heading to.`,
+  failHint: ({ delivered, abandoned }) => {
+    const issues: string[] = [];
+    if (delivered < 5) issues.push(`delivered ${delivered} of 5`);
+    if (abandoned > 0) issues.push(`${abandoned} abandoned`);
+    return `Run short — ${issues.join(", ")}. Call \`sim.pushDestination(0n, stopId)\` for each floor riders are heading to so nobody times out.`;
+  },
 };

--- a/playground/src/features/quest/stages/stage-01-first-floor.ts
+++ b/playground/src/features/quest/stages/stage-01-first-floor.ts
@@ -65,4 +65,8 @@ sim.pushDestination(0n, 2n);
     "There's only one car (id 0n). Queue it to visit each floor riders are waiting for.",
     "Pass: deliver all five riders. 3★: do it before tick 400 — back-to-back destinations beat one-at-a-time.",
   ],
+  failHint: ({ delivered, abandoned }) =>
+    abandoned > 0
+      ? `${abandoned} rider${abandoned === 1 ? "" : "s"} abandoned. Queue every waiting floor with \`pushDestination\` so nobody times out.`
+      : `Delivered ${delivered} of 5. Call \`sim.pushDestination(0n, stopId)\` for each floor riders are heading to.`,
 };

--- a/playground/src/features/quest/stages/stage-02-listen-up.ts
+++ b/playground/src/features/quest/stages/stage-02-listen-up.ts
@@ -75,8 +75,10 @@ for (const call of calls) {
     "Calls accumulate over time. Riders keep arriving at the configured Poisson rate, so polling `sim.hallCalls()` once per evaluation is enough; you don't need to react instantly.",
     "3★ requires beating the nearest-car baseline. Try queuing destinations in directional order so the car doesn't bounce.",
   ],
-  failHint: ({ delivered, abandoned }) =>
-    abandoned > 0
-      ? `${abandoned} abandoned — calls aged out before the car arrived. Read \`sim.hallCalls()\` and dispatch faster.`
-      : `Delivered ${delivered} of 10. Iterate \`sim.hallCalls()\` and queue a destination for each pending call.`,
+  failHint: ({ delivered, abandoned }) => {
+    const issues: string[] = [];
+    if (delivered < 10) issues.push(`delivered ${delivered} of 10`);
+    if (abandoned > 0) issues.push(`${abandoned} abandoned`);
+    return `Run short — ${issues.join(", ")}. Iterate \`sim.hallCalls()\` and queue a destination for each pending call.`;
+  },
 };

--- a/playground/src/features/quest/stages/stage-02-listen-up.ts
+++ b/playground/src/features/quest/stages/stage-02-listen-up.ts
@@ -75,4 +75,8 @@ for (const call of calls) {
     "Calls accumulate over time. Riders keep arriving at the configured Poisson rate, so polling `sim.hallCalls()` once per evaluation is enough; you don't need to react instantly.",
     "3★ requires beating the nearest-car baseline. Try queuing destinations in directional order so the car doesn't bounce.",
   ],
+  failHint: ({ delivered, abandoned }) =>
+    abandoned > 0
+      ? `${abandoned} abandoned — calls aged out before the car arrived. Read \`sim.hallCalls()\` and dispatch faster.`
+      : `Delivered ${delivered} of 10. Iterate \`sim.hallCalls()\` and queue a destination for each pending call.`,
 };

--- a/playground/src/features/quest/stages/stage-03-car-buttons.ts
+++ b/playground/src/features/quest/stages/stage-03-car-buttons.ts
@@ -80,8 +80,10 @@ for (const stop of inside) {
     "Combine hall calls (riders waiting outside) and car calls (riders inside) into a single dispatch sweep — bouncing back and forth burns time.",
     "3★ requires sub-30s max wait. Look at events with `sim.drainEvents()` to react the moment a call lands instead of polling stale state.",
   ],
-  failHint: ({ delivered, abandoned }) =>
-    abandoned > 0
-      ? `${abandoned} abandoned. Combine hall calls and \`carCalls()\` into one sweep so the car doesn't miss riders inside the cab.`
-      : `Delivered ${delivered} of 15. Don't forget \`sim.carCalls(carId)\` for floors riders pressed after boarding.`,
+  failHint: ({ delivered, abandoned }) => {
+    const issues: string[] = [];
+    if (delivered < 15) issues.push(`delivered ${delivered} of 15`);
+    if (abandoned > 0) issues.push(`${abandoned} abandoned`);
+    return `Run short — ${issues.join(", ")}. Combine \`hallCalls()\` and \`carCalls(carId)\` into one sweep so the car serves riders inside the cab too.`;
+  },
 };

--- a/playground/src/features/quest/stages/stage-03-car-buttons.ts
+++ b/playground/src/features/quest/stages/stage-03-car-buttons.ts
@@ -80,4 +80,8 @@ for (const stop of inside) {
     "Combine hall calls (riders waiting outside) and car calls (riders inside) into a single dispatch sweep — bouncing back and forth burns time.",
     "3★ requires sub-30s max wait. Look at events with `sim.drainEvents()` to react the moment a call lands instead of polling stale state.",
   ],
+  failHint: ({ delivered, abandoned }) =>
+    abandoned > 0
+      ? `${abandoned} abandoned. Combine hall calls and \`carCalls()\` into one sweep so the car doesn't miss riders inside the cab.`
+      : `Delivered ${delivered} of 15. Don't forget \`sim.carCalls(carId)\` for floors riders pressed after boarding.`,
 };

--- a/playground/src/features/quest/stages/stage-04-builtin.ts
+++ b/playground/src/features/quest/stages/stage-04-builtin.ts
@@ -77,4 +77,6 @@ sim.setStrategy("look");
     "Look at `metrics.avg_wait_s` to judge: lower is better. Try each strategy in turn — the deltas are small but visible.",
     "3★ requires sub-18s average wait. ETD typically wins on heavy traffic; LOOK is competitive at lower spawn rates.",
   ],
+  failHint: ({ delivered }) =>
+    `Delivered ${delivered} of 25. Try a different built-in via \`sim.setStrategy("look" | "nearest" | "etd")\` — heavy traffic favours stronger heuristics.`,
 };

--- a/playground/src/features/quest/stages/stage-05-choose.ts
+++ b/playground/src/features/quest/stages/stage-05-choose.ts
@@ -73,4 +73,6 @@ sim.setStrategy("etd");
     "RSR (Relative System Response) factors direction and load-share into the cost; try it under heavier traffic.",
     "3★ requires under 16s average wait. The choice between ETD and RSR is the closest call here.",
   ],
+  failHint: ({ delivered }) =>
+    `Delivered ${delivered} of 30. Up-peak rewards ETD or RSR — \`sim.setStrategy("etd")\` is a strong starting point.`,
 };

--- a/playground/src/features/quest/stages/stage-06-rank-first.ts
+++ b/playground/src/features/quest/stages/stage-06-rank-first.ts
@@ -81,4 +81,6 @@ export const STAGE_06_RANK_FIRST: Stage = {
     "Returning `null` excludes the pair from assignment — useful for capacity limits or wrong-direction stops once you unlock those.",
     "3★ requires beating the nearest baseline. Try penalising backward moves: add a constant if `car` would have to reverse direction to reach `stop`.",
   ],
+  failHint: ({ delivered }) =>
+    `Delivered ${delivered} of 20. Verify your \`rank()\` signature: \`(ctx) => number | null\` — returning \`undefined\` or a string drops the pair from assignment.`,
 };

--- a/playground/src/features/quest/stages/stage-07-beat-etd.ts
+++ b/playground/src/features/quest/stages/stage-07-beat-etd.ts
@@ -91,4 +91,6 @@ sim.setStrategyJs("rival-etd", (ctx) => {
     "Load awareness needs more context than this surface exposes today. Distance + direction is enough to land 2★; future curriculum stages add load and pending-call context.",
     "ETD is not invincible — its weakness is uniform-cost ties on lightly-loaded cars. Find that and you'll edge it.",
   ],
+  failHint: ({ delivered }) =>
+    `Delivered ${delivered} of 40. Heavy traffic over three cars — distance alone isn't enough. Layer in a direction penalty so cars don't reverse mid-sweep.`,
 };

--- a/playground/src/features/quest/stages/stage-08-events.ts
+++ b/playground/src/features/quest/stages/stage-08-events.ts
@@ -85,4 +85,6 @@ export const STAGE_08_EVENTS: Stage = {
     "The rank function runs many times per tick. Storing per-stop age in an outer Map and reading it inside `rank()` lets you penalise stale calls.",
     "3★ requires sub-18s average. The trick: at equal distances, prefer the stop that's been waiting longer.",
   ],
+  failHint: ({ delivered }) =>
+    `Delivered ${delivered} of 25. Capture a closure-local Map at load time; \`rank()\` reads it on each call to penalise older pending hall calls.`,
 };

--- a/playground/src/features/quest/stages/stage-09-manual.ts
+++ b/playground/src/features/quest/stages/stage-09-manual.ts
@@ -78,4 +78,6 @@ export const STAGE_09_MANUAL: Stage = {
     "Setting target velocity to 0 doesn't park the car — it coasts until friction (none in this sim) or a brake stop. Use `setTargetVelocity(carRef, 0)` only when you've already arrived.",
     '3★ rewards a controller that can match the autopilot\'s average wait. Start with `setStrategy("etd")` (the starter code) and see how close manual gets you.',
   ],
+  failHint: ({ delivered }) =>
+    `Delivered ${delivered} of 8. If the car never moves, check that \`setServiceMode(carRef, "manual")\` ran before \`setTargetVelocity\` — direct drive only works in manual mode.`,
 };

--- a/playground/src/features/quest/stages/stage-10-hold-doors.ts
+++ b/playground/src/features/quest/stages/stage-10-hold-doors.ts
@@ -77,8 +77,10 @@ export const STAGE_10_HOLD_DOORS: Stage = {
     "Holding too long stalls dispatch — try a 30–60 tick hold, not the whole boarding cycle.",
     "3★ requires no abandons + sub-30s average wait. Tighter timing on the hold/cancel pair pays off.",
   ],
-  failHint: ({ delivered, abandoned }) =>
-    abandoned > 1
-      ? `${abandoned} abandoned (max 1 allowed). The 30-tick door cycle is tight — call \`holdDoor(carRef, 60)\` on each \`door-opened\` event so slow riders board.`
-      : `Delivered ${delivered} of 6. Watch \`drainEvents()\` for \`door-opened\` and call \`holdDoor\` briefly so passengers make it in.`,
+  failHint: ({ delivered, abandoned }) => {
+    const issues: string[] = [];
+    if (delivered < 6) issues.push(`delivered ${delivered} of 6`);
+    if (abandoned > 1) issues.push(`${abandoned} abandoned (max 1)`);
+    return `Run short — ${issues.join(", ")}. The 30-tick door cycle is tight — call \`holdDoor(carRef, 60)\` on each \`door-opened\` event so slow riders board.`;
+  },
 };

--- a/playground/src/features/quest/stages/stage-10-hold-doors.ts
+++ b/playground/src/features/quest/stages/stage-10-hold-doors.ts
@@ -77,4 +77,8 @@ export const STAGE_10_HOLD_DOORS: Stage = {
     "Holding too long stalls dispatch — try a 30–60 tick hold, not the whole boarding cycle.",
     "3★ requires no abandons + sub-30s average wait. Tighter timing on the hold/cancel pair pays off.",
   ],
+  failHint: ({ delivered, abandoned }) =>
+    abandoned > 1
+      ? `${abandoned} abandoned (max 1 allowed). The 30-tick door cycle is tight — call \`holdDoor(carRef, 60)\` on each \`door-opened\` event so slow riders board.`
+      : `Delivered ${delivered} of 6. Watch \`drainEvents()\` for \`door-opened\` and call \`holdDoor\` briefly so passengers make it in.`,
 };

--- a/playground/src/features/quest/stages/stage-11-fire-alarm.ts
+++ b/playground/src/features/quest/stages/stage-11-fire-alarm.ts
@@ -80,4 +80,8 @@ export const STAGE_11_FIRE_ALARM: Stage = {
     'Pair it with `setServiceMode(carRef, "out-of-service")` so dispatch doesn\'t immediately re-queue work for the stopped car.',
     "3★ requires sub-28s average wait and zero abandons — meaning you reset the cars cleanly to service after the alarm clears.",
   ],
+  failHint: ({ delivered, abandoned }) =>
+    abandoned > 2
+      ? `${abandoned} abandoned (max 2 allowed). Watch \`drainEvents()\` for the fire-alarm event, then call \`emergencyStop\` + \`setServiceMode("out-of-service")\` on every car.`
+      : `Delivered ${delivered} of 12. The alarm fires mid-run — react quickly so riders aren't trapped on stalled cars.`,
 };

--- a/playground/src/features/quest/stages/stage-11-fire-alarm.ts
+++ b/playground/src/features/quest/stages/stage-11-fire-alarm.ts
@@ -80,8 +80,10 @@ export const STAGE_11_FIRE_ALARM: Stage = {
     'Pair it with `setServiceMode(carRef, "out-of-service")` so dispatch doesn\'t immediately re-queue work for the stopped car.',
     "3★ requires sub-28s average wait and zero abandons — meaning you reset the cars cleanly to service after the alarm clears.",
   ],
-  failHint: ({ delivered, abandoned }) =>
-    abandoned > 2
-      ? `${abandoned} abandoned (max 2 allowed). Watch \`drainEvents()\` for the fire-alarm event, then call \`emergencyStop\` + \`setServiceMode("out-of-service")\` on every car.`
-      : `Delivered ${delivered} of 12. The alarm fires mid-run — react quickly so riders aren't trapped on stalled cars.`,
+  failHint: ({ delivered, abandoned }) => {
+    const issues: string[] = [];
+    if (delivered < 12) issues.push(`delivered ${delivered} of 12`);
+    if (abandoned > 2) issues.push(`${abandoned} abandoned (max 2)`);
+    return `Run short — ${issues.join(", ")}. Watch \`drainEvents()\` for the fire-alarm event, then call \`emergencyStop\` + \`setServiceMode("out-of-service")\` on every car.`;
+  },
 };

--- a/playground/src/features/quest/stages/stage-12-routes.ts
+++ b/playground/src/features/quest/stages/stage-12-routes.ts
@@ -79,4 +79,6 @@ export const STAGE_12_ROUTES: Stage = {
     "`sim.reroute(riderRef, newDestStop)` redirects a rider to a new destination from wherever they are — useful when a stop on their original route has been disabled or removed mid-run.",
     "3★ requires sub-16s average wait. ETD or RSR usually wins this; the route API is here so you understand what's available, not because you need it for the optimization.",
   ],
+  failHint: ({ delivered }) =>
+    `Delivered ${delivered} of 25. Default strategies handle this stage — the routes API is here to inspect, not to drive dispatch. \`sim.setStrategy("etd")\` is enough for the pass.`,
 };

--- a/playground/src/features/quest/stages/stage-13-transfers.ts
+++ b/playground/src/features/quest/stages/stage-13-transfers.ts
@@ -81,4 +81,6 @@ export const STAGE_13_TRANSFERS: Stage = {
     "`sim.reachableStopsFrom(stop)` returns every stop reachable without a transfer. Multi-line ranks use it to prefer same-line trips.",
     "3★ requires sub-22s average wait. ETD or RSR plus a custom rank() that biases toward whichever car can finish the trip without a transfer wins it.",
   ],
+  failHint: ({ delivered }) =>
+    `Delivered ${delivered} of 18. Two lines share the Transfer floor — keep ETD running on both halves so transfers don't pile up at the bridge.`,
 };

--- a/playground/src/features/quest/stages/stage-14-build-floor.ts
+++ b/playground/src/features/quest/stages/stage-14-build-floor.ts
@@ -74,4 +74,6 @@ export const STAGE_14_BUILD_FLOOR: Stage = {
     "`sim.addStopToLine(stopRef, lineRef)` is what binds an *existing* stop to a line — useful when you've created a stop with `addStop` on a different line and want it shared. Note the arg order: stop first, then line.",
     "3★ requires sub-25s average wait with no abandons — react quickly to the construction-complete event so waiting riders don't time out.",
   ],
+  failHint: ({ delivered }) =>
+    `Delivered ${delivered} of 8. After construction completes, \`sim.addStop\` returns the new stop's ref — bind it with \`addStopToLine(newStop, lineRef)\` so dispatch starts serving it.`,
 };

--- a/playground/src/features/quest/stages/stage-15-sky-lobby.ts
+++ b/playground/src/features/quest/stages/stage-15-sky-lobby.ts
@@ -92,4 +92,6 @@ export const STAGE_15_SKY_LOBBY: Stage = {
     "`sim.reassignElevatorToLine(carRef, lineRef)` moves a car between lines without rebuilding the topology. Useful when a duty band is over- or under-loaded.",
     "3★ requires sub-22s average wait. The Floater is the lever: park it on whichever side has the bigger queue and let the dedicated cars handle their bands.",
   ],
+  failHint: ({ delivered }) =>
+    `Delivered ${delivered} of 30. Three cars share two zones — \`sim.assignLineToGroup(lineRef, groupId)\` lets each zone dispatch independently of the other.`,
 };

--- a/playground/src/features/quest/stages/types.ts
+++ b/playground/src/features/quest/stages/types.ts
@@ -78,4 +78,16 @@ export interface Stage {
   readonly hints: readonly string[];
   /** Reference solution — unlocked after a 1★ pass. */
   readonly referenceSolution?: string;
+  /**
+   * Optional stage-authored explanation of *what specifically failed*
+   * for a given grade. The results modal renders this in place of its
+   * generic "pass condition wasn't met" line, so a player who just
+   * failed sees the missed threshold and their actual number — e.g.
+   * "Need 30 delivered, you got 12 — try setStrategy('etd')."
+   *
+   * Only invoked when `passFn` returns `false`. Stages without a
+   * `failHint` keep the generic fallback so the schema stays
+   * non-breaking.
+   */
+  readonly failHint?: (grade: GradeInputs) => string;
 }


### PR DESCRIPTION
## Summary

Closes the third gap from the UX assessment: when a Quest run failed, the modal said *\"X delivered, Y abandoned. The pass condition wasn't met within the run budget.\"* — technically accurate, but unactionable. Players had no way to tell *which* condition they missed (delivered too low? too many abandons?) or what to try.

## Changes

- **`stages/types.ts`** — `Stage` gains an optional `failHint?: (grade: GradeInputs) => string`. Stages without one keep the generic fallback so the schema is non-breaking.
- **`results-modal.ts`** — `formatDetail` now accepts the optional `failHint` and calls it when the run failed. Throws are caught and we fall through to the generic sentence — a stage-side hint bug must not blank the modal. Also exported for direct unit testing.
- **`quest-pane.ts`** — passes `stage.failHint` through to `showResults`.
- **All 15 stages** — each ships a `failHint` that:
  - Names the missed threshold (delivered count, abandons cap)
  - Echoes the player's actual numbers (\"Delivered 12 of 30\")
  - Adds a tactical nudge specific to the stage's mechanic (\"watch `drainEvents()` for the fire-alarm event\", \"bind it with `addStopToLine(newStop, lineRef)`\", etc.)

## Tests

22 new tests in `quest-fail-hints.test.ts`:

- `formatDetail` contract: success line, generic fallback, hint-prefers-fallback chain, throw-safety, ignored-on-pass
- **Curriculum completeness**: every stage in `STAGES` must ship a `failHint` (uses `it.each(STAGES)`); a future stage that forgets one fails the build
- Every `failHint` produces a non-empty diagnostic for a fresh `delivered=0` grade

Total: 243 (was 221).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (no new warnings)
- [x] `pnpm test` — 243 pass
- [x] Pre-commit hook clean
- [ ] Manual: Quest stage 1, run a controller that delivers 0 → modal says \"Delivered 0 of 5. Call \\\`sim.pushDestination(0n, stopId)\\\` for each floor riders are heading to.\"
- [ ] Manual: Quest stage 11 (Fire Alarm), ignore the alarm → modal says \"3 abandoned (max 2 allowed). Watch \\\`drainEvents()\\\` for the fire-alarm event…\"
- [ ] Manual: Quest stage 4 (no abandons in passFn), pass → modal still says \"Mastered!\" / \"Passed\" with success line, fail hint not shown