### PR TITLE
test(core): add unit tests for empty-queue manifest accessors

### DIFF
--- a/crates/elevator-core/src/tests/manifest_tests.rs
+++ b/crates/elevator-core/src/tests/manifest_tests.rs
@@ -8,6 +8,7 @@
 //! unvisited stop in just the right way. These direct tests pin the
 //! contract.
 
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 
 use crate::components::Weight;
@@ -15,11 +16,17 @@ use crate::dispatch::{DispatchManifest, RiderInfo};
 use crate::entity::EntityId;
 use slotmap::SlotMap;
 
-/// Make a fresh `EntityId` without spinning up a full `World`. Each
-/// call returns a distinct id from a private slotmap.
+thread_local! {
+    /// Per-thread `SlotMap` so successive `fresh_id()` calls produce
+    /// genuinely distinct keys. Constructing a new map per call would
+    /// always return slot 0 / version 1 — same key every time.
+    static ID_SOURCE: RefCell<SlotMap<EntityId, ()>> = RefCell::new(SlotMap::with_key());
+}
+
+/// Allocate a fresh `EntityId` without spinning up a full `World`.
+/// Each call yields a distinct id within the current thread.
 fn fresh_id() -> EntityId {
-    let mut sm: SlotMap<EntityId, ()> = SlotMap::with_key();
-    sm.insert(())
+    ID_SOURCE.with(|sm| sm.borrow_mut().insert(()))
 }
 
 #[test]

--- a/crates/elevator-core/src/tests/manifest_tests.rs
+++ b/crates/elevator-core/src/tests/manifest_tests.rs
@@ -1,0 +1,128 @@
+//! Unit tests for the read-only accessors on `DispatchManifest`.
+//!
+//! Integration tests cover these accessors indirectly — every dispatch
+//! scenario reads them — but mutation testing flagged the empty-queue
+//! returns (zero / zero-weight branches) as weakly covered: a mutation
+//! flipping the `unwrap_or(0)` to e.g. `unwrap_or(1)` would not fail
+//! any existing dispatch scenario unless it happened to exercise an
+//! unvisited stop in just the right way. These direct tests pin the
+//! contract.
+
+use std::collections::BTreeMap;
+
+use crate::components::Weight;
+use crate::dispatch::{DispatchManifest, RiderInfo};
+use crate::entity::EntityId;
+use slotmap::SlotMap;
+
+/// Make a fresh `EntityId` without spinning up a full `World`. Each
+/// call returns a distinct id from a private slotmap.
+fn fresh_id() -> EntityId {
+    let mut sm: SlotMap<EntityId, ()> = SlotMap::with_key();
+    sm.insert(())
+}
+
+#[test]
+fn waiting_count_at_unvisited_stop_is_zero() {
+    let manifest = DispatchManifest::default();
+    let stop = fresh_id();
+    assert_eq!(manifest.waiting_count_at(stop), 0);
+}
+
+#[test]
+fn total_weight_at_unvisited_stop_is_zero() {
+    let manifest = DispatchManifest::default();
+    let stop = fresh_id();
+    assert_eq!(manifest.total_weight_at(stop), 0.0);
+}
+
+#[test]
+fn riding_count_to_unvisited_stop_is_zero() {
+    let manifest = DispatchManifest::default();
+    let stop = fresh_id();
+    assert_eq!(manifest.riding_count_to(stop), 0);
+}
+
+#[test]
+fn resident_count_at_unvisited_stop_is_zero() {
+    let manifest = DispatchManifest::default();
+    let stop = fresh_id();
+    assert_eq!(manifest.resident_count_at(stop), 0);
+}
+
+#[test]
+fn arrivals_at_unvisited_stop_is_zero() {
+    let manifest = DispatchManifest::default();
+    let stop = fresh_id();
+    assert_eq!(manifest.arrivals_at(stop), 0);
+}
+
+#[test]
+fn has_demand_unvisited_stop_is_false() {
+    let manifest = DispatchManifest::default();
+    let stop = fresh_id();
+    assert!(!manifest.has_demand(stop));
+}
+
+#[test]
+fn empty_waiting_vec_still_returns_zero_count_and_weight() {
+    // Different from "unvisited": the stop *is* in the map but its
+    // vec is empty. A bug summing over an explicit empty entry should
+    // still produce 0, not e.g. NaN from an over-eager sum.
+    let stop = fresh_id();
+    let mut waiting = BTreeMap::new();
+    waiting.insert(stop, Vec::<RiderInfo>::new());
+    let manifest = DispatchManifest {
+        waiting_at_stop: waiting,
+        ..Default::default()
+    };
+    assert_eq!(manifest.waiting_count_at(stop), 0);
+    assert_eq!(manifest.total_weight_at(stop), 0.0);
+}
+
+#[test]
+fn total_weight_at_sums_rider_weights() {
+    let stop = fresh_id();
+    let rider1 = fresh_id();
+    let rider2 = fresh_id();
+    let mut waiting = BTreeMap::new();
+    waiting.insert(
+        stop,
+        vec![
+            RiderInfo {
+                id: rider1,
+                destination: None,
+                weight: Weight::try_new(70.0).unwrap(),
+                wait_ticks: 0,
+            },
+            RiderInfo {
+                id: rider2,
+                destination: None,
+                weight: Weight::try_new(50.0).unwrap(),
+                wait_ticks: 0,
+            },
+        ],
+    );
+    let manifest = DispatchManifest {
+        waiting_at_stop: waiting,
+        ..Default::default()
+    };
+    assert_eq!(manifest.total_weight_at(stop), 120.0);
+    assert_eq!(manifest.waiting_count_at(stop), 2);
+}
+
+#[test]
+fn resident_count_at_returns_explicit_zero() {
+    // A stop with an explicit zero entry should still return 0 — not
+    // confuse "explicit zero" with "missing key" (both currently map
+    // to the same return value, but a future internal-representation
+    // change shouldn't accidentally diverge them).
+    let stop = fresh_id();
+    let mut residents = BTreeMap::new();
+    residents.insert(stop, 0_usize);
+    let manifest = DispatchManifest {
+        resident_count_at_stop: residents,
+        ..Default::default()
+    };
+    assert_eq!(manifest.resident_count_at(stop), 0);
+}

--- a/crates/elevator-core/src/tests/mod.rs
+++ b/crates/elevator-core/src/tests/mod.rs
@@ -66,6 +66,7 @@ mod hall_call_tests;
 mod home_stop_tests;
 mod idle_with_riders_tests;
 mod invariants_tests;
+mod manifest_tests;
 mod manual_mode_tests;
 mod move_count_tests;
 mod movement_boundary_tests;


### PR DESCRIPTION
## Summary

Mutation testing flagged the empty-queue branches of `DispatchManifest::{waiting_count_at, total_weight_at, riding_count_to, resident_count_at, arrivals_at, has_demand}` as weakly covered: a mutation flipping `unwrap_or(0)` to e.g. `unwrap_or(1)` slips through because every existing dispatch test happens to query stops with at least one rider.

Add a focused `manifest_tests.rs` module that pins the empty cases directly:

- Accessor on an unvisited stop returns 0 / 0.0 / false (6 tests, one per accessor).
- Accessor on a stop with an explicit empty vec also returns 0 (the contract shouldn't depend on whether the key is present).
- Summing / counting still works correctly when riders are present (the positive control — guards against a "return 0 always" mutation).

Closes #665.

## Test plan

- [x] All 9 new tests pass locally (`cargo test -p elevator-core --lib tests::manifest_tests`).
- [x] Pre-commit gate passes.
- [ ] Greptile review.