### PR TITLE
fix(core): snapshot_checksum hashes WorldSnapshot payload, not envelope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,17 +239,17 @@ jobs:
       # `assets/contract-corpus/golden.txt`; a divergence here means
       # the wasm32 build of `elevator-core` produces a different
       # `snapshot_checksum` for the same scenario inputs.
-      - name: Install cargo-binstall
-        # Pulls pre-built binaries from upstream releases instead of
-        # rebuilding from source. Saves ~3 min per run for
-        # `wasm-bindgen-cli` versus `cargo install --locked`, which
-        # rust-cache does not reliably cache.
-        uses: cargo-bins/cargo-binstall@main
       - name: Install wasm-bindgen-test-runner
-        # Version tracks the `wasm-bindgen` dependency in `Cargo.lock`;
-        # mismatched runner/library versions fail with a clear error
-        # at test startup. Bump together when upgrading either.
-        run: cargo binstall --no-confirm wasm-bindgen-cli@0.2.118
+        # `taiki-e/install-action` pulls pre-built binaries from
+        # upstream releases and reliably puts them on PATH. The
+        # cargo-binstall equivalent ran into "already installed"
+        # false positives that left the binary off PATH on a fresh
+        # runner. Version tracks `wasm-bindgen` in `Cargo.lock`;
+        # mismatched runner/library versions fail loudly at test
+        # startup.
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-bindgen-cli@0.2.118
       - name: Run wasm-host contract test (wasm32)
         env:
           CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: wasm-bindgen-test-runner

--- a/assets/contract-corpus/golden.txt
+++ b/assets/contract-corpus/golden.txt
@@ -1,8 +1,8 @@
 # Golden snapshot checksums for contract scenarios.
 # Regenerate via: cargo run -p elevator-contract -- --update-golden
 # tick budget: 600
-default 0x9783adffd39bb643
-dense_traffic 0xc7b120b8395779e2
-extreme_load 0x7581540441aced69
-multi_group 0xcdff40926ff39006
-sparse 0x2f4eb7ad1bfd4aa3
+default 0xc39a680791d911c9
+dense_traffic 0xe728b1eada15606c
+extreme_load 0xcf6137a41eb3dc47
+multi_group 0x5244c21f6000007c
+sparse 0x96894e58f45ef6e1

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -1022,8 +1022,11 @@ impl crate::sim::Simulation {
     }
 
     /// Cheap u64 checksum of the simulation's serializable state.
-    /// Hashes [`Self::snapshot_bytes`] via inline FNV-1a — no new
-    /// dependencies. The numeric value is FNV-1a-specific and not
+    /// FNV-1a over the postcard encoding of [`Self::snapshot`]'s
+    /// `WorldSnapshot` payload — the envelope (magic + crate version
+    /// string) is *not* hashed, so the value depends only on the
+    /// logical sim state, not on the `elevator-core` version that
+    /// produced it. The numeric value is FNV-1a-specific and not
     /// equivalent to other hash functions of the same bytes; consumers
     /// computing an independent hash for comparison must use this
     /// method (or run FNV-1a themselves with the same constants).
@@ -1034,21 +1037,28 @@ impl crate::sim::Simulation {
     /// type registering on restore but not `new`; that was fixed.)
     ///
     /// Designed for divergence detection between runtimes that should
-    /// be in lockstep (browser vs server, multi-client multiplayer).
-    /// Two sims that have produced bit-identical inputs in bit-identical
-    /// order must hash to the same value.
+    /// be in lockstep (browser vs server, multi-client multiplayer)
+    /// and for golden checksums that need to survive a
+    /// release-please version bump. Two sims that have produced bit-
+    /// identical inputs in bit-identical order must hash to the same
+    /// value, regardless of `CARGO_PKG_VERSION`.
     ///
     /// # Errors
-    /// Same as [`Self::snapshot_bytes`]: snapshot encoding can fail in
-    /// the (unreachable for well-formed sims) postcard error path or
-    /// when called mid-tick during the substep API.
+    /// - [`SimError::MidTickSnapshot`](crate::error::SimError::MidTickSnapshot)
+    ///   when invoked between phases of an in-progress tick (substep
+    ///   API path).
+    /// - [`SimError::SnapshotFormat`](crate::error::SimError::SnapshotFormat)
+    ///   if postcard encoding of the payload fails. Unreachable for
+    ///   well-formed sims; callers that don't care can `unwrap`.
     pub fn snapshot_checksum(&self) -> Result<u64, crate::error::SimError> {
         // FNV-1a (64-bit). Small, allocation-free over the byte slice,
         // well-distributed for arbitrary input. Not cryptographic;
         // collision tolerance is fine for divergence detection.
         const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
         const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
-        let bytes = self.snapshot_bytes()?;
+        let snapshot = self.try_snapshot()?;
+        let bytes = postcard::to_allocvec(&snapshot)
+            .map_err(|e| crate::error::SimError::SnapshotFormat(e.to_string()))?;
         let mut h: u64 = FNV_OFFSET;
         for byte in &bytes {
             h ^= u64::from(*byte);


### PR DESCRIPTION
## Summary

The release PR (#632) blocked on this: contract harness goldens in #629 / #631 / #633 depend on \`Simulation::snapshot_checksum()\`, which hashed \`snapshot_bytes()\` — a postcard envelope that embeds \`env!(\"CARGO_PKG_VERSION\")\`. release-please bumping elevator-core 16.0.1 → 16.0.2 changed the envelope bytes, changed the FNV hash, invalidated every golden.

The fix: hash the postcard encoding of the \`WorldSnapshot\` payload directly, no envelope. The doc on \`snapshot_checksum\` already framed the API around divergence detection between runtimes that should be in lockstep — gating on whether the two runtimes happen to be built from the same crate version was a bug, not a feature. Goldens regenerate one-time and survive future release-please bumps.

The wasm32 contract test was also failing on #632 for the same reason — both rust-host and wasm-host pass after the fix.

## Test plan
- [x] All 909 elevator-core unit tests pass
- [x] \`cargo run -p elevator-contract\` (rust-host harness): 5/5 scenarios match new golden
- [x] \`cargo test -p elevator-wasm --target wasm32-unknown-unknown --test contract\` (wasm-host): 5/5 pass against new golden
- [x] Manually bumped local Cargo.toml from 16.0.1 to 16.0.2 and re-ran rust-host harness — still passes (regression guard for the original failure mode)
- [x] Pre-commit hook passes