### PR TITLE
test(movement): property + boundary tests for braking and clamp paths (#661)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "16.0.1"
+version = "16.0.2"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-wasm"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "elevator-core",
  "getrandom 0.4.2",

--- a/crates/elevator-core/src/tests/movement_boundary_tests.rs
+++ b/crates/elevator-core/src/tests/movement_boundary_tests.rs
@@ -142,19 +142,23 @@ fn tick_movement_accelerate_does_not_cap_below_max_speed() {
 /// Kills `replace * with + in tick_movement` on `velocity * sign < 0.0`
 /// (the opposing-direction detector).
 ///
-/// With velocity in one direction and target in the other:
-/// - Original `velocity * sign`: `1.0 * (-1) = -1.0`, < 0 → opposing → decelerate.
-/// - Mutant `velocity + sign`: `1.0 + (-1) = 0.0`, NOT < 0 → fall through to
-///   accelerate. The car would speed *up* away from the target instead of
-///   braking back toward it — a silent correctness disaster.
+/// With velocity in one direction and target in the other (`vel=2`,
+/// `sign=-1`):
+/// - Original `velocity * sign = -2 < 0` → `opposing = true` → decelerate
+///   branch: `fma(-decel·dt, sign(vel), vel) = fma(-5, +1, 2) = -3`,
+///   sign-flip clamp → `0`.
+/// - Mutant `velocity + sign = 1`, NOT `< 0` → `opposing = false` →
+///   falls through to accelerate: `fma(accel·dt, sign, vel) =
+///   fma(1, -1, 2) = 1`. The car *accelerates* further from the target
+///   instead of braking back toward it.
 ///
-/// Observable: velocity magnitude after one tick. Original brakes
-/// (`new_vel = 1 - 5 · 1 = -4`, sign-flip clamp → 0). Mutant accelerates
-/// further away.
+/// `vel = 1.0` would coincidentally cancel: mutant accelerate produces
+/// `fma(1, -1, 1) = 0`, identical to the original sign-flip clamp, so
+/// the mutation survives. `vel = 2.0` breaks the symmetry.
 #[test]
 fn tick_movement_opposing_velocity_decelerates() {
-    // pos=0, vel=+1 (moving up), target=-10 (down), decel=5, dt=1.
-    let result = tick_movement(0.0, 1.0, -10.0, 10.0, 1.0, 5.0, 1.0);
+    // pos=0, vel=+2 (moving up), target=-10 (down), decel=5, dt=1.
+    let result = tick_movement(0.0, 2.0, -10.0, 10.0, 1.0, 5.0, 1.0);
     assert!(
         result.velocity <= 0.0,
         "opposing-velocity branch must not accelerate further from target: got velocity={}",

--- a/crates/elevator-core/src/tests/movement_boundary_tests.rs
+++ b/crates/elevator-core/src/tests/movement_boundary_tests.rs
@@ -136,3 +136,55 @@ fn tick_movement_accelerate_does_not_cap_below_max_speed() {
         result.velocity
     );
 }
+
+// ── tick_movement opposing-velocity branch ──────────────────────────
+
+/// Kills `replace * with + in tick_movement` on `velocity * sign < 0.0`
+/// (the opposing-direction detector).
+///
+/// With velocity in one direction and target in the other:
+/// - Original `velocity * sign`: `1.0 * (-1) = -1.0`, < 0 → opposing → decelerate.
+/// - Mutant `velocity + sign`: `1.0 + (-1) = 0.0`, NOT < 0 → fall through to
+///   accelerate. The car would speed *up* away from the target instead of
+///   braking back toward it — a silent correctness disaster.
+///
+/// Observable: velocity magnitude after one tick. Original brakes
+/// (`new_vel = 1 - 5 · 1 = -4`, sign-flip clamp → 0). Mutant accelerates
+/// further away.
+#[test]
+fn tick_movement_opposing_velocity_decelerates() {
+    // pos=0, vel=+1 (moving up), target=-10 (down), decel=5, dt=1.
+    let result = tick_movement(0.0, 1.0, -10.0, 10.0, 1.0, 5.0, 1.0);
+    assert!(
+        result.velocity <= 0.0,
+        "opposing-velocity branch must not accelerate further from target: got velocity={}",
+        result.velocity
+    );
+}
+
+// ── tick_movement already-arrived guard ─────────────────────────────
+
+/// Kills `replace < with <= in tick_movement` on the `displacement.abs()
+/// < EPSILON` half of the already-arrived guard. Shows the guard does
+/// **not** fire when displacement is non-zero (even if velocity is at
+/// EPSILON exactly), so mutants flipping the displacement check from
+/// `<` to `<=` would still need a separate displacement-equals-EPSILON
+/// case to diverge — and at exactly EPSILON the guard's velocity half
+/// (also `<`, not `<=`) keeps the mutant equivalent. The behavioural
+/// signal is "we did integrate, not short-circuit": post-tick position
+/// is no longer the start position when displacement is meaningful.
+#[test]
+fn tick_movement_does_not_short_circuit_with_pending_displacement() {
+    // displacement = 1.0 (well above EPSILON), velocity = 0.
+    // The guard must not fire — must integrate one step.
+    let result = tick_movement(0.0, 0.0, 1.0, 10.0, 1.0, 1.0, 0.5);
+    assert!(
+        !result.arrived,
+        "already-arrived guard fired with non-zero displacement (pos=0, target=1)"
+    );
+    assert!(
+        result.position > 0.0,
+        "expected forward integration, got position={}",
+        result.position
+    );
+}

--- a/crates/elevator-core/src/tests/proptest_tests.rs
+++ b/crates/elevator-core/src/tests/proptest_tests.rs
@@ -5,9 +5,46 @@ use crate::config::{
     BuildingConfig, ElevatorConfig, PassengerSpawnConfig, SimConfig, SimulationParams,
 };
 use crate::dispatch::scan::ScanDispatch;
-use crate::movement::tick_movement;
+use crate::movement::{braking_distance, tick_movement};
 use crate::sim::Simulation;
 use crate::stop::{StopConfig, StopId};
+
+// ── A0) braking_distance properties ─────────────────────────────────
+
+proptest! {
+    /// `braking_distance` returns a non-negative result for any input.
+    /// The formula `v² / (2·a)` is mathematically non-negative when
+    /// `a > 0`; the function returns `0.0` for `a <= 0` defensively.
+    /// Property: this contract holds for arbitrary finite floats.
+    #[test]
+    fn braking_distance_is_never_negative(
+        velocity in -1_000.0..1_000.0_f64,
+        deceleration in -100.0..100.0_f64,
+    ) {
+        let d = braking_distance(velocity, deceleration);
+        prop_assert!(d >= 0.0, "braking_distance({velocity}, {deceleration}) = {d} < 0");
+    }
+
+    /// `braking_distance` scales with `v²`, not `v`. Doubling velocity
+    /// must quadruple the distance (within float epsilon). Kills any
+    /// mutation that swaps `*` for `+` or drops the squaring step.
+    #[test]
+    fn braking_distance_scales_with_velocity_squared(
+        velocity in 0.1..50.0_f64,
+        deceleration in 0.1..50.0_f64,
+    ) {
+        let d1 = braking_distance(velocity, deceleration);
+        let d2 = braking_distance(velocity * 2.0, deceleration);
+        // Allow proportional float slop (relative epsilon), since the
+        // absolute scale of `d` varies with the input range.
+        let expected = d1 * 4.0;
+        prop_assert!(
+            (d2 - expected).abs() <= expected * 1e-9 + 1e-12,
+            "braking_distance not v²-proportional: d({velocity})={d1}, d({})={d2}, expected≈{expected}",
+            velocity * 2.0,
+        );
+    }
+}
 
 // ── A) tick_movement invariants ─────────────────────────────────────
 
@@ -91,6 +128,41 @@ proptest! {
             arrived,
             "did not converge after 100k ticks: pos={pos}, vel={vel}, target={target}",
         );
+    }
+
+    /// Deterministic stopping under parametric initial conditions.
+    /// Two runs of `tick_movement` from the same `(pos, vel, target,
+    /// params)` must produce bit-identical trajectories — the
+    /// integrator carries no hidden state. Pairs with the convergence
+    /// property above to pin both *that* and *how* the car arrives.
+    #[test]
+    fn tick_movement_is_deterministic(
+        position in -100.0..100.0_f64,
+        target in -100.0..100.0_f64,
+        max_speed in 0.5..50.0_f64,
+        acceleration in 0.1..20.0_f64,
+        deceleration in 0.1..20.0_f64,
+        dt in 0.01..0.5_f64,
+    ) {
+        prop_assume!((target - position).abs() > 1e-6);
+
+        let trajectory = || -> Vec<(f64, f64)> {
+            let mut pos = position;
+            let mut vel = 0.0;
+            let mut out = Vec::new();
+            for _ in 0..10_000 {
+                let r = tick_movement(pos, vel, target, max_speed, acceleration, deceleration, dt);
+                pos = r.position;
+                vel = r.velocity;
+                out.push((pos, vel));
+                if r.arrived {
+                    break;
+                }
+            }
+            out
+        };
+
+        prop_assert_eq!(trajectory(), trajectory());
     }
 }
 


### PR DESCRIPTION
## Summary
- Closes #661.
- Adds three property tests in \`proptest_tests.rs\` matching the issue's acceptance criteria: \`braking_distance\` non-negativity for any input, \`v²\` scaling (kills \`* ↔ +\` mutants on the squaring step), and trajectory determinism for parametric initial conditions.
- Adds two boundary tests in \`movement_boundary_tests.rs\` for gaps that proptest sampling won't reliably hit:
  - **Opposing-velocity detection**: targets the \`velocity * sign < 0.0\` line — a single mutation here lets a car silently *accelerate* away from a retargeted destination.
  - **Already-arrived guard**: pins that the integrator runs when displacement is meaningful, regardless of velocity.

## Why both kinds
Property tests sample probabilistically and miss exact-EPSILON / symmetric-input boundaries (e.g. \`d=2\` makes \`2*d == 2+d\`). Boundary tests pin those exact constants. The two complement each other; neither is sufficient alone — see \`movement_boundary_tests.rs\` module doc for the existing pattern.

## Test plan
- [x] \`cargo test -p elevator-core --all-features\` (924 passed).
- [x] \`cargo clippy -p elevator-core --all-features --all-targets\` clean.
- [x] Pre-commit hook green.