### PR TITLE
docs(ffi): polish GameMaker how-to + clarify ABI policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "cbindgen",
  "elevator-core",

--- a/crates/elevator-ffi/README.md
+++ b/crates/elevator-ffi/README.md
@@ -61,17 +61,27 @@ installed via `ev_set_log_callback` is protected by an internal mutex.
 
 Two paths, both seeing the same per-step stream:
 
-```c
-// Path A: callback (Unity, Godot, native).
-void on_log(uint8_t level, const char *msg) { /* ... */ }
-ev_set_log_callback(on_log);
+**Path A: callback** — wired through higher-level binding layers
+(C# P/Invoke, Godot gdnative, etc.) since cbindgen emits the
+function-pointer arg as the opaque `Option_EvLogFn` wrapper, which
+isn't directly constructible from raw C. See
+[`include/elevator_ffi.h`](include/elevator_ffi.h) for the type.
 
-// Path B: polling (GameMaker — GML can't pass C function pointers).
+**Path B: polling** — works equally from C, GameMaker (which can't
+pass C function pointers), and any other host:
+
+```c
 EvLogMessage logs[64];
 uint32_t written = 0;
 ev_drain_log_messages(sim, logs, 64, &written);
-// logs[i].msg_ptr borrows from sim's internal buffer; valid until
-// the next ev_drain_log_messages call on the same handle.
+for (uint32_t i = 0; i < written; ++i) {
+    // logs[i].msg_ptr / .msg_len: UTF-8 bytes, NOT null-terminated.
+    // Always read with the length — never strlen / printf("%s", ...).
+    // The slice borrows from sim's internal buffer and is valid only
+    // until the next ev_drain_log_messages call on the same handle.
+    fwrite(logs[i].msg_ptr, 1, logs[i].msg_len, stdout);
+    fputc('\n', stdout);
+}
 ```
 
 **Lazy opt-in:** the per-handle log queue is empty until the first

--- a/crates/elevator-ffi/README.md
+++ b/crates/elevator-ffi/README.md
@@ -14,7 +14,15 @@ by `build.rs` via [cbindgen](https://github.com/mozilla/cbindgen) into
 uint32_t v = ev_abi_version();  // must equal EV_ABI_VERSION from the header
 ```
 
-Always check this at startup. Any breaking layout change bumps the constant.
+Always check this at startup. The constant tracks **layout** changes
+to the C structs and enums — a bump means existing callers must
+recompile against the new header. New entry points (e.g. additional
+`ev_*` functions) are additive and do **not** bump the constant; a
+v5 caller can safely link against a newer cdylib that exposes more
+symbols.
+
+See [`include/elevator_ffi.h`](include/elevator_ffi.h)'s
+`EV_ABI_VERSION` doc-comment for the per-version delta.
 
 ## Lifecycle
 
@@ -48,6 +56,28 @@ null-terminated.
 Each `EvSim *` is single-threaded. Serialize all calls on a given handle.
 Distinct handles can be driven from distinct threads. The global log callback
 installed via `ev_set_log_callback` is protected by an internal mutex.
+
+## Logs
+
+Two paths, both seeing the same per-step stream:
+
+```c
+// Path A: callback (Unity, Godot, native).
+void on_log(uint8_t level, const char *msg) { /* ... */ }
+ev_set_log_callback(on_log);
+
+// Path B: polling (GameMaker — GML can't pass C function pointers).
+EvLogMessage logs[64];
+uint32_t written = 0;
+ev_drain_log_messages(sim, logs, 64, &written);
+// logs[i].msg_ptr borrows from sim's internal buffer; valid until
+// the next ev_drain_log_messages call on the same handle.
+```
+
+**Lazy opt-in:** the per-handle log queue is empty until the first
+call to `ev_drain_log_messages` or `ev_pending_log_message_count`.
+Callback-only consumers pay zero per-handle buffering. Polling
+consumers should drain regularly to bound queue growth.
 
 ## Error model
 
@@ -119,3 +149,11 @@ harness against the compiled cdylib on three host platforms:
 The header-diff check runs only on Linux (all three produce identical
 output). `fail-fast: false` is set so a regression on one platform
 doesn't hide issues on the others.
+
+A second harness at [`examples/gms2-harness/main.c`](../../examples/gms2-harness/main.c)
+exercises the FFI under GameMaker Studio 2's stricter type
+constraints (no callbacks, struct out-params via caller buffers,
+pointers staged through `double`). It runs on Linux only — the layout
+asserts are platform-independent so one OS catches the regression
+before the GML decoders in
+[`examples/gms2-extension`](../../examples/gms2-extension) break.

--- a/examples/gms2-extension/README.md
+++ b/examples/gms2-extension/README.md
@@ -40,19 +40,29 @@ FFI function the manifest marks as exported (`gms = "..."` in
 `bindings.toml`). Hand-written helpers in `elevator_ffi.gml` cover
 the cases that need GML-side decoding.
 
+## Installing (end users)
+
+Download `elevator_ffi_gms2-<version>.zip` from the
+[Releases page](https://github.com/andymai/elevator-core/releases?q=elevator-ffi)
+— the [release-please packaging
+job](../../.github/workflows/release-please.yml) attaches it to every
+`elevator-ffi-v*` tag with all three platform binaries plus the dual
+MIT/Apache LICENSE files pre-staged. Extract the zip and follow the
+manual import recipe at the bottom of this README.
+
 ## Local testing (developers)
 
-GameMaker end-users get binaries via the release `.zip` /
-`.yymps` (PR 4 wires the packaging). To test the extension against a
-local build of the cdylib:
+To test against a local build of the cdylib instead of waiting for a
+tagged release:
 
 ```bash
 # 1. Build the cdylib
 cargo build -p elevator-ffi --release
 
-# 2. Copy the produced artefact into the extension folder
-#    (path varies per platform):
-cp "$(cargo metadata --format-version 1 --no-deps | jq -r .target_directory)/release/libelevator_ffi.so" \
+# 2. Copy the produced artefact into the extension folder.
+#    (cargo writes to a workspace-local target/release/ unless you
+#    set CARGO_TARGET_DIR; adjust the source path accordingly.)
+cp target/release/libelevator_ffi.so \
    examples/gms2-extension/extension/elevator_ffi/binaries/    # Linux
 # or libelevator_ffi.dylib on macOS, elevator_ffi.dll on Windows
 
@@ -96,9 +106,9 @@ need a different target.
 ## Manifest (`elevator_ffi.yy`) — work in progress
 
 The `.yy` file in this folder is a structural placeholder. GameMaker
-Studio 2's extension manifest schema evolves across LTS versions; PR
-4 adds verified `.yy` + `.yymps` packaging once the format has been
-exercised against a working extension import.
+Studio 2's extension manifest schema evolves across LTS versions, so
+a follow-up PR adds verified `.yy` + `.yymps` packaging once the
+format has been exercised against a working extension import.
 
 Until then, treat the bundle as a folder of GML scripts + binaries
 that you manually wire up by:


### PR DESCRIPTION
## Summary

Wraps up the GameMaker plan with three focused doc improvements:

1. **ABI version policy clarified.** The constant tracks struct/enum *layout* changes; new entry points (e.g. `ev_drain_log_messages` added during the v5 cycle) are purely additive and don't bump it. Callers can safely link a v5-built consumer against a newer cdylib that exposes more symbols.
2. **New "Logs" section in `crates/elevator-ffi/README.md`** documents both the callback path (Unity, Godot, native) and the polling path (GameMaker, plus anyone who prefers polling). Lazy-opt-in flag is called out so callback-only consumers know they pay zero per-handle buffering.
3. **GMS extension README reoriented around the GitHub release zip** now that PR 4's packaging job lands a ready-to-import bundle on every `elevator-ffi-v*` tag. Drop the `cargo metadata | jq` indirection from local-testing instructions — workspace-local `target/release/` is portable and matches the `ffi-harness` pattern.

Also cross-references the GMS C harness from the FFI README's CI coverage section so future maintainers see the second harness exists and what it covers.

## Out of scope

- A real GMS-side test cycle's transcript (the plan's "manual-verification screenshot" item). Capturing that requires a working GMS install with the release zip imported and is best done on the first end-user feedback cycle, not speculatively.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] Pre-commit hook passes (no Rust changes; doc lint not triggered since no `docs/` files staged).
- [x] All cross-references resolve: the new "Logs" example references real symbols (`ev_set_log_callback`, `ev_drain_log_messages`, `ev_pending_log_message_count`); the FFI README's pointer to `examples/gms2-harness/main.c` matches the file shipped in #616; the GMS README's pointer to the release-please workflow matches PR #618's job names.