### PR TITLE
feat(playground): live shaft visualization while a quest stage runs

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -589,6 +589,23 @@
         class="min-h-[260px] bg-surface-elevated border border-stroke-subtle rounded-md overflow-hidden"
         aria-label="Quest controller editor"
       ></div>
+      <div
+        id="quest-shaft-wrap"
+        class="relative h-[240px] bg-[radial-gradient(ellipse_at_50%_0%,var(--bg-hover)_0%,var(--bg-secondary)_80%)] border border-stroke-subtle rounded-md overflow-hidden shadow-[inset_0_1px_0_rgba(255,255,255,0.02)]"
+      >
+        <canvas id="quest-shaft" class="absolute inset-0 w-full h-full block"></canvas>
+        <div
+          id="quest-shaft-idle"
+          class="absolute inset-0 flex items-center justify-center text-content-tertiary text-[12px] tracking-[0.02em] pointer-events-none"
+        >
+          Click
+          <span
+            class="px-1.5 py-0.5 mx-1 rounded-sm bg-surface-elevated border border-stroke-subtle text-[11px] font-mono text-content"
+            >Run</span
+          >
+          to see your controller drive the cars.
+        </div>
+      </div>
       <div id="quest-snippets" class="flex flex-wrap gap-1.5" aria-label="Insert API call"></div>
       <div class="flex flex-wrap items-center gap-x-3 gap-y-1.5">
         <button

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -106,16 +106,28 @@ function stageOptionLabel(stage: Stage, index: number, stars: StarCount): string
  * each click so a navigation between Run presses pulls the new
  * stage cleanly.
  */
+/**
+ * Shared mutable flag scoped to `bootQuestPane`. Lets the stage-change
+ * handler signal an active run's rAF loop to stop drawing — without
+ * it, the loop's closure-local flag stays `true` after navigation and
+ * keeps painting the previous stage's snapshot through the (transparent)
+ * idle overlay.
+ */
+interface RunLoop {
+  active: boolean;
+}
+
 function attachRunButton(
   handles: QuestPaneHandles,
   modal: ResultsModalHandles,
   editor: QuestEditor,
   renderer: CanvasRenderer,
+  runLoop: RunLoop,
   getStage: () => Stage,
   onGraded: (stage: Stage, result: StageResult) => void,
 ): void {
   const runOnce = (): void => {
-    void executeRun(handles, modal, editor, renderer, getStage(), runOnce, onGraded);
+    void executeRun(handles, modal, editor, renderer, runLoop, getStage(), runOnce, onGraded);
   };
   handles.runBtn.addEventListener("click", runOnce);
 }
@@ -125,6 +137,7 @@ async function executeRun(
   modal: ResultsModalHandles,
   editor: QuestEditor,
   renderer: CanvasRenderer,
+  runLoop: RunLoop,
   stage: Stage,
   retry: () => void,
   onGraded: (stage: Stage, result: StageResult) => void,
@@ -140,15 +153,15 @@ async function executeRun(
   // would stutter at the worker's batch cadence rather than
   // animating smoothly.
   //
-  // `loopActive` gates the recursive `requestAnimationFrame` instead
-  // of tracking a `rafId` we'd then have to cancel — at most one
-  // extra frame fires after the run ends, vs the bookkeeping the
-  // alternative would need across the closure boundary.
+  // `runLoop.active` lives at `bootQuestPane` scope — that lets the
+  // stage-change handler flip it on navigation, stopping draws so
+  // the next stage's idle overlay isn't painted over by the
+  // outgoing run's last snapshot.
   let latestSnap: Snapshot | null = null;
   let snapshotsRendered = 0;
-  let loopActive = true;
+  runLoop.active = true;
   const renderTick = (): void => {
-    if (!loopActive) return;
+    if (!runLoop.active) return;
     if (latestSnap !== null) {
       renderer.draw(latestSnap, 1);
     }
@@ -220,7 +233,10 @@ async function executeRun(
     handles.runBtn.disabled = false;
     // Stop the rAF loop. The canvas keeps its last drawn frame so
     // the player can study the final state — we don't clear it.
-    loopActive = false;
+    // The stage-change handler may have already flipped this off
+    // (in which case the loop is already idle); writing it again
+    // here is harmless either way.
+    runLoop.active = false;
     // Bring the idle overlay back only if no snapshot ever rendered
     // (e.g. the controller threw before the first batch resolved).
     // Once a snapshot has rendered, leaving the canvas exposed is
@@ -270,7 +286,16 @@ export async function bootQuestPane(opts: {
   // language across modes. Tether scenarios don't apply in Quest
   // (the curriculum is all building configs), so we leave the
   // tether-config null.
+  // `bootQuestPane` is mounted exactly once per page (the mode toggle
+  // hard-reloads on swap), so the renderer's resize listener lives
+  // for the page lifetime — `dispose()` is intentionally never called
+  // since there's no remount path that would benefit.
   const shaftRenderer = new CanvasRenderer(handles.shaft, QUEST_SHAFT_ACCENT);
+  // Shared rAF-loop control. Hoisted to this scope so the stage-change
+  // handler can flip `active` to false on navigation; without it, the
+  // outgoing run's loop keeps drawing through the (transparent) idle
+  // overlay on the next stage.
+  const runLoop: RunLoop = { active: false };
 
   // Disable Run while the Monaco bundle loads so a click before
   // mount completes doesn't run against an undefined editor.
@@ -291,6 +316,7 @@ export async function bootQuestPane(opts: {
     modal,
     editor,
     shaftRenderer,
+    runLoop,
     () => activeStage,
     (stage, result) => {
       // Persist a new high score and refresh the picker labels so the
@@ -382,6 +408,11 @@ export async function bootQuestPane(opts: {
     // changed. Without this clear, the last "Tick X · N delivered"
     // readout from the orphaned run sticks on the new stage's UI.
     handles.progress.textContent = "";
+    // Stop any in-flight rAF loop before clearing the canvas. Without
+    // this the outgoing run's loop would keep drawing through the
+    // transparent idle overlay on every animation frame, painting
+    // the previous stage's cars over the next stage's idle prompt.
+    runLoop.active = false;
     // Restore the idle overlay and clear any frozen frame from the
     // previous stage's run — the next stage gets a fresh canvas so
     // the player isn't looking at stale cars from a different

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -101,12 +101,6 @@ function stageOptionLabel(stage: Stage, index: number, stars: StarCount): string
 }
 
 /**
- * Wire the Run button to execute the editor's current text against
- * the active stage. The stage is read via the supplied getter on
- * each click so a navigation between Run presses pulls the new
- * stage cleanly.
- */
-/**
  * Shared mutable flag scoped to `bootQuestPane`. Lets the stage-change
  * handler signal an active run's rAF loop to stop drawing — without
  * it, the loop's closure-local flag stays `true` after navigation and
@@ -117,6 +111,12 @@ interface RunLoop {
   active: boolean;
 }
 
+/**
+ * Wire the Run button to execute the editor's current text against
+ * the active stage. The stage is read via the supplied getter on
+ * each click so a navigation between Run presses pulls the new
+ * stage cleanly.
+ */
 function attachRunButton(
   handles: QuestPaneHandles,
   modal: ResultsModalHandles,
@@ -240,8 +240,13 @@ async function executeRun(
     // Bring the idle overlay back only if no snapshot ever rendered
     // (e.g. the controller threw before the first batch resolved).
     // Once a snapshot has rendered, leaving the canvas exposed is
-    // the more useful state.
+    // the more useful state. Clear the canvas in the no-snapshot
+    // branch — a previous run's last frame would otherwise show
+    // through the (transparent) idle overlay and contradict the
+    // "Click Run" prompt the player just got back.
     if (snapshotsRendered === 0) {
+      const ctx = handles.shaft.getContext("2d");
+      if (ctx) ctx.clearRect(0, 0, handles.shaft.width, handles.shaft.height);
       handles.shaftIdle.hidden = false;
     }
   }

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -19,6 +19,11 @@ import { runStage, type StageResult } from "./stage-runner";
 import { nextStage, STAGES, stageById } from "./stages";
 import type { StarCount, Stage } from "./stages";
 import { clearCode, loadBestStars, loadCode, saveBestStars, saveCode } from "./storage";
+import { CanvasRenderer } from "../../render";
+import type { Snapshot } from "../../types";
+
+/** Accent for car bodies in the Quest shaft visualization. */
+const QUEST_SHAFT_ACCENT = "#f59e0b";
 
 export interface QuestPaneHandles {
   readonly root: HTMLElement;
@@ -36,6 +41,10 @@ export interface QuestPaneHandles {
    * spammed by the per-batch update stream.
    */
   readonly progress: HTMLElement;
+  /** Canvas for the live shaft visualization. */
+  readonly shaft: HTMLCanvasElement;
+  /** Idle-state overlay shown when no run is in flight. */
+  readonly shaftIdle: HTMLElement;
 }
 
 /**
@@ -55,6 +64,8 @@ export function wireQuestPane(): QuestPaneHandles {
     resetBtn: requireElement("quest-reset", m) as HTMLButtonElement,
     result: requireElement("quest-result", m),
     progress: requireElement("quest-progress", m),
+    shaft: requireElement("quest-shaft", m) as HTMLCanvasElement,
+    shaftIdle: requireElement("quest-shaft-idle", m),
   };
 }
 
@@ -99,11 +110,12 @@ function attachRunButton(
   handles: QuestPaneHandles,
   modal: ResultsModalHandles,
   editor: QuestEditor,
+  renderer: CanvasRenderer,
   getStage: () => Stage,
   onGraded: (stage: Stage, result: StageResult) => void,
 ): void {
   const runOnce = (): void => {
-    void executeRun(handles, modal, editor, getStage(), runOnce, onGraded);
+    void executeRun(handles, modal, editor, renderer, getStage(), runOnce, onGraded);
   };
   handles.runBtn.addEventListener("click", runOnce);
 }
@@ -112,6 +124,7 @@ async function executeRun(
   handles: QuestPaneHandles,
   modal: ResultsModalHandles,
   editor: QuestEditor,
+  renderer: CanvasRenderer,
   stage: Stage,
   retry: () => void,
   onGraded: (stage: Stage, result: StageResult) => void,
@@ -119,6 +132,33 @@ async function executeRun(
   handles.runBtn.disabled = true;
   handles.result.textContent = "Running…";
   handles.progress.textContent = "";
+
+  // Live shaft loop: snapshots arrive from the worker every batch
+  // (~3-5 Hz). Cache the latest one and let an rAF loop redraw
+  // every animation frame so the renderer's tweens fill the
+  // gaps between server-side updates. Without rAF, the picture
+  // would stutter at the worker's batch cadence rather than
+  // animating smoothly.
+  //
+  // `loopActive` gates the recursive `requestAnimationFrame` instead
+  // of tracking a `rafId` we'd then have to cancel — at most one
+  // extra frame fires after the run ends, vs the bookkeeping the
+  // alternative would need across the closure boundary.
+  let latestSnap: Snapshot | null = null;
+  let snapshotsRendered = 0;
+  let loopActive = true;
+  const renderTick = (): void => {
+    if (!loopActive) return;
+    if (latestSnap !== null) {
+      renderer.draw(latestSnap, 1);
+    }
+    requestAnimationFrame(renderTick);
+  };
+  // Hide the idle overlay the moment we kick off — the canvas
+  // takes over the space until the run ends.
+  handles.shaftIdle.hidden = true;
+  requestAnimationFrame(renderTick);
+
   try {
     // Cap the controller's initial run at one second — long enough
     // for honest setup work, short enough that an infinite loop
@@ -131,6 +171,13 @@ async function executeRun(
         // stage's fresh state isn't overwritten by stale text.
         if (handles.select.value !== stage.id) return;
         handles.progress.textContent = formatProgress(grade);
+      },
+      onSnapshot: (snap) => {
+        // Snapshot stream stays live even if the player navigated
+        // away — the rAF loop is what gates rendering, and we stop
+        // it in the finally below for that case anyway.
+        latestSnap = snap;
+        snapshotsRendered += 1;
       },
     });
     // Always grade — a passed run earns its stars even if the player
@@ -171,6 +218,16 @@ async function executeRun(
     }
   } finally {
     handles.runBtn.disabled = false;
+    // Stop the rAF loop. The canvas keeps its last drawn frame so
+    // the player can study the final state — we don't clear it.
+    loopActive = false;
+    // Bring the idle overlay back only if no snapshot ever rendered
+    // (e.g. the controller threw before the first batch resolved).
+    // Once a snapshot has rendered, leaving the canvas exposed is
+    // the more useful state.
+    if (snapshotsRendered === 0) {
+      handles.shaftIdle.hidden = false;
+    }
   }
 }
 
@@ -207,6 +264,14 @@ export async function bootQuestPane(opts: {
   const hints: HintsDrawerHandles = wireHintsDrawer();
   renderHints(hints, activeStage);
 
+  // Live shaft renderer. Reuses the compare-mode CanvasRenderer so
+  // car kinematics, door cycles, and rider tweens look identical to
+  // the rest of the playground — the player learns one visual
+  // language across modes. Tether scenarios don't apply in Quest
+  // (the curriculum is all building configs), so we leave the
+  // tether-config null.
+  const shaftRenderer = new CanvasRenderer(handles.shaft, QUEST_SHAFT_ACCENT);
+
   // Disable Run while the Monaco bundle loads so a click before
   // mount completes doesn't run against an undefined editor.
   handles.runBtn.disabled = true;
@@ -225,6 +290,7 @@ export async function bootQuestPane(opts: {
     handles,
     modal,
     editor,
+    shaftRenderer,
     () => activeStage,
     (stage, result) => {
       // Persist a new high score and refresh the picker labels so the
@@ -316,6 +382,13 @@ export async function bootQuestPane(opts: {
     // changed. Without this clear, the last "Tick X · N delivered"
     // readout from the orphaned run sticks on the new stage's UI.
     handles.progress.textContent = "";
+    // Restore the idle overlay and clear any frozen frame from the
+    // previous stage's run — the next stage gets a fresh canvas so
+    // the player isn't looking at stale cars from a different
+    // building config.
+    handles.shaftIdle.hidden = false;
+    const ctx = handles.shaft.getContext("2d");
+    if (ctx) ctx.clearRect(0, 0, handles.shaft.width, handles.shaft.height);
     opts.onStageChange?.(next.id);
   });
 

--- a/playground/src/features/quest/stage-runner.ts
+++ b/playground/src/features/quest/stage-runner.ts
@@ -19,7 +19,7 @@
 
 import { createWorkerSim } from "./worker-sim";
 import type { GradeInputs, StarCount, Stage } from "./stages";
-import type { MetricsDto } from "../../types";
+import type { MetricsDto, Snapshot } from "../../types";
 
 export interface StageResult {
   /** `true` iff the stage's `passFn` returned `true` for the final grade. */
@@ -55,6 +55,14 @@ export interface RunStageOptions {
    * UI update error must not abort an in-flight run.
    */
   readonly onProgress?: (grade: GradeInputs) => void;
+  /**
+   * Called after each batch with the latest sim snapshot. Setting this
+   * implicitly opts into the worker's `wantVisuals: true` path so the
+   * snapshot bundle gets serialized — leave it `undefined` for headless
+   * grading runs and the runner skips the per-batch snapshot/event
+   * computation. Throws are caught for the same reason as `onProgress`.
+   */
+  readonly onSnapshot?: (snap: Snapshot) => void;
 }
 
 /**
@@ -98,10 +106,11 @@ export async function runStage(
     let lastMetrics: MetricsDto | null = null;
     let endTick = 0;
 
+    const wantVisuals = opts.onSnapshot !== undefined;
     while (endTick < maxTicks) {
       const remaining = maxTicks - endTick;
       const step = Math.min(batchTicks, remaining);
-      const result = await sim.tick(step);
+      const result = await sim.tick(step, wantVisuals ? { wantVisuals: true } : undefined);
       lastMetrics = result.metrics;
       endTick = result.tick;
       const grade = makeGrade(lastMetrics, endTick);
@@ -110,6 +119,13 @@ export async function runStage(
           opts.onProgress(grade);
         } catch {
           // A UI bug in the progress renderer must not abort the run.
+        }
+      }
+      if (opts.onSnapshot && result.snapshot) {
+        try {
+          opts.onSnapshot(result.snapshot);
+        } catch {
+          // A UI bug in the snapshot renderer must not abort the run.
         }
       }
       if (stage.passFn(grade)) {


### PR DESCRIPTION
## Summary

Closes the saga-style \"see your code drive the cars\" gap from the user's playtest report (\"I was expecting to see an elevator-saga-like UI with the elevator in view\").

The previous live-progress feature (#597) shipped a textual ticker beneath the Run row — *Tick X · N delivered*. That was the \"cheap version\" and stopped well short of the actual ask. This PR replaces the silent canvas with the **actual elevator visualization**, fed by the worker's per-batch Snapshot stream.

## Changes

- **\`index.html\`** — adds \`<canvas id=\"quest-shaft\">\` (240px tall, full width) beneath the editor with a *\"Click Run to see your controller drive the cars\"* idle-state overlay.
- **\`stage-runner.ts\`** — \`RunStageOptions\` gains \`onSnapshot?: (snap: Snapshot) => void\`. Setting it implicitly opts the worker into \`wantVisuals: true\` so the snapshot bundle gets serialized; leave it undefined and headless graders skip the cost as before. Throws caught for the same reason as \`onProgress\`.
- **\`quest-pane.ts\`** — instantiates the existing \`CanvasRenderer\` (the one compare-mode uses) so cars, doors, and rider tweens look identical across modes. During a run, an rAF loop redraws every animation frame using the latest snapshot the worker pushed (~3-5 Hz updates, ~60 Hz draws — the renderer's built-in tweens fill the gap smoothly).

## State machine

- **Idle** (boot, between runs after stage nav, after a controller throw before any snapshot): overlay visible, canvas blank.
- **Running** (Run clicked → first snapshot arrived): overlay hidden, canvas live.
- **Settled** (run ended, modal showing): overlay stays hidden, canvas keeps its last drawn frame so the player can study the final state.
- **Stage navigation**: canvas clears, overlay restores.

## Loop control

The rAF loop uses a \`loopActive\` flag rather than tracking a \`rafId\` we'd then have to cancel. At most one extra frame fires after the run ends, vs the bookkeeping the alternative would need across the closure boundary (TS doesn't track closure-mutated nullable variables, so a \`rafId | null\` pattern hits two no-useless-assignment / no-unnecessary-condition lint errors).

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 255 pass
- [x] Pre-commit hook clean
- [ ] Manual: stage 1, click Run → idle overlay disappears, cars start moving in the shaft, stops light up, riders animate
- [ ] Manual: stage 1, run completes → modal shows; closing it leaves the final shaft frame visible
- [ ] Manual: stage 1 → stage 2 mid-run → outgoing run's last frame clears, idle overlay returns
- [ ] Manual: stage with throwing controller (e.g. \`sim.totallyNotAMethod()\`) → idle overlay restores, error shown inline
- [ ] Manual mobile: shaft height (240px) reads cleanly on portrait + landscape; no overflow