### PR TITLE
feat(bindings): track GameMaker Studio 2 coverage

### DIFF
--- a/bindings.toml
+++ b/bindings.toml
@@ -15,6 +15,7 @@
 #   wasm      = "<status>"             # required — see status values
 #   ffi       = "<status>"             # required — see status values
 #   tui       = "<status>"             # required — see status values
+#   gms       = "<status>"             # required — see status values
 #
 # Status values
 # -------------
@@ -22,7 +23,11 @@
 #                         For wasm/ffi this is the binding name (e.g.
 #                         "stepMany", "ev_sim_step"). For tui this is
 #                         the user-facing capability that uses it (e.g.
-#                         "events_panel", "metrics_panel").
+#                         "events_panel", "metrics_panel"). For gms this
+#                         is the GameMaker Studio 2 GML wrapper script
+#                         name (typically the same as `ffi` since the
+#                         generated `external_define` declares the
+#                         underlying C symbol under the same name).
 #   "skip:<reason>"     — intentionally not bound. Reason is mandatory and
 #                         must explain *why* (lifetimes, internal detail,
 #                         covered by another binding, read-only viewer,
@@ -66,6 +71,7 @@ category = "lifecycle"
 wasm = "constructor"
 ffi  = "ev_sim_create"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_create"
 
 [[methods]]
 name = "step"
@@ -73,6 +79,7 @@ category = "lifecycle"
 wasm = "stepMany"  # exposes batched step, internally calls step in loop
 ffi  = "ev_sim_step"
 tui  = "auto_tick_or_dot_hotkey"
+gms  = "ev_sim_step"
 
 [[methods]]
 name = "advance_tick"
@@ -80,6 +87,7 @@ category = "lifecycle"
 wasm = "skip:internal — driven by step()"
 ffi  = "skip:internal — driven by step()"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:internal — driven by step()"
 
 [[methods]]
 name = "run_until_quiet"
@@ -87,6 +95,7 @@ category = "lifecycle"
 wasm = "runUntilQuiet"
 ffi  = "ev_sim_run_until_quiet"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_run_until_quiet"
 
 # ─── Substep / phase-by-phase ticking ─────────────────────────────────────
 # Internal — exposing these would let consumers run an out-of-order tick
@@ -98,6 +107,7 @@ category = "internal"
 wasm = "skip:internal — phase ordering invariant"
 ffi  = "skip:internal — phase ordering invariant"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:internal — phase ordering invariant"
 
 [[methods]]
 name = "run_dispatch"
@@ -105,6 +115,7 @@ category = "internal"
 wasm = "skip:internal — phase ordering invariant"
 ffi  = "skip:internal — phase ordering invariant"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:internal — phase ordering invariant"
 
 [[methods]]
 name = "run_advance_queue"
@@ -112,6 +123,7 @@ category = "internal"
 wasm = "skip:internal — phase ordering invariant"
 ffi  = "skip:internal — phase ordering invariant"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:internal — phase ordering invariant"
 
 [[methods]]
 name = "run_doors"
@@ -119,6 +131,7 @@ category = "internal"
 wasm = "skip:internal — phase ordering invariant"
 ffi  = "skip:internal — phase ordering invariant"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:internal — phase ordering invariant"
 
 [[methods]]
 name = "run_loading"
@@ -126,6 +139,7 @@ category = "internal"
 wasm = "skip:internal — phase ordering invariant"
 ffi  = "skip:internal — phase ordering invariant"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:internal — phase ordering invariant"
 
 [[methods]]
 name = "run_metrics"
@@ -133,6 +147,7 @@ category = "internal"
 wasm = "skip:internal — phase ordering invariant"
 ffi  = "skip:internal — phase ordering invariant"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:internal — phase ordering invariant"
 
 [[methods]]
 name = "run_movement"
@@ -140,6 +155,7 @@ category = "internal"
 wasm = "skip:internal — phase ordering invariant"
 ffi  = "skip:internal — phase ordering invariant"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:internal — phase ordering invariant"
 
 [[methods]]
 name = "run_reposition"
@@ -147,6 +163,7 @@ category = "internal"
 wasm = "skip:internal — phase ordering invariant"
 ffi  = "skip:internal — phase ordering invariant"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:internal — phase ordering invariant"
 
 # ─── Modes (the original concern: \"emergency stop doesn't work\") ────────
 
@@ -156,6 +173,7 @@ category = "modes"
 wasm = "setServiceMode"
 ffi  = "ev_sim_set_service_mode"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_set_service_mode"
 
 [[methods]]
 name = "service_mode"
@@ -163,6 +181,7 @@ category = "modes"
 wasm = "serviceMode"
 ffi  = "ev_sim_service_mode"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_service_mode"
 
 [[methods]]
 name = "set_target_velocity"
@@ -170,6 +189,7 @@ category = "modes"
 wasm = "setTargetVelocity"
 ffi  = "ev_sim_set_target_velocity"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_set_target_velocity"
 
 [[methods]]
 name = "emergency_stop"
@@ -177,6 +197,7 @@ category = "modes"
 wasm = "emergencyStop"
 ffi  = "ev_sim_emergency_stop"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_emergency_stop"
 
 [[methods]]
 name = "open_door"
@@ -184,6 +205,7 @@ category = "modes"
 wasm = "openDoor"
 ffi  = "ev_sim_open_door"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_open_door"
 
 [[methods]]
 name = "close_door"
@@ -191,6 +213,7 @@ category = "modes"
 wasm = "closeDoor"
 ffi  = "ev_sim_close_door"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_close_door"
 
 [[methods]]
 name = "hold_door"
@@ -198,6 +221,7 @@ category = "modes"
 wasm = "holdDoor"
 ffi  = "ev_sim_hold_door"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_hold_door"
 
 [[methods]]
 name = "cancel_door_hold"
@@ -205,6 +229,7 @@ category = "modes"
 wasm = "cancelDoorHold"
 ffi  = "ev_sim_cancel_door_hold"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_cancel_door_hold"
 
 # ─── Dispatch ─────────────────────────────────────────────────────────────
 
@@ -214,6 +239,7 @@ category = "dispatch"
 wasm = "setStrategy"
 ffi  = "ev_sim_set_strategy"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_set_strategy"
 
 [[methods]]
 name = "strategy_id"
@@ -221,6 +247,7 @@ category = "dispatch"
 wasm = "strategyName"
 ffi  = "ev_sim_strategy_id"
 tui  = "dispatch_panel"
+gms  = "ev_sim_strategy_id"
 
 [[methods]]
 name = "set_reposition"
@@ -228,6 +255,7 @@ category = "dispatch"
 wasm = "setReposition"
 ffi  = "ev_sim_set_reposition"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_set_reposition"
 
 [[methods]]
 name = "remove_reposition"
@@ -235,6 +263,7 @@ category = "dispatch"
 wasm = "removeReposition"
 ffi  = "ev_sim_remove_reposition"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_remove_reposition"
 
 [[methods]]
 name = "reposition_id"
@@ -242,6 +271,7 @@ category = "dispatch"
 wasm = "repositionStrategyName"
 ffi  = "ev_sim_reposition_id"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_reposition_id"
 
 [[methods]]
 name = "build_dispatch_manifest"
@@ -249,6 +279,7 @@ category = "internal"
 wasm = "skip:internal — strategies consume this"
 ffi  = "skip:internal — strategies consume this"
 tui  = "dispatch_panel"
+gms  = "skip:internal — strategies consume this"
 
 [[methods]]
 name = "peek_dispatch_manifest"
@@ -256,6 +287,7 @@ category = "internal"
 wasm = "skip:internal — strategies consume this"
 ffi  = "skip:internal — strategies consume this"
 tui  = "dispatch_panel"
+gms  = "skip:internal — strategies consume this"
 
 [[methods]]
 name = "pin_assignment"
@@ -263,6 +295,7 @@ category = "dispatch"
 wasm = "pinAssignment"
 ffi  = "ev_sim_pin_assignment"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_pin_assignment"
 
 [[methods]]
 name = "unpin_assignment"
@@ -270,6 +303,7 @@ category = "dispatch"
 wasm = "unpinAssignment"
 ffi  = "ev_sim_unpin_assignment"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_unpin_assignment"
 
 [[methods]]
 name = "assigned_car"
@@ -277,6 +311,7 @@ category = "dispatch"
 wasm = "assignedCar"
 ffi  = "ev_sim_assigned_car"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_assigned_car"
 
 [[methods]]
 name = "assigned_cars_by_line"
@@ -284,6 +319,7 @@ category = "dispatch"
 wasm = "assignedCarsByLine"
 ffi  = "ev_sim_assigned_cars_by_line"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_assigned_cars_by_line"
 
 [[methods]]
 name = "best_eta"
@@ -291,6 +327,7 @@ category = "dispatch"
 wasm = "bestEta"
 ffi  = "ev_sim_best_eta"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_best_eta"
 
 [[methods]]
 name = "eta_for_call"
@@ -298,6 +335,7 @@ category = "dispatch"
 wasm = "etaForCall"
 ffi  = "ev_sim_eta_for_call"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_eta_for_call"
 
 [[methods]]
 name = "eta"
@@ -305,6 +343,7 @@ category = "dispatch"
 wasm = "eta"
 ffi  = "ev_sim_eta"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_eta"
 
 # ─── Buttons ──────────────────────────────────────────────────────────────
 
@@ -314,6 +353,7 @@ category = "buttons"
 wasm = "pressHallCall"
 ffi  = "ev_sim_press_hall_button"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_press_hall_button"
 
 [[methods]]
 name = "press_car_button"
@@ -321,6 +361,7 @@ category = "buttons"
 wasm = "pressCarButton"
 ffi  = "ev_sim_press_car_button"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_press_car_button"
 
 [[methods]]
 name = "hall_calls"
@@ -328,6 +369,7 @@ category = "buttons"
 wasm = "hallCalls"
 ffi  = "ev_sim_hall_calls_snapshot"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_hall_calls_snapshot"
 
 [[methods]]
 name = "car_calls"
@@ -335,6 +377,7 @@ category = "buttons"
 wasm = "carCalls"
 ffi  = "ev_sim_car_calls_snapshot"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_car_calls_snapshot"
 
 # ─── Events ───────────────────────────────────────────────────────────────
 
@@ -344,6 +387,7 @@ category = "events"
 wasm = "drainEvents"
 ffi  = "ev_sim_drain_events"
 tui  = "events_panel"
+gms  = "ev_sim_drain_events"
 
 [[methods]]
 name = "drain_events_where"
@@ -351,6 +395,7 @@ category = "events"
 wasm = "skip:closure marshaling — JS consumers filter drainEvents() output client-side"
 ffi  = "skip:closure marshaling — C consumers filter drain_events output"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:closure marshaling — C consumers filter drain_events output"
 
 [[methods]]
 name = "pending_events"
@@ -358,6 +403,7 @@ category = "events"
 wasm = "pendingEvents"
 ffi  = "ev_sim_pending_event_count"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_pending_event_count"
 
 # ─── Riders ───────────────────────────────────────────────────────────────
 
@@ -367,6 +413,7 @@ category = "riders"
 wasm = "spawnRider"
 ffi  = "ev_sim_spawn_rider"
 tui  = "headless_poisson_traffic"
+gms  = "ev_sim_spawn_rider"
 
 [[methods]]
 name = "build_rider"
@@ -374,6 +421,7 @@ category = "riders"
 wasm = "spawnRiderByRef"
 ffi  = "ev_sim_spawn_rider_ex"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_spawn_rider_ex"
 
 [[methods]]
 name = "despawn_rider"
@@ -381,6 +429,7 @@ category = "riders"
 wasm = "despawnRider"
 ffi  = "ev_sim_despawn_rider"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_despawn_rider"
 
 [[methods]]
 name = "settle_rider"
@@ -388,6 +437,7 @@ category = "riders"
 wasm = "settleRider"
 ffi  = "ev_sim_settle_rider"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_settle_rider"
 
 # ─── Routes ───────────────────────────────────────────────────────────────
 
@@ -411,6 +461,7 @@ category = "routes"
 wasm = "reroute"
 ffi  = "ev_sim_reroute"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_reroute"
 
 [[methods]]
 name = "set_rider_access"
@@ -418,6 +469,7 @@ category = "routes"
 wasm = "setRiderAccess"
 ffi  = "ev_sim_set_rider_access"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_set_rider_access"
 
 [[methods]]
 name = "set_rider_tag"
@@ -425,6 +477,7 @@ category = "riders"
 wasm = "setRiderTag"
 ffi  = "ev_sim_set_rider_tag"
 tui  = "skip:opaque consumer-attached id — TUI viewer has no concept of an external tag space"
+gms  = "ev_sim_set_rider_tag"
 
 [[methods]]
 name = "rider_tag"
@@ -432,6 +485,7 @@ category = "riders"
 wasm = "riderTag"
 ffi  = "ev_sim_rider_tag"
 tui  = "skip:opaque consumer-attached id — TUI viewer has no concept of an external tag space"
+gms  = "ev_sim_rider_tag"
 
 [[methods]]
 name = "shortest_route"
@@ -439,6 +493,7 @@ category = "routes"
 wasm = "shortestRoute"
 ffi  = "ev_sim_shortest_route"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_shortest_route"
 
 [[methods]]
 name = "transfer_points"
@@ -446,6 +501,7 @@ category = "routes"
 wasm = "transferPoints"
 ffi  = "ev_sim_transfer_points"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_transfer_points"
 
 [[methods]]
 name = "reachable_stops_from"
@@ -453,6 +509,7 @@ category = "routes"
 wasm = "reachableStopsFrom"
 ffi  = "ev_sim_reachable_stops_from"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_reachable_stops_from"
 
 # ─── Topology ─────────────────────────────────────────────────────────────
 
@@ -462,6 +519,7 @@ category = "topology"
 wasm = "addGroup"
 ffi  = "ev_sim_add_group"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_add_group"
 
 [[methods]]
 name = "add_line"
@@ -469,6 +527,7 @@ category = "topology"
 wasm = "addLine"
 ffi  = "ev_sim_add_line"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_add_line"
 
 [[methods]]
 name = "add_stop"
@@ -476,6 +535,7 @@ category = "topology"
 wasm = "addStop"
 ffi  = "ev_sim_add_stop"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_add_stop"
 
 [[methods]]
 name = "add_stop_to_line"
@@ -483,6 +543,7 @@ category = "topology"
 wasm = "addStopToLine"
 ffi  = "ev_sim_add_stop_to_line"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_add_stop_to_line"
 
 [[methods]]
 name = "add_elevator"
@@ -490,6 +551,7 @@ category = "topology"
 wasm = "addElevator"
 ffi  = "ev_sim_add_elevator"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_add_elevator"
 
 [[methods]]
 name = "remove_elevator"
@@ -497,6 +559,7 @@ category = "topology"
 wasm = "removeElevator"
 ffi  = "ev_sim_remove_elevator"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_remove_elevator"
 
 [[methods]]
 name = "remove_line"
@@ -504,6 +567,7 @@ category = "topology"
 wasm = "removeLine"
 ffi  = "ev_sim_remove_line"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_remove_line"
 
 [[methods]]
 name = "remove_stop"
@@ -511,6 +575,7 @@ category = "topology"
 wasm = "removeStop"
 ffi  = "ev_sim_remove_stop"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_remove_stop"
 
 [[methods]]
 name = "remove_stop_from_line"
@@ -518,6 +583,7 @@ category = "topology"
 wasm = "removeStopFromLine"
 ffi  = "ev_sim_remove_stop_from_line"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_remove_stop_from_line"
 
 [[methods]]
 name = "set_line_range"
@@ -525,6 +591,7 @@ category = "topology"
 wasm = "setLineRange"
 ffi  = "ev_sim_set_line_range"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_set_line_range"
 
 [[methods]]
 name = "assign_line_to_group"
@@ -532,6 +599,7 @@ category = "topology"
 wasm = "assignLineToGroup"
 ffi  = "ev_sim_assign_line_to_group"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_assign_line_to_group"
 
 [[methods]]
 name = "reassign_elevator_to_line"
@@ -539,6 +607,7 @@ category = "topology"
 wasm = "reassignElevatorToLine"
 ffi  = "ev_sim_reassign_elevator_to_line"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_reassign_elevator_to_line"
 
 [[methods]]
 name = "set_elevator_restricted_stops"
@@ -546,6 +615,7 @@ category = "topology"
 wasm = "setElevatorRestrictedStops"
 ffi  = "ev_sim_set_elevator_restricted_stops"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_set_elevator_restricted_stops"
 
 [[methods]]
 name = "set_elevator_home_stop"
@@ -553,6 +623,7 @@ category = "dispatch"
 wasm = "setElevatorHomeStop"
 ffi  = "ev_sim_set_elevator_home_stop"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_set_elevator_home_stop"
 
 [[methods]]
 name = "clear_elevator_home_stop"
@@ -560,6 +631,7 @@ category = "dispatch"
 wasm = "clearElevatorHomeStop"
 ffi  = "ev_sim_clear_elevator_home_stop"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_clear_elevator_home_stop"
 
 [[methods]]
 name = "elevator_home_stop"
@@ -567,6 +639,7 @@ category = "dispatch"
 wasm = "elevatorHomeStop"
 ffi  = "ev_sim_elevator_home_stop"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_elevator_home_stop"
 
 # ─── Introspection ────────────────────────────────────────────────────────
 
@@ -576,6 +649,7 @@ category = "introspection"
 wasm = "currentTick"
 ffi  = "ev_sim_current_tick"
 tui  = "title_bar"
+gms  = "ev_sim_current_tick"
 
 [[methods]]
 name = "dt"
@@ -583,6 +657,7 @@ category = "introspection"
 wasm = "dt"
 ffi  = "ev_sim_dt"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_dt"
 
 [[methods]]
 name = "metrics"
@@ -590,6 +665,7 @@ category = "metrics"
 wasm = "metrics"
 ffi  = "ev_sim_metrics"
 tui  = "metrics_panel"
+gms  = "ev_sim_metrics"
 
 [[methods]]
 name = "time"
@@ -597,6 +673,7 @@ category = "internal"
 wasm = "skip:returns &TimeAdapter — internal layout"
 ffi  = "skip:returns &TimeAdapter — internal layout"
 tui  = "tick_rate_calc"
+gms  = "skip:returns &TimeAdapter — internal layout"
 
 [[methods]]
 name = "events_mut"
@@ -604,6 +681,7 @@ category = "internal"
 wasm = "skip:returns &mut EventBus — never bound"
 ffi  = "skip:returns &mut EventBus — never bound"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:returns &mut EventBus — never bound"
 
 [[methods]]
 name = "metrics_mut"
@@ -611,6 +689,7 @@ category = "internal"
 wasm = "skip:returns &mut Metrics — never bound"
 ffi  = "skip:returns &mut Metrics — never bound"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:returns &mut Metrics — never bound"
 
 [[methods]]
 name = "phase_context"
@@ -618,6 +697,7 @@ category = "internal"
 wasm = "skip:returns PhaseContext — internal scheduling helper"
 ffi  = "skip:returns PhaseContext — internal scheduling helper"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:returns PhaseContext — internal scheduling helper"
 
 [[methods]]
 name = "elevators_on_line"
@@ -625,6 +705,7 @@ category = "introspection"
 wasm = "elevatorsOnLine"
 ffi  = "ev_sim_elevators_on_line"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_elevators_on_line"
 
 [[methods]]
 name = "groups_serving_stop"
@@ -632,6 +713,7 @@ category = "introspection"
 wasm = "groupsServingStop"
 ffi  = "ev_sim_groups_serving_stop"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_groups_serving_stop"
 
 [[methods]]
 name = "lines_in_group"
@@ -639,6 +721,7 @@ category = "introspection"
 wasm = "linesInGroup"
 ffi  = "ev_sim_lines_in_group"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_lines_in_group"
 
 [[methods]]
 name = "lines_serving_stop"
@@ -646,6 +729,7 @@ category = "introspection"
 wasm = "linesServingStop"
 ffi  = "ev_sim_lines_serving_stop"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_lines_serving_stop"
 
 [[methods]]
 name = "stops_served_by_line"
@@ -653,6 +737,7 @@ category = "introspection"
 wasm = "stopsServedByLine"
 ffi  = "ev_sim_stops_served_by_line"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_stops_served_by_line"
 
 [[methods]]
 name = "line_for_elevator"
@@ -660,6 +745,7 @@ category = "introspection"
 wasm = "lineForElevator"
 ffi  = "ev_sim_line_for_elevator"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_line_for_elevator"
 
 [[methods]]
 name = "all_lines"
@@ -667,6 +753,7 @@ category = "introspection"
 wasm = "allLines"
 ffi  = "ev_sim_all_lines"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_all_lines"
 
 [[methods]]
 name = "line_count"
@@ -674,6 +761,7 @@ category = "introspection"
 wasm = "lineCount"
 ffi  = "ev_sim_line_count"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_line_count"
 
 [[methods]]
 name = "stop_lookup_iter"
@@ -681,6 +769,7 @@ category = "introspection"
 wasm = "stopLookupIter"
 ffi  = "ev_sim_stop_lookup_iter"
 tui  = "shaft_view"
+gms  = "ev_sim_stop_lookup_iter"
 
 [[methods]]
 name = "stop_entity"
@@ -688,6 +777,7 @@ category = "introspection"
 wasm = "stopEntity"
 ffi  = "ev_sim_stop_entity"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_stop_entity"
 
 [[methods]]
 name = "find_stop_at_position_on_line"
@@ -695,6 +785,7 @@ category = "introspection"
 wasm = "findStopAtPositionOnLine"
 ffi  = "ev_sim_find_stop_at_position_on_line"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_find_stop_at_position_on_line"
 
 [[methods]]
 name = "velocity"
@@ -702,6 +793,7 @@ category = "introspection"
 wasm = "velocity"
 ffi  = "ev_sim_velocity"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_velocity"
 
 [[methods]]
 name = "position_at"
@@ -709,6 +801,7 @@ category = "introspection"
 wasm = "positionAt"
 ffi  = "ev_sim_position_at"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_position_at"
 
 [[methods]]
 name = "elevator_load"
@@ -716,6 +809,7 @@ category = "introspection"
 wasm = "elevatorLoad"
 ffi  = "ev_sim_elevator_load"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_elevator_load"
 
 [[methods]]
 name = "occupancy"
@@ -723,6 +817,7 @@ category = "introspection"
 wasm = "occupancy"
 ffi  = "ev_sim_occupancy"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_occupancy"
 
 [[methods]]
 name = "elevator_direction"
@@ -730,6 +825,7 @@ category = "introspection"
 wasm = "elevatorDirection"
 ffi  = "ev_sim_elevator_direction"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_elevator_direction"
 
 [[methods]]
 name = "elevator_going_up"
@@ -737,6 +833,7 @@ category = "introspection"
 wasm = "elevatorGoingUp"
 ffi  = "ev_sim_elevator_going_up"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_elevator_going_up"
 
 [[methods]]
 name = "elevator_going_down"
@@ -744,6 +841,7 @@ category = "introspection"
 wasm = "elevatorGoingDown"
 ffi  = "ev_sim_elevator_going_down"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_elevator_going_down"
 
 [[methods]]
 name = "elevator_move_count"
@@ -751,6 +849,7 @@ category = "introspection"
 wasm = "elevatorMoveCount"
 ffi  = "ev_sim_elevator_move_count"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_elevator_move_count"
 
 [[methods]]
 name = "braking_distance"
@@ -758,6 +857,7 @@ category = "introspection"
 wasm = "brakingDistance"
 ffi  = "ev_sim_braking_distance"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_braking_distance"
 
 [[methods]]
 name = "future_stop_position"
@@ -765,6 +865,7 @@ category = "introspection"
 wasm = "futureStopPosition"
 ffi  = "ev_sim_future_stop_position"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_future_stop_position"
 
 [[methods]]
 name = "destination_queue"
@@ -772,6 +873,7 @@ category = "introspection"
 wasm = "destinationQueue"
 ffi  = "ev_sim_destination_queue"
 tui  = "drilldown_panel"
+gms  = "ev_sim_destination_queue"
 
 [[methods]]
 name = "elevators_in_phase"
@@ -779,6 +881,7 @@ category = "introspection"
 wasm = "elevatorsInPhase"
 ffi  = "ev_sim_elevators_in_phase"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_elevators_in_phase"
 
 [[methods]]
 name = "iter_repositioning_elevators"
@@ -786,6 +889,7 @@ category = "introspection"
 wasm = "iterRepositioningElevators"
 ffi  = "ev_sim_iter_repositioning_elevators"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_iter_repositioning_elevators"
 
 [[methods]]
 name = "idle_elevator_count"
@@ -793,6 +897,7 @@ category = "introspection"
 wasm = "idleElevatorCount"
 ffi  = "ev_sim_idle_elevator_count"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_idle_elevator_count"
 
 [[methods]]
 name = "is_elevator"
@@ -800,6 +905,7 @@ category = "introspection"
 wasm = "isElevator"
 ffi  = "ev_sim_is_elevator"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_is_elevator"
 
 [[methods]]
 name = "is_rider"
@@ -807,6 +913,7 @@ category = "introspection"
 wasm = "isRider"
 ffi  = "ev_sim_is_rider"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_is_rider"
 
 [[methods]]
 name = "is_stop"
@@ -814,6 +921,7 @@ category = "introspection"
 wasm = "isStop"
 ffi  = "ev_sim_is_stop"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_is_stop"
 
 [[methods]]
 name = "is_disabled"
@@ -821,6 +929,7 @@ category = "introspection"
 wasm = "isDisabled"
 ffi  = "ev_sim_is_disabled"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_is_disabled"
 
 [[methods]]
 name = "waiting_at"
@@ -828,6 +937,7 @@ category = "introspection"
 wasm = "waitingAt"
 ffi  = "ev_sim_waiting_at"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_waiting_at"
 
 [[methods]]
 name = "waiting_count_at"
@@ -835,6 +945,7 @@ category = "introspection"
 wasm = "waitingCountAt"
 ffi  = "ev_sim_waiting_count_at"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_waiting_count_at"
 
 [[methods]]
 name = "waiting_counts_by_line_at"
@@ -842,6 +953,7 @@ category = "introspection"
 wasm = "waitingCountsByLineAt"
 ffi  = "ev_sim_waiting_counts_by_line_at"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_waiting_counts_by_line_at"
 
 [[methods]]
 name = "waiting_direction_counts_at"
@@ -849,6 +961,7 @@ category = "introspection"
 wasm = "waitingDirectionCountsAt"
 ffi  = "ev_sim_waiting_direction_counts_at"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_waiting_direction_counts_at"
 
 [[methods]]
 name = "residents_at"
@@ -856,6 +969,7 @@ category = "introspection"
 wasm = "residentsAt"
 ffi  = "ev_sim_residents_at"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_residents_at"
 
 [[methods]]
 name = "resident_count_at"
@@ -863,6 +977,7 @@ category = "introspection"
 wasm = "residentCountAt"
 ffi  = "ev_sim_resident_count_at"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_resident_count_at"
 
 [[methods]]
 name = "abandoned_at"
@@ -870,6 +985,7 @@ category = "introspection"
 wasm = "abandonedAt"
 ffi  = "ev_sim_abandoned_at"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_abandoned_at"
 
 [[methods]]
 name = "abandoned_count_at"
@@ -877,6 +993,7 @@ category = "introspection"
 wasm = "abandonedCountAt"
 ffi  = "ev_sim_abandoned_count_at"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_abandoned_count_at"
 
 [[methods]]
 name = "riders_on"
@@ -884,6 +1001,7 @@ category = "introspection"
 wasm = "ridersOn"
 ffi  = "ev_sim_riders_on"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_riders_on"
 
 # ─── Destinations ─────────────────────────────────────────────────────────
 
@@ -893,6 +1011,7 @@ category = "destinations"
 wasm = "pushDestination"
 ffi  = "ev_sim_push_destination"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_push_destination"
 
 [[methods]]
 name = "push_destination_front"
@@ -900,6 +1019,7 @@ category = "destinations"
 wasm = "pushDestinationFront"
 ffi  = "ev_sim_push_destination_front"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_push_destination_front"
 
 [[methods]]
 name = "clear_destinations"
@@ -907,6 +1027,7 @@ category = "destinations"
 wasm = "clearDestinations"
 ffi  = "ev_sim_clear_destinations"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_clear_destinations"
 
 [[methods]]
 name = "abort_movement"
@@ -914,6 +1035,7 @@ category = "destinations"
 wasm = "abortMovement"
 ffi  = "ev_sim_abort_movement"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_abort_movement"
 
 [[methods]]
 name = "recall_to"
@@ -921,6 +1043,7 @@ category = "destinations"
 wasm = "recallTo"
 ffi  = "ev_sim_recall_to"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_recall_to"
 
 # ─── Parameters ───────────────────────────────────────────────────────────
 # Note: wasm exposes "*All" sweeping helpers (setMaxSpeedAll, etc.) that
@@ -936,6 +1059,7 @@ category = "parameters"
 wasm = "setMaxSpeed"
 ffi  = "ev_sim_set_max_speed"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_set_max_speed"
 
 [[methods]]
 name = "set_acceleration"
@@ -943,6 +1067,7 @@ category = "parameters"
 wasm = "setAcceleration"
 ffi  = "ev_sim_set_acceleration"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_set_acceleration"
 
 [[methods]]
 name = "set_deceleration"
@@ -950,6 +1075,7 @@ category = "parameters"
 wasm = "setDeceleration"
 ffi  = "ev_sim_set_deceleration"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_set_deceleration"
 
 [[methods]]
 name = "set_door_open_ticks"
@@ -959,6 +1085,7 @@ category = "parameters"
 wasm = "setDoorOpenTicks"
 ffi  = "ev_sim_set_door_open_ticks"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_set_door_open_ticks"
 
 [[methods]]
 name = "set_door_transition_ticks"
@@ -967,6 +1094,7 @@ category = "parameters"
 wasm = "setDoorTransitionTicks"
 ffi  = "ev_sim_set_door_transition_ticks"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_set_door_transition_ticks"
 
 [[methods]]
 name = "set_weight_capacity"
@@ -975,6 +1103,7 @@ category = "parameters"
 wasm = "setWeightCapacity"
 ffi  = "ev_sim_set_weight_capacity"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_set_weight_capacity"
 
 [[methods]]
 name = "set_arrival_log_retention_ticks"
@@ -982,6 +1111,7 @@ category = "parameters"
 wasm = "setArrivalLogRetentionTicks"
 ffi  = "ev_sim_set_arrival_log_retention_ticks"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_set_arrival_log_retention_ticks"
 
 [[methods]]
 name = "enable"
@@ -989,6 +1119,7 @@ category = "parameters"
 wasm = "enable"
 ffi  = "ev_sim_enable"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_enable"
 
 [[methods]]
 name = "disable"
@@ -996,6 +1127,7 @@ category = "parameters"
 wasm = "disable"
 ffi  = "ev_sim_disable"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_disable"
 
 # ─── Hooks (closures don't survive the binding boundary) ──────────────────
 
@@ -1005,6 +1137,7 @@ category = "hooks"
 wasm = "skip:closures don't survive the wasm boundary — use streaming events"
 ffi  = "skip:closures don't survive the FFI boundary — use streaming events"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:closures don't survive the FFI boundary — use streaming events"
 
 [[methods]]
 name = "add_before_hook"
@@ -1012,6 +1145,7 @@ category = "hooks"
 wasm = "skip:closures don't survive the wasm boundary — use streaming events"
 ffi  = "skip:closures don't survive the FFI boundary — use streaming events"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:closures don't survive the FFI boundary — use streaming events"
 
 [[methods]]
 name = "add_after_group_hook"
@@ -1019,6 +1153,7 @@ category = "hooks"
 wasm = "skip:closures don't survive the wasm boundary"
 ffi  = "skip:closures don't survive the FFI boundary"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:closures don't survive the FFI boundary"
 
 [[methods]]
 name = "add_before_group_hook"
@@ -1026,6 +1161,7 @@ category = "hooks"
 wasm = "skip:closures don't survive the wasm boundary"
 ffi  = "skip:closures don't survive the FFI boundary"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:closures don't survive the FFI boundary"
 
 [[methods]]
 name = "load_extensions"
@@ -1033,6 +1169,7 @@ category = "hooks"
 wasm = "skip:builder-pattern entry point — runs at construction"
 ffi  = "skip:builder-pattern entry point — runs at construction"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:builder-pattern entry point — runs at construction"
 
 [[methods]]
 name = "load_extensions_with"
@@ -1040,6 +1177,7 @@ category = "hooks"
 wasm = "skip:takes a generic closure"
 ffi  = "skip:takes a generic closure"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:takes a generic closure"
 
 # ─── Tagging + per-tag metrics ────────────────────────────────────────────
 
@@ -1049,6 +1187,7 @@ category = "tagging"
 wasm = "tagEntity"
 ffi  = "ev_sim_tag_entity"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_tag_entity"
 
 [[methods]]
 name = "untag_entity"
@@ -1056,6 +1195,7 @@ category = "tagging"
 wasm = "untagEntity"
 ffi  = "ev_sim_untag_entity"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_untag_entity"
 
 [[methods]]
 name = "all_tags"
@@ -1063,6 +1203,7 @@ category = "tagging"
 wasm = "allTags"
 ffi  = "ev_sim_all_tags"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_all_tags"
 
 [[methods]]
 name = "metrics_for_tag"
@@ -1070,6 +1211,7 @@ category = "metrics"
 wasm = "metricsForTag"
 ffi  = "ev_sim_metrics_for_tag"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_metrics_for_tag"
 
 # ─── Internal — exposes &World, &mut World, internal slices ───────────────
 
@@ -1079,6 +1221,7 @@ category = "internal"
 wasm = "skip:returns &World — consumers use snapshot/worldView DTOs"
 ffi  = "skip:returns &World — consumers use ev_sim_frame"
 tui  = "shaft_view"
+gms  = "skip:returns &World — consumers use ev_sim_frame"
 
 [[methods]]
 name = "world_mut"
@@ -1086,6 +1229,7 @@ category = "internal"
 wasm = "skip:returns &mut World — never bound"
 ffi  = "skip:returns &mut World — never bound"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:returns &mut World — never bound"
 
 [[methods]]
 name = "dispatchers"
@@ -1093,6 +1237,7 @@ category = "internal"
 wasm = "skip:returns trait-object slice — never bound"
 ffi  = "skip:returns trait-object slice — never bound"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:returns trait-object slice — never bound"
 
 [[methods]]
 name = "dispatchers_mut"
@@ -1100,6 +1245,7 @@ category = "internal"
 wasm = "skip:returns &mut trait-object slice — never bound"
 ffi  = "skip:returns &mut trait-object slice — never bound"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:returns &mut trait-object slice — never bound"
 
 [[methods]]
 name = "groups"
@@ -1107,6 +1253,7 @@ category = "internal"
 wasm = "skip:returns &[ElevatorGroup] — internal layout"
 ffi  = "skip:returns &[ElevatorGroup] — internal layout"
 tui  = "shaft_view"
+gms  = "skip:returns &[ElevatorGroup] — internal layout"
 
 [[methods]]
 name = "groups_mut"
@@ -1114,3 +1261,4 @@ category = "internal"
 wasm = "skip:returns &mut [ElevatorGroup] — never bound"
 ffi  = "skip:returns &mut [ElevatorGroup] — never bound"
 tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:returns &mut [ElevatorGroup] — never bound"

--- a/scripts/check-bindings.sh
+++ b/scripts/check-bindings.sh
@@ -83,8 +83,11 @@ fi
 # Validate status fields and emit progress summary. Each
 # `wasm = ` / `ffi = ` / `tui = ` / `gms = ` line must be either an
 # identifier (exported name), `skip:<reason>`, or `todo:<phase>`.
-# Anything else is malformed.
-malformed=$(awk '
+# Anything else is malformed. `gawk` (not `awk`) is required because
+# the 3-argument `match()` capture-array form is a gawk extension —
+# on macOS BSD awk it silently no-ops and lets malformed values
+# through.
+malformed=$(gawk '
   /^\s*(wasm|ffi|tui|gms)\s*=\s*"/ {
     match($0, /^\s*(wasm|ffi|tui|gms)\s*=\s*"([^"]*)"/, m)
     binding = m[1]
@@ -101,6 +104,43 @@ if [[ -n "$malformed" ]]; then
   echo "$malformed" | sed 's/^/  - /'
   echo ""
   echo "Each status must be an identifier, skip:<reason>, or todo:<phase>."
+  status=1
+fi
+
+# Per-block completeness: every [[methods]] block must declare all
+# four required status columns. The malformed check above only
+# validates the format of lines that are already present, so a block
+# that simply omits e.g. `gms` would slip through silently.
+incomplete=$(gawk '
+  function flush(    missing) {
+    if (!in_block) return
+    missing = ""
+    if (!has_wasm) missing = missing " wasm"
+    if (!has_ffi)  missing = missing " ffi"
+    if (!has_tui)  missing = missing " tui"
+    if (!has_gms)  missing = missing " gms"
+    if (missing != "") print (name == "" ? "<unnamed>" : name) " (block at line " block_line "): missing" missing
+  }
+  /^\[\[methods\]\]/ {
+    flush()
+    in_block = 1; block_line = NR
+    name = ""; has_wasm = 0; has_ffi = 0; has_tui = 0; has_gms = 0
+    next
+  }
+  /^\s*\[/ && !/^\[\[methods\]\]/ { flush(); in_block = 0 }
+  in_block && /^name\s*=\s*"/ { match($0, /"([^"]+)"/, m); name = m[1] }
+  in_block && /^\s*wasm\s*=\s*"/ { has_wasm = 1 }
+  in_block && /^\s*ffi\s*=\s*"/  { has_ffi  = 1 }
+  in_block && /^\s*tui\s*=\s*"/  { has_tui  = 1 }
+  in_block && /^\s*gms\s*=\s*"/  { has_gms  = 1 }
+  END { flush() }
+' "$MANIFEST")
+
+if [[ -n "$incomplete" ]]; then
+  echo "::error::bindings.toml has [[methods]] blocks missing required columns:"
+  echo "$incomplete" | sed 's/^/  - /'
+  echo ""
+  echo "Every entry must declare wasm, ffi, tui, and gms (exported name, skip:<reason>, or todo:<phase>)."
   status=1
 fi
 

--- a/scripts/check-bindings.sh
+++ b/scripts/check-bindings.sh
@@ -68,7 +68,7 @@ if [[ -n "$missing" ]]; then
   echo "$missing" | sed 's/^/  - /'
   echo ""
   echo "Add a [[methods]] entry to bindings.toml for each, with explicit"
-  echo "wasm + ffi + tui status (exported name, skip:<reason>, or todo:<phase>)."
+  echo "wasm + ffi + tui + gms status (exported name, skip:<reason>, or todo:<phase>)."
   status=1
 fi
 
@@ -81,12 +81,12 @@ if [[ -n "$stale" ]]; then
 fi
 
 # Validate status fields and emit progress summary. Each
-# `wasm = ` / `ffi = ` / `tui = ` line must be either an identifier
-# (exported name), `skip:<reason>`, or `todo:<phase>`. Anything else
-# is malformed.
+# `wasm = ` / `ffi = ` / `tui = ` / `gms = ` line must be either an
+# identifier (exported name), `skip:<reason>`, or `todo:<phase>`.
+# Anything else is malformed.
 malformed=$(awk '
-  /^\s*(wasm|ffi|tui)\s*=\s*"/ {
-    match($0, /^\s*(wasm|ffi|tui)\s*=\s*"([^"]*)"/, m)
+  /^\s*(wasm|ffi|tui|gms)\s*=\s*"/ {
+    match($0, /^\s*(wasm|ffi|tui|gms)\s*=\s*"([^"]*)"/, m)
     binding = m[1]
     value = m[2]
     if (value ~ /^skip:.+/) next
@@ -111,15 +111,17 @@ fi
 # ── Progress summary ───────────────────────────────────────────────────
 total=$(echo "$code_methods" | wc -l)
 
-# Categorize each wasm / ffi / tui status line.
+# Categorize each wasm / ffi / tui / gms status line.
 read -r wasm_exported wasm_skipped wasm_todo \
         ffi_exported  ffi_skipped  ffi_todo \
-        tui_exported  tui_skipped  tui_todo < <(
+        tui_exported  tui_skipped  tui_todo \
+        gms_exported  gms_skipped  gms_todo < <(
   gawk '
     BEGIN {
       we=0; ws=0; wt=0
       fe=0; fs=0; ft=0
       te=0; ts=0; tt=0
+      ge=0; gs=0; gt=0
     }
     /^\s*wasm\s*=\s*"/ {
       match($0, /^\s*wasm\s*=\s*"([^"]*)"/, m); v = m[1]
@@ -139,7 +141,13 @@ read -r wasm_exported wasm_skipped wasm_todo \
       else if (v ~ /^todo:/) tt++
       else te++
     }
-    END { print we, ws, wt, fe, fs, ft, te, ts, tt }
+    /^\s*gms\s*=\s*"/ {
+      match($0, /^\s*gms\s*=\s*"([^"]*)"/, m); v = m[1]
+      if (v ~ /^skip:/) gs++
+      else if (v ~ /^todo:/) gt++
+      else ge++
+    }
+    END { print we, ws, wt, fe, fs, ft, te, ts, tt, ge, gs, gt }
   ' "$MANIFEST"
 )
 
@@ -149,3 +157,4 @@ printf "  %-12s %10s %10s %10s\n" "binding" "exported" "skipped" "todo"
 printf "  %-12s %10s %10s %10s\n" "wasm" "$wasm_exported" "$wasm_skipped" "$wasm_todo"
 printf "  %-12s %10s %10s %10s\n" "ffi"  "$ffi_exported"  "$ffi_skipped"  "$ffi_todo"
 printf "  %-12s %10s %10s %10s\n" "tui"  "$tui_exported"  "$tui_skipped"  "$tui_todo"
+printf "  %-12s %10s %10s %10s\n" "gms"  "$gms_exported"  "$gms_skipped"  "$gms_todo"


### PR DESCRIPTION
## Summary

- Adds a fourth `gms` column to `bindings.toml` alongside `wasm`/`ffi`/`tui` so every \`Simulation\` method is explicitly tracked for GameMaker Studio 2 coverage.
- Extends `scripts/check-bindings.sh` to validate the new column and surface it in the progress summary.
- Initial values mirror `ffi` (rationale below); diverging on a per-method basis happens organically as future PRs land.

## Why

We're preparing to ship a GameMaker Studio 2 native-extension bundle (PR 3). The repo's strict-coverage contract — every \`pub fn\` on \`Simulation\` must appear in the manifest with an explicit binding decision — is the contract that prevents \"fully supported lib\" drift. Adding GMS as a tracked consumer extends that contract.

## Why mirror ffi by default

- \`skip:\` markers (internal phases, \`&World\` returns, generic closures) are equally unreachable from GML — no analysis required.
- \`ev_sim_*\` exported names: the GML wrapper script that calls \`external_define\` declares the underlying C symbol under the same name, so the manifest entry doubles as the GML script's name.
- \`todo:\` markers carry over for the same phased-rollout reason.

## Coverage delta

Run \`bash scripts/check-bindings.sh\` post-merge:

\`\`\`
ok: bindings.toml is in sync with 143 public Simulation methods

  binding        exported    skipped       todo
  wasm                115         28          0
  ffi                 115         28          0
  tui                  13        130          0
  gms                 115         28          0
\`\`\`

## Test plan

- [x] \`bash scripts/check-bindings.sh\` — passes; 143 methods, 143 gms entries, no malformed/missing/stale.
- [x] \`cargo check --workspace\` — clean.
- [x] \`cargo fmt --all -- --check\` — clean.
- [x] Pre-commit hook passes end-to-end.

## Notes for reviewers

- This PR is purely manifest plumbing; no production code changes.
- The mirror rule is documented in the bindings.toml schema header (lines 22-30).
- A follow-up PR (#3 in the GameMaker bundle plan) will rely on the \`gms\` column to code-gen \`external_define\` calls.