### PR TITLE
refactor(core): RankContext caches positions via accessors

### DIFF
--- a/crates/elevator-core/examples/custom_dispatch.rs
+++ b/crates/elevator-core/examples/custom_dispatch.rs
@@ -91,7 +91,7 @@ impl DispatchStrategy for IdlePenaltyDispatch {
     /// used recently. Returning `None` would exclude a `(car, stop)`
     /// pair entirely — useful for capacity limits or restricted stops.
     fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
-        let distance = (ctx.car_position - ctx.stop_position).abs();
+        let distance = (ctx.car_position() - ctx.stop_position()).abs();
         let idle_for = self.idle_for.get(&ctx.car).copied().unwrap_or(0.0);
         // Bias toward long-idle cars; clamp so cost stays non-negative.
         Some(0.01f64.mul_add(-idle_for, distance).max(0.0))

--- a/crates/elevator-core/src/dispatch/etd.rs
+++ b/crates/elevator-core/src/dispatch/etd.rs
@@ -221,7 +221,8 @@ impl DispatchStrategy for EtdDispatch {
         if !pair_is_useful(ctx, false) {
             return None;
         }
-        let mut cost = self.compute_cost(ctx.car, ctx.car_position, ctx.stop_position, ctx.world);
+        let mut cost =
+            self.compute_cost(ctx.car, ctx.car_position(), ctx.stop_position(), ctx.world);
         if self.wait_squared_weight > 0.0 {
             let wait_sq: f64 = ctx
                 .manifest

--- a/crates/elevator-core/src/dispatch/look.rs
+++ b/crates/elevator-core/src/dispatch/look.rs
@@ -93,8 +93,8 @@ impl DispatchStrategy for LookDispatch {
         sweep::rank(
             self.mode_for(ctx.car),
             self.direction_for(ctx.car),
-            ctx.car_position,
-            ctx.stop_position,
+            ctx.car_position(),
+            ctx.stop_position(),
         )
     }
 

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -20,7 +20,7 @@
 //!     fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
 //!         // Prefer the group's first stop; everything else is unavailable.
 //!         if Some(&ctx.stop) == ctx.group.stop_entities().first() {
-//!             Some((ctx.car_position - ctx.stop_position).abs())
+//!             Some((ctx.car_position() - ctx.stop_position()).abs())
 //!         } else {
 //!             None
 //!         }
@@ -168,7 +168,7 @@ pub fn pair_is_useful(ctx: &RankContext<'_>, respect_aboard_path: bool) -> bool 
     // Pickups allowed only on the path to an aboard rider's destination.
     // Candidate at the car's position (to_cand = 0) trivially qualifies —
     // useful for same-floor boards.
-    let to_cand = ctx.stop_position - ctx.car_position;
+    let to_cand = ctx.stop_position() - ctx.car_position();
     car.riders().iter().any(|&rid| {
         let Some(dest) = ctx.world.route(rid).and_then(Route::current_destination) else {
             return false;
@@ -176,7 +176,7 @@ pub fn pair_is_useful(ctx: &RankContext<'_>, respect_aboard_path: bool) -> bool 
         let Some(dest_pos) = ctx.world.stop_position(dest) else {
             return false;
         };
-        let to_dest = dest_pos - ctx.car_position;
+        let to_dest = dest_pos - ctx.car_position();
         to_dest * to_cand >= 0.0 && to_cand.abs() <= to_dest.abs()
     })
 }
@@ -206,10 +206,10 @@ fn rider_can_board(
     let Some(dest_pos) = ctx.world.stop_position(dest) else {
         return true;
     };
-    if dest_pos > ctx.stop_position && !car.going_up() {
+    if dest_pos > ctx.stop_position() && !car.going_up() {
         return false;
     }
-    if dest_pos < ctx.stop_position && !car.going_down() {
+    if dest_pos < ctx.stop_position() && !car.going_down() {
         return false;
     }
     true
@@ -227,8 +227,8 @@ fn bypass_in_current_direction(car: &crate::components::Elevator, ctx: &RankCont
     let Some(target_pos) = ctx.world.stop_position(target) else {
         return false;
     };
-    let going_up = target_pos > ctx.car_position;
-    let going_down = target_pos < ctx.car_position;
+    let going_up = target_pos > ctx.car_position();
+    let going_down = target_pos < ctx.car_position();
     if !going_up && !going_down {
         return false;
     }
@@ -249,8 +249,8 @@ fn bypass_in_current_direction(car: &crate::components::Elevator, ctx: &RankCont
         return false;
     }
     // Only same-direction pickups get bypassed.
-    let stop_above = ctx.stop_position > ctx.car_position;
-    let stop_below = ctx.stop_position < ctx.car_position;
+    let stop_above = ctx.stop_position() > ctx.car_position();
+    let stop_below = ctx.stop_position() < ctx.car_position();
     (going_up && stop_above) || (going_down && stop_below)
 }
 
@@ -845,12 +845,8 @@ pub fn elevator_line_serves_indexed<'a>(
 pub struct RankContext<'a> {
     /// The elevator being evaluated.
     pub car: EntityId,
-    /// Current position of the car along the shaft axis.
-    pub car_position: f64,
     /// The stop being evaluated as a candidate destination.
     pub stop: EntityId,
-    /// Position of the candidate stop along the shaft axis.
-    pub stop_position: f64,
     /// The dispatch group this assignment belongs to.
     pub group: &'a ElevatorGroup,
     /// Demand snapshot for the current dispatch pass.
@@ -859,13 +855,39 @@ pub struct RankContext<'a> {
     pub world: &'a World,
 }
 
+impl RankContext<'_> {
+    /// Position of [`car`](Self::car) along the shaft axis.
+    ///
+    /// Returns `0.0` for an entity that has no `Position` component
+    /// (which would never reach this method through normal dispatch
+    /// — `compute_assignments` filters out cars without positions
+    /// upstream — but the defensive default protects custom callers).
+    /// Derived from [`world`](Self::world) on each call: the dispatch
+    /// loop never moves elevators between rank calls, so re-deriving
+    /// is free, and skipping the duplicate field eliminates the
+    /// synchronisation risk of the old shape.
+    #[must_use]
+    pub fn car_position(&self) -> f64 {
+        self.world.position(self.car).map_or(0.0, |p| p.value)
+    }
+
+    /// Position of [`stop`](Self::stop) along the shaft axis.
+    ///
+    /// Returns `0.0` for an entity that has no `Stop` component (same
+    /// rationale as [`car_position`](Self::car_position)).
+    #[must_use]
+    pub fn stop_position(&self) -> f64 {
+        self.world.stop_position(self.stop).unwrap_or(0.0)
+    }
+}
+
 impl std::fmt::Debug for RankContext<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RankContext")
             .field("car", &self.car)
-            .field("car_position", &self.car_position)
+            .field("car_position", &self.car_position())
             .field("stop", &self.stop)
-            .field("stop_position", &self.stop_position)
+            .field("stop_position", &self.stop_position())
             .field("group", &self.group)
             .field("manifest", &self.manifest)
             .field("world", &"World { .. }")
@@ -1374,7 +1396,7 @@ pub(crate) fn assign_with_scratch(
                 "car {car_eid:?} on line not present in its group's lines list"
             );
 
-            for (j, &(stop_eid, stop_pos)) in pending_stops.iter().enumerate() {
+            for (j, &(stop_eid, _stop_pos)) in pending_stops.iter().enumerate() {
                 if restricted.is_some_and(|r| r.contains(&stop_eid)) {
                     continue; // leave SENTINEL — this pair is unavailable
                 }
@@ -1383,9 +1405,7 @@ pub(crate) fn assign_with_scratch(
                 }
                 let ctx = RankContext {
                     car: car_eid,
-                    car_position: car_pos,
                     stop: stop_eid,
-                    stop_position: stop_pos,
                     group,
                     manifest,
                     world,

--- a/crates/elevator-core/src/dispatch/nearest_car.rs
+++ b/crates/elevator-core/src/dispatch/nearest_car.rs
@@ -41,7 +41,7 @@ impl DispatchStrategy for NearestCarDispatch {
         if !pair_is_useful(ctx, true) {
             return None;
         }
-        Some((ctx.car_position - ctx.stop_position).abs())
+        Some((ctx.car_position() - ctx.stop_position()).abs())
     }
 
     fn builtin_id(&self) -> Option<super::BuiltinStrategy> {

--- a/crates/elevator-core/src/dispatch/rsr.rs
+++ b/crates/elevator-core/src/dispatch/rsr.rs
@@ -319,7 +319,7 @@ impl DispatchStrategy for RsrDispatch {
         let car = ctx.world.elevator(ctx.car)?;
 
         // ETA — travel time to the candidate stop.
-        let distance = (ctx.car_position - ctx.stop_position).abs();
+        let distance = (ctx.car_position() - ctx.stop_position()).abs();
         let max_speed = car.max_speed.value();
         if max_speed <= 0.0 {
             return None;
@@ -334,10 +334,10 @@ impl DispatchStrategy for RsrDispatch {
             && let Some(target) = car.phase.moving_target()
             && let Some(target_pos) = ctx.world.stop_position(target)
         {
-            let car_going_up = target_pos > ctx.car_position;
-            let car_going_down = target_pos < ctx.car_position;
-            let cand_above = ctx.stop_position > ctx.car_position;
-            let cand_below = ctx.stop_position < ctx.car_position;
+            let car_going_up = target_pos > ctx.car_position();
+            let car_going_down = target_pos < ctx.car_position();
+            let cand_above = ctx.stop_position() > ctx.car_position();
+            let cand_below = ctx.stop_position() < ctx.car_position();
             if (car_going_up && cand_below) || (car_going_down && cand_above) {
                 // During up-peak/down-peak the directional invariant
                 // is load-bearing (a committed car shouldn't reverse

--- a/crates/elevator-core/src/dispatch/scan.rs
+++ b/crates/elevator-core/src/dispatch/scan.rs
@@ -99,8 +99,8 @@ impl DispatchStrategy for ScanDispatch {
         sweep::rank(
             self.mode_for(ctx.car),
             self.direction_for(ctx.car),
-            ctx.car_position,
-            ctx.stop_position,
+            ctx.car_position(),
+            ctx.stop_position(),
         )
     }
 

--- a/crates/elevator-core/src/tests/dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/dispatch_tests.rs
@@ -543,6 +543,8 @@ fn scan_notify_removed_cleans_state() {
     scan.notify_removed(elev);
 
     // Re-query same elevator from position 4.0 with demand above AND below.
+    // Move it in the world so RankContext's cached `car_position()` reflects it.
+    world.set_position(elev, Position { value: 4.0 });
     add_demand(&mut manifest, &mut world, stops[2], 70.0);
     let d2 = decide_one(&mut scan, elev, 4.0, &group, &manifest, &mut world);
     // If notify_removed worked: default direction is Up → goes to stops[2] (pos 8.0).
@@ -565,6 +567,8 @@ fn look_notify_removed_cleans_state() {
     // Remove elevator.
     look.notify_removed(elev);
     // Reuse the same ID — direction should be gone.
+    // Move the elevator in the world so the cached `car_position()` matches.
+    world.set_position(elev, Position { value: 4.0 });
     add_demand(&mut manifest, &mut world, stops[2], 70.0);
     let decision = decide_one(&mut look, elev, 4.0, &group, &manifest, &mut world);
     // Default direction is Up, should go up to stop[2] (pos 8.0).
@@ -911,7 +915,7 @@ fn strategy_rank_is_order_independent_when_state_lives_in_prepare_car() {
             let boost = self.idle.get(&ctx.car).copied().unwrap_or(0.0);
             Some(
                 0.001f64
-                    .mul_add(-boost, (ctx.car_position - ctx.stop_position).abs())
+                    .mul_add(-boost, (ctx.car_position() - ctx.stop_position()).abs())
                     .max(0.0),
             )
         }

--- a/crates/elevator-core/src/tests/etd_compute_cost_tests.rs
+++ b/crates/elevator-core/src/tests/etd_compute_cost_tests.rs
@@ -416,9 +416,7 @@ fn rank_age_linear_weight_subtracts_from_cost_when_active() {
 
     let ctx = RankContext {
         car: elev,
-        car_position: 0.0,
         stop: stops[1],
-        stop_position: 10.0,
         group: &g,
         manifest: &m,
         world: &world,
@@ -450,9 +448,7 @@ fn rank_zero_age_weight_skips_the_subtraction() {
 
     let ctx = RankContext {
         car: elev,
-        car_position: 0.0,
         stop: stops[1],
-        stop_position: 10.0,
         group: &g,
         manifest: &m,
         world: &world,
@@ -497,9 +493,7 @@ fn rank_wait_squared_weight_subtracts_quadratically() {
 
     let ctx = RankContext {
         car: elev,
-        car_position: 0.0,
         stop: stops[1],
-        stop_position: 10.0,
         group: &g,
         manifest: &m,
         world: &world,
@@ -535,9 +529,7 @@ fn rank_returns_none_when_compute_cost_returns_infinity() {
     etd.pre_dispatch(&g, &m, &mut world);
     let ctx = RankContext {
         car: elev,
-        car_position: 0.0,
         stop: stops[1],
-        stop_position: 10.0,
         group: &g,
         manifest: &m,
         world: &world,

--- a/crates/elevator-core/src/tests/feature_tests.rs
+++ b/crates/elevator-core/src/tests/feature_tests.rs
@@ -566,7 +566,7 @@ fn disable_elevator_notifies_dispatcher() {
     }
     impl DispatchStrategy for Counter {
         fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
-            Some((ctx.car_position - ctx.stop_position).abs())
+            Some((ctx.car_position() - ctx.stop_position()).abs())
         }
         fn notify_removed(&mut self, _elevator: EntityId) {
             self.removed.fetch_add(1, Ordering::Relaxed);
@@ -616,7 +616,7 @@ fn remove_elevator_notifies_dispatcher_exactly_once() {
     }
     impl DispatchStrategy for Counter {
         fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
-            Some((ctx.car_position - ctx.stop_position).abs())
+            Some((ctx.car_position() - ctx.stop_position()).abs())
         }
         fn notify_removed(&mut self, _elevator: EntityId) {
             self.removed.fetch_add(1, Ordering::Relaxed);

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -750,7 +750,7 @@ fn custom_strategy_reads_hall_calls_from_manifest() {
             {
                 self.saw_call.fetch_add(1, Ordering::Relaxed);
             }
-            Some((ctx.car_position - ctx.stop_position).abs())
+            Some((ctx.car_position() - ctx.stop_position()).abs())
         }
     }
 
@@ -797,7 +797,7 @@ fn custom_strategy_reads_car_calls_from_manifest() {
             if !ctx.manifest.car_calls_for(ctx.car).is_empty() {
                 self.saw_car_call.fetch_add(1, Ordering::Relaxed);
             }
-            Some((ctx.car_position - ctx.stop_position).abs())
+            Some((ctx.car_position() - ctx.stop_position()).abs())
         }
     }
 
@@ -858,7 +858,7 @@ fn unacknowledged_hall_calls_hidden_from_manifest() {
         }
 
         fn rank(&self, ctx: &crate::dispatch::RankContext<'_>) -> Option<f64> {
-            Some((ctx.car_position - ctx.stop_position).abs())
+            Some((ctx.car_position() - ctx.stop_position()).abs())
         }
     }
 

--- a/crates/elevator-core/src/tests/reposition_look_boundary_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_look_boundary_tests.rs
@@ -489,25 +489,17 @@ fn strict_demand_ahead_up_accepts_demand_strictly_above_car() {
 
 // ===== LookDispatch degenerate request shapes =====
 
-#[allow(
-    clippy::too_many_arguments,
-    reason = "test helper threading rank context"
-)]
 fn rank_via_look(
     look: &LookDispatch,
     car: EntityId,
-    car_pos: f64,
     stop: EntityId,
-    stop_pos: f64,
     g: &ElevatorGroup,
     m: &DispatchManifest,
     world: &World,
 ) -> Option<f64> {
     let ctx = RankContext {
         car,
-        car_position: car_pos,
         stop,
-        stop_position: stop_pos,
         group: g,
         manifest: m,
         world,
@@ -526,7 +518,7 @@ fn look_all_demand_strictly_above_car_keeps_up_sweep() {
     look.prepare_car(elev, 10.0, &g, &m, &world);
     // Sweep stays Up: a stop above the car must rank, the (synthetic)
     // self-stop at the car's position must not.
-    let above = rank_via_look(&look, elev, 10.0, stops[0], 15.0, &g, &m, &world);
+    let above = rank_via_look(&look, elev, stops[0], &g, &m, &world);
     assert!(above.is_some(), "Up sweep accepts stop above car");
 }
 
@@ -541,7 +533,7 @@ fn look_all_demand_strictly_below_car_reverses_to_down() {
     // Default direction is Up but no demand is up → prepare_car
     // reverses to Down + Lenient.
     look.prepare_car(elev, 10.0, &g, &m, &world);
-    let below = rank_via_look(&look, elev, 10.0, stops[0], 0.0, &g, &m, &world);
+    let below = rank_via_look(&look, elev, stops[0], &g, &m, &world);
     assert!(
         below.is_some(),
         "after reversal, a stop below the car must rank (Down sweep accepts it)"
@@ -563,7 +555,7 @@ fn look_repeated_stops_at_same_position_all_rank_equally() {
 
     let costs: Vec<_> = stops
         .iter()
-        .map(|&s| rank_via_look(&look, elev, 10.0, s, 20.0, &g, &m, &world))
+        .map(|&s| rank_via_look(&look, elev, s, &g, &m, &world))
         .collect();
     assert!(costs.iter().all(Option::is_some));
     let first = costs[0].unwrap();

--- a/crates/elevator-wasm/src/js_dispatch.rs
+++ b/crates/elevator-wasm/src/js_dispatch.rs
@@ -73,9 +73,9 @@ impl DispatchStrategy for JsDispatchStrategy {
     fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
         let dto = JsRankContext {
             car: ctx.car.data().as_ffi(),
-            car_position: ctx.car_position,
+            car_position: ctx.car_position(),
             stop: ctx.stop.data().as_ffi(),
-            stop_position: ctx.stop_position,
+            stop_position: ctx.stop_position(),
         };
         // `to_value` defaults to f64 numbers for `u64`, which truncates
         // any slotmap key above 2^53. Switching to bigint preserves

--- a/docs/src/custom-dispatch.md
+++ b/docs/src/custom-dispatch.md
@@ -92,7 +92,7 @@ struct BusyStopNearest;
 
 impl DispatchStrategy for BusyStopNearest {
     fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
-        let distance = (ctx.car_position - ctx.stop_position).abs();
+        let distance = (ctx.car_position() - ctx.stop_position()).abs();
         let waiting = ctx.manifest.waiting_count_at(ctx.stop) as f64;
         // Subtract a crowding bonus so busier stops look cheaper. Clamp
         // so the solver never sees a negative cost.
@@ -155,15 +155,15 @@ impl DispatchStrategy for DirectionalDispatch {
     fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
         let going_up = self.sweep_up.get(&ctx.car).copied().unwrap_or(true);
         let is_ahead = if going_up {
-            ctx.stop_position >= ctx.car_position
+            ctx.stop_position() >= ctx.car_position()
         } else {
-            ctx.stop_position <= ctx.car_position
+            ctx.stop_position() <= ctx.car_position()
         };
         if is_ahead {
-            Some((ctx.car_position - ctx.stop_position).abs())
+            Some((ctx.car_position() - ctx.stop_position()).abs())
         } else {
             // Penalize stops behind the sweep direction.
-            Some((ctx.car_position - ctx.stop_position).abs() + 1000.0)
+            Some((ctx.car_position() - ctx.stop_position()).abs() + 1000.0)
         }
     }
 


### PR DESCRIPTION
## Summary

Drop the duplicated `car_position` / `stop_position` fields from `RankContext` in favour of cached accessor methods that derive from `world` on call. Fifth architecture PR from the queue audited in #710 (MEDIUM #5 of 8).

## Why

The dispatch loop's `compute_assignments` previously snapshotted both positions into each `RankContext` before calling `rank`. With both fields living on the struct alongside `world`, two synchronisation hazards loomed:

1. A strategy that stashed `ctx` for later use (or captured it in a closure) could read positions that diverged from `world` if anything ever mutated the world between rank passes.
2. Adding new derived per-pair facts (line distance, neighbour density, …) meant growing the struct rather than adding accessors — a maintenance penalty for every future cross-cut.

The audit's exact words: *"`RankContext` carries pre-computed `car_position`/`stop_position` redundant with `world`. Strategies receive both the entity and its position as separate fields. With `world` in scope, the positions are derivable in O(1), and keeping them separate creates a synchronization risk."*

## What changes

### `RankContext` (`crates/elevator-core/src/dispatch/mod.rs`)
- Drops `pub car_position: f64` and `pub stop_position: f64` fields.
- Adds `RankContext::car_position(&self) -> f64` and `RankContext::stop_position(&self) -> f64` accessor methods.
- Both derive from `world` on call (one slotmap lookup each — cheap).
- Defensive defaults: `0.0` for entities missing the relevant component (the dispatch loop filters those upstream, but the default protects custom callers).
- `Debug` impl updated to call the accessors.

### Construction site (`compute_assignments`)
The struct literal no longer sets the dropped fields. The pre-computed `car_pos` / `stop_pos` from `idle_cars` and `pending_stops` are still used by `prepare_car` (its signature is unchanged), so they aren't dead code.

### Migrated consumers (in-crate)
- Six built-in strategies: `scan`, `look`, `etd`, `nearest_car`, `destination`, `rsr`
- Three test stubs in `dispatch_tests.rs`, `feature_tests.rs`, `hall_call_tests.rs`
- The wasm bridge `crates/elevator-wasm/src/js_dispatch.rs`
- The example at `crates/elevator-core/examples/custom_dispatch.rs`
- The `rank_via_look` test helper signature simplifies (drops two now-unused parameters)
- Two test files that built `RankContext` literals strip the obsolete field initialisers

### Documentation
- `docs/src/custom-dispatch.md` — two doctests + the `DirectionalDispatch` walkthrough updated to call the accessor methods.

### Test correctness
Two tests in `dispatch_tests.rs` (`scan_notify_removed_cleans_state`, `look_notify_removed_cleans_state`) used the old fields as an escape hatch: they passed a `pos: f64` to `decide_one(elev, 4.0, …)` that did **not** match the elevator's position in `world` (12.0). With cached accessors, the world is the truth — updated both tests to `world.set_position(elev, …)` before the re-query, mirroring how production dispatch updates the world before each tick. Surfacing the test/world mismatch was the audit's exact goal.

## What's NOT in scope
`bindings.toml` unchanged — this PR adds no `pub fn` on `impl Simulation`. `RankContext` is `#[non_exhaustive]`, so callers using `..ctx` patterns continue to compile; only direct field reads (`ctx.car_position`) need the parens.

## BREAKING CHANGE

Custom external `DispatchStrategy` implementations that read `ctx.car_position` or `ctx.stop_position` as fields must change to method calls (`ctx.car_position()`, `ctx.stop_position()`).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-features --all-targets` clean (zero warnings)
- [x] `cargo test -p elevator-core --all-features` — 984 lib + scenarios + doctests all pass (the two tests that initially failed surfaced the audit's silent-divergence concern; both fixed)
- [x] `cargo check --workspace --all-features --all-targets` clean
- [x] `scripts/check-bindings.sh` clean
- [x] `scripts/lint-docs.sh --quick` clean
- [x] Pre-commit hook full battery green