### PR TITLE
fix(ffi): namespace cbindgen enums to fix Custom collision

### DIFF
--- a/crates/elevator-ffi/cbindgen.toml
+++ b/crates/elevator-ffi/cbindgen.toml
@@ -11,3 +11,14 @@ line_length = 100
 tab_width = 4
 documentation = true
 documentation_style = "doxy"
+
+[enum]
+# Namespace every C enum constant with the enum name to avoid
+# collisions across enums sharing a variant name. Without this,
+# `EvStrategy::Custom` and `EvReposition::Custom` (both = 99) emit
+# bare `Custom = 99` lines that prevent any pure-C consumer from
+# including the header. With it, they become `EvStrategy_Custom`
+# and `EvReposition_Custom`. Pure-Rust consumers (Unity P/Invoke,
+# elevator-gdext) round-trip the integer values regardless of the
+# C enumerator names, so this is a non-breaking ABI change.
+prefix_with_name = true

--- a/crates/elevator-ffi/include/elevator_ffi.h
+++ b/crates/elevator-ffi/include/elevator_ffi.h
@@ -415,39 +415,39 @@ typedef enum EvStatus {
     /**
      * Operation succeeded.
      */
-    Ok = 0,
+    EvStatus_Ok = 0,
     /**
      * A required pointer argument was null.
      */
-    NullArg = 1,
+    EvStatus_NullArg = 1,
     /**
      * A C string argument was not valid UTF-8.
      */
-    InvalidUtf8 = 2,
+    EvStatus_InvalidUtf8 = 2,
     /**
      * The config file could not be read from disk.
      */
-    ConfigLoad = 3,
+    EvStatus_ConfigLoad = 3,
     /**
      * The config file failed to parse as RON.
      */
-    ConfigParse = 4,
+    EvStatus_ConfigParse = 4,
     /**
      * [`SimulationBuilder::build`] returned an error.
      */
-    BuildFailed = 5,
+    EvStatus_BuildFailed = 5,
     /**
      * The requested entity, group, or resource was not found.
      */
-    NotFound = 6,
+    EvStatus_NotFound = 6,
     /**
      * An argument was structurally valid but semantically rejected.
      */
-    InvalidArg = 7,
+    EvStatus_InvalidArg = 7,
     /**
      * A Rust panic was caught at the FFI boundary.
      */
-    Panic = 99,
+    EvStatus_Panic = 99,
 } EvStatus;
 
 /**
@@ -460,34 +460,34 @@ typedef enum EvStrategy {
     /**
      * SCAN — sweep end-to-end.
      */
-    Scan = 0,
+    EvStrategy_Scan = 0,
     /**
      * LOOK — reverse at last request.
      */
-    Look = 1,
+    EvStrategy_Look = 1,
     /**
      * Nearest-car.
      */
-    NearestCar = 2,
+    EvStrategy_NearestCar = 2,
     /**
      * Estimated time to destination.
      */
-    Etd = 3,
+    EvStrategy_Etd = 3,
     /**
      * Destination dispatch (lobby kiosk, hall-button mode = Destination).
      */
-    Destination = 4,
+    EvStrategy_Destination = 4,
     /**
      * RSR — composite cost-stack with stock weights.
      */
-    Rsr = 5,
+    EvStrategy_Rsr = 5,
     /**
      * Custom (non-builtin) strategy. Passed only as an output value
      * from [`ev_sim_strategy_id`]; passing it to a setter returns
      * `EvStatus::InvalidArg` since FFI consumers cannot register
      * custom strategies.
      */
-    Custom = 99,
+    EvStrategy_Custom = 99,
 } EvStrategy;
 
 /**
@@ -502,31 +502,31 @@ typedef enum EvReposition {
     /**
      * Distribute idle elevators evenly across stops.
      */
-    SpreadEvenly = 0,
+    EvReposition_SpreadEvenly = 0,
     /**
      * Return idle elevators to a configured home stop.
      */
-    ReturnToLobby = 1,
+    EvReposition_ReturnToLobby = 1,
     /**
      * Position near stops with historically high demand.
      */
-    DemandWeighted = 2,
+    EvReposition_DemandWeighted = 2,
     /**
      * Keep idle elevators where they are.
      */
-    NearestIdle = 3,
+    EvReposition_NearestIdle = 3,
     /**
      * Pre-position cars near stops with the highest recent arrival rate.
      */
-    PredictiveParking = 4,
+    EvReposition_PredictiveParking = 4,
     /**
      * Mode-gated picker between `ReturnToLobby` / `PredictiveParking`.
      */
-    Adaptive = 5,
+    EvReposition_Adaptive = 5,
     /**
      * Custom (output-only).
      */
-    Custom = 99,
+    EvReposition_Custom = 99,
 } EvReposition;
 
 /**
@@ -537,24 +537,24 @@ typedef enum EvServiceMode {
     /**
      * Normal operation: dispatch assigns stops, doors auto-cycle.
      */
-    Normal = 0,
+    EvServiceMode_Normal = 0,
     /**
      * Excluded from dispatch and repositioning. Consumer drives movement.
      */
-    Independent = 1,
+    EvServiceMode_Independent = 1,
     /**
      * Reduced speed, doors hold open indefinitely.
      */
-    Inspection = 2,
+    EvServiceMode_Inspection = 2,
     /**
      * Driven by direct velocity commands. Doors follow manual API.
      */
-    Manual = 3,
+    EvServiceMode_Manual = 3,
     /**
      * Shut down: excluded from dispatch, no auto-boarding, fully inert
      * once idle.
      */
-    OutOfService = 4,
+    EvServiceMode_OutOfService = 4,
 } EvServiceMode;
 
 /**

--- a/crates/elevator-ffi/include/elevator_ffi.h
+++ b/crates/elevator-ffi/include/elevator_ffi.h
@@ -484,7 +484,7 @@ typedef enum EvStrategy {
     /**
      * Custom (non-builtin) strategy. Passed only as an output value
      * from [`ev_sim_strategy_id`]; passing it to a setter returns
-     * `EvStatus::InvalidArg` since FFI consumers cannot register
+     * `EvStatus_InvalidArg` since FFI consumers cannot register
      * custom strategies.
      */
     EvStrategy_Custom = 99,
@@ -493,10 +493,10 @@ typedef enum EvStrategy {
 /**
  * Built-in reposition strategy identifier (ABI v3+).
  *
- * Mirrors [`elevator_core::dispatch::BuiltinReposition`]. `Custom` is
- * an output-only sentinel for non-built-in strategies registered via
- * the Rust API; FFI consumers passing `Custom` to a setter receive
- * `EvStatus::InvalidArg`.
+ * Mirrors [`elevator_core::dispatch::BuiltinReposition`].
+ * `EvReposition_Custom` is an output-only sentinel for non-built-in
+ * strategies registered via the Rust API; FFI consumers passing
+ * `EvReposition_Custom` to a setter receive `EvStatus_InvalidArg`.
  */
 typedef enum EvReposition {
     /**
@@ -1200,7 +1200,7 @@ enum EvStatus ev_sim_frame(struct EvSim *handle, struct EvFrame *out);
  * Query the best ETA to a stop across eligible elevators.
  *
  * `direction`: `-1` = Down, `0` = Either, `1` = Up. Returns
- * [`EvStatus::NotFound`] if no eligible elevator has `stop_entity_id`
+ * `EvStatus_NotFound` if no eligible elevator has `stop_entity_id`
  * queued; in that case the out-parameters are written as `(0, NaN)`.
  *
  * # Safety
@@ -1236,7 +1236,7 @@ enum EvStatus ev_sim_remove_reposition(struct EvSim *handle, uint32_t group_id);
 
 /**
  * Get the dispatch strategy currently active on `group_id`. Writes the
- * result to `*out_strategy`. Returns `EvStatus::NotFound` if the group
+ * result to `*out_strategy`. Returns `EvStatus_NotFound` if the group
  * has no registered strategy (or doesn't exist).
  *
  * # Safety
@@ -1249,7 +1249,7 @@ enum EvStatus ev_sim_strategy_id(struct EvSim *handle,
                                  enum EvStrategy *out_strategy);
 
 /**
- * Set the reposition strategy on `group_id`. Pass [`EvReposition::Custom`]
+ * Set the reposition strategy on `group_id`. Pass `EvReposition_Custom`
  * returns `InvalidArg` — FFI consumers cannot register custom strategies.
  *
  * # Safety
@@ -1262,7 +1262,7 @@ enum EvStatus ev_sim_set_reposition(struct EvSim *handle,
 
 /**
  * Get the reposition strategy currently set on `group_id`. Returns
- * `EvStatus::NotFound` if the group has no reposition strategy.
+ * `EvStatus_NotFound` if the group has no reposition strategy.
  *
  * # Safety
  *
@@ -1280,8 +1280,8 @@ enum EvStatus ev_sim_reposition_id(struct EvSim *handle,
  * pending hall calls, all cars idle). Writes the actual tick count
  * to `*out_ticks_run` on both success and timeout.
  *
- * Returns `EvStatus::Ok` if the world quieted within `max_ticks`,
- * `EvStatus::InvalidArg` if it failed to quiet (loop guard).
+ * Returns `EvStatus_Ok` if the world quieted within `max_ticks`,
+ * `EvStatus_InvalidArg` if it failed to quiet (loop guard).
  *
  * # Safety
  *
@@ -1415,10 +1415,10 @@ uint32_t ev_sim_hall_call_count(struct EvSim *handle);
  * real buffer.
  *
  * Returns:
- * - [`EvStatus::Ok`] when all calls fit in `capacity` (`out_written
+ * - `EvStatus_Ok` when all calls fit in `capacity` (`out_written
  *   <= capacity`); the first `out_written` slots of `out` are
  *   populated.
- * - [`EvStatus::InvalidArg`] when the buffer is too small;
+ * - `EvStatus_InvalidArg` when the buffer is too small;
  *   `out_written` carries the required slot count and no slot of
  *   `out` is written. [`ev_last_error`] carries a diagnostic string
  *   **only** when `capacity > 0` — the documented `(null, 0)` probe
@@ -1427,9 +1427,9 @@ uint32_t ev_sim_hall_call_count(struct EvSim *handle);
  *   mistake" after a deliberate size query.
  *
  * **ABI v4 contract change:** prior versions silently truncated to
- * `capacity` and returned `Ok` regardless. Callers that previously
- * passed an under-sized buffer and ignored the count must now
- * either grow the buffer or check for `InvalidArg`. Use
+ * `capacity` and returned `EvStatus_Ok` regardless. Callers that
+ * previously passed an under-sized buffer and ignored the count must
+ * now either grow the buffer or check for `EvStatus_InvalidArg`. Use
  * [`ev_sim_hall_call_count`] for size-only probes when the buffer
  * pattern feels heavyweight.
  *
@@ -1822,7 +1822,7 @@ enum EvStatus ev_sim_clear_elevator_home_stop(struct EvSim *handle, uint64_t ele
 /**
  * Read the home-stop pin for `elevator_entity_id`. Writes the stop
  * entity id (or `0` for unpinned) into `*out_stop_id` and returns
- * [`EvStatus::Ok`].
+ * `EvStatus_Ok`.
  *
  * # Safety
  *
@@ -1887,7 +1887,7 @@ enum EvStatus ev_sim_set_rider_tag(struct EvSim *handle, uint64_t rider_entity_i
 
 /**
  * Read the opaque tag attached to a rider. Writes the value into
- * `*out_tag` and returns [`EvStatus::Ok`]. Returns `0` for the default
+ * `*out_tag` and returns `EvStatus_Ok`. Returns `0` for the default
  * "untagged" state.
  *
  * # Safety
@@ -1916,7 +1916,7 @@ enum EvStatus ev_sim_set_rider_route_direct(struct EvSim *handle,
  * Replace a rider's remaining route with a multi-leg route built from
  * `shortest_route(rider's current_stop → to_stop)`.
  *
- * Returns [`EvStatus::NotFound`] if no route exists or the rider has
+ * Returns `EvStatus_NotFound` if no route exists or the rider has
  * no current stop.
  *
  * # Safety
@@ -1947,7 +1947,7 @@ enum EvStatus ev_sim_reroute_rider_direct(struct EvSim *handle,
  * `shortest_route(rider's current_stop → to_stop)`, transitioning them
  * back to `Waiting`.
  *
- * Returns [`EvStatus::NotFound`] if the rider has no current stop or
+ * Returns `EvStatus_NotFound` if the rider has no current stop or
  * no route exists.
  *
  * # Safety
@@ -2201,7 +2201,7 @@ enum EvStatus ev_sim_set_service_mode(struct EvSim *handle,
 /**
  * Get the current operational mode of an elevator.
  *
- * Writes the mode to `*out_mode`. Returns `Normal` for missing/disabled
+ * Writes the mode to `*out_mode`. Returns `EvServiceMode_Normal` for missing/disabled
  * elevators (matches core's `service_mode` accessor, which returns the
  * default rather than erroring). Use [`ev_sim_frame`] to verify existence.
  *
@@ -2716,12 +2716,12 @@ enum EvStatus ev_sim_riders_on(struct EvSim *handle,
  * can probe with `(null, 0)` to size a real buffer.
  *
  * Returns:
- * - [`EvStatus::Ok`] if a route exists and fits in `capacity`.
- * - [`EvStatus::InvalidArg`] if the route exists but `capacity` is too
+ * - `EvStatus_Ok` if a route exists and fits in `capacity`.
+ * - `EvStatus_InvalidArg` if the route exists but `capacity` is too
  *   small; `out_written` contains the required slot count.
  *   [`ev_last_error`] carries a diagnostic string only when
  *   `capacity > 0` — the documented `(null, 0)` probe is silent.
- * - [`EvStatus::NotFound`] if no route exists.
+ * - `EvStatus_NotFound` if no route exists.
  *
  * # Safety
  *
@@ -2754,10 +2754,10 @@ uint32_t ev_sim_car_call_count(struct EvSim *handle, uint64_t elevator_entity_id
  * real buffer.
  *
  * Returns:
- * - [`EvStatus::Ok`] when all calls fit in `capacity` (`out_written
+ * - `EvStatus_Ok` when all calls fit in `capacity` (`out_written
  *   <= capacity`); the first `out_written` slots of `out` are
  *   populated.
- * - [`EvStatus::InvalidArg`] when the buffer is too small;
+ * - `EvStatus_InvalidArg` when the buffer is too small;
  *   `out_written` carries the required slot count and no slot of
  *   `out` is written. [`ev_last_error`] carries a diagnostic string
  *   only when `capacity > 0` — the documented `(null, 0)` probe is
@@ -2778,7 +2778,7 @@ enum EvStatus ev_sim_car_calls_snapshot(struct EvSim *handle,
 /**
  * Pending rider list for the `index`-th car call inside `elevator_entity_id`.
  * Caller-owned buffer pattern matching the call snapshot. Returns
- * [`EvStatus::NotFound`] if the index is out of range.
+ * `EvStatus_NotFound` if the index is out of range.
  *
  * # Safety
  *
@@ -2804,7 +2804,7 @@ enum EvStatus ev_sim_car_call_pending_riders(struct EvSim *handle,
 enum EvStatus ev_sim_metrics(struct EvSim *handle, struct EvMetrics *out_metrics);
 
 /**
- * Read the per-tag aggregates for `tag`. Returns [`EvStatus::NotFound`]
+ * Read the per-tag aggregates for `tag`. Returns `EvStatus_NotFound`
  * if no riders carrying the tag have been recorded yet.
  *
  * # Safety
@@ -2835,7 +2835,7 @@ uint32_t ev_sim_tag_count(struct EvSim *handle);
  * `out_scratch_used` the number of bytes written to the scratch buffer
  * (including null terminators).
  *
- * Returns [`EvStatus::InvalidArg`] if either buffer is too small; the
+ * Returns `EvStatus_InvalidArg` if either buffer is too small; the
  * `out_*` counts indicate the required sizes. [`ev_last_error`]
  * carries a diagnostic string only when at least one capacity is
  * non-zero — the documented `(null, 0, null, 0)` pure probe is
@@ -2863,7 +2863,7 @@ enum EvStatus ev_sim_all_tags(struct EvSim *handle,
  * Only data-less variants are supported: `0` `Idle`, `3` `DoorOpening`,
  * `4` `Loading`, `5` `DoorClosing`, `6` `Stopped`.
  *
- * Returns [`EvStatus::InvalidArg`] for unknown phase codes.
+ * Returns `EvStatus_InvalidArg` for unknown phase codes.
  *
  * # Safety
  *
@@ -2876,8 +2876,8 @@ enum EvStatus ev_sim_elevators_in_phase(struct EvSim *handle, uint8_t phase, uin
  * ETA from `elevator_entity_id` to `stop_entity_id` in **ticks**.
  * Mirrors [`Simulation::eta`](elevator_core::sim::Simulation::eta).
  *
- * Returns [`EvStatus::InvalidArg`] if the entities don't refer to a
- * valid elevator/stop pair, or [`EvStatus::NotFound`] if the elevator
+ * Returns `EvStatus_InvalidArg` if the entities don't refer to a
+ * valid elevator/stop pair, or `EvStatus_NotFound` if the elevator
  * cannot reach the stop (e.g. stop not on the elevator's line, or
  * disabled).
  *

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -22,7 +22,7 @@
 //!   valid only until the next FFI call on the same thread.
 //! - **Panics:** every FFI function wraps its body in
 //!   [`std::panic::catch_unwind`]; a Rust panic surfaces as
-//!   [`EvStatus::Panic`] (or null for constructors).
+//!   `EvStatus_Panic` (or null for constructors).
 
 #![allow(unsafe_code)]
 
@@ -408,7 +408,7 @@ pub enum EvStrategy {
     Rsr = 5,
     /// Custom (non-builtin) strategy. Passed only as an output value
     /// from [`ev_sim_strategy_id`]; passing it to a setter returns
-    /// `EvStatus::InvalidArg` since FFI consumers cannot register
+    /// `EvStatus_InvalidArg` since FFI consumers cannot register
     /// custom strategies.
     Custom = 99,
 }
@@ -447,10 +447,10 @@ impl EvStrategy {
 
 /// Built-in reposition strategy identifier (ABI v3+).
 ///
-/// Mirrors [`elevator_core::dispatch::BuiltinReposition`]. `Custom` is
-/// an output-only sentinel for non-built-in strategies registered via
-/// the Rust API; FFI consumers passing `Custom` to a setter receive
-/// `EvStatus::InvalidArg`.
+/// Mirrors [`elevator_core::dispatch::BuiltinReposition`].
+/// `EvReposition_Custom` is an output-only sentinel for non-built-in
+/// strategies registered via the Rust API; FFI consumers passing
+/// `EvReposition_Custom` to a setter receive `EvStatus_InvalidArg`.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EvReposition {
@@ -864,7 +864,7 @@ fn populate_frame(ev: &mut EvSim) {
 /// Query the best ETA to a stop across eligible elevators.
 ///
 /// `direction`: `-1` = Down, `0` = Either, `1` = Up. Returns
-/// [`EvStatus::NotFound`] if no eligible elevator has `stop_entity_id`
+/// `EvStatus_NotFound` if no eligible elevator has `stop_entity_id`
 /// queued; in that case the out-parameters are written as `(0, NaN)`.
 ///
 /// # Safety
@@ -986,7 +986,7 @@ pub unsafe extern "C" fn ev_sim_remove_reposition(handle: *mut EvSim, group_id: 
 }
 
 /// Get the dispatch strategy currently active on `group_id`. Writes the
-/// result to `*out_strategy`. Returns `EvStatus::NotFound` if the group
+/// result to `*out_strategy`. Returns `EvStatus_NotFound` if the group
 /// has no registered strategy (or doesn't exist).
 ///
 /// # Safety
@@ -1021,7 +1021,7 @@ pub unsafe extern "C" fn ev_sim_strategy_id(
     })
 }
 
-/// Set the reposition strategy on `group_id`. Pass [`EvReposition::Custom`]
+/// Set the reposition strategy on `group_id`. Pass `EvReposition_Custom`
 /// returns `InvalidArg` — FFI consumers cannot register custom strategies.
 ///
 /// # Safety
@@ -1058,7 +1058,7 @@ pub unsafe extern "C" fn ev_sim_set_reposition(
 }
 
 /// Get the reposition strategy currently set on `group_id`. Returns
-/// `EvStatus::NotFound` if the group has no reposition strategy.
+/// `EvStatus_NotFound` if the group has no reposition strategy.
 ///
 /// # Safety
 ///
@@ -1100,8 +1100,8 @@ pub unsafe extern "C" fn ev_sim_reposition_id(
 /// pending hall calls, all cars idle). Writes the actual tick count
 /// to `*out_ticks_run` on both success and timeout.
 ///
-/// Returns `EvStatus::Ok` if the world quieted within `max_ticks`,
-/// `EvStatus::InvalidArg` if it failed to quiet (loop guard).
+/// Returns `EvStatus_Ok` if the world quieted within `max_ticks`,
+/// `EvStatus_InvalidArg` if it failed to quiet (loop guard).
 ///
 /// # Safety
 ///
@@ -1463,10 +1463,10 @@ pub unsafe extern "C" fn ev_sim_hall_call_count(handle: *mut EvSim) -> u32 {
 /// real buffer.
 ///
 /// Returns:
-/// - [`EvStatus::Ok`] when all calls fit in `capacity` (`out_written
+/// - `EvStatus_Ok` when all calls fit in `capacity` (`out_written
 ///   <= capacity`); the first `out_written` slots of `out` are
 ///   populated.
-/// - [`EvStatus::InvalidArg`] when the buffer is too small;
+/// - `EvStatus_InvalidArg` when the buffer is too small;
 ///   `out_written` carries the required slot count and no slot of
 ///   `out` is written. [`ev_last_error`] carries a diagnostic string
 ///   **only** when `capacity > 0` — the documented `(null, 0)` probe
@@ -1475,9 +1475,9 @@ pub unsafe extern "C" fn ev_sim_hall_call_count(handle: *mut EvSim) -> u32 {
 ///   mistake" after a deliberate size query.
 ///
 /// **ABI v4 contract change:** prior versions silently truncated to
-/// `capacity` and returned `Ok` regardless. Callers that previously
-/// passed an under-sized buffer and ignored the count must now
-/// either grow the buffer or check for `InvalidArg`. Use
+/// `capacity` and returned `EvStatus_Ok` regardless. Callers that
+/// previously passed an under-sized buffer and ignored the count must
+/// now either grow the buffer or check for `EvStatus_InvalidArg`. Use
 /// [`ev_sim_hall_call_count`] for size-only probes when the buffer
 /// pattern feels heavyweight.
 ///
@@ -3750,7 +3750,7 @@ pub unsafe extern "C" fn ev_sim_clear_elevator_home_stop(
 
 /// Read the home-stop pin for `elevator_entity_id`. Writes the stop
 /// entity id (or `0` for unpinned) into `*out_stop_id` and returns
-/// [`EvStatus::Ok`].
+/// `EvStatus_Ok`.
 ///
 /// # Safety
 ///
@@ -4011,7 +4011,7 @@ pub unsafe extern "C" fn ev_sim_set_rider_tag(
 }
 
 /// Read the opaque tag attached to a rider. Writes the value into
-/// `*out_tag` and returns [`EvStatus::Ok`]. Returns `0` for the default
+/// `*out_tag` and returns `EvStatus_Ok`. Returns `0` for the default
 /// "untagged" state.
 ///
 /// # Safety
@@ -4105,7 +4105,7 @@ pub unsafe extern "C" fn ev_sim_set_rider_route_direct(
 /// Replace a rider's remaining route with a multi-leg route built from
 /// `shortest_route(rider's current_stop → to_stop)`.
 ///
-/// Returns [`EvStatus::NotFound`] if no route exists or the rider has
+/// Returns `EvStatus_NotFound` if no route exists or the rider has
 /// no current stop.
 ///
 /// # Safety
@@ -4208,7 +4208,7 @@ pub unsafe extern "C" fn ev_sim_reroute_rider_direct(
 /// `shortest_route(rider's current_stop → to_stop)`, transitioning them
 /// back to `Waiting`.
 ///
-/// Returns [`EvStatus::NotFound`] if the rider has no current stop or
+/// Returns `EvStatus_NotFound` if the rider has no current stop or
 /// no route exists.
 ///
 /// # Safety
@@ -4948,7 +4948,7 @@ pub unsafe extern "C" fn ev_sim_set_service_mode(
 
 /// Get the current operational mode of an elevator.
 ///
-/// Writes the mode to `*out_mode`. Returns `Normal` for missing/disabled
+/// Writes the mode to `*out_mode`. Returns `EvServiceMode_Normal` for missing/disabled
 /// elevators (matches core's `service_mode` accessor, which returns the
 /// default rather than erroring). Use [`ev_sim_frame`] to verify existence.
 ///
@@ -6422,12 +6422,12 @@ pub unsafe extern "C" fn ev_sim_riders_on(
 /// can probe with `(null, 0)` to size a real buffer.
 ///
 /// Returns:
-/// - [`EvStatus::Ok`] if a route exists and fits in `capacity`.
-/// - [`EvStatus::InvalidArg`] if the route exists but `capacity` is too
+/// - `EvStatus_Ok` if a route exists and fits in `capacity`.
+/// - `EvStatus_InvalidArg` if the route exists but `capacity` is too
 ///   small; `out_written` contains the required slot count.
 ///   [`ev_last_error`] carries a diagnostic string only when
 ///   `capacity > 0` — the documented `(null, 0)` probe is silent.
-/// - [`EvStatus::NotFound`] if no route exists.
+/// - `EvStatus_NotFound` if no route exists.
 ///
 /// # Safety
 ///
@@ -6558,10 +6558,10 @@ pub unsafe extern "C" fn ev_sim_car_call_count(handle: *mut EvSim, elevator_enti
 /// real buffer.
 ///
 /// Returns:
-/// - [`EvStatus::Ok`] when all calls fit in `capacity` (`out_written
+/// - `EvStatus_Ok` when all calls fit in `capacity` (`out_written
 ///   <= capacity`); the first `out_written` slots of `out` are
 ///   populated.
-/// - [`EvStatus::InvalidArg`] when the buffer is too small;
+/// - `EvStatus_InvalidArg` when the buffer is too small;
 ///   `out_written` carries the required slot count and no slot of
 ///   `out` is written. [`ev_last_error`] carries a diagnostic string
 ///   only when `capacity > 0` — the documented `(null, 0)` probe is
@@ -6632,7 +6632,7 @@ pub unsafe extern "C" fn ev_sim_car_calls_snapshot(
 
 /// Pending rider list for the `index`-th car call inside `elevator_entity_id`.
 /// Caller-owned buffer pattern matching the call snapshot. Returns
-/// [`EvStatus::NotFound`] if the index is out of range.
+/// `EvStatus_NotFound` if the index is out of range.
 ///
 /// # Safety
 ///
@@ -6784,7 +6784,7 @@ pub struct EvTaggedMetric {
     pub total_spawned: u64,
 }
 
-/// Read the per-tag aggregates for `tag`. Returns [`EvStatus::NotFound`]
+/// Read the per-tag aggregates for `tag`. Returns `EvStatus_NotFound`
 /// if no riders carrying the tag have been recorded yet.
 ///
 /// # Safety
@@ -6873,7 +6873,7 @@ pub unsafe extern "C" fn ev_sim_tag_count(handle: *mut EvSim) -> u32 {
 /// `out_scratch_used` the number of bytes written to the scratch buffer
 /// (including null terminators).
 ///
-/// Returns [`EvStatus::InvalidArg`] if either buffer is too small; the
+/// Returns `EvStatus_InvalidArg` if either buffer is too small; the
 /// `out_*` counts indicate the required sizes. [`ev_last_error`]
 /// carries a diagnostic string only when at least one capacity is
 /// non-zero — the documented `(null, 0, null, 0)` pure probe is
@@ -6958,7 +6958,7 @@ pub unsafe extern "C" fn ev_sim_all_tags(
 /// Only data-less variants are supported: `0` `Idle`, `3` `DoorOpening`,
 /// `4` `Loading`, `5` `DoorClosing`, `6` `Stopped`.
 ///
-/// Returns [`EvStatus::InvalidArg`] for unknown phase codes.
+/// Returns `EvStatus_InvalidArg` for unknown phase codes.
 ///
 /// # Safety
 ///
@@ -7026,8 +7026,8 @@ fn duration_to_ticks(duration: std::time::Duration, dt: f64) -> u64 {
 /// ETA from `elevator_entity_id` to `stop_entity_id` in **ticks**.
 /// Mirrors [`Simulation::eta`](elevator_core::sim::Simulation::eta).
 ///
-/// Returns [`EvStatus::InvalidArg`] if the entities don't refer to a
-/// valid elevator/stop pair, or [`EvStatus::NotFound`] if the elevator
+/// Returns `EvStatus_InvalidArg` if the entities don't refer to a
+/// valid elevator/stop pair, or `EvStatus_NotFound` if the elevator
 /// cannot reach the stop (e.g. stop not on the elevator's line, or
 /// disabled).
 ///

--- a/examples/gms2-harness/main.c
+++ b/examples/gms2-harness/main.c
@@ -20,15 +20,6 @@
  *     type constraints but not the runtime. A working extension still
  *     needs a manual GMS-side import per examples/gms2-extension/README.md.
  *
- * Why we don't include elevator_ffi.h: at the time of writing the
- * cbindgen-generated header has duplicate enumerator names across
- * enums (`Custom = 99` in both `EvStrategy` and `EvReposition`),
- * which a pure C consumer can't compile. The C# / .NET P/Invoke side
- * works around this via per-enum namespacing. The handful of symbols
- * we exercise here are declared locally — drift between these decls
- * and the real ABI is caught by the offset asserts and by the
- * runtime smoke pass.
- *
  * Build: examples/gms2-harness/build.sh resolves cc/cl per platform
  * and links against the in-tree libelevator_ffi shared object. CI runs
  * the same script as part of the ffi-harness matrix.
@@ -41,35 +32,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* ── Local minimal ABI declarations ─────────────────────────────── */
+#include "elevator_ffi.h"
 
 #define EXPECTED_ABI 5
-
-/* EvStatus.Ok happens to be 0 across every cbindgen revision; this
- * file's contract is "exit non-zero on any non-Ok status", so the
- * literal 0 is the only value we need. */
-#define EV_STATUS_OK 0
-
-typedef struct EvSim EvSim;
-
-/* Mirrors crates/elevator-ffi/src/lib.rs::EvLogMessage at ABI v5.
- * The static asserts below pin the offsets so a future cbindgen
- * reorder breaks CI here, not on the GML side. */
-struct EvLogMessage {
-    uint8_t  level;
-    int64_t  ts_ns;
-    const uint8_t *msg_ptr;
-    uint32_t msg_len;
-};
-
-extern uint32_t      ev_abi_version(void);
-extern const char   *ev_last_error(void);
-extern EvSim        *ev_sim_create(const char *config_path);
-extern void          ev_sim_destroy(EvSim *handle);
-extern int32_t       ev_sim_step(EvSim *handle);
-extern uint32_t      ev_pending_log_message_count(EvSim *handle);
-extern int32_t       ev_drain_log_messages(EvSim *handle, struct EvLogMessage *out,
-                                            uint32_t capacity, uint32_t *out_written);
 
 /* ── Layout asserts ─────────────────────────────────────────────── */
 
@@ -133,12 +98,12 @@ int main(int argc, char **argv) {
      * would (external_define says ty_real for pointer args/returns).
      * If the bit pattern doesn't survive the round-trip, every
      * subsequent FFI call would dereference garbage. */
-    EvSim *handle = ev_sim_create(argv[1]);
+    struct EvSim *handle = ev_sim_create(argv[1]);
     if (!handle) {
         return fail("ev_sim_create");
     }
     double handle_as_real = handle_to_real(handle);
-    EvSim *roundtrip = (EvSim *)real_to_handle(handle_as_real);
+    struct EvSim *roundtrip = (struct EvSim *)real_to_handle(handle_as_real);
     if (roundtrip != handle) {
         fprintf(stderr, "FAIL: handle round-trip through double altered the pointer\n");
         ev_sim_destroy(handle);
@@ -151,7 +116,7 @@ int main(int argc, char **argv) {
     (void)ev_pending_log_message_count(roundtrip);
 
     for (int i = 0; i < TICKS; ++i) {
-        if (ev_sim_step(roundtrip) != EV_STATUS_OK) {
+        if (ev_sim_step(roundtrip) != EvStatus_Ok) {
             ev_sim_destroy(roundtrip);
             return fail("ev_sim_step");
         }
@@ -162,7 +127,7 @@ int main(int argc, char **argv) {
      * GML decoder in elevator_ffi.gml does on the GameMaker side. */
     struct EvLogMessage logs[LOG_BUF_CAPACITY];
     uint32_t written = 0;
-    if (ev_drain_log_messages(roundtrip, logs, LOG_BUF_CAPACITY, &written) != EV_STATUS_OK) {
+    if (ev_drain_log_messages(roundtrip, logs, LOG_BUF_CAPACITY, &written) != EvStatus_Ok) {
         ev_sim_destroy(roundtrip);
         return fail("ev_drain_log_messages");
     }
@@ -194,7 +159,7 @@ int main(int argc, char **argv) {
          * since we just emptied it) without crashing on the cleared
          * log_drain_buf. */
         uint32_t second = 0;
-        if (ev_drain_log_messages(roundtrip, logs, LOG_BUF_CAPACITY, &second) != EV_STATUS_OK) {
+        if (ev_drain_log_messages(roundtrip, logs, LOG_BUF_CAPACITY, &second) != EvStatus_Ok) {
             ev_sim_destroy(roundtrip);
             return fail("ev_drain_log_messages (second call)");
         }


### PR DESCRIPTION
## Summary

The cbindgen-generated header had duplicate `Custom = 99` enumerator names across `EvStrategy` and `EvReposition`, preventing pure-C consumers from including it. The gms2-harness worked around this by declaring symbols locally; this PR closes the gap.

- Adds `[enum] prefix_with_name = true` to `cbindgen.toml`. Header now emits `EvStrategy_Custom`, `EvReposition_Custom`, `EvStatus_Ok`, etc. — namespaced, no collisions.
- gms2-harness now `#include "elevator_ffi.h"` directly (drops the local declaration block).
- 56 lines of diff in the regenerated header (rename only — no semantic changes).

## Why

PR 7 in the binding-sync plan needs the header to be includable from raw C so the contract harness can use it directly. Fixing the collision now is a one-line cbindgen config change that unblocks the chain.

## ABI semantics

This is a **non-breaking ABI change**: every enum constant's numeric value is unchanged, only the C identifier spellings differ. Pure-Rust consumers (Unity via P/Invoke, elevator-gdext via direct Rust dep) round-trip the integer values and never see the C names. Anyone with a hand-rolled C wrapper using the bare `Ok` / `Custom` / `Idle` literals needs to update — flagged for the CHANGELOG entry.

## Test plan

- [x] `cargo build -p elevator-ffi --release` regenerates header cleanly.
- [x] `bash examples/gms2-harness/build.sh` builds + runs against the new header. Output: `ABI version: 5`, `OK: GMS-shaped harness passed`.
- [x] `cargo check --workspace` clean.
- [x] `cargo test -p elevator-ffi` passes.
- [x] `cargo fmt --all -- --check` clean.
- [x] Pre-commit hook end-to-end clean.