### PR TITLE
feat(core): add schema_version to SimConfig with explicit migration policy (#654)

### DIFF
--- a/assets/config/annotated.ron
+++ b/assets/config/annotated.ron
@@ -2,6 +2,12 @@
 // All fields are required unless noted otherwise.
 
 SimConfig(
+    // Schema version of this config file. Bumped when the RON shape
+    // changes incompatibly. Pre-versioning configs (no field) deserialize
+    // to 0, which `Simulation::new` rejects with an explicit migration
+    // hint. See docs/src/config-versioning.md for the bump policy.
+    schema_version: 1,
+
     building: BuildingConfig(
         // Human-readable building name (for display/logging).
         name: "Demo Tower",

--- a/assets/config/default.ron
+++ b/assets/config/default.ron
@@ -6,6 +6,7 @@
 // idles higher, the locals oscillate). For a sparser/faster mover
 // scenario see `space_elevator.ron`.
 SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Demo Tower",
         stops: [

--- a/assets/config/space_elevator.ron
+++ b/assets/config/space_elevator.ron
@@ -1,4 +1,5 @@
 SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Orbital Tether",
         stops: [

--- a/assets/contract-corpus/default.ron
+++ b/assets/contract-corpus/default.ron
@@ -6,6 +6,7 @@
 // idles higher, the locals oscillate). For a sparser/faster mover
 // scenario see `space_elevator.ron`.
 SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Demo Tower",
         stops: [

--- a/assets/contract-corpus/dense_traffic.ron
+++ b/assets/contract-corpus/dense_traffic.ron
@@ -4,6 +4,7 @@
 // harness to exercise the dispatcher's tie-breaking, the loading
 // phase, and the rider-abandonment path under saturation.
 SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Dense Tower",
         stops: [

--- a/assets/contract-corpus/extreme_load.ron
+++ b/assets/contract-corpus/extreme_load.ron
@@ -5,6 +5,7 @@
 // the dispatcher. Useful for catching off-by-one / saturation
 // regressions that don't manifest at moderate load.
 SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Skyscraper",
         stops: [

--- a/assets/contract-corpus/multi_group.ron
+++ b/assets/contract-corpus/multi_group.ron
@@ -10,6 +10,7 @@
 // `SimConfig` schema as the others; the contract harness can
 // optionally wrap it in a runtime add_group call.
 SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Mixed Tower",
         stops: [

--- a/assets/contract-corpus/sparse.ron
+++ b/assets/contract-corpus/sparse.ron
@@ -1,4 +1,5 @@
 SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Orbital Tether",
         stops: [

--- a/crates/elevator-core/benches/dispatch_bench.rs
+++ b/crates/elevator-core/benches/dispatch_bench.rs
@@ -43,6 +43,7 @@ fn make_config(num_stops: u32, num_elevators: u32) -> SimConfig {
         .collect();
 
     SimConfig {
+        schema_version: elevator_core::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "DispatchBench".into(),
             stops,

--- a/crates/elevator-core/benches/multi_line_bench.rs
+++ b/crates/elevator-core/benches/multi_line_bench.rs
@@ -106,6 +106,7 @@ fn multi_group_config(
     }
 
     SimConfig {
+        schema_version: elevator_core::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "MultiLineBench".into(),
             stops,
@@ -145,6 +146,7 @@ fn single_group_config(num_stops: u32, num_elevators: u32) -> SimConfig {
         .collect();
 
     SimConfig {
+        schema_version: elevator_core::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "SingleGroupBench".into(),
             stops,

--- a/crates/elevator-core/benches/query_bench.rs
+++ b/crates/elevator-core/benches/query_bench.rs
@@ -39,6 +39,7 @@ fn make_config(num_stops: u32, num_elevators: u32) -> SimConfig {
         .collect();
 
     SimConfig {
+        schema_version: elevator_core::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "QueryBench".into(),
             stops,

--- a/crates/elevator-core/benches/scaling_bench.rs
+++ b/crates/elevator-core/benches/scaling_bench.rs
@@ -36,6 +36,7 @@ fn make_config(num_stops: u32, num_elevators: u32) -> SimConfig {
         .collect();
 
     SimConfig {
+        schema_version: elevator_core::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Scaling".into(),
             stops,

--- a/crates/elevator-core/benches/sim_bench.rs
+++ b/crates/elevator-core/benches/sim_bench.rs
@@ -37,6 +37,7 @@ fn make_config(num_stops: u32, num_elevators: u32) -> SimConfig {
         .collect();
 
     SimConfig {
+        schema_version: elevator_core::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Bench".into(),
             stops,

--- a/crates/elevator-core/examples/dispatch_comparison.rs
+++ b/crates/elevator-core/examples/dispatch_comparison.rs
@@ -86,6 +86,7 @@ fn make_config() -> SimConfig {
         .collect();
 
     SimConfig {
+        schema_version: elevator_core::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Bench".into(),
             stops,

--- a/crates/elevator-core/examples/playground_audit.rs
+++ b/crates/elevator-core/examples/playground_audit.rs
@@ -426,6 +426,7 @@ const OFFICE_PHASES: &[Phase] = &[
 ];
 
 const OFFICE_RON: &str = r#"SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Mid-Rise Office",
         stops: [
@@ -511,6 +512,7 @@ const SKY_PHASES: &[Phase] = &[
 ];
 
 const SKY_RON: &str = r#"SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Skyscraper (Sky Lobby)",
         stops: [

--- a/crates/elevator-core/examples/scenario.rs
+++ b/crates/elevator-core/examples/scenario.rs
@@ -13,6 +13,7 @@ fn main() {
     let scenario = Scenario {
         name: "Basic up-peak".into(),
         config: SimConfig {
+            schema_version: elevator_core::config::CURRENT_CONFIG_SCHEMA_VERSION,
             building: BuildingConfig {
                 name: "Test Building".into(),
                 stops: vec![

--- a/crates/elevator-core/examples/showcase.rs
+++ b/crates/elevator-core/examples/showcase.rs
@@ -364,6 +364,7 @@ fn part6_configuration() {
 
     // Build a SimConfig entirely in code (no RON file needed).
     let config = SimConfig {
+        schema_version: elevator_core::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Space Needle".into(),
             stops: vec![

--- a/crates/elevator-core/src/builder.rs
+++ b/crates/elevator-core/src/builder.rs
@@ -107,6 +107,7 @@ impl SimulationBuilder {
     #[must_use]
     pub fn new() -> Self {
         let config = SimConfig {
+            schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
             building: BuildingConfig {
                 name: "Untitled".into(),
                 stops: Vec::new(),

--- a/crates/elevator-core/src/config.rs
+++ b/crates/elevator-core/src/config.rs
@@ -5,12 +5,33 @@ use crate::dispatch::{BuiltinReposition, BuiltinStrategy, HallCallMode};
 use crate::stop::{StopConfig, StopId};
 use serde::{Deserialize, Serialize};
 
+/// Schema version of [`SimConfig`].
+///
+/// Bumped when the RON shape changes in a way that legacy
+/// `assets/config/*.ron` would silently mis-deserialize (a removed
+/// field, a renamed field, a changed default that materially alters
+/// behaviour). Pre-versioning configs deserialize to `0` via
+/// `#[serde(default)]` and validation flags them as legacy so
+/// consumers can migrate explicitly. See `docs/src/config-versioning.md`
+/// for the full bump-trigger policy and migration playbook.
+pub const CURRENT_CONFIG_SCHEMA_VERSION: u32 = 1;
+
 /// Top-level simulation configuration, loadable from RON.
 ///
 /// Validated at construction time by [`Simulation::new()`](crate::sim::Simulation::new)
 /// or [`SimulationBuilder::build()`](crate::builder::SimulationBuilder::build).
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SimConfig {
+    /// Schema version of this config. Use [`CURRENT_CONFIG_SCHEMA_VERSION`]
+    /// for new configs; `0` (the `#[serde(default)]`) marks a legacy
+    /// pre-versioning RON file. Validation rejects versions strictly
+    /// greater than the current version (forward-incompatible) and
+    /// surfaces a `legacy_config: 0` reason for `0` so the consumer
+    /// has to opt in to running pre-versioning configs.
+    ///
+    /// See `docs/src/config-versioning.md` for the bump policy.
+    #[serde(default)]
+    pub schema_version: u32,
     /// Building layout describing the stops (floors/stations) along the shaft.
     pub building: BuildingConfig,
     /// Elevator cars to install in the building.
@@ -27,6 +48,24 @@ pub struct SimConfig {
     /// The core library does not consume these directly; they are stored here
     /// for games and traffic generators that read the config.
     pub passenger_spawning: PassengerSpawnConfig,
+}
+
+impl Default for SimConfig {
+    /// A fresh `SimConfig` pinned to [`CURRENT_CONFIG_SCHEMA_VERSION`].
+    ///
+    /// Programmatically-built configs always start at the current
+    /// version; the legacy `0` marker is reserved for RON files that
+    /// pre-date the version field, where it surfaces via
+    /// `#[serde(default)]` on missing input.
+    fn default() -> Self {
+        Self {
+            schema_version: CURRENT_CONFIG_SCHEMA_VERSION,
+            building: BuildingConfig::default(),
+            elevators: Vec::new(),
+            simulation: SimulationParams::default(),
+            passenger_spawning: PassengerSpawnConfig::default(),
+        }
+    }
 }
 
 /// Building layout.

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -734,6 +734,32 @@ impl Simulation {
 
     /// Validate configuration before constructing the simulation.
     pub(crate) fn validate_config(config: &SimConfig) -> Result<(), SimError> {
+        // Schema-version gate: reject forward-incompatible configs (a
+        // future build's RON would silently mis-deserialize fields a
+        // current build doesn't know about) and surface legacy
+        // pre-versioning configs (`schema_version = 0`) as an explicit
+        // upgrade prompt rather than a silent serde-default smear. See
+        // `docs/src/config-versioning.md` for the migration playbook.
+        if config.schema_version > crate::config::CURRENT_CONFIG_SCHEMA_VERSION {
+            return Err(SimError::InvalidConfig {
+                field: "schema_version",
+                reason: format!(
+                    "config schema_version={} is newer than this build's CURRENT_CONFIG_SCHEMA_VERSION={}; upgrade elevator-core or downgrade the config",
+                    config.schema_version,
+                    crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
+                ),
+            });
+        }
+        if config.schema_version == 0 {
+            return Err(SimError::InvalidConfig {
+                field: "schema_version",
+                reason: format!(
+                    "config schema_version=0 (pre-versioning legacy file) — set schema_version: {} explicitly after auditing field defaults; see docs/src/config-versioning.md",
+                    crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
+                ),
+            });
+        }
+
         if config.building.stops.is_empty() {
             return Err(SimError::InvalidConfig {
                 field: "building.stops",

--- a/crates/elevator-core/src/tests/builder_tests.rs
+++ b/crates/elevator-core/src/tests/builder_tests.rs
@@ -27,6 +27,7 @@ fn demo_builder_produces_valid_sim() {
 #[test]
 fn from_config_produces_valid_sim() {
     let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Test".into(),
             stops: vec![
@@ -181,6 +182,7 @@ fn from_config_honours_config_group_dispatch() {
     use crate::ids::GroupId;
 
     let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "DispatchPrecedence".into(),
             stops: vec![
@@ -268,6 +270,7 @@ fn from_config_dispatch_override_records_dispatcher_identity() {
     use crate::ids::GroupId;
 
     let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "DispatchOverride".into(),
             stops: vec![

--- a/crates/elevator-core/src/tests/config_tests.rs
+++ b/crates/elevator-core/src/tests/config_tests.rs
@@ -241,3 +241,103 @@ fn rejects_empty_line_serves() {
         "empty line.serves should be rejected, got {result:?}"
     );
 }
+
+// ===== schema_version validation (#654) =====
+
+#[test]
+fn rejects_legacy_zero_schema_version() {
+    use super::helpers;
+    // `serde(default)` deserializes a missing schema_version field as
+    // `0`. The validator must surface this as an explicit migration
+    // prompt, not a silent serde-default smear.
+    let mut config = helpers::default_config();
+    config.schema_version = 0;
+    let result = crate::sim::Simulation::new(&config, helpers::scan());
+    assert!(
+        matches!(
+            result,
+            Err(SimError::InvalidConfig {
+                field: "schema_version",
+                ..
+            })
+        ),
+        "schema_version=0 must be rejected with a migration hint, got {result:?}"
+    );
+}
+
+#[test]
+fn rejects_forward_incompatible_schema_version() {
+    use super::helpers;
+    let mut config = helpers::default_config();
+    config.schema_version = crate::config::CURRENT_CONFIG_SCHEMA_VERSION + 1;
+    let result = crate::sim::Simulation::new(&config, helpers::scan());
+    assert!(
+        matches!(
+            result,
+            Err(SimError::InvalidConfig {
+                field: "schema_version",
+                ..
+            })
+        ),
+        "schema_version > CURRENT must be rejected as forward-incompatible, got {result:?}"
+    );
+}
+
+#[test]
+fn accepts_current_schema_version() {
+    use super::helpers;
+    let config = helpers::default_config();
+    assert_eq!(
+        config.schema_version,
+        crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
+        "test fixture must pin to current version so this test isn't vacuous"
+    );
+    assert!(crate::sim::Simulation::new(&config, helpers::scan()).is_ok());
+}
+
+#[test]
+fn ron_without_schema_version_field_deserializes_to_zero() {
+    // The `#[serde(default)]` contract: a RON file with no
+    // schema_version field must deserialize successfully but with
+    // schema_version=0, which the validator then catches.
+    let ron_str = r#"
+        SimConfig(
+            building: BuildingConfig(
+                name: "Legacy",
+                stops: [
+                    StopConfig(id: StopId(0), name: "G", position: 0.0),
+                ],
+            ),
+            elevators: [],
+            simulation: SimulationParams(ticks_per_second: 60.0),
+            passenger_spawning: PassengerSpawnConfig(
+                mean_interval_ticks: 120,
+                weight_range: (50.0, 100.0),
+            ),
+        )
+    "#;
+    let config: SimConfig = ron::from_str(ron_str).expect("legacy RON deserializes");
+    assert_eq!(
+        config.schema_version, 0,
+        "RON without schema_version field must deserialize as 0, the legacy marker"
+    );
+}
+
+#[test]
+fn shipped_assets_pin_to_current_schema_version() {
+    // Every config under assets/config/ must declare the current
+    // version explicitly; otherwise the asset itself becomes a legacy
+    // file the next time someone bumps CURRENT_CONFIG_SCHEMA_VERSION.
+    for asset in [
+        include_str!("../../../../assets/config/default.ron"),
+        include_str!("../../../../assets/config/space_elevator.ron"),
+        include_str!("../../../../assets/config/annotated.ron"),
+    ] {
+        let config: SimConfig = ron::from_str(asset).expect("shipped asset deserializes");
+        assert_eq!(
+            config.schema_version,
+            crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
+            "shipped asset must pin to CURRENT_CONFIG_SCHEMA_VERSION"
+        );
+    }
+}

--- a/crates/elevator-core/src/tests/destination_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/destination_dispatch_tests.rs
@@ -16,6 +16,7 @@ use crate::stop::{StopConfig, StopId};
 /// Single-elevator 3-stop config.
 fn single_car_config() -> SimConfig {
     SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "DCS Test".into(),
             stops: vec![
@@ -71,6 +72,7 @@ fn single_car_config() -> SimConfig {
 /// 4-stop, 1-line, 2-car config. Both cars serve all 4 stops in the same group.
 fn two_cars_same_group_config() -> SimConfig {
     SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "DCS Two Car".into(),
             stops: vec![
@@ -746,6 +748,7 @@ fn single_car_heavy_load_drains_within_tick_budget() {
     // up-front so the dispatcher sees the full workload at tick 0.
     const TICK_BUDGET: u64 = 8_000;
     let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "DCS Heavy Load".into(),
             stops: (0..4)

--- a/crates/elevator-core/src/tests/feature_tests.rs
+++ b/crates/elevator-core/src/tests/feature_tests.rs
@@ -862,6 +862,7 @@ fn weight_rejection_boundary() {
 
     // 2 stops, 1 elevator with capacity 100.0.
     let config = crate::config::SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: crate::config::BuildingConfig {
             name: "WeightTest".into(),
             stops: vec![
@@ -943,6 +944,7 @@ fn passing_floor_events_emitted() {
     // Setup: 5 stops, elevator going from stop 0 (pos 0) to stop 4 (pos 40).
     // Should pass through stops 1-3 along the way.
     let config = crate::config::SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: crate::config::BuildingConfig {
             name: "PassFloor".into(),
             stops: vec![

--- a/crates/elevator-core/src/tests/helpers.rs
+++ b/crates/elevator-core/src/tests/helpers.rs
@@ -7,6 +7,7 @@ use crate::stop::{StopConfig, StopId};
 /// Standard 3-stop, 1-elevator test config.
 pub fn default_config() -> SimConfig {
     SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Test Building".into(),
             stops: vec![
@@ -111,6 +112,7 @@ pub fn multi_floor_config(stops: usize, cars: usize) -> SimConfig {
         })
         .collect();
     SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: format!("{stops}-stop test building"),
             stops: stop_configs,

--- a/crates/elevator-core/src/tests/home_stop_tests.rs
+++ b/crates/elevator-core/src/tests/home_stop_tests.rs
@@ -322,6 +322,7 @@ fn already_at_home_does_not_reposition_redundantly() {
 /// distinct dispatch groups. Used to test cross-line pin rejection.
 fn two_line_config() -> SimConfig {
     SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Two Lines".into(),
             stops: vec![
@@ -394,6 +395,7 @@ fn two_line_config() -> SimConfig {
 /// car is pinned.
 fn two_car_one_line_config() -> SimConfig {
     SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Two Cars".into(),
             stops: vec![

--- a/crates/elevator-core/src/tests/invariants_tests.rs
+++ b/crates/elevator-core/src/tests/invariants_tests.rs
@@ -168,6 +168,7 @@ impl Workload {
             })
             .collect();
         SimConfig {
+            schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
             building: BuildingConfig {
                 name: "Invariant Building".into(),
                 stops,

--- a/crates/elevator-core/src/tests/move_count_tests.rs
+++ b/crates/elevator-core/src/tests/move_count_tests.rs
@@ -10,6 +10,7 @@ use crate::tests::helpers;
 
 fn two_elevator_config() -> SimConfig {
     SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Test".into(),
             stops: vec![

--- a/crates/elevator-core/src/tests/multi_elevator_tests.rs
+++ b/crates/elevator-core/src/tests/multi_elevator_tests.rs
@@ -9,6 +9,7 @@ use crate::stop::{StopConfig, StopId};
 
 fn two_elevator_config() -> SimConfig {
     SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Test".into(),
             stops: vec![

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -26,6 +26,7 @@ use crate::stop::{StopConfig, StopId};
 /// ```
 fn two_group_config() -> SimConfig {
     SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Transfer Tower".into(),
             stops: vec![
@@ -142,6 +143,7 @@ fn two_group_config() -> SimConfig {
 /// Config where both lines/groups serve the same set of stops (for ambiguity tests).
 fn overlapping_groups_config() -> SimConfig {
     SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Overlap Tower".into(),
             stops: vec![
@@ -599,6 +601,7 @@ fn rider_only_boards_elevator_from_matching_group() {
 fn line_pinned_rider_boards_only_specified_line_elevator() {
     // Config with one group containing two lines, each with one elevator.
     let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Twin Shaft".into(),
             stops: vec![
@@ -922,6 +925,7 @@ fn reachable_stops_from_isolated_stop_returns_empty() {
     use super::helpers::scan;
 
     let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Island".into(),
             stops: vec![
@@ -1073,6 +1077,7 @@ fn shortest_route_spans_groups_via_transfer() {
 fn shortest_route_returns_none_for_unreachable_stop() {
     // Two groups with no shared stops.
     let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Disconnected".into(),
             stops: vec![
@@ -1282,6 +1287,7 @@ fn orphaned_stop_not_in_any_line_fails_validation() {
 #[test]
 fn no_elevators_in_any_line_fails_validation() {
     let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Elevator-less".into(),
             stops: vec![
@@ -1822,6 +1828,7 @@ fn reassign_elevator_to_line_moves_elevator() {
 fn reassign_elevator_to_line_at_max_cars_returns_error() {
     // Build a config where the high line has max_cars: Some(1).
     let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Cap Test".into(),
             stops: vec![
@@ -1991,6 +1998,7 @@ fn reassign_elevator_emits_elevator_reassigned_event() {
 fn max_cars_exactly_met_at_config_time_succeeds() {
     // max_cars: Some(2) with exactly 2 elevators: valid.
     let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Capped".into(),
             stops: vec![
@@ -2080,6 +2088,7 @@ fn max_cars_exactly_met_at_config_time_succeeds() {
 fn max_cars_exceeded_at_config_time_fails_validation() {
     // max_cars: Some(1) with 2 elevators: invalid.
     let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Over Cap".into(),
             stops: vec![
@@ -2175,6 +2184,7 @@ fn max_cars_exceeded_at_config_time_fails_validation() {
 fn runtime_add_elevator_to_line_at_max_cars_returns_error() {
     // Build a sim with max_cars: Some(1) on a line that already has 1 elevator.
     let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Runtime Cap".into(),
             stops: vec![
@@ -2260,6 +2270,7 @@ fn runtime_add_elevator_to_line_at_max_cars_returns_error() {
 /// ```
 fn three_group_config() -> SimConfig {
     SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Three-Group Tower".into(),
             stops: vec![
@@ -2857,6 +2868,7 @@ fn passing_floor_event_moving_up_is_false_when_descending() {
 fn orphan_line_not_referenced_by_any_group_fails_validation() {
     // Line 2 exists but is not in any group's lines list.
     let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Orphan Line".into(),
             stops: vec![
@@ -3368,6 +3380,7 @@ fn dispatch_does_not_assign_car_to_stop_its_line_does_not_serve() {
     //   Line B: serves stops 2 and 3
     // A car on Line B must NOT be dispatched to a hall call at stop 0.
     let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Disjoint".into(),
             stops: vec![
@@ -3524,6 +3537,7 @@ fn loading_resolves_co_located_stops_to_the_cars_own_line() {
     use crate::components::RiderPhase;
 
     let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Co-located".into(),
             // Order matters: declare B's stops first so they receive

--- a/crates/elevator-core/src/tests/proptest_tests.rs
+++ b/crates/elevator-core/src/tests/proptest_tests.rs
@@ -202,6 +202,7 @@ fn make_config(stop_count: u32, elevator_count: u32) -> SimConfig {
         .collect();
 
     SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Proptest Building".into(),
             stops,
@@ -314,6 +315,7 @@ proptest! {
         use crate::stop::{StopConfig, StopId};
 
         let config = SimConfig {
+            schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
             building: BuildingConfig {
                 name: "Cap test".into(),
                 stops: vec![

--- a/crates/elevator-core/src/tests/reroute_tests.rs
+++ b/crates/elevator-core/src/tests/reroute_tests.rs
@@ -13,6 +13,7 @@ use crate::stop::{StopConfig, StopId};
 
 fn three_stop_config() -> SimConfig {
     SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Reroute".into(),
             stops: vec![
@@ -129,6 +130,7 @@ fn disable_stop_emits_route_invalidated_event() {
 fn disable_only_stop_causes_abandonment() {
     // Config with only 2 stops. Disable the destination — no alternative.
     let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Two".into(),
             stops: vec![
@@ -397,6 +399,7 @@ fn remove_only_destination_with_riding_passenger_returns_to_origin() {
     // back to the origin and the car turns around to deliver them. This
     // is the graceful "demolish destination floor" outcome — no deadlock.
     let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Two".into(),
             stops: vec![
@@ -471,6 +474,7 @@ fn remove_stop_without_alternative_emits_stop_removed_not_no_alternative() {
     // Reason should be `StopRemoved` (not `NoAlternative`) so consumers
     // can distinguish a permanent removal from a transient disable.
     let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Two".into(),
             stops: vec![

--- a/crates/elevator-core/tests/scenarios/basic.rs
+++ b/crates/elevator-core/tests/scenarios/basic.rs
@@ -18,6 +18,7 @@ mod common;
 
 fn basic_config() -> SimConfig {
     SimConfig {
+        schema_version: elevator_core::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Basic".into(),
             stops: vec![

--- a/crates/elevator-core/tests/scenarios/common/mod.rs
+++ b/crates/elevator-core/tests/scenarios/common/mod.rs
@@ -67,6 +67,7 @@ pub fn canonical_building() -> SimConfig {
         .collect();
 
     SimConfig {
+        schema_version: elevator_core::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Canonical".into(),
             stops,
@@ -112,6 +113,7 @@ pub fn twin_shaft_building() -> SimConfig {
     };
 
     SimConfig {
+        schema_version: elevator_core::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Twin Shaft".into(),
             stops: vec![
@@ -157,6 +159,7 @@ pub fn twin_shaft_building() -> SimConfig {
 #[must_use]
 pub fn compact_building() -> SimConfig {
     SimConfig {
+        schema_version: elevator_core::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Compact".into(),
             stops: vec![

--- a/crates/elevator-core/tests/scenarios/single_call_single_car.rs
+++ b/crates/elevator-core/tests/scenarios/single_call_single_car.rs
@@ -212,6 +212,7 @@ fn twin_shaft_sim() -> Simulation {
         max_cars: None,
     };
     let config = SimConfig {
+        schema_version: elevator_core::config::CURRENT_CONFIG_SCHEMA_VERSION,
         building: BuildingConfig {
             name: "Twin Shaft".into(),
             stops: vec![

--- a/crates/elevator-tui/src/headless.rs
+++ b/crates/elevator-tui/src/headless.rs
@@ -164,6 +164,7 @@ mod tests {
         // hand-roll one matching the demo topology for the Poisson
         // source. Mirrors what builder::demo configures internally.
         let config = SimConfig {
+            schema_version: elevator_core::config::CURRENT_CONFIG_SCHEMA_VERSION,
             building: elevator_core::config::BuildingConfig {
                 name: "Demo".into(),
                 stops: vec![

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -273,6 +273,7 @@ impl WasmSim {
     #[wasm_bindgen(js_name = empty)]
     pub fn empty(strategy: &str, reposition: Option<String>) -> Result<Self, JsError> {
         const MINIMAL: &str = r#"SimConfig(
+            schema_version: 1,
             building: BuildingConfig(
                 name: "Empty",
                 stops: [StopConfig(id: StopId(0), name: "_seed", position: 0.0)],

--- a/crates/elevator-wasm/tests/empty_constructor.rs
+++ b/crates/elevator-wasm/tests/empty_constructor.rs
@@ -31,6 +31,7 @@ fn empty_has_no_lines_or_elevators_or_stops() {
     };
     let populated = WasmSim::new(
         r#"SimConfig(
+            schema_version: 1,
             building: BuildingConfig(
                 name: "P",
                 stops: [

--- a/crates/elevator-wasm/tests/event_tag.rs
+++ b/crates/elevator-wasm/tests/event_tag.rs
@@ -9,6 +9,7 @@
 use elevator_wasm::{EventDto, WasmSim, WasmU64Result, WasmVoidResult};
 
 const SCENARIO: &str = r#"SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Tag Events",
         stops: [

--- a/crates/elevator-wasm/tests/home_stop.rs
+++ b/crates/elevator-wasm/tests/home_stop.rs
@@ -9,6 +9,7 @@
 use elevator_wasm::{WasmSim, WasmU64Result, WasmVoidResult};
 
 const SCENARIO: &str = r#"SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Home Stop",
         stops: [

--- a/crates/elevator-wasm/tests/per_elevator_setters.rs
+++ b/crates/elevator-wasm/tests/per_elevator_setters.rs
@@ -10,6 +10,7 @@
 use elevator_wasm::{WasmSim, WasmVoidResult};
 
 const SCENARIO: &str = r#"SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Per-Elevator Setters",
         stops: [

--- a/crates/elevator-wasm/tests/playground_scenarios.rs
+++ b/crates/elevator-wasm/tests/playground_scenarios.rs
@@ -12,6 +12,7 @@ use elevator_core::dispatch::{DestinationDispatch, EtdDispatch, ScanDispatch};
 use elevator_core::sim::Simulation;
 
 const OFFICE: &str = r#"SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Mid-Rise Office",
         stops: [
@@ -40,6 +41,7 @@ const OFFICE: &str = r#"SimConfig(
 )"#;
 
 const SKYSCRAPER: &str = r#"SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Skyscraper (Sky Lobby)",
         stops: [
@@ -92,6 +94,7 @@ const SKYSCRAPER: &str = r#"SimConfig(
 )"#;
 
 const RESIDENTIAL: &str = r#"SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Residential Tower",
         stops: [
@@ -129,6 +132,7 @@ const RESIDENTIAL: &str = r#"SimConfig(
 )"#;
 
 const HOTEL: &str = r#"SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Hotel 24/7",
         stops: [
@@ -175,6 +179,7 @@ const HOTEL: &str = r#"SimConfig(
 )"#;
 
 const CONVENTION: &str = r#"SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Convention Center",
         stops: [
@@ -209,6 +214,7 @@ const CONVENTION: &str = r#"SimConfig(
 )"#;
 
 const SPACE: &str = r#"SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Orbital Tether",
         stops: [

--- a/crates/elevator-wasm/tests/positions_packed.rs
+++ b/crates/elevator-wasm/tests/positions_packed.rs
@@ -5,6 +5,7 @@
 use elevator_wasm::WasmSim;
 
 const SCENARIO: &str = r#"SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Packed Positions",
         stops: [

--- a/crates/elevator-wasm/tests/rider_tag.rs
+++ b/crates/elevator-wasm/tests/rider_tag.rs
@@ -9,6 +9,7 @@
 use elevator_wasm::{WasmBytesResult, WasmSim, WasmU64Result, WasmVoidResult};
 
 const SCENARIO: &str = r#"SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Tag",
         stops: [

--- a/crates/elevator-wasm/tests/snapshot_bytes.rs
+++ b/crates/elevator-wasm/tests/snapshot_bytes.rs
@@ -15,6 +15,7 @@
 use elevator_wasm::{WasmBytesResult, WasmSim};
 
 const SCENARIO: &str = r#"SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Snapshot Round-Trip",
         stops: [

--- a/crates/elevator-wasm/tests/snapshot_checksum.rs
+++ b/crates/elevator-wasm/tests/snapshot_checksum.rs
@@ -12,6 +12,7 @@
 use elevator_wasm::{WasmBytesResult, WasmSim, WasmU64Result};
 
 const SCENARIO: &str = r#"SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Checksum",
         stops: [

--- a/crates/elevator-wasm/tests/spawn_rider_ref.rs
+++ b/crates/elevator-wasm/tests/spawn_rider_ref.rs
@@ -8,6 +8,7 @@
 use elevator_wasm::{WasmSim, WasmU64Result};
 
 const SCENARIO: &str = r#"SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Spawn Ref",
         stops: [

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -41,6 +41,7 @@
 - [Traffic Generation](traffic-generation.md)
 - [Snapshots and Determinism](snapshots-determinism.md)
 - [Snapshot Versioning](snapshot-versioning.md)
+- [Config Versioning](config-versioning.md)
 - [Testing Your Simulation](testing.md)
 - [Stability and Versioning](stability.md)
 

--- a/docs/src/config-versioning.md
+++ b/docs/src/config-versioning.md
@@ -1,0 +1,117 @@
+# Config Versioning
+
+`SimConfig` (the RON format under `assets/config/`) carries an explicit
+`schema_version: u32` field that the core validates at construction
+time. This page is the canonical reference for what the version means,
+when to bump it, and how to migrate older configs.
+
+## Why explicit versioning
+
+Without an explicit version, a legacy `assets/config/*.ron` loaded by a
+newer build would silently fall through `serde`'s `default` paths for
+any newly-added fields and reject any removed-or-renamed fields with a
+generic deserialization error. Both modes mask intent: the operator
+sees a config that "looks loaded" but is actually running a different
+shape than they wrote.
+
+The explicit `schema_version` makes the contract observable:
+
+- A *legacy* config (no `schema_version` field) deserializes to
+  `schema_version: 0` via `#[serde(default)]`.
+- `Simulation::new` rejects `schema_version: 0` with an `InvalidConfig`
+  error pointing at this page, so the operator audits the field
+  defaults rather than running a silent migration.
+- A config with `schema_version > CURRENT_CONFIG_SCHEMA_VERSION` is
+  rejected as forward-incompatible; the operator must upgrade
+  `elevator-core` or downgrade the config.
+
+## Asymmetry with snapshot versioning
+
+Snapshots (see [Snapshot Versioning](snapshot-versioning.md)) carry
+*two* version markers — a `u32` schema number and a crate-version
+string in the bytes envelope. Configs only need the `u32`, because:
+
+- Configs are human-edited RON, so the `crate-version` envelope (which
+  pins encoder details for postcard) has no equivalent — RON is
+  text-stable across crate versions.
+- The set of compatible mismatches is much smaller: there is no
+  "savefile from a different patch release" case. Either the schema
+  matches or it does not.
+
+## Bump triggers
+
+Bump `CURRENT_CONFIG_SCHEMA_VERSION` (in `crates/elevator-core/src/config.rs`)
+when *any* of these change in a way that legacy `assets/config/*.ron`
+files would silently mis-deserialize:
+
+- A field is removed or renamed.
+- A field's type changes (`u32` → `Option<u32>`, `Vec<T>` → `BTreeMap<K, T>`).
+- A field's default value changes in a way that materially alters
+  behaviour (e.g. flipping a feature flag's default, changing a
+  capacity threshold).
+- The set of valid enum variants expands and the additions are not
+  marked `#[non_exhaustive]`-safe (the legacy config would silently
+  pick the deserialization fallback on the new variants).
+
+Do **not** bump for:
+
+- Adding a new optional field with `#[serde(default)]` whose default
+  matches existing behaviour. Legacy configs continue to deserialize
+  correctly; bumping would force operators to audit an unchanged shape.
+- Pure refactors that reorder fields, rename internal types, or
+  reorganize modules without changing the RON shape.
+
+## Migration playbook
+
+When bumping the version, in the same PR:
+
+1. Update `CURRENT_CONFIG_SCHEMA_VERSION` and the doc comment on the
+   constant naming the change.
+2. Update every `assets/config/*.ron` to declare the new
+   `schema_version` value.
+3. Add a migration entry to this page (a "v1 → v2" subsection) listing
+   every changed field and the manual edit operators must apply.
+4. If the change is mechanical, ship a one-shot upgrade tool
+   (`elevator-config-upgrade --from 1 --to 2 < old.ron > new.ron`)
+   alongside the doc.
+
+The migration entries are kept in this doc so an operator carrying a
+pinned config across multiple core upgrades has a single canonical
+source for the diff. Migration code does not live in `core` itself —
+the validator is intentionally strict about version mismatches; the
+upgrade lives outside the read path.
+
+## Migrations
+
+Versions issued so far. Each section below lists the field changes the
+operator must apply when moving a config from the previous version to
+the current one.
+
+### v0 → v1 (initial versioning)
+
+There is no shape change; v1 is the first explicit version marker. To
+adopt:
+
+- Open the RON file and add `schema_version: 1,` as the first field
+  inside the top-level `SimConfig(...)` block.
+- Run `cargo run -- path/to/config.ron` (or `Simulation::new` from
+  Rust) to confirm validation passes.
+
+After v1, every v(N) → v(N+1) transition will have a real shape diff
+and an entry here.
+
+## Related
+
+- [`crates/elevator-core/src/config.rs`](https://docs.rs/elevator-core/latest/elevator_core/config/index.html)
+  — the `SimConfig` struct definition and `CURRENT_CONFIG_SCHEMA_VERSION`.
+- [Snapshot Versioning](snapshot-versioning.md) — the parallel policy
+  for `WorldSnapshot` bytes.
+- `Simulation::new` — the validator that surfaces version mismatches
+  as `SimError::InvalidConfig { field: "schema_version", reason: ... }`.
+
+## Next steps
+
+- For new configs, copy `assets/config/default.ron` and adjust — it
+  always pins to the current schema version.
+- For older configs, use the v0 → v1 entry above as a template; future
+  bumps will add new entries describing each shape change.

--- a/playground/src/domain/params/params.ts
+++ b/playground/src/domain/params/params.ts
@@ -194,6 +194,7 @@ export function buildScenarioRon(scenario: ScenarioMeta, overrides: Overrides): 
     .join("\n");
 
   return `SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: ${ronString(scenario.buildingName)},
         stops: [

--- a/playground/src/domain/scenarios/scenarios.ts
+++ b/playground/src/domain/scenarios/scenarios.ts
@@ -112,6 +112,7 @@ const convention: ScenarioMeta = {
   passengerMeanIntervalTicks: 30,
   passengerWeightRange: [55.0, 100.0],
   ron: `SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Convention Center",
         stops: [
@@ -389,6 +390,7 @@ function buildSkyscraperRon(): string {
                 ),`;
 
   return `SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Skyscraper",
         stops: [
@@ -638,6 +640,7 @@ const spaceElevator: ScenarioMeta = {
     showDayNight: false,
   },
   ron: `SimConfig(
+    schema_version: 1,
     building: BuildingConfig(
         name: "Orbital Tether",
         stops: [


### PR DESCRIPTION
## Summary
Adds a \`schema_version: u32\` field to \`SimConfig\` (RON shape) with a \`CURRENT_CONFIG_SCHEMA_VERSION = 1\` constant. Validation in \`Simulation::new\` now rejects:

- \`schema_version > CURRENT\` — forward-incompatible RON shape.
- \`schema_version == 0\` — legacy pre-versioning file (the \`#[serde(default)]\` value when the field is missing). The error surfaces an \`InvalidConfig { field: "schema_version", reason: ... }\` pointing at \`docs/src/config-versioning.md\` for the migration steps.

This closes the gap where a stale \`assets/config/*.ron\` loaded by a newer build would silently fall through serde defaults for added fields, masking config drift.

### What changed
- \`SimConfig\` gains \`schema_version: u32\` with \`#[serde(default)]\` so legacy RON deserializes to \`0\`, then explicitly fails validation.
- \`SimConfig::default()\` is now a manual \`impl\` that pins to \`CURRENT_CONFIG_SCHEMA_VERSION\`, so programmatically-built configs are valid by construction.
- All shipped \`assets/config/*.ron\` (default, annotated, space_elevator) declare \`schema_version: 1\`.
- All test fixtures and example configs declare the current version.
- New \`docs/src/config-versioning.md\` chapter covers the bump-trigger policy, the asymmetry with snapshot versioning (configs only need the \`u32\` — no crate-version envelope since RON is text-stable), and the v0 → v1 migration playbook.
- Four new \`config_tests.rs\` tests pin: legacy \`0\` rejected, forward-incompatible rejected, current accepted, all shipped assets pinned to current.

Closes #654.

## Test plan
- [x] \`cargo test -p elevator-core --all-features\` — all tests pass
- [x] \`cargo clippy -p elevator-core --all-features\` — no warnings
- [x] \`cargo build --workspace --all-features --all-targets\` — clean across workspace
- [x] \`scripts/lint-docs.sh --quick\` — clean
- [x] Pre-commit hook (fmt + clippy + tests + doctests + workspace check + docs lint) — pass