### PR TITLE
ci(release): GameMaker Studio 2 extension bundle packaging

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release-created: ${{ steps.release.outputs['crates/elevator-core--release_created'] }}
+      ffi-release-created: ${{ steps.release.outputs['crates/elevator-ffi--release_created'] }}
+      ffi-tag-name: ${{ steps.release.outputs['crates/elevator-ffi--tag_name'] }}
+      ffi-version: ${{ steps.release.outputs['crates/elevator-ffi--version'] }}
     steps:
       # Mint the App token first so release-please-action creates its
       # PR using the App identity (release-kun). PRs created via the
@@ -79,3 +82,115 @@ jobs:
         run: cargo publish -p elevator-core
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+  # ── GameMaker Studio 2 extension bundle ──────────────────────────
+  # Triggers on every elevator-ffi release. Builds the cdylib on each
+  # target platform, then a final job downloads all three artefacts,
+  # assembles examples/gms2-extension/ with the right binaries +
+  # LICENSE files, zips the bundle, and uploads it to the GitHub
+  # release as elevator_ffi_gms2-<version>.zip.
+  #
+  # Why rebuild instead of reusing ffi-harness artefacts: cross-job
+  # artefact handoff requires explicit upload-artifact wiring and
+  # short retention (1 day default), and ffi-harness might not have
+  # run on the tagged SHA at all if the release was cut off-cycle.
+  # Rebuild is ~30 s per platform warm with rust-cache.
+  package-gms-binaries:
+    needs: release-please
+    if: needs.release-please.outputs.ffi-release-created == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            lib_name: libelevator_ffi.so
+          - os: windows-latest
+            lib_name: elevator_ffi.dll
+          - os: macos-15
+            lib_name: libelevator_ffi.dylib
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.ffi-tag-name }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev libasound2-dev
+
+      - name: Build elevator-ffi cdylib
+        run: cargo build -p elevator-ffi --release
+
+      - name: Stage cdylib
+        env:
+          LIB_NAME: ${{ matrix.lib_name }}
+        run: |
+          mkdir -p staged
+          # Workspace shares target/ via .cargo/config.toml; resolve
+          # the actual location from cargo metadata.
+          TARGET_DIR=$(cargo metadata --format-version 1 --no-deps \
+            | python3 -c "import json,sys; print(json.load(sys.stdin)['target_directory'])")
+          cp "$TARGET_DIR/release/$LIB_NAME" "staged/$LIB_NAME"
+
+      - name: Upload cdylib artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gms-binary-${{ matrix.lib_name }}
+          path: staged/
+          retention-days: 1
+
+  package-gms-bundle:
+    needs: [release-please, package-gms-binaries]
+    if: needs.release-please.outputs.ffi-release-created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.ffi-tag-name }}
+
+      - name: Download all platform binaries
+        uses: actions/download-artifact@v4
+        with:
+          path: pickup/
+          pattern: gms-binary-*
+          merge-multiple: true
+
+      - name: Assemble bundle
+        env:
+          VERSION: ${{ needs.release-please.outputs.ffi-version }}
+        run: |
+          BUNDLE="elevator_ffi_gms2-${VERSION}"
+          mkdir -p "$BUNDLE"
+          # Copy the in-tree extension folder verbatim, then drop the
+          # platform binaries into binaries/. The extension folder
+          # already includes elevator_ffi.gml + elevator_ffi_generated.gml
+          # + elevator_ffi.yy + README + the binaries/.gitkeep that
+          # the release fills in here.
+          cp -r examples/gms2-extension/* "$BUNDLE/"
+          mkdir -p "$BUNDLE/extension/elevator_ffi/binaries"
+          cp pickup/libelevator_ffi.so      "$BUNDLE/extension/elevator_ffi/binaries/"
+          cp pickup/elevator_ffi.dll        "$BUNDLE/extension/elevator_ffi/binaries/"
+          cp pickup/libelevator_ffi.dylib   "$BUNDLE/extension/elevator_ffi/binaries/"
+          # License compliance: the dual MIT/Apache notice ships with
+          # every binary distribution.
+          cp LICENSE LICENSE-MIT LICENSE-APACHE "$BUNDLE/"
+          # Drop the empty .gitkeep marker that's there only to make
+          # the repo path real before release packaging populates it.
+          rm -f "$BUNDLE/extension/elevator_ffi/binaries/.gitkeep"
+          zip -r "$BUNDLE.zip" "$BUNDLE"
+
+      - name: Upload bundle to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release-please.outputs.ffi-tag-name }}
+          VERSION: ${{ needs.release-please.outputs.ffi-version }}
+        run: |
+          gh release upload "$TAG" "elevator_ffi_gms2-${VERSION}.zip" \
+            --repo "${GITHUB_REPOSITORY}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -98,6 +98,12 @@ jobs:
   package-gms-binaries:
     needs: release-please
     if: needs.release-please.outputs.ffi-release-created == 'true'
+    # Job-level override: this job only needs read access to check
+    # out the tagged ref and write back via upload-artifact (which
+    # uses the workflow token, not release write). Mirrors the
+    # `publish` job's least-privilege override below.
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -131,11 +137,12 @@ jobs:
           LIB_NAME: ${{ matrix.lib_name }}
         run: |
           mkdir -p staged
-          # Workspace shares target/ via .cargo/config.toml; resolve
-          # the actual location from cargo metadata.
-          TARGET_DIR=$(cargo metadata --format-version 1 --no-deps \
-            | python3 -c "import json,sys; print(json.load(sys.stdin)['target_directory'])")
-          cp "$TARGET_DIR/release/$LIB_NAME" "staged/$LIB_NAME"
+          # No --target was passed to cargo build, so the cdylib is
+          # always at the workspace-local target/release/. The
+          # ffi-harness job uses the same path; matching it here
+          # avoids Windows-path edge cases that the cargo-metadata
+          # JSON parse would inherit (backslashes in target_directory).
+          cp "target/release/$LIB_NAME" "staged/$LIB_NAME"
 
       - name: Upload cdylib artefact
         uses: actions/upload-artifact@v4
@@ -192,5 +199,10 @@ jobs:
           TAG: ${{ needs.release-please.outputs.ffi-tag-name }}
           VERSION: ${{ needs.release-please.outputs.ffi-version }}
         run: |
+          # --clobber: a re-run after a partial failure (e.g. asset
+          # uploaded but a later step failed) needs to overwrite the
+          # previous attempt rather than refusing with "already
+          # exists" and aborting the rerun.
           gh release upload "$TAG" "elevator_ffi_gms2-${VERSION}.zip" \
+            --clobber \
             --repo "${GITHUB_REPOSITORY}"


### PR DESCRIPTION
## Summary

Adds two new jobs to `.github/workflows/release-please.yml` that fire when release-please cuts an elevator-ffi tag:

1. **`package-gms-binaries`** — matrix-builds the cdylib on Linux x64 / Windows x64 / macOS arm64 from the tagged SHA, uploads each as a 1-day-retention artefact.
2. **`package-gms-bundle`** — downloads all three platform binaries, copies `examples/gms2-extension/` verbatim, populates `extension/elevator_ffi/binaries/`, copies `LICENSE`/`LICENSE-MIT`/`LICENSE-APACHE`, zips the result, attaches `elevator_ffi_gms2-<version>.zip` to the GitHub release.

New release-please outputs (`ffi-release-created`, `ffi-tag-name`, `ffi-version`) so the new jobs gate on elevator-ffi releases specifically — the existing `release-created` flag tracks elevator-core only.

## Why rebuild instead of reusing ffi-harness artefacts

Cross-job artefact handoff requires explicit `upload-artifact` wiring with short retention (1 day default), and `ffi-harness` might not have run on the tagged SHA at all if a release was cut off-cycle. Rebuilding is ~30 s warm with rust-cache.

## Out of scope (follow-up)

- **`.yymps` packaging.** It's a renamed zip with a manifest, but the manifest schema evolves across GMS LTS versions; verification needs a real GMS install. The `.zip` we ship is import-compatible via the manual recipe in [`examples/gms2-extension/README.md`](../blob/main/examples/gms2-extension/README.md), and a future PR can add a verified `.yymps` once the schema has been exercised.
- **Intel macOS (`x86_64-apple-darwin`).** Matrix uses `macos-15` only; an Intel-Mac entry is the open question flagged in the GameMaker plan.

## Test plan

- [x] YAML syntactically valid (`python3 -c 'import yaml; yaml.safe_load(...)'`).
- [x] Pre-commit hook passes end-to-end.
- [ ] End-to-end run validated on the next elevator-ffi release (e.g. when PR 5 docs polish lands and bumps the patch). The packaging job runs only on tag creation, so it can't be exercised on this PR itself.