### PR TITLE
chore(hooks): run pre-commit fmt check in parallel with clippy

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -40,13 +40,22 @@ if [ "$has_rust" = true ]; then
     # lock, so it can run in parallel with clippy. clippy compiles core,
     # which is the slowest step here (~30 s cold), so overlapping fmt
     # with it shaves a small but consistent slice off every commit.
+    #
+    # Output handling: clippy stays in the foreground so its progress
+    # streams live (the developer wants to see "Compiling …"). fmt's
+    # output is buffered so its diff lines don't interleave with clippy
+    # diagnostics on a failed commit; we replay the buffer afterwards if
+    # fmt failed.
     echo "pre-commit: running fmt check + clippy in parallel..."
-    cargo fmt --check &
+    fmt_log=$(mktemp)
+    trap 'rm -f "$fmt_log"' EXIT
+    cargo fmt --check >"$fmt_log" 2>&1 &
     fmt_pid=$!
     cargo clippy -p elevator-core --all-features -- -D warnings || clippy_rc=$?
     wait $fmt_pid || fmt_rc=$?
     if [ "${fmt_rc:-0}" -ne 0 ]; then
         echo "pre-commit: fmt check failed." >&2
+        cat "$fmt_log" >&2
     fi
     if [ "${clippy_rc:-0}" -ne 0 ]; then
         echo "pre-commit: clippy failed." >&2

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -36,11 +36,24 @@ if [ "$has_rust" = true ]; then
         fi
     fi
 
-    echo "pre-commit: checking formatting..."
-    cargo fmt --check
-
-    echo "pre-commit: running clippy..."
-    cargo clippy -p elevator-core --all-features -- -D warnings
+    # fmt --check uses rustfmt directly and does not take the cargo build
+    # lock, so it can run in parallel with clippy. clippy compiles core,
+    # which is the slowest step here (~30 s cold), so overlapping fmt
+    # with it shaves a small but consistent slice off every commit.
+    echo "pre-commit: running fmt check + clippy in parallel..."
+    cargo fmt --check &
+    fmt_pid=$!
+    cargo clippy -p elevator-core --all-features -- -D warnings || clippy_rc=$?
+    wait $fmt_pid || fmt_rc=$?
+    if [ "${fmt_rc:-0}" -ne 0 ]; then
+        echo "pre-commit: fmt check failed." >&2
+    fi
+    if [ "${clippy_rc:-0}" -ne 0 ]; then
+        echo "pre-commit: clippy failed." >&2
+    fi
+    if [ "${fmt_rc:-0}" -ne 0 ] || [ "${clippy_rc:-0}" -ne 0 ]; then
+        exit 1
+    fi
 
     echo "pre-commit: running core tests..."
     cargo test -p elevator-core --all-features --quiet


### PR DESCRIPTION
## Summary

\`cargo fmt --check\` invokes rustfmt directly and doesn't contend for the cargo build lock that clippy / test / check share. Overlapping fmt with the slowest single step (clippy on core, ~30 s cold) shaves a small but consistent slice off every commit. Both exit codes are captured separately so a failure in either still fails the hook with a clear message; the overall pre-commit semantics are unchanged.

Closes #666.

## Test plan

- [x] Hook ran cleanly during this commit (pre-commit output shows the new \`fmt check + clippy in parallel\` line).
- [ ] Greptile review.