### PR TITLE
refactor(core)!: elevator accessors take ElevatorId

### DIFF
--- a/crates/elevator-core/src/sim/destinations.rs
+++ b/crates/elevator-core/src/sim/destinations.rs
@@ -154,7 +154,7 @@ impl super::Simulation {
 
         let pos = self.world.position(eid).map_or(0.0, |p| p.value);
         let vel = self.world.velocity(eid).map_or(0.0, |v| v.value);
-        let Some(brake_pos) = self.future_stop_position(eid) else {
+        let Some(brake_pos) = self.future_stop_position(elev) else {
             return Ok(());
         };
 

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -495,9 +495,9 @@ impl Simulation {
     ///
     /// Returns an empty slice if the elevator does not exist.
     #[must_use]
-    pub fn riders_on(&self, elevator: EntityId) -> &[EntityId] {
+    pub fn riders_on(&self, elevator: ElevatorId) -> &[EntityId] {
         self.world
-            .elevator(elevator)
+            .elevator(elevator.entity())
             .map_or(&[], |car| car.riders())
     }
 
@@ -505,9 +505,9 @@ impl Simulation {
     ///
     /// Returns 0 if the elevator does not exist.
     #[must_use]
-    pub fn occupancy(&self, elevator: EntityId) -> usize {
+    pub fn occupancy(&self, elevator: ElevatorId) -> usize {
         self.world
-            .elevator(elevator)
+            .elevator(elevator.entity())
             .map_or(0, |car| car.riders().len())
     }
 
@@ -1054,51 +1054,51 @@ impl Simulation {
 
     /// Whether the elevator's up-direction indicator lamp is lit.
     ///
-    /// Returns `None` if the entity is not an elevator. See
+    /// Returns `None` if the elevator does not exist. See
     /// [`Elevator::going_up`] for semantics.
     #[must_use]
-    pub fn elevator_going_up(&self, id: EntityId) -> Option<bool> {
-        self.world.elevator(id).map(Elevator::going_up)
+    pub fn elevator_going_up(&self, id: ElevatorId) -> Option<bool> {
+        self.world.elevator(id.entity()).map(Elevator::going_up)
     }
 
     /// Whether the elevator's down-direction indicator lamp is lit.
     ///
-    /// Returns `None` if the entity is not an elevator. See
+    /// Returns `None` if the elevator does not exist. See
     /// [`Elevator::going_down`] for semantics.
     #[must_use]
-    pub fn elevator_going_down(&self, id: EntityId) -> Option<bool> {
-        self.world.elevator(id).map(Elevator::going_down)
+    pub fn elevator_going_down(&self, id: ElevatorId) -> Option<bool> {
+        self.world.elevator(id.entity()).map(Elevator::going_down)
     }
 
     /// Direction the elevator is currently signalling, derived from the
-    /// indicator-lamp pair. Returns `None` if the entity is not an elevator.
+    /// indicator-lamp pair. Returns `None` if the elevator does not exist.
     #[must_use]
-    pub fn elevator_direction(&self, id: EntityId) -> Option<crate::components::Direction> {
-        self.world.elevator(id).map(Elevator::direction)
+    pub fn elevator_direction(&self, id: ElevatorId) -> Option<crate::components::Direction> {
+        self.world.elevator(id.entity()).map(Elevator::direction)
     }
 
     /// Count of rounded-floor transitions for an elevator (passing-floor
-    /// crossings plus arrivals). Returns `None` if the entity is not an
-    /// elevator.
+    /// crossings plus arrivals). Returns `None` if the elevator does not
+    /// exist.
     #[must_use]
-    pub fn elevator_move_count(&self, id: EntityId) -> Option<u64> {
-        self.world.elevator(id).map(Elevator::move_count)
+    pub fn elevator_move_count(&self, id: ElevatorId) -> Option<u64> {
+        self.world.elevator(id.entity()).map(Elevator::move_count)
     }
 
     /// Distance the elevator would travel while braking to a stop from its
     /// current velocity, at its configured deceleration rate.
     ///
     /// Uses the standard `v² / (2·a)` kinematic formula. A stationary
-    /// elevator returns `Some(0.0)`. Returns `None` if the entity is not
-    /// an elevator or lacks a velocity component.
+    /// elevator returns `Some(0.0)`. Returns `None` if the elevator does
+    /// not exist or lacks a velocity component.
     ///
     /// Useful for writing opportunistic dispatch strategies (e.g. "stop at
     /// this floor if we can brake in time") without duplicating the physics
     /// computation.
     #[must_use]
-    pub fn braking_distance(&self, id: EntityId) -> Option<f64> {
-        let car = self.world.elevator(id)?;
-        let vel = self.world.velocity(id)?.value;
+    pub fn braking_distance(&self, id: ElevatorId) -> Option<f64> {
+        let car = self.world.elevator(id.entity())?;
+        let vel = self.world.velocity(id.entity())?.value;
         Some(crate::movement::braking_distance(
             vel,
             car.deceleration.value(),
@@ -1109,13 +1109,13 @@ impl Simulation {
     /// this instant. Current position plus a signed braking distance in the
     /// direction of travel.
     ///
-    /// Returns `None` if the entity is not an elevator or lacks the required
+    /// Returns `None` if the elevator does not exist or lacks the required
     /// components.
     #[must_use]
-    pub fn future_stop_position(&self, id: EntityId) -> Option<f64> {
-        let pos = self.world.position(id)?.value;
-        let vel = self.world.velocity(id)?.value;
-        let car = self.world.elevator(id)?;
+    pub fn future_stop_position(&self, id: ElevatorId) -> Option<f64> {
+        let pos = self.world.position(id.entity())?.value;
+        let vel = self.world.velocity(id.entity())?.value;
+        let car = self.world.elevator(id.entity())?;
         let dist = crate::movement::braking_distance(vel, car.deceleration.value());
         Some(crate::fp::fma(vel.signum(), dist, pos))
     }
@@ -1190,9 +1190,9 @@ impl Simulation {
 
     /// Get the current service mode for an elevator.
     #[must_use]
-    pub fn service_mode(&self, elevator: EntityId) -> crate::components::ServiceMode {
+    pub fn service_mode(&self, elevator: ElevatorId) -> crate::components::ServiceMode {
         self.world
-            .service_mode(elevator)
+            .service_mode(elevator.entity())
             .copied()
             .unwrap_or_default()
     }

--- a/crates/elevator-core/src/tests/abort_movement_tests.rs
+++ b/crates/elevator-core/src/tests/abort_movement_tests.rs
@@ -151,7 +151,7 @@ fn abort_mid_flight_brake_target_is_reachable_in_direction() {
 
     let pos = sim.world().position(elev.entity()).unwrap().value;
     let vel = sim.world().velocity(elev.entity()).unwrap().value;
-    let brake_pos = sim.future_stop_position(elev.entity()).unwrap();
+    let brake_pos = sim.future_stop_position(elev).unwrap();
     sim.abort_movement(elev).unwrap();
 
     let car = sim.world().elevator(elev.entity()).unwrap();

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -586,7 +586,7 @@ fn riders_on_returns_empty_for_idle_elevator() {
     let config = default_config();
     let sim = Simulation::new(&config, scan()).unwrap();
     let elevator_id = sim.groups()[0].elevator_entities()[0];
-    assert!(sim.riders_on(elevator_id).is_empty());
+    assert!(sim.riders_on(elevator_id.into()).is_empty());
 }
 
 #[test]
@@ -613,7 +613,8 @@ fn riders_on_returns_rider_ids_after_boarding() {
         RiderPhase::Riding(_)
     ) {
         assert!(
-            sim.riders_on(elevator_id).contains(&rider_id.entity()),
+            sim.riders_on(elevator_id.into())
+                .contains(&rider_id.entity()),
             "rider should appear in riders_on after boarding"
         );
     }
@@ -624,7 +625,7 @@ fn riders_on_returns_empty_for_nonexistent_elevator() {
     let config = default_config();
     let sim = Simulation::new(&config, scan()).unwrap();
     let fake_id = EntityId::default();
-    assert!(sim.riders_on(fake_id).is_empty());
+    assert!(sim.riders_on(fake_id.into()).is_empty());
 }
 
 // ── occupancy ─────────────────────────────────────────────────────────────────
@@ -634,7 +635,7 @@ fn occupancy_returns_zero_for_idle_elevator() {
     let config = default_config();
     let sim = Simulation::new(&config, scan()).unwrap();
     let elevator_id = sim.groups()[0].elevator_entities()[0];
-    assert_eq!(sim.occupancy(elevator_id), 0);
+    assert_eq!(sim.occupancy(elevator_id.into()), 0);
 }
 
 #[test]
@@ -661,7 +662,7 @@ fn occupancy_returns_correct_count_after_boarding() {
         RiderPhase::Riding(_)
     ) {
         assert_eq!(
-            sim.occupancy(elevator_id),
+            sim.occupancy(elevator_id.into()),
             1,
             "occupancy should be 1 after one rider boards"
         );
@@ -673,7 +674,7 @@ fn occupancy_returns_zero_for_nonexistent_elevator() {
     let config = default_config();
     let sim = Simulation::new(&config, scan()).unwrap();
     let fake_id = EntityId::default();
-    assert_eq!(sim.occupancy(fake_id), 0);
+    assert_eq!(sim.occupancy(fake_id.into()), 0);
 }
 
 // ── iter_repositioning_elevators ──────────────────────────────────────────────
@@ -1100,7 +1101,7 @@ fn remove_elevator_then_riders_on_returns_empty() {
     sim.remove_elevator(elevator_id).unwrap();
 
     // After removal, riders_on should return empty (not panic).
-    assert!(sim.riders_on(elevator_id).is_empty());
+    assert!(sim.riders_on(elevator_id.into()).is_empty());
 }
 
 #[test]
@@ -1111,7 +1112,7 @@ fn remove_elevator_then_occupancy_returns_zero() {
 
     sim.remove_elevator(elevator_id).unwrap();
 
-    assert_eq!(sim.occupancy(elevator_id), 0);
+    assert_eq!(sim.occupancy(elevator_id.into()), 0);
 }
 
 #[test]

--- a/crates/elevator-core/src/tests/braking_tests.rs
+++ b/crates/elevator-core/src/tests/braking_tests.rs
@@ -1,6 +1,7 @@
 //! Tests for the public braking-distance helpers.
 
 use crate::components::ElevatorPhase;
+use crate::entity::ElevatorId;
 use crate::movement::braking_distance;
 use crate::sim::Simulation;
 use crate::stop::StopId;
@@ -37,7 +38,7 @@ fn braking_distance_rejects_nonpositive_deceleration() {
 fn sim_braking_distance_stationary_elevator_is_zero() {
     let sim = Simulation::new(&default_config(), scan()).unwrap();
     let elev = first_elevator(&sim);
-    assert_eq!(sim.braking_distance(elev.entity()), Some(0.0));
+    assert_eq!(sim.braking_distance(elev), Some(0.0));
 }
 
 #[test]
@@ -59,7 +60,7 @@ fn sim_braking_distance_nonzero_while_moving() {
         }
     }
 
-    let d = sim.braking_distance(elev.entity()).expect("is an elevator");
+    let d = sim.braking_distance(elev).expect("is an elevator");
     assert!(d > 0.0, "expected nonzero braking distance while moving");
 }
 
@@ -68,7 +69,7 @@ fn sim_future_stop_position_stationary_equals_current() {
     let sim = Simulation::new(&default_config(), scan()).unwrap();
     let elev = first_elevator(&sim);
     let pos = sim.world().position(elev.entity()).unwrap().value;
-    assert_eq!(sim.future_stop_position(elev.entity()), Some(pos));
+    assert_eq!(sim.future_stop_position(elev), Some(pos));
 }
 
 #[test]
@@ -86,7 +87,7 @@ fn sim_future_stop_position_ahead_while_moving_up() {
     }
 
     let pos = sim.world().position(elev.entity()).unwrap().value;
-    let future = sim.future_stop_position(elev.entity()).unwrap();
+    let future = sim.future_stop_position(elev).unwrap();
     assert!(
         future > pos,
         "future stop position {future} should be above current {pos} while moving up",
@@ -97,6 +98,10 @@ fn sim_future_stop_position_ahead_while_moving_up() {
 fn sim_braking_distance_none_for_non_elevator() {
     let mut sim = Simulation::new(&default_config(), scan()).unwrap();
     let rider = sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
-    assert_eq!(sim.braking_distance(rider.entity()), None);
-    assert_eq!(sim.future_stop_position(rider.entity()), None);
+    // Defense-in-depth: a caller that bypasses the type system with
+    // `ElevatorId::from(non_elevator_entity)` still gets `None` from the
+    // accessor's runtime kind check.
+    let bogus = ElevatorId::from(rider.entity());
+    assert_eq!(sim.braking_distance(bogus), None);
+    assert_eq!(sim.future_stop_position(bogus), None);
 }

--- a/crates/elevator-core/src/tests/destination_queue_tests.rs
+++ b/crates/elevator-core/src/tests/destination_queue_tests.rs
@@ -306,8 +306,8 @@ fn redirect_via_push_front_updates_direction_indicators() {
             break;
         }
     }
-    assert_eq!(sim.elevator_going_up(elev.entity()), Some(true));
-    assert_eq!(sim.elevator_going_down(elev.entity()), Some(false));
+    assert_eq!(sim.elevator_going_up(elev), Some(true));
+    assert_eq!(sim.elevator_going_down(elev), Some(false));
 
     // Game imperatively redirects to a stop below the current position.
     let stop_0 = sim.stop_entity(StopId(0)).unwrap();
@@ -316,11 +316,11 @@ fn redirect_via_push_front_updates_direction_indicators() {
     sim.step();
 
     assert_eq!(
-        sim.elevator_going_up(elev.entity()),
+        sim.elevator_going_up(elev),
         Some(false),
         "push_destination_front to a lower stop must clear going_up",
     );
-    assert_eq!(sim.elevator_going_down(elev.entity()), Some(true));
+    assert_eq!(sim.elevator_going_down(elev), Some(true));
 }
 
 // ── recall_to ──────────────────────────────────────────────────────

--- a/crates/elevator-core/src/tests/direction_indicator_tests.rs
+++ b/crates/elevator-core/src/tests/direction_indicator_tests.rs
@@ -19,8 +19,8 @@ fn default_indicators_both_true() {
     let sim = Simulation::new(&config, scan()).unwrap();
     let elev = first_elevator(&sim);
 
-    assert_eq!(sim.elevator_going_up(elev.entity()), Some(true));
-    assert_eq!(sim.elevator_going_down(elev.entity()), Some(true));
+    assert_eq!(sim.elevator_going_up(elev), Some(true));
+    assert_eq!(sim.elevator_going_down(elev), Some(true));
 }
 
 #[test]
@@ -42,8 +42,8 @@ fn dispatch_upward_sets_going_up_only() {
         }
     }
     assert!(saw_moving, "elevator should start moving within 1000 ticks");
-    assert_eq!(sim.elevator_going_up(elev.entity()), Some(true));
-    assert_eq!(sim.elevator_going_down(elev.entity()), Some(false));
+    assert_eq!(sim.elevator_going_up(elev), Some(true));
+    assert_eq!(sim.elevator_going_down(elev), Some(false));
 }
 
 #[test]
@@ -67,8 +67,8 @@ fn dispatch_downward_sets_going_down_only() {
         }
     }
     assert!(saw_moving, "elevator should start moving within 1000 ticks");
-    assert_eq!(sim.elevator_going_up(elev.entity()), Some(false));
-    assert_eq!(sim.elevator_going_down(elev.entity()), Some(true));
+    assert_eq!(sim.elevator_going_up(elev), Some(false));
+    assert_eq!(sim.elevator_going_down(elev), Some(true));
 }
 
 /// Regression: a car that just delivered a down-bound rider and
@@ -115,8 +115,8 @@ fn indicators_reset_at_door_close_not_at_next_dispatch() {
     // Without the fix, `going_up` would still be `false` from the
     // delivery trip and a subsequent up-bound rider at this stop would
     // be rejected by `pair_is_useful`.
-    assert_eq!(sim.elevator_going_up(elev.entity()), Some(true));
-    assert_eq!(sim.elevator_going_down(elev.entity()), Some(true));
+    assert_eq!(sim.elevator_going_up(elev), Some(true));
+    assert_eq!(sim.elevator_going_down(elev), Some(true));
 }
 
 #[test]
@@ -139,8 +139,8 @@ fn becoming_idle_resets_both_true() {
     }
 
     let elev = first_elevator(&sim);
-    assert_eq!(sim.elevator_going_up(elev.entity()), Some(true));
-    assert_eq!(sim.elevator_going_down(elev.entity()), Some(true));
+    assert_eq!(sim.elevator_going_up(elev), Some(true));
+    assert_eq!(sim.elevator_going_down(elev), Some(true));
 }
 
 #[test]
@@ -324,25 +324,18 @@ fn snapshot_roundtrip_preserves_indicators() {
     // Step until indicators are (true, false) — upward-only.
     for _ in 0..1_000 {
         sim.step();
-        if sim.elevator_going_up(elev.entity()) == Some(true)
-            && sim.elevator_going_down(elev.entity()) == Some(false)
+        if sim.elevator_going_up(elev) == Some(true) && sim.elevator_going_down(elev) == Some(false)
         {
             break;
         }
     }
-    assert_eq!(sim.elevator_going_up(elev.entity()), Some(true));
-    assert_eq!(sim.elevator_going_down(elev.entity()), Some(false));
+    assert_eq!(sim.elevator_going_up(elev), Some(true));
+    assert_eq!(sim.elevator_going_down(elev), Some(false));
 
     let snap = sim.snapshot();
     let restored = snap.restore(None).unwrap();
     let restored_elev = ElevatorId::from(restored.world().elevator_ids()[0]);
 
-    assert_eq!(
-        restored.elevator_going_up(restored_elev.entity()),
-        Some(true)
-    );
-    assert_eq!(
-        restored.elevator_going_down(restored_elev.entity()),
-        Some(false)
-    );
+    assert_eq!(restored.elevator_going_up(restored_elev), Some(true));
+    assert_eq!(restored.elevator_going_down(restored_elev), Some(false));
 }

--- a/crates/elevator-core/src/tests/move_count_tests.rs
+++ b/crates/elevator-core/src/tests/move_count_tests.rs
@@ -97,7 +97,7 @@ fn move_count_starts_at_zero() {
         .map(|(id, _, _)| id)
         .unwrap();
 
-    assert_eq!(sim.elevator_move_count(elev), Some(0));
+    assert_eq!(sim.elevator_move_count(elev.into()), Some(0));
     assert_eq!(sim.metrics().total_moves(), 0);
 }
 
@@ -128,7 +128,7 @@ fn move_count_increments_on_arrival() {
     }
 
     assert_eq!(
-        sim.elevator_move_count(elev),
+        sim.elevator_move_count(elev.into()),
         Some(1),
         "one arrival = one move"
     );
@@ -162,7 +162,7 @@ fn move_count_counts_passing_floors() {
     }
 
     assert_eq!(
-        sim.elevator_move_count(elev),
+        sim.elevator_move_count(elev.into()),
         Some(2),
         "1 passing floor + 1 arrival"
     );
@@ -231,7 +231,7 @@ fn move_count_zero_when_stationary() {
         sim.step();
     }
 
-    assert_eq!(sim.elevator_move_count(elev), Some(0));
+    assert_eq!(sim.elevator_move_count(elev.into()), Some(0));
     assert_eq!(sim.metrics().total_moves(), 0);
 }
 
@@ -262,7 +262,7 @@ fn move_count_persists_across_snapshot() {
         .next()
         .map(|(id, _, _)| id)
         .unwrap();
-    let per_elev_before = sim.elevator_move_count(elev).unwrap();
+    let per_elev_before = sim.elevator_move_count(elev.into()).unwrap();
 
     let snap = sim.snapshot();
     let restored = snap.restore(None).unwrap();
@@ -275,7 +275,7 @@ fn move_count_persists_across_snapshot() {
         .map(|(id, _, _)| id)
         .unwrap();
     assert_eq!(
-        restored.elevator_move_count(restored_elev),
+        restored.elevator_move_count(restored_elev.into()),
         Some(per_elev_before)
     );
 }
@@ -322,7 +322,7 @@ fn move_count_counts_reposition_arrivals() {
     }
 
     // Expected: 1 passing (stop 1) + 1 arrival (stop 0) = 2 moves.
-    let count = sim.elevator_move_count(elev).unwrap();
+    let count = sim.elevator_move_count(elev.into()).unwrap();
     assert!(
         count >= 2,
         "expected at least 2 moves (passing + arrival) during reposition, got {count}",

--- a/crates/elevator-core/src/tests/phase_helpers_tests.rs
+++ b/crates/elevator-core/src/tests/phase_helpers_tests.rs
@@ -60,29 +60,33 @@ fn elevator_direction_reflects_lamps() {
     let elev = sim.world().elevator_ids()[0];
 
     // Fresh demo elevator: both lamps lit → Either.
-    assert_eq!(sim.elevator_direction(elev), Some(Direction::Either));
+    assert_eq!(sim.elevator_direction(elev.into()), Some(Direction::Either));
 
     // Non-elevator returns None.
     let stop = sim.stop_entity(StopId(0)).unwrap();
-    assert_eq!(sim.elevator_direction(stop), None);
+    // Defense-in-depth: bypass the type system with a wrong-kind ID.
+    assert_eq!(
+        sim.elevator_direction(crate::entity::ElevatorId::from(stop)),
+        None
+    );
 
     // Exercise Up / Down / neither-set arms directly — poking the flags
     // guards against a silent swap or broken match in Elevator::direction.
     let car = sim.world_mut().elevator_mut(elev).unwrap();
     car.going_up = true;
     car.going_down = false;
-    assert_eq!(sim.elevator_direction(elev), Some(Direction::Up));
+    assert_eq!(sim.elevator_direction(elev.into()), Some(Direction::Up));
 
     let car = sim.world_mut().elevator_mut(elev).unwrap();
     car.going_up = false;
     car.going_down = true;
-    assert_eq!(sim.elevator_direction(elev), Some(Direction::Down));
+    assert_eq!(sim.elevator_direction(elev.into()), Some(Direction::Down));
 
     // Neither lamp lit also collapses to Either (see doc on Direction::Either).
     let car = sim.world_mut().elevator_mut(elev).unwrap();
     car.going_up = false;
     car.going_down = false;
-    assert_eq!(sim.elevator_direction(elev), Some(Direction::Either));
+    assert_eq!(sim.elevator_direction(elev.into()), Some(Direction::Either));
 }
 
 // ── Event::category ──────────────────────────────────────────────────

--- a/crates/elevator-core/src/tests/service_mode_tests.rs
+++ b/crates/elevator-core/src/tests/service_mode_tests.rs
@@ -11,7 +11,7 @@ fn default_mode_is_normal() {
     let mut sim = crate::sim::Simulation::new(&config, scan()).unwrap();
 
     let elev = sim.world().elevator_ids()[0];
-    assert_eq!(sim.service_mode(elev), ServiceMode::Normal);
+    assert_eq!(sim.service_mode(elev.into()), ServiceMode::Normal);
 
     sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
 

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -4537,7 +4537,7 @@ pub unsafe extern "C" fn ev_sim_service_mode(
         };
         // Safety: validity guaranteed by caller.
         let ev = unsafe { &*handle };
-        let mode = EvServiceMode::from_core(ev.sim.service_mode(elevator));
+        let mode = EvServiceMode::from_core(ev.sim.service_mode(elevator.into()));
         // Safety: caller guarantees out_mode is writable.
         unsafe { *out_mode = mode };
         EvStatus::Ok
@@ -5191,7 +5191,7 @@ pub unsafe extern "C" fn ev_sim_occupancy(handle: *mut EvSim, elevator_entity_id
         };
         // Safety: validity guaranteed by caller.
         let ev = unsafe { &*handle };
-        u32::try_from(ev.sim.occupancy(elevator)).unwrap_or(u32::MAX)
+        u32::try_from(ev.sim.occupancy(elevator.into())).unwrap_or(u32::MAX)
     })
 }
 
@@ -5218,7 +5218,7 @@ pub unsafe extern "C" fn ev_sim_elevator_direction(
         };
         // Safety: validity guaranteed by caller.
         let ev = unsafe { &*handle };
-        match ev.sim.elevator_direction(elevator) {
+        match ev.sim.elevator_direction(elevator.into()) {
             Some(elevator_core::components::Direction::Up) => 1,
             Some(elevator_core::components::Direction::Down) => -1,
             _ => 0,
@@ -5246,7 +5246,7 @@ pub unsafe extern "C" fn ev_sim_elevator_going_up(
         entity_from_u64(elevator_entity_id).is_some_and(|e| {
             // Safety: validity guaranteed by caller.
             let ev = unsafe { &*handle };
-            ev.sim.elevator_going_up(e).unwrap_or(false)
+            ev.sim.elevator_going_up(e.into()).unwrap_or(false)
         })
     })
 }
@@ -5271,7 +5271,7 @@ pub unsafe extern "C" fn ev_sim_elevator_going_down(
         entity_from_u64(elevator_entity_id).is_some_and(|e| {
             // Safety: validity guaranteed by caller.
             let ev = unsafe { &*handle };
-            ev.sim.elevator_going_down(e).unwrap_or(false)
+            ev.sim.elevator_going_down(e.into()).unwrap_or(false)
         })
     })
 }
@@ -5298,7 +5298,7 @@ pub unsafe extern "C" fn ev_sim_elevator_move_count(
         };
         // Safety: validity guaranteed by caller.
         let ev = unsafe { &*handle };
-        ev.sim.elevator_move_count(elevator).unwrap_or(0)
+        ev.sim.elevator_move_count(elevator.into()).unwrap_or(0)
     })
 }
 
@@ -5325,7 +5325,7 @@ pub unsafe extern "C" fn ev_sim_braking_distance(
         };
         // Safety: validity guaranteed by caller.
         let ev = unsafe { &*handle };
-        ev.sim.braking_distance(elevator).unwrap_or(f64::NAN)
+        ev.sim.braking_distance(elevator.into()).unwrap_or(f64::NAN)
     })
 }
 
@@ -5351,7 +5351,9 @@ pub unsafe extern "C" fn ev_sim_future_stop_position(
         };
         // Safety: validity guaranteed by caller.
         let ev = unsafe { &*handle };
-        ev.sim.future_stop_position(elevator).unwrap_or(f64::NAN)
+        ev.sim
+            .future_stop_position(elevator.into())
+            .unwrap_or(f64::NAN)
     })
 }
 
@@ -5965,7 +5967,7 @@ pub unsafe extern "C" fn ev_sim_riders_on(
         };
         // Safety: validity guaranteed by caller.
         let ev = unsafe { &*handle };
-        let riders = ev.sim.riders_on(elevator);
+        let riders = ev.sim.riders_on(elevator.into());
         // Safety: `out` validity guaranteed by caller.
         let written = unsafe { write_entity_buffer(riders.iter().copied(), out, capacity) };
         // Safety: out_written non-null per check above.

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -1181,7 +1181,7 @@ impl WasmSim {
     #[wasm_bindgen(js_name = serviceMode)]
     #[must_use]
     pub fn service_mode(&self, elevator_ref: u64) -> String {
-        format_service_mode(self.inner.service_mode(u64_to_entity(elevator_ref))).to_string()
+        format_service_mode(self.inner.service_mode(u64_to_entity(elevator_ref).into())).to_string()
     }
 
     /// Set the target velocity for a Manual-mode elevator (distance/tick).
@@ -1536,7 +1536,7 @@ impl WasmSim {
     #[wasm_bindgen(js_name = occupancy)]
     #[must_use]
     pub fn occupancy(&self, elevator_ref: u64) -> u32 {
-        u32::try_from(self.inner.occupancy(u64_to_entity(elevator_ref))).unwrap_or(u32::MAX)
+        u32::try_from(self.inner.occupancy(u64_to_entity(elevator_ref).into())).unwrap_or(u32::MAX)
     }
 
     /// Indicator-lamp direction of `elevator_ref`: `"up"`, `"down"`, or
@@ -1546,7 +1546,7 @@ impl WasmSim {
     #[must_use]
     pub fn elevator_direction(&self, elevator_ref: u64) -> Option<String> {
         self.inner
-            .elevator_direction(u64_to_entity(elevator_ref))
+            .elevator_direction(u64_to_entity(elevator_ref).into())
             .map(|d| format_direction(d).to_string())
     }
 
@@ -1556,7 +1556,8 @@ impl WasmSim {
     #[wasm_bindgen(js_name = elevatorGoingUp)]
     #[must_use]
     pub fn elevator_going_up(&self, elevator_ref: u64) -> Option<bool> {
-        self.inner.elevator_going_up(u64_to_entity(elevator_ref))
+        self.inner
+            .elevator_going_up(u64_to_entity(elevator_ref).into())
     }
 
     /// Whether `elevator_ref` is currently committed downward. Returns
@@ -1564,7 +1565,8 @@ impl WasmSim {
     #[wasm_bindgen(js_name = elevatorGoingDown)]
     #[must_use]
     pub fn elevator_going_down(&self, elevator_ref: u64) -> Option<bool> {
-        self.inner.elevator_going_down(u64_to_entity(elevator_ref))
+        self.inner
+            .elevator_going_down(u64_to_entity(elevator_ref).into())
     }
 
     /// Total number of completed trips by `elevator_ref` since spawn.
@@ -1572,7 +1574,8 @@ impl WasmSim {
     #[wasm_bindgen(js_name = elevatorMoveCount)]
     #[must_use]
     pub fn elevator_move_count(&self, elevator_ref: u64) -> Option<u64> {
-        self.inner.elevator_move_count(u64_to_entity(elevator_ref))
+        self.inner
+            .elevator_move_count(u64_to_entity(elevator_ref).into())
     }
 
     /// Distance `elevator_ref` would travel if it began decelerating
@@ -1581,7 +1584,8 @@ impl WasmSim {
     #[wasm_bindgen(js_name = brakingDistance)]
     #[must_use]
     pub fn braking_distance(&self, elevator_ref: u64) -> Option<f64> {
-        self.inner.braking_distance(u64_to_entity(elevator_ref))
+        self.inner
+            .braking_distance(u64_to_entity(elevator_ref).into())
     }
 
     /// Position of the next stop in `elevator_ref`'s destination queue,
@@ -1590,7 +1594,8 @@ impl WasmSim {
     #[wasm_bindgen(js_name = futureStopPosition)]
     #[must_use]
     pub fn future_stop_position(&self, elevator_ref: u64) -> Option<f64> {
-        self.inner.future_stop_position(u64_to_entity(elevator_ref))
+        self.inner
+            .future_stop_position(u64_to_entity(elevator_ref).into())
     }
 
     /// Total number of currently-idle elevators across the simulation.
@@ -1809,7 +1814,7 @@ impl WasmSim {
     #[must_use]
     pub fn riders_on(&self, elevator_ref: u64) -> Vec<u64> {
         self.inner
-            .riders_on(u64_to_entity(elevator_ref))
+            .riders_on(u64_to_entity(elevator_ref).into())
             .iter()
             .copied()
             .map(entity_to_u64)

--- a/docs/src/elevators.md
+++ b/docs/src/elevators.md
@@ -67,7 +67,7 @@ Read the lamps through the simulation API:
 ```rust,no_run
 # use elevator_core::prelude::*;
 # use elevator_core::__doctest_prelude::*;
-# fn run(sim: &Simulation, elevator_id: EntityId) {
+# fn run(sim: &Simulation, elevator_id: ElevatorId) {
 let going_up = sim.elevator_going_up(elevator_id);
 let going_down = sim.elevator_going_down(elevator_id);
 # let _ = (going_up, going_down);


### PR DESCRIPTION
## Summary

Tighten nine elevator-only accessors on `Simulation` from raw `EntityId` to typed `ElevatorId`. Second architecture PR from the queue audited in #710 (HIGH #1 of 8).

## What changes

### Core trait surface (`crates/elevator-core/src/sim/lifecycle.rs`)
Nine accessors flip their argument type:

| Method | Before | After |
|---|---|---|
| `riders_on` | `EntityId` | `ElevatorId` |
| `occupancy` | `EntityId` | `ElevatorId` |
| `elevator_going_up` | `EntityId` | `ElevatorId` |
| `elevator_going_down` | `EntityId` | `ElevatorId` |
| `elevator_direction` | `EntityId` | `ElevatorId` |
| `elevator_move_count` | `EntityId` | `ElevatorId` |
| `braking_distance` | `EntityId` | `ElevatorId` |
| `future_stop_position` | `EntityId` | `ElevatorId` |
| `service_mode` | `EntityId` | `ElevatorId` |

These methods all internally call `world.elevator(id)` and return the elevator-specific shape; passing a non-elevator entity returned `None` or `0` at runtime. With `ElevatorId`, the caller proves the entity is an elevator at compile time. Sibling Simulation accessors (`set_max_speed`, `push_destination`, `clear_destinations`, `elevator_load`) already took `ElevatorId`; this PR brings the rest of the elevator-typed surface into alignment with that pattern.

### Out of scope (deliberate)
- Discriminator helpers `is_elevator`/`is_rider`/`is_stop`/`is_disabled` remain `EntityId` — they answer questions about kind.
- Polymorphic ops `disable`/`enable` remain `EntityId` — they accept any kind.
- `residents_at`/`waiting_at`/`abandoned_at` etc. remain `EntityId` for the stop argument: `StopId` is a config-level u32 identifier (`crates/elevator-core/src/stop.rs:8`), not a phantom-typed wrapper. Introducing a `StopEntityId` phantom is a separate refactor not in the audit's HIGH/MEDIUM queue.

### Host updates (same PR per CLAUDE.md)
- **elevator-ffi** (`crates/elevator-ffi/src/lib.rs`) — 9 call sites adopt `.into()` on the `entity_from_u64` result.
- **elevator-wasm** (`crates/elevator-wasm/src/lib.rs`) — same pattern; the `u64_to_entity(elevator_ref)` results flow into `.into()` for the typed methods. Three siblings (`remove_elevator`, `velocity`, `line_for_elevator`) still take `EntityId` and remain unchanged.
- **elevator-gdext** — no consumer of the affected methods; no change needed.
- **bindings.toml** — unchanged. The file tracks method names + binding statuses, not signatures.

### Test update — defense-in-depth preserved
The runtime kind check inside each accessor still fires for callers that bypass the type system with `ElevatorId::from(non_elevator_entity)`. Two tests exercise this path explicitly so the runtime guard remains exercised even after the static check lands:

- `tests/braking_tests.rs::sim_braking_distance_none_for_non_elevator` — uses `ElevatorId::from(rider.entity())` and asserts `None`.
- `tests/phase_helpers_tests.rs::elevator_direction_reflects_lamps` — uses `ElevatorId::from(stop)` and asserts `None`.

### Doc update
`docs/src/elevators.md` example signature flips from `elevator_id: EntityId` to `elevator_id: ElevatorId` to match the new method shape.

## Why

The audit (#710) flagged inconsistency on the accessor surface: `lifecycle.rs` took raw `EntityId` while `runtime.rs` / `destinations.rs` / `calls.rs` already took typed IDs. Callers couldn't predict which form a method took; FFI/wasm had to thread untyped IDs everywhere because the surface wasn't uniform. This PR normalizes the elevator-typed half of the surface.

## BREAKING CHANGE

Callers passing `EntityId` to the affected accessors must now pass `ElevatorId`. Migration: convert with `.into()` or use the typed `Simulation::elevator_ids` return values directly. (HIGH #2 in the queue will replace the `From<EntityId>` impl with a fallible constructor — `.into()` is preserved here for now to keep this PR's blast radius contained.)

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-features --all-targets` clean (zero warnings)
- [x] `cargo test -p elevator-core --all-features` — 159 unit + 8 doc + scenario suites all pass
- [x] `cargo check --workspace --all-features --all-targets` clean
- [x] `scripts/check-bindings.sh` clean (no method names added/removed/renamed)
- [x] `scripts/lint-docs.sh --quick` clean
- [x] Pre-commit hook full battery green