### PR TITLE
refactor(tui): replace AppState bool soup with UiOverlay enum (#648)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "16.0.3"
+version = "16.1.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-wasm"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "elevator-core",
  "getrandom 0.4.2",

--- a/crates/elevator-tui/src/app.rs
+++ b/crates/elevator-tui/src/app.rs
@@ -15,7 +15,7 @@ use elevator_core::traffic::{PoissonSource, TrafficSource as _};
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 
-use crate::state::{AppState, RightPanel, ShaftMode, Sparkline};
+use crate::state::{AppState, RightPanel, ShaftMode, Sparkline, UiOverlay};
 use crate::ui;
 
 /// Run the interactive TUI until the user quits.
@@ -60,7 +60,9 @@ fn event_loop(
     show_welcome: bool,
 ) -> Result<()> {
     let mut state = AppState::new(initial_tick_rate);
-    state.show_welcome = show_welcome;
+    if !show_welcome {
+        state = state.without_welcome();
+    }
     let mut traffic = PoissonSource::from_config(config);
     let cfg_tps = sim.time().ticks_per_second();
     let mut accumulator = 0.0_f64;
@@ -194,13 +196,16 @@ fn handle_key(state: &mut AppState, sim: &mut Simulation, code: KeyCode, modifie
         state.quit = true;
         return;
     }
-    if state.show_welcome {
-        handle_key_welcome(state);
-        return;
-    }
-    if state.show_help {
-        handle_key_help(state, code);
-        return;
+    match state.overlay {
+        Some(UiOverlay::Welcome) => {
+            handle_key_welcome(state);
+            return;
+        }
+        Some(UiOverlay::Help) => {
+            handle_key_help(state, code);
+            return;
+        }
+        None => {}
     }
     handle_key_main(state, sim, code);
 }
@@ -211,7 +216,7 @@ fn handle_key(state: &mut AppState, sim: &mut Simulation, code: KeyCode, modifie
 /// `q`, so a user who hits q-then-q doesn't accidentally quit while
 /// reading. Ctrl-C is checked in the dispatcher and still escapes.
 const fn handle_key_welcome(state: &mut AppState) {
-    state.show_welcome = false;
+    state.overlay = None;
 }
 
 /// Help overlay handler.
@@ -220,7 +225,7 @@ const fn handle_key_welcome(state: &mut AppState) {
 /// "quit the app" — same justification as welcome above.
 const fn handle_key_help(state: &mut AppState, code: KeyCode) {
     if matches!(code, KeyCode::Char('?' | 'q') | KeyCode::Esc) {
-        state.show_help = false;
+        state.overlay = None;
     }
 }
 
@@ -229,7 +234,7 @@ const fn handle_key_help(state: &mut AppState, code: KeyCode) {
 /// `Overview` and `DrillDown` without changing the keymap.
 fn handle_key_main(state: &mut AppState, sim: &mut Simulation, code: KeyCode) {
     match code {
-        KeyCode::Char('?') => state.show_help = true,
+        KeyCode::Char('?') => state.overlay = Some(UiOverlay::Help),
         KeyCode::Char('q') => state.quit = true,
         KeyCode::Char(' ') => {
             state.paused = !state.paused;

--- a/crates/elevator-tui/src/state.rs
+++ b/crates/elevator-tui/src/state.rs
@@ -88,9 +88,23 @@ impl Sparkline {
     }
 }
 
+/// Mutually-exclusive UI overlays the viewer can show on top of the
+/// active panels.
+///
+/// Replaces the old pair of `show_welcome` / `show_help` booleans,
+/// which carried an implicit "at most one is `true`" invariant the
+/// type system didn't enforce.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UiOverlay {
+    /// First-launch welcome card. Default on a fresh session unless
+    /// suppressed by `--no-welcome`.
+    Welcome,
+    /// Help cheat-sheet (toggled by `?`).
+    Help,
+}
+
 /// Top-level interactive app state.
 #[derive(Debug)]
-#[allow(clippy::struct_excessive_bools)]
 pub struct AppState {
     /// Sim is paused (no auto-stepping). `space` toggles, `.` single-steps.
     pub paused: bool,
@@ -136,11 +150,12 @@ pub struct AppState {
     ///
     /// [`flash`]: Self::flash
     pub status_seq: u64,
-    /// Help overlay is visible (toggled by `?`).
-    pub show_help: bool,
-    /// First-launch welcome overlay is visible. Dismissed by any key.
-    /// Default `true` unless suppressed by `--no-welcome`.
-    pub show_welcome: bool,
+    /// Currently-displayed overlay (welcome card or help cheat-sheet),
+    /// or `None` for the active viewer. The two were previously
+    /// flat `show_welcome`/`show_help` booleans with an implicit
+    /// "never both `true`" invariant; the enum makes the contract
+    /// explicit.
+    pub overlay: Option<UiOverlay>,
     /// User has requested a clean exit.
     pub quit: bool,
 }
@@ -167,8 +182,7 @@ impl AppState {
             snapshot_slot: None,
             status: None,
             status_seq: 0,
-            show_help: false,
-            show_welcome: true,
+            overlay: Some(UiOverlay::Welcome),
             quit: false,
         }
     }
@@ -176,7 +190,12 @@ impl AppState {
     /// Suppress the first-launch welcome overlay. Honoured by `--no-welcome`.
     #[must_use]
     pub const fn without_welcome(mut self) -> Self {
-        self.show_welcome = false;
+        // Only clears the welcome overlay, not other overlays (the
+        // help overlay can't be active at construction anyway, but
+        // matching on `Welcome` keeps the intent obvious).
+        if matches!(self.overlay, Some(UiOverlay::Welcome)) {
+            self.overlay = None;
+        }
         self
     }
 

--- a/crates/elevator-tui/src/ui/mod.rs
+++ b/crates/elevator-tui/src/ui/mod.rs
@@ -8,7 +8,7 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
-use crate::state::{AppState, RightPanel};
+use crate::state::{AppState, RightPanel, UiOverlay};
 
 pub mod dispatch;
 pub mod drilldown;
@@ -54,10 +54,10 @@ pub fn draw(frame: &mut Frame<'_>, state: &AppState, sim: &Simulation) {
     draw_footer(frame, outer[3], state);
 
     // Modal overlays render last so they sit above every panel.
-    if state.show_help {
-        help::draw(frame, frame.area());
-    } else if state.show_welcome {
-        welcome::draw(frame, frame.area(), sim);
+    match state.overlay {
+        Some(UiOverlay::Help) => help::draw(frame, frame.area()),
+        Some(UiOverlay::Welcome) => welcome::draw(frame, frame.area(), sim),
+        None => {}
     }
 }
 

--- a/crates/elevator-tui/tests/render_snapshot.rs
+++ b/crates/elevator-tui/tests/render_snapshot.rs
@@ -84,7 +84,7 @@ fn frame_with_welcome_overlay() {
 fn frame_with_help_overlay() {
     let sim = demo_sim(60);
     let mut state = AppState::new(1.0).without_welcome();
-    state.show_help = true;
+    state.overlay = Some(elevator_tui::state::UiOverlay::Help);
     let frame = render(&sim, &state, 100, 30);
     insta::assert_snapshot!("help_overlay", frame);
 }


### PR DESCRIPTION
## Summary
\`AppState\` carried \`#[allow(clippy::struct_excessive_bools)]\` because its \`show_welcome\` / \`show_help\` flags interleaved presentational overlay state with input/runtime state, with an implicit "at most one overlay is \`true\`" invariant the type system didn't enforce.

### What changed
- New \`pub enum UiOverlay { Welcome, Help }\`.
- \`show_welcome: bool, show_help: bool\` collapsed into \`overlay: Option<UiOverlay>\`. The mutual exclusion is now type-enforced — there is no representable state where both overlays are simultaneously visible.
- \`AppState::without_welcome\` clears the overlay only when it is \`Welcome\`, matching the original semantics.
- \`app.rs\` keymap dispatcher routes through a \`match state.overlay\` block instead of two if-checks.
- \`ui::draw\` similarly matches on the overlay enum.
- \`tests/render_snapshot.rs\` uses \`state.overlay = Some(UiOverlay::Help)\` instead of \`state.show_help = true\`.
- \`#[allow(clippy::struct_excessive_bools)]\` is removed; the remaining three independent bools (\`paused\`, \`follow_focused\`, \`quit\`) are below the lint's default threshold.

No behavior change: all existing TUI snapshot tests pass without re-baselining.

Closes #648.

## Test plan
- [x] \`cargo test -p elevator-tui\` — 17 tests pass (snapshots unchanged).
- [x] \`cargo clippy -p elevator-tui --all-features --tests\` — no warnings (the prior \`struct_excessive_bools\` suppression is gone).
- [x] Pre-commit hook (fmt + clippy + tests + doctests + workspace check) — pass.