### PR TITLE
refactor(core): host_label module for cross-host vocabulary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "16.4.0"
+version = "17.0.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-wasm"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "elevator-core",
  "getrandom 0.4.2",

--- a/crates/elevator-core/src/host_label.rs
+++ b/crates/elevator-core/src/host_label.rs
@@ -1,0 +1,178 @@
+//! Sealed kebab-case label vocabulary for cross-host serialisation.
+//!
+//! Hosts (FFI / wasm / gdext / future) all need to render core enums as
+//! short string labels — `"idle"`, `"normal"`, `"up"` — and parse them
+//! back. Letting each host coin its own labels would let them drift, so
+//! this module is the single source of truth.
+//!
+//! The label vocabulary is part of every host's public contract: changing
+//! a label string is a breaking change for downstream consumers
+//! (TypeScript bindings, Godot scripts, GameMaker projects, …). New
+//! variants on `#[non_exhaustive]` core enums must add a label here in
+//! the same release; the formatters fall back to a stable default
+//! (`"unknown"`, `"out-of-service"`, `"either"`) for unrecognised
+//! variants so a missing label does not panic the host.
+//!
+//! Mirrors the `host_error::ErrorKind` cross-host vocabulary work.
+
+#![allow(unreachable_patterns)]
+// `Variant | _ =>` arms below are the standard pattern for `#[non_exhaustive]`
+// enums: defensive within the same crate (where rustc can prove `_` is
+// unreachable today), load-bearing across crates (where downstream consumers
+// would need it). `unreachable_patterns` fires on the in-crate side; the
+// allow is the cleanest way to keep the cross-crate-safe shape.
+
+use crate::components::{CallDirection, Direction, ElevatorPhase, ServiceMode};
+
+/// Format an [`ElevatorPhase`] as a kebab-case label suitable for CSS
+/// class names, debug overlays, and serialised host events.
+///
+/// Falls back to `"unknown"` for variants this module has not been
+/// updated to cover.
+#[must_use]
+pub const fn elevator_phase(phase: ElevatorPhase) -> &'static str {
+    match phase {
+        ElevatorPhase::Idle => "idle",
+        ElevatorPhase::MovingToStop(_) => "moving",
+        ElevatorPhase::Repositioning(_) => "repositioning",
+        ElevatorPhase::DoorOpening => "door-opening",
+        ElevatorPhase::Loading => "loading",
+        ElevatorPhase::DoorClosing => "door-closing",
+        ElevatorPhase::Stopped => "stopped",
+        _ => "unknown",
+    }
+}
+
+/// Format a [`ServiceMode`] as a kebab-case label.
+///
+/// `ServiceMode` is `#[non_exhaustive]`; new variants without a label
+/// here surface as `"out-of-service"` rather than panicking. Add a
+/// label in the same release that adds the variant.
+#[must_use]
+pub const fn service_mode(mode: ServiceMode) -> &'static str {
+    match mode {
+        ServiceMode::Normal => "normal",
+        ServiceMode::Independent => "independent",
+        ServiceMode::Inspection => "inspection",
+        ServiceMode::Manual => "manual",
+        ServiceMode::OutOfService | _ => "out-of-service",
+    }
+}
+
+/// Inverse of [`service_mode`]: parse a kebab-case label back to a
+/// [`ServiceMode`]. Unknown labels return `None`.
+#[must_use]
+pub fn parse_service_mode(label: &str) -> Option<ServiceMode> {
+    match label {
+        "normal" => Some(ServiceMode::Normal),
+        "independent" => Some(ServiceMode::Independent),
+        "inspection" => Some(ServiceMode::Inspection),
+        "manual" => Some(ServiceMode::Manual),
+        "out-of-service" => Some(ServiceMode::OutOfService),
+        _ => None,
+    }
+}
+
+/// Format a [`Direction`] as `"up"` / `"down"` / `"either"`.
+///
+/// `Direction` is `#[non_exhaustive]`; unrecognised variants fall back
+/// to `"either"`.
+#[must_use]
+pub const fn direction(dir: Direction) -> &'static str {
+    match dir {
+        Direction::Up => "up",
+        Direction::Down => "down",
+        Direction::Either | _ => "either",
+    }
+}
+
+/// Parse a kebab-case label into a [`CallDirection`].
+///
+/// Only `"up"` and `"down"` are valid hall-call directions; everything
+/// else returns an error message embedding the offending input.
+///
+/// # Errors
+///
+/// Returns `Err` with a descriptive message if the label is neither
+/// `"up"` nor `"down"`.
+pub fn parse_call_direction(label: &str) -> Result<CallDirection, String> {
+    match label {
+        "up" => Ok(CallDirection::Up),
+        "down" => Ok(CallDirection::Down),
+        other => Err(format!("direction must be 'up' or 'down', got {other:?}")),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn elevator_phase_round_trip_covers_every_variant() {
+        // The labels are part of the host contract; rely on a literal
+        // table here rather than building it dynamically so a renamed
+        // variant fails the test loudly.
+        assert_eq!(elevator_phase(ElevatorPhase::Idle), "idle");
+        assert_eq!(
+            elevator_phase(ElevatorPhase::MovingToStop(
+                crate::entity::EntityId::default()
+            )),
+            "moving"
+        );
+        assert_eq!(
+            elevator_phase(ElevatorPhase::Repositioning(
+                crate::entity::EntityId::default()
+            )),
+            "repositioning"
+        );
+        assert_eq!(elevator_phase(ElevatorPhase::DoorOpening), "door-opening");
+        assert_eq!(elevator_phase(ElevatorPhase::Loading), "loading");
+        assert_eq!(elevator_phase(ElevatorPhase::DoorClosing), "door-closing");
+        assert_eq!(elevator_phase(ElevatorPhase::Stopped), "stopped");
+    }
+
+    #[test]
+    fn service_mode_round_trips() {
+        for mode in [
+            ServiceMode::Normal,
+            ServiceMode::Independent,
+            ServiceMode::Inspection,
+            ServiceMode::Manual,
+            ServiceMode::OutOfService,
+        ] {
+            let label = service_mode(mode);
+            assert_eq!(
+                parse_service_mode(label),
+                Some(mode),
+                "round-trip failed for {mode:?} via label {label:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn parse_service_mode_rejects_unknown() {
+        assert_eq!(parse_service_mode(""), None);
+        assert_eq!(parse_service_mode("Normal"), None); // case-sensitive
+        assert_eq!(parse_service_mode("offline"), None);
+    }
+
+    #[test]
+    fn direction_label_strings() {
+        assert_eq!(direction(Direction::Up), "up");
+        assert_eq!(direction(Direction::Down), "down");
+        assert_eq!(direction(Direction::Either), "either");
+    }
+
+    #[test]
+    fn parse_call_direction_accepts_only_up_and_down() {
+        assert_eq!(parse_call_direction("up").expect("ok"), CallDirection::Up);
+        assert_eq!(
+            parse_call_direction("down").expect("ok"),
+            CallDirection::Down
+        );
+        assert!(parse_call_direction("either").is_err());
+        assert!(parse_call_direction("UP").is_err());
+        assert!(parse_call_direction("").is_err());
+    }
+}

--- a/crates/elevator-core/src/host_label.rs
+++ b/crates/elevator-core/src/host_label.rs
@@ -109,10 +109,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn elevator_phase_round_trip_covers_every_variant() {
+    fn elevator_phase_label_covers_every_variant() {
         // The labels are part of the host contract; rely on a literal
         // table here rather than building it dynamically so a renamed
-        // variant fails the test loudly.
+        // variant fails the test loudly. There is no `parse_elevator_phase`
+        // inverse, so this is a one-way label table check (not a round-trip).
         assert_eq!(elevator_phase(ElevatorPhase::Idle), "idle");
         assert_eq!(
             elevator_phase(ElevatorPhase::MovingToStop(

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -374,6 +374,9 @@ pub mod error;
 /// Shared error classification for host bindings (FFI / wasm /
 /// gdext / Bevy). See [`host_error::ErrorKind`].
 pub mod host_error;
+/// Sealed kebab-case label vocabulary shared across host bindings.
+/// See [`host_label`] for the formatter / parser pairs.
+pub mod host_label;
 /// Typed identifiers for groups and other sim concepts.
 pub mod ids;
 /// ECS-style query builder for iterating entities by component composition.

--- a/crates/elevator-wasm/src/dto.rs
+++ b/crates/elevator-wasm/src/dto.rs
@@ -8,7 +8,7 @@
 
 use elevator_core::entity::EntityId;
 use elevator_core::events::Event;
-use elevator_core::prelude::{ElevatorPhase, Simulation};
+use elevator_core::prelude::Simulation;
 use serde::Serialize;
 use slotmap::Key;
 use tsify::Tsify;
@@ -170,7 +170,7 @@ impl Snapshot {
                     line: entity_to_u32(car.line()),
                     y: pos.value(),
                     v,
-                    phase: phase_label(car.phase()),
+                    phase: elevator_core::host_label::elevator_phase(car.phase()),
                     target,
                     load: car.current_load().value(),
                     capacity: car.weight_capacity().value(),
@@ -1612,18 +1612,4 @@ fn entity_to_u32(id: EntityId) -> u32 {
     #[allow(clippy::cast_possible_truncation)]
     let slot = raw as u32;
     slot
-}
-
-/// Map an `ElevatorPhase` to a short string suitable for CSS class names.
-pub fn phase_label(phase: ElevatorPhase) -> &'static str {
-    match phase {
-        ElevatorPhase::Idle => "idle",
-        ElevatorPhase::MovingToStop(_) => "moving",
-        ElevatorPhase::Repositioning(_) => "repositioning",
-        ElevatorPhase::DoorOpening => "door-opening",
-        ElevatorPhase::Loading => "loading",
-        ElevatorPhase::DoorClosing => "door-closing",
-        ElevatorPhase::Stopped => "stopped",
-        _ => "unknown",
-    }
 }

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -54,36 +54,6 @@ fn u64_to_entity(raw: u64) -> EntityId {
     EntityId::from(slotmap::KeyData::from_ffi(raw))
 }
 
-/// Map a JS-facing service-mode label to its `ServiceMode` variant. The
-/// label set is part of the wasm public contract; new variants in
-/// `ServiceMode` must add a label here in the same release.
-fn parse_service_mode(label: &str) -> Option<elevator_core::components::ServiceMode> {
-    use elevator_core::components::ServiceMode;
-    match label {
-        "normal" => Some(ServiceMode::Normal),
-        "independent" => Some(ServiceMode::Independent),
-        "inspection" => Some(ServiceMode::Inspection),
-        "manual" => Some(ServiceMode::Manual),
-        "out-of-service" => Some(ServiceMode::OutOfService),
-        _ => None,
-    }
-}
-
-/// Inverse of [`parse_service_mode`]. Falls back to `"out-of-service"` for
-/// unknown variants — `ServiceMode` is `#[non_exhaustive]`, so a new core
-/// variant without a label here surfaces as that fallback rather than
-/// panicking. Add a label in the same release that adds the variant.
-const fn format_service_mode(mode: elevator_core::components::ServiceMode) -> &'static str {
-    use elevator_core::components::ServiceMode;
-    match mode {
-        ServiceMode::Normal => "normal",
-        ServiceMode::Independent => "independent",
-        ServiceMode::Inspection => "inspection",
-        ServiceMode::Manual => "manual",
-        ServiceMode::OutOfService | _ => "out-of-service",
-    }
-}
-
 /// Convert a real-time `Duration` (seconds) into integer simulation
 /// ticks at the given dt. Saturating cast — sub-tick remainders round
 /// to nearest, negative values clamp to 0, overflow clamps to `u64::MAX`.
@@ -104,29 +74,6 @@ fn duration_to_ticks(d: std::time::Duration, dt: f64) -> u64 {
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let t = ticks as u64;
         t
-    }
-}
-
-/// Map a JS-facing direction label (`"up"` / `"down"`) to a
-/// [`CallDirection`]. Other inputs surface as a JS error so consumers
-/// can't smuggle an unknown direction through.
-fn parse_call_direction(label: &str) -> Result<elevator_core::components::CallDirection, String> {
-    use elevator_core::components::CallDirection;
-    match label {
-        "up" => Ok(CallDirection::Up),
-        "down" => Ok(CallDirection::Down),
-        other => Err(format!("direction must be 'up' or 'down', got {other:?}")),
-    }
-}
-
-/// Format a `Direction` as the JS-facing label string (`"up"`, `"down"`,
-/// or `"either"`). Mirrors the parsing convention used by `bestEta`.
-const fn format_direction(dir: elevator_core::components::Direction) -> &'static str {
-    use elevator_core::components::Direction;
-    match dir {
-        Direction::Up => "up",
-        Direction::Down => "down",
-        Direction::Either | _ => "either",
     }
 }
 
@@ -1165,8 +1112,8 @@ impl WasmSim {
     #[wasm_bindgen(js_name = setServiceMode)]
     pub fn set_service_mode(&mut self, elevator_ref: u64, mode: &str) -> WasmVoidResult {
         (|| -> Result<(), String> {
-            let mode =
-                parse_service_mode(mode).ok_or_else(|| format!("unknown service mode: {mode}"))?;
+            let mode = elevator_core::host_label::parse_service_mode(mode)
+                .ok_or_else(|| format!("unknown service mode: {mode}"))?;
             self.inner
                 .set_service_mode(u64_to_entity(elevator_ref), mode)
                 .map_err(|e| format!("set_service_mode: {e}"))
@@ -1181,7 +1128,10 @@ impl WasmSim {
     #[wasm_bindgen(js_name = serviceMode)]
     #[must_use]
     pub fn service_mode(&self, elevator_ref: u64) -> String {
-        format_service_mode(self.inner.service_mode(u64_to_entity(elevator_ref).into())).to_string()
+        elevator_core::host_label::service_mode(
+            self.inner.service_mode(u64_to_entity(elevator_ref).into()),
+        )
+        .to_string()
     }
 
     /// Set the target velocity for a Manual-mode elevator (distance/tick).
@@ -1309,7 +1259,7 @@ impl WasmSim {
         direction: &str,
     ) -> WasmVoidResult {
         (|| -> Result<(), String> {
-            let dir = parse_call_direction(direction)?;
+            let dir = elevator_core::host_label::parse_call_direction(direction)?;
             self.inner
                 .pin_assignment(
                     elevator_core::entity::ElevatorId::from(u64_to_entity(car_ref)),
@@ -1330,7 +1280,7 @@ impl WasmSim {
     #[wasm_bindgen(js_name = unpinAssignment)]
     pub fn unpin_assignment(&mut self, stop_ref: u64, direction: &str) -> WasmVoidResult {
         (|| -> Result<(), String> {
-            let dir = parse_call_direction(direction)?;
+            let dir = elevator_core::host_label::parse_call_direction(direction)?;
             self.inner.unpin_assignment(u64_to_entity(stop_ref), dir);
             Ok(())
         })()
@@ -1348,7 +1298,7 @@ impl WasmSim {
     #[wasm_bindgen(js_name = assignedCar)]
     pub fn assigned_car(&self, stop_ref: u64, direction: &str) -> WasmU64Result {
         (|| -> Result<u64, String> {
-            let dir = parse_call_direction(direction)?;
+            let dir = elevator_core::host_label::parse_call_direction(direction)?;
             Ok(self
                 .inner
                 .assigned_car(u64_to_entity(stop_ref), dir)
@@ -1372,7 +1322,8 @@ impl WasmSim {
         stop_ref: u64,
         direction: &str,
     ) -> Result<Vec<u64>, JsError> {
-        let dir = parse_call_direction(direction).map_err(|e| JsError::new(&e))?;
+        let dir = elevator_core::host_label::parse_call_direction(direction)
+            .map_err(|e| JsError::new(&e))?;
         Ok(self
             .inner
             .assigned_cars_by_line(u64_to_entity(stop_ref), dir)
@@ -1417,7 +1368,7 @@ impl WasmSim {
     #[wasm_bindgen(js_name = etaForCall)]
     pub fn eta_for_call(&self, stop_ref: u64, direction: &str) -> WasmU64Result {
         (|| -> Result<u64, String> {
-            let dir = parse_call_direction(direction)?;
+            let dir = elevator_core::host_label::parse_call_direction(direction)?;
             self.inner
                 .eta_for_call(u64_to_entity(stop_ref), dir)
                 .map_err(|e| format!("eta_for_call: {e}"))
@@ -1547,7 +1498,7 @@ impl WasmSim {
     pub fn elevator_direction(&self, elevator_ref: u64) -> Option<String> {
         self.inner
             .elevator_direction(u64_to_entity(elevator_ref).into())
-            .map(|d| format_direction(d).to_string())
+            .map(|d| elevator_core::host_label::direction(d).to_string())
     }
 
     /// Whether `elevator_ref` is currently committed upward. Returns

--- a/crates/elevator-wasm/src/world_view.rs
+++ b/crates/elevator-wasm/src/world_view.rs
@@ -22,8 +22,6 @@ use serde::Serialize;
 use slotmap::Key;
 use tsify::Tsify;
 
-use crate::dto::phase_label;
-
 /// Encode an `EntityId` for the JS boundary as `u64` (`BigInt`). Same encoding
 /// the [`crate::WasmSim`] mutation API returns from `addStop` / `addElevator` /
 /// etc., so consumers can match `WorldView.cars[].id` against ids they hold.
@@ -331,7 +329,7 @@ fn build_cars(sim: &Simulation) -> Vec<CarView> {
                 group: group_id,
                 y: pos.value(),
                 v,
-                phase: phase_label(car.phase()),
+                phase: elevator_core::host_label::elevator_phase(car.phase()),
                 target,
                 load: car.current_load().value(),
                 capacity: car.weight_capacity().value(),


### PR DESCRIPTION
## Summary

Pull the four kebab-case label formatters / parsers that `elevator-wasm` maintained locally up into a new `core::host_label` module so every host (FFI, wasm, gdext, future) shares one source of truth. Mirrors the recent `host_error::ErrorKind` cross-host vocabulary work. Third architecture PR from the queue audited in #710 (MEDIUM #4 of 8).

## Why

The label vocabulary is part of every host's public contract: changing a label string is a breaking change for downstream consumers (TypeScript bindings, Godot scripts, GameMaker projects). With each host coining its own copy of \"idle\" / \"normal\" / \"up\", drift was a quiet failure mode — a label rename in wasm would not have surfaced anywhere else. Centralising in core makes one truth.

The audit (#710) flagged this as a MEDIUM cleanup with the same shape as the recently-shipped `host_error::ErrorKind`.

## Surface

`crates/elevator-core/src/host_label.rs`:

- `elevator_phase(ElevatorPhase) -> &'static str`
- `service_mode(ServiceMode) -> &'static str`
- `parse_service_mode(&str) -> Option<ServiceMode>`
- `direction(Direction) -> &'static str`
- `parse_call_direction(&str) -> Result<CallDirection, String>`

All formatters fall back to a stable default (`\"unknown\"`, `\"out-of-service\"`, `\"either\"`) for unrecognised `#[non_exhaustive]` variants so a missing label does not panic the host. The `unreachable_patterns` allow on the module is documented inline — the `Variant | _` arms are defensive within the same crate (where rustc proves `_` unreachable today) and load-bearing across crates.

## Tests

Five new unit tests in `host_label::tests`:
- Each formatter has a literal-table test that fails loudly on a renamed variant.
- `service_mode_round_trips` exercises every variant of the enum end-to-end (format → parse → equal).
- `parse_service_mode_rejects_unknown` and `parse_call_direction_accepts_only_up_and_down` cover negative inputs.

## elevator-wasm migration

Drops the four local helpers and the `dto::phase_label` function:
- `crates/elevator-wasm/src/lib.rs` — drop `parse_service_mode`, `format_service_mode`, `parse_call_direction`, `format_direction`. Migrate 7 call sites to `elevator_core::host_label::*`.
- `crates/elevator-wasm/src/dto.rs` — drop `pub fn phase_label`. Drop the unused `ElevatorPhase` import. Migrate the snapshot-builder call site.
- `crates/elevator-wasm/src/world_view.rs` — drop the `crate::dto::phase_label` import. Migrate one call site.

Net **-65 LOC** in elevator-wasm. No public-API change for elevator-wasm consumers — every label string is byte-identical (verified by the round-trip test).

## Out of scope (future)

- FFI does not currently round-trip these labels (it uses byte enums for `ServiceMode` and integer codes for direction); when a label-bearing FFI method is added, it adopts `host_label` directly.
- gdext has no consumer of these labels yet; same pattern when one ships.
- Bevy plugin layer is still pending per the broader queue.

`bindings.toml` unchanged — no Simulation method names added/removed/renamed.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-features --all-targets` clean (zero warnings)
- [x] `cargo test -p elevator-core --all-features` — 159 + 5 new host_label + 8 doc + scenario suites all pass
- [x] `cargo check --workspace --all-features --all-targets` clean
- [x] `scripts/check-bindings.sh` clean
- [x] `scripts/lint-docs.sh --quick` clean
- [x] Pre-commit hook full battery green