### PR TITLE
feat(core): expose log_format helper for non-FFI host log-drain parity (#656)

### DIFF
--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -941,3 +941,35 @@ impl<T> Default for EventChannel<T> {
         Self::new()
     }
 }
+
+/// Helpers for surfacing simulation events as log-style records.
+///
+/// The FFI host exposes a "log drain" API ([`ev_drain_log_messages`])
+/// that polling consumers (e.g. `GameMaker`) call to surface
+/// debug-formatted strings for events emitted during the most recent
+/// step. Other binding crates wrap the same primitive via this
+/// module so every host produces the same message text and severity
+/// for a given `Event`.
+///
+/// [`ev_drain_log_messages`]: https://docs.rs/elevator-ffi/latest/elevator_ffi/fn.ev_drain_log_messages.html
+pub mod log_format {
+    use super::Event;
+
+    /// Severity level matching the syslog/FFI convention used by
+    /// host log-drain APIs: `0` trace · `1` debug · `2` info ·
+    /// `3` warn · `4` error.
+    pub const LEVEL_DEBUG: u8 = 1;
+
+    /// Format an event for log-style consumption. Returns
+    /// `(level, message)` where `message` is the `Debug` rendering
+    /// of the event and `level` is currently always
+    /// [`LEVEL_DEBUG`].
+    ///
+    /// Hosts wrap this in their idiomatic surface — e.g. a
+    /// `Vec<JsValue>` for wasm, a Godot `Array` of dictionaries,
+    /// or the FFI's borrowed `EvLogMessage` struct.
+    #[must_use]
+    pub fn format_event(event: &Event) -> (u8, String) {
+        (LEVEL_DEBUG, format!("{event:?}"))
+    }
+}

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -679,8 +679,6 @@ pub unsafe extern "C" fn ev_sim_step(handle: *mut EvSim) -> EvStatus {
     })
 }
 
-const LEVEL_DEBUG: u8 = 1;
-
 fn forward_pending_events(ev: &mut EvSim) {
     let maybe_cb = LOG_CALLBACK.lock().ok().and_then(|slot| *slot);
     // Skip both legs entirely if neither side wants the stream.
@@ -695,16 +693,16 @@ fn forward_pending_events(ev: &mut EvSim) {
         .and_then(|d| i64::try_from(d.as_nanos()).ok())
         .unwrap_or(0);
     for event in ev.sim.pending_events() {
-        let msg = format!("{event:?}");
+        let (level, msg) = elevator_core::events::log_format::format_event(event);
         let Ok(c) = CString::new(msg) else { continue };
         if let Some(cb) = maybe_cb {
             // Safety: ev_set_log_callback's contract covers pointer
             // validity for the duration of the callback installation.
-            unsafe { cb(LEVEL_DEBUG, c.as_ptr()) };
+            unsafe { cb(level, c.as_ptr()) };
         }
         if ev.log_polling_active {
             ev.pending_log_messages.push_back(LogRecord {
-                level: LEVEL_DEBUG,
+                level,
                 ts_ns: now_ns,
                 msg: c,
             });

--- a/crates/elevator-gdext/src/sim_node.rs
+++ b/crates/elevator-gdext/src/sim_node.rs
@@ -579,6 +579,34 @@ impl ElevatorSim {
         }
         arr
     }
+
+    /// Format the currently-pending events as log-style records,
+    /// matching the FFI's `ev_drain_log_messages` shape. Non-consuming
+    /// — events remain in the queue and are still returned by
+    /// [`drain_events`](Self::drain_events).
+    ///
+    /// Each entry is a `Dictionary` with `level` (int — `1` debug)
+    /// and `message` (String — `Debug` rendering of the core event).
+    /// Closes the log-drain parity gap so Godot hosts can surface
+    /// simulator diagnostics with the same text Unity / `GameMaker`
+    /// consumers see.
+    #[func]
+    fn peek_log_messages(&mut self) -> Array<Dictionary<Variant, Variant>> {
+        use elevator_core::events::log_format;
+        let Some(sim) = self.sim.as_mut() else {
+            return Array::new();
+        };
+        let mut arr = Array::new();
+        for event in sim.pending_events() {
+            let (level, message) = log_format::format_event(event);
+            let d = dict! {
+                "level" => i64::from(level),
+                "message" => message,
+            };
+            arr.push(&d);
+        }
+        arr
+    }
 }
 
 impl ElevatorSim {

--- a/crates/elevator-wasm/src/dto.rs
+++ b/crates/elevator-wasm/src/dto.rs
@@ -93,6 +93,22 @@ pub struct StopDto {
     pub residents: u32,
 }
 
+/// Debug-formatted view of a pending event, paired with a syslog-style
+/// severity level. Mirrors the `EvLogMessage` shape exposed by the FFI's
+/// `ev_drain_log_messages` API so JS consumers can log simulator
+/// diagnostics with the same text and level codes as Unity / `GameMaker`
+/// hosts.
+#[derive(Serialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct LogMessageDto {
+    /// Severity (`0` trace · `1` debug · `2` info · `3` warn · `4` error).
+    /// Currently always `1` — every event is surfaced at debug.
+    pub level: u8,
+    /// Debug-rendered event text. Format matches
+    /// `format!("{event:?}")` for the underlying core `Event`.
+    pub message: String,
+}
+
 /// Top-level snapshot returned by [`WasmSim::snapshot`](crate::WasmSim::snapshot).
 #[derive(Serialize, Tsify)]
 #[tsify(into_wasm_abi)]

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -697,6 +697,28 @@ impl WasmSim {
             .collect()
     }
 
+    /// Format the currently-pending events as log-style records,
+    /// matching the FFI's `ev_drain_log_messages` shape. Non-consuming
+    /// — events remain in the queue and are still returned by
+    /// [`drain_events`](Self::drain_events).
+    ///
+    /// Severity is currently always `1` (debug); message text is the
+    /// `Debug` rendering of the underlying core event. Closes the
+    /// log-drain parity gap so browser hosts can surface simulator
+    /// diagnostics with the same text Unity / `GameMaker` consumers see.
+    #[wasm_bindgen(js_name = peekLogMessages)]
+    pub fn peek_log_messages(&mut self) -> Vec<dto::LogMessageDto> {
+        use elevator_core::events::log_format;
+        self.inner
+            .pending_events()
+            .iter()
+            .map(|event| {
+                let (level, message) = log_format::format_event(event);
+                dto::LogMessageDto { level, message }
+            })
+            .collect()
+    }
+
     /// Current aggregate metrics.
     pub fn metrics(&self) -> dto::MetricsDto {
         dto::MetricsDto::build(&self.inner)


### PR DESCRIPTION
## Summary

Closes #656 — adds log-drain parity for wasm and gdext hosts, with the format string centralized in core.

- **core**: new `elevator_core::events::log_format::format_event(event) → (level, message)` helper. Single source of truth for the debug-formatted log text and severity.
- **ffi**: `forward_pending_events` now uses the core helper instead of inline `format!("{event:?}")`. Behavior unchanged.
- **wasm**: new `peekLogMessages()` method returning `LogMessageDto[]`. Added to the tsify-generated TS bindings.
- **gdext**: new `peek_log_messages()` returning `Array<Dictionary>` with `level` (i64) + `message` (String) keys.
- **bevy**: intentionally skipped — Bevy hosts already receive events through the message bus and have native `tracing` for log-style output, so no parity wrapper is needed.

Both `peekLogMessages` / `peek_log_messages` are non-consuming peeks: events stay in the core queue and are still returned by `drainEvents` / `drain_events`. Severity is always `1` (debug), matching the FFI's current behavior.

## Test plan

- [x] `cargo build -p elevator-ffi --all-features`
- [x] `cargo check --workspace --all-features --all-targets`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo test -p elevator-core --all-features` (159 + doc-tests pass)
- [x] `cargo test -p elevator-ffi --all-features` (53 + 10 pass)
- [x] `cargo fmt --all --check`
- [x] `scripts/build-wasm.sh` — TS bindings regenerated; `LogMessageDto` and `peekLogMessages` show up in `playground/public/pkg/elevator_wasm.d.ts`
- [x] `scripts/check-bindings.sh`
- [x] `scripts/check-abi-pins.sh` (ABI v5, unchanged — pure additive change to host wrappers)
- [x] Pre-commit hook full gate green