### PR TITLE
ci: tighten PR concurrency, paths, lock-drift guard, and commitlint

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -14,13 +14,15 @@ if echo "$staged" | grep -qvE '^playground/'; then
 fi
 
 if [ "$has_rust" = true ]; then
-    # Cargo.lock drift guard: staging Cargo.toml without Cargo.lock is almost
-    # always a mistake — the lockfile will be out of sync with deps.
-    if grep -qE '(^|/)Cargo\.toml$' <<<"$staged" \
-        && ! grep -qE '(^|/)Cargo\.lock$' <<<"$staged"; then
-        if ! git diff --quiet Cargo.lock 2>/dev/null; then
-            echo "pre-commit: Cargo.toml is staged but Cargo.lock has unstaged changes." >&2
-            echo "  Stage Cargo.lock too, or revert the Cargo.toml change." >&2
+    # Cargo.lock drift guard: when Cargo.toml is staged, verify the lockfile
+    # is internally consistent with it. `cargo metadata --frozen` errors if
+    # Cargo.lock would need regeneration, regardless of whether Cargo.lock is
+    # staged. Catches the "both files staged but author forgot to actually
+    # rebuild" case as well as the unstaged-lock case.
+    if grep -qE '(^|/)Cargo\.toml$' <<<"$staged"; then
+        if ! cargo metadata --frozen --format-version 1 --quiet >/dev/null 2>&1; then
+            echo "pre-commit: Cargo.toml is staged but Cargo.lock is out of sync." >&2
+            echo "  Run 'cargo build' (or 'cargo update --workspace') to regenerate it, then re-stage." >&2
             exit 1
         fi
     fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -14,15 +14,24 @@ if echo "$staged" | grep -qvE '^playground/'; then
 fi
 
 if [ "$has_rust" = true ]; then
-    # Cargo.lock drift guard: when Cargo.toml is staged, verify the lockfile
-    # is internally consistent with it. `cargo metadata --frozen` errors if
-    # Cargo.lock would need regeneration, regardless of whether Cargo.lock is
-    # staged. Catches the "both files staged but author forgot to actually
-    # rebuild" case as well as the unstaged-lock case.
+    # Cargo.lock drift guard. Two complementary checks fire when
+    # Cargo.toml is staged:
+    #   (a) `cargo metadata --frozen` errors if the on-disk Cargo.lock
+    #       is inconsistent with Cargo.toml — catches the "both files
+    #       staged together but never rebuilt" case.
+    #   (b) `git diff --quiet Cargo.lock` catches the "Cargo.lock is
+    #       fresh on disk but the author forgot to stage it" case —
+    #       without this, the staged commit would capture a stale
+    #       lockfile snapshot.
     if grep -qE '(^|/)Cargo\.toml$' <<<"$staged"; then
         if ! cargo metadata --frozen --format-version 1 --quiet >/dev/null 2>&1; then
             echo "pre-commit: Cargo.toml is staged but Cargo.lock is out of sync." >&2
             echo "  Run 'cargo build' (or 'cargo update --workspace') to regenerate it, then re-stage." >&2
+            exit 1
+        fi
+        if ! git diff --quiet Cargo.lock 2>/dev/null; then
+            echo "pre-commit: Cargo.toml is staged but Cargo.lock has unstaged changes." >&2
+            echo "  Stage Cargo.lock too." >&2
             exit 1
         fi
     fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,30 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'media/**'
+      - 'AI-DISCLOSURE.md'
+      - 'STABILITY.md'
+      - 'LICENSE*'
+      - '.research/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'media/**'
+      - 'AI-DISCLOSURE.md'
+      - 'STABILITY.md'
+      - 'LICENSE*'
+      - '.research/**'
+
+# Cancel superseded PR runs to avoid wasted runner time on rapid pushes.
+# `pull_request.number` is integer-only so it is safe to interpolate; on
+# main pushes we fall back to `run_id`, which is unique per run, so two
+# main commits never cancel each other.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -272,3 +294,38 @@ jobs:
 
       - name: Build elevator-core on MSRV
         run: cargo build -p elevator-core --all-features
+
+  commitlint:
+    name: Commitlint
+    # PR-only: commits on main have already landed. The local
+    # `.githooks/commit-msg` hook covers contributors who installed it,
+    # but anyone bypassing the hook (or editing on the GitHub web UI)
+    # would otherwise sneak through. release-please commits follow the
+    # `chore(main): release` convention by construction.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need the full PR commit range, not just the merge.
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: playground/pnpm-lock.yaml
+      - name: Install playground deps (provides commitlint)
+        working-directory: playground
+        run: pnpm install --frozen-lockfile
+      - name: Lint PR commits
+        env:
+          # `${{ … }}` interpolation into shell would be unsafe with
+          # arbitrary strings; SHAs are hex-only so this is fine, but
+          # passing them through env keeps the pattern uniform.
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        working-directory: playground
+        run: pnpm exec commitlint --from "$PR_BASE_SHA" --to "$PR_HEAD_SHA" --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,9 +300,14 @@ jobs:
     # PR-only: commits on main have already landed. The local
     # `.githooks/commit-msg` hook covers contributors who installed it,
     # but anyone bypassing the hook (or editing on the GitHub web UI)
-    # would otherwise sneak through. release-please commits follow the
-    # `chore(main): release` convention by construction.
-    if: github.event_name == 'pull_request'
+    # would otherwise sneak through. Skip release-please PRs to match
+    # every other job's guard — their commits follow `chore(main):
+    # release` by construction, but a future bot quirk shouldn't be able
+    # to block a machine-generated PR.
+    if: |
+      github.event_name == 'pull_request' &&
+      (github.event.pull_request.user.login != 'release-kun[bot]' ||
+       !startsWith(github.event.pull_request.title, 'chore(main): release'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Cluster of small CI / hook hardening items from the tech-debt audit.

- **`paths-ignore`**: Rust CI now skips when only `docs/`, `media/`, `.research/`, or pure-prose markdown (AI-DISCLOSURE / STABILITY / LICENSE) changed. README.md stays in scope because the doctest harness pulls it in.
- **`concurrency` group**: superseded PR runs cancel. Group key uses `pull_request.number` (numeric — safe to interpolate) with `run_id` fallback so two main-push runs never cancel each other.
- **`commitlint` job (PR-only)**: backs the promise the local `commit-msg` hook already makes about CI catching non-conventional messages. Reuses the existing playground commitlint config so there's one source of truth — no new package added.
- **Cargo.lock drift guard** rewritten: replace the staging heuristic (which skipped the case where both `Cargo.toml` and a stale `Cargo.lock` were staged) with `cargo metadata --frozen`, which errors whenever the lockfile is inconsistent regardless of staging.

Closes #640, #641, #643, #644.

## Test plan

- [x] Pre-commit gate (fmt, clippy, core tests, doc tests, workspace check) passes locally.
- [ ] Greptile review.
- [ ] CI green on this PR (concurrency / commitlint / paths-ignore exercised in real run).