### PR TITLE
feat(core): host_error::ErrorKind for cross-host error vocabulary (step 3 of #655)

### DIFF
--- a/crates/elevator-core/src/host_error.rs
+++ b/crates/elevator-core/src/host_error.rs
@@ -1,0 +1,104 @@
+//! Shared error classification for host bindings.
+//!
+//! Each host crate (FFI, wasm, gdext, Bevy) translates simulation
+//! failures into its own idiomatic error shape — `EvStatus` integers
+//! for FFI, `JsValue`-shaped exceptions for wasm, Godot exceptions
+//! for gdext. Without a shared classification the bindings used to
+//! enumerate the *kinds* of failures separately, drifting whenever a
+//! new failure mode landed.
+//!
+//! [`ErrorKind`] is the shared vocabulary. Hosts map it to their
+//! native error type (FFI provides `From<ErrorKind> for EvStatus`).
+//!
+//! See [Host Binding Parity](https://andymai.github.io/elevator-core/host-binding-parity.html)
+//! for the wider cross-host contract this enum is part of.
+
+use serde::{Deserialize, Serialize};
+
+/// Classification of failures every host binding can surface.
+///
+/// Variants mirror FFI's historical `EvStatus` enum (minus `Ok`,
+/// which represents *success* rather than an error kind). Hosts
+/// that can't yet emit a given variant should still match against
+/// the full set with a `_` fallback so future variants don't break
+/// existing call sites.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum ErrorKind {
+    /// A required pointer / handle argument was null.
+    NullArg,
+    /// A C string argument was not valid UTF-8.
+    InvalidUtf8,
+    /// A config file could not be read from disk.
+    ConfigLoad,
+    /// A config file failed to parse.
+    ConfigParse,
+    /// `SimulationBuilder::build` rejected the resolved config.
+    BuildFailed,
+    /// The referenced entity, group, or resource was not found.
+    NotFound,
+    /// The argument was structurally valid but semantically rejected.
+    InvalidArg,
+    /// A Rust panic was caught at the host boundary; the underlying
+    /// state may be partially mutated and the host handle should be
+    /// considered unsafe to reuse.
+    Panic,
+}
+
+impl ErrorKind {
+    /// Stable string label for a variant.
+    ///
+    /// Hosts that need to surface the kind to a non-Rust consumer
+    /// (e.g. wasm's JS side, gdext's `GDScript` side) can use this to
+    /// produce a kebab-case label without paying for full
+    /// `Debug` rendering. The set of returned strings is part of
+    /// the cross-host contract — adding a new variant requires
+    /// adding a label here.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::NullArg => "null-arg",
+            Self::InvalidUtf8 => "invalid-utf8",
+            Self::ConfigLoad => "config-load",
+            Self::ConfigParse => "config-parse",
+            Self::BuildFailed => "build-failed",
+            Self::NotFound => "not-found",
+            Self::InvalidArg => "invalid-arg",
+            Self::Panic => "panic",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ErrorKind;
+
+    #[test]
+    fn label_is_kebab_case_and_stable() {
+        // Locked: changing any of these breaks consumer parsers.
+        assert_eq!(ErrorKind::NullArg.label(), "null-arg");
+        assert_eq!(ErrorKind::InvalidUtf8.label(), "invalid-utf8");
+        assert_eq!(ErrorKind::ConfigLoad.label(), "config-load");
+        assert_eq!(ErrorKind::ConfigParse.label(), "config-parse");
+        assert_eq!(ErrorKind::BuildFailed.label(), "build-failed");
+        assert_eq!(ErrorKind::NotFound.label(), "not-found");
+        assert_eq!(ErrorKind::InvalidArg.label(), "invalid-arg");
+        assert_eq!(ErrorKind::Panic.label(), "panic");
+    }
+
+    #[test]
+    fn labels_are_unique() {
+        let labels = [
+            ErrorKind::NullArg.label(),
+            ErrorKind::InvalidUtf8.label(),
+            ErrorKind::ConfigLoad.label(),
+            ErrorKind::ConfigParse.label(),
+            ErrorKind::BuildFailed.label(),
+            ErrorKind::NotFound.label(),
+            ErrorKind::InvalidArg.label(),
+            ErrorKind::Panic.label(),
+        ];
+        let unique: std::collections::HashSet<_> = labels.iter().collect();
+        assert_eq!(unique.len(), labels.len());
+    }
+}

--- a/crates/elevator-core/src/host_error.rs
+++ b/crates/elevator-core/src/host_error.rs
@@ -7,8 +7,9 @@
 //! enumerate the *kinds* of failures separately, drifting whenever a
 //! new failure mode landed.
 //!
-//! [`ErrorKind`] is the shared vocabulary. Hosts map it to their
-//! native error type (FFI provides `From<ErrorKind> for EvStatus`).
+//! [`ErrorKind`](crate::host_error::ErrorKind) is the shared
+//! vocabulary. Hosts map it to their native error type (FFI provides
+//! `From<ErrorKind> for EvStatus`).
 //!
 //! See [Host Binding Parity](https://andymai.github.io/elevator-core/host-binding-parity.html)
 //! for the wider cross-host contract this enum is part of.

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -369,6 +369,9 @@ pub mod components;
 pub mod entity;
 /// Simulation error types.
 pub mod error;
+/// Shared error classification for host bindings (FFI / wasm /
+/// gdext / Bevy). See [`host_error::ErrorKind`].
+pub mod host_error;
 /// Typed identifiers for groups and other sim concepts.
 pub mod ids;
 /// ECS-style query builder for iterating entities by component composition.

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -102,6 +102,40 @@ pub enum EvStatus {
     Panic = 99,
 }
 
+impl From<elevator_core::host_error::ErrorKind> for EvStatus {
+    /// Map the cross-host error classification onto the FFI's
+    /// `#[repr(C)]` integer status. The two enums share a vocabulary
+    /// (see issue #655); FFI consumers continue to receive integer
+    /// codes while non-FFI hosts can produce / interpret errors via
+    /// the shared `ErrorKind`.
+    fn from(kind: elevator_core::host_error::ErrorKind) -> Self {
+        use elevator_core::host_error::ErrorKind;
+        // The explicit `Panic` arm and the `_` arm both produce
+        // `Self::Panic`, but they're semantically distinct: the
+        // first is the documented mapping for the existing
+        // variant; the second is a future-proofing fallback for
+        // variants `ErrorKind` may add. Keeping them apart makes
+        // the intent visible and lets a future PR replace the `_`
+        // with a concrete arm without rediscovering the design.
+        #[allow(clippy::match_same_arms)]
+        match kind {
+            ErrorKind::NullArg => Self::NullArg,
+            ErrorKind::InvalidUtf8 => Self::InvalidUtf8,
+            ErrorKind::ConfigLoad => Self::ConfigLoad,
+            ErrorKind::ConfigParse => Self::ConfigParse,
+            ErrorKind::BuildFailed => Self::BuildFailed,
+            ErrorKind::NotFound => Self::NotFound,
+            ErrorKind::InvalidArg => Self::InvalidArg,
+            ErrorKind::Panic => Self::Panic,
+            // ErrorKind is `#[non_exhaustive]` — a future variant
+            // the FFI hasn't enumerated surfaces as `Panic` so the
+            // caller treats it as "unsafe to retry" rather than
+            // silently mis-classifying it as `Ok`.
+            _ => Self::Panic,
+        }
+    }
+}
+
 thread_local! {
     static LAST_ERROR: RefCell<Option<CString>> = const { RefCell::new(None) };
 }
@@ -6615,6 +6649,28 @@ mod tests {
     fn abi_version_matches_constant() {
         assert_eq!(ev_abi_version(), EV_ABI_VERSION);
         assert_eq!(EV_ABI_VERSION, 5);
+    }
+
+    #[test]
+    fn error_kind_maps_to_ev_status() {
+        use elevator_core::host_error::ErrorKind;
+        assert_eq!(EvStatus::from(ErrorKind::NullArg), EvStatus::NullArg);
+        assert_eq!(
+            EvStatus::from(ErrorKind::InvalidUtf8),
+            EvStatus::InvalidUtf8
+        );
+        assert_eq!(EvStatus::from(ErrorKind::ConfigLoad), EvStatus::ConfigLoad);
+        assert_eq!(
+            EvStatus::from(ErrorKind::ConfigParse),
+            EvStatus::ConfigParse
+        );
+        assert_eq!(
+            EvStatus::from(ErrorKind::BuildFailed),
+            EvStatus::BuildFailed
+        );
+        assert_eq!(EvStatus::from(ErrorKind::NotFound), EvStatus::NotFound);
+        assert_eq!(EvStatus::from(ErrorKind::InvalidArg), EvStatus::InvalidArg);
+        assert_eq!(EvStatus::from(ErrorKind::Panic), EvStatus::Panic);
     }
 
     #[test]

--- a/docs/src/host-binding-parity.md
+++ b/docs/src/host-binding-parity.md
@@ -45,7 +45,7 @@ risk that motivated `bindings.toml` for the per-method surface.
 | Event drain (consume)| `Simulation::drain_events`                   | `ev_sim_drain_events` | `drainEvents` | `drain_events` | `EventWrapper` messages | All four route through `Simulation::drain_events`. |
 | Event peek (non-consuming) | `Simulation::pending_events`           | (internal, used by log forwarder) | `pendingEvents` | (none yet) | (none yet) | gdext / Bevy parity is a follow-up. |
 | Log drain (formatted)| `events::log_format::format_event`           | `ev_drain_log_messages` | `peekLogMessages` (#656) | `peek_log_messages` (#656) | *skip — uses `tracing`* | Severity constants in `events::log_format`. |
-| Error marshalling    | (host-specific; see below)                   | `EvStatus` + `ev_last_error` | thrown `Error` | Godot exception | Rust panic | Map to a shared classification — see "Error vocabulary" below. |
+| Error marshalling    | `host_error::ErrorKind`                       | `EvStatus` (`From<ErrorKind>`) + `ev_last_error` | thrown `Error` | Godot exception | Rust panic | Shared classification lives in `elevator_core::host_error`; FFI maps it to `EvStatus`. wasm / gdext consume `ErrorKind::label()` for kebab-case classification strings. |
 | ABI / wire version   | `elevator_core::HOST_PROTOCOL_VERSION`        | `EV_ABI_VERSION` (literal, asserted equal to core) | `ABI_VERSION` (refs core) | `ABI_VERSION` (refs core) | crate semver | FFI keeps a literal so cbindgen can emit `#define EV_ABI_VERSION` in the generated C header; a compile-time `assert!` ties the literal to core. |
 
 ## Error vocabulary
@@ -84,10 +84,16 @@ ships independently, and keeps every host runnable.
    `peekLogMessages` / `peek_log_messages` mirroring FFI's
    `ev_drain_log_messages`. Bevy is intentionally skipped because
    it has native `tracing`.
-3. ⬜ **Shared error classification** — extract the `EvStatus`
-   shape from FFI to a shared `elevator_core::host_error::ErrorKind`
-   enum. FFI re-exports it under the `EvStatus` name; wasm /
-   gdext use it to tag thrown errors.
+3. ✅ **Shared error classification** —
+   `elevator_core::host_error::ErrorKind` is the cross-host failure
+   vocabulary (`NullArg`, `InvalidUtf8`, `ConfigLoad`,
+   `ConfigParse`, `BuildFailed`, `NotFound`, `InvalidArg`,
+   `Panic`). FFI provides `impl From<ErrorKind> for EvStatus`; new
+   FFI / wasm / gdext call sites should produce errors via the
+   shared kind so the integer / string / Variant representations
+   stay aligned. Adoption across existing call sites is
+   intentionally incremental — the shared enum is the foothold,
+   not a flag-day migration.
 4. ✅ **Snapshot field-set guard** — a tripwire test
    (`elevator_ffi::tests::snapshot_dto_field_names_locked`) locks
    the field names on every snapshot DTO (`EvElevatorView`,
@@ -98,10 +104,13 @@ ships independently, and keeps every host runnable.
    dict → bump `HOST_PROTOCOL_VERSION` if breaking → update the
    locked list). Catches the silent-drift failure mode without
    requiring CI access to wasm / gdext crate internals.
-5. ⬜ **Wire-version constant** — surface a single
-   `elevator_core::HOST_PROTOCOL_VERSION` consumed by every host;
-   the FFI's existing ABI-pin guard becomes a check that
-   `EV_ABI_VERSION == HOST_PROTOCOL_VERSION`.
+5. ✅ **Wire-version constant** — `elevator_core::HOST_PROTOCOL_VERSION`
+   is the single source of truth. wasm's `ABI_VERSION` and gdext's
+   `ABI_VERSION` reference it directly at compile time; FFI keeps a
+   literal `EV_ABI_VERSION` (so cbindgen can resolve it into the
+   generated C header) plus a `const _: () = assert!(...)` guard
+   that traps any drift. `scripts/check-abi-pins.sh` was extended to
+   verify both literal and reference shapes.
 6. ⬜ **`HostBinding` trait (or pattern)** — once the four
    capabilities above share a vocabulary, decide whether a Rust
    trait is the right shape (it might not be — each host's I/O


### PR DESCRIPTION
## Summary

Step 3 of the multi-PR host-binding parity work tracked by [host-binding-parity.md](https://github.com/andymai/elevator-core/blob/main/docs/src/host-binding-parity.md). Establishes the shared error-classification vocabulary referenced by step 3 of the migration plan.

- **\`elevator_core::host_error::ErrorKind\`** (new module): \`#[non_exhaustive]\` enum with the cross-host failure variants — \`NullArg\`, \`InvalidUtf8\`, \`ConfigLoad\`, \`ConfigParse\`, \`BuildFailed\`, \`NotFound\`, \`InvalidArg\`, \`Panic\`. Exposes \`label()\` returning a stable kebab-case string for hosts that need to surface the kind to a non-Rust consumer.
- **FFI**: \`impl From<ErrorKind> for EvStatus\` so a host that fails internally with \`ErrorKind\` can hand the integer status to a C consumer in one call. Variants mirror FFI's existing \`EvStatus\` discriminator-by-discriminator so the C ABI stays bit-for-bit identical.
- **wasm / gdext**: not migrated in this PR — the shared enum exists as the foothold for future call-site updates. Documented as such in \`host-binding-parity.md\`. Adoption is intentionally incremental: each error site picks up \`ErrorKind\` as it's touched, rather than via a flag-day rewrite.
- **Tests**: round-trip \`ErrorKind → EvStatus\` mapping for all eight variants; \`label()\` stability + uniqueness.
- **Doc**: marks step 3 ✅ in \`host-binding-parity.md\`; updates the parity table to reflect the new shape.

## Why \`#[non_exhaustive]\`?

The enum may grow as new failure modes surface (the doc speculates about \`Capacity\`, for example). Marking it \`#[non_exhaustive]\` lets future variants land additively. FFI's \`From\` impl includes a \`_\` wildcard arm mapping unknown kinds to \`Self::Panic\` — a future variant the FFI hasn't enumerated surfaces as \"unsafe to retry\" rather than silently mis-classifying it as success.

## Test plan

- [x] \`cargo build --workspace --all-features\`
- [x] \`cargo clippy --workspace --all-features --all-targets -- -D warnings\`
- [x] \`cargo test -p elevator-core --all-features\` — 159 + doc-tests + new \`label()\` unit tests
- [x] \`cargo test -p elevator-ffi --all-features\` — 53 + new \`error_kind_maps_to_ev_status\` test
- [x] \`scripts/check-abi-pins.sh\` (still 8 files in sync)
- [x] \`scripts/lint-docs.sh --quick\`
- [x] Pre-commit gate full pass