### PR TITLE
chore(deps): override dompurify to ^3.4.2

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -53,5 +53,10 @@
   "dependencies": {
     "monaco-editor": "^0.55.1",
     "random-words": "^2.0.1"
+  },
+  "pnpm": {
+    "overrides": {
+      "dompurify": "^3.4.2"
+    }
   }
 }

--- a/playground/pnpm-lock.yaml
+++ b/playground/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  dompurify: ^3.4.2
+
 importers:
 
   .:
@@ -1287,8 +1290,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  dompurify@3.2.7:
-    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
+  dompurify@3.4.2:
+    resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -3212,7 +3215,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  dompurify@3.2.7:
+  dompurify@3.4.2:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -3706,7 +3709,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.2.7
+      dompurify: 3.4.2
       marked: 14.0.0
 
   ms@2.1.3: {}


### PR DESCRIPTION
## Summary

Closes the 8 open Dependabot alerts on dompurify (all moderate-severity prototype-pollution / mutation-XSS / FORBID_TAGS bypasses, all fixed in 3.4.x).

The vulnerable version is `dompurify@3.2.7`, transitively pulled in by `monaco-editor@0.55.1` (latest). Monaco hasn't bumped its bundled dompurify, so a top-level `pnpm.overrides` is the only path forward without forking the editor. dompurify 3.x is API-additive — Monaco's internal usage keeps working.

## Test plan

- [x] `pnpm install` resolves `dompurify@3.4.2` for the single transitive consumer (`pnpm why dompurify`)
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 332/332 pass against the bumped resolution
- [ ] Dependabot re-scan dismisses the 8 alerts after merge