### PR TITLE
feat(playground): warm-dark monaco theme for the quest editor

### DIFF
--- a/playground/src/features/quest/editor.ts
+++ b/playground/src/features/quest/editor.ts
@@ -151,6 +151,12 @@ function registerWarmDarkTheme(monaco: typeof Monaco): void {
       "editorSuggestWidget.foreground": "#fafafa",
       "editorSuggestWidget.selectedBackground": "#323240",
       "editorSuggestWidget.highlightForeground": "#f59e0b",
+      // Monaco draws the matched-prefix highlight in two states:
+      // `highlightForeground` for unfocused rows, and a separate
+      // `focusHighlightForeground` for the active row. Without the
+      // focused variant, the focused row falls back to vs-dark's
+      // cool-blue and breaks the warm-accent guarantee.
+      "editorSuggestWidget.focusHighlightForeground": "#fbbf24", // --accent-up
       "editorHoverWidget.background": "#1a1a1f",
       "editorHoverWidget.border": "#3a3a45",
     },

--- a/playground/src/features/quest/editor.ts
+++ b/playground/src/features/quest/editor.ts
@@ -101,13 +101,70 @@ async function configureWorkerEnvironment(): Promise<void> {
   };
 }
 
+/**
+ * Define a Monaco theme keyed off the playground's warm-dark palette
+ * so the editor sits inside a container styled with `--bg-*` /
+ * `--text-*` without standing out as a cooler-toned rectangle.
+ *
+ * Colour values are pinned literals (Monaco's theme API doesn't
+ * resolve CSS custom properties), kept in sync with `:root` in
+ * `style.css`. The base `vs-dark` is inherited so token-level syntax
+ * highlighting comes along for free; only chrome (background, line
+ * numbers, selection, cursor, scrollbar) gets retinted.
+ *
+ * Idempotent — Monaco lets `defineTheme` re-register the same name.
+ * Called from `mountQuestEditor` after `loadMonaco`, so multiple
+ * mounts on the same page redefine without harm.
+ */
+function registerWarmDarkTheme(monaco: typeof Monaco): void {
+  monaco.editor.defineTheme("quest-warm-dark", {
+    base: "vs-dark",
+    inherit: true,
+    rules: [],
+    colors: {
+      "editor.background": "#0f0f12", // --bg-primary
+      "editor.foreground": "#fafafa", // --text-primary
+      "editorLineNumber.foreground": "#6b6b75", // --text-disabled
+      "editorLineNumber.activeForeground": "#a1a1aa", // --text-secondary
+      "editor.lineHighlightBackground": "#1a1a1f", // --bg-secondary
+      "editor.lineHighlightBorder": "#1a1a1f00",
+      "editor.selectionBackground": "#323240", // --bg-active
+      "editor.inactiveSelectionBackground": "#252530", // --bg-elevated
+      "editor.selectionHighlightBackground": "#2a2a35", // --bg-hover
+      "editorCursor.foreground": "#f59e0b", // --accent
+      "editorWhitespace.foreground": "#3a3a45", // --border-default
+      "editorIndentGuide.background1": "#2a2a35", // --border-subtle
+      "editorIndentGuide.activeBackground1": "#3a3a45", // --border-default
+      "editor.findMatchBackground": "#fbbf2440", // --accent-up + alpha
+      "editor.findMatchHighlightBackground": "#fbbf2420",
+      "editorBracketMatch.background": "#3a3a4580",
+      "editorBracketMatch.border": "#f59e0b80",
+      "editorOverviewRuler.border": "#2a2a35",
+      "scrollbar.shadow": "#00000000",
+      "scrollbarSlider.background": "#3a3a4540",
+      "scrollbarSlider.hoverBackground": "#3a3a4580",
+      "scrollbarSlider.activeBackground": "#3a3a45c0",
+      "editorWidget.background": "#1a1a1f", // --bg-secondary
+      "editorWidget.border": "#3a3a45", // --border-default
+      "editorSuggestWidget.background": "#1a1a1f",
+      "editorSuggestWidget.border": "#3a3a45",
+      "editorSuggestWidget.foreground": "#fafafa",
+      "editorSuggestWidget.selectedBackground": "#323240",
+      "editorSuggestWidget.highlightForeground": "#f59e0b",
+      "editorHoverWidget.background": "#1a1a1f",
+      "editorHoverWidget.border": "#3a3a45",
+    },
+  });
+}
+
 /** Mount a Monaco editor in the supplied container. */
 export async function mountQuestEditor(opts: EditorMountOptions): Promise<QuestEditor> {
   const monaco = await loadMonaco();
+  registerWarmDarkTheme(monaco);
   const editor = monaco.editor.create(opts.container, {
     value: opts.initialValue,
     language: opts.language ?? "typescript",
-    theme: "vs-dark",
+    theme: "quest-warm-dark",
     readOnly: opts.readOnly ?? false,
     automaticLayout: true,
     minimap: { enabled: false },


### PR DESCRIPTION
## Summary

Closes the seventh gap from the UX assessment: Monaco mounted with \`theme: \"vs-dark\"\` inside containers styled with the playground's warm-dark palette, so the editor sat as a visibly cooler-toned rectangle against the rest of the UI.

## Changes

- **\`editor.ts\`** — adds \`registerWarmDarkTheme\` which defines a Monaco theme keyed off the playground's \`--bg-*\` / \`--text-*\` / \`--accent\` tokens. Inherits from \`vs-dark\` so token-level syntax highlighting is preserved; only the chrome (background, line numbers, selection, cursor, scrollbar, suggestion / hover widgets, indent guides, bracket match, find-match, overview ruler) gets retinted.
- \`mountQuestEditor\` now uses \`theme: \"quest-warm-dark\"\` instead of \`vs-dark\`.

## Why pinned literals

Monaco's theme API takes a static color object and doesn't resolve CSS custom properties at runtime. Color values are pinned to the same hex literals \`:root\` in \`style.css\` declares, with each mapping carrying a comment naming the underlying token (e.g. \`\"editor.background\": \"#0f0f12\", // --bg-primary\`) so a future palette tweak can be propagated cleanly.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 264 pass
- [x] Pre-commit hook clean
- [ ] Manual: open Quest mode → editor matches the surrounding panels (line numbers in disabled-text grey, selection in active-bg, cursor in accent orange)
- [ ] Manual: type \`sim.\` → autocomplete dropdown is in elevated-bg with accent highlight on the matched prefix
- [ ] Manual mobile: theme reads cleanly on dark mode (the only mode the playground ships)