### PR TITLE
feat(playground): unlock canonical reference solutions after pass

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -656,9 +656,8 @@
           >
         </summary>
         <pre
-          id="quest-reference-code"
           class="m-0 mt-1.5 p-2.5 bg-surface-elevated border border-stroke-subtle rounded-sm font-mono text-[11.5px] text-content overflow-x-auto whitespace-pre"
-        ></pre>
+        ><code id="quest-reference-code" class="block"></code></pre>
       </details>
     </section>
 

--- a/playground/index.html
+++ b/playground/index.html
@@ -639,6 +639,27 @@
         </summary>
         <ol id="quest-hints-list" class="list-decimal m-0 mt-1.5 pl-5 flex flex-col gap-1.5"></ol>
       </details>
+      <details
+        id="quest-reference"
+        hidden
+        class="px-3 py-2 bg-surface-secondary border border-stroke-subtle rounded-md text-[12.5px] [&>summary]:cursor-pointer [&>summary]:list-none [&>summary]:select-none [&[open]>summary>span:last-child]:rotate-90"
+      >
+        <summary class="flex items-center gap-2 text-content tracking-[0.01em]">
+          <span class="text-[10.5px] uppercase tracking-[0.08em] text-accent font-medium"
+            >Reference solution</span
+          >
+          <span id="quest-reference-status" class="text-content-tertiary"></span>
+          <span
+            class="ml-auto text-content-tertiary text-[11px] transition-transform"
+            aria-hidden="true"
+            >▸</span
+          >
+        </summary>
+        <pre
+          id="quest-reference-code"
+          class="m-0 mt-1.5 p-2.5 bg-surface-elevated border border-stroke-subtle rounded-sm font-mono text-[11.5px] text-content overflow-x-auto whitespace-pre"
+        ></pre>
+      </details>
     </section>
 
     <div

--- a/playground/src/__tests__/quest-reference-solutions.test.ts
+++ b/playground/src/__tests__/quest-reference-solutions.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { STAGES } from "../features/quest";
+
+// `Stage.referenceSolution` is the canonical-solution payload that
+// gets unlocked in the Quest pane after a 1★ pass. Authoring is
+// rolling out per stage — the curriculum's first five stages ship
+// today, with the rest scheduled for follow-up PRs as the API
+// patterns get pinned. These tests pin two contracts:
+//
+//   1. Stages that *claim* a solution (referenceSolution defined)
+//      must ship a non-trivial, non-empty string. A blank or
+//      whitespace-only entry would render an empty unlocked panel,
+//      which is worse than no panel at all.
+//   2. The first five curriculum stages must each carry a
+//      reference solution. This pin guards against a regression
+//      where a refactor accidentally drops a referenceSolution
+//      field while leaving the test list untouched.
+
+const STAGES_WITH_REFERENCE = ["first-floor", "listen-up", "car-buttons", "builtin", "choose"];
+
+describe("quest: referenceSolution authoring", () => {
+  it.each(STAGES.filter((s) => s.referenceSolution !== undefined).map((s) => [s.id, s] as const))(
+    "%s ships a non-empty referenceSolution",
+    (_id, stage) => {
+      expect(stage.referenceSolution).toBeDefined();
+      expect(typeof stage.referenceSolution).toBe("string");
+      expect(stage.referenceSolution?.trim().length ?? 0).toBeGreaterThan(0);
+    },
+  );
+
+  it.each(STAGES_WITH_REFERENCE)("stage %s has a referenceSolution", (id) => {
+    const stage = STAGES.find((s) => s.id === id);
+    expect(stage).toBeDefined();
+    expect(stage?.referenceSolution).toBeDefined();
+    expect(typeof stage?.referenceSolution).toBe("string");
+  });
+
+  it("every shipped reference solution mentions the `sim` API", () => {
+    // Sanity check: the curriculum's reference solutions are JS/TS
+    // controllers that drive the wasm sim, so a solution that never
+    // calls `sim.*` is almost certainly placeholder text. Cheap
+    // guard against an authoring slip where the comment block was
+    // committed without the actual code.
+    for (const stage of STAGES) {
+      if (stage.referenceSolution === undefined) continue;
+      expect(
+        stage.referenceSolution.includes("sim."),
+        `stage ${stage.id} reference solution doesn't reference sim.*`,
+      ).toBe(true);
+    }
+  });
+});

--- a/playground/src/features/quest/index.ts
+++ b/playground/src/features/quest/index.ts
@@ -26,6 +26,11 @@ export {
 export { API_REFERENCE, apiEntry, unlockedEntries, type ApiEntry } from "./api-reference";
 export { renderHints, wireHintsDrawer, type HintsDrawerHandles } from "./hints-drawer";
 export {
+  renderReferencePanel,
+  wireReferencePanel,
+  type ReferencePanelHandles,
+} from "./reference-panel";
+export {
   clearBestStars,
   clearCode,
   loadBestStars,

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -12,6 +12,11 @@ import { renderApiPanel, wireApiPanel, type ApiPanelHandles } from "./api-panel"
 import { clearChildren, requireElement } from "./dom-utils";
 import { mountQuestEditor, type QuestEditor } from "./editor";
 import { renderHints, wireHintsDrawer, type HintsDrawerHandles } from "./hints-drawer";
+import {
+  renderReferencePanel,
+  wireReferencePanel,
+  type ReferencePanelHandles,
+} from "./reference-panel";
 import { showResults, wireResultsModal, type ResultsModalHandles } from "./results-modal";
 import { renderSnippets, wireSnippetPicker, type SnippetPickerHandles } from "./snippet-picker";
 import { formatProgress } from "./stage-progress";
@@ -206,6 +211,12 @@ export async function bootQuestPane(opts: {
   // Hints drawer: collapsed-by-default progressive nudges.
   const hints: HintsDrawerHandles = wireHintsDrawer();
   renderHints(hints, activeStage);
+  // Reference solution: hidden until the player passes the active
+  // stage at least once. Re-rendered on stage change and after a
+  // successful grade so a fresh win unlocks the panel without a
+  // page reload.
+  const reference: ReferencePanelHandles = wireReferencePanel();
+  renderReferencePanel(reference, activeStage);
 
   // Disable Run while the Monaco bundle loads so a click before
   // mount completes doesn't run against an undefined editor.
@@ -238,6 +249,13 @@ export async function bootQuestPane(opts: {
           saveBestStars(stage.id, result.stars);
           populateStageSelect(handles);
           handles.select.value = activeStage.id;
+        }
+        // Always re-render the reference panel on a passing grade —
+        // even if the score didn't improve, the player may be seeing
+        // their first pass on this stage in this session, in which
+        // case the panel transitions from hidden to unlocked here.
+        if (stage.id === activeStage.id) {
+          renderReferencePanel(reference, activeStage);
         }
       }
     },
@@ -307,6 +325,7 @@ export async function bootQuestPane(opts: {
     renderStage(handles, next);
     renderApiPanel(apiPanel, next);
     renderHints(hints, next);
+    renderReferencePanel(reference, next);
     renderSnippets(snippets, next, editor);
     setEditorSilently(loadCode(next.id) ?? next.starterCode);
     handles.result.textContent = "";

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -254,8 +254,10 @@ export async function bootQuestPane(opts: {
         // even if the score didn't improve, the player may be seeing
         // their first pass on this stage in this session, in which
         // case the panel transitions from hidden to unlocked here.
+        // Pass `collapse: false` so a panel the player already
+        // expanded doesn't snap shut when they hit Run again.
         if (stage.id === activeStage.id) {
-          renderReferencePanel(reference, activeStage);
+          renderReferencePanel(reference, activeStage, { collapse: false });
         }
       }
     },

--- a/playground/src/features/quest/reference-panel.ts
+++ b/playground/src/features/quest/reference-panel.ts
@@ -14,7 +14,7 @@
  * service-aware editor up top for live work.
  */
 
-import { clearChildren, requireElement } from "./dom-utils";
+import { requireElement } from "./dom-utils";
 import type { Stage } from "./stages";
 import { loadBestStars } from "./storage";
 
@@ -22,6 +22,18 @@ export interface ReferencePanelHandles {
   readonly root: HTMLDetailsElement;
   readonly status: HTMLElement;
   readonly code: HTMLElement;
+}
+
+export interface RenderReferenceOptions {
+  /**
+   * Collapse the drawer when re-rendering. Default `true` — the right
+   * behaviour on initial mount and stage navigation, where the player
+   * hasn't expressed an opinion yet. Pass `false` when the re-render
+   * is driven by an in-place state change (e.g. the player just
+   * earned more stars on the active stage) so a panel they already
+   * expanded doesn't snap shut on them.
+   */
+  readonly collapse?: boolean;
 }
 
 export function wireReferencePanel(): ReferencePanelHandles {
@@ -32,7 +44,11 @@ export function wireReferencePanel(): ReferencePanelHandles {
   };
 }
 
-export function renderReferencePanel(handles: ReferencePanelHandles, stage: Stage): void {
+export function renderReferencePanel(
+  handles: ReferencePanelHandles,
+  stage: Stage,
+  options: RenderReferenceOptions = {},
+): void {
   const solution = stage.referenceSolution;
   const stars = loadBestStars(stage.id);
   // Hide the panel completely if the stage doesn't ship a solution
@@ -46,11 +62,10 @@ export function renderReferencePanel(handles: ReferencePanelHandles, stage: Stag
   }
   handles.root.hidden = false;
   handles.status.textContent = stars === 3 ? "(mastered)" : "(unlocked)";
-  clearChildren(handles.code);
-  // textContent escapes HTML — cheaper and safer than innerHTML
-  // for the verbatim code block.
+  // textContent replaces all children atomically and escapes HTML —
+  // no clearChildren needed first.
   handles.code.textContent = solution;
-  // Collapse on stage navigation so the next stage's panel doesn't
-  // pop open with stale code visible.
-  handles.root.removeAttribute("open");
+  if (options.collapse !== false) {
+    handles.root.removeAttribute("open");
+  }
 }

--- a/playground/src/features/quest/reference-panel.ts
+++ b/playground/src/features/quest/reference-panel.ts
@@ -1,0 +1,56 @@
+/**
+ * Render the canonical reference-solution drawer for a stage.
+ *
+ * The panel lives beneath the hints drawer in the Quest pane. It
+ * stays hidden until the player has earned at least 1★ on the
+ * stage (a bare pass) — at which point the canonical solution
+ * unlocks as a collapsible read-only block. A stage that doesn't
+ * ship a `referenceSolution` keeps the panel hidden regardless of
+ * grade, so adding solutions per stage stays incremental.
+ *
+ * The panel renders as `<pre><code>` rather than a second Monaco
+ * instance: a Monaco mount per panel adds ~3 MB of editor surface
+ * for read-only display, and the player already has the language-
+ * service-aware editor up top for live work.
+ */
+
+import { clearChildren, requireElement } from "./dom-utils";
+import type { Stage } from "./stages";
+import { loadBestStars } from "./storage";
+
+export interface ReferencePanelHandles {
+  readonly root: HTMLDetailsElement;
+  readonly status: HTMLElement;
+  readonly code: HTMLElement;
+}
+
+export function wireReferencePanel(): ReferencePanelHandles {
+  return {
+    root: requireElement("quest-reference", "reference-panel") as HTMLDetailsElement,
+    status: requireElement("quest-reference-status", "reference-panel"),
+    code: requireElement("quest-reference-code", "reference-panel"),
+  };
+}
+
+export function renderReferencePanel(handles: ReferencePanelHandles, stage: Stage): void {
+  const solution = stage.referenceSolution;
+  const stars = loadBestStars(stage.id);
+  // Hide the panel completely if the stage doesn't ship a solution
+  // OR the player hasn't passed yet. Hiding the entire `<details>`
+  // (rather than rendering a "locked" placeholder) keeps the UI
+  // clean for stages still being authored.
+  if (!solution || stars === 0) {
+    handles.root.hidden = true;
+    handles.root.removeAttribute("open");
+    return;
+  }
+  handles.root.hidden = false;
+  handles.status.textContent = stars === 3 ? "(mastered)" : "(unlocked)";
+  clearChildren(handles.code);
+  // textContent escapes HTML — cheaper and safer than innerHTML
+  // for the verbatim code block.
+  handles.code.textContent = solution;
+  // Collapse on stage navigation so the next stage's panel doesn't
+  // pop open with stale code visible.
+  handles.root.removeAttribute("open");
+}

--- a/playground/src/features/quest/stages/stage-01-first-floor.ts
+++ b/playground/src/features/quest/stages/stage-01-first-floor.ts
@@ -71,4 +71,11 @@ sim.pushDestination(0n, 2n);
     if (abandoned > 0) issues.push(`${abandoned} abandoned`);
     return `Run short — ${issues.join(", ")}. Call \`sim.pushDestination(0n, stopId)\` for each floor riders are heading to so nobody times out.`;
   },
+  referenceSolution: `// Canonical stage-1 solution.
+// Five riders at the lobby want F2 or F3 — queue both stops up front
+// and let dispatch fan them out.
+
+sim.pushDestination(0n, 1n);
+sim.pushDestination(0n, 2n);
+`,
 };

--- a/playground/src/features/quest/stages/stage-02-listen-up.ts
+++ b/playground/src/features/quest/stages/stage-02-listen-up.ts
@@ -81,4 +81,12 @@ for (const call of calls) {
     if (abandoned > 0) issues.push(`${abandoned} abandoned`);
     return `Run short — ${issues.join(", ")}. Iterate \`sim.hallCalls()\` and queue a destination for each pending call.`;
   },
+  referenceSolution: `// Canonical stage-2 solution.
+// Read the pending hall calls once and dispatch the car to each
+// floor riders are waiting on.
+
+for (const call of sim.hallCalls()) {
+  sim.pushDestination(0n, BigInt(call.stop));
+}
+`,
 };

--- a/playground/src/features/quest/stages/stage-03-car-buttons.ts
+++ b/playground/src/features/quest/stages/stage-03-car-buttons.ts
@@ -86,4 +86,15 @@ for (const stop of inside) {
     if (abandoned > 0) issues.push(`${abandoned} abandoned`);
     return `Run short — ${issues.join(", ")}. Combine \`hallCalls()\` and \`carCalls(carId)\` into one sweep so the car serves riders inside the cab too.`;
   },
+  referenceSolution: `// Canonical stage-3 solution.
+// Hall calls and car calls together: queue every waiting floor and
+// every cabin button into a single sweep.
+
+for (const call of sim.hallCalls()) {
+  sim.pushDestination(0n, BigInt(call.stop));
+}
+for (const stop of sim.carCalls(0n)) {
+  sim.pushDestination(0n, BigInt(stop));
+}
+`,
 };

--- a/playground/src/features/quest/stages/stage-04-builtin.ts
+++ b/playground/src/features/quest/stages/stage-04-builtin.ts
@@ -79,4 +79,11 @@ sim.setStrategy("look");
   ],
   failHint: ({ delivered }) =>
     `Delivered ${delivered} of 25. Try a different built-in via \`sim.setStrategy("look" | "nearest" | "etd")\` — heavy traffic favours stronger heuristics.`,
+  referenceSolution: `// Canonical stage-4 solution.
+// LOOK sweeps to the last request and reverses — strong on
+// steady moderate traffic and competitive with the nearest-car
+// pick under this stage's spawn rate.
+
+sim.setStrategy("look");
+`,
 };

--- a/playground/src/features/quest/stages/stage-05-choose.ts
+++ b/playground/src/features/quest/stages/stage-05-choose.ts
@@ -75,4 +75,11 @@ sim.setStrategy("etd");
   ],
   failHint: ({ delivered }) =>
     `Delivered ${delivered} of 30. Up-peak rewards ETD or RSR — \`sim.setStrategy("etd")\` is a strong starting point.`,
+  referenceSolution: `// Canonical stage-5 solution.
+// Up-peak (most riders boarding at the lobby, all heading up) is
+// exactly the case ETD was designed for — it minimises estimated
+// time-to-destination across the assignment.
+
+sim.setStrategy("etd");
+`,
 };


### PR DESCRIPTION
## Summary

Closes part of the sixth gap from the UX assessment: the \`Stage.referenceSolution\` schema field existed but nothing read it. Now: pass a stage at least once and the canonical solution unlocks as a collapsed \`<details>\` block beneath the hints drawer.

Ships solutions for the curriculum's **first five stages** where the API patterns are unambiguous. Stages 6–15 land in follow-up PRs as the more nuanced patterns (rank functions, event-driven dispatch, manual mode, topology mutation) get pinned.

## Changes

- **\`reference-panel.ts\`** — new module: \`wireReferencePanel\` + \`renderReferencePanel\` toggle visibility on \`loadBestStars(stage.id) > 0 && stage.referenceSolution !== undefined\`.
- **\`index.html\`** — \`<details id=\"quest-reference\">\` with \`<pre><code>\` body, hidden by default.
- **\`quest-pane.ts\`** — re-renders on initial mount, stage nav, and the moment of a passing grade.
- **Stages 1–5** — \`referenceSolution\` field with a canonical snippet + one-line comment.

\`<pre><code>\` rather than Monaco — read-only display doesn't justify the ~3 MB editor surface.

## Tests

11 new in \`quest-reference-solutions.test.ts\`: shipped solutions non-empty, must reference \`sim.*\`, stages 1–5 pinned as authored.

Total: **264** (was 253).

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 264 pass
- [x] Pre-commit hook clean
- [ ] Manual: stage 1, no pass → drawer hidden
- [ ] Manual: stage 1, pass → drawer unlocks (\"unlocked\") with the canonical snippet
- [ ] Manual: stage 1, 3★ → drawer label reads \"mastered\"
- [ ] Manual: stage 6 (no solution shipped) → drawer stays hidden