### PR TITLE
refactor(core): explicit-name typed-id constructors and verified accessors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "cbindgen",
  "elevator-core",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-wasm"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "elevator-core",
  "getrandom 0.4.2",

--- a/bindings.toml
+++ b/bindings.toml
@@ -1162,6 +1162,26 @@ gdext = "todo:future-binding"
 bevy = "todo:plugin-layer"
 
 [[methods]]
+name = "elevator_id"
+category = "introspection"
+wasm = "todo:future-binding"
+ffi  = "todo:future-binding"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "todo:future-binding"
+gdext = "todo:future-binding"
+bevy = "todo:plugin-layer"
+
+[[methods]]
+name = "rider_id"
+category = "introspection"
+wasm = "todo:future-binding"
+ffi  = "todo:future-binding"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "todo:future-binding"
+gdext = "todo:future-binding"
+bevy = "todo:plugin-layer"
+
+[[methods]]
 name = "is_disabled"
 category = "introspection"
 wasm = "isDisabled"

--- a/crates/elevator-core/src/entity.rs
+++ b/crates/elevator-core/src/entity.rs
@@ -35,13 +35,44 @@ macro_rules! typed_entity_id {
             }
         }
 
+        impl $name {
+            /// Wrap an `EntityId` in this typed newtype **without** verifying
+            /// the entity is actually of that kind. Wrong-kind IDs surface
+            /// later as `EntityNotFound` / `NotAnElevator` from accessor
+            /// calls.
+            ///
+            /// The explicit name signals the unsafety that the silent
+            /// [`From<EntityId>`] impl on this type also exposes — both
+            /// constructors are intended for callers that already hold a
+            /// confirmed-kind id (typed-ID accessors like
+            /// [`World::elevator_ids`](crate::world::World::elevator_ids),
+            /// snapshot deserialization, defense-in-depth tests). At host
+            /// boundaries, prefer [`Simulation::elevator_id`](crate::sim::Simulation::elevator_id)
+            /// / [`Simulation::rider_id`](crate::sim::Simulation::rider_id),
+            /// which return `Option` after a runtime kind check.
+            #[inline]
+            #[must_use]
+            pub const fn wrap_unchecked(id: EntityId) -> Self {
+                Self(id)
+            }
+        }
+
+        impl From<$name> for EntityId {
+            #[inline]
+            fn from(id: $name) -> Self {
+                id.0
+            }
+        }
+
         impl From<EntityId> for $name {
             /// Wrap an `EntityId` in this typed newtype **without** verifying
-            /// the entity is actually of that kind. Wrong-type IDs surface
+            /// the entity is actually of that kind. Wrong-kind IDs surface
             /// later as `EntityNotFound` / `NotAnElevator` from accessor
-            /// calls — for compile-time safety, prefer the typed
-            /// `_id` accessors on `Simulation` (`elevator_ids`,
-            /// `rider_ids`, etc.) that yield typed IDs directly. (#290)
+            /// calls. Equivalent to [`wrap_unchecked`](Self::wrap_unchecked);
+            /// at host boundaries, prefer the verified
+            /// [`Simulation::elevator_id`](crate::sim::Simulation::elevator_id)
+            /// / [`Simulation::rider_id`](crate::sim::Simulation::rider_id)
+            /// accessors, which return `Option` after a runtime kind check.
             #[inline]
             fn from(id: EntityId) -> Self {
                 Self(id)

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -341,7 +341,7 @@ impl RiderBuilder<'_> {
             self.sim.world.set_access_control(eid, ac);
         }
 
-        Ok(RiderId::from(eid))
+        Ok(RiderId::wrap_unchecked(eid))
     }
 }
 

--- a/crates/elevator-core/src/sim/eta.rs
+++ b/crates/elevator-core/src/sim/eta.rs
@@ -167,7 +167,9 @@ impl super::Simulation {
                 if !direction_ok {
                     return None;
                 }
-                self.eta(ElevatorId::from(eid), stop).ok().map(|d| (eid, d))
+                self.eta(ElevatorId::wrap_unchecked(eid), stop)
+                    .ok()
+                    .map(|d| (eid, d))
             })
             .min_by_key(|(_, d)| *d)
     }

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -1019,6 +1019,40 @@ impl Simulation {
         self.world.stop(id).is_some()
     }
 
+    /// Verified [`ElevatorId`] constructor for host code holding a raw
+    /// [`EntityId`] (FFI marshalling, wasm boundary, etc).
+    ///
+    /// Returns `Some` only if `id` is alive and has an elevator
+    /// component. Hosts that previously used `ElevatorId::from(id)` —
+    /// which silently produced wrong-kind IDs — should switch here:
+    /// the runtime kind check catches the bug at the boundary instead
+    /// of letting a `RiderId`-shaped value flow into elevator-only
+    /// accessors and surface as `None`/`0` deeper in.
+    ///
+    /// Internal core code that already holds a confirmed-kind id
+    /// (snapshot deserialization, lifecycle helpers, defense-in-depth
+    /// tests) uses [`ElevatorId::wrap_unchecked`] instead.
+    #[must_use]
+    pub fn elevator_id(&self, id: EntityId) -> Option<ElevatorId> {
+        if self.world.elevator(id).is_some() {
+            Some(ElevatorId::from(id))
+        } else {
+            None
+        }
+    }
+
+    /// Verified [`RiderId`] constructor for host code holding a raw
+    /// [`EntityId`]. Mirror of [`Simulation::elevator_id`]; same
+    /// rationale.
+    #[must_use]
+    pub fn rider_id(&self, id: EntityId) -> Option<RiderId> {
+        if self.world.rider(id).is_some() {
+            Some(RiderId::from(id))
+        } else {
+            None
+        }
+    }
+
     // ── Aggregate queries ───────────────────────────────────────────
 
     /// Count of elevators currently in the [`Idle`](ElevatorPhase::Idle) phase.

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -1035,7 +1035,7 @@ impl Simulation {
     #[must_use]
     pub fn elevator_id(&self, id: EntityId) -> Option<ElevatorId> {
         if self.world.elevator(id).is_some() {
-            Some(ElevatorId::from(id))
+            Some(ElevatorId::wrap_unchecked(id))
         } else {
             None
         }
@@ -1047,7 +1047,7 @@ impl Simulation {
     #[must_use]
     pub fn rider_id(&self, id: EntityId) -> Option<RiderId> {
         if self.world.rider(id).is_some() {
-            Some(RiderId::from(id))
+            Some(RiderId::wrap_unchecked(id))
         } else {
             None
         }

--- a/crates/elevator-core/src/sim/rider.rs
+++ b/crates/elevator-core/src/sim/rider.rs
@@ -91,7 +91,7 @@ impl super::Simulation {
         let group = self.auto_detect_group(origin, destination)?;
 
         let route = Route::direct(origin, destination, group);
-        Ok(RiderId::from(self.spawn_rider_inner(
+        Ok(RiderId::wrap_unchecked(self.spawn_rider_inner(
             origin,
             destination,
             weight,


### PR DESCRIPTION
## Summary

Add two new paths for constructing typed IDs (`ElevatorId`/`RiderId`) that make the unsafety explicit at the call site. Fourth architecture PR from the queue audited in #710 (HIGH #2 of 8). Net **+77 / -10 LOC** across 6 files.

This PR is intentionally additive — it does **not** force migration of the ~50+ existing `From::from` / `.into()` callers, which would balloon scope. The audit's silent-coercion concern is addressed by adding the alternatives; the `From<EntityId>` removal can come in a follow-up after consumers adopt the verified path.

## What's added

### `ElevatorId::wrap_unchecked(EntityId)` / `RiderId::wrap_unchecked(EntityId)`
Explicit-name constructor for callers that already hold a confirmed-kind id (typed-ID accessors like `World::elevator_ids`, snapshot deserialization, internal lifecycle helpers, defense-in-depth tests). Same semantics as the still-pub `From<EntityId>` impl, but the name flags the lack of a runtime check at every call site.

### `Simulation::elevator_id(EntityId) -> Option<ElevatorId>` / `Simulation::rider_id(EntityId) -> Option<RiderId>`
Verified accessors for host boundaries (FFI, wasm, gdext, future Bevy plugin). Returns `Some` only after a runtime kind check — wrong-kind IDs are caught at construction and surface as `None` instead of producing a typed value that fails far away. Hosts that previously used `ElevatorId::from(eid)` (silent) should switch here for new code; existing call sites can migrate organically.

### Three internal call sites flipped to `wrap_unchecked` to demonstrate intent
- `crates/elevator-core/src/sim.rs::RiderBuilder::build` — confirmed-kind id from internal spawn
- `crates/elevator-core/src/sim/eta.rs::Simulation::best_eta` — entity from `iter_elevators()`
- `crates/elevator-core/src/sim/rider.rs::Simulation::spawn_rider` — confirmed-kind id from internal spawn

These are well-known confirmed-kind sites where the explicit name documents the intent in code rather than relying on convention.

### Doc updates on the existing `From<EntityId>` impl
Point readers at the verified accessors as the recommended path for host boundaries; clarify that `From` is the unchecked path equivalent to `wrap_unchecked`.

## Why this PR is additive (not a removal)

The audit's recommendation ("replace `From<EntityId>` with a fallible `try_from_world` (or seal construction)") would force migration of roughly:

- ~30+ call sites in `crates/elevator-ffi/src/lib.rs` (mostly `entity_from_u64(..).into()`)
- ~30+ call sites in `crates/elevator-wasm/src/lib.rs` (mostly `ElevatorId::from(u64_to_entity(..))`)
- ~20+ call sites across `crates/elevator-core/src/tests/*.rs`, `tests/scenarios/*.rs`, and `examples/*.rs`
- A handful in `crates/elevator-tui/src/ui/*.rs` and `crates/elevator-gdext/src/sim_node.rs`

All mechanical, but enough churn to warrant its own PR with its own review. With the verified accessor in place, that follow-up can land deliberately rather than forcing the migration here.

## What's NOT in this PR (deferred)

- Removing the `From<EntityId>` impl. Follow-up PR after consumers adopt the verified path.
- Migrating existing host call sites to `Simulation::elevator_id`/`rider_id`. Same follow-up.

`bindings.toml` unchanged — the new accessors are additive on the public Simulation surface, not yet bound by hosts; bindings entries will be added when a host adopts them.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-features --all-targets` clean (zero warnings)
- [x] `cargo test -p elevator-core --all-features` — 159 + scenarios + doctests all pass
- [x] `cargo check --workspace --all-features --all-targets` clean
- [x] `scripts/check-bindings.sh` clean
- [x] Pre-commit hook full battery green