### PR TITLE
refactor(core)!: dispatch rank takes &self

### DIFF
--- a/crates/elevator-core/examples/custom_dispatch.rs
+++ b/crates/elevator-core/examples/custom_dispatch.rs
@@ -90,7 +90,7 @@ impl DispatchStrategy for IdlePenaltyDispatch {
     /// Cost is distance minus a small bonus for cars that haven't been
     /// used recently. Returning `None` would exclude a `(car, stop)`
     /// pair entirely — useful for capacity limits or restricted stops.
-    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+    fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
         let distance = (ctx.car_position - ctx.stop_position).abs();
         let idle_for = self.idle_for.get(&ctx.car).copied().unwrap_or(0.0);
         // Bias toward long-idle cars; clamp so cost stays non-negative.

--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -256,7 +256,7 @@ impl DispatchStrategy for DestinationDispatch {
         }
     }
 
-    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+    fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
         // The queue is the source of truth — route each car strictly to
         // its own queue front. Every other stop is unavailable for this
         // car, so the Hungarian assignment reduces to the identity match

--- a/crates/elevator-core/src/dispatch/etd.rs
+++ b/crates/elevator-core/src/dispatch/etd.rs
@@ -210,7 +210,7 @@ impl DispatchStrategy for EtdDispatch {
         }
     }
 
-    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+    fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
         // Exclude `(car, stop)` pairs that can't produce any useful work.
         // Without this guard, a full car whose only candidate stop is a
         // pickup it lacks capacity to serve collapses to a zero-cost

--- a/crates/elevator-core/src/dispatch/look.rs
+++ b/crates/elevator-core/src/dispatch/look.rs
@@ -83,7 +83,7 @@ impl DispatchStrategy for LookDispatch {
         }
     }
 
-    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+    fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
         // Same guard as SCAN: deny un-servable pairs so an over-capacity
         // waiting rider at the car's own stop can't pull the car into a
         // cost-0 self-assignment during the Lenient reversal tick.

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -17,7 +17,7 @@
 //! struct AlwaysFirstStop;
 //!
 //! impl DispatchStrategy for AlwaysFirstStop {
-//!     fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+//!     fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
 //!         // Prefer the group's first stop; everything else is unavailable.
 //!         if Some(&ctx.stop) == ctx.group.stop_entities().first() {
 //!             Some((ctx.car_position - ctx.stop_position).abs())
@@ -928,14 +928,11 @@ pub trait DispatchStrategy: Send + Sync {
     /// Must return a finite, non-negative value if `Some` — infinities
     /// and NaN can destabilize the underlying Hungarian solver.
     ///
-    /// Implementations must not mutate per-car state inside `rank`: the
-    /// dispatch system calls `rank(car, stop_0..stop_m)` in a loop, so
-    /// mutating `self` on one call affects subsequent calls for the same
-    /// car within the same pass and produces an asymmetric cost matrix
-    /// whose results depend on iteration order. Use
-    /// [`prepare_car`](Self::prepare_car) to compute and store any
-    /// per-car state before `rank` is called.
-    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64>;
+    /// Takes `&self` so the assignment loop can score `(car, stop)` pairs
+    /// in any order without producing an asymmetric cost matrix. Compute
+    /// any per-car scratch in [`prepare_car`](Self::prepare_car) (which
+    /// takes `&mut self`) before this method is called.
+    fn rank(&self, ctx: &RankContext<'_>) -> Option<f64>;
 
     /// Decide what an idle car should do when no stop was assigned to it.
     ///

--- a/crates/elevator-core/src/dispatch/nearest_car.rs
+++ b/crates/elevator-core/src/dispatch/nearest_car.rs
@@ -37,7 +37,7 @@ impl Default for NearestCarDispatch {
 }
 
 impl DispatchStrategy for NearestCarDispatch {
-    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+    fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
         if !pair_is_useful(ctx, true) {
             return None;
         }

--- a/crates/elevator-core/src/dispatch/rsr.rs
+++ b/crates/elevator-core/src/dispatch/rsr.rs
@@ -304,7 +304,7 @@ impl Default for RsrDispatch {
 }
 
 impl DispatchStrategy for RsrDispatch {
-    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+    fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
         // `pair_is_useful(ctx, true)` enables the aboard-rider path
         // guard on top of the servability check. Without it, a loaded
         // RSR car gets pulled off the path to its aboard riders'

--- a/crates/elevator-core/src/dispatch/scan.rs
+++ b/crates/elevator-core/src/dispatch/scan.rs
@@ -86,7 +86,7 @@ impl DispatchStrategy for ScanDispatch {
         }
     }
 
-    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+    fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
         // Reject un-servable pairs so a full car with only
         // over-capacity waiting demand at its own stop can't open/close
         // doors indefinitely. SCAN's direction reversal normally lifts

--- a/crates/elevator-core/src/tests/canonical_benchmarks.rs
+++ b/crates/elevator-core/src/tests/canonical_benchmarks.rs
@@ -257,7 +257,7 @@ impl DispatchStrategy for BoxedStrategy {
         self.0.prepare_car(car, pos, group, manifest, world);
     }
 
-    fn rank(&mut self, ctx: &crate::dispatch::RankContext<'_>) -> Option<f64> {
+    fn rank(&self, ctx: &crate::dispatch::RankContext<'_>) -> Option<f64> {
         self.0.rank(ctx)
     }
 

--- a/crates/elevator-core/src/tests/dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/dispatch_tests.rs
@@ -651,7 +651,7 @@ fn nearest_car_distance_calculation() {
 struct AlwaysIdleDispatch;
 
 impl DispatchStrategy for AlwaysIdleDispatch {
-    fn rank(&mut self, _ctx: &RankContext<'_>) -> Option<f64> {
+    fn rank(&self, _ctx: &RankContext<'_>) -> Option<f64> {
         None
     }
 }
@@ -907,7 +907,7 @@ fn strategy_rank_is_order_independent_when_state_lives_in_prepare_car() {
             // Snapshot once; `rank` reads only.
             self.idle.insert(car, self.tick as f64);
         }
-        fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+        fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
             let boost = self.idle.get(&ctx.car).copied().unwrap_or(0.0);
             Some(
                 0.001f64

--- a/crates/elevator-core/src/tests/feature_tests.rs
+++ b/crates/elevator-core/src/tests/feature_tests.rs
@@ -565,7 +565,7 @@ fn disable_elevator_notifies_dispatcher() {
         removed: Arc<AtomicUsize>,
     }
     impl DispatchStrategy for Counter {
-        fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+        fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
             Some((ctx.car_position - ctx.stop_position).abs())
         }
         fn notify_removed(&mut self, _elevator: EntityId) {
@@ -615,7 +615,7 @@ fn remove_elevator_notifies_dispatcher_exactly_once() {
         removed: Arc<AtomicUsize>,
     }
     impl DispatchStrategy for Counter {
-        fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+        fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
             Some((ctx.car_position - ctx.stop_position).abs())
         }
         fn notify_removed(&mut self, _elevator: EntityId) {

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -740,7 +740,7 @@ fn custom_strategy_reads_hall_calls_from_manifest() {
     }
 
     impl DispatchStrategy for Observer {
-        fn rank(&mut self, ctx: &crate::dispatch::RankContext<'_>) -> Option<f64> {
+        fn rank(&self, ctx: &crate::dispatch::RankContext<'_>) -> Option<f64> {
             let target = *self.target_stop.lock().unwrap();
             if Some(ctx.stop) == target
                 && ctx
@@ -793,7 +793,7 @@ fn custom_strategy_reads_car_calls_from_manifest() {
         saw_car_call: Arc<AtomicUsize>,
     }
     impl DispatchStrategy for Observer {
-        fn rank(&mut self, ctx: &crate::dispatch::RankContext<'_>) -> Option<f64> {
+        fn rank(&self, ctx: &crate::dispatch::RankContext<'_>) -> Option<f64> {
             if !ctx.manifest.car_calls_for(ctx.car).is_empty() {
                 self.saw_car_call.fetch_add(1, Ordering::Relaxed);
             }
@@ -857,7 +857,7 @@ fn unacknowledged_hall_calls_hidden_from_manifest() {
             self.visible_call_count.fetch_max(count, Ordering::Relaxed);
         }
 
-        fn rank(&mut self, ctx: &crate::dispatch::RankContext<'_>) -> Option<f64> {
+        fn rank(&self, ctx: &crate::dispatch::RankContext<'_>) -> Option<f64> {
             Some((ctx.car_position - ctx.stop_position).abs())
         }
     }

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -1751,7 +1751,7 @@ fn reassign_elevator_to_line_notifies_old_group_dispatcher_on_cross_group() {
         inner: ScanDispatch,
     }
     impl DispatchStrategy for TrackingDispatch {
-        fn rank(&mut self, ctx: &crate::dispatch::RankContext<'_>) -> Option<f64> {
+        fn rank(&self, ctx: &crate::dispatch::RankContext<'_>) -> Option<f64> {
             self.inner.rank(ctx)
         }
         fn notify_removed(&mut self, elevator: EntityId) {

--- a/crates/elevator-core/src/tests/reposition_look_boundary_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_look_boundary_tests.rs
@@ -494,7 +494,7 @@ fn strict_demand_ahead_up_accepts_demand_strictly_above_car() {
     reason = "test helper threading rank context"
 )]
 fn rank_via_look(
-    look: &mut LookDispatch,
+    look: &LookDispatch,
     car: EntityId,
     car_pos: f64,
     stop: EntityId,
@@ -526,7 +526,7 @@ fn look_all_demand_strictly_above_car_keeps_up_sweep() {
     look.prepare_car(elev, 10.0, &g, &m, &world);
     // Sweep stays Up: a stop above the car must rank, the (synthetic)
     // self-stop at the car's position must not.
-    let above = rank_via_look(&mut look, elev, 10.0, stops[0], 15.0, &g, &m, &world);
+    let above = rank_via_look(&look, elev, 10.0, stops[0], 15.0, &g, &m, &world);
     assert!(above.is_some(), "Up sweep accepts stop above car");
 }
 
@@ -541,7 +541,7 @@ fn look_all_demand_strictly_below_car_reverses_to_down() {
     // Default direction is Up but no demand is up → prepare_car
     // reverses to Down + Lenient.
     look.prepare_car(elev, 10.0, &g, &m, &world);
-    let below = rank_via_look(&mut look, elev, 10.0, stops[0], 0.0, &g, &m, &world);
+    let below = rank_via_look(&look, elev, 10.0, stops[0], 0.0, &g, &m, &world);
     assert!(
         below.is_some(),
         "after reversal, a stop below the car must rank (Down sweep accepts it)"
@@ -563,7 +563,7 @@ fn look_repeated_stops_at_same_position_all_rank_equally() {
 
     let costs: Vec<_> = stops
         .iter()
-        .map(|&s| rank_via_look(&mut look, elev, 10.0, s, 20.0, &g, &m, &world))
+        .map(|&s| rank_via_look(&look, elev, 10.0, s, 20.0, &g, &m, &world))
         .collect();
     assert!(costs.iter().all(Option::is_some));
     let first = costs[0].unwrap();

--- a/crates/elevator-wasm/src/js_dispatch.rs
+++ b/crates/elevator-wasm/src/js_dispatch.rs
@@ -70,7 +70,7 @@ unsafe impl Send for JsDispatchStrategy {}
 unsafe impl Sync for JsDispatchStrategy {}
 
 impl DispatchStrategy for JsDispatchStrategy {
-    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+    fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
         let dto = JsRankContext {
             car: ctx.car.data().as_ffi(),
             car_position: ctx.car_position,

--- a/docs/src/custom-dispatch.md
+++ b/docs/src/custom-dispatch.md
@@ -45,7 +45,7 @@ pub trait DispatchStrategy: Send + Sync {
     /// Score sending `car` to `stop`. Lower is better. `None` marks
     /// the pair unavailable (capacity limits, wrong-direction, sticky).
     /// Must return a finite, non-negative value when `Some`.
-    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64>;
+    fn rank(&self, ctx: &RankContext<'_>) -> Option<f64>;
 
     /// Decide what a car should do when the assignment phase couldn't
     /// give it a stop (no demand or all candidate ranks were `None`).
@@ -91,7 +91,7 @@ use elevator_core::dispatch::{DispatchStrategy, RankContext};
 struct BusyStopNearest;
 
 impl DispatchStrategy for BusyStopNearest {
-    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+    fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
         let distance = (ctx.car_position - ctx.stop_position).abs();
         let waiting = ctx.manifest.waiting_count_at(ctx.stop) as f64;
         // Subtract a crowding bonus so busier stops look cheaper. Clamp
@@ -152,7 +152,7 @@ impl DispatchStrategy for DirectionalDispatch {
         self.sweep_up.insert(car, demand_above >= demand_below);
     }
 
-    fn rank(&mut self, ctx: &RankContext<'_>) -> Option<f64> {
+    fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
         let going_up = self.sweep_up.get(&ctx.car).copied().unwrap_or(true);
         let is_ahead = if going_up {
             ctx.stop_position >= ctx.car_position
@@ -232,7 +232,7 @@ struct PriorityDispatch {
 
 impl DispatchStrategy for PriorityDispatch {
     // Real implementations score against `ctx`; see `BusyStopNearest` above.
-    fn rank(&mut self, _ctx: &RankContext<'_>) -> Option<f64> { Some(0.0) }
+    fn rank(&self, _ctx: &RankContext<'_>) -> Option<f64> { Some(0.0) }
 
     fn builtin_id(&self) -> Option<BuiltinStrategy> {
         // Identify the strategy to the snapshot layer. Keep this name
@@ -293,7 +293,7 @@ Two levels of test coverage work well:
 # use elevator_core::__doctest_prelude::*;
 # struct BusyStopNearest;
 # impl DispatchStrategy for BusyStopNearest {
-#     fn rank(&mut self, _ctx: &RankContext<'_>) -> Option<f64> { Some(0.0) }
+#     fn rank(&self, _ctx: &RankContext<'_>) -> Option<f64> { Some(0.0) }
 # }
 #[test]
 fn custom_strategy_assigns_nearest_car() {

--- a/docs/src/snapshots-determinism.md
+++ b/docs/src/snapshots-determinism.md
@@ -75,7 +75,7 @@ Built-in strategies (`Scan`, `Look`, `NearestCar`, `Etd`, `Rsr`, `Destination`) 
 # use elevator_core::snapshot::WorldSnapshot;
 # struct HighestFirstDispatch;
 # impl DispatchStrategy for HighestFirstDispatch {
-#   fn rank(&mut self, _ctx: &RankContext<'_>) -> Option<f64> { Some(0.0) }
+#   fn rank(&self, _ctx: &RankContext<'_>) -> Option<f64> { Some(0.0) }
 # }
 # fn run(snapshot: WorldSnapshot) {
 let sim = snapshot.restore(Some(&|name: &str| match name {


### PR DESCRIPTION
## Summary

Tighten `DispatchStrategy::rank` from `&mut self` to `&self`. First architecture PR from the queue audited in #710 (HIGH #3 of 8).

The dispatch loop calls `rank(car, stop_0..stop_m)` for every `(car, stop)` pair when building the cost matrix. With `&mut self`, mutating per-car state inside `rank` produced an asymmetric cost matrix whose results depended on iteration order — the trait doc warned against this in prose. Per-car scratch was already supposed to live in `prepare_car` (which stays `&mut self`); now the type system enforces it.

## What changes

**Trait** (`crates/elevator-core/src/dispatch/mod.rs`):
- `fn rank(&mut self, …)` → `fn rank(&self, …)`
- Trait doc rewritten: drops the long "implementations must not mutate per-car state inside `rank`" warning (made redundant by the signature) and replaces it with a one-line contract pointing at `prepare_car`.
- Module-level doctest example (`AlwaysFirstStop`) updated.

**Built-in impls — all already pure-read on `self`, no logic change:**
- `scan.rs`, `look.rs` — `mode_for(&self, …)` and `direction_for(&self, …)` were already `&self`
- `etd.rs` — reads weights and `compute_cost(&self, …)`
- `nearest_car.rs` — pure (no `self.` access in body)
- `destination.rs` — uses `ctx.world` only
- `rsr.rs` — all field reads

**Host bridges & examples:**
- `crates/elevator-wasm/src/js_dispatch.rs` — flip
- `crates/elevator-core/examples/custom_dispatch.rs` — flip

**Tests** (8 stub impls flipped; all already use interior mutability — `Arc<AtomicUsize>`, `Arc<Mutex<…>>` — for the few that observe state):
- `dispatch_tests.rs`, `feature_tests.rs`, `hall_call_tests.rs`, `multi_line_tests.rs`, `canonical_benchmarks.rs`
- `reposition_look_boundary_tests.rs::rank_via_look` helper drops a vestigial `&mut` (caught by `clippy::needless_pass_by_ref_mut` from the nursery group, which would have stayed silent without this PR)

**Docs** (`docs/src/`):
- `custom-dispatch.md` — 4 occurrences, including the trait declaration shown to readers
- `snapshots-determinism.md` — 1 doctest hidden line

## Why

This is the smallest-blast-radius HIGH item in the architecture queue. It is internal-only — no FFI, wasm bindings, gdext, or `bindings.toml` need updates because `DispatchStrategy::rank` is not a `Simulation` public API method. Future parallel-rank work over the cost matrix becomes possible once the receiver is shared.

## Migration

Implementations of `DispatchStrategy` outside this repo must change their `rank` signature from `&mut self` to `&self`. If your `rank` was mutating state, move it to `prepare_car(&mut self, car, …)`, which the dispatch loop already calls exactly once per car before any `rank` call for that car.

## BREAKING CHANGE

`DispatchStrategy::rank` signature change. Marked with `!` per conventional-commits.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p elevator-core --all-features --all-targets` clean (zero warnings)
- [x] `cargo test -p elevator-core --all-features` — 159 unit + 8 doc + scenario suites all pass
- [x] `cargo check --workspace --all-features --all-targets` clean
- [x] `scripts/check-bindings.sh` clean (no public API change)
- [x] `scripts/lint-docs.sh --quick` clean
- [x] Pre-commit hook (full battery: fmt, clippy, tests, workspace check, ABI pins, docs lint) green