### PR TITLE
feat(playground): pin monaco markers on controller throws

### DIFF
--- a/playground/src/__tests__/quest-controller-error.test.ts
+++ b/playground/src/__tests__/quest-controller-error.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { ControllerError, extractTopFrameLineCol } from "../features/quest/controller-error";
+
+// `extractTopFrameLineCol` is the bridge between an Error's stack
+// string and a Monaco marker. Browsers format frames differently
+// (Chrome's `at <anonymous>:5:10`, Safari's `<anonymous>:5:10`,
+// Firefox's `@<anonymous>:5:10`, plus eval-wrapper variants), so
+// pin the extraction against representative samples from each.
+
+describe("quest: extractTopFrameLineCol", () => {
+  it("returns null on undefined / empty stacks", () => {
+    expect(extractTopFrameLineCol(undefined)).toBeNull();
+    expect(extractTopFrameLineCol("")).toBeNull();
+    expect(extractTopFrameLineCol("\n\n\n")).toBeNull();
+  });
+
+  it("returns null when no frame carries a :line:column suffix", () => {
+    expect(extractTopFrameLineCol("Error: something\n  at <anonymous>")).toBeNull();
+  });
+
+  it("parses a Chrome-style frame", () => {
+    const stack = `TypeError: foo is not a function
+    at <anonymous>:5:10
+    at <anonymous>:1:1`;
+    expect(extractTopFrameLineCol(stack)).toEqual({ line: 5, column: 10 });
+  });
+
+  it("parses a Chrome paren-wrapped frame", () => {
+    const stack = `TypeError: foo is not a function
+    at anonymous (eval at <anonymous>:1:1, <anonymous>:7:23)
+    at <anonymous>:1:1`;
+    expect(extractTopFrameLineCol(stack)).toEqual({ line: 7, column: 23 });
+  });
+
+  it("parses a Firefox-style frame", () => {
+    const stack = `anonymous@<anonymous>:4:9
+@<anonymous>:1:1`;
+    expect(extractTopFrameLineCol(stack)).toEqual({ line: 4, column: 9 });
+  });
+
+  it("returns the topmost frame, not the deepest", () => {
+    const stack = `TypeError: bad
+    at <anonymous>:9:3
+    at <anonymous>:5:10
+    at <anonymous>:1:1`;
+    expect(extractTopFrameLineCol(stack)).toEqual({ line: 9, column: 3 });
+  });
+
+  it("ignores frames whose line/column are not finite integers", () => {
+    const stack = `Error: bad
+    at <anonymous>:NaN:Infinity
+    at <anonymous>:5:10`;
+    expect(extractTopFrameLineCol(stack)).toEqual({ line: 5, column: 10 });
+  });
+});
+
+describe("quest: ControllerError", () => {
+  it("preserves the message and the location together", () => {
+    const err = new ControllerError("sim.fooBar is not a function", { line: 5, column: 10 });
+    expect(err.message).toBe("sim.fooBar is not a function");
+    expect(err.location).toEqual({ line: 5, column: 10 });
+    expect(err.name).toBe("ControllerError");
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("accepts a null location for protocol/timeout errors", () => {
+    const err = new ControllerError("controller did not return within 1000ms", null);
+    expect(err.location).toBeNull();
+  });
+
+  it("instanceof checks survive the catch path", () => {
+    // The host catches an unknown `unknown` and uses `instanceof
+    // ControllerError` to decide whether to pin a Monaco marker.
+    // Pin that branch's behaviour so a future refactor can't subclass
+    // the relationship away.
+    const err: unknown = new ControllerError("nope", { line: 1, column: 1 });
+    expect(err instanceof ControllerError).toBe(true);
+    expect(err instanceof Error).toBe(true);
+  });
+});

--- a/playground/src/features/quest/controller-error.ts
+++ b/playground/src/features/quest/controller-error.ts
@@ -1,0 +1,52 @@
+/**
+ * Custom error class carrying the line/column where a player's
+ * controller threw, so the host can pin a Monaco marker at that
+ * location instead of just dumping the message into a status span.
+ *
+ * Worker.ts captures the stack on `new Function`-evaluation throws
+ * and extracts the `<anonymous>:N:M` frame; worker-sim re-throws as
+ * a `ControllerError` so the stage-runner / quest-pane catch path
+ * can branch on it without awkward duck-typing.
+ */
+
+export interface ControllerErrorLocation {
+  /** 1-based line number in the player's source. */
+  readonly line: number;
+  /** 1-based column number. May be approximate on older browsers. */
+  readonly column: number;
+}
+
+export class ControllerError extends Error {
+  readonly location: ControllerErrorLocation | null;
+
+  constructor(message: string, location: ControllerErrorLocation | null) {
+    super(message);
+    this.name = "ControllerError";
+    this.location = location;
+  }
+}
+
+/**
+ * Pull the topmost `:line:column` pair out of an error stack. Browsers
+ * differ on the exact frame format (Chrome's `at anonymous:5:10`,
+ * Safari's `<anonymous>:5:10`, Firefox's `@<anonymous>:5:10`), but
+ * they all end frames with `:N:M` (sometimes wrapped in parens).
+ *
+ * Returns `null` when no frame matches — the caller should fall back
+ * to an inline message instead of pinning a marker at a guessed line.
+ */
+const TRAILING_LINE_COL = /:(\d+):(\d+)\)?\s*$/;
+
+export function extractTopFrameLineCol(stack: string | undefined): ControllerErrorLocation | null {
+  if (!stack) return null;
+  for (const raw of stack.split("\n")) {
+    const match = TRAILING_LINE_COL.exec(raw.trim());
+    if (!match) continue;
+    const line = Number.parseInt(match[1] ?? "", 10);
+    const column = Number.parseInt(match[2] ?? "", 10);
+    if (Number.isInteger(line) && Number.isInteger(column)) {
+      return { line, column };
+    }
+  }
+  return null;
+}

--- a/playground/src/features/quest/editor.ts
+++ b/playground/src/features/quest/editor.ts
@@ -26,6 +26,15 @@ export interface EditorMountOptions {
   readonly readOnly?: boolean;
 }
 
+export interface RuntimeErrorMarker {
+  /** 1-based line where the error landed. */
+  readonly line: number;
+  /** 1-based column. */
+  readonly column: number;
+  /** Single-line error message — shown in Monaco's hover tooltip. */
+  readonly message: string;
+}
+
 export interface QuestEditor {
   /** Current text in the editor. */
   getValue(): string;
@@ -40,9 +49,21 @@ export interface QuestEditor {
   onDidChange(listener: () => void): { dispose(): void };
   /** Insert `text` at the current cursor position and focus the editor. */
   insertAtCursor(text: string): void;
+  /**
+   * Pin a runtime-error squiggle at `line` / `column`. Replaces any
+   * existing runtime marker so a fresh throw doesn't accumulate dots
+   * across reruns. Use `clearRuntimeMarker` to drop the marker
+   * (called at the start of each run).
+   */
+  setRuntimeMarker(marker: RuntimeErrorMarker): void;
+  /** Drop any runtime-error squiggle. */
+  clearRuntimeMarker(): void;
   /** Tear down the editor and free its DOM/worker resources. */
   dispose(): void;
 }
+
+/** Owner string for runtime markers — keeps them disjoint from the TS service's diagnostics. */
+const RUNTIME_MARKER_OWNER = "quest-runtime";
 
 let monacoModule: typeof Monaco | null = null;
 let monacoLoading: Promise<typeof Monaco> | null = null;
@@ -266,6 +287,37 @@ export async function mountQuestEditor(opts: EditorMountOptions): Promise<QuestE
       };
       editor.executeEdits("quest-snippet", [{ range, text, forceMoveMarkers: true }]);
       editor.focus();
+    },
+    setRuntimeMarker(marker) {
+      const model = editor.getModel();
+      if (!model) return;
+      // Use the message's first line as the marker's `message` field
+      // so Monaco's hover tooltip stays compact; longer details still
+      // land in the inline result span.
+      const headline = marker.message.split("\n")[0] ?? marker.message;
+      // `severity: 8` is `MarkerSeverity.Error`. Monaco's runtime
+      // expects the numeric value; the type stub for the enum is
+      // tucked behind the same deprecated-typescript flag we worked
+      // around in `configureTypeScriptService`.
+      monaco.editor.setModelMarkers(model, RUNTIME_MARKER_OWNER, [
+        {
+          severity: 8,
+          message: headline,
+          startLineNumber: marker.line,
+          startColumn: marker.column,
+          endLineNumber: marker.line,
+          endColumn: Math.max(marker.column + 1, marker.column),
+        },
+      ]);
+      // Reveal the line so the squiggle isn't off-screen in a long
+      // editor; centred so the player can read context above and
+      // below without manual scroll.
+      editor.revealLineInCenterIfOutsideViewport(marker.line);
+    },
+    clearRuntimeMarker() {
+      const model = editor.getModel();
+      if (!model) return;
+      monaco.editor.setModelMarkers(model, RUNTIME_MARKER_OWNER, []);
     },
     dispose: () => {
       // Dispose the backing model first — `editor.dispose()` releases

--- a/playground/src/features/quest/editor.ts
+++ b/playground/src/features/quest/editor.ts
@@ -306,7 +306,10 @@ export async function mountQuestEditor(opts: EditorMountOptions): Promise<QuestE
           startLineNumber: marker.line,
           startColumn: marker.column,
           endLineNumber: marker.line,
-          endColumn: Math.max(marker.column + 1, marker.column),
+          // Single-character squiggle — the location is approximate
+          // (browser stacks don't span a token range), so a one-char
+          // hit reads cleaner than a synthetic "to end of line".
+          endColumn: marker.column + 1,
         },
       ]);
       // Reveal the line so the squiggle isn't off-screen in a long

--- a/playground/src/features/quest/protocol.ts
+++ b/playground/src/features/quest/protocol.ts
@@ -142,6 +142,16 @@ export interface ErrorResponse {
   readonly kind: "error";
   readonly id: number;
   readonly message: string;
+  /**
+   * 1-based line / column in the player's controller source where
+   * the error landed, when the worker could pin one — populated for
+   * `load-controller` throws after the stack-frame extractor finds
+   * a usable `<anonymous>:N:M` frame. Other error sources (init
+   * failures, missing-method protocol drift, etc.) leave both
+   * undefined and the host falls back to a generic inline message.
+   */
+  readonly line?: number;
+  readonly column?: number;
 }
 
 export type WorkerToHost = OkResponse | TickResponse | SpawnResponse | ErrorResponse;

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -10,6 +10,7 @@
  */
 
 import { renderApiPanel, wireApiPanel, type ApiPanelHandles } from "./api-panel";
+import { ControllerError } from "./controller-error";
 import { requireElement } from "./dom-utils";
 import { mountQuestEditor, type QuestEditor } from "./editor";
 import { renderHints, wireHintsDrawer, type HintsDrawerHandles } from "./hints-drawer";
@@ -263,6 +264,10 @@ export async function bootQuestPane(opts: {
     renderReferencePanel(reference, next);
     renderSnippets(snippets, next, editor);
     setEditorSilently(loadCode(next.id) ?? next.starterCode);
+    // Drop any runtime marker carried over from the outgoing stage's
+    // last failure — the line numbers wouldn't match the new code,
+    // and a stale red squiggle on freshly-loaded code is misleading.
+    editor.clearRuntimeMarker();
     handles.result.textContent = "";
     handles.progress.textContent = "";
     stopLoopAndResetCanvas();
@@ -313,6 +318,10 @@ export async function bootQuestPane(opts: {
     handles.runBtn.disabled = true;
     handles.result.textContent = "Running…";
     handles.progress.textContent = "";
+    // Drop any squiggle from a previous failing run before starting
+    // afresh — keeping the old marker around would tell the player
+    // the line they're about to re-execute is already broken.
+    editor.clearRuntimeMarker();
 
     // Live shaft loop. Snapshots arrive from the worker every batch
     // (~3-5 Hz). Cache the latest one and let an rAF loop redraw
@@ -395,6 +404,18 @@ export async function bootQuestPane(opts: {
         // Errors stay inline — the modal is for graded outcomes.
         handles.result.textContent = `Error: ${msg}`;
         handles.progress.textContent = "";
+        // When the worker pinned a source location, paint a Monaco
+        // marker so the player sees a red squiggle at the line that
+        // threw. Without a location (init/protocol/timeout errors)
+        // the inline message is the only signal — that's fine; we'd
+        // be guessing if we forced a marker.
+        if (err instanceof ControllerError && err.location !== null) {
+          editor.setRuntimeMarker({
+            line: err.location.line,
+            column: err.location.column,
+            message: msg,
+          });
+        }
       }
     } finally {
       handles.runBtn.disabled = false;
@@ -423,6 +444,9 @@ export async function bootQuestPane(opts: {
     if (!ok) return;
     clearCode(activeStage.id);
     setEditorSilently(activeStage.starterCode);
+    // Drop any squiggle the previous code had — the new starter is
+    // the canonical fresh state.
+    editor.clearRuntimeMarker();
     handles.result.textContent = "";
   });
 

--- a/playground/src/features/quest/worker-sim.ts
+++ b/playground/src/features/quest/worker-sim.ts
@@ -7,6 +7,7 @@
  */
 
 import type { RepositionStrategyName, StrategyName } from "../../types";
+import { ControllerError, type ControllerErrorLocation } from "./controller-error";
 import type { HostToWorker, InitPayload, TickResultPayload, WorkerToHost } from "./protocol";
 
 interface PendingResolver {
@@ -251,9 +252,21 @@ export class WorkerSim {
           resolver.resolve(msg.riderId);
         }
         return;
-      case "error":
-        resolver.reject(new Error(msg.message));
+      case "error": {
+        // Worker-side controller throws come back with line/column
+        // populated; surface those as a `ControllerError` so the host
+        // can pin a Monaco marker at the source location. Other
+        // error sources (init / spawn / tick) leave both unset and
+        // bubble as plain Errors.
+        const loc: ControllerErrorLocation | null =
+          msg.line !== undefined && msg.column !== undefined
+            ? { line: msg.line, column: msg.column }
+            : null;
+        resolver.reject(
+          loc !== null ? new ControllerError(msg.message, loc) : new Error(msg.message),
+        );
         return;
+      }
       default: {
         // An unknown `kind` from a future worker version would silently
         // leave the host promise unresolved — reject loudly instead so

--- a/playground/src/features/quest/worker.ts
+++ b/playground/src/features/quest/worker.ts
@@ -12,7 +12,51 @@
 declare const self: DedicatedWorkerGlobalScope;
 
 import type { EventDto, MetricsDto, Snapshot } from "../../types";
+import { extractTopFrameLineCol, type ControllerErrorLocation } from "./controller-error";
 import type { HostToWorker, InitPayload, TickResultPayload, WorkerToHost } from "./protocol";
+
+/**
+ * Line offset between the player's source and the wrapped function
+ * body the runtime sees. `handleLoadController` uses the existing
+ * `Function` constructor to evaluate the player's code and the
+ * runtime synthesises a wrapper around it; different runtimes
+ * attribute body line 1 differently. The probe runs once at module
+ * load by throwing from a known line and reading back the reported
+ * number — the resulting offset gets subtracted from controller
+ * stack frames so the line/column we send back to the host matches
+ * the player's source.
+ *
+ * Cached at module load. If the probe doesn't yield a usable stack
+ * the offset stays at the default and the resulting markers may
+ * sit a line or two off; the inline message still tells the truth.
+ */
+const PROBE_KNOWN_LINE = 3;
+let controllerLineOffset = 0;
+{
+  // Same `Function` access pattern `handleLoadController` uses below.
+  const ProbeCtor = Function;
+  try {
+    // Two empty body lines so we don't share line 1 with the wrapper.
+    new ProbeCtor('\n\nthrow new Error("__quest_probe__")')();
+  } catch (probe) {
+    const reported = extractTopFrameLineCol((probe as Error).stack);
+    if (reported && reported.line >= PROBE_KNOWN_LINE) {
+      controllerLineOffset = reported.line - PROBE_KNOWN_LINE;
+    }
+  }
+}
+
+/** One leading line — the `"use strict";\n` prefix `handleLoadController` adds. */
+const SOURCE_PREFIX_LINES = 1;
+
+function controllerErrorLocation(err: unknown): ControllerErrorLocation | null {
+  if (!(err instanceof Error)) return null;
+  const reported = extractTopFrameLineCol(err.stack);
+  if (!reported) return null;
+  const sourceLine = reported.line - SOURCE_PREFIX_LINES - controllerLineOffset;
+  if (sourceLine < 1) return null;
+  return { line: sourceLine, column: reported.column };
+}
 
 interface WasmModule {
   default: (input: string) => Promise<unknown>;
@@ -275,7 +319,16 @@ function handleLoadController(
     factory(gatedSim(sim, unlockedApi));
     post({ kind: "ok", id });
   } catch (err) {
-    post({ kind: "error", id, message: errorMessage(err) });
+    // Player-source errors land here — pin the location so the host
+    // can paint a Monaco marker at the offending line. Other error
+    // sources in this worker (init / tick / spawn / set-strategy)
+    // leave line/column unset since their throws aren't user-source.
+    const loc = controllerErrorLocation(err);
+    const response: WorkerToHost =
+      loc !== null
+        ? { kind: "error", id, message: errorMessage(err), line: loc.line, column: loc.column }
+        : { kind: "error", id, message: errorMessage(err) };
+    post(response);
   }
 }
 


### PR DESCRIPTION
## Summary

When the player's controller throws, the error message used to land in a 12.5px gray status span next to the Run button. The thrown line was nowhere to be seen — players had to count opening braces and guess which \`sim.foo()\` call broke. This PR pipes the error location to Monaco so the offending line gets a red squiggle with a hover tooltip showing the message.

## Pieces

- **\`controller-error.ts\`** (new) — exports \`ControllerError\` (Error subclass with optional \`{line, column}\`) and \`extractTopFrameLineCol(stack)\` which pulls the topmost \`:N:M\` pair out of a browser stack string. Cross-browser tested (Chrome, Safari, Firefox).
- **\`worker.ts\`** — at module load, probes the runtime's wrapper line offset by throwing from a known body line and reading back the reported number. On controller-source throws, applies the probe offset + the \`\"use strict\";\\n\` prefix offset to map runtime lines back to source lines.
- **\`protocol.ts\`** — \`ErrorResponse\` gains optional \`line\` / \`column\`. Other error sources (init / spawn / tick) leave both unset so the host falls back to a plain \`Error\`.
- **\`worker-sim.ts\`** — \`case \"error\"\` rejects with \`ControllerError\` when location info is present, plain \`Error\` otherwise.
- **\`editor.ts\`** — \`QuestEditor\` interface gains \`setRuntimeMarker({line, column, message})\` and \`clearRuntimeMarker()\`. Implementation calls \`monaco.editor.setModelMarkers\` with a dedicated owner string so runtime markers stay disjoint from the TS service's diagnostics, and \`revealLineInCenterIfOutsideViewport\` so a long editor doesn't bury the squiggle.
- **\`quest-pane.ts\`** — \`runOnce\` clears any previous runtime marker at start. \`catch\` branch sets a marker when the error is a \`ControllerError\` with a location. Stage navigation and Reset both clear the marker so line numbers from the previous source don't leak.

## Tests

10 new tests in \`quest-controller-error.test.ts\` (283 total, was 273): null/empty stack handling, frame parsing for Chrome / Firefox / Safari forms, eval-wrapper paren frames, topmost-frame selection, NaN/Infinity guards, \`ControllerError\` instanceof contract.

## Out of scope

The probe-offset mechanism handles the common case but a runtime that reports \`<anonymous>\` at a non-obvious base line would mis-pin markers by one or two. The inline message still tells the truth in that case — markers degrade to \"approximately right\" rather than breaking the player's debugging flow.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 283 pass
- [x] Pre-commit hook clean
- [ ] Manual: write \`sim.totallyNotAMethod()\` in stage 1 → red squiggle pins on that line, hover shows the message
- [ ] Manual: ReferenceError on a typo'd local → red squiggle on the throw line
- [ ] Manual: fix the error and click Run → squiggle clears at run start
- [ ] Manual: navigate to another stage → squiggle clears
- [ ] Manual: click Reset → squiggle clears
- [ ] Manual: timeout error (controller infinite loop) → no marker, just inline \"controller did not return within 1000ms\"