### PR TITLE
chore(core): cleanup pass — drop dead code, redundant clippy allows, historical comment narratives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "16.3.0"
+version = "16.4.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "cbindgen",
  "elevator-core",
@@ -5427,9 +5427,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "smithay-client-toolkit"

--- a/crates/elevator-core/Cargo.toml
+++ b/crates/elevator-core/Cargo.toml
@@ -37,7 +37,7 @@ ron.workspace = true
 rand = { workspace = true, optional = true }
 slotmap.workspace = true
 ordered-float = { version = "5", features = ["serde"] }
-smallvec = { version = "1", features = ["serde"] }
+smallvec = "1"
 postcard.workspace = true
 pathfinding = { version = "4", default-features = false }
 

--- a/crates/elevator-core/src/builder.rs
+++ b/crates/elevator-core/src/builder.rs
@@ -203,9 +203,6 @@ impl SimulationBuilder {
     /// [`.dispatch_for_group()`](Self::dispatch_for_group) to override the
     /// per-group strategy from code; otherwise the config's choice (or
     /// `ScanDispatch` if neither config nor builder specifies) is used.
-    /// Pre-fix this function unconditionally seeded `ScanDispatch` for
-    /// `GroupId(0)` and the override loop in construction stomped any
-    /// config-supplied strategy for that group (#287).
     #[must_use]
     pub fn from_config(config: SimConfig) -> Self {
         Self {

--- a/crates/elevator-core/src/components/units.rs
+++ b/crates/elevator-core/src/components/units.rs
@@ -35,6 +35,22 @@ impl fmt::Display for UnitError {
 
 impl std::error::Error for UnitError {}
 
+/// Implements `From<f64>` for a unit newtype by delegating to its `try_new`
+/// constructor and panicking on validation failure.
+///
+/// The panic is the documented contract for the infallible conversion;
+/// callers that need fallibility use `try_new` directly.
+macro_rules! impl_unit_from_f64 {
+    ($ty:ident) => {
+        #[allow(clippy::panic)]
+        impl From<f64> for $ty {
+            fn from(value: f64) -> Self {
+                Self::try_new(value).unwrap_or_else(|e| panic!("{e}"))
+            }
+        }
+    };
+}
+
 /// Weight / mass (always non-negative).
 ///
 /// Used for rider weight, elevator load, and weight capacity.
@@ -92,12 +108,7 @@ impl fmt::Display for Weight {
     }
 }
 
-#[allow(clippy::panic)]
-impl From<f64> for Weight {
-    fn from(value: f64) -> Self {
-        Self::try_new(value).unwrap_or_else(|e| panic!("{e}"))
-    }
-}
+impl_unit_from_f64!(Weight);
 
 impl std::ops::Add for Weight {
     type Output = Self;
@@ -179,12 +190,7 @@ impl fmt::Display for Speed {
     }
 }
 
-#[allow(clippy::panic)]
-impl From<f64> for Speed {
-    fn from(value: f64) -> Self {
-        Self::try_new(value).unwrap_or_else(|e| panic!("{e}"))
-    }
-}
+impl_unit_from_f64!(Speed);
 
 /// Acceleration / deceleration rate (always non-negative, distance units per second²).
 ///
@@ -236,9 +242,4 @@ impl fmt::Display for Accel {
     }
 }
 
-#[allow(clippy::panic)]
-impl From<f64> for Accel {
-    fn from(value: f64) -> Self {
-        Self::try_new(value).unwrap_or_else(|e| panic!("{e}"))
-    }
-}
+impl_unit_from_f64!(Accel);

--- a/crates/elevator-core/src/metrics.rs
+++ b/crates/elevator-core/src/metrics.rs
@@ -214,8 +214,6 @@ impl Metrics {
         let mut sorted: Vec<u64> = self.wait_samples.iter().copied().collect();
         sorted.sort_unstable();
         let n = sorted.len();
-        #[allow(clippy::cast_precision_loss)] // n ≤ capacity, set by user
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let rank = ((p / 100.0) * n as f64).ceil() as usize;
         let idx = rank.saturating_sub(1).min(n - 1);
         sorted[idx]
@@ -341,7 +339,6 @@ impl Metrics {
     }
 
     /// Record a rider boarding. `wait_ticks` = `tick_boarded` - `tick_spawned`.
-    #[allow(clippy::cast_precision_loss)] // rider counts fit in f64 mantissa
     pub(crate) fn record_board(&mut self, wait_ticks: u64) {
         self.boarded_count += 1;
         self.sum_wait_ticks += wait_ticks;
@@ -358,7 +355,6 @@ impl Metrics {
     }
 
     /// Record a rider exiting. `ride_ticks` = `tick_exited` - `tick_boarded`.
-    #[allow(clippy::cast_precision_loss)] // rider counts fit in f64 mantissa
     pub(crate) fn record_delivery(&mut self, ride_ticks: u64, tick: u64) {
         self.delivered_count += 1;
         self.total_delivered += 1;
@@ -368,7 +364,6 @@ impl Metrics {
     }
 
     /// Record a rider abandoning.
-    #[allow(clippy::cast_precision_loss)] // rider counts fit in f64 mantissa
     pub(crate) fn record_abandonment(&mut self) {
         self.total_abandoned += 1;
         if self.total_spawned > 0 {
@@ -404,7 +399,6 @@ impl Metrics {
     }
 
     /// Update windowed throughput. Call once per tick.
-    #[allow(clippy::cast_possible_truncation)] // window len always fits in u64
     pub(crate) fn update_throughput(&mut self, current_tick: u64) {
         let cutoff = current_tick.saturating_sub(self.throughput_window_ticks);
         // Delivery ticks are inserted in order, so expired entries are at the front.

--- a/crates/elevator-core/src/scenario.rs
+++ b/crates/elevator-core/src/scenario.rs
@@ -398,7 +398,6 @@ impl SpawnSchedule {
             // Exponential inter-arrival time, clamped to avoid ln(0).
             let u: f64 = rng.random_range(0.0001..1.0);
             let interval = -(f64::from(mean_interval_ticks)) * u.ln();
-            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
             let step = (interval as u64).max(1);
             tick = tick.saturating_add(step);
             if tick >= duration_ticks {

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -296,17 +296,11 @@ impl RiderBuilder<'_> {
                 }
                 Route::direct(self.origin, self.destination, group)
             } else {
-                // Single-group case first (fast path). `NoRoute` falls
-                // back to the multi-leg topology-graph search — zoned
-                // buildings (low-bank + sky-lobby + high-bank) work
-                // through the plain `spawn_rider` API without callers
-                // knowing about transfer points. `AmbiguousRoute` also
-                // defers to `shortest_route`, which picks one concrete
-                // group deterministically; the alternative (surfacing
-                // the error to callers) would make specialty-overlap
-                // floors like a lobby served by both a passenger bank
-                // and an executive elevator un-spawnable without
-                // threading a group pick all the way up.
+                // Auto-detect the single-group case first; on `NoRoute` or
+                // `AmbiguousRoute`, fall back to the multi-leg topology
+                // search so zoned buildings and specialty-overlap floors
+                // work through the plain `spawn_rider` API without callers
+                // having to thread a group pick through transfer points.
                 match self.sim.auto_detect_group(self.origin, self.destination) {
                     Ok(group) => Route::direct(self.origin, self.destination, group),
                     Err(

--- a/crates/elevator-core/src/sim/accessors.rs
+++ b/crates/elevator-core/src/sim/accessors.rs
@@ -193,8 +193,8 @@ impl super::Simulation {
     /// returned slice reflects every event emitted up to this call —
     /// matching what [`drain_events`](Self::drain_events) would return.
     /// Without the flush, events emitted outside the tick loop
-    /// (`spawn_rider`, `disable`, …) would be invisible to peek but
-    /// visible to drain — observed during round-2 audit (#264).
+    /// (`spawn_rider`, `disable`, …) would be visible to drain but not
+    /// peek.
     ///
     /// Takes `&mut self` because the flush mutates internal state. If
     /// you only need a count or a quick check after `step()`, prefer

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -436,29 +436,18 @@ impl Simulation {
 
         let group = ElevatorGroup::new(GroupId(0), "Default".into(), vec![default_line_info]);
 
-        // Legacy topology has exactly one group: GroupId(0). Honour a
-        // builder-provided dispatcher for that group; ignore any builder
-        // entry keyed on a different GroupId (it would have nothing to
-        // attach to). Pre-fix this used `into_iter().next()` which
-        // discarded the GroupId entirely and could attach a dispatcher
-        // intended for a different group to GroupId(0). (#288)
+        // Legacy topology has exactly one group: GroupId(0). Take a builder
+        // entry keyed on that group; ignore entries keyed on any other group
+        // (they would have nothing to attach to in the legacy schema).
         let mut dispatchers = BTreeMap::new();
         let mut strategy_ids = BTreeMap::new();
         let user_dispatcher = builder_dispatchers
             .into_iter()
             .find_map(|(gid, d)| if gid == GroupId(0) { Some(d) } else { None });
-        // Infer the snapshot identity from the dispatcher itself via
-        // `DispatchStrategy::builtin_id`. Pre-fix this was hard-coded to
-        // `BuiltinStrategy::Scan` regardless of the impl actually passed,
-        // so `Simulation::new(config, NearestCarDispatch::new())` would
-        // record `Scan` as the group's identity — and a snapshot round-
-        // trip would silently swap the running strategy back to Scan,
-        // breaking determinism. Built-ins override `builtin_id` to
-        // return their own variant; custom strategies can override it
-        // to return `BuiltinStrategy::Custom(name)` for snapshot fidelity.
-        // Strategies that don't override (returning `None`) still fall
-        // back to Scan, matching the previous behaviour for callers that
-        // never cared about round-trip identity.
+        // Snapshot identity comes from the dispatcher's own `builtin_id`, not
+        // from a hard-coded variant — otherwise a snapshot round-trip would
+        // silently swap a custom strategy back to Scan. Strategies that
+        // return `None` fall back to Scan for snapshot fidelity.
         let inferred_id = user_dispatcher
             .as_ref()
             .and_then(|d| d.builtin_id())
@@ -615,15 +604,10 @@ impl Simulation {
             strategy_ids.insert(group_id, BuiltinStrategy::Scan);
         }
 
-        // Override with builder-provided dispatchers (they take precedence).
-        // Pre-fix this could mismatch `strategy_ids` against `dispatchers`
-        // when both config and builder specified a strategy for the same
-        // group (#287). The new precedence: builder wins for the dispatcher
-        // and, for snapshot fidelity, we prefer the dispatcher's own
-        // `builtin_id()` over any stale config-supplied id. Falling back
-        // to the config id when the dispatcher is unidentified matches
-        // the pre-fix behaviour for custom strategies that don't override
-        // `builtin_id`.
+        // Builder-provided dispatchers override the config. For the matching
+        // `strategy_ids` entry, prefer the dispatcher's own `builtin_id()`
+        // (snapshot fidelity); fall back to the config id only when the
+        // dispatcher is unidentified (custom strategies that don't override).
         for (gid, d) in builder_dispatchers {
             let inferred_id = d.builtin_id();
             dispatchers.insert(gid, d);
@@ -657,20 +641,13 @@ impl Simulation {
     ) -> Self {
         let mut rider_index = RiderIndex::default();
         rider_index.rebuild(&world);
-        // Ensure the dispatch-visible tick rate matches the simulation
-        // tick rate after a snapshot restore; a snapshot that predates
-        // the `TickRate` resource leaves it absent and dispatch would
-        // otherwise fall back to the 60 Hz default even for a 30 Hz
-        // sim, silently halving ETD's door-cost scale.
+        // Forward-compat: snapshots predating these resources won't carry
+        // them. `TickRate` would otherwise default to 60 Hz and silently
+        // halve ETD's door-cost scale on a 30 Hz sim; the traffic detector
+        // would no-op forever in the metrics phase. `insert_resource` is
+        // last-writer-wins, so snapshots that already carry them are kept.
         let mut world = world;
         world.insert_resource(crate::time::TickRate(ticks_per_second));
-        // Re-insert the traffic detector for the same forward-compat
-        // reason as `TickRate`: a snapshot taken before this resource
-        // existed wouldn't carry it, and `refresh_traffic_detector` in
-        // the metrics phase would silently no-op forever post-restore
-        // (greptile review of #361). `insert_resource` is
-        // last-writer-wins, so snapshots that already carry a
-        // detector keep their stored state.
         if world
             .resource::<crate::traffic_detector::TrafficDetector>()
             .is_none()

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -125,11 +125,6 @@ impl Simulation {
     ///   are recorded so dispatch sees the rider as fresh demand.
     /// - **Any other phase**: returns [`SimError::WrongRiderPhase`].
     ///
-    /// Replaces the prior `reroute(RiderId, EntityId)` /
-    /// `reroute_rider(EntityId, Route)` / `set_rider_route(EntityId, Route)`
-    /// trio. Callers that previously passed only a destination should
-    /// construct a `Route::direct(rider_current_stop, destination, group)`.
-    ///
     /// # Errors
     ///
     /// - [`SimError::EntityNotFound`] if `rider` does not exist.

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -234,11 +234,10 @@ impl WorldSnapshot {
     ) -> Result<crate::sim::Simulation, crate::error::SimError> {
         use crate::world::{SortedStops, World};
 
-        // Reject snapshots from incompatible schema versions. The bytes
-        // envelope path also checks the crate semver string, but the RON/
-        // JSON path was previously unguarded — older snapshots silently
-        // deserialized with `#[serde(default)]` filling new fields, masking
-        // schema mismatches. (#295)
+        // Reject snapshots from incompatible schema versions. Without this
+        // guard, `#[serde(default)]` on newly-added fields would silently
+        // fill them in and mask the mismatch. The bytes envelope path
+        // separately checks the crate semver string.
         if self.version != SNAPSHOT_SCHEMA_VERSION {
             return Err(crate::error::SimError::SnapshotVersion {
                 saved: format!("schema {}", self.version),

--- a/crates/elevator-core/src/systems/metrics.rs
+++ b/crates/elevator-core/src/systems/metrics.rs
@@ -112,7 +112,6 @@ pub fn run(
                 }
             }
         }
-        #[allow(clippy::cast_precision_loss)]
         let util = if total > 0 {
             moving as f64 / total as f64
         } else {

--- a/crates/elevator-core/src/tagged_metrics.rs
+++ b/crates/elevator-core/src/tagged_metrics.rs
@@ -69,7 +69,6 @@ impl TaggedMetric {
     }
 
     /// Record a board event with wait time.
-    #[allow(clippy::cast_precision_loss)]
     pub(crate) fn record_board(&mut self, wait_ticks: u64) {
         self.boarded_count += 1;
         self.sum_wait_ticks += wait_ticks;

--- a/crates/elevator-core/src/time.rs
+++ b/crates/elevator-core/src/time.rs
@@ -42,28 +42,24 @@ impl TimeAdapter {
     }
 
     /// Convert ticks to seconds.
-    #[allow(clippy::cast_precision_loss)] // tick counts within f64 range
     #[must_use]
     pub fn ticks_to_seconds(&self, ticks: u64) -> f64 {
         ticks as f64 / self.ticks_per_second
     }
 
     /// Convert seconds to ticks, rounded to nearest.
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)] // intentional rounding
     #[must_use]
     pub fn seconds_to_ticks(&self, seconds: f64) -> u64 {
         (seconds * self.ticks_per_second).round() as u64
     }
 
     /// Convert a `Duration` to ticks, rounded to nearest.
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)] // intentional rounding
     #[must_use]
     pub fn duration_to_ticks(&self, duration: Duration) -> u64 {
         (duration.as_secs_f64() * self.ticks_per_second).round() as u64
     }
 
     /// Convert ticks to a `Duration`.
-    #[allow(clippy::cast_precision_loss)] // tick counts within f64 range
     #[must_use]
     pub fn ticks_to_duration(&self, ticks: u64) -> Duration {
         Duration::from_secs_f64(ticks as f64 / self.ticks_per_second)

--- a/crates/elevator-core/src/topology.rs
+++ b/crates/elevator-core/src/topology.rs
@@ -21,9 +21,6 @@ struct Edge {
     to: EntityId,
     /// Group that connects these stops.
     group: GroupId,
-    /// Line within the group (retained for future per-line routing).
-    #[allow(dead_code)]
-    line: EntityId,
 }
 
 /// Lazy-rebuilt connectivity graph for topology queries.
@@ -72,7 +69,6 @@ impl TopologyGraph {
                             self.adjacency.entry(from).or_default().push(Edge {
                                 to,
                                 group: group.id(),
-                                line: line_info.entity(),
                             });
                         }
                     }
@@ -166,7 +162,6 @@ impl TopologyGraph {
             }
         }
 
-        // If `to` was never reached, return None.
         if !visited.contains_key(&to) {
             return None;
         }

--- a/crates/elevator-core/src/traffic_detector.rs
+++ b/crates/elevator-core/src/traffic_detector.rs
@@ -236,13 +236,11 @@ impl TrafficDetector {
             self.current = TrafficMode::Idle;
             return;
         }
-        #[allow(clippy::cast_precision_loss)] // counts fit in f64 mantissa
         let rate_per_tick = total_origin as f64 / self.window_ticks as f64;
         if rate_per_tick < self.idle_rate_threshold {
             self.current = TrafficMode::Idle;
             return;
         }
-        #[allow(clippy::cast_precision_loss)]
         let up_fraction = lobby_origin_count as f64 / total_origin as f64;
         if up_fraction >= self.up_peak_fraction {
             self.current = TrafficMode::UpPeak;
@@ -254,7 +252,6 @@ impl TrafficDetector {
         // spuriously match the threshold at `0/0 = NaN` — falling
         // through to `InterFloor` is the safer default.
         if total_dest > 0 {
-            #[allow(clippy::cast_precision_loss)]
             let down_fraction = lobby_dest_count as f64 / total_dest as f64;
             if down_fraction >= self.down_peak_fraction {
                 self.current = TrafficMode::DownPeak;

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -75,6 +75,15 @@ impl<T> Default for ExtKey<T> {
 /// Built-in components are accessed via typed methods. Games can attach
 /// custom data via the extension storage (`insert_ext` / `ext`).
 /// The query builder (`world.query::<...>()`) provides ECS-style iteration.
+///
+/// # Component-accessor semantics
+///
+/// All `<component>(&self, id)` accessors return `Option`. They return `None`
+/// when the entity is dead **or** when it is alive but lacks that component —
+/// slotmap semantics make these two cases indistinguishable through this
+/// surface. Use [`World::is_alive`] (or check the typed component you expect
+/// to be present, e.g. `elevator()` for an elevator entity) when the
+/// distinction matters.
 pub struct World {
     /// Primary key storage. An entity exists iff its key is here.
     pub(crate) alive: SlotMap<EntityId, ()>,


### PR DESCRIPTION
## Summary

Three-commit cleanup pass on `elevator-core`, derived from a comprehensive code-cleanup, architecture, and comment-quality audit. Net **-52 LOC**, no behaviour change. Workspace `cargo clippy --all-features --all-targets` and `cargo test -p elevator-core --all-features` clean.

## What's in this PR

### `chore(core): drop dead code and unused dependency feature` (8ac5848)
- Drop `serde` feature on `smallvec` — the only `SmallVec` field (`EtdDispatch::pending_positions`) is `#[serde(skip)]`.
- Delete `Edge::line` from the topology adjacency list. Set on every edge but never read; the `#[allow(dead_code)]` and "future per-line routing" hint had no movement. Re-derive when the need actually surfaces.
- Macro-collapse three byte-identical `From<f64>` impls for `Weight`/`Speed`/`Accel`. The `#[allow(clippy::panic)]` lives inside the macro so the deliberate-panic pattern stays co-located with its lint suppression.
- Drop one inline comment in `topology.rs::shortest_route` that just narrated the next two lines.

### `chore(core): remove redundant clippy::cast_* allows` (8800c39)
The workspace `Cargo.toml` already sets `cast_precision_loss`, `cast_possible_truncation`, `cast_sign_loss`, and `cast_lossless` to `allow` (priority 0, beating the `pedantic`/`nursery` group's priority -1 warn). Per-function `#[allow(clippy::cast_*)]` attributes were therefore suppressing nothing reachable.

13 such attributes removed across `metrics.rs`, `traffic_detector.rs`, `tagged_metrics.rs`, `scenario.rs`, `time.rs`, `systems/metrics.rs`. Verified by `cargo clippy -p elevator-core --all-features --all-targets` (zero new warnings).

### `docs(core): trim historical narratives and document accessor semantics` (ad43698)
Production source documentation should describe current behaviour, not narrate the history of the fix that produced it. **Test docstrings are exempt** — a regression-test docstring saying "pre-fix this would silently swap to Scan" is documenting what the test guards against, which is its job.

Trimmed eight non-test sites:
- `builder.rs::from_config` — drop the (#287) pre-fix paragraph; keep the current-behaviour doc.
- `sim/construction.rs` — three trims around dispatcher-id inference and the `TickRate` / traffic-detector forward-compat block.
- `sim/accessors.rs::pending_events` — drop the round-2 audit reference; keep the flush-vs-drain rationale.
- `snapshot.rs::restore` — collapse the `#[serde(default)]` failure-mode history into the forward-looking one-liner.
- `sim/lifecycle.rs::reroute` — drop the migration-guide paragraph for a function that no longer exists.
- `sim.rs::spawn_rider` — collapse the philosophical justification for topology fallback; long-form belongs in `docs/`.

Added a "Component-accessor semantics" note to the `World` struct doc so the slotmap-backed `Option`-return convention (returns `None` for dead entities **or** missing components, indistinguishably) is documented once at the type level rather than padding 30+ trivial accessor docstrings.

## What's deferred (follow-up PRs)

The audit also surfaced architecture and missing-WHY-comment items that each deserve their own PR (every change lands via PR per `CLAUDE.md`). Ordered by planned execution:

**Architecture (HIGH):**
1. `DispatchStrategy::rank` should take `&self`, not `&mut self`. Mutation contract was already extracted to `prepare_car`. Internal-only; smallest blast radius. (`dispatch/mod.rs:938`)
2. Uniform typed-ID adoption on `Simulation` accessor surface. `lifecycle.rs` takes raw `EntityId` while `runtime.rs`/`destinations.rs` take typed IDs. Touches FFI, wasm, gdext, `bindings.toml`.
3. Replace `From<EntityId>` for typed IDs with a fallible `try_from_world`. `entity.rs:38` macro silently coerces wrong-type IDs (per `project_typed_id_silent_coercion` memory).

**Architecture (MEDIUM):**
4. Promote phase / service-mode label formatters from `elevator-wasm` into a core `host_label` module — same shape as the recent `host_error::ErrorKind` work.
5. Collapse `RankContext::car_position`/`stop_position` into cached accessors over `world`.
6. Remove redundant `tick: u64` from every `Event` variant; wrap as `TickedEvent { tick, payload }`.
7. Demote `World::set_*` raw setters to `pub(crate)` so they can't bypass `RiderIndex` invariants and event emission.
8. Replace `LineInfo::elevators_mut` / `serves_mut` raw `&mut Vec` access with invariant-preserving helpers.

**Missing-WHY comments:** ETD weight rationales, FNV-1a constant pointers, ServiceMode::Manual gating notes, route-trust caveat — bundled into a single follow-up PR.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p elevator-core --all-features --all-targets` clean
- [x] `cargo test -p elevator-core --all-features` — 159 unit + 8 doc + scenario suites all passing
- [x] `cargo check --workspace --all-features --all-targets` clean (matches pre-commit hook)
- [x] No public API change → no `bindings.toml` updates required