### PR TITLE
fix(playground): teach monaco about the sim global

### DIFF
--- a/playground/src/features/quest/editor.ts
+++ b/playground/src/features/quest/editor.ts
@@ -103,6 +103,18 @@ async function configureWorkerEnvironment(): Promise<void> {
 }
 
 /**
+ * Minimal shape of the Monaco TypeScript defaults surface we touch.
+ * Monaco's published types mark the entire `languages.typescript`
+ * subpath as `{ deprecated: true }`, hiding the actual runtime API
+ * behind that opaque flag — the surface still exists and works,
+ * we just have to declare the slice we need.
+ */
+interface TypescriptDefaults {
+  setCompilerOptions(options: Record<string, unknown>): void;
+  addExtraLib(content: string, filePath?: string): { dispose(): void };
+}
+
+/**
  * Configure Monaco's TypeScript service so the player's controller
  * code typechecks correctly:
  *
@@ -117,18 +129,6 @@ async function configureWorkerEnvironment(): Promise<void> {
  * Idempotent: Monaco's `setCompilerOptions` and `addExtraLib`
  * accept repeated calls; the latter dedupes by path.
  */
-/**
- * Minimal shape of the Monaco TypeScript defaults surface we touch.
- * Monaco's published types mark the entire `languages.typescript`
- * subpath as `{ deprecated: true }`, hiding the actual runtime API
- * behind that opaque flag — the surface still exists and works,
- * we just have to declare the slice we need.
- */
-interface TypescriptDefaults {
-  setCompilerOptions(options: Record<string, unknown>): void;
-  addExtraLib(content: string, filePath?: string): { dispose(): void };
-}
-
 function configureTypeScriptService(monaco: typeof Monaco): void {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const tsModule = (monaco.languages as any).typescript as

--- a/playground/src/features/quest/editor.ts
+++ b/playground/src/features/quest/editor.ts
@@ -13,6 +13,7 @@
  */
 
 import type * as Monaco from "monaco-editor";
+import { SIM_GLOBALS_DTS } from "./sim-globals-dts";
 
 export interface EditorMountOptions {
   /** Container element the editor will fill. */
@@ -102,6 +103,63 @@ async function configureWorkerEnvironment(): Promise<void> {
 }
 
 /**
+ * Configure Monaco's TypeScript service so the player's controller
+ * code typechecks correctly:
+ *
+ *   - Target ES2020 — `0n` BigInt literals, optional chaining, `??`.
+ *   - Lib `esnext` — every globals the player might reach for.
+ *   - Relaxed strictness — the curriculum welcomes JS-shaped code,
+ *     and "you didn't return on every branch" warnings are not the
+ *     teaching here.
+ *   - `addExtraLib(SIM_GLOBALS_DTS)` so `sim.foo(...)` doesn't paint
+ *     the whole file with "Cannot find name 'sim'" squigglies.
+ *
+ * Idempotent: Monaco's `setCompilerOptions` and `addExtraLib`
+ * accept repeated calls; the latter dedupes by path.
+ */
+/**
+ * Minimal shape of the Monaco TypeScript defaults surface we touch.
+ * Monaco's published types mark the entire `languages.typescript`
+ * subpath as `{ deprecated: true }`, hiding the actual runtime API
+ * behind that opaque flag — the surface still exists and works,
+ * we just have to declare the slice we need.
+ */
+interface TypescriptDefaults {
+  setCompilerOptions(options: Record<string, unknown>): void;
+  addExtraLib(content: string, filePath?: string): { dispose(): void };
+}
+
+function configureTypeScriptService(monaco: typeof Monaco): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const tsModule = (monaco.languages as any).typescript as
+    | { typescriptDefaults?: TypescriptDefaults }
+    | undefined;
+  const ts = tsModule?.typescriptDefaults;
+  if (!ts) return; // Monaco was loaded without the TS service — leave defaults alone.
+  // Numeric enum values from the upstream `typescript` package.
+  // ES2020 = 7 (covers BigInt, optional chaining, nullish coalesce).
+  // ESNext = 99.
+  ts.setCompilerOptions({
+    target: 7,
+    module: 99,
+    lib: ["esnext"],
+    allowJs: true,
+    checkJs: false,
+    noImplicitAny: false,
+    strict: false,
+    noUnusedLocals: false,
+    noUnusedParameters: false,
+    noImplicitReturns: false,
+    allowNonTsExtensions: true,
+  });
+  // The `ts:filename/` namespace is Monaco's convention for ambient
+  // lib files. Pinning a stable path means a hot reload (or a
+  // re-mount in tests) replaces the lib in place rather than
+  // accumulating duplicates.
+  ts.addExtraLib(SIM_GLOBALS_DTS, "ts:filename/quest-sim-globals.d.ts");
+}
+
+/**
  * Define a Monaco theme keyed off the playground's warm-dark palette
  * so the editor sits inside a container styled with `--bg-*` /
  * `--text-*` without standing out as a cooler-toned rectangle.
@@ -166,6 +224,7 @@ function registerWarmDarkTheme(monaco: typeof Monaco): void {
 /** Mount a Monaco editor in the supplied container. */
 export async function mountQuestEditor(opts: EditorMountOptions): Promise<QuestEditor> {
   const monaco = await loadMonaco();
+  configureTypeScriptService(monaco);
   registerWarmDarkTheme(monaco);
   const editor = monaco.editor.create(opts.container, {
     value: opts.initialValue,

--- a/playground/src/features/quest/sim-globals-dts.ts
+++ b/playground/src/features/quest/sim-globals-dts.ts
@@ -1,0 +1,94 @@
+/**
+ * Ambient declaration of the `sim` global the player's controller
+ * runs against, fed to Monaco's TypeScript service via `addExtraLib`.
+ *
+ * Without this, every `sim.foo(...)` call in the editor flags as
+ * "Cannot find name 'sim'", drowning the whole file in red squigglies
+ * and breaking IntelliSense / autocomplete on the only API the
+ * curriculum is teaching.
+ *
+ * The declaration lists every method in the `sim.*` surface — even
+ * ones that aren't unlocked at the current stage. Stage-level
+ * gating happens in the worker's sim-proxy at runtime; the editor
+ * doesn't try to mirror that, both because re-deriving extra-libs
+ * per stage swap would churn Monaco's TS service and because the
+ * "method exists but is locked here" error is more useful surfaced
+ * at run time (the failHint can name what to try) than as a static
+ * unknown-name squiggle.
+ */
+
+export const SIM_GLOBALS_DTS = `// Quest curriculum — sim global declaration.
+// Loaded into Monaco's TypeScript service so the editor knows about
+// the methods the player can call on the elevator-core wasm sim.
+
+declare type Ref = bigint;
+
+declare type StrategyName = "scan" | "look" | "nearest" | "etd" | "rsr";
+declare type ServiceMode = "normal" | "manual" | "out-of-service";
+declare type Direction = "up" | "down";
+
+/** Pending hall call at a floor. */
+declare interface HallCall {
+  readonly stop: number;
+  readonly direction: Direction;
+}
+
+/** Per-(car, stop) context the rank function receives. */
+declare interface RankCtx {
+  readonly car: Ref;
+  readonly carPosition: number;
+  readonly carDirection: number;
+  readonly stop: Ref;
+  readonly stopPosition: number;
+}
+
+/** Lower returned cost wins; \`null\` excludes the pair from assignment. */
+declare type RankFn = (ctx: RankCtx) => number | null;
+
+/** Loose typing for the event union — players narrow by \`type\`. */
+declare interface SimEvent {
+  readonly type: string;
+  readonly [key: string]: unknown;
+}
+
+declare const sim: {
+  /** Append a stop to the back of the car's destination queue. */
+  pushDestination(carRef: Ref, stopRef: Ref): void;
+  /** Pending hall calls — riders waiting at floors. */
+  hallCalls(): readonly HallCall[];
+  /** Stop ids the riders inside the car have pressed. */
+  carCalls(carRef: Ref): readonly number[];
+  /** Take the events fired since the last drain. */
+  drainEvents(): readonly SimEvent[];
+  /** Swap to a built-in dispatch strategy. */
+  setStrategy(name: StrategyName): boolean;
+  /** Register a JS rank function as the dispatcher. */
+  setStrategyJs(name: string, rank: RankFn): boolean;
+  /** Switch a car between normal / manual / out-of-service. */
+  setServiceMode(carRef: Ref, mode: ServiceMode): void;
+  /** Drive a manual-mode car directly. Positive is up, negative is down. */
+  setTargetVelocity(carRef: Ref, vMps: number): void;
+  /** Hold the car's doors open for extra ticks. */
+  holdDoor(carRef: Ref, ticks: number): void;
+  /** Release a holdDoor; doors close on the next loading-complete tick. */
+  cancelDoorHold(carRef: Ref): void;
+  /** Halt a car immediately — no door cycle, no queue drain. */
+  emergencyStop(carRef: Ref): void;
+  /** Canonical route between two stops. First entry is origin, last is destination. */
+  shortestRoute(originStop: Ref, destStop: Ref): readonly number[];
+  /** Send a rider to a new destination from wherever they currently are. */
+  reroute(riderRef: Ref, newDestStop: Ref): void;
+  /** Stops that bridge two lines. */
+  transferPoints(): readonly number[];
+  /** Every stop reachable without changing lines. */
+  reachableStopsFrom(stop: Ref): readonly number[];
+  /** Create a new stop on a line. Returns the new stop's ref. */
+  addStop(lineRef: Ref, name: string, position: number): Ref;
+  /** Register a stop on a line so dispatch routes to it. */
+  addStopToLine(stopRef: Ref, lineRef: Ref): void;
+  /** Put a line under a group's dispatcher. Returns the new dispatcher's id. */
+  assignLineToGroup(lineRef: Ref, groupId: number): number;
+  /** Move a car to a different line. */
+  reassignElevatorToLine(carRef: Ref, lineRef: Ref): void;
+};
+`;

--- a/playground/src/features/quest/sim-globals-dts.ts
+++ b/playground/src/features/quest/sim-globals-dts.ts
@@ -33,11 +33,19 @@ declare interface HallCall {
   readonly direction: Direction;
 }
 
-/** Per-(car, stop) context the rank function receives. */
+/**
+ * Per-(car, stop) context the rank function receives.
+ *
+ * \`carDirection\` is the car's signed sweep direction:
+ * \`+1\` heading up, \`-1\` heading down, \`0\` idle. It's an
+ * integer rather than the \`HallCall\` "up" / "down" string union
+ * because the rank function typically multiplies it (e.g. against
+ * \`stopPosition - carPosition\`) for direction-aware costs.
+ */
 declare interface RankCtx {
   readonly car: Ref;
   readonly carPosition: number;
-  readonly carDirection: number;
+  readonly carDirection: -1 | 0 | 1;
   readonly stop: Ref;
   readonly stopPosition: number;
 }


### PR DESCRIPTION
## Summary

User report: \"sim has a red squiggly\". Monaco's TypeScript service didn't know \`sim\` existed, so every \`sim.foo(...)\` call in the editor flagged as \`Cannot find name 'sim'\`. The whole stage's code painted red, autocomplete on the only API the curriculum teaches was broken, and a player typing \`sim.set\` saw nothing useful.

## Fix

- **New \`sim-globals-dts.ts\` module** exports an ambient TypeScript declaration covering every \`sim.*\` method in the curriculum surface (push/queue, hall/car calls, drainEvents, strategies, manual mode, doors, routes, topology mutators). Each method carries a one-line JSDoc so hover-docs show inline help.
- **\`editor.ts\` gains \`configureTypeScriptService\`** which feeds the declaration to Monaco via \`addExtraLib\` and configures the TS service for ES2020 / non-strict / JS-friendly so the player's controller code typechecks the way you'd expect from a beginner-friendly editor:
  - \`0n\` BigInt literals work
  - \`BigInt(call.stop)\` works
  - Optional chaining + \`??\` work
  - Unused-variable warnings are off

## Stage gating

The declaration lists every method even ones not unlocked at the current stage. Re-deriving extra-libs per stage swap would churn the TS service, and the runtime \`failHint\` (\"method locked here, try X\") explains it better than a static squiggle would. The worker still enforces unlocked-API at run time.

## Type cast notes

Monaco's published types mark the entire \`languages.typescript\` subpath as \`{ deprecated: true }\`, hiding the runtime surface (\`typescriptDefaults\`, \`ScriptTarget\`, etc.). The cast declares only the \`setCompilerOptions\` + \`addExtraLib\` slice we touch — using numeric enum values for \`target\` (\`7\` = ES2020) and \`module\` (\`99\` = ESNext) since the enum exports were also hidden.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 273 pass
- [x] Pre-commit hook clean
- [ ] Manual: open Quest stage 1 → no red squigglies on \`sim.pushDestination(0n, 1n)\`
- [ ] Manual: type \`sim.\` in the editor → autocomplete shows the unlocked methods (and locked ones too — see commit body for why)
- [ ] Manual: hover on \`sim.hallCalls\` → JSDoc tooltip shows \"Pending hall calls — riders waiting at floors.\"
- [ ] Manual: type \`for (const call of sim.hallCalls()) { call.\` → autocomplete shows \`stop\`, \`direction\`