### PR TITLE
chore: gitignore .research/ to match its local-only convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ crates/*/proptest-regressions/
 .claude/*.lock
 .claude/worktrees/
 .worktrees/
+# Per-author scratch space for in-flight research, audits, and review
+# notes. Not part of the repo; findings worth keeping get folded into
+# tracked GitHub issues or `docs/` chapters.
+.research/
 .idea/
 .vscode/
 *.code-workspace


### PR DESCRIPTION
## Summary

The audit issue assumed \`.research/\` was a tracked directory full of stale findings to clean up. It is not, and never was — \`git ls-tree main -- .research/\` returns nothing. The directory is per-author scratch space for in-flight audits / review notes / literature surveys.

This commit just makes the convention explicit so future scratch notes don't get accidentally committed. Three residual actionable findings from existing local \`.research/\` snapshots are tracked as issues #675, #676, #677.

Closes #669.

## Test plan

- [x] Pre-commit hook passes (this is a single-line gitignore addition).
- [ ] Greptile review.