### PR TITLE
fix(playground): disable global keyboard shortcuts in quest mode

### DIFF
--- a/playground/src/shell/listeners.ts
+++ b/playground/src/shell/listeners.ts
@@ -215,13 +215,27 @@ function attachKeyboardShortcuts(
   switchHooks: ScenarioSwitchHooks,
 ): void {
   window.addEventListener("keydown", (ev) => {
+    // Quest mode is its own surface. Every shortcut here drives the
+    // compare-mode chrome (Pause sim, Reset sim, Compare toggle, Share,
+    // Tweak, scenario cards) — none of which exist in Quest. Worse:
+    // single-letter shortcuts like `s`, `r`, `c`, `t`, `?` collide
+    // with characters the player needs to type into the Monaco editor,
+    // and the global handler intercepts the keydown in the bubble
+    // phase and `preventDefault`s the input even though the textarea
+    // already received it. Bail out wholesale in Quest mode.
+    if (state.permalink.mode === "quest") return;
     if (ev.target instanceof HTMLElement) {
       const tag = ev.target.tagName;
       if (
         tag === "INPUT" ||
         tag === "TEXTAREA" ||
         tag === "SELECT" ||
-        ev.target.isContentEditable
+        ev.target.isContentEditable ||
+        // Defensive belt for any future Monaco mount in compare mode:
+        // the editor's hidden `<textarea>` already trips the tag check
+        // above, but the wider monaco-editor surface includes a
+        // contenteditable child for IME composition.
+        ev.target.closest(".monaco-editor")
       ) {
         return;
       }


### PR DESCRIPTION
## Summary

**Urgent.** User report: \"I literally can't type the letter 's' in the code editor.\"

The compare-mode shortcuts (\`s\` = share, \`r\` = reset, \`c\` = compare toggle, \`t\` = tweak, \`?\` = sheet) were registered on \`window\` and fired in the bubble phase regardless of which surface had focus. In Quest mode the player can't type those letters into Monaco: the textarea receives the keydown first, then the window handler bubbles up and \`preventDefault\`s the event, cancelling the character insertion that would otherwise have happened during the default action.

The existing early-return for \`tag === \"TEXTAREA\"\` was *supposed* to prevent this. In practice at least one Monaco focus path ends up with the event target on a non-TEXTAREA element inside the editor (the editor surface has multiple input vectors for IME composition / mouse selection / etc.), so the shortcut fires anyway and the keystroke gets eaten.

## Two-layer fix

- **Bail out wholesale when \`mode === \"quest\"\`.** Quest's chrome doesn't include any of the targets the shortcuts drive (no Pause sim, Reset sim, Compare toggle, Share, Tweak, scenario cards). There's nothing to control via single-letter keys, so suppression is the right default.
- **Belt-and-suspenders:** also bail out when the keydown originates inside any \`.monaco-editor\` subtree. Quest mode is the only place we mount Monaco today, but a future Monaco mount in compare mode shouldn't regress the same way.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 253 pass
- [x] Pre-commit hook clean
- [ ] Manual: Quest mode → type \"setStrategy\" in the editor without losing the s
- [ ] Manual: Quest mode → press R / C / T / ? while focused in the editor → no shortcut fires; the letter types into the editor
- [ ] Manual: Compare mode → press R / C / S / T → respective compare-mode action still fires (no regression)
- [ ] Manual: Compare mode → click into seed input, press S → seed gets the letter, share doesn't fire (existing INPUT bail-out still works)

## Related

This is a hotfix while the broader \"give Quest a live shaft view\" work (the \"Right\" version of the live-progress feature from the UX assessment) lands separately.