### PR TITLE
chore(bindings): break down todo: phases in coverage summary

### DIFF
--- a/bindings.toml
+++ b/bindings.toml
@@ -52,14 +52,31 @@
 # convention — the CI gate treats `todo:<phase>` identically across
 # every column (no failure, just summary count).
 #
-# Phase markers (see PR plan in design doc)
-# -----------------------------------------
-#   PR-B   FFI catchup, wave 1 — topology + dispatch introspection
-#   PR-C   FFI catchup, wave 2 — parameters, introspection, destinations
-#   PR-D   Mode APIs (both bindings) — service modes, manual, emergency stop
-#   PR-E   Wasm error-rewrite + log callback + metrics + tagging
-#   PR-F   Persistence — snapshot bytes/JSON, seed control
-#   PR-G   AsyncIterator event stream
+# Phase markers
+# -------------
+# Two phase markers are currently in use, semantically distinct:
+#
+#   plugin-layer    — gated by the Bevy plugin-layer rewrite. Used
+#                     exclusively in the `bevy` column. This is the
+#                     *expected* state for every non-`internal`
+#                     Simulation method until the plugin layer ships;
+#                     it is not an actionable gap.
+#
+#   future-binding  — gdext methods that have no current binding but
+#                     are slated for future coverage. Used exclusively
+#                     in the `gdext` column. These are the actionable
+#                     "next thing to implement" entries — when looking
+#                     for binding work to pick up, this is the queue.
+#
+# CI accepts both identically (no failure, just summary count). The
+# `scripts/check-bindings.sh` summary breaks them out so `future-binding`
+# (real coverage gaps) doesn't get lost in the `plugin-layer` (expected
+# state) noise.
+#
+# Earlier rollout phases (PR-B FFI catchup, PR-E wasm error-rewrite,
+# etc.) used phase-specific markers; all of those have shipped and the
+# corresponding entries are now `<exported>` — git history is the
+# canonical record of those rollouts.
 
 [categories]
 lifecycle     = "Construction, ticking"

--- a/scripts/check-bindings.sh
+++ b/scripts/check-bindings.sh
@@ -222,3 +222,30 @@ printf "  %-12s %10s %10s %10s\n" "tui"   "$tui_exported"   "$tui_skipped"   "$t
 printf "  %-12s %10s %10s %10s\n" "gms"   "$gms_exported"   "$gms_skipped"   "$gms_todo"
 printf "  %-12s %10s %10s %10s\n" "gdext" "$gdext_exported" "$gdext_skipped" "$gdext_todo"
 printf "  %-12s %10s %10s %10s\n" "bevy"  "$bevy_exported"  "$bevy_skipped"  "$bevy_todo"
+
+# Per-phase breakdown of `todo:` entries. The two phases are
+# semantically distinct (see the header of bindings.toml):
+# `plugin-layer` is the expected state for `bevy` until the plugin
+# layer ships; `future-binding` is the actionable queue of gdext gaps.
+# Surfacing them separately keeps the real coverage gaps visible
+# instead of buried in a generic "todo" total.
+phase_counts=$(gawk '
+  # Only count phase markers that appear as real status values, i.e.
+  # `<binding> = "todo:<phase>"`. Mentions inside comment blocks
+  # describing the schema are skipped.
+  /^\s*(wasm|ffi|tui|gms|gdext|bevy)\s*=\s*"todo:[a-z0-9-]+"/ {
+    match($0, /"todo:([a-z0-9-]+)"/, m)
+    if (m[1] != "") counts[m[1]]++
+  }
+  END {
+    for (phase in counts) print counts[phase] " " phase
+  }
+' "$MANIFEST" | sort -rn)
+
+if [[ -n "$phase_counts" ]]; then
+  echo ""
+  echo "  todo phase distribution:"
+  while read -r count phase; do
+    printf "    %-16s %4s\n" "$phase" "$count"
+  done <<<"$phase_counts"
+fi


### PR DESCRIPTION
## Summary

The two `todo:` markers currently in `bindings.toml` have very different meanings:

- `todo:plugin-layer` (123 entries, all in `bevy`) is the *expected* state until the Bevy plugin-layer rewrite ships. Not an actionable gap.
- `todo:future-binding` (115 entries, all in `gdext`) is the actionable queue of binding gaps to close.

Today both sum into one `todo` column in the `scripts/check-bindings.sh` summary, so real coverage gaps get buried in expected-state noise. Add a per-phase breakdown after the existing per-binding table so the distinction is visible at a glance:

```
  todo phase distribution:
    plugin-layer      123
    future-binding    115
```

Also refresh the comment block at the top of `bindings.toml`: it listed PR-B through PR-G phase markers that have all shipped (none of those strings appear anywhere else in the file). Replace with a description of the two markers actually in use.

Closes #657.

## Test plan

- [x] `scripts/check-bindings.sh` passes locally and shows the new per-phase breakdown.
- [ ] Greptile review.