### PR TITLE
feat(playground): next-stage CTA in the results modal

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -695,9 +695,17 @@
           <button
             type="button"
             id="quest-results-retry"
-            class="inline-flex items-center px-3 py-1.5 rounded-sm bg-accent text-surface text-[12.5px] font-semibold tracking-[0.01em] cursor-pointer transition-opacity duration-fast hover:opacity-90"
+            class="inline-flex items-center px-3 py-1.5 rounded-sm bg-accent text-surface text-[12.5px] font-semibold tracking-[0.01em] cursor-pointer transition-opacity duration-fast hover:opacity-90 data-[demoted=true]:bg-surface-elevated data-[demoted=true]:border data-[demoted=true]:border-stroke-subtle data-[demoted=true]:text-content-secondary data-[demoted=true]:font-medium data-[demoted=true]:text-[12px] data-[demoted=true]:px-2.5"
           >
             Run again
+          </button>
+          <button
+            type="button"
+            id="quest-results-next"
+            hidden
+            class="inline-flex items-center px-3 py-1.5 rounded-sm bg-accent text-surface text-[12.5px] font-semibold tracking-[0.01em] cursor-pointer transition-opacity duration-fast hover:opacity-90"
+          >
+            Next stage
           </button>
         </div>
       </div>

--- a/playground/src/__tests__/quest-next-stage.test.ts
+++ b/playground/src/__tests__/quest-next-stage.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { nextStage, STAGES, type Stage } from "../features/quest";
+
+// `nextStage` walks the curriculum's display order; the modal's
+// "Next stage" CTA is the user-visible end of that walk. Pin the
+// helper's edge cases (unknown id, last stage) and the registry
+// traversal so a future shuffle can't silently break the success-
+// path advance. Modal-DOM behaviour (hidden flag, focus target,
+// retry-demoted) is verified manually — the test environment runs
+// without a DOM and the existing surface tests don't pull one in.
+
+describe("quest: nextStage", () => {
+  it("returns the next stage in registry order", () => {
+    const first = STAGES[0];
+    expect(first).toBeDefined();
+    if (!first) return;
+    const next = nextStage(first.id);
+    expect(next).toBeDefined();
+    expect(next?.id).toBe(STAGES[1]?.id);
+  });
+
+  it("returns undefined for the last stage", () => {
+    const last = STAGES[STAGES.length - 1];
+    expect(last).toBeDefined();
+    if (!last) return;
+    expect(nextStage(last.id)).toBeUndefined();
+  });
+
+  it("returns undefined for an unknown stage id", () => {
+    expect(nextStage("not-a-real-stage-id")).toBeUndefined();
+  });
+
+  it("walks the full registry without skipping or repeating", () => {
+    const visited: string[] = [];
+    let current: Stage | undefined = STAGES[0];
+    while (current) {
+      visited.push(current.id);
+      current = nextStage(current.id);
+    }
+    expect(visited).toEqual(STAGES.map((s) => s.id));
+  });
+});

--- a/playground/src/features/quest/index.ts
+++ b/playground/src/features/quest/index.ts
@@ -3,6 +3,7 @@ export { WorkerSim, createWorkerSim, type WorkerSimOptions } from "./worker-sim"
 export { loadMonaco, mountQuestEditor, type EditorMountOptions, type QuestEditor } from "./editor";
 export {
   STAGES,
+  nextStage,
   stageById,
   type Baseline,
   type GradeInputs,

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -151,7 +151,11 @@ async function executeRun(
       const onNext = next
         ? () => {
             handles.select.value = next.id;
-            handles.select.dispatchEvent(new Event("change"));
+            // Match native select behaviour — `change` events bubble
+            // by default, and any future delegated listener on a
+            // wrapping form / fieldset should see this synthetic
+            // dispatch the same way it sees a real user pick.
+            handles.select.dispatchEvent(new Event("change", { bubbles: true }));
           }
         : undefined;
       showResults(modal, result, retry, stage.failHint, onNext);

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -16,7 +16,7 @@ import { showResults, wireResultsModal, type ResultsModalHandles } from "./resul
 import { renderSnippets, wireSnippetPicker, type SnippetPickerHandles } from "./snippet-picker";
 import { formatProgress } from "./stage-progress";
 import { runStage, type StageResult } from "./stage-runner";
-import { STAGES, stageById } from "./stages";
+import { nextStage, STAGES, stageById } from "./stages";
 import type { StarCount, Stage } from "./stages";
 import { clearCode, loadBestStars, loadCode, saveBestStars, saveCode } from "./storage";
 
@@ -142,7 +142,19 @@ async function executeRun(
     if (handles.select.value === stage.id) {
       handles.result.textContent = "";
       handles.progress.textContent = "";
-      showResults(modal, result, retry, stage.failHint);
+      // Build a Next-stage handler when the run passed AND the
+      // registry has a stage after this one. The select-driven swap
+      // path already handles flushSave / re-render / URL sync, so we
+      // route the click through a programmatic "change" event rather
+      // than re-implementing the swap inline.
+      const next = result.passed ? nextStage(stage.id) : undefined;
+      const onNext = next
+        ? () => {
+            handles.select.value = next.id;
+            handles.select.dispatchEvent(new Event("change"));
+          }
+        : undefined;
+      showResults(modal, result, retry, stage.failHint, onNext);
     }
   } catch (err) {
     if (handles.select.value === stage.id) {

--- a/playground/src/features/quest/results-modal.ts
+++ b/playground/src/features/quest/results-modal.ts
@@ -20,6 +20,14 @@ export interface ResultsModalHandles {
   readonly detail: HTMLElement;
   readonly close: HTMLButtonElement;
   readonly retry: HTMLButtonElement;
+  /**
+   * "Next stage" CTA. Hidden by default and only revealed when the
+   * caller supplies an `onNext` handler — i.e. the run passed and a
+   * later stage exists in the registry. When visible the retry button
+   * gets demoted (via `data-demoted=true`) so the dialog has one
+   * primary action, not two competing accents.
+   */
+  readonly next: HTMLButtonElement;
 }
 
 export function wireResultsModal(): ResultsModalHandles {
@@ -31,13 +39,19 @@ export function wireResultsModal(): ResultsModalHandles {
     detail: requireElement("quest-results-detail", m),
     close: requireElement("quest-results-close", m) as HTMLButtonElement,
     retry: requireElement("quest-results-retry", m) as HTMLButtonElement,
+    next: requireElement("quest-results-next", m) as HTMLButtonElement,
   };
 }
 
 /**
- * Show the modal with a graded `StageResult` payload. The retry
- * button's behaviour is wired by the caller via `onRetry` so the
- * modal stays decoupled from the run mechanics.
+ * Show the modal with a graded `StageResult` payload. Caller-supplied
+ * callbacks decouple the modal from run mechanics:
+ *
+ *   - `onRetry` fires on the Run again button.
+ *   - `onNext`, when supplied, fires on the Next stage button. Pass
+ *     `undefined` (or omit) to hide the button entirely — typical for
+ *     fails, the last stage in the registry, or any case where there's
+ *     no obvious "next" target.
  *
  * `failHint` is the active stage's optional diagnostic — when the
  * grade fails, the modal renders this in place of the generic "pass
@@ -49,6 +63,7 @@ export function showResults(
   result: StageResult,
   onRetry: () => void,
   failHint?: (grade: GradeInputs) => string,
+  onNext?: () => void,
 ): void {
   if (result.passed) {
     handles.title.textContent = result.stars === 3 ? "Mastered!" : "Passed";
@@ -71,10 +86,31 @@ export function showResults(
     hideResults(handles);
   };
 
+  // Next-stage CTA is the success-path primary action. When shown,
+  // demote Run again to the secondary slot so the dialog reads with
+  // a single accented button.
+  const nextHandler = result.passed ? onNext : undefined;
+  if (nextHandler) {
+    handles.next.hidden = false;
+    handles.next.onclick = () => {
+      hideResults(handles);
+      nextHandler();
+    };
+    handles.retry.dataset["demoted"] = "true";
+  } else {
+    handles.next.hidden = true;
+    handles.next.onclick = null;
+    delete handles.retry.dataset["demoted"];
+  }
+
   handles.root.classList.add("show");
-  // Focus the close button so keyboard users can dismiss without
-  // hunting for the dialog's tabbable surface.
-  handles.close.focus();
+  // Focus the success-path primary if it's there, otherwise fall back
+  // to Close so keyboard users can always dismiss with Enter / Esc.
+  if (nextHandler) {
+    handles.next.focus();
+  } else {
+    handles.close.focus();
+  }
 }
 
 export function hideResults(handles: ResultsModalHandles): void {

--- a/playground/src/features/quest/results-modal.ts
+++ b/playground/src/features/quest/results-modal.ts
@@ -88,8 +88,10 @@ export function showResults(
 
   // Next-stage CTA is the success-path primary action. When shown,
   // demote Run again to the secondary slot so the dialog reads with
-  // a single accented button.
-  const nextHandler = result.passed ? onNext : undefined;
+  // a single accented button. Caller is responsible for only passing
+  // `onNext` on a passing run — the modal trusts that contract rather
+  // than re-checking `result.passed` here.
+  const nextHandler = onNext;
   if (nextHandler) {
     handles.next.hidden = false;
     handles.next.onclick = () => {

--- a/playground/src/features/quest/stages/index.ts
+++ b/playground/src/features/quest/stages/index.ts
@@ -47,4 +47,15 @@ export function stageById(id: string): Stage | undefined {
   return STAGES.find((s) => s.id === id);
 }
 
+/**
+ * Resolve the stage immediately following `currentId` in the registry's
+ * display order, or `undefined` if `currentId` is the last stage or
+ * isn't in the registry. Powers the results modal's "Next stage" CTA.
+ */
+export function nextStage(currentId: string): Stage | undefined {
+  const idx = STAGES.findIndex((s) => s.id === currentId);
+  if (idx < 0) return undefined;
+  return STAGES[idx + 1];
+}
+
 export type { Stage, Baseline, StarCount, UnlockedApi, GradeInputs, PassFn, StarFn } from "./types";


### PR DESCRIPTION
## Summary

Closes the fourth gap from the UX assessment: after a successful Quest run the modal only offered **Close** + **Run again**, so the natural action — advance to the next stage — cost two extra clicks via the dropdown picker. Now there's a **Next stage** button: primary on a successful run with a follow-up stage available, hidden on fail or on the last stage.

## Changes

- **`stages/index.ts`** — new `nextStage(currentId): Stage | undefined` helper that walks the registry's display order. Returns `undefined` for the last stage or an unknown id.
- **`results-modal.ts`** — `showResults` gains an optional `onNext` argument. When the run passed *and* `onNext` is supplied, the Next button is shown and Run again is demoted (a `data-demoted=\"true\"` attribute drives Tailwind's `data-[demoted=true]:*` variants, swapping the bg/font/padding for the secondary style). On fail or last-stage, the Next button stays hidden and Run again keeps its accent.
- **`quest-pane.ts`** — wires the handler by routing the click through the *existing* select-driven swap path (programmatic `change` event). All the existing flushSave / re-render / URL-sync logic runs without duplicating it inline.
- **`index.html`** — adds `#quest-results-next` to the modal markup with the data-attribute-driven demoted styling on the retry button.
- **Focus** — on a success path with `onNext`, focus goes to Next so Enter advances; on fail or last stage, focus stays on Close so Enter dismisses.

## Tests

5 new helper tests in `quest-next-stage.test.ts` covering:

- Returns the next stage in registry order
- Returns `undefined` for the last stage
- Returns `undefined` for an unknown id
- Walks the full registry without skipping or repeating

The modal's DOM-coupled behaviour (hidden flag, focus, retry-demoted) is **verified manually** — the test environment runs without a DOM and the existing surface tests follow the same node-only pattern. Adding jsdom would be a bigger dep change than this PR warrants; if/when it lands, the wiring tests already drafted in #${"comment"} can come back.

Total: 253 (was 248).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 253 pass
- [x] Pre-commit hook clean
- [ ] Manual: stage 1, run a passing controller → modal shows \"Mastered!\"/\"Passed\" + **Next stage** button (focused, accent), Run again demoted
- [ ] Manual: stage 15 (last), pass → no Next button, Run again stays primary
- [ ] Manual: any stage, fail → no Next button, Run again primary, focus on Close
- [ ] Manual: click Next → editor swaps to next stage's starter, picker advances, URL updates
- [ ] Manual mobile: Next button doesn't overflow the modal on narrow widths