### PR TITLE
feat(core): HOST_PROTOCOL_VERSION as single wire-version source of truth (step 5 of #655)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "16.1.0"
+version = "16.2.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "cbindgen",
  "elevator-core",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-wasm"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "elevator-core",
  "getrandom 0.4.2",

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -345,6 +345,21 @@
 #![forbid(unsafe_code)]
 #![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
+/// Single source of truth for the host-binding wire/ABI version.
+///
+/// Every consumer crate (FFI's `EV_ABI_VERSION`, wasm's
+/// `ABI_VERSION`, gdext's `ABI_VERSION`) references this constant
+/// at compile time so they cannot drift apart in-source. The C
+/// header (`elevator_ffi.h`) and the example harnesses still embed
+/// a literal copy; `scripts/check-abi-pins.sh` enforces that those
+/// copies match this value.
+///
+/// Bump when any host-facing wire format changes — `EvEvent`
+/// layout, `EvSnapshot` layout, an enum value re-numbering, etc.
+/// See [Host Binding Parity](https://andymai.github.io/elevator-core/host-binding-parity.html)
+/// for the cross-host contract this constant is part of.
+pub const HOST_PROTOCOL_VERSION: u32 = 5;
+
 #[cfg(doctest)]
 mod doctests;
 

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -63,6 +63,13 @@ use slotmap::{Key, KeyData};
 /// kind discriminator was extended from 9 known kinds to 49.
 pub const EV_ABI_VERSION: u32 = 5;
 
+// Compile-time guard: keep the FFI's literal in lock-step with the
+// shared `HOST_PROTOCOL_VERSION` source of truth in `elevator-core`.
+// `EV_ABI_VERSION` stays a literal so cbindgen can resolve it into
+// the generated C header (`elevator_ffi.h`); this assert traps the
+// drift the moment someone bumps one without the other.
+const _: () = assert!(EV_ABI_VERSION == elevator_core::HOST_PROTOCOL_VERSION);
+
 /// Return the ABI version compiled into this shared library.
 #[unsafe(no_mangle)]
 pub const extern "C" fn ev_abi_version() -> u32 {

--- a/crates/elevator-gdext/src/sim_node.rs
+++ b/crates/elevator-gdext/src/sim_node.rs
@@ -36,7 +36,7 @@ use elevator_core::sim::Simulation;
 /// this constant and `EV_ABI_VERSION` in the FFI header fails the
 /// gate, surfacing a stale gdext pin before runtime. Public so a
 /// curious GDScript caller can verify the binding's ABI generation.
-pub const ABI_VERSION: u32 = 5;
+pub const ABI_VERSION: u32 = elevator_core::HOST_PROTOCOL_VERSION;
 
 /// Elevator simulation node.
 ///

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -30,7 +30,7 @@ use wasm_bindgen::prelude::*;
 /// Watched by `scripts/check-abi-pins.sh` in CI: any drift between
 /// this constant and `EV_ABI_VERSION` in the FFI header fails the
 /// gate, surfacing a stale wasm pin before runtime.
-pub const ABI_VERSION: u32 = 5;
+pub const ABI_VERSION: u32 = elevator_core::HOST_PROTOCOL_VERSION;
 
 mod dto;
 mod js_dispatch;

--- a/docs/src/host-binding-parity.md
+++ b/docs/src/host-binding-parity.md
@@ -46,7 +46,7 @@ risk that motivated `bindings.toml` for the per-method surface.
 | Event peek (non-consuming) | `Simulation::pending_events`           | (internal, used by log forwarder) | `pendingEvents` | (none yet) | (none yet) | gdext / Bevy parity is a follow-up. |
 | Log drain (formatted)| `events::log_format::format_event`           | `ev_drain_log_messages` | `peekLogMessages` (#656) | `peek_log_messages` (#656) | *skip — uses `tracing`* | Severity constants in `events::log_format`. |
 | Error marshalling    | (host-specific; see below)                   | `EvStatus` + `ev_last_error` | thrown `Error` | Godot exception | Rust panic | Map to a shared classification — see "Error vocabulary" below. |
-| ABI / wire version   | `crates/elevator-ffi/src/lib.rs::EV_ABI_VERSION` | `5` (pinned by ABI guard) | `package.json` semver | crate semver | crate semver | Wasm/gdext don't have a binary ABI; their consumers track the published crate/package version. |
+| ABI / wire version   | `elevator_core::HOST_PROTOCOL_VERSION`        | `EV_ABI_VERSION` (literal, asserted equal to core) | `ABI_VERSION` (refs core) | `ABI_VERSION` (refs core) | crate semver | FFI keeps a literal so cbindgen can emit `#define EV_ABI_VERSION` in the generated C header; a compile-time `assert!` ties the literal to core. |
 
 ## Error vocabulary
 

--- a/scripts/check-abi-pins.sh
+++ b/scripts/check-abi-pins.sh
@@ -1,20 +1,24 @@
 #!/usr/bin/env bash
 # Cross-consumer ABI-version gate.
 #
-# Every consumer of elevator-ffi embeds the ABI version it was built
-# against as a hardcoded constant. If the lib bumps EV_ABI_VERSION
-# without each consumer updating, drift surfaces in production rather
-# than in CI. This script extracts every such constant from the
-# watched files and fails if any two values disagree.
+# `elevator_core::HOST_PROTOCOL_VERSION` is the single source of
+# truth. The Rust binding crates (FFI, wasm, gdext) reference it at
+# compile time, so they cannot drift in-source — but the C header
+# and the C# / GMS2 example harnesses still embed a literal copy
+# that has to be updated by hand. This script enforces that those
+# literal copies match core's value.
 #
-# Watched files + grep patterns:
-#   crates/elevator-ffi/include/elevator_ffi.h    `#define EV_ABI_VERSION N`  (source of truth)
-#   crates/elevator-ffi/src/lib.rs                `pub const EV_ABI_VERSION: u32 = N`
+# Watched files:
+#   crates/elevator-core/src/lib.rs               `pub const HOST_PROTOCOL_VERSION: u32 = N`  (source of truth)
+#   crates/elevator-ffi/include/elevator_ffi.h    `#define EV_ABI_VERSION N`
 #   examples/csharp-harness/Program.cs            `private const uint EXPECTED_ABI = N`
 #   examples/gms2-harness/main.c                  `#define EXPECTED_ABI N`
 #   examples/gms2-extension/README.md             `// expect: "ABI version: N"`
-#   crates/elevator-wasm/src/lib.rs               `pub const ABI_VERSION: u32 = N`
-#   crates/elevator-gdext/src/sim_node.rs         `const ABI_VERSION: u32 = N`
+#
+# The Rust crates that reference `elevator_core::HOST_PROTOCOL_VERSION`
+# (FFI's `EV_ABI_VERSION`, wasm's `ABI_VERSION`, gdext's `ABI_VERSION`)
+# are also verified for *presence* of the reference — if someone
+# regresses one back to a literal, we want to know.
 #
 # Output on success: `ok: ABI version is in sync at N across <count> watched files`
 # Output on failure: a per-file table showing which versions live where.
@@ -23,25 +27,36 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
-# Each entry: "<path>|<extractor pattern>" where the pattern is a
-# `grep -oE` regex that captures only the integer literal.
-WATCHED=(
-  "crates/elevator-ffi/include/elevator_ffi.h|#define EV_ABI_VERSION [0-9]+"
+# Files whose value is extracted as an integer literal. FFI keeps a
+# literal in `lib.rs` (cbindgen resolves it into the generated C
+# header — a cross-crate `const` reference would not survive that
+# codegen). A compile-time `assert!` in `lib.rs` ties FFI's literal
+# to core's `HOST_PROTOCOL_VERSION` so the two cannot drift.
+LITERAL_WATCHED=(
+  "crates/elevator-core/src/lib.rs|pub const HOST_PROTOCOL_VERSION: u32 = [0-9]+"
   "crates/elevator-ffi/src/lib.rs|pub const EV_ABI_VERSION: u32 = [0-9]+"
+  "crates/elevator-ffi/include/elevator_ffi.h|#define EV_ABI_VERSION [0-9]+"
   "examples/csharp-harness/Program.cs|private const uint EXPECTED_ABI = [0-9]+"
   "examples/gms2-harness/main.c|#define EXPECTED_ABI [0-9]+"
   # Anchored to the literal verification-recipe comment so a future
   # changelog / migration-guide section in the README that mentions
   # an old version doesn't trick `head -1` into extracting it.
   "examples/gms2-extension/README.md|// expect: \"ABI version: [0-9]+\""
-  "crates/elevator-wasm/src/lib.rs|pub const ABI_VERSION: u32 = [0-9]+"
-  "crates/elevator-gdext/src/sim_node.rs|pub const ABI_VERSION: u32 = [0-9]+"
+)
+
+# Files that must reference `elevator_core::HOST_PROTOCOL_VERSION`.
+# These get the source-of-truth value implicitly via Rust's compiler;
+# we only verify the reference is present (regression guard against
+# someone reintroducing a literal).
+REFERENCE_WATCHED=(
+  "crates/elevator-wasm/src/lib.rs|pub const ABI_VERSION: u32 = elevator_core::HOST_PROTOCOL_VERSION"
+  "crates/elevator-gdext/src/sim_node.rs|pub const ABI_VERSION: u32 = elevator_core::HOST_PROTOCOL_VERSION"
 )
 
 declare -A versions
 declare -a missing=()
 
-for entry in "${WATCHED[@]}"; do
+for entry in "${LITERAL_WATCHED[@]}"; do
   path="${entry%%|*}"
   pattern="${entry#*|}"
   abs="$REPO_ROOT/$path"
@@ -60,6 +75,27 @@ for entry in "${WATCHED[@]}"; do
   # digit run via a tail call instead.
   version=$(echo "$match" | grep -oE '[0-9]+' | tail -1)
   versions["$path"]="$version"
+done
+
+# Reference checks: presence-only. The Rust compiler enforces value
+# equality at build time; this guard catches the regression where a
+# crate is changed back to a literal.
+core_version="${versions[crates/elevator-core/src/lib.rs]:-}"
+for entry in "${REFERENCE_WATCHED[@]}"; do
+  path="${entry%%|*}"
+  pattern="${entry#*|}"
+  abs="$REPO_ROOT/$path"
+  if [[ ! -f "$abs" ]]; then
+    missing+=("$path")
+    continue
+  fi
+  if ! grep -qF "$pattern" "$abs"; then
+    missing+=("$path (missing: $pattern)")
+    continue
+  fi
+  # Track under the core value so the disagreement check below
+  # reports a single coherent table.
+  versions["$path"]="$core_version"
 done
 
 status=0
@@ -85,8 +121,8 @@ if (( ${#unique[@]} > 1 )); then
     printf '  %-60s %s\n' "$path" "${versions[$path]}"
   done | sort
   echo ""
-  echo "Resolve by updating each pin to match the EV_ABI_VERSION value"
-  echo "in crates/elevator-ffi/include/elevator_ffi.h (the source of truth)."
+  echo "Resolve by updating each literal pin to match HOST_PROTOCOL_VERSION"
+  echo "in crates/elevator-core/src/lib.rs (the single source of truth)."
   status=1
 fi
 


### PR DESCRIPTION
## Summary

Step 5 of the multi-PR host-binding parity work tracked by [host-binding-parity.md](https://github.com/andymai/elevator-core/blob/main/docs/src/host-binding-parity.md). Centralizes the wire/ABI version on a single \`elevator_core::HOST_PROTOCOL_VERSION\` constant.

- **wasm** (\`crates/elevator-wasm/src/lib.rs\`): \`ABI_VERSION\` references core's const at compile time. No literal to drift.
- **gdext** (\`crates/elevator-gdext/src/sim_node.rs\`): same — references core.
- **FFI** (\`crates/elevator-ffi/src/lib.rs\`): \`EV_ABI_VERSION\` stays a literal because cbindgen can't resolve cross-crate const references at codegen time (it would silently drop the \`#define\` from the generated C header). A compile-time \`const _: () = assert!(EV_ABI_VERSION == elevator_core::HOST_PROTOCOL_VERSION)\` guards against drift.
- **\`scripts/check-abi-pins.sh\`**: split watched files into a \`LITERAL_WATCHED\` set (C header, FFI lib.rs, C#/GMS2 harnesses, core) and a \`REFERENCE_WATCHED\` set (wasm, gdext). Reference files are checked for *presence* of the cross-crate ref — regression guard against someone reintroducing a literal.
- **\`host-binding-parity.md\`**: step 5 marked ✅; parity table updated to reflect the new shape.

## Test plan

- [x] \`cargo build --workspace --all-features\` — drift assert compiles, meaning literals agree
- [x] \`cargo clippy --workspace --all-features --all-targets -- -D warnings\`
- [x] \`cargo test -p elevator-core --all-features\` (159 tests + doc-tests)
- [x] \`cargo test -p elevator-ffi --all-features\` (53 + 10 pass; existing \`abi_version_matches_constant\` test still green)
- [x] \`scripts/check-abi-pins.sh\` — \"in sync at 5 across 8 watched files\" (was 7 — core's new const adds one)
- [x] \`scripts/check-bindings.sh\`
- [x] \`scripts/lint-docs.sh --quick\`
- [x] Pre-commit gate full pass