### PR TITLE
test(core): add 2-cars / 3-hot-stops PredictiveParking case

### DIFF
--- a/crates/elevator-core/src/tests/reposition_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_tests.rs
@@ -537,12 +537,17 @@ fn predictive_parking_picks_hottest_when_cars_undersupplied() {
         "two cars must cover the two hottest stops; got {result:?}"
     );
     assert!(
-        !targets.contains(&stops[4]),
-        "third-hottest stop must not be covered when there are only 2 cars; got {result:?}"
-    );
-    assert!(
         result.len() <= 2,
         "must not generate more moves than idle cars; got {result:?}"
+    );
+    // Independent invariant: no double-targeting (mirrors the
+    // `asymmetric_extra_car_stays_put` companion test). The
+    // "third-hottest stop is unserved" property follows from the two
+    // assertions above plus this one — no separate check needed.
+    assert_eq!(
+        targets.len(),
+        result.len(),
+        "each covered stop must appear at most once; got {result:?}"
     );
 }
 

--- a/crates/elevator-core/src/tests/reposition_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_tests.rs
@@ -494,6 +494,58 @@ fn predictive_parking_asymmetric_extra_car_stays_put() {
     );
 }
 
+/// Inverse asymmetry: more hot stops than cars. The 2 cars must
+/// cover the 2 hottest stops; the 3rd hot stop is unserved by
+/// design (you can't be in three places at once). Pins the
+/// "rank-by-arrivals, then take the top N" semantics.
+#[test]
+fn predictive_parking_picks_hottest_when_cars_undersupplied() {
+    let (mut world, stops) = test_world_n(5);
+    let elev_a = spawn_elevator(&mut world, 0.0);
+    let elev_b = spawn_elevator(&mut world, 4.0);
+    let group = test_group(&stops, vec![elev_a, elev_b]);
+
+    // Three hot stops with strictly different arrival counts so the
+    // ordering is deterministic. stops[2] is hottest, stops[3] second,
+    // stops[4] third.
+    let mut log = ArrivalLog::default();
+    for _ in 0..15 {
+        log.record(50, stops[2]);
+    }
+    for _ in 0..10 {
+        log.record(50, stops[3]);
+    }
+    for _ in 0..5 {
+        log.record(50, stops[4]);
+    }
+    world.insert_resource(log);
+    world.insert_resource(CurrentTick(100));
+
+    let idle = vec![(elev_a, 0.0), (elev_b, 4.0)];
+    let stop_pos: Vec<(EntityId, f64)> = stops
+        .iter()
+        .map(|&sid| (sid, world.stop_position(sid).unwrap()))
+        .collect();
+
+    let mut strategy = PredictiveParking::new();
+    let mut result = Vec::new();
+    strategy.reposition(&idle, &stop_pos, &group, &world, &mut result);
+
+    let targets: std::collections::HashSet<_> = result.iter().map(|(_, s)| *s).collect();
+    assert!(
+        targets.contains(&stops[2]) && targets.contains(&stops[3]),
+        "two cars must cover the two hottest stops; got {result:?}"
+    );
+    assert!(
+        !targets.contains(&stops[4]),
+        "third-hottest stop must not be covered when there are only 2 cars; got {result:?}"
+    );
+    assert!(
+        result.len() <= 2,
+        "must not generate more moves than idle cars; got {result:?}"
+    );
+}
+
 // ReturnToLobby with `with_home(2)`.
 #[test]
 fn return_to_lobby_custom_home() {


### PR DESCRIPTION
## Summary

The reposition test suite already covers 2 cars / 2 hot stops (`predictive_parking_spreads_across_hot_stops`) and 3 cars / 2 hot stops (`predictive_parking_asymmetric_extra_car_stays_put`). The inverse asymmetry — fewer cars than hot stops — was missing.

Add the 2-cars / 3-hot-stops case to pin the contract: 2 cars must cover the 2 hottest stops; the third-hottest goes unserved by construction. Catches a regression where the hottest-first ordering breaks down when the input set is larger than the car count.

Closes #677.

## Test plan

- [x] All 6 PredictiveParking tests pass (existing 5 + the new one).
- [x] Pre-commit gate passes.
- [ ] Greptile review.