### PR TITLE
feat: MultiHostLayout proc-macro for repr-C struct introspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2608,6 +2608,9 @@ version = "0.16.0"
 dependencies = [
  "cbindgen",
  "elevator-core",
+ "elevator-layout-derive",
+ "elevator-layout-runtime",
+ "linkme",
  "ron",
  "serde",
  "slotmap",
@@ -2622,6 +2625,22 @@ dependencies = [
  "rand 0.10.1",
  "ron",
  "slotmap",
+]
+
+[[package]]
+name = "elevator-layout-derive"
+version = "1.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "elevator-layout-runtime"
+version = "1.0.0"
+dependencies = [
+ "linkme",
 ]
 
 [[package]]
@@ -3694,6 +3713,26 @@ name = "linebender_resource_handle"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ members = [
     "crates/elevator-bevy",
     "crates/elevator-ffi",
     "crates/elevator-gdext",
+    "crates/elevator-layout-derive",
+    "crates/elevator-layout-runtime",
     "crates/elevator-tui",
     "crates/elevator-wasm",
 ]

--- a/crates/elevator-ffi/Cargo.toml
+++ b/crates/elevator-ffi/Cargo.toml
@@ -40,6 +40,9 @@ deterministic-fp = ["elevator-core/deterministic-fp"]
 
 [dependencies]
 elevator-core = { path = "../elevator-core" }
+elevator-layout-derive = { path = "../elevator-layout-derive" }
+elevator-layout-runtime = { path = "../elevator-layout-runtime" }
+linkme = "0.3"
 ron = { workspace = true }
 serde = { workspace = true }
 slotmap = { workspace = true }

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -176,7 +176,7 @@ pub type EvLogFn = unsafe extern "C" fn(level: u8, msg: *const c_char);
 /// same handle. The bytes are UTF-8 and are **not** null-terminated;
 /// use `msg_len` to bound the read.
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, elevator_layout_derive::MultiHostLayout)]
 pub struct EvLogMessage {
     /// Severity level (0 = trace, 1 = debug, 2 = info, 3 = warn, 4 = error).
     pub level: u8,
@@ -211,7 +211,7 @@ pub unsafe extern "C" fn ev_set_log_callback(cb: Option<EvLogFn>) {
 
 /// View of a single elevator at the current tick.
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, elevator_layout_derive::MultiHostLayout)]
 pub struct EvElevatorView {
     /// Elevator entity id (raw slotmap `as_ffi()`).
     pub entity_id: u64,
@@ -244,7 +244,7 @@ pub struct EvElevatorView {
 
 /// View of a single stop at the current tick.
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, elevator_layout_derive::MultiHostLayout)]
 pub struct EvStopView {
     /// Stop entity id.
     pub entity_id: u64,
@@ -266,7 +266,7 @@ pub struct EvStopView {
 
 /// View of a single rider at the current tick.
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, elevator_layout_derive::MultiHostLayout)]
 pub struct EvRiderView {
     /// Rider entity id.
     pub entity_id: u64,
@@ -283,7 +283,7 @@ pub struct EvRiderView {
 
 /// Aggregate metrics at the current tick.
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, elevator_layout_derive::MultiHostLayout)]
 pub struct EvMetricsView {
     /// Cumulative riders delivered.
     pub total_delivered: u64,
@@ -300,7 +300,7 @@ pub struct EvMetricsView {
 /// Borrowed per-tick snapshot. All slice pointers are valid until the next
 /// call to [`ev_sim_frame`] on the same handle.
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, elevator_layout_derive::MultiHostLayout)]
 pub struct EvFrame {
     /// Pointer to contiguous elevator views.
     pub elevators: *const EvElevatorView,
@@ -1557,7 +1557,7 @@ pub unsafe extern "C" fn ev_sim_hall_calls_snapshot(
 
 /// C-ABI-flat projection of a `HallCall` for FFI consumers.
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, elevator_layout_derive::MultiHostLayout)]
 pub struct EvHallCall {
     /// Stop entity id (same encoding as elsewhere in the FFI).
     pub stop_entity_id: u64,
@@ -1588,7 +1588,7 @@ pub struct EvHallCall {
 /// One `(line, car)` assignment on a hall call. Read by
 /// [`ev_sim_assigned_cars_by_line`].
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, elevator_layout_derive::MultiHostLayout)]
 pub struct EvAssignment {
     /// Line entity id the car runs on.
     pub line_entity_id: u64,
@@ -1843,7 +1843,7 @@ pub mod ev_upgrade_field {
 /// against v3 must rebuild and check [`EV_ABI_VERSION`].
 #[allow(clippy::doc_markdown)]
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, elevator_layout_derive::MultiHostLayout)]
 pub struct EvEvent {
     /// Event kind discriminator. Values outside [`ev_event_kind`] are
     /// reserved — surface as [`UNKNOWN`](ev_event_kind::UNKNOWN) and
@@ -3245,7 +3245,7 @@ pub unsafe extern "C" fn ev_sim_remove_stop(handle: *mut EvSim, stop_entity_id: 
 /// supply `restricted_stops` separately as a `(*const u64, count)` pair
 /// to [`ev_sim_add_elevator`].
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, elevator_layout_derive::MultiHostLayout)]
 pub struct EvElevatorParams {
     /// Maximum travel speed (distance/tick); must be positive and finite.
     pub max_speed: f64,
@@ -6504,7 +6504,7 @@ pub unsafe extern "C" fn ev_sim_shortest_route(
 /// surfaced as a count (call [`ev_sim_car_call_pending_riders`] to read
 /// the actual rider list).
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, elevator_layout_derive::MultiHostLayout)]
 pub struct EvCarCall {
     /// Elevator the button was pressed inside.
     pub car_entity_id: u64,
@@ -6691,7 +6691,7 @@ pub unsafe extern "C" fn ev_sim_car_call_pending_riders(
 /// for real-time. The narrower [`EvMetricsView`] embedded in [`EvFrame`]
 /// is kept for backward compatibility; new code should prefer this struct.
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, elevator_layout_derive::MultiHostLayout)]
 pub struct EvMetrics {
     /// Cumulative riders delivered.
     pub total_delivered: u64,
@@ -6770,7 +6770,7 @@ pub unsafe extern "C" fn ev_sim_metrics(
 /// Per-tag metric snapshot. Mirrors
 /// [`elevator_core::tagged_metrics::TaggedMetric`].
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, elevator_layout_derive::MultiHostLayout)]
 pub struct EvTaggedMetric {
     /// Average wait time in ticks for tagged riders.
     pub avg_wait_ticks: f64,
@@ -7086,6 +7086,90 @@ mod tests {
     fn abi_version_matches_constant() {
         assert_eq!(ev_abi_version(), EV_ABI_VERSION);
         assert_eq!(EV_ABI_VERSION, 5);
+    }
+
+    #[test]
+    fn layout_derive_matches_offset_of() {
+        // The proc-macro emits `core::mem::offset_of!` calls; verify
+        // the captured offsets agree with native offset_of for every
+        // field. This is the core invariant PR 6's codegen relies
+        // on — if it ever drifts, every consumer-side struct
+        // definition becomes silently wrong.
+        use elevator_layout_runtime::LayoutInfo;
+        let fields = <EvLogMessage as LayoutInfo>::fields();
+        assert_eq!(fields.len(), 4, "EvLogMessage has 4 fields");
+        assert_eq!(fields[0].name, "level");
+        assert_eq!(fields[0].offset, std::mem::offset_of!(EvLogMessage, level));
+        assert_eq!(fields[1].name, "ts_ns");
+        assert_eq!(fields[1].offset, std::mem::offset_of!(EvLogMessage, ts_ns));
+        assert_eq!(fields[2].name, "msg_ptr");
+        assert_eq!(
+            fields[2].offset,
+            std::mem::offset_of!(EvLogMessage, msg_ptr)
+        );
+        assert_eq!(fields[3].name, "msg_len");
+        assert_eq!(
+            fields[3].offset,
+            std::mem::offset_of!(EvLogMessage, msg_len)
+        );
+        assert_eq!(
+            <EvLogMessage as LayoutInfo>::size(),
+            std::mem::size_of::<EvLogMessage>()
+        );
+    }
+
+    #[test]
+    fn layout_registry_includes_every_host_bound_struct() {
+        // Registry holds an entry for every #[derive(MultiHostLayout)]
+        // type linked into the binary. The codegen (PR 6) iterates
+        // this slice to enumerate everything to emit.
+        let names: std::collections::HashSet<&str> = elevator_layout_runtime::REGISTRY
+            .iter()
+            .map(|e| e.name)
+            .collect();
+        // The 13 host-bound repr-C structs in elevator-ffi as of this
+        // ABI generation. Adding a struct without #[derive(MultiHostLayout)]
+        // lets the codegen miss it silently — this list is the gate.
+        for required in [
+            "EvLogMessage",
+            "EvElevatorView",
+            "EvStopView",
+            "EvRiderView",
+            "EvMetricsView",
+            "EvFrame",
+            "EvHallCall",
+            "EvAssignment",
+            "EvEvent",
+            "EvElevatorParams",
+            "EvCarCall",
+            "EvMetrics",
+            "EvTaggedMetric",
+        ] {
+            assert!(
+                names.contains(required),
+                "registry missing {required}; got: {names:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn layout_offsets_round_trip_via_registry() {
+        // Spot-check a few structs through the registry (rather than
+        // direct LayoutInfo calls) so the codegen's iteration path
+        // is exercised in tests too. Field counts and total sizes
+        // must match native size_of / offset_of.
+        let entry = elevator_layout_runtime::REGISTRY
+            .iter()
+            .find(|e| e.name == "EvLogMessage")
+            .expect("EvLogMessage in registry");
+        assert_eq!(entry.size, std::mem::size_of::<EvLogMessage>());
+        assert_eq!(entry.fields.len(), 4);
+
+        let frame_entry = elevator_layout_runtime::REGISTRY
+            .iter()
+            .find(|e| e.name == "EvFrame")
+            .expect("EvFrame in registry");
+        assert_eq!(frame_entry.size, std::mem::size_of::<EvFrame>());
     }
 
     #[test]

--- a/crates/elevator-layout-derive/Cargo.toml
+++ b/crates/elevator-layout-derive/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "elevator-layout-derive"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Proc-macro that emits LayoutInfo metadata for #[repr(C)] structs in elevator-ffi."
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"

--- a/crates/elevator-layout-derive/src/lib.rs
+++ b/crates/elevator-layout-derive/src/lib.rs
@@ -1,0 +1,133 @@
+//! `#[derive(MultiHostLayout)]` proc-macro.
+//!
+//! Inspects a `#[repr(C)]` struct's fields, classifies each by
+//! primitive kind (u8/i64/Ptr/etc.), and emits an `impl LayoutInfo`
+//! plus a `#[distributed_slice(REGISTRY)]` entry in
+//! `elevator-layout-runtime`'s global registry.
+//!
+//! See `crates/elevator-layout-runtime/src/lib.rs` for the trait and
+//! registry definitions, and `crates/elevator-layout-codegen` (PR 6)
+//! for the consumer that reads the registry to emit C# / GML / C
+//! struct definitions.
+
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{Data, DeriveInput, Fields, Type, parse_macro_input};
+
+#[proc_macro_derive(MultiHostLayout)]
+pub fn derive_multi_host_layout(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+    let name_str = name.to_string();
+
+    let fields = match &input.data {
+        Data::Struct(s) => match &s.fields {
+            Fields::Named(named) => &named.named,
+            _ => {
+                return syn::Error::new_spanned(
+                    name,
+                    "MultiHostLayout requires a named-field struct",
+                )
+                .to_compile_error()
+                .into();
+            }
+        },
+        _ => {
+            return syn::Error::new_spanned(name, "MultiHostLayout can only be derived on structs")
+                .to_compile_error()
+                .into();
+        }
+    };
+
+    // Per-field metadata literals. Each generates one Field entry
+    // in the emitted FIELDS slice — declaration order is preserved.
+    let mut field_entries = Vec::with_capacity(fields.len());
+    for field in fields {
+        let Some(field_ident) = field.ident.as_ref() else {
+            continue;
+        };
+        let field_name_str = field_ident.to_string();
+        let kind_tokens = classify_type(&field.ty);
+        let ty = &field.ty;
+        field_entries.push(quote! {
+            ::elevator_layout_runtime::Field {
+                name: #field_name_str,
+                offset: ::core::mem::offset_of!(#name, #field_ident),
+                size: ::core::mem::size_of::<#ty>(),
+                kind: #kind_tokens,
+            }
+        });
+    }
+
+    // Generate a unique constant ident for the registry submission so
+    // multiple derives in the same crate don't collide.
+    let registry_const = format_ident!("__LAYOUT_REGISTRY_ENTRY_{}", name);
+
+    let expanded = quote! {
+        impl ::elevator_layout_runtime::LayoutInfo for #name {
+            fn name() -> &'static str {
+                #name_str
+            }
+            fn size() -> usize {
+                ::core::mem::size_of::<Self>()
+            }
+            fn fields() -> &'static [::elevator_layout_runtime::Field] {
+                static FIELDS: &[::elevator_layout_runtime::Field] = &[
+                    #(#field_entries),*
+                ];
+                FIELDS
+            }
+        }
+
+        // linkme distributed slice entry. The codegen binary in
+        // crates/elevator-layout-codegen iterates REGISTRY at runtime
+        // to discover every host-bound repr-C struct without a
+        // hardcoded list.
+        #[::linkme::distributed_slice(::elevator_layout_runtime::REGISTRY)]
+        #[allow(non_upper_case_globals)]
+        static #registry_const: ::elevator_layout_runtime::LayoutEntry =
+            ::elevator_layout_runtime::LayoutEntry {
+                name: #name_str,
+                size: ::core::mem::size_of::<#name>(),
+                fields: {
+                    static FIELDS: &[::elevator_layout_runtime::Field] = &[
+                        #(#field_entries),*
+                    ];
+                    FIELDS
+                },
+            };
+    };
+
+    expanded.into()
+}
+
+/// Map a Rust type token to a `FieldKind` variant.
+///
+/// The mapping is purely structural — anything that doesn't match
+/// a known primitive falls through to `Bytes` so the codegen can
+/// emit raw bytes for nested structs / fixed arrays.
+fn classify_type(ty: &Type) -> proc_macro2::TokenStream {
+    let s = quote!(#ty).to_string().replace(' ', "");
+    let kind = match s.as_str() {
+        "u8" => quote!(U8),
+        "i8" => quote!(I8),
+        "u16" => quote!(U16),
+        "i16" => quote!(U16),
+        "u32" => quote!(U32),
+        "i32" => quote!(I32),
+        "u64" => quote!(U64),
+        "i64" => quote!(I64),
+        "f32" => quote!(F32),
+        "f64" => quote!(F64),
+        // Pointer-sized: any *const/*mut, usize/isize. The token
+        // shape `*const T` or `*mut T` always starts with one of
+        // these prefixes, so a string match suffices for the
+        // pre-PR-5 type universe.
+        s if s.starts_with("*const") || s.starts_with("*mut") => quote!(Ptr),
+        "usize" | "isize" => quote!(Ptr),
+        // Anything else (nested structs, arrays) is an opaque byte
+        // run from the codegen's perspective.
+        _ => quote!(Bytes),
+    };
+    quote!(::elevator_layout_runtime::FieldKind::#kind)
+}

--- a/crates/elevator-layout-derive/src/lib.rs
+++ b/crates/elevator-layout-derive/src/lib.rs
@@ -20,6 +20,21 @@ pub fn derive_multi_host_layout(input: TokenStream) -> TokenStream {
     let name = &input.ident;
     let name_str = name.to_string();
 
+    // Require #[repr(C)]. Without it, `core::mem::offset_of!` still
+    // compiles but the offsets follow the compiler's layout choices,
+    // which are unstable across targets and rustc versions. PR 6's
+    // codegen would then emit C# / GML / C definitions assuming
+    // FFI-stable offsets — silently corrupting cross-language
+    // memory reads.
+    if !has_repr_c(&input.attrs) {
+        return syn::Error::new_spanned(
+            name,
+            "MultiHostLayout requires #[repr(C)] for FFI-stable offsets",
+        )
+        .to_compile_error()
+        .into();
+    }
+
     let fields = match &input.data {
         Data::Struct(s) => match &s.fields {
             Fields::Named(named) => &named.named,
@@ -59,11 +74,20 @@ pub fn derive_multi_host_layout(input: TokenStream) -> TokenStream {
         });
     }
 
-    // Generate a unique constant ident for the registry submission so
-    // multiple derives in the same crate don't collide.
+    // Generate unique idents for the per-type statics so multiple
+    // derives in the same crate don't collide.
     let registry_const = format_ident!("__LAYOUT_REGISTRY_ENTRY_{}", name);
+    let fields_static = format_ident!("__LAYOUT_FIELDS_{}", name);
 
     let expanded = quote! {
+        // Single per-type FIELDS table — referenced by both the
+        // LayoutInfo::fields() impl and the registry entry below
+        // so the field-literal token stream is only expanded once.
+        #[allow(non_upper_case_globals)]
+        const #fields_static: &[::elevator_layout_runtime::Field] = &[
+            #(#field_entries),*
+        ];
+
         impl ::elevator_layout_runtime::LayoutInfo for #name {
             fn name() -> &'static str {
                 #name_str
@@ -72,10 +96,7 @@ pub fn derive_multi_host_layout(input: TokenStream) -> TokenStream {
                 ::core::mem::size_of::<Self>()
             }
             fn fields() -> &'static [::elevator_layout_runtime::Field] {
-                static FIELDS: &[::elevator_layout_runtime::Field] = &[
-                    #(#field_entries),*
-                ];
-                FIELDS
+                #fields_static
             }
         }
 
@@ -89,16 +110,34 @@ pub fn derive_multi_host_layout(input: TokenStream) -> TokenStream {
             ::elevator_layout_runtime::LayoutEntry {
                 name: #name_str,
                 size: ::core::mem::size_of::<#name>(),
-                fields: {
-                    static FIELDS: &[::elevator_layout_runtime::Field] = &[
-                        #(#field_entries),*
-                    ];
-                    FIELDS
-                },
+                fields: #fields_static,
             };
     };
 
     expanded.into()
+}
+
+/// Detect whether the input struct carries `#[repr(C)]`.
+///
+/// `#[repr(C, ...other...)]` (e.g. `#[repr(C, packed)]`) is also
+/// accepted — we walk every nested meta in the repr list.
+fn has_repr_c(attrs: &[syn::Attribute]) -> bool {
+    for attr in attrs {
+        if !attr.path().is_ident("repr") {
+            continue;
+        }
+        let mut found = false;
+        let _ = attr.parse_nested_meta(|nested| {
+            if nested.path.is_ident("C") {
+                found = true;
+            }
+            Ok(())
+        });
+        if found {
+            return true;
+        }
+    }
+    false
 }
 
 /// Map a Rust type token to a `FieldKind` variant.
@@ -112,7 +151,7 @@ fn classify_type(ty: &Type) -> proc_macro2::TokenStream {
         "u8" => quote!(U8),
         "i8" => quote!(I8),
         "u16" => quote!(U16),
-        "i16" => quote!(U16),
+        "i16" => quote!(I16),
         "u32" => quote!(U32),
         "i32" => quote!(I32),
         "u64" => quote!(U64),

--- a/crates/elevator-layout-runtime/Cargo.toml
+++ b/crates/elevator-layout-runtime/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "elevator-layout-runtime"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Runtime trait + linkme registry consumed by the elevator-layout-derive proc-macro and the elevator-layout-codegen binary."
+publish = false
+
+[dependencies]
+linkme = "0.3"

--- a/crates/elevator-layout-runtime/src/lib.rs
+++ b/crates/elevator-layout-runtime/src/lib.rs
@@ -1,0 +1,102 @@
+//! Runtime support for `#[derive(MultiHostLayout)]`.
+//!
+//! Defines the `LayoutInfo` trait and a `linkme`-backed global registry
+//! so the layout-codegen binary can iterate every host-bound repr-C
+//! struct without a hardcoded list.
+//!
+//! Why a separate crate: proc-macros (`crates/elevator-layout-derive`)
+//! emit code that references this trait, but a proc-macro crate cannot
+//! itself define the trait — Rust requires the derive crate to be
+//! `proc-macro = true`, which precludes exposing non-proc-macro items
+//! to consumers. Splitting into derive + runtime is the standard
+//! pattern (e.g. `serde_derive` + `serde`, `clap_derive` + `clap`).
+
+use linkme::distributed_slice;
+
+/// Static metadata for a single field of a `#[repr(C)]` struct.
+#[derive(Debug, Clone, Copy)]
+pub struct Field {
+    /// Field name as written in the Rust source.
+    pub name: &'static str,
+    /// Byte offset within the parent struct (computed via
+    /// `core::mem::offset_of!` at the derive site).
+    pub offset: usize,
+    /// Byte size of the field (computed via `core::mem::size_of`).
+    pub size: usize,
+    /// Classified primitive kind — drives the consumer-side type
+    /// emitted by the codegen binary (e.g. `byte` in C#, `u8` in
+    /// `buffer_peek`'s second argument in GML).
+    pub kind: FieldKind,
+}
+
+/// Primitive kinds the host-side layouts care about.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FieldKind {
+    /// `u8`.
+    U8,
+    /// `i8`.
+    I8,
+    /// `u16` / `i16`. Currently unused; reserved for future structs.
+    U16,
+    /// `u32`.
+    U32,
+    /// `i32`. Currently unused; reserved.
+    I32,
+    /// `u64`.
+    U64,
+    /// `i64`.
+    I64,
+    /// `f32`. Currently unused; reserved.
+    F32,
+    /// `f64`.
+    F64,
+    /// Pointer-sized: any `*const T`, `*mut T`, `usize`, or
+    /// `isize`. Eight bytes on every supported target.
+    Ptr,
+    /// Compound nested type (a derived struct or `[u8; N]` blob)
+    /// the codegen emits as raw bytes. Reserved for future structs
+    /// that contain nested repr-C records.
+    Bytes,
+}
+
+/// Static metadata for one `#[derive(MultiHostLayout)]` struct.
+///
+/// Implementations are emitted by the derive macro; the codegen
+/// binary iterates [`REGISTRY`] at runtime to enumerate every host-
+/// bound repr-C struct in elevator-ffi.
+pub trait LayoutInfo: 'static {
+    /// Type name as a static string (e.g. `"EvLogMessage"`).
+    fn name() -> &'static str
+    where
+        Self: Sized;
+
+    /// Total byte size of the struct (from `core::mem::size_of`).
+    fn size() -> usize
+    where
+        Self: Sized;
+
+    /// Static slice of every field in declaration order.
+    fn fields() -> &'static [Field]
+    where
+        Self: Sized;
+}
+
+/// Erased reference into [`REGISTRY`] so the static slice can hold
+/// every concrete `LayoutInfo` implementation regardless of type.
+#[derive(Debug, Clone, Copy)]
+pub struct LayoutEntry {
+    /// `T::name()` — the struct's identifier.
+    pub name: &'static str,
+    /// `T::size()` — total byte size.
+    pub size: usize,
+    /// `T::fields()` — declaration-order field metadata.
+    pub fields: &'static [Field],
+}
+
+/// Distributed slice that every `#[derive(MultiHostLayout)]` push an
+/// entry into via the derive's emitted `#[distributed_slice(REGISTRY)]`
+/// item. Iterate this from the codegen binary to discover all
+/// host-bound types without a hardcoded list.
+#[distributed_slice]
+pub static REGISTRY: [LayoutEntry] = [..];

--- a/crates/elevator-layout-runtime/src/lib.rs
+++ b/crates/elevator-layout-runtime/src/lib.rs
@@ -37,8 +37,10 @@ pub enum FieldKind {
     U8,
     /// `i8`.
     I8,
-    /// `u16` / `i16`. Currently unused; reserved for future structs.
+    /// `u16`. Currently unused; reserved for future structs.
     U16,
+    /// `i16`. Currently unused; reserved for future structs.
+    I16,
     /// `u32`.
     U32,
     /// `i32`. Currently unused; reserved.


### PR DESCRIPTION
## Summary

Two new workspace crates that provide compile-time layout metadata for elevator-ffi's host-bound `#[repr(C)]` structs. PR 6's codegen binary will iterate this registry and emit consumer-side definitions (C# / GML / C asserts) from a single Rust source of truth, replacing the current 5-place hand-mirrored offset duplication.

- **`crates/elevator-layout-runtime`** — Defines `LayoutInfo` trait, `Field`, `FieldKind`, and a `linkme` distributed-slice `REGISTRY`. ~80 LoC. Lives in a non-proc-macro crate so both the derive's emitted code and PR 6's codegen binary can depend on it (standard derive/runtime split).
- **`crates/elevator-layout-derive`** — Proc-macro `#[derive(MultiHostLayout)]` walks named struct fields, emits an impl with a static `FIELDS` slice (offsets via `core::mem::offset_of!`, sizes via `size_of`), classifies each field by primitive kind (u8/i64/Ptr/...), and registers the type into `REGISTRY` via `linkme`. ~130 LoC.
- **elevator-ffi** gains both crates as deps and applies `#[derive(MultiHostLayout)]` to all 13 host-bound repr-C structs: `EvLogMessage`, `EvElevatorView`, `EvStopView`, `EvRiderView`, `EvMetricsView`, `EvFrame`, `EvHallCall`, `EvAssignment`, `EvEvent`, `EvElevatorParams`, `EvCarCall`, `EvMetrics`, `EvTaggedMetric`.

## Why

Today, `EvLogMessage`'s offsets exist in five places: `lib.rs` `#[repr(C)]`, the cbindgen-generated header, csharp-harness `[FieldOffset]`, gms2-harness `_Static_assert`, GML `EV_*_OFFSET` macros. Adding one field requires five touches; missing one silently corrupts reads on whatever host wasn't updated. PR 5 puts the metadata behind one Rust source-of-truth that PR 6 will use to generate the rest.

## Test plan

Three new unit tests pin the invariants:

- `layout_derive_matches_offset_of`: emitted offsets agree with native `offset_of!` for every `EvLogMessage` field.
- `layout_registry_includes_every_host_bound_struct`: `REGISTRY` enumerates all 13 expected structs (gates against forgetting the derive on a future repr-C addition).
- `layout_offsets_round_trip_via_registry`: spot-checks size + field count via the registry path the codegen binary will use.

- [x] `cargo test -p elevator-ffi` — 53 tests pass (3 new).
- [x] `cargo check --workspace` clean.
- [x] `cargo clippy -p elevator-layout-runtime -p elevator-layout-derive --all-targets` clean.
- [x] `cargo fmt --all -- --check` clean.

## Out of scope

- The codegen binary that consumes the registry — PR 6.
- Replacing existing hand-mirrored harness layouts — PR 6 wires those up.