### PR TITLE
test(ffi): snapshot DTO field-set tripwire (step 4 of #655)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "16.2.0"
+version = "16.3.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "cbindgen",
  "elevator-core",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-wasm"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "elevator-core",
  "getrandom 0.4.2",

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -6681,6 +6681,100 @@ mod tests {
         }
     }
 
+    /// Snapshot DTO field-set tripwire — see step 4 of
+    /// [host-binding-parity.md][parity] for the cross-host contract.
+    ///
+    /// When this test fails, an FFI snapshot DTO grew, shrank, or
+    /// renamed a field. Before updating the expected list below:
+    ///
+    ///   1. Update wasm's `CarDto` / `StopDto` / `Snapshot` /
+    ///      `MetricsDto` (`crates/elevator-wasm/src/dto.rs`) to
+    ///      mirror the change.
+    ///   2. Update gdext's snapshot dictionary keys
+    ///      (`crates/elevator-gdext/src/sim_node.rs`).
+    ///   3. Bump `HOST_PROTOCOL_VERSION` if the change is
+    ///      consumer-visible (a new field is additive but a rename
+    ///      is breaking).
+    ///   4. *Then* update the locked field list here.
+    ///
+    /// Skipping these steps is the structural failure mode that
+    /// motivated the parity work — silent host drift. The trip-and-update
+    /// cycle is deliberate friction.
+    ///
+    /// [parity]: https://andymai.github.io/elevator-core/host-binding-parity.html
+    #[test]
+    fn snapshot_dto_field_names_locked() {
+        use elevator_layout_runtime::LayoutInfo;
+
+        fn field_names<T: LayoutInfo>() -> Vec<&'static str> {
+            T::fields().iter().map(|f| f.name).collect()
+        }
+
+        assert_eq!(
+            field_names::<EvElevatorView>(),
+            [
+                "entity_id",
+                "group_id",
+                "line_id",
+                "phase",
+                "position",
+                "velocity",
+                "current_stop_id",
+                "target_stop_id",
+                "occupancy",
+                "capacity_kg",
+                "door_state",
+                "going_up",
+                "going_down",
+            ],
+        );
+        assert_eq!(
+            field_names::<EvStopView>(),
+            [
+                "entity_id",
+                "stop_id",
+                "position",
+                "waiting",
+                "residents",
+                "abandoned",
+                "name_ptr",
+                "name_len",
+            ],
+        );
+        assert_eq!(
+            field_names::<EvRiderView>(),
+            [
+                "entity_id",
+                "phase",
+                "origin_stop_id",
+                "destination_stop_id",
+                "elevator_id",
+            ],
+        );
+        assert_eq!(
+            field_names::<EvMetricsView>(),
+            [
+                "total_delivered",
+                "total_abandoned",
+                "avg_wait_seconds",
+                "avg_ride_seconds",
+                "current_tick",
+            ],
+        );
+        assert_eq!(
+            field_names::<EvFrame>(),
+            [
+                "elevators",
+                "elevator_count",
+                "stops",
+                "stop_count",
+                "riders",
+                "rider_count",
+                "metrics",
+            ],
+        );
+    }
+
     #[test]
     fn layout_offsets_round_trip_via_registry() {
         // Spot-check a few structs through the registry (rather than

--- a/docs/src/host-binding-parity.md
+++ b/docs/src/host-binding-parity.md
@@ -88,10 +88,16 @@ ships independently, and keeps every host runnable.
    shape from FFI to a shared `elevator_core::host_error::ErrorKind`
    enum. FFI re-exports it under the `EvStatus` name; wasm /
    gdext use it to tag thrown errors.
-4. ⬜ **Snapshot field-set guard** — a CI lint that fails when the
-   FFI / wasm / gdext snapshot DTOs and the core `Snapshot` drift
-   in field names. Cheap version: a doc-test that lists field
-   names and compares.
+4. ✅ **Snapshot field-set guard** — a tripwire test
+   (`elevator_ffi::tests::snapshot_dto_field_names_locked`) locks
+   the field names on every snapshot DTO (`EvElevatorView`,
+   `EvStopView`, `EvRiderView`, `EvMetricsView`, `EvFrame`) using
+   the existing `MultiHostLayout::fields()` registry. When a field
+   is added, removed, or renamed, the test fails and walks the
+   developer through the parity update sequence (wasm DTO → gdext
+   dict → bump `HOST_PROTOCOL_VERSION` if breaking → update the
+   locked list). Catches the silent-drift failure mode without
+   requiring CI access to wasm / gdext crate internals.
 5. ⬜ **Wire-version constant** — surface a single
    `elevator_core::HOST_PROTOCOL_VERSION` consumed by every host;
    the FFI's existing ABI-pin guard becomes a check that


### PR DESCRIPTION
## Summary

Step 4 of the host-binding parity migration plan tracked by [host-binding-parity.md](https://github.com/andymai/elevator-core/blob/main/docs/src/host-binding-parity.md).

Adds \`snapshot_dto_field_names_locked\` — a unit test that asserts the exact field-name list on every snapshot DTO (\`EvElevatorView\`, \`EvStopView\`, \`EvRiderView\`, \`EvMetricsView\`, \`EvFrame\`) using the \`MultiHostLayout::fields()\` registry the \`elevator-layout-runtime\` crate already maintains.

When a field is added, removed, or renamed, the test fails with a doc comment that walks the developer through the parity update sequence:

1. Update wasm's \`CarDto\` / \`StopDto\` / \`Snapshot\` / \`MetricsDto\`
2. Update gdext's snapshot dictionary keys
3. Bump \`HOST_PROTOCOL_VERSION\` if the change is consumer-visible
4. *Then* update the locked field list

## Why a tripwire instead of a static cross-crate check

- A direct cross-crate field comparison would require \`elevator-core\` to depend on FFI / wasm / gdext (circular).
- The renaming gap (snake_case in Rust, camelCase in TS, Variant keys in gdext) means no string-equality check is meaningful across hosts; the tripwire forces a deliberate human-led sync.
- This is the \"cheap version\" called out in the parity doc as acceptable for step 4.

## Test plan

- [x] \`cargo test -p elevator-ffi --all-features\` — new test passes (54 total now)
- [x] \`cargo clippy --workspace --all-features --all-targets -- -D warnings\`
- [x] \`scripts/lint-docs.sh --quick\`
- [x] \`scripts/check-abi-pins.sh\` — 8 watched files in sync
- [x] Pre-commit gate full pass