### PR TITLE
feat(ci): cross-consumer ABI version gate

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -53,6 +53,15 @@ if [ "$has_rust" = true ]; then
         echo "pre-commit: linting docs..."
         scripts/lint-docs.sh --quick
     fi
+
+    # ABI version pin sync: run the gate if any watched file is staged.
+    # The full list lives in scripts/check-abi-pins.sh; checking the
+    # parent directories here is a coarse approximation that catches
+    # every relevant edit without re-listing the file set.
+    if grep -qE '^(crates/elevator-(ffi|wasm|gdext)/|examples/(csharp-harness|gms2-harness|gms2-extension)/)' <<<"$staged"; then
+        echo "pre-commit: checking ABI version pins..."
+        scripts/check-abi-pins.sh
+    fi
 fi
 
 # ─── Playground (TypeScript) ─────────────────────────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Check binding coverage
         run: scripts/check-bindings.sh
 
+      - name: Check ABI version pins
+        run: scripts/check-abi-pins.sh
+
   supply-chain:
     name: Supply chain (cargo-deny)
     if: |

--- a/crates/elevator-gdext/src/lib.rs
+++ b/crates/elevator-gdext/src/lib.rs
@@ -6,7 +6,7 @@
 
 mod sim_node;
 
-pub use sim_node::ElevatorSim;
+pub use sim_node::{ABI_VERSION, ElevatorSim};
 
 use godot::prelude::*;
 

--- a/crates/elevator-gdext/src/sim_node.rs
+++ b/crates/elevator-gdext/src/sim_node.rs
@@ -30,6 +30,14 @@ use elevator_core::dispatch::BuiltinStrategy;
 use elevator_core::dispatch::scan::ScanDispatch;
 use elevator_core::sim::Simulation;
 
+/// elevator-ffi ABI version this crate is pinned against.
+///
+/// Watched by `scripts/check-abi-pins.sh` in CI: any drift between
+/// this constant and `EV_ABI_VERSION` in the FFI header fails the
+/// gate, surfacing a stale gdext pin before runtime. Public so a
+/// curious GDScript caller can verify the binding's ABI generation.
+pub const ABI_VERSION: u32 = 5;
+
 /// Elevator simulation node.
 ///
 /// Attach to your scene tree and configure via exported properties.

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -25,6 +25,13 @@ use elevator_core::prelude::{Simulation, StopId};
 use slotmap::Key;
 use wasm_bindgen::prelude::*;
 
+/// elevator-ffi ABI version this crate is pinned against.
+///
+/// Watched by `scripts/check-abi-pins.sh` in CI: any drift between
+/// this constant and `EV_ABI_VERSION` in the FFI header fails the
+/// gate, surfacing a stale wasm pin before runtime.
+pub const ABI_VERSION: u32 = 5;
+
 mod dto;
 mod js_dispatch;
 mod result;

--- a/scripts/check-abi-pins.sh
+++ b/scripts/check-abi-pins.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Cross-consumer ABI-version gate.
+#
+# Every consumer of elevator-ffi embeds the ABI version it was built
+# against as a hardcoded constant. If the lib bumps EV_ABI_VERSION
+# without each consumer updating, drift surfaces in production rather
+# than in CI. This script extracts every such constant from the
+# watched files and fails if any two values disagree.
+#
+# Watched files + grep patterns:
+#   crates/elevator-ffi/include/elevator_ffi.h    `#define EV_ABI_VERSION N`  (source of truth)
+#   crates/elevator-ffi/src/lib.rs                `pub const EV_ABI_VERSION: u32 = N`
+#   examples/csharp-harness/Program.cs            `private const uint EXPECTED_ABI = N`
+#   examples/gms2-harness/main.c                  `#define EXPECTED_ABI N`
+#   examples/gms2-extension/README.md             `// expect: "ABI version: N"`
+#   crates/elevator-wasm/src/lib.rs               `pub const ABI_VERSION: u32 = N`
+#   crates/elevator-gdext/src/sim_node.rs         `const ABI_VERSION: u32 = N`
+#
+# Output on success: `ok: ABI version is in sync at N across <count> watched files`
+# Output on failure: a per-file table showing which versions live where.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Each entry: "<path>|<extractor pattern>" where the pattern is a
+# `grep -oE` regex that captures only the integer literal.
+WATCHED=(
+  "crates/elevator-ffi/include/elevator_ffi.h|#define EV_ABI_VERSION [0-9]+"
+  "crates/elevator-ffi/src/lib.rs|pub const EV_ABI_VERSION: u32 = [0-9]+"
+  "examples/csharp-harness/Program.cs|private const uint EXPECTED_ABI = [0-9]+"
+  "examples/gms2-harness/main.c|#define EXPECTED_ABI [0-9]+"
+  "examples/gms2-extension/README.md|ABI version: [0-9]+"
+  "crates/elevator-wasm/src/lib.rs|pub const ABI_VERSION: u32 = [0-9]+"
+  "crates/elevator-gdext/src/sim_node.rs|const ABI_VERSION: u32 = [0-9]+"
+)
+
+declare -A versions
+declare -a missing=()
+
+for entry in "${WATCHED[@]}"; do
+  path="${entry%%|*}"
+  pattern="${entry#*|}"
+  abs="$REPO_ROOT/$path"
+  if [[ ! -f "$abs" ]]; then
+    missing+=("$path")
+    continue
+  fi
+  match=$(grep -oE "$pattern" "$abs" | head -1 || true)
+  if [[ -z "$match" ]]; then
+    missing+=("$path")
+    continue
+  fi
+  # Strip everything except the trailing integer.
+  version=$(echo "$match" | grep -oE '[0-9]+$')
+  versions["$path"]="$version"
+done
+
+status=0
+
+if (( ${#missing[@]} > 0 )); then
+  echo "::error::check-abi-pins.sh could not extract a version from these files:"
+  printf '  - %s\n' "${missing[@]}"
+  echo ""
+  echo "Either the file is missing or the watched pattern no longer matches."
+  echo "Update WATCHED in scripts/check-abi-pins.sh if the constant moved."
+  status=1
+fi
+
+# Count distinct values across the captured set.
+declare -A unique
+for v in "${versions[@]}"; do
+  unique["$v"]=1
+done
+
+if (( ${#unique[@]} > 1 )); then
+  echo "::error::ABI version pins disagree across consumers:"
+  for path in "${!versions[@]}"; do
+    printf '  %-60s %s\n' "$path" "${versions[$path]}"
+  done | sort
+  echo ""
+  echo "Resolve by updating each pin to match the EV_ABI_VERSION value"
+  echo "in crates/elevator-ffi/include/elevator_ffi.h (the source of truth)."
+  status=1
+fi
+
+if (( status != 0 )); then
+  exit $status
+fi
+
+# Success: report the agreed-on value and the count of files checked.
+agreed=$(printf '%s\n' "${!unique[@]}")
+echo "ok: ABI version is in sync at $agreed across ${#versions[@]} watched files"

--- a/scripts/check-abi-pins.sh
+++ b/scripts/check-abi-pins.sh
@@ -30,9 +30,12 @@ WATCHED=(
   "crates/elevator-ffi/src/lib.rs|pub const EV_ABI_VERSION: u32 = [0-9]+"
   "examples/csharp-harness/Program.cs|private const uint EXPECTED_ABI = [0-9]+"
   "examples/gms2-harness/main.c|#define EXPECTED_ABI [0-9]+"
-  "examples/gms2-extension/README.md|ABI version: [0-9]+"
+  # Anchored to the literal verification-recipe comment so a future
+  # changelog / migration-guide section in the README that mentions
+  # an old version doesn't trick `head -1` into extracting it.
+  "examples/gms2-extension/README.md|// expect: \"ABI version: [0-9]+\""
   "crates/elevator-wasm/src/lib.rs|pub const ABI_VERSION: u32 = [0-9]+"
-  "crates/elevator-gdext/src/sim_node.rs|const ABI_VERSION: u32 = [0-9]+"
+  "crates/elevator-gdext/src/sim_node.rs|pub const ABI_VERSION: u32 = [0-9]+"
 )
 
 declare -A versions
@@ -51,8 +54,11 @@ for entry in "${WATCHED[@]}"; do
     missing+=("$path")
     continue
   fi
-  # Strip everything except the trailing integer.
-  version=$(echo "$match" | grep -oE '[0-9]+$')
+  # Pull the last integer literal out of the matched line; the
+  # README's anchor ends with a closing quote, not a digit, so a
+  # bare `[0-9]+$` won't anchor against the line end. Take the last
+  # digit run via a tail call instead.
+  version=$(echo "$match" | grep -oE '[0-9]+' | tail -1)
   versions["$path"]="$version"
 done
 


### PR DESCRIPTION
## Summary

- New `scripts/check-abi-pins.sh` text-greps the ABI version literal from seven watched files and fails if any two values disagree.
- `crates/elevator-wasm/src/lib.rs` and `crates/elevator-gdext/src/sim_node.rs` gain a `pub const ABI_VERSION: u32 = 5` (neither crate had a pin before; the gate needed something to extract).
- CI: new "Check ABI version pins" step in the existing `check` job — no extra runner cost.
- Pre-commit hook: runs the gate when any file under `crates/elevator-(ffi|wasm|gdext)/` or `examples/(csharp-harness|gms2-harness|gms2-extension)/` is staged.

## Why

PR #613 caught a stale ABI pin only because the `csharp-harness` happened to exist. Future bumps without a synchronized update on every consumer would surface in production rather than CI. This gate makes that impossible.

## Watched files

| File | Pattern |
|---|---|
| `crates/elevator-ffi/include/elevator_ffi.h` | `#define EV_ABI_VERSION N` (source of truth) |
| `crates/elevator-ffi/src/lib.rs` | `pub const EV_ABI_VERSION: u32 = N` |
| `examples/csharp-harness/Program.cs` | `private const uint EXPECTED_ABI = N` |
| `examples/gms2-harness/main.c` | `#define EXPECTED_ABI N` |
| `examples/gms2-extension/README.md` | `"ABI version: N"` |
| `crates/elevator-wasm/src/lib.rs` | `pub const ABI_VERSION: u32 = N` (new in this PR) |
| `crates/elevator-gdext/src/sim_node.rs` | `pub const ABI_VERSION: u32 = N` (new in this PR) |

## Test plan

- [x] Happy path: `bash scripts/check-abi-pins.sh` reports `ok: ABI version is in sync at 5 across 7 watched files`.
- [x] Failure path: manually flipped the wasm constant to `4`; gate printed a per-file table and exited 1.
- [x] Pre-commit hook fires the gate locally (verified during the commit on this branch).
- [x] `cargo check --workspace` clean (new `pub const ABI_VERSION` in wasm + gdext both re-exported).