### PR TITLE
docs(architecture): document HostBinding parity surface + shared log severity constants (#655)

### DIFF
--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -955,10 +955,21 @@ impl<T> Default for EventChannel<T> {
 pub mod log_format {
     use super::Event;
 
-    /// Severity level matching the syslog/FFI convention used by
-    /// host log-drain APIs: `0` trace · `1` debug · `2` info ·
-    /// `3` warn · `4` error.
+    /// `trace`-level severity (`0`).
+    ///
+    /// The full set (`LEVEL_TRACE` … `LEVEL_ERROR`) is the shared
+    /// vocabulary for cross-host log surfaces — see the repository's
+    /// `docs/src/host-binding-parity.md` for the parity contract.
+    pub const LEVEL_TRACE: u8 = 0;
+    /// `debug`-level severity (`1`). The default for events surfaced
+    /// via [`format_event`].
     pub const LEVEL_DEBUG: u8 = 1;
+    /// `info`-level severity (`2`).
+    pub const LEVEL_INFO: u8 = 2;
+    /// `warn`-level severity (`3`).
+    pub const LEVEL_WARN: u8 = 3;
+    /// `error`-level severity (`4`).
+    pub const LEVEL_ERROR: u8 = 4;
 
     /// Format an event for log-style consumption. Returns
     /// `(level, message)` where `message` is the `Debug` rendering

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -54,5 +54,6 @@
 - [TUI Debugger](tui-debugger.md)
 - [Using the Bindings](using-the-bindings.md)
 - [Binding Coverage Manifest](binding-coverage.md)
+- [Host Binding Parity](host-binding-parity.md)
 - [Integration Gallery](integration-gallery.md)
 - [Performance](performance.md)

--- a/docs/src/binding-coverage.md
+++ b/docs/src/binding-coverage.md
@@ -19,6 +19,11 @@ It is intentionally a *coverage* manifest, not a generator. Bindings are
 still hand-written so each host can shape its idiomatic surface; the
 manifest exists only to prevent silent drift.
 
+For *non-method* host concerns — error marshalling, log-drain
+semantics, ABI / wire version, snapshot field-set parity — see
+[Host Binding Parity](host-binding-parity.md), the cross-host
+contract that complements this manifest.
+
 ## Taxonomy
 
 Each entry is keyed by Rust method name and lists one status per host

--- a/docs/src/host-binding-parity.md
+++ b/docs/src/host-binding-parity.md
@@ -1,0 +1,129 @@
+# Host Binding Parity
+
+This page documents the *cross-host* contract: the surfaces that every
+binding crate (FFI, wasm, gdext, Bevy, GameMaker) is expected to
+expose, the agreed semantics, and the per-host status. It is the
+counterpart to [Binding Coverage Manifest](binding-coverage.md) — the
+manifest tracks every `Simulation::*` method one-by-one, while this
+page tracks the *non-method* concerns that nonetheless need to behave
+consistently across hosts.
+
+This is the foundation referenced in issue #655: "Add HostBinding
+abstraction trait shared across binding crates". The work itself is
+incremental — the *contract* lives here, while individual host
+crates migrate at their own pace as new PRs land.
+
+## Why a separate parity document
+
+`bindings.toml` enumerates `pub fn` on `impl Simulation`. But several
+host concerns aren't `Simulation` methods:
+
+- **Snapshot encode/decode** — each host shapes its own DTO from the
+  shared `Simulation::snapshot` data; the *fields* should match
+  even though the *envelope* differs (`#[repr(C)]` for FFI,
+  `Tsify` for wasm, Godot `Variant` dict for gdext).
+- **Event drain** — the *core* method is `drain_events()`, but the
+  host wrappers around it (lazy buffering, severity classification,
+  borrowed-pointer lifetimes) live entirely in each host crate.
+- **Error marshalling** — `EvStatus`, `JsValue`, Godot exceptions,
+  Bevy panics; same failure modes, different wire shapes.
+- **ABI version** — the FFI `EV_ABI_VERSION` constant has no direct
+  analogue in wasm/gdext, but consumers still need *something* to
+  pin against.
+- **Log drain** — convenience surface on top of the event stream;
+  parity work landed in #656.
+
+These cross-host concerns previously had no canonical home. Without
+one, "fully supported in language X" drifts silently — exactly the
+risk that motivated `bindings.toml` for the per-method surface.
+
+## The parity surface
+
+| Concern              | Source of truth                              | FFI | wasm | gdext | Bevy | Notes |
+|----------------------|----------------------------------------------|-----|------|-------|------|-------|
+| Snapshot encode      | `Simulation::snapshot`                       | `EvSnapshot` (`#[repr(C)]`) | `Snapshot` (`Tsify`) | `Dictionary` | `SimSnapshot` resource | Fields must align — adding a field to the core snapshot requires updating every host. |
+| Event drain (consume)| `Simulation::drain_events`                   | `ev_sim_drain_events` | `drainEvents` | `drain_events` | `EventWrapper` messages | All four route through `Simulation::drain_events`. |
+| Event peek (non-consuming) | `Simulation::pending_events`           | (internal, used by log forwarder) | `pendingEvents` | (none yet) | (none yet) | gdext / Bevy parity is a follow-up. |
+| Log drain (formatted)| `events::log_format::format_event`           | `ev_drain_log_messages` | `peekLogMessages` (#656) | `peek_log_messages` (#656) | *skip — uses `tracing`* | Severity constants in `events::log_format`. |
+| Error marshalling    | (host-specific; see below)                   | `EvStatus` + `ev_last_error` | thrown `Error` | Godot exception | Rust panic | Map to a shared classification — see "Error vocabulary" below. |
+| ABI / wire version   | `crates/elevator-ffi/src/lib.rs::EV_ABI_VERSION` | `5` (pinned by ABI guard) | `package.json` semver | crate semver | crate semver | Wasm/gdext don't have a binary ABI; their consumers track the published crate/package version. |
+
+## Error vocabulary
+
+The FFI's `EvStatus` enum classifies failure modes in a way that
+non-FFI hosts also need (e.g. *which kind of error did the wasm
+binding throw?*). The intended classification:
+
+- `Ok` — success.
+- `NullArg` — required pointer / handle was null.
+- `InvalidArg` — argument is not null but is malformed (bad utf-8,
+  invalid entity id, out-of-range value).
+- `NotFound` — referenced entity does not exist (or has been
+  removed) at the time of the call.
+- `Capacity` — operation would exceed a configured limit (rider
+  weight, line size, …).
+- `Panic` — internal panic recovered at the host boundary; the
+  callable is unsafe to retry without recreating the handle.
+
+Today only the FFI lifts this vocabulary into a typed enum. Future
+PRs will lift these to a shared module so wasm / gdext error
+constructors map their underlying language errors onto the same
+classification.
+
+## Migration plan (multi-PR)
+
+The work below is intentionally incremental — each step is small,
+ships independently, and keeps every host runnable.
+
+1. ✅ **Shared log severity constants** (this PR) — `LEVEL_TRACE`
+   … `LEVEL_ERROR` lifted from FFI's hardcoded values into
+   `elevator_core::events::log_format`. Hosts that surface
+   formatted log records reference the constants instead of
+   knowing "1 means debug" out-of-band.
+2. ✅ **Cross-host log drain** (#656) — wasm and gdext expose
+   `peekLogMessages` / `peek_log_messages` mirroring FFI's
+   `ev_drain_log_messages`. Bevy is intentionally skipped because
+   it has native `tracing`.
+3. ⬜ **Shared error classification** — extract the `EvStatus`
+   shape from FFI to a shared `elevator_core::host_error::ErrorKind`
+   enum. FFI re-exports it under the `EvStatus` name; wasm /
+   gdext use it to tag thrown errors.
+4. ⬜ **Snapshot field-set guard** — a CI lint that fails when the
+   FFI / wasm / gdext snapshot DTOs and the core `Snapshot` drift
+   in field names. Cheap version: a doc-test that lists field
+   names and compares.
+5. ⬜ **Wire-version constant** — surface a single
+   `elevator_core::HOST_PROTOCOL_VERSION` consumed by every host;
+   the FFI's existing ABI-pin guard becomes a check that
+   `EV_ABI_VERSION == HOST_PROTOCOL_VERSION`.
+6. ⬜ **`HostBinding` trait (or pattern)** — once the four
+   capabilities above share a vocabulary, decide whether a Rust
+   trait is the right shape (it might not be — each host's I/O
+   types are too divergent for `impl HostBinding` to be useful
+   without heavy generics; a documented contract + per-host
+   adapter modules may be the better landing).
+
+Steps 3-5 each get their own issue once step 2 has soaked. Step 6
+is the close-out and only happens after the smaller steps prove
+out the design.
+
+## Next steps
+
+- Read [Binding Coverage Manifest](binding-coverage.md) for the
+  per-method coverage view that complements this page.
+- Pick a host you ship against in [Using the Bindings](using-the-bindings.md)
+  and check the relevant column above for known gaps.
+- For the umbrella issue and the live status of each migration
+  step, see [#655] in the issue tracker.
+
+## Cross-references
+
+- [Binding Coverage Manifest](binding-coverage.md) — per-method
+  coverage in `bindings.toml`.
+- [Using the Bindings](using-the-bindings.md) — host-by-host
+  consumer guide.
+- Issue [#655] — the umbrella issue this document tracks.
+- Issue [#656] — log-drain parity, completed.
+
+[#655]: https://github.com/andymai/elevator-core/issues/655
+[#656]: https://github.com/andymai/elevator-core/issues/656


### PR DESCRIPTION
## Summary

Refs #655 — this PR is the **foundation** for the multi-PR HostBinding work. The issue itself acknowledges \"This is a structural change — likely staged across multiple PRs\"; this is step 1.

**`docs/src/host-binding-parity.md`** (new) — the cross-host contract that complements `bindings.toml`. Where the manifest tracks per-method coverage of `Simulation::*`, this page documents the *non-method* concerns that need to behave consistently across binding crates:

- Snapshot encode/decode (per-host DTO field-set parity)
- Event drain (consume + non-consuming peek)
- Log drain (formatted records — closed by #656)
- Error marshalling (`EvStatus` vocabulary, mappable to wasm / gdext errors)
- ABI / wire version (FFI's `EV_ABI_VERSION` analogue for wasm/gdext)

Includes per-host status tables and a 6-step migration plan. Steps 1-2 are done; 3-5 each get focused follow-up PRs; step 6 (trait-vs-documented-pattern decision) is deferred until the smaller steps prove out the design.

**`elevator_core::events::log_format` constants** — lifts `LEVEL_TRACE` … `LEVEL_ERROR` from FFI's hardcoded values into public constants. wasm / gdext consumers now reference shared symbols instead of knowing \"1 means debug\" out-of-band. The constants are the severity vocabulary the new doc references.

**`binding-coverage.md`** — adds a forward-pointer to the new parity doc so the two manifests are discoverable from each other.

## Why not extract a Rust trait now?

Each host's I/O types are fundamentally divergent (`*mut EvSim` raw pointers vs. `JsValue` vs. Godot `Variant` vs. Bevy ECS messages). A trait abstracting them would have to be heavily generic, which would make it harder to use than the current per-host glue. The doc's step 6 frames this as an *open* decision — to be made after steps 3-5 establish the shared vocabulary.

## Test plan

- [x] `cargo build -p elevator-core --all-features`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo test -p elevator-core --all-features` (159 + doc-tests pass)
- [x] `scripts/lint-docs.sh --quick` (internal links, code fences, structure all green; \"## Next steps\" anchor present)
- [x] Pre-commit hook full gate green