### PR TITLE
fix(core): cross-process snapshot byte determinism

### DIFF
--- a/assets/contract-corpus/golden.txt
+++ b/assets/contract-corpus/golden.txt
@@ -1,8 +1,8 @@
 # Golden snapshot checksums for contract scenarios.
 # Regenerate via: cargo run -p elevator-contract -- --update-golden
 # tick budget: 600
-default 0x86252d510384fa1f
-dense_traffic 0xdce9bdfba0f88ab7
-extreme_load 0x796a55323fe7339b
-multi_group 0xa1af5311e9625909
-sparse 0x5969c0ff2e711058
+default 0x9783adffd39bb643
+dense_traffic 0xc7b120b8395779e2
+extreme_load 0x7581540441aced69
+multi_group 0xcdff40926ff39006
+sparse 0x2f4eb7ad1bfd4aa3

--- a/crates/elevator-contract/src/main.rs
+++ b/crates/elevator-contract/src/main.rs
@@ -21,14 +21,12 @@
 //! seed, `make_rng` would pull from the OS entropy and every harness
 //! run would produce different metrics.
 //!
-//! We don't use `Simulation::snapshot_checksum()` directly — empirical
-//! testing showed that snapshot bytes still leak HashMap iteration
-//! order somewhere in the World plumbing (a small permutation of stop
-//! IDs visible in the postcard output). Until that's tracked down, the
-//! harness instead hashes a hand-picked deterministic projection of
-//! the sim state: `(current_tick, total_delivered, total_abandoned,
-//! total_spawned, throughput, total_distance.to_bits())`. Every value
-//! is a primitive integer/float that doesn't traverse a HashMap.
+//! The checksum is `Simulation::snapshot_checksum()` — FNV-1a over
+//! `snapshot_bytes()`. This covers the entire serializable sim state
+//! (entities, components, groups, metrics, world resources, dispatcher
+//! configs), so a behaviour change anywhere in that surface surfaces
+//! as a divergence. Snapshot bytes are deterministic across processes
+//! since every map field that gets serialized uses `BTreeMap`.
 //!
 //! ## Update protocol
 //!
@@ -225,32 +223,8 @@ fn run_scenario(cfg_path: &Path, ticks: u64, seed: u64) -> u64 {
         }
         sim.step();
     }
-    metrics_checksum(&sim)
-}
-
-/// FNV-1a over the deterministic-projection tuple. Runs in 6 mixes;
-/// no allocation. Identical across hosts so long as the underlying
-/// Simulation API computes the same values from the same inputs.
-fn metrics_checksum(sim: &Simulation) -> u64 {
-    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
-    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
-    let m = sim.metrics();
-    let words: [u64; 6] = [
-        sim.current_tick(),
-        m.total_delivered(),
-        m.total_abandoned(),
-        m.total_spawned(),
-        m.throughput(),
-        m.total_distance().to_bits(),
-    ];
-    let mut h = FNV_OFFSET;
-    for w in words {
-        for byte in w.to_le_bytes() {
-            h ^= u64::from(byte);
-            h = h.wrapping_mul(FNV_PRIME);
-        }
-    }
-    h
+    sim.snapshot_checksum()
+        .unwrap_or_else(|e| panic!("snapshot_checksum {}: {e}", cfg_path.display()))
 }
 
 fn parse_golden(path: &Path) -> std::io::Result<BTreeMap<String, u64>> {

--- a/crates/elevator-core/src/dispatch/look.rs
+++ b/crates/elevator-core/src/dispatch/look.rs
@@ -10,7 +10,7 @@
 //! the car drives to the physical shaft end between sweeps — applies to
 //! the motion layer, not dispatch.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::entity::EntityId;
 use crate::world::World;
@@ -25,8 +25,9 @@ pub struct LookDispatch {
     /// (reversed once a sweep exhausts demand ahead) and round-tripped
     /// through [`DispatchStrategy::snapshot_config`] so a restored sim
     /// continues the current sweep instead of defaulting to `Up` for
-    /// every car.
-    direction: HashMap<EntityId, SweepDirection>,
+    /// every car. `BTreeMap` so RON serialization in `snapshot_config`
+    /// is byte-identical across processes (#254 follow-up).
+    direction: BTreeMap<EntityId, SweepDirection>,
     /// Per-elevator accept mode for the current dispatch pass.
     /// Overwritten in full by `prepare_car` every pass, so no round-
     /// trip is needed.
@@ -39,7 +40,7 @@ impl LookDispatch {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            direction: HashMap::new(),
+            direction: BTreeMap::new(),
             mode: HashMap::new(),
         }
     }

--- a/crates/elevator-core/src/dispatch/reposition.rs
+++ b/crates/elevator-core/src/dispatch/reposition.rs
@@ -12,7 +12,7 @@
 //!     .unwrap();
 //! ```
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use serde::{Deserialize, Serialize};
 
@@ -46,8 +46,11 @@ pub const DEFAULT_REPOSITION_COOLDOWN_TICKS: u64 = 240;
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RepositionCooldowns {
     /// Tick counter when each car becomes eligible again. Cars not
-    /// present in the map have no cooldown (fresh state).
-    pub eligible_at: HashMap<EntityId, u64>,
+    /// present in the map have no cooldown (fresh state). `BTreeMap`
+    /// for deterministic snapshot bytes across processes — `HashMap`
+    /// iteration order varies by per-process hash seed and leaked into
+    /// the postcard byte stream (#254 follow-up).
+    pub eligible_at: BTreeMap<EntityId, u64>,
 }
 
 impl RepositionCooldowns {
@@ -70,7 +73,7 @@ impl RepositionCooldowns {
     /// any entries whose car wasn't re-allocated during snapshot
     /// restore. Mirrors `ArrivalLog::remap_entity_ids`.
     pub fn remap_entity_ids(&mut self, id_remap: &HashMap<EntityId, EntityId>) {
-        let remapped: HashMap<EntityId, u64> = std::mem::take(&mut self.eligible_at)
+        let remapped: BTreeMap<EntityId, u64> = std::mem::take(&mut self.eligible_at)
             .into_iter()
             .filter_map(|(old, eligible)| id_remap.get(&old).map(|&new| (new, eligible)))
             .collect();

--- a/crates/elevator-core/src/dispatch/reposition.rs
+++ b/crates/elevator-core/src/dispatch/reposition.rs
@@ -49,8 +49,11 @@ pub struct RepositionCooldowns {
     /// present in the map have no cooldown (fresh state). `BTreeMap`
     /// for deterministic snapshot bytes across processes — `HashMap`
     /// iteration order varies by per-process hash seed and leaked into
-    /// the postcard byte stream (#254 follow-up).
-    pub eligible_at: BTreeMap<EntityId, u64>,
+    /// the postcard byte stream (#254 follow-up). `pub(crate)` rather
+    /// than `pub` so external consumers go through `record_arrival` /
+    /// `is_cooling_down` instead of mutating the map directly, and so a
+    /// future container swap doesn't ripple into downstream API breaks.
+    pub(crate) eligible_at: BTreeMap<EntityId, u64>,
 }
 
 impl RepositionCooldowns {

--- a/crates/elevator-core/src/dispatch/scan.rs
+++ b/crates/elevator-core/src/dispatch/scan.rs
@@ -5,7 +5,7 @@
 //! Joint Computer Conference*, 9–21. The same sweep discipline is the
 //! textbook "elevator" algorithm.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::entity::EntityId;
 use crate::world::World;
@@ -27,8 +27,9 @@ pub struct ScanDispatch {
     /// (reversed once a sweep exhausts demand ahead) and round-tripped
     /// through [`DispatchStrategy::snapshot_config`] so a restored sim
     /// continues the current sweep instead of defaulting to `Up` for
-    /// every car.
-    direction: HashMap<EntityId, SweepDirection>,
+    /// every car. `BTreeMap` so RON serialization in `snapshot_config`
+    /// is byte-identical across processes (#254 follow-up).
+    direction: BTreeMap<EntityId, SweepDirection>,
     /// Per-elevator accept mode for the current dispatch pass.
     /// Overwritten in full by `prepare_car` every pass, so no round-
     /// trip is needed; `#[serde(skip)]` keeps snapshot bytes compact
@@ -42,7 +43,7 @@ impl ScanDispatch {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            direction: HashMap::new(),
+            direction: BTreeMap::new(),
             mode: HashMap::new(),
         }
     }

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -387,7 +387,17 @@ impl Simulation {
         stop_lookup: &HashMap<StopId, EntityId>,
         builder_dispatchers: BTreeMap<GroupId, Box<dyn DispatchStrategy>>,
     ) -> TopologyResult {
-        let all_stop_entities: Vec<EntityId> = stop_lookup.values().copied().collect();
+        // Iterate the config's stop list (deterministic Vec order) and
+        // resolve each through the lookup. Walking `stop_lookup.values()`
+        // would expose `HashMap` iteration order — which varies by
+        // per-process hash seed — into `LineInfo.serves` and from
+        // there into snapshot bytes.
+        let all_stop_entities: Vec<EntityId> = config
+            .building
+            .stops
+            .iter()
+            .filter_map(|s| stop_lookup.get(&s.id).copied())
+            .collect();
         let stop_positions: Vec<f64> = config.building.stops.iter().map(|s| s.position).collect();
         let min_pos = stop_positions.iter().copied().fold(f64::INFINITY, f64::min);
         let max_pos = stop_positions
@@ -475,8 +485,12 @@ impl Simulation {
         stop_lookup: &HashMap<StopId, EntityId>,
         builder_dispatchers: BTreeMap<GroupId, Box<dyn DispatchStrategy>>,
     ) -> TopologyResult {
-        // Map line config id → (line EntityId, LineInfo).
-        let mut line_map: HashMap<u32, (EntityId, LineInfo)> = HashMap::new();
+        // Map line config id → (line EntityId, LineInfo). `BTreeMap`
+        // (not `HashMap`) so the auto-inferred-groups branch iterates
+        // `.values()` in deterministic key order — otherwise the
+        // resulting `LineInfo` sequence permutes across processes and
+        // leaks into snapshot bytes via `GroupSnapshot::lines`.
+        let mut line_map: BTreeMap<u32, (EntityId, LineInfo)> = BTreeMap::new();
 
         for lc in line_configs {
             // Resolve served stop entities.

--- a/crates/elevator-core/src/tagged_metrics.rs
+++ b/crates/elevator-core/src/tagged_metrics.rs
@@ -136,15 +136,8 @@ impl MetricTags {
     }
 
     /// Iterate all registered tags in deterministic (lexicographic) order.
-    ///
-    /// The internal storage is a `HashMap`, but this accessor sorts the
-    /// keys so that repeated calls — and callers comparing output across
-    /// runs — observe a stable order. O(n log n) in the number of tags;
-    /// cheap in practice since tag counts are small.
     pub fn all_tags(&self) -> impl Iterator<Item = &str> {
-        let mut tags: Vec<&str> = self.tag_metrics.keys().map(String::as_str).collect();
-        tags.sort_unstable();
-        tags.into_iter()
+        self.tag_metrics.keys().map(String::as_str)
     }
 
     /// Call `f` on the metric accumulator for each tag attached to `entity`.

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -956,12 +956,12 @@ fn reposition_cooldowns_serialize_independent_of_insertion_order() {
     use crate::dispatch::reposition::RepositionCooldowns;
     use crate::entity::EntityId;
 
-    let key_a = EntityId::default();
-    let key_b = {
-        let mut sm = slotmap::SlotMap::<EntityId, ()>::with_key();
-        sm.insert(());
-        sm.insert(())
-    };
+    // Use real allocated slotmap keys (not `EntityId::default()`,
+    // which is the slotmap null sentinel that production never
+    // produces) so the fixture mirrors the runtime shape.
+    let mut sm = slotmap::SlotMap::<EntityId, ()>::with_key();
+    let key_a = sm.insert(());
+    let key_b = sm.insert(());
 
     let mut forward = RepositionCooldowns::default();
     forward.eligible_at.insert(key_a, 100);

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -940,6 +940,86 @@ fn snapshot_bytes_roundtrip_is_byte_stable() {
     );
 }
 
+/// `RepositionCooldowns` must serialize identically regardless of the
+/// order in which entries were inserted. With `HashMap`, insertion
+/// order influenced bucket layout and thus iteration order, leaking
+/// per-process hash-seed randomness into the postcard byte stream;
+/// `BTreeMap` keys are walked in `Ord` order so two maps with the
+/// same `(key, value)` set produce byte-identical output.
+///
+/// Regression guard for cross-process snapshot drift observed in the
+/// contract harness: scenarios with ≥2 cars under cooldown produced
+/// different `snapshot_bytes()` across runs, defeating golden-hash
+/// equality even though the simulation state was logically identical.
+#[test]
+fn reposition_cooldowns_serialize_independent_of_insertion_order() {
+    use crate::dispatch::reposition::RepositionCooldowns;
+    use crate::entity::EntityId;
+
+    let key_a = EntityId::default();
+    let key_b = {
+        let mut sm = slotmap::SlotMap::<EntityId, ()>::with_key();
+        sm.insert(());
+        sm.insert(())
+    };
+
+    let mut forward = RepositionCooldowns::default();
+    forward.eligible_at.insert(key_a, 100);
+    forward.eligible_at.insert(key_b, 200);
+
+    let mut reverse = RepositionCooldowns::default();
+    reverse.eligible_at.insert(key_b, 200);
+    reverse.eligible_at.insert(key_a, 100);
+
+    let bytes_forward = postcard::to_allocvec(&forward).unwrap();
+    let bytes_reverse = postcard::to_allocvec(&reverse).unwrap();
+
+    assert_eq!(
+        bytes_forward, bytes_reverse,
+        "RepositionCooldowns must serialize identically regardless of insertion order; \
+         a difference here means iteration order leaks into the byte stream",
+    );
+}
+
+/// Snapshot bytes must be stable across a `restore -> snapshot` cycle
+/// even when reposition cooldowns are populated. The cooldowns map is
+/// rebuilt from scratch on restore, so a non-deterministic container
+/// (e.g. `HashMap`) would surface here as a byte mismatch — the fresh
+/// hash seed picks a different bucket layout than the source map.
+#[test]
+fn snapshot_bytes_with_reposition_cooldowns_roundtrip_is_stable() {
+    use crate::dispatch::reposition::RepositionCooldowns;
+
+    // Need ≥2 elevators so the cooldowns map has multiple entries —
+    // a single-entry map is trivially insertion-order-independent.
+    let config = helpers::multi_floor_config(4, 3);
+    let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+    for _ in 0..50 {
+        sim.step();
+    }
+
+    let elevators = sim.world().elevator_ids();
+    assert!(elevators.len() >= 2, "fixture sim has ≥2 elevators");
+
+    let mut cooldowns = RepositionCooldowns::default();
+    cooldowns.eligible_at.insert(elevators[0], 100);
+    cooldowns.eligible_at.insert(elevators[1], 200);
+    cooldowns.eligible_at.insert(elevators[2], 300);
+    sim.world_mut().insert_resource(cooldowns);
+
+    let bytes_before = sim.snapshot_bytes().expect("initial snapshot_bytes");
+    let restored =
+        crate::sim::Simulation::restore_bytes(&bytes_before, None).expect("restore_bytes");
+    let bytes_after = restored
+        .snapshot_bytes()
+        .expect("post-restore snapshot_bytes");
+
+    assert_eq!(
+        bytes_before, bytes_after,
+        "snapshot bytes must be byte-stable across restore even with populated reposition cooldowns",
+    );
+}
+
 /// RON text format must also be byte-stable across a deserialize +
 /// reserialize cycle. RON has no envelope, so this isolates the
 /// `WorldSnapshot` `Serialize` / `Deserialize` impls themselves —


### PR DESCRIPTION
## Summary

Five paths leaked HashMap iteration order into `Simulation::snapshot_bytes()`, defeating cross-process golden-hash equality even though the sim state was logically identical. The contract harness from #629 worked around this by hashing a metrics-only projection; this restores the proper `Simulation::snapshot_checksum()` path.

The leaks:

- `RepositionCooldowns.eligible_at` — top-level snapshot field
- `ScanDispatch.direction` and `LookDispatch.direction` — round-tripped via `snapshot_config` into `WorldSnapshot::dispatch_config`
- legacy-topology `stop_lookup.values().copied().collect()` — `LineInfo.serves` order leaked through `GroupSnapshot::lines`
- explicit-topology `line_map: HashMap<u32, ...>` — auto-inferred-groups branch iterates `.values()` in HashMap order

Drop the redundant sort in `MetricTags::all_tags` — already `BTreeMap`-backed; the docstring claiming `HashMap` storage was stale since #254.

Postcard serializes `BTreeMap` and `HashMap` with the same wire format (length-prefixed `Vec<(K,V)>`) so existing snapshots continue to deserialize.

Closes the #254 follow-up the contract harness called out in `crates/elevator-contract/src/main.rs`.

## Test plan
- [x] New unit test `reposition_cooldowns_serialize_independent_of_insertion_order` — fails before fix, passes after (verified)
- [x] New integration test `snapshot_bytes_with_reposition_cooldowns_roundtrip_is_stable` — exercises the snapshot/restore round-trip with populated cooldowns
- [x] All 909 elevator-core unit tests + 5 integration tests pass
- [x] Verified byte-equal `snapshot_bytes()` across two separate harness processes for all 5 contract scenarios
- [x] Goldens regenerated; harness `cargo run -p elevator-contract` passes
- [x] `cargo clippy -p elevator-core --all-features` clean
- [x] `cargo check --workspace` clean