### PR TITLE
feat(test): wasm-host contract test runs on wasm32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,24 @@ jobs:
         # combination where core with `traffic` is expected to reach wasm.
         run: cargo check -p elevator-wasm --target wasm32-unknown-unknown
 
+      # Run the cross-target contract test under a real wasm runtime.
+      # `wasm-bindgen-test-runner` shells the test wasm out to node.js,
+      # so this catches actual runtime divergence between native and
+      # wasm32 builds — `cargo check` only proves it compiles. Goldens
+      # live alongside the rust-host harness in
+      # `assets/contract-corpus/golden.txt`; a divergence here means
+      # the wasm32 build of `elevator-core` produces a different
+      # `snapshot_checksum` for the same scenario inputs.
+      - name: Install wasm-bindgen-test-runner
+        # Version tracks the `wasm-bindgen` dependency in `Cargo.lock`;
+        # mismatched runner/library versions fail with a clear error
+        # at test startup. Bump together when upgrading either.
+        run: cargo install --locked wasm-bindgen-cli@0.2.118
+      - name: Run wasm-host contract test (wasm32)
+        env:
+          CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: wasm-bindgen-test-runner
+        run: cargo test -p elevator-wasm --target wasm32-unknown-unknown --test contract
+
   msrv:
     name: MSRV (elevator-core)
     if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,11 +239,17 @@ jobs:
       # `assets/contract-corpus/golden.txt`; a divergence here means
       # the wasm32 build of `elevator-core` produces a different
       # `snapshot_checksum` for the same scenario inputs.
+      - name: Install cargo-binstall
+        # Pulls pre-built binaries from upstream releases instead of
+        # rebuilding from source. Saves ~3 min per run for
+        # `wasm-bindgen-cli` versus `cargo install --locked`, which
+        # rust-cache does not reliably cache.
+        uses: cargo-bins/cargo-binstall@main
       - name: Install wasm-bindgen-test-runner
         # Version tracks the `wasm-bindgen` dependency in `Cargo.lock`;
         # mismatched runner/library versions fail with a clear error
         # at test startup. Bump together when upgrading either.
-        run: cargo install --locked wasm-bindgen-cli@0.2.118
+        run: cargo binstall --no-confirm wasm-bindgen-cli@0.2.118
       - name: Run wasm-host contract test (wasm32)
         env:
           CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: wasm-bindgen-test-runner

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2683,12 +2694,14 @@ dependencies = [
  "elevator-core",
  "getrandom 0.4.2",
  "js-sys",
+ "rand 0.10.1",
  "ron",
  "serde",
  "serde-wasm-bindgen",
  "slotmap",
  "tsify",
  "wasm-bindgen",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -3848,6 +3861,16 @@ dependencies = [
  "log",
  "objc",
  "paste",
+]
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
 ]
 
 [[package]]
@@ -6142,6 +6165,45 @@ checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb55e2540ad1c56eec35fd63e2aea15f83b11ce487fd2de9ad11578dfc047ea"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf0ca1bd612b988616bac1ab34c4e4290ef18f7148a1d8b7f31c150080e9295"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cda5ecc67248c48d3e705d3e03e00af905769b78b9d2a1678b663b8b9d4472"
 
 [[package]]
 name = "wasm-encoder"

--- a/crates/elevator-wasm/Cargo.toml
+++ b/crates/elevator-wasm/Cargo.toml
@@ -52,3 +52,11 @@ slotmap = { workspace = true }
 # native (x86_64) builds of this crate are unaffected.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.4", features = ["wasm_js"] }
+
+[dev-dependencies]
+# Drives the cross-target contract test in `tests/contract.rs`. Verifies
+# `Simulation` produces byte-identical snapshot bytes on wasm32 and
+# native — the gate that catches a `getrandom`/`HashMap`-style
+# divergence before it ships to the playground.
+wasm-bindgen-test = "0.3"
+rand = { workspace = true }

--- a/crates/elevator-wasm/tests/contract.rs
+++ b/crates/elevator-wasm/tests/contract.rs
@@ -12,12 +12,17 @@
 //! Invoked via:
 //!
 //! ```sh
-//! cargo test -p elevator-wasm --target wasm32-unknown-unknown
+//! CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner \
+//!   cargo test -p elevator-wasm --target wasm32-unknown-unknown --test contract
 //! ```
 //!
-//! Requires `wasm-bindgen-test-runner` on PATH; the workspace
-//! `.cargo/config.toml` wires this up automatically for the wasm32
-//! target.
+//! The env-var override sets cargo's runner for the wasm32 target.
+//! `.cargo/config.toml` is gitignored in this repo (it carries a
+//! machine-local `PKG_CONFIG_PATH` plus the shared `target-dir`), so
+//! the runner cannot live there; CI sets the same env var directly.
+//! `wasm-bindgen-test-runner` ships with `wasm-bindgen-cli` — install
+//! via `cargo install --locked wasm-bindgen-cli` (or `cargo binstall
+//! wasm-bindgen-cli` for a pre-built binary).
 
 use elevator_core::builder::SimulationBuilder;
 use elevator_core::config::SimConfig;

--- a/crates/elevator-wasm/tests/contract.rs
+++ b/crates/elevator-wasm/tests/contract.rs
@@ -5,7 +5,7 @@
 //! wasm-bindgen-test runner, and asserts the resulting
 //! `snapshot_checksum` matches the golden value committed in
 //! `assets/contract-corpus/golden.txt`. A divergence between the
-//! native and wasm32 build of `elevator-core` (HashMap iteration
+//! native and wasm32 build of `elevator-core` (`HashMap` iteration
 //! drift, FP semantics, `getrandom` impl difference, etc.) surfaces
 //! here as a checksum mismatch keyed by scenario name.
 //!

--- a/crates/elevator-wasm/tests/contract.rs
+++ b/crates/elevator-wasm/tests/contract.rs
@@ -1,0 +1,116 @@
+//! Cross-target contract test: wasm32 host.
+//!
+//! Compiles the same `Simulation` driver loop as the rust-host harness
+//! in `crates/elevator-contract/`, runs it on wasm32 inside a
+//! wasm-bindgen-test runner, and asserts the resulting
+//! `snapshot_checksum` matches the golden value committed in
+//! `assets/contract-corpus/golden.txt`. A divergence between the
+//! native and wasm32 build of `elevator-core` (HashMap iteration
+//! drift, FP semantics, `getrandom` impl difference, etc.) surfaces
+//! here as a checksum mismatch keyed by scenario name.
+//!
+//! Invoked via:
+//!
+//! ```sh
+//! cargo test -p elevator-wasm --target wasm32-unknown-unknown
+//! ```
+//!
+//! Requires `wasm-bindgen-test-runner` on PATH; the workspace
+//! `.cargo/config.toml` wires this up automatically for the wasm32
+//! target.
+
+use elevator_core::builder::SimulationBuilder;
+use elevator_core::config::SimConfig;
+use elevator_core::traffic::{PoissonSource, TrafficSource};
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+const SCENARIO_TICKS: u64 = 600;
+
+const DEFAULT_RON: &str = include_str!("../../../assets/contract-corpus/default.ron");
+const SPARSE_RON: &str = include_str!("../../../assets/contract-corpus/sparse.ron");
+const DENSE_TRAFFIC_RON: &str = include_str!("../../../assets/contract-corpus/dense_traffic.ron");
+const MULTI_GROUP_RON: &str = include_str!("../../../assets/contract-corpus/multi_group.ron");
+const EXTREME_LOAD_RON: &str = include_str!("../../../assets/contract-corpus/extreme_load.ron");
+const GOLDEN_TXT: &str = include_str!("../../../assets/contract-corpus/golden.txt");
+
+/// Drive one scenario for [`SCENARIO_TICKS`] ticks under a Poisson
+/// rider stream seeded with `seed`, then return the FNV checksum of
+/// the resulting snapshot bytes.
+///
+/// Identical to `crates/elevator-contract/src/main.rs::run_scenario`
+/// in shape — keep them in lockstep so a divergence fingers an actual
+/// `elevator-core` cross-target drift, not a harness mismatch.
+fn run_scenario(cfg_text: &str, seed: u64) -> u64 {
+    let cfg: SimConfig = ron::from_str(cfg_text).expect("parse scenario RON");
+    let mut sim = SimulationBuilder::from_config(cfg.clone())
+        .build()
+        .expect("build sim");
+    let mut source = PoissonSource::from_config(&cfg).with_rng(StdRng::seed_from_u64(seed));
+    for tick in 0..SCENARIO_TICKS {
+        for req in source.generate(tick) {
+            let _ = sim.spawn_rider(req.origin, req.destination, req.weight);
+        }
+        sim.step();
+    }
+    sim.snapshot_checksum().expect("snapshot_checksum")
+}
+
+/// Pull the golden checksum for `name` out of the workspace's
+/// `golden.txt` corpus. Format mirrors the rust-host parser:
+/// `<name> 0x<hex>` per line, `#` comments skipped.
+fn golden_for(name: &str) -> u64 {
+    for line in GOLDEN_TXT.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let mut parts = trimmed.split_whitespace();
+        let scenario = parts.next().unwrap_or("");
+        let hex = parts.next().unwrap_or("");
+        if scenario == name {
+            let stripped = hex
+                .strip_prefix("0x")
+                .unwrap_or_else(|| panic!("golden {name}: missing 0x prefix in {hex:?}"));
+            return u64::from_str_radix(stripped, 16)
+                .unwrap_or_else(|e| panic!("golden {name}: parse {hex:?}: {e}"));
+        }
+    }
+    panic!("golden.txt missing entry for {name:?}");
+}
+
+fn assert_scenario(name: &str, ron: &str, seed: u64) {
+    let computed = run_scenario(ron, seed);
+    let expected = golden_for(name);
+    assert_eq!(
+        computed, expected,
+        "wasm32 scenario {name:?}: expected {expected:#018x}, got {computed:#018x}; \
+         either a cross-target compilation divergence or an unintended core change"
+    );
+}
+
+#[wasm_bindgen_test]
+fn contract_default() {
+    assert_scenario("default", DEFAULT_RON, 0x00D0_FA17);
+}
+
+#[wasm_bindgen_test]
+fn contract_sparse() {
+    assert_scenario("sparse", SPARSE_RON, 0x0051_41FE);
+}
+
+#[wasm_bindgen_test]
+fn contract_dense_traffic() {
+    assert_scenario("dense_traffic", DENSE_TRAFFIC_RON, 0x00DE_15E0);
+}
+
+#[wasm_bindgen_test]
+fn contract_multi_group() {
+    assert_scenario("multi_group", MULTI_GROUP_RON, 0x0066_00BD);
+}
+
+#[wasm_bindgen_test]
+fn contract_extreme_load() {
+    assert_scenario("extreme_load", EXTREME_LOAD_RON, 0x00E7_104D);
+}


### PR DESCRIPTION
## Summary

Adds the wasm-host counterpart of the rust-host contract harness from #629, deferred from PR 7 of the binding-sync plan. The existing wasm-gate only proved the crate compiled to wasm32 — this drives the same 5 scenarios through \`Simulation\` compiled to wasm32, executes them under wasm-bindgen-test-runner (node-based), and asserts each \`snapshot_checksum\` matches the golden committed in \`assets/contract-corpus/golden.txt\`.

A divergence means the wasm32 build of elevator-core is producing different snapshot bytes for the same inputs as native — the kind of HashMap-iteration / FP-codegen bug the cross-process fix in #631 was a prerequisite for catching reliably.

The driver intentionally mirrors \`crates/elevator-contract/src/main.rs::run_scenario\` so a future drift between the two harnesses is obvious; both consume the same \`golden.txt\` via \`include_str!\`.

## Test plan
- [x] All 5 wasm32 scenarios pass against existing rust-host goldens (verified locally via \`cargo test -p elevator-wasm --target wasm32-unknown-unknown --test contract\`)
- [x] Native-target tests in \`crates/elevator-wasm/tests/\` still pass (\`#[wasm_bindgen_test]\` is inert on x86_64)
- [x] \`cargo check -p elevator-wasm --target wasm32-unknown-unknown\` clean
- [x] Pre-commit hook passes (fmt, clippy, core tests, doc lint, ABI pin gate)