### PR TITLE
refactor(core): demote World::set_* setters to pub(crate)

### DIFF
--- a/crates/elevator-core/src/energy.rs
+++ b/crates/elevator-core/src/energy.rs
@@ -11,9 +11,11 @@ use serde::{Deserialize, Serialize};
 
 /// Per-elevator energy cost parameters.
 ///
-/// Attach to an elevator entity through the simulation's curated energy
-/// profile setter to enable energy tracking for that car. The energy system
-/// automatically initializes [`EnergyMetrics`] if not already present.
+/// Attach to an elevator entity by setting the
+/// [`energy_profile`](crate::config::ElevatorConfig::energy_profile) field on
+/// [`ElevatorConfig`](crate::config::ElevatorConfig) before constructing the
+/// simulation. The energy system automatically initializes [`EnergyMetrics`]
+/// if not already present.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EnergyProfile {
     /// Energy consumed per tick while idle (doors closed, stationary).

--- a/crates/elevator-core/src/energy.rs
+++ b/crates/elevator-core/src/energy.rs
@@ -11,9 +11,9 @@ use serde::{Deserialize, Serialize};
 
 /// Per-elevator energy cost parameters.
 ///
-/// Attach to an elevator entity via [`World::set_energy_profile`](crate::world::World::set_energy_profile)
-/// to enable energy tracking for that car. The energy system automatically
-/// initializes [`EnergyMetrics`] if not already present.
+/// Attach to an elevator entity through the simulation's curated energy
+/// profile setter to enable energy tracking for that car. The energy system
+/// automatically initializes [`EnergyMetrics`] if not already present.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EnergyProfile {
     /// Energy consumed per tick while idle (doors closed, stationary).

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -275,7 +275,7 @@ impl World {
     }
 
     /// Set an entity's position.
-    pub fn set_position(&mut self, id: EntityId, pos: Position) {
+    pub(crate) fn set_position(&mut self, id: EntityId, pos: Position) {
         self.positions.insert(id, pos);
     }
 
@@ -314,7 +314,7 @@ impl World {
     }
 
     /// Set an entity's velocity.
-    pub fn set_velocity(&mut self, id: EntityId, vel: Velocity) {
+    pub(crate) fn set_velocity(&mut self, id: EntityId, vel: Velocity) {
         self.velocities.insert(id, vel);
     }
 
@@ -332,7 +332,7 @@ impl World {
     }
 
     /// Set an entity's elevator component.
-    pub fn set_elevator(&mut self, id: EntityId, elev: Elevator) {
+    pub(crate) fn set_elevator(&mut self, id: EntityId, elev: Elevator) {
         self.elevators.insert(id, elev);
     }
 
@@ -374,7 +374,7 @@ impl World {
     }
 
     /// Set an entity's stop component.
-    pub fn set_stop(&mut self, id: EntityId, stop: Stop) {
+    pub(crate) fn set_stop(&mut self, id: EntityId, stop: Stop) {
         self.stops.insert(id, stop);
     }
 
@@ -392,7 +392,7 @@ impl World {
     }
 
     /// Set an entity's route.
-    pub fn set_route(&mut self, id: EntityId, route: Route) {
+    pub(crate) fn set_route(&mut self, id: EntityId, route: Route) {
         self.routes.insert(id, route);
     }
 
@@ -410,7 +410,7 @@ impl World {
     }
 
     /// Set an entity's line component.
-    pub fn set_line(&mut self, id: EntityId, line: Line) {
+    pub(crate) fn set_line(&mut self, id: EntityId, line: Line) {
         self.lines.insert(id, line);
     }
 
@@ -438,7 +438,7 @@ impl World {
     }
 
     /// Set an entity's patience.
-    pub fn set_patience(&mut self, id: EntityId, patience: Patience) {
+    pub(crate) fn set_patience(&mut self, id: EntityId, patience: Patience) {
         self.patience.insert(id, patience);
     }
 
@@ -451,7 +451,7 @@ impl World {
     }
 
     /// Set an entity's preferences.
-    pub fn set_preferences(&mut self, id: EntityId, prefs: Preferences) {
+    pub(crate) fn set_preferences(&mut self, id: EntityId, prefs: Preferences) {
         self.preferences.insert(id, prefs);
     }
 
@@ -469,7 +469,7 @@ impl World {
     }
 
     /// Set an entity's access control.
-    pub fn set_access_control(&mut self, id: EntityId, ac: AccessControl) {
+    pub(crate) fn set_access_control(&mut self, id: EntityId, ac: AccessControl) {
         self.access_controls.insert(id, ac);
     }
 
@@ -497,13 +497,13 @@ impl World {
 
     #[cfg(feature = "energy")]
     /// Set an entity's energy profile.
-    pub fn set_energy_profile(&mut self, id: EntityId, profile: EnergyProfile) {
+    pub(crate) fn set_energy_profile(&mut self, id: EntityId, profile: EnergyProfile) {
         self.energy_profiles.insert(id, profile);
     }
 
     #[cfg(feature = "energy")]
     /// Set an entity's energy metrics.
-    pub fn set_energy_metrics(&mut self, id: EntityId, metrics: EnergyMetrics) {
+    pub(crate) fn set_energy_metrics(&mut self, id: EntityId, metrics: EnergyMetrics) {
         self.energy_metrics.insert(id, metrics);
     }
 
@@ -516,7 +516,7 @@ impl World {
     }
 
     /// Set an entity's service mode.
-    pub fn set_service_mode(&mut self, id: EntityId, mode: ServiceMode) {
+    pub(crate) fn set_service_mode(&mut self, id: EntityId, mode: ServiceMode) {
         self.service_modes.insert(id, mode);
     }
 
@@ -535,7 +535,7 @@ impl World {
     }
 
     /// Set an entity's destination queue.
-    pub fn set_destination_queue(&mut self, id: EntityId, queue: DestinationQueue) {
+    pub(crate) fn set_destination_queue(&mut self, id: EntityId, queue: DestinationQueue) {
         self.destination_queues.insert(id, queue);
     }
 


### PR DESCRIPTION
## Summary

Demote 13 `pub fn set_*` component setters on `World` to `pub(crate)`. Closing-out architecture PR from the queue audited in #710 (MEDIUM #7 of 8). Remaining open: MEDIUM #6 (`Event` tick redundancy), intentionally deferred.

## Why

The audit (#710) flagged that `World`'s raw `pub fn set_*` component setters bypass invariants that the curated `Simulation`-level mutators carry:

> *"World exposes per-component setters publicly; encourages bypass of invariants. Setting an elevator's destination queue directly skips `RiderIndex` updates and event emission. Once the playground or a host writes such code it cements the leak."*

A pre-condition for the demotion was that no host actually uses the raw setters today — verified by grep across `elevator-ffi`, `elevator-wasm`, `elevator-gdext`, `elevator-tui`, `elevator-bevy`, plus all integration tests under `tests/scenarios/` and the `examples/`. None do; every host path goes through `Simulation::push_destination`, `Simulation::set_max_speed`, `Simulation::set_service_mode`, `Simulation::spawn_rider`, etc.

This PR closes the gap so future host code **can't** accidentally introduce the invariant break — it's a compile-time error to call the raw setter from outside `elevator-core`.

## What changes

Visibility-only edit on the 13 listed setters in `crates/elevator-core/src/world.rs`. No body changes; no signature changes; no behavioural change.

| Setter | Before | After |
|---|---|---|
| `set_position` | `pub` | `pub(crate)` |
| `set_velocity` | `pub` | `pub(crate)` |
| `set_elevator` | `pub` | `pub(crate)` |
| `set_stop` | `pub` | `pub(crate)` |
| `set_route` | `pub` | `pub(crate)` |
| `set_line` | `pub` | `pub(crate)` |
| `set_patience` | `pub` | `pub(crate)` |
| `set_preferences` | `pub` | `pub(crate)` |
| `set_access_control` | `pub` | `pub(crate)` |
| `set_energy_profile` (feature) | `pub` | `pub(crate)` |
| `set_energy_metrics` (feature) | `pub` | `pub(crate)` |
| `set_service_mode` | `pub` | `pub(crate)` |
| `set_destination_queue` | `pub` | `pub(crate)` |

`set_rider` was already `pub(crate)`.

## What stays public

- All component **readers** (`elevator()`, `rider()`, `position()`, etc.) — read-only access has no invariant concern.
- **Extension storage** (`insert_ext` / `ext` / `remove_ext`) — the audit explicitly carved this out: *"For extension storage and component reads, leave `pub`."*
- **Resource APIs** (`insert_resource` / `remove_resource`) — same rationale.
- **Spawn / despawn** lifecycle (`spawn`, `despawn`, `is_alive`) — already invariant-preserving by construction.

## BREAKING CHANGE

External code (a hypothetical future host or a downstream user obtaining `&mut World` through `Simulation::world_mut()`) calling any of the demoted setters will now get a `private function` error. Migration: use the corresponding `Simulation` method, which carries the invariants. None of the in-tree hosts needed updating.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-features --all-targets` clean (zero warnings)
- [x] `cargo test -p elevator-core --all-features` — 159 lib + scenarios + doctests all pass
- [x] `cargo check --workspace --all-features --all-targets` clean
- [x] `scripts/check-bindings.sh` clean (no `Simulation` method change)
- [x] Pre-commit hook full battery green

## Queue status (post-merge)

| Audit item | Status |
|---|---|
| HIGH #3 — `DispatchStrategy::rank` &self | ✅ #711 |
| HIGH #1 — typed-ID accessor sweep | ✅ #713 |
| HIGH #2 — verified ID constructors | ✅ #716 |
| MEDIUM #4 — `host_label` module | ✅ #715 |
| MEDIUM #5 — `RankContext` cached accessors | ✅ #717 |
| MEDIUM #8 — `LineInfo` helpers | ✅ #718 |
| MEDIUM #7 — `World::set_*` pub(crate) | this PR |
| MEDIUM #6 — `Event` tick redundancy | deferred (snapshot-shape change) |

Plus the missing-WHY comments PR queued separately (next user-driven item).