### PR TITLE
refactor: justify or remove three clippy suppressions

### DIFF
--- a/crates/elevator-bevy/src/plugin.rs
+++ b/crates/elevator-bevy/src/plugin.rs
@@ -21,6 +21,9 @@ use elevator_core::sim::Simulation;
 pub struct ElevatorSimPlugin;
 
 impl Plugin for ElevatorSimPlugin {
+    // Plugin construction runs once at app startup. Bad config has no
+    // recovery path here — the simulation can't initialize without it —
+    // so panicking is the correct termination signal.
     #[allow(clippy::panic)]
     fn build(&self, app: &mut App) {
         // Load config — check CLI arg first, fall back to default.

--- a/crates/elevator-bevy/src/sim_bridge.rs
+++ b/crates/elevator-bevy/src/sim_bridge.rs
@@ -20,7 +20,6 @@ pub struct SimSpeed {
 
 /// Bevy message wrapper for core simulation events.
 #[derive(Message, Debug, Clone)]
-#[allow(dead_code)]
 pub struct EventWrapper(pub Event);
 
 /// System that ticks the simulation and emits events into Bevy.

--- a/crates/elevator-wasm/src/dto.rs
+++ b/crates/elevator-wasm/src/dto.rs
@@ -229,6 +229,10 @@ pub struct MetricsDto {
 }
 
 impl MetricsDto {
+    // Wait/ride times are tick counts (u64) bounded by the run length;
+    // the f64 cast is exact up to 2^53 ticks, well past any plausible
+    // playground workload (>2^53 ticks would mean the sim has been
+    // running for hundreds of thousands of years at 60 Hz).
     #[allow(clippy::cast_precision_loss)]
     pub fn build(sim: &Simulation) -> Self {
         let m = sim.metrics();
@@ -1587,6 +1591,8 @@ fn event_tick(event: &Event) -> u64 {
 /// >2^32 entity destructions — far beyond any playground workload.
 fn entity_to_u32(id: EntityId) -> u32 {
     let raw = id.data().as_ffi();
+    // Truncation is intentional — see the fn-level doc comment above:
+    // the low 32 bits are stable within a sim run and fit a JS Number.
     #[allow(clippy::cast_possible_truncation)]
     let slot = raw as u32;
     slot


### PR DESCRIPTION
## Summary

Three small clippy-suppression hygiene fixes from the tech-debt audit.

- **`elevator-bevy/src/sim_bridge.rs`**: remove `#[allow(dead_code)]` from `EventWrapper`. The type is constructed (`tick_simulation` writes `EventWrapper(event)`) and read (`tally_hall_call_events` reads `wrapper.0`) — the suppression was leftover scaffolding.
- **`elevator-bevy/src/plugin.rs`**: add a justification comment to the `#[allow(clippy::panic)]` on `Plugin::build`. Plugin construction has no recovery path for bad config, so panicking is the correct termination signal — the `clippy::panic` lint is opted out for that reason.
- **`elevator-wasm/src/dto.rs`**: document the two cast suppressions inline. `MetricsDto::build` casts u64 tick counts to f64 (exact through 2^53, comfortably above any plausible run length); `entity_to_u32` mirrors the truncation invariant already in the fn-level doc comment.

Closes #646, #647, #649. Issue #645 (consolidate the five `dead_code` allows in `world.rs`) is a separate, slightly more involved change; deferring to a focused later PR.

## Test plan

- [x] Pre-commit gate passes locally (clippy with `-D warnings` would have caught the EventWrapper allow removal had the type really been dead).
- [ ] Greptile review.