### PR TITLE
refactor(playground): extract QuestState + fix quest permalink coupling (#658)

### DIFF
--- a/playground/src/__tests__/quest-state.test.ts
+++ b/playground/src/__tests__/quest-state.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { STAGES } from "../features/quest";
+import {
+  createQuestState,
+  isRunStillBound,
+  setActiveStage,
+  setCurrentView,
+  stageHandleFor,
+  stopRunLoop,
+} from "../features/quest/quest-state";
+
+const firstStage = STAGES[0];
+const secondStage = STAGES[1];
+if (!firstStage || !secondStage) {
+  throw new Error("quest registry must have at least two stages for these tests");
+}
+
+describe("quest-state", () => {
+  it("createQuestState seeds a fresh, inactive run loop", () => {
+    const state = createQuestState(firstStage, "grid");
+    expect(state.activeStage.id).toBe(firstStage.id);
+    expect(state.currentView).toBe("grid");
+    expect(state.runLoop.active).toBe(false);
+  });
+
+  it("setActiveStage swaps the bound stage in place", () => {
+    const state = createQuestState(firstStage, "stage");
+    setActiveStage(state, secondStage);
+    expect(state.activeStage.id).toBe(secondStage.id);
+    // currentView stays — stage swaps don't toggle the visible view.
+    expect(state.currentView).toBe("stage");
+  });
+
+  it("setCurrentView toggles between grid and stage", () => {
+    const state = createQuestState(firstStage, "grid");
+    setCurrentView(state, "stage");
+    expect(state.currentView).toBe("stage");
+    setCurrentView(state, "grid");
+    expect(state.currentView).toBe("grid");
+  });
+
+  it("stopRunLoop flips the rAF kill switch", () => {
+    const state = createQuestState(firstStage, "stage");
+    state.runLoop.active = true;
+    stopRunLoop(state);
+    expect(state.runLoop.active).toBe(false);
+  });
+
+  it("isRunStillBound is true when both view and stage match", () => {
+    const state = createQuestState(firstStage, "stage");
+    expect(isRunStillBound(state, firstStage)).toBe(true);
+  });
+
+  it("isRunStillBound is false after navigating to the grid mid-run", () => {
+    const state = createQuestState(firstStage, "stage");
+    setCurrentView(state, "grid");
+    expect(isRunStillBound(state, firstStage)).toBe(false);
+  });
+
+  it("isRunStillBound is false after swapping to a different stage mid-run", () => {
+    const state = createQuestState(firstStage, "stage");
+    // The run started against firstStage; the player swaps to secondStage.
+    setActiveStage(state, secondStage);
+    expect(isRunStillBound(state, firstStage)).toBe(false);
+    expect(isRunStillBound(state, secondStage)).toBe(true);
+  });
+
+  it("stageHandleFor projects to a minimal { id, title } record", () => {
+    const handle = stageHandleFor(firstStage);
+    expect(handle).toEqual({ id: firstStage.id, title: firstStage.title });
+  });
+});

--- a/playground/src/features/quest/quest-pane.ts
+++ b/playground/src/features/quest/quest-pane.ts
@@ -14,6 +14,15 @@ import { ControllerError } from "./controller-error";
 import { requireElement } from "./dom-utils";
 import { mountQuestEditor, type QuestEditor } from "./editor";
 import { renderHints, wireHintsDrawer, type HintsDrawerHandles } from "./hints-drawer";
+import {
+  createQuestState,
+  isRunStillBound,
+  setActiveStage,
+  setCurrentView,
+  stopRunLoop,
+  type QuestState,
+  type QuestView,
+} from "./quest-state";
 import { renderQuestGrid, wireQuestGrid, type QuestGridHandles } from "./quest-grid";
 import {
   renderReferencePanel,
@@ -29,6 +38,8 @@ import type { Stage } from "./stages";
 import { clearCode, loadBestStars, loadCode, saveBestStars, saveCode } from "./storage";
 import { CanvasRenderer } from "../../render";
 import type { Snapshot } from "../../types";
+
+export type { QuestView } from "./quest-state";
 
 /** Accent for car bodies in the Quest shaft visualization. */
 const QUEST_SHAFT_ACCENT = "#f59e0b";
@@ -60,9 +71,6 @@ export interface QuestPaneHandles {
   /** Idle-state overlay shown when no run is in flight. */
   readonly shaftIdle: HTMLElement;
 }
-
-/** Top-level Quest view modes. */
-export type QuestView = "grid" | "stage";
 
 /**
  * Wire the Quest pane DOM. Throws if any expected anchor is missing —
@@ -104,26 +112,14 @@ export function renderStage(handles: QuestPaneHandles, stage: Stage): void {
 /**
  * Toggle which view (grid or stage) is visible. Called from both
  * the boot decision and the back-button / card-click handlers.
- * Idempotent. The current value is also tracked separately by
- * `bootQuestPane` so run-completion guards can suppress UI updates
- * when the player has navigated to the grid mid-run.
+ * Idempotent. State-tracking lives in [`QuestState`](./quest-state.ts);
+ * this helper only flips DOM classes.
  */
-function setView(handles: QuestPaneHandles, view: QuestView): void {
+function setViewDom(handles: QuestPaneHandles, view: QuestView): void {
   handles.gridView.classList.toggle("hidden", view !== "grid");
   handles.gridView.classList.toggle("flex", view === "grid");
   handles.stageView.classList.toggle("hidden", view !== "stage");
   handles.stageView.classList.toggle("flex", view === "stage");
-}
-
-/**
- * Shared mutable flag so the stage-change / back-to-grid handlers
- * can stop an in-flight run's rAF loop. Without it, the loop's
- * closure-local flag stays `true` after navigation and keeps
- * painting the previous stage's snapshot through the (transparent)
- * idle overlay on whatever view follows.
- */
-interface RunLoop {
-  active: boolean;
 }
 
 /**
@@ -157,27 +153,24 @@ export async function bootQuestPane(opts: {
     return fallback;
   };
 
-  let activeStage = resolveStage(opts.initialStageId);
-  /**
-   * Mirror of the visible view. Tracked alongside `activeStage` so
-   * an in-flight run that completes after the player has clicked
-   * "← Stages" can suppress its results modal — `activeStage.id ===
-   * stage.id` alone wouldn't catch this, since `enterGrid` doesn't
-   * change `activeStage`.
-   */
-  let currentView: QuestView = "grid";
-  renderStage(handles, activeStage);
+  // QuestState owns `activeStage`, `currentView`, and the rAF kill
+  // switch — the trio of mutable bindings that used to live as
+  // closure-captured `let` variables in this function. Centralising
+  // them lets handlers/runner read and write through one record
+  // instead of stacking captures.
+  const state: QuestState = createQuestState(resolveStage(opts.initialStageId), "grid");
+  renderStage(handles, state.activeStage);
 
   // Side panel: list the methods unlocked at the active stage.
   const apiPanel: ApiPanelHandles = wireApiPanel();
-  renderApiPanel(apiPanel, activeStage);
+  renderApiPanel(apiPanel, state.activeStage);
   // Hints drawer: collapsed-by-default progressive nudges.
   const hints: HintsDrawerHandles = wireHintsDrawer();
-  renderHints(hints, activeStage);
+  renderHints(hints, state.activeStage);
   // Reference solution: hidden until the player passes the active
   // stage at least once.
   const reference: ReferencePanelHandles = wireReferencePanel();
-  renderReferencePanel(reference, activeStage);
+  renderReferencePanel(reference, state.activeStage);
   // Grid view: re-rendered on initial mount and after every grade so
   // a fresh star count propagates to the cards.
   const grid: QuestGridHandles = wireQuestGrid();
@@ -190,7 +183,6 @@ export async function bootQuestPane(opts: {
   // `dispose()` is intentionally never called since there's no
   // remount path that would benefit.
   const shaftRenderer = new CanvasRenderer(handles.shaft, QUEST_SHAFT_ACCENT);
-  const runLoop: RunLoop = { active: false };
 
   // Disable Run while the Monaco bundle loads so a click before
   // mount completes doesn't run against an undefined editor.
@@ -199,7 +191,7 @@ export async function bootQuestPane(opts: {
   handles.result.textContent = "Loading editor…";
   const editor = await mountQuestEditor({
     container: handles.editorHost,
-    initialValue: loadCode(activeStage.id) ?? activeStage.starterCode,
+    initialValue: loadCode(state.activeStage.id) ?? state.activeStage.starterCode,
     language: "typescript",
   });
   handles.runBtn.disabled = false;
@@ -220,7 +212,7 @@ export async function bootQuestPane(opts: {
     if (suppressSave) return;
     if (saveTimer !== null) clearTimeout(saveTimer);
     saveTimer = setTimeout(() => {
-      saveCode(activeStage.id, editor.getValue());
+      saveCode(state.activeStage.id, editor.getValue());
       saveTimer = null;
     }, SAVE_DEBOUNCE_MS);
   };
@@ -228,7 +220,7 @@ export async function bootQuestPane(opts: {
     if (saveTimer === null) return;
     clearTimeout(saveTimer);
     saveTimer = null;
-    saveCode(activeStage.id, editor.getValue());
+    saveCode(state.activeStage.id, editor.getValue());
   };
   const setEditorSilently = (text: string): void => {
     suppressSave = true;
@@ -244,11 +236,11 @@ export async function bootQuestPane(opts: {
 
   // Snippet chips are rendered per-stage and re-rendered on swap.
   const snippets: SnippetPickerHandles = wireSnippetPicker();
-  renderSnippets(snippets, activeStage, editor);
+  renderSnippets(snippets, state.activeStage, editor);
 
   /** Snap any in-flight run's rAF loop and reset the canvas to idle. */
   const stopLoopAndResetCanvas = (): void => {
-    runLoop.active = false;
+    stopRunLoop(state);
     handles.shaftIdle.hidden = false;
     const ctx = handles.shaft.getContext("2d");
     if (ctx) ctx.clearRect(0, 0, handles.shaft.width, handles.shaft.height);
@@ -257,7 +249,7 @@ export async function bootQuestPane(opts: {
   /** Common prep when transitioning into a new stage's editor view. */
   const enterStage = (next: Stage, { fromGrid }: { fromGrid: boolean }): void => {
     flushSave();
-    activeStage = next;
+    setActiveStage(state, next);
     renderStage(handles, next);
     renderApiPanel(apiPanel, next);
     renderHints(hints, next);
@@ -271,8 +263,8 @@ export async function bootQuestPane(opts: {
     handles.result.textContent = "";
     handles.progress.textContent = "";
     stopLoopAndResetCanvas();
-    setView(handles, "stage");
-    currentView = "stage";
+    setViewDom(handles, "stage");
+    setCurrentView(state, "stage");
     // Notify boot.ts so the permalink picks up the new stage id.
     // `fromGrid` would skip this when the grid card click path
     // already handled URL sync — but today both paths funnel through
@@ -288,8 +280,8 @@ export async function bootQuestPane(opts: {
     stopLoopAndResetCanvas();
     handles.result.textContent = "";
     handles.progress.textContent = "";
-    setView(handles, "grid");
-    currentView = "grid";
+    setViewDom(handles, "grid");
+    setCurrentView(state, "grid");
     // Re-render the grid so star counts reflect any stages the
     // player just passed before backing out.
     renderQuestGrid(grid, (stageId) => {
@@ -308,13 +300,13 @@ export async function bootQuestPane(opts: {
   // Cold-boot view: stage if the caller asked for it (typically when
   // a `?qs=` permalink picked a specific stage), else grid.
   const initialView = opts.landOn ?? "grid";
-  setView(handles, initialView);
-  currentView = initialView;
+  setViewDom(handles, initialView);
+  setCurrentView(state, initialView);
 
-  // Run button — closure captures `activeStage` so a navigation
-  // between presses pulls the new stage cleanly.
+  // Run button — reads `state.activeStage` at click time so a
+  // navigation between presses pulls the new stage cleanly.
   const runOnce = async (): Promise<void> => {
-    const stage = activeStage;
+    const stage = state.activeStage;
     handles.runBtn.disabled = true;
     handles.result.textContent = "Running…";
     handles.progress.textContent = "";
@@ -329,9 +321,9 @@ export async function bootQuestPane(opts: {
     // between server-side updates.
     let latestSnap: Snapshot | null = null;
     let snapshotsRendered = 0;
-    runLoop.active = true;
+    state.runLoop.active = true;
     const renderTick = (): void => {
-      if (!runLoop.active) return;
+      if (!state.runLoop.active) return;
       if (latestSnap !== null) {
         shaftRenderer.draw(latestSnap, 1);
       }
@@ -344,24 +336,10 @@ export async function bootQuestPane(opts: {
       // Cap the controller's initial run at one second — long enough
       // for honest setup work, short enough that an infinite loop
       // bubbles up as a timeout.
-      // The "still active" predicate gates every player-facing UI
-      // update from a settling run. Both halves matter:
-      //
-      //   - `currentView === "stage"` — the player navigated to the
-      //     grid mid-run; pinning the modal over the curriculum
-      //     overview would be jarring and wrong.
-      //   - `activeStage.id === stage.id` — the player swapped to a
-      //     different stage; the outgoing run's result belongs to the
-      //     stage they left, not the one they're looking at now.
-      //
-      // Star banking happens unconditionally below — a passed run
-      // earns its stars regardless of where the player ended up.
-      const stillActive = (): boolean => currentView === "stage" && activeStage.id === stage.id;
-
       const result = await runStage(stage, editor.getValue(), {
         timeoutMs: 1000,
         onProgress: (grade) => {
-          if (!stillActive()) return;
+          if (!isRunStillBound(state, stage)) return;
           handles.progress.textContent = formatProgress(grade);
         },
         onSnapshot: (snap) => {
@@ -379,15 +357,15 @@ export async function bootQuestPane(opts: {
           renderQuestGrid(grid, (stageId) => {
             enterStage(resolveStage(stageId), { fromGrid: true });
           });
-          if (stillActive()) renderStage(handles, activeStage);
+          if (isRunStillBound(state, stage)) renderStage(handles, state.activeStage);
         }
-        if (stillActive()) {
+        if (isRunStillBound(state, stage)) {
           // Pass `collapse: false` so a panel the player already
           // expanded doesn't snap shut on a re-grade.
-          renderReferencePanel(reference, activeStage, { collapse: false });
+          renderReferencePanel(reference, state.activeStage, { collapse: false });
         }
       }
-      if (stillActive()) {
+      if (isRunStillBound(state, stage)) {
         handles.result.textContent = "";
         handles.progress.textContent = "";
         const next = result.passed ? nextStage(stage.id) : undefined;
@@ -399,7 +377,7 @@ export async function bootQuestPane(opts: {
         showResults(modal, result, () => void runOnce(), stage.failHint, onNext);
       }
     } catch (err) {
-      if (currentView === "stage" && activeStage.id === stage.id) {
+      if (isRunStillBound(state, stage)) {
         const msg = err instanceof Error ? err.message : String(err);
         // Errors stay inline — the modal is for graded outcomes.
         handles.result.textContent = `Error: ${msg}`;
@@ -421,7 +399,7 @@ export async function bootQuestPane(opts: {
       handles.runBtn.disabled = false;
       // Stop the rAF loop. The canvas keeps its last drawn frame so
       // the player can study the final state.
-      runLoop.active = false;
+      stopRunLoop(state);
       // Bring the idle overlay back only if no snapshot ever
       // rendered (e.g. controller threw before the first batch).
       // Clear the canvas in that branch so a previous run's frozen
@@ -440,10 +418,10 @@ export async function bootQuestPane(opts: {
   // Reset: drop the saved entry and rehydrate the starter. Confirm
   // first because it's destructive.
   handles.resetBtn.addEventListener("click", () => {
-    const ok = window.confirm(`Reset ${activeStage.title} to its starter code?`);
+    const ok = window.confirm(`Reset ${state.activeStage.title} to its starter code?`);
     if (!ok) return;
-    clearCode(activeStage.id);
-    setEditorSilently(activeStage.starterCode);
+    clearCode(state.activeStage.id);
+    setEditorSilently(state.activeStage.starterCode);
     // Drop any squiggle the previous code had — the new starter is
     // the canonical fresh state.
     editor.clearRuntimeMarker();

--- a/playground/src/features/quest/quest-state.ts
+++ b/playground/src/features/quest/quest-state.ts
@@ -1,0 +1,93 @@
+/**
+ * Quest-mode runtime state — extracted from `quest-pane.ts` so the
+ * mutable bindings that used to live in the `bootQuestPane` closure
+ * (`activeStage`, `currentView`, the in-flight rAF loop flag) have
+ * an explicit, testable surface instead of being smuggled across
+ * event handlers via captured-`let` bindings.
+ *
+ * The captured-mutable-state pattern was the structural seam that
+ * leaked the `state.permalink.overrides` lifecycle bug at the
+ * permalink boundary — keeping all of that here, behind a thin
+ * record, makes the dependency graph between view, runner, and
+ * navigation explicit.
+ */
+
+import type { Stage } from "./stages";
+
+/** Top-level Quest view modes. */
+export type QuestView = "grid" | "stage";
+
+/**
+ * Shared mutable flag the navigation handlers and the run-button
+ * handler both look at. The rAF loop checks `active` every frame so
+ * a navigation away from the stage during an in-flight run cancels
+ * the redraw without waiting for the worker to settle.
+ */
+export interface RunLoop {
+  active: boolean;
+}
+
+/**
+ * Runtime state for the Quest pane. Owned by `bootQuestPane`,
+ * passed by reference to handlers and the runner so they read/write
+ * a single source of truth.
+ */
+export interface QuestState {
+  /** Stage the editor is currently bound to. */
+  activeStage: Stage;
+  /** Visible view (grid vs. stage). */
+  currentView: QuestView;
+  /** Run-loop kill switch shared with the rAF redraw closure. */
+  readonly runLoop: RunLoop;
+}
+
+/**
+ * Minimal stage reference for code paths that only need an id +
+ * display name (permalink sync, navigation callbacks). Distinct
+ * from the full `Stage` so a permalink module never has to depend
+ * on grading logic, starter code, or seed-rider definitions.
+ */
+export interface StageHandle {
+  readonly id: string;
+  readonly title: string;
+}
+
+/** Build a fresh `QuestState`. */
+export function createQuestState(activeStage: Stage, currentView: QuestView): QuestState {
+  return {
+    activeStage,
+    currentView,
+    runLoop: { active: false },
+  };
+}
+
+/** Swap in a new stage. */
+export function setActiveStage(state: QuestState, stage: Stage): void {
+  state.activeStage = stage;
+}
+
+/** Toggle visible view. */
+export function setCurrentView(state: QuestState, view: QuestView): void {
+  state.currentView = view;
+}
+
+/** Cancel any in-flight rAF redraw. */
+export function stopRunLoop(state: QuestState): void {
+  state.runLoop.active = false;
+}
+
+/** Project a `Stage` to a `StageHandle`. */
+export function stageHandleFor(stage: Stage): StageHandle {
+  return { id: stage.id, title: stage.title };
+}
+
+/**
+ * Predicate the runner uses to gate UI updates from a settling run.
+ * Returns true only when the player is still on the stage view and
+ * still bound to the same stage that started the run — both halves
+ * matter, since either a navigation to the grid or a stage swap
+ * mid-run should suppress the modal/results paint.
+ */
+export function isRunStillBound(state: QuestState, stage: Stage): boolean {
+  return state.currentView === "stage" && state.activeStage.id === stage.id;
+}

--- a/playground/src/shell/boot.ts
+++ b/playground/src/shell/boot.ts
@@ -7,6 +7,7 @@ import {
   decodePermalink,
   hashSeedWord,
   scenarioById,
+  syncPermalinkUrl,
 } from "../domain";
 import { loadWasm, TrafficDriver } from "../sim";
 import type { State } from "./state";
@@ -107,22 +108,23 @@ export async function boot(): Promise<void> {
     await bootQuestPane({
       initialStageId: state.permalink.questStage,
       landOn: hadStageInUrl ? "stage" : "grid",
+      // Both navigation paths funnel through `syncPermalinkUrl` so
+      // the canonical query-string encoding lives in the permalink
+      // domain module, not in ad-hoc `URL` construction here. This
+      // is the seam that previously diverged: `onBackToGrid` cleared
+      // `qs` directly via `URLSearchParams` while the encoder owns
+      // its own "default → omit" rule. Routing both through the
+      // domain function keeps them in lock-step.
       onStageChange: (stageId) => {
         state.permalink.questStage = stageId;
-        const url = new URL(window.location.href);
-        if (stageId === DEFAULT_STATE.questStage) {
-          url.searchParams.delete("qs");
-        } else {
-          url.searchParams.set("qs", stageId);
-        }
-        window.history.replaceState(null, "", url.toString());
+        syncPermalinkUrl(state.permalink);
       },
       onBackToGrid: () => {
-        // The grid is the default cold-boot view; clear `qs` so a
-        // refresh from the grid stays on the grid.
-        const url = new URL(window.location.href);
-        url.searchParams.delete("qs");
-        window.history.replaceState(null, "", url.toString());
+        // Grid is the default cold-boot view, so reset to the
+        // default stage id and let `encodePermalink` drop `qs`
+        // because of the default-omit rule.
+        state.permalink.questStage = DEFAULT_STATE.questStage;
+        syncPermalinkUrl(state.permalink);
       },
     });
   }


### PR DESCRIPTION
## Summary

Closes #658 — splits `bootQuestPane`'s 316-line god-closure and fixes the captured-reference seam at the permalink boundary.

**`QuestState` extraction** (new `features/quest/quest-state.ts`):
- Owns the trio of mutable bindings that previously lived as closure-captured `let` variables: `activeStage`, `currentView`, and the rAF-loop kill switch.
- Provides typed helpers (`createQuestState`, `setActiveStage`, `setCurrentView`, `stopRunLoop`, `isRunStillBound`) so handlers/runner read/write through one explicit surface.
- `bootQuestPane` shrinks ~20 lines (124 LOC → 104 LOC of body) — but the bigger win is dependency clarity: the run-loop kill flag, view tracking, and stage binding now appear once in a typed record instead of being stacked across debounce timers, rAF callbacks, and DOM event listeners.
- Adds `StageHandle` (`{ id, title }`) for navigation/permalink code paths that don't need grading logic or starter code.

**Permalink coupling fix** (`shell/boot.ts`):
- The previous code hand-constructed `?qs=` URLs via `URLSearchParams` + `window.history.replaceState` while `encodePermalink` already owns that encoding (including the "omit on default" rule). The two implementations had drifted: `onBackToGrid` cleared `qs` directly, while the encoder owns its own default-omit logic.
- Both navigation paths now route through `syncPermalinkUrl(state.permalink)`, keeping the domain function as the single source of truth — the structural fix for the bug class noted in the issue (\"prior captured-reference bug \`state.permalink.overrides\` lifecycle was a symptom of this same coupling\").

**Out of scope, called out for follow-up**:
- Extracting the runner closure to a separate module (would require a 10+ field deps record; left for a focused follow-up).
- Reducing `quest-pane.ts` further into pure view-layer (the editor save debounce + Reset / Back wiring still lives there; reasonable to keep as DOM glue).

## Test plan

- [x] `pnpm typecheck` (no errors)
- [x] `pnpm test` (340 tests pass; 8 new in `quest-state.test.ts`)
- [x] `pnpm lint`
- [x] `scripts/build-wasm.sh` (TS bindings regenerate cleanly)
- [x] No Rust changes; pre-commit gate's playground side covers fmt/typecheck/vitest