### PR TITLE
test(core): pin energy thresholds and load-ratio boundary (#662)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "16.0.1"
+version = "16.0.2"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-wasm"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "elevator-core",
  "getrandom 0.4.2",

--- a/crates/elevator-core/src/tests/boundary_tests.rs
+++ b/crates/elevator-core/src/tests/boundary_tests.rs
@@ -292,19 +292,29 @@ fn weight_exactly_at_capacity_boards() {
 /// `current_load * weight_capacity` magnitude that always exceeds any
 /// realistic `max_crowding_factor`, silently rejecting riders the
 /// preference rule would let through. The rider must board.
+///
+/// Stage the load by separating the boarding stops: r1 boards at stop 0
+/// heading to stop 2, r2 boards at stop 1 heading to stop 2. By the
+/// time the elevator reaches stop 1, r1 is committed aboard and
+/// `current_load = 400`, so r2's crowding check evaluates against the
+/// intended `load_ratio = 0.5`. Spawning both at the same stop would
+/// let r2's check race against r1's not-yet-committed weight, leaving
+/// the mutation undetected.
 #[test]
 fn preferences_below_crowding_threshold_boards_at_half_load() {
-    let config = default_config(); // capacity = 800
+    let config = default_config(); // capacity = 800, stops at 0/1/2
     let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
-    // First rider takes the elevator to half-capacity (400 / 800 = 0.5).
+    // r1 at stop 0 → stop 2, weight 400 kg.
     let r1 = sim.spawn_rider(StopId(0), StopId(2), 400.0).unwrap();
 
-    // Second rider tolerates up to 60% crowding — at 50% they should
-    // board. A mutation that multiplied instead of divided would
-    // compute load_ratio = 400 * 800 = 320_000, well above 0.6,
-    // and reject this rider.
-    let r2 = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    // r2 at stop 1 → stop 2 with a 60% crowding tolerance. The elevator
+    // picks up r1 at stop 0, commits the 400 kg to `current_load`, then
+    // arrives at stop 1 to consider r2 — at which point `load_ratio =
+    // 400 / 800 = 0.5 < 0.6` and r2 must board. Under a `/ ↔ *`
+    // mutation the computed ratio would be `400 * 800 = 320_000`,
+    // which exceeds 0.6 and rejects r2.
+    let r2 = sim.spawn_rider(StopId(1), StopId(2), 70.0).unwrap();
     sim.world_mut().set_preferences(
         r2.entity(),
         Preferences {
@@ -315,23 +325,37 @@ fn preferences_below_crowding_threshold_boards_at_half_load() {
         },
     );
 
+    let mut r1_aboard = false;
     let mut r2_boarded = false;
-    for _ in 0..1_000 {
+    for _ in 0..2_000 {
         sim.step();
-        if sim.world().rider(r2.entity()).is_some_and(|r| {
-            matches!(
-                r.phase,
-                RiderPhase::Boarding(_) | RiderPhase::Riding(_) | RiderPhase::Arrived
-            )
-        }) {
+        if !r1_aboard
+            && sim
+                .world()
+                .rider(r1.entity())
+                .is_some_and(|r| matches!(r.phase, RiderPhase::Riding(_) | RiderPhase::Arrived))
+        {
+            r1_aboard = true;
+        }
+        if r1_aboard
+            && sim.world().rider(r2.entity()).is_some_and(|r| {
+                matches!(
+                    r.phase,
+                    RiderPhase::Boarding(_) | RiderPhase::Riding(_) | RiderPhase::Arrived
+                )
+            })
+        {
             r2_boarded = true;
             break;
         }
     }
-    let _ = r1;
+    assert!(
+        r1_aboard,
+        "precondition: r1 must board so the elevator carries 400 kg when r2 is evaluated"
+    );
     assert!(
         r2_boarded,
         "rider with max_crowding=0.6 should board when load_ratio=0.5; \
-         a `/` ↔ `*` or `%` mutation on the ratio would silently reject"
+         a `/ ↔ *` or `/ ↔ %` mutation on the ratio would silently reject"
     );
 }

--- a/crates/elevator-core/src/tests/boundary_tests.rs
+++ b/crates/elevator-core/src/tests/boundary_tests.rs
@@ -285,3 +285,53 @@ fn weight_exactly_at_capacity_boards() {
         "rider weighing exactly capacity should be able to board"
     );
 }
+
+/// Crowding test that targets the `current_load / weight_capacity`
+/// division at a non-degenerate ratio (load = half-capacity, prefs at
+/// 0.6). A `/ ↔ *` or `/ ↔ %` mutation flips the ratio to a
+/// `current_load * weight_capacity` magnitude that always exceeds any
+/// realistic `max_crowding_factor`, silently rejecting riders the
+/// preference rule would let through. The rider must board.
+#[test]
+fn preferences_below_crowding_threshold_boards_at_half_load() {
+    let config = default_config(); // capacity = 800
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+
+    // First rider takes the elevator to half-capacity (400 / 800 = 0.5).
+    let r1 = sim.spawn_rider(StopId(0), StopId(2), 400.0).unwrap();
+
+    // Second rider tolerates up to 60% crowding — at 50% they should
+    // board. A mutation that multiplied instead of divided would
+    // compute load_ratio = 400 * 800 = 320_000, well above 0.6,
+    // and reject this rider.
+    let r2 = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.world_mut().set_preferences(
+        r2.entity(),
+        Preferences {
+            skip_full_elevator: true,
+            max_crowding_factor: 0.6,
+            abandon_after_ticks: None,
+            abandon_on_full: false,
+        },
+    );
+
+    let mut r2_boarded = false;
+    for _ in 0..1_000 {
+        sim.step();
+        if sim.world().rider(r2.entity()).is_some_and(|r| {
+            matches!(
+                r.phase,
+                RiderPhase::Boarding(_) | RiderPhase::Riding(_) | RiderPhase::Arrived
+            )
+        }) {
+            r2_boarded = true;
+            break;
+        }
+    }
+    let _ = r1;
+    assert!(
+        r2_boarded,
+        "rider with max_crowding=0.6 should board when load_ratio=0.5; \
+         a `/` ↔ `*` or `%` mutation on the ratio would silently reject"
+    );
+}

--- a/crates/elevator-core/src/tests/energy_tests.rs
+++ b/crates/elevator-core/src/tests/energy_tests.rs
@@ -192,3 +192,60 @@ fn energy_consumed_events_emitted() {
         "expected at least one EnergyConsumed event per tick"
     );
 }
+
+/// An all-zero profile must not emit `EnergyConsumed` events. Pins the
+/// emission threshold — the `if consumed > 0.0 || regenerated > 0.0`
+/// guard. Any boundary mutation (`>` → `>=`, `||` → `&&`) that flipped
+/// the guard's behaviour at `(0.0, 0.0)` would either spam the bus with
+/// no-op events or — under the `&&` swap — never emit even when energy
+/// is being consumed (caught by `energy_consumed_events_emitted` above).
+#[test]
+fn energy_zero_costs_emit_no_event() {
+    let cfg = config_with_energy(EnergyProfile::new(0.0, 0.0, 0.0, 0.0));
+    let mut sim = crate::sim::Simulation::new(&cfg, helpers::scan()).unwrap();
+
+    for _ in 0..50 {
+        sim.step();
+    }
+    let events = sim.drain_events();
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, Event::EnergyConsumed { .. })),
+        "expected no EnergyConsumed events when both consumed and regenerated are zero"
+    );
+}
+
+/// Energy metrics must never go negative under arbitrary sim activity.
+/// Pins the contract that `total_consumed - total_regenerated` (the
+/// `net_consumed` accessor) and the per-component totals stay
+/// non-negative — a regen-factor mutation that flipped a sign or
+/// substituted regen for consumption would push one of these below
+/// zero almost immediately.
+#[test]
+fn energy_metrics_never_negative_under_load() {
+    let cfg = config_with_energy(default_profile());
+    let mut sim = crate::sim::Simulation::new(&cfg, helpers::scan()).unwrap();
+
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.spawn_rider(StopId(2), StopId(0), 70.0).unwrap();
+
+    let elevator_ids = sim.world().elevator_ids();
+    let eid = elevator_ids[0];
+
+    for _ in 0..2_000 {
+        sim.step();
+        if let Some(metrics) = sim.world().energy_metrics(eid) {
+            assert!(
+                metrics.total_consumed() >= 0.0,
+                "total_consumed went negative: {}",
+                metrics.total_consumed()
+            );
+            assert!(
+                metrics.total_regenerated() >= 0.0,
+                "total_regenerated went negative: {}",
+                metrics.total_regenerated()
+            );
+        }
+    }
+}

--- a/crates/elevator-core/src/tests/energy_tests.rs
+++ b/crates/elevator-core/src/tests/energy_tests.rs
@@ -217,11 +217,13 @@ fn energy_zero_costs_emit_no_event() {
 }
 
 /// Energy metrics must never go negative under arbitrary sim activity.
-/// Pins the contract that `total_consumed - total_regenerated` (the
-/// `net_consumed` accessor) and the per-component totals stay
-/// non-negative — a regen-factor mutation that flipped a sign or
-/// substituted regen for consumption would push one of these below
-/// zero almost immediately.
+/// Pins the per-component non-negativity invariant and — separately —
+/// the `net_energy = total_consumed - total_regenerated >= 0` contract.
+/// Both component totals being non-negative does not imply
+/// `net_energy >= 0`: a mutation that scaled `regenerated` past
+/// `consumed` (e.g. dropped the `regen_factor` clamp or swapped
+/// `consumed * regen_factor` for `consumed + regen_factor`) leaves
+/// totals positive while driving net negative.
 #[test]
 fn energy_metrics_never_negative_under_load() {
     let cfg = config_with_energy(default_profile());
@@ -245,6 +247,14 @@ fn energy_metrics_never_negative_under_load() {
                 metrics.total_regenerated() >= 0.0,
                 "total_regenerated went negative: {}",
                 metrics.total_regenerated()
+            );
+            assert!(
+                metrics.net_energy() >= 0.0,
+                "net_energy went negative — regenerated outpaced consumed: \
+                 consumed={}, regenerated={}, net={}",
+                metrics.total_consumed(),
+                metrics.total_regenerated(),
+                metrics.net_energy()
             );
         }
     }


### PR DESCRIPTION
## Summary
- Closes #662.
- Three new energy tests in \`energy_tests.rs\`:
  - \`energy_zero_costs_emit_no_event\` — pins the \`consumed > 0.0 || regenerated > 0.0\` emission guard at the (0, 0) boundary. Catches both \`> ↔ >=\` and \`|| ↔ &&\` mutations on the threshold check.
  - \`energy_metrics_never_negative_under_load\` — invariant that \`total_consumed\` and \`total_regenerated\` stay non-negative across realistic sim activity.
- One loading test in \`boundary_tests.rs\`:
  - \`preferences_below_crowding_threshold_boards_at_half_load\` — pins the \`current_load / weight_capacity\` division at \`load_ratio=0.5\` with \`max_crowding=0.6\`. A \`/ ↔ *\` or \`/ ↔ %\` mutation flips the ratio magnitude past any realistic crowding factor.

## Coverage map vs. issue acceptance
- ✅ \"Tests for energy threshold transitions\" — \`energy_zero_costs_emit_no_event\`.
- ✅ \"Capacity-exceeded scenarios\" — already pinned by \`weight_exactly_at_capacity_boards\` and \`weight_exceeds_capacity_by_epsilon_rejects\`; the new ratio test fills the half-load preference gap.
- ✅ \"Energy never negative\" — \`energy_metrics_never_negative_under_load\`.
- ✅ \"Occupancy ≤ capacity\" — already a property in \`proptest_tests::loading_respects_weight_capacity\`.

## Test plan
- [x] \`cargo test -p elevator-core --all-features\` (922 passed).
- [x] \`cargo clippy -p elevator-core --all-features --all-targets\` clean.
- [x] Pre-commit hook green.