### PR TITLE
chore(playground): remove quest toggle from header

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -29,32 +29,6 @@
           >
         </h1>
 
-        <div
-          id="mode-toggle"
-          role="group"
-          aria-label="Playground mode"
-          class="md:order-1 inline-flex items-center gap-0 rounded-md bg-surface-secondary border border-stroke-subtle p-0.5 shrink-0"
-        >
-          <button
-            type="button"
-            data-mode="compare"
-            data-active="true"
-            aria-pressed="true"
-            class="px-2.5 py-1 rounded-sm bg-transparent border-0 text-[11.5px] font-semibold tracking-[0.02em] cursor-pointer transition-colors duration-fast text-content-tertiary hover:text-content data-[active=true]:text-content data-[active=true]:bg-surface-elevated focus-visible:outline-none focus-visible:text-content"
-          >
-            Compare
-          </button>
-          <button
-            type="button"
-            data-mode="quest"
-            data-active="false"
-            aria-pressed="false"
-            class="px-2.5 py-1 rounded-sm bg-transparent border-0 text-[11.5px] font-semibold tracking-[0.02em] cursor-pointer transition-colors duration-fast text-content-tertiary hover:text-content data-[active=true]:text-content data-[active=true]:bg-surface-elevated focus-visible:outline-none focus-visible:text-content"
-          >
-            Quest
-          </button>
-        </div>
-
         <nav
           class="ml-auto md:order-3 flex items-center gap-4 shrink-0 max-md:gap-3"
           aria-label="External links"


### PR DESCRIPTION
## Summary
- Quest mode is not ready for public release; drop the Compare/Quest segmented toggle from `playground/index.html` so it isn't discoverable from the UI
- Quest infrastructure (`features/quest/*`, stages, worker, editor, tests) is untouched — only the public entry point is removed
- `?m=quest` deep-links still work for ongoing development; `wireModeToggle` no-ops gracefully when `#mode-toggle` is missing (`mode-toggle.ts:64`)

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run` — 332/332 passing
- [x] Pre-commit hook (lint-staged + typecheck + vitest) green