### PR TITLE
fix(core): widen arrival-log retention to match reposition window (#675)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "16.0.1"
+version = "16.0.2"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-wasm"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "elevator-core",
  "getrandom 0.4.2",

--- a/crates/elevator-core/src/arrival_log.rs
+++ b/crates/elevator-core/src/arrival_log.rs
@@ -46,12 +46,16 @@ pub const DEFAULT_ARRIVAL_WINDOW_TICKS: u64 = 18_000;
 /// World resource controlling how far back the [`ArrivalLog`] retains
 /// entries before `Simulation::advance_tick` prunes them.
 ///
-/// Defaults to [`DEFAULT_ARRIVAL_WINDOW_TICKS`]. Strategies that query
-/// a longer window (e.g.
-/// [`PredictiveParking::with_window_ticks`](crate::dispatch::reposition::PredictiveParking::with_window_ticks)
-/// with a value greater than the default) will silently see only the
-/// last `DEFAULT_ARRIVAL_WINDOW_TICKS` unless this retention is
-/// widened via [`Simulation::set_arrival_log_retention_ticks`](crate::sim::Simulation::set_arrival_log_retention_ticks).
+/// Defaults to [`DEFAULT_ARRIVAL_WINDOW_TICKS`].
+/// [`Simulation::set_reposition`](crate::sim::Simulation::set_reposition)
+/// auto-widens this to the installed strategy's
+/// [`min_arrival_log_window`](crate::dispatch::RepositionStrategy::min_arrival_log_window)
+/// so e.g. `PredictiveParking::with_window_ticks(50_000)` keeps
+/// `50_000` ticks of arrivals retained without a separate setter call.
+/// Override manually via
+/// [`Simulation::set_arrival_log_retention_ticks`](crate::sim::Simulation::set_arrival_log_retention_ticks)
+/// when retention should differ from any strategy's window (e.g. tests
+/// or custom consumers reading the log directly).
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct ArrivalLogRetention(pub u64);
 

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -1458,6 +1458,22 @@ pub trait RepositionStrategy: Send + Sync {
     fn builtin_id(&self) -> Option<BuiltinReposition> {
         None
     }
+
+    /// Minimum [`ArrivalLog`](crate::arrival_log::ArrivalLog) retention
+    /// (in ticks) the strategy needs to function. Strategies that read
+    /// the log directly with a custom rolling window must override this
+    /// so [`Simulation::set_reposition`](crate::sim::Simulation::set_reposition)
+    /// can widen
+    /// [`ArrivalLogRetention`](crate::arrival_log::ArrivalLogRetention)
+    /// to keep the data alive long enough for the query.
+    ///
+    /// Default `0` — strategies that don't read the arrival log (or that
+    /// only consume it through [`DispatchManifest::arrivals_at`], which
+    /// already tracks retention) impose no requirement.
+    #[must_use]
+    fn min_arrival_log_window(&self) -> u64 {
+        0
+    }
 }
 
 /// Serializable identifier for built-in repositioning strategies.

--- a/crates/elevator-core/src/dispatch/reposition.rs
+++ b/crates/elevator-core/src/dispatch/reposition.rs
@@ -353,6 +353,10 @@ impl RepositionStrategy for PredictiveParking {
     fn builtin_id(&self) -> Option<super::BuiltinReposition> {
         Some(super::BuiltinReposition::PredictiveParking)
     }
+
+    fn min_arrival_log_window(&self) -> u64 {
+        self.window_ticks
+    }
 }
 
 /// Mode-gated reposition: dispatches to an inner strategy chosen
@@ -455,6 +459,10 @@ impl RepositionStrategy for AdaptiveParking {
 
     fn builtin_id(&self) -> Option<super::BuiltinReposition> {
         Some(super::BuiltinReposition::Adaptive)
+    }
+
+    fn min_arrival_log_window(&self) -> u64 {
+        self.predictive.min_arrival_log_window()
     }
 }
 

--- a/crates/elevator-core/src/sim/accessors.rs
+++ b/crates/elevator-core/src/sim/accessors.rs
@@ -128,8 +128,8 @@ impl super::Simulation {
     /// Set how far back the arrival log retains entries before
     /// `advance_tick` prunes them.
     ///
-    /// [`Simulation::set_reposition`] auto-widens retention to the
-    /// installed strategy's
+    /// [`set_reposition`](super::Simulation::set_reposition) auto-widens
+    /// retention to the installed strategy's
     /// [`min_arrival_log_window`](crate::dispatch::RepositionStrategy::min_arrival_log_window),
     /// so most callers don't need this. Reach for it only when retention
     /// must differ from any strategy's window — tests, custom consumers

--- a/crates/elevator-core/src/sim/accessors.rs
+++ b/crates/elevator-core/src/sim/accessors.rs
@@ -126,11 +126,24 @@ impl super::Simulation {
     }
 
     /// Set how far back the arrival log retains entries before
-    /// `advance_tick` prunes them. Strategies querying a window longer
-    /// than the default (`5` minutes at 60 Hz, see
-    /// [`DEFAULT_ARRIVAL_WINDOW_TICKS`](crate::arrival_log::DEFAULT_ARRIVAL_WINDOW_TICKS))
-    /// must call this with a matching retention or they will silently
-    /// see only the last 5 minutes of arrivals.
+    /// `advance_tick` prunes them.
+    ///
+    /// [`Simulation::set_reposition`] auto-widens retention to the
+    /// installed strategy's
+    /// [`min_arrival_log_window`](crate::dispatch::RepositionStrategy::min_arrival_log_window),
+    /// so most callers don't need this. Reach for it only when retention
+    /// must differ from any strategy's window — tests, custom consumers
+    /// reading [`ArrivalLog`](crate::arrival_log::ArrivalLog) directly,
+    /// or to pre-stage retention before installing a strategy.
+    ///
+    /// ## Footgun
+    /// Calling this *after* `set_reposition` with a value smaller than
+    /// the installed strategy's window silently re-introduces the
+    /// truncation bug `set_reposition` was designed to avoid: the
+    /// strategy will see only the last `retention_ticks` of arrivals,
+    /// not its configured window. The setter trusts the caller; if you
+    /// only want to ensure retention is at least N ticks, do
+    /// `max(N, current_retention)` at the call site.
     pub fn set_arrival_log_retention_ticks(&mut self, retention_ticks: u64) {
         if let Some(r) = self
             .world

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -1046,8 +1046,22 @@ impl Simulation {
         id: BuiltinReposition,
     ) {
         let resolved_id = strategy.builtin_id().unwrap_or(id);
+        let needed_window = strategy.min_arrival_log_window();
         self.repositioners.insert(group, strategy);
         self.reposition_ids.insert(group, resolved_id);
+        // Widen the arrival-log retention if the freshly installed
+        // strategy queries a window the pruner would otherwise truncate
+        // under it. Without this, `PredictiveParking::with_window_ticks`
+        // (or any custom strategy advertising a longer window) silently
+        // sees only the last `DEFAULT_ARRIVAL_WINDOW_TICKS` of arrivals.
+        if needed_window > 0
+            && let Some(retention) = self
+                .world
+                .resource_mut::<crate::arrival_log::ArrivalLogRetention>()
+            && needed_window > retention.0
+        {
+            retention.0 = needed_window;
+        }
     }
 
     /// Remove the reposition strategy for a group, disabling repositioning.

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -1039,6 +1039,22 @@ impl Simulation {
     /// Custom strategies that don't override `builtin_id` fall back
     /// to the caller-supplied `id`, preserving the prior API for
     /// registered custom factories.
+    ///
+    /// ## Retention
+    /// Widens [`ArrivalLogRetention`](crate::arrival_log::ArrivalLogRetention)
+    /// to the strategy's
+    /// [`min_arrival_log_window`](crate::dispatch::RepositionStrategy::min_arrival_log_window)
+    /// when that exceeds current retention, never narrows it. This is
+    /// monotonic by design — replacing a wide-window strategy with a
+    /// narrow one (or [`remove_reposition`](Self::remove_reposition))
+    /// leaves retention at the high-water mark rather than recomputing
+    /// across the remaining strategies, since shrinking would also
+    /// clobber any explicit
+    /// [`set_arrival_log_retention_ticks`](Self::set_arrival_log_retention_ticks)
+    /// the caller made afterwards. Long-running sims that hot-swap
+    /// strategies pay a memory cost equal to the largest historic
+    /// window; if that matters, call `set_arrival_log_retention_ticks`
+    /// explicitly after the swap.
     pub fn set_reposition(
         &mut self,
         group: GroupId,
@@ -1065,6 +1081,15 @@ impl Simulation {
     }
 
     /// Remove the reposition strategy for a group, disabling repositioning.
+    ///
+    /// Does not narrow
+    /// [`ArrivalLogRetention`](crate::arrival_log::ArrivalLogRetention)
+    /// — see the retention note on
+    /// [`set_reposition`](Self::set_reposition) for why retention is
+    /// monotonic across strategy lifecycle changes. Call
+    /// [`set_arrival_log_retention_ticks`](Self::set_arrival_log_retention_ticks)
+    /// explicitly to shrink retention after removing a wide-window
+    /// strategy.
     pub fn remove_reposition(&mut self, group: GroupId) {
         self.repositioners.remove(&group);
         self.reposition_ids.remove(&group);

--- a/crates/elevator-core/src/tests/arrival_log_tests.rs
+++ b/crates/elevator-core/src/tests/arrival_log_tests.rs
@@ -212,6 +212,78 @@ fn reroute_records_arrival_and_resets_spawn_tick() {
 }
 
 #[test]
+fn set_reposition_widens_retention_for_strategy_window() {
+    // Regression for #675: installing a `PredictiveParking` strategy
+    // with a window longer than `DEFAULT_ARRIVAL_WINDOW_TICKS` must
+    // widen `ArrivalLogRetention` so the pruner doesn't truncate the
+    // signal the strategy is asking for.
+    use crate::arrival_log::ArrivalLogRetention;
+    use crate::dispatch::BuiltinReposition;
+    use crate::dispatch::reposition::PredictiveParking;
+    use crate::ids::GroupId;
+
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let long_window = DEFAULT_ARRIVAL_WINDOW_TICKS * 3;
+    sim.set_reposition(
+        GroupId(0),
+        Box::new(PredictiveParking::with_window_ticks(long_window)),
+        BuiltinReposition::PredictiveParking,
+    );
+
+    let retention = sim
+        .world()
+        .resource::<ArrivalLogRetention>()
+        .expect("ArrivalLogRetention installed by sim::new")
+        .0;
+    assert!(
+        retention >= long_window,
+        "set_reposition must widen retention to the strategy's window: \
+         retention={retention} expected ≥ {long_window}"
+    );
+}
+
+#[test]
+fn predictive_parking_window_survives_long_run() {
+    // Behavioural counterpart to the previous test: stepping past the
+    // default window must not silently undercount arrivals when the
+    // strategy is configured for a longer one.
+    use crate::dispatch::BuiltinReposition;
+    use crate::dispatch::reposition::PredictiveParking;
+    use crate::ids::GroupId;
+
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    let long_window = DEFAULT_ARRIVAL_WINDOW_TICKS * 3;
+    sim.set_reposition(
+        GroupId(0),
+        Box::new(PredictiveParking::with_window_ticks(long_window)),
+        BuiltinReposition::PredictiveParking,
+    );
+
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+
+    // Step past the default window but well within the strategy's.
+    let target = DEFAULT_ARRIVAL_WINDOW_TICKS + 500;
+    while sim.current_tick() < target {
+        sim.step();
+    }
+
+    let origin = sim.stop_entity(StopId(0)).unwrap();
+    let count = sim
+        .world()
+        .resource::<ArrivalLog>()
+        .unwrap()
+        .arrivals_in_window(origin, sim.current_tick(), long_window);
+    assert_eq!(
+        count, 2,
+        "arrivals must survive in the log for the strategy's full window"
+    );
+}
+
+#[test]
 fn dispatch_manifest_exposes_recent_arrivals() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();


### PR DESCRIPTION
## Summary
- Fixes #675: `PredictiveParking::with_window_ticks(50_000)` silently undercounted because `Simulation::advance_tick` pruned `ArrivalLog` to the default 18,000-tick window regardless of consumer requests.
- Adds `RepositionStrategy::min_arrival_log_window()` (default `0`); `set_reposition` reads it on install and bumps `ArrivalLogRetention` when the strategy demands a longer view.
- `PredictiveParking` and `AdaptiveParking` advertise their configured windows; other built-ins default to no requirement (they don't read the log directly).

## Why this design
The issue offered two paths: respect the longest configured window, or panic in `with_window_ticks(w > default)`. Path 1 wins because:
- `with_window_ticks` is a `const fn` constructor with no `&Simulation` reference, so it can't validate against runtime retention.
- `DispatchManifest::arrivals_at` already reads retention as its window — extending the same contract to reposition strategies makes the model coherent.
- Auto-widening eliminates a footgun rather than turning it into a runtime panic.

## Test plan
- [x] New `set_reposition_widens_retention_for_strategy_window` pins the install-time bump.
- [x] New `predictive_parking_window_survives_long_run` is the behavioural counterpart — steps past the default window and asserts arrivals are still counted.
- [x] `cargo test -p elevator-core --all-features` (1136 passed).
- [x] `cargo clippy -p elevator-core --all-features --all-targets` clean.
- [x] Pre-commit hook: fmt + clippy + core tests + doc tests + workspace check all green.