### PR TITLE
feat(playground): bloomberg-style metrics row redesign

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -596,7 +596,7 @@
         </header>
         <div
           id="metrics-a"
-          class="metric-strip grid grid-cols-5 gap-1.5 p-0.5 tabular-nums max-md:grid-cols-3"
+          class="metric-strip grid grid-cols-5 tabular-nums border-y border-stroke-subtle py-1 max-md:grid-cols-3"
         ></div>
         <div
           class="shaft-wrap relative bg-[radial-gradient(ellipse_at_50%_0%,var(--bg-hover)_0%,var(--bg-secondary)_80%)] border border-stroke-subtle rounded-md overflow-hidden shadow-[inset_0_1px_0_rgba(255,255,255,0.02)]"
@@ -684,7 +684,7 @@
         </header>
         <div
           id="metrics-b"
-          class="metric-strip grid grid-cols-5 gap-1.5 p-0.5 tabular-nums max-md:grid-cols-3"
+          class="metric-strip grid grid-cols-5 tabular-nums border-y border-stroke-subtle py-1 max-md:grid-cols-3"
         ></div>
         <div
           class="shaft-wrap relative bg-[radial-gradient(ellipse_at_50%_0%,var(--bg-hover)_0%,var(--bg-secondary)_80%)] border border-stroke-subtle rounded-md overflow-hidden shadow-[inset_0_1px_0_rgba(255,255,255,0.02)]"

--- a/playground/src/features/scoreboard/metric-rows.ts
+++ b/playground/src/features/scoreboard/metric-rows.ts
@@ -3,14 +3,14 @@ import type { MetricKey, MetricsDto } from "../../types";
 import { buildSparklinePath } from "./sparkline";
 
 // Metric row layout: 5 fixed rows, always the same keys in the same order.
-// We build the DOM once and mutate text + verdict + sparkline in place
-// every frame.
+// We build the DOM once and mutate text + verdict + sparkline + delta in
+// place every frame.
 export const METRIC_DEFS: Array<[string, MetricKey]> = [
-  ["Avg wait", "avg_wait_s"],
-  ["Max wait", "max_wait_s"],
-  ["Delivered", "delivered"],
-  ["Abandoned", "abandoned"],
-  ["Utilization", "utilization"],
+  ["wait avg", "avg_wait_s"],
+  ["wait max", "max_wait_s"],
+  ["delivered", "delivered"],
+  ["abandoned", "abandoned"],
+  ["util", "utilization"],
 ];
 
 export function metricValue(m: MetricsDto, key: MetricKey): string {
@@ -25,6 +25,44 @@ export function metricValue(m: MetricsDto, key: MetricKey): string {
       return String(m.abandoned);
     case "utilization":
       return `${(m.utilization * 100).toFixed(0)}%`;
+  }
+}
+
+// Arithmetic delta from `self` to `other` for the cell's metric. Sign
+// reflects raw difference; the verdict (win/lose/tie) drives color
+// independently. Returned `text` is "▲ +0.3 s" / "▼ −2 %"; callers hide
+// the element on tie to mirror the verdict's epsilon-based smoothing.
+function metricDelta(self: MetricsDto, other: MetricsDto, key: MetricKey): string {
+  const sv = numericMetric(self, key);
+  const ov = numericMetric(other, key);
+  const diff = sv - ov;
+  const arrow = diff > 0 ? "▲" : "▼";
+  const sign = diff > 0 ? "+" : diff < 0 ? "−" : "";
+  const mag = Math.abs(diff);
+  switch (key) {
+    case "avg_wait_s":
+    case "max_wait_s":
+      return `${arrow} ${sign}${mag.toFixed(1)} s`;
+    case "delivered":
+    case "abandoned":
+      return `${arrow} ${sign}${mag.toFixed(0)}`;
+    case "utilization":
+      return `${arrow} ${sign}${(mag * 100).toFixed(0)}%`;
+  }
+}
+
+function numericMetric(m: MetricsDto, key: MetricKey): number {
+  switch (key) {
+    case "avg_wait_s":
+      return m.avg_wait_s;
+    case "max_wait_s":
+      return m.max_wait_s;
+    case "delivered":
+      return m.delivered;
+    case "abandoned":
+      return m.abandoned;
+    case "utilization":
+      return m.utilization;
   }
 }
 
@@ -65,26 +103,24 @@ export function diffMetrics(
 export function initMetricRows(root: HTMLElement): void {
   const frag = document.createDocumentFragment();
   for (const [label] of METRIC_DEFS) {
-    const row = el(
-      "div",
-      "metric-row flex flex-col gap-[3px] px-2.5 py-[7px] bg-surface-elevated border border-stroke-subtle rounded-md transition-colors duration-normal",
-    );
+    // Hairline column rules between cells, no card chrome — the row
+    // floats on the surface. Column rules are grid-aware (CSS in
+    // style.css handles 5-col desktop vs 3-col mobile wrapping).
+    // data-verdict on the row drives delta + sparkline color via
+    // attribute selectors in style.css.
+    const row = el("div", "metric-row flex flex-col gap-[2px] px-2 py-1 text-right");
     // SVG sparkline lives in the metric row and is mutated in place each
-    // frame. Using SVG (not another canvas) keeps it crisp at any DPR
-    // and lets CSS drive the stroke color via `currentColor` / the
-    // `data-verdict` attribute on the row.
+    // frame. SVG (not canvas) keeps it crisp at any DPR and lets CSS drive
+    // the stroke color via `currentColor` / data-verdict on the row.
     const spark = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     spark.classList.add("metric-spark");
     spark.setAttribute("viewBox", "0 0 100 14");
     spark.setAttribute("preserveAspectRatio", "none");
     spark.appendChild(document.createElementNS("http://www.w3.org/2000/svg", "path"));
     row.append(
-      el(
-        "span",
-        "text-[9.5px] uppercase tracking-[0.08em] text-content-disabled font-medium",
-        label,
-      ),
-      el("span", "metric-v text-[15px] text-content font-medium [font-feature-settings:'tnum'_1]"),
+      el("span", "metric-k", label),
+      el("span", "metric-v"),
+      el("span", "metric-d"),
       spark,
     );
     frag.appendChild(row);
@@ -97,6 +133,7 @@ export function renderMetricRows(
   m: MetricsDto,
   verdicts: MetricVerdicts | null,
   history: Record<MetricKey, number[]>,
+  other: MetricsDto | null,
 ): void {
   const rows = root.children;
   for (let i = 0; i < METRIC_DEFS.length; i++) {
@@ -110,7 +147,15 @@ export function renderMetricRows(
     const vs = row.children[1] as HTMLElement;
     const val = metricValue(m, key);
     if (vs.textContent !== val) vs.textContent = val;
-    const spark = row.children[2] as SVGSVGElement;
+    const ds = row.children[2] as HTMLElement;
+    // Show delta only in compare mode and only when the verdict is
+    // non-tie — ties hide entirely so the row collapses cleanly to label
+    // + value + sparkline in single-pane mode and on indistinguishable
+    // values.
+    const showDelta = other !== null && verdict !== "tie" && verdict !== "";
+    const deltaText = showDelta ? metricDelta(m, other, key) : "";
+    if (ds.textContent !== deltaText) ds.textContent = deltaText;
+    const spark = row.children[3] as SVGSVGElement;
     const path = spark.firstElementChild as SVGPathElement;
     const d = buildSparklinePath(history[key]);
     if (path.getAttribute("d") !== d) path.setAttribute("d", d);

--- a/playground/src/features/scoreboard/metric-rows.ts
+++ b/playground/src/features/scoreboard/metric-rows.ts
@@ -109,9 +109,11 @@ export function initMetricRows(root: HTMLElement): void {
     // data-verdict on the row drives delta + sparkline color via
     // attribute selectors in style.css.
     const row = el("div", "metric-row flex flex-col gap-[2px] px-2 py-1 text-right");
-    // SVG sparkline lives in the metric row and is mutated in place each
-    // frame. SVG (not canvas) keeps it crisp at any DPR and lets CSS drive
-    // the stroke color via `currentColor` / data-verdict on the row.
+    // SVG sparkline lives in the metric row and is mutated in place
+    // each frame. SVG (not canvas) keeps it crisp at any DPR and lets
+    // CSS drive the stroke colour via the `.metric-row[data-verdict]`
+    // selectors in style.css (tertiary by default; --ok / --bad on
+    // win / lose).
     const spark = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     spark.classList.add("metric-spark");
     spark.setAttribute("viewBox", "0 0 100 14");
@@ -149,9 +151,9 @@ export function renderMetricRows(
     if (vs.textContent !== val) vs.textContent = val;
     const ds = row.children[2] as HTMLElement;
     // Show delta only in compare mode and only when the verdict is
-    // non-tie — ties hide entirely so the row collapses cleanly to label
-    // + value + sparkline in single-pane mode and on indistinguishable
-    // values.
+    // non-tie — ties + single-pane render an empty string so no
+    // arrow/sign is drawn. The slot itself stays at `.metric-d`'s
+    // reserved height so toggling Compare doesn't reflow the strip.
     const showDelta = other !== null && verdict !== "tie" && verdict !== "";
     const deltaText = showDelta ? metricDelta(m, other, key) : "";
     if (ds.textContent !== deltaText) ds.textContent = deltaText;

--- a/playground/src/shell/loop.ts
+++ b/playground/src/shell/loop.ts
@@ -11,10 +11,22 @@ function updateScoreboard(state: State): void {
   const paneB = state.paneB;
   if (paneB?.latestMetrics) {
     const compare = diffMetrics(paneA.latestMetrics, paneB.latestMetrics);
-    renderMetricRows(paneA.metricsEl, paneA.latestMetrics, compare.a, paneA.metricHistory);
-    renderMetricRows(paneB.metricsEl, paneB.latestMetrics, compare.b, paneB.metricHistory);
+    renderMetricRows(
+      paneA.metricsEl,
+      paneA.latestMetrics,
+      compare.a,
+      paneA.metricHistory,
+      paneB.latestMetrics,
+    );
+    renderMetricRows(
+      paneB.metricsEl,
+      paneB.latestMetrics,
+      compare.b,
+      paneB.metricHistory,
+      paneA.latestMetrics,
+    );
   } else {
-    renderMetricRows(paneA.metricsEl, paneA.latestMetrics, null, paneA.metricHistory);
+    renderMetricRows(paneA.metricsEl, paneA.latestMetrics, null, paneA.metricHistory, null);
   }
   updateModeBadge(paneA);
   if (paneB) updateModeBadge(paneB);

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -1040,8 +1040,11 @@
       "ss01" 1;
     line-height: 1.15;
   }
-  /* Delta hides cleanly when the row mutates `textContent` to ""; no
-   * visibility toggle needed because it has no padding/margin of its own. */
+  /* Reserved height (`min-height: 10.5px`) keeps the row at a stable
+   * vertical size whether the delta string is empty (single-pane or
+   * tie) or filled — toggling Compare doesn't shift the strip. We
+   * intentionally trade that 10.5px of always-on space for layout
+   * stability across modes. */
   .metric-d {
     font-family: var(--font-stack-mono);
     font-size: 10.5px;

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -997,22 +997,79 @@
     min-height: 1.35em;
   }
 
-  /* ── Metric sparkline ───────────────────────────────────────────────── */
+  /* ── Metric row (Bloomberg-style) ──────────────────────────────────── */
 
+  /* The row floats on the surface — no card bg, no border. Vertical
+   * column rules sit on every cell except the rightmost-of-its-visible-row
+   * (5 cols on desktop, 3 on mobile — the strip wraps the 5 cells into
+   * 2 mobile rows so we kill the 5n rule and gate by last-child instead).
+   * Verdict drives delta + sparkline color; the row itself stays neutral. */
   .metric-row {
     position: relative;
+    border-right: 1px solid var(--border-subtle);
+  }
+  .metric-strip .metric-row:nth-child(5n),
+  .metric-strip .metric-row:last-child {
+    border-right: 0;
+  }
+  @media (max-width: 767px) {
+    .metric-strip .metric-row:nth-child(5n) {
+      border-right: 1px solid var(--border-subtle);
+    }
+    .metric-strip .metric-row:nth-child(3n),
+    .metric-strip .metric-row:last-child {
+      border-right: 0;
+    }
+  }
+  .metric-k {
+    font-family: var(--font-stack-mono);
+    font-size: 10.5px;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+    line-height: 1;
+  }
+  .metric-v {
+    font-family: var(--font-stack-mono);
+    font-size: 15px;
+    font-weight: 500;
+    color: var(--text-primary);
+    font-feature-settings:
+      "tnum" 1,
+      "ss01" 1;
+    line-height: 1.15;
+  }
+  /* Delta hides cleanly when the row mutates `textContent` to ""; no
+   * visibility toggle needed because it has no padding/margin of its own. */
+  .metric-d {
+    font-family: var(--font-stack-mono);
+    font-size: 10.5px;
+    font-weight: 500;
+    line-height: 1;
+    min-height: 10.5px;
+    color: var(--text-tertiary);
+    font-feature-settings: "tnum" 1;
+  }
+  .metric-row[data-verdict="win"] .metric-d {
+    color: var(--ok);
+  }
+  .metric-row[data-verdict="lose"] .metric-d {
+    color: var(--bad);
   }
   .metric-spark {
-    margin-top: 2px;
+    margin-top: 1px;
     width: 100%;
-    height: 14px;
+    max-width: 56px;
+    height: 8px;
+    margin-left: auto;
     display: block;
-    opacity: 0.85;
+    opacity: 0.7;
   }
   .metric-spark path {
     fill: none;
     stroke: var(--text-tertiary);
-    stroke-width: 1.1;
+    stroke-width: 1;
     stroke-linecap: round;
     stroke-linejoin: round;
     vector-effect: non-scaling-stroke;
@@ -1242,23 +1299,6 @@
     background: color-mix(in oklab, var(--bad) 22%, var(--bg-elevated));
     color: var(--bad);
     border-color: color-mix(in oklab, var(--bad) 35%, var(--border-subtle));
-  }
-
-  /* Metric row: win/lose verdict colors the bg/border AND the nested
-   * .metric-v value. Uses a parent→child cascade. */
-  .metric-row[data-verdict="win"] {
-    background: linear-gradient(180deg, var(--ok-soft) 0%, var(--bg-elevated) 100%);
-    border-color: color-mix(in srgb, var(--ok) 30%, transparent);
-  }
-  .metric-row[data-verdict="lose"] {
-    background: linear-gradient(180deg, var(--bad-soft) 0%, var(--bg-elevated) 100%);
-    border-color: color-mix(in srgb, var(--bad) 25%, transparent);
-  }
-  .metric-row[data-verdict="win"] .metric-v {
-    color: var(--ok);
-  }
-  .metric-row[data-verdict="lose"] .metric-v {
-    color: var(--bad);
   }
 }
 


### PR DESCRIPTION
## Summary

PR 2 of the polish sequence — see `playground/POLISH_PLAN.md`.

The signature surface from the plan: a metrics row that reads like a Bloomberg terminal — hairline column rules, mono tabular numerals, deltas in green/red. The screenshot moment.

### What changes

- **Card chrome dropped**: no more `bg-surface-elevated border rounded-md` per row. The strip is flat, and a top + bottom hairline (`border-y border-stroke-subtle`) frames the whole row against the surface.
- **Vertical column rules**: 1 px `--border-subtle` between cells, grid-aware so the rightmost visible cell of each row (5n on desktop, 3n on mobile) skips its rule.
- **Labels in mono**: Geist Mono, 10.5 px, `--text-tertiary`, uppercased via CSS. Source strings are now engineering shorthand: `wait avg` / `wait max` / `delivered` / `abandoned` / `util`.
- **Values in mono**: Geist Mono with `tnum` + `ss01` (slashed zero) for terminal-grade alignment.
- **New explicit deltas** (`.metric-d`): in compare mode, each row shows the arithmetic delta vs the other pane prefixed with ▲ / ▼ and coloured by the verdict (`--ok` / `--bad`). Hidden on tie or single-pane so the row collapses cleanly.
- **Smaller sparkline**: 56 × 8 px, right-aligned, 1 px stroke. Was full-width 14 px.
- **Verdict bg gradient + coloured value: removed**. The explicit delta carries the win/lose signal now. Row chrome stays neutral; accent stays reserved (rubric #6).

### Visual diff

The redesigned row in compare mode (default scenario, SCAN vs RSR):

```
WAIT AVG       WAIT MAX       DELIVERED      ABANDONED      UTIL
0.0 s          0.0 s          0              0              25%
                                                            ▲ +25%
[───]          [───]          [───]          [───]          [▂▂▂]
```

Mobile (375 × 667) wraps to 3 columns × 2 rows; column rules collapse correctly at row boundaries.

### Rubric scorecard (`POLISH_PLAN.md` § Rubric)

| # | Item | Status |
|---|------|--------|
| 1 | Tabular-nums coverage 100% on changing digits | ✅ pass — values + deltas use Geist Mono with `tnum`/`ss01` |
| 2 | No spring on input feedback | n/a |
| 3 | Hover budget 60–90 ms | n/a |
| 4 | Copy voice (engineer shorthand) | ✅ pass — labels rewritten |
| 5 | Iconography weight | n/a |
| 6 | Accent reserved | ✅ pass — verdict uses --ok/--bad only, no accent |
| 7 | No new gradients / shadows | ✅ pass — net delta is −1 gradient block |
| 8 | Mobile parity (375×667, 390×844, 667×375) | ✅ pass — verified after fixing the `:nth-child(5n)` + `:last-child` collision in the mobile media query |
| 9 | No marketing copy | ✅ pass |
| 10 | Footer signature | n/a (lands in PR 4) |

### Verification

- `pnpm typecheck` ✅
- `pnpm test` ✅ (340/340 — `metricValue` + `diffMetrics` contracts unchanged)
- `pnpm lint` ✅
- `pnpm build` ✅
- `pnpm snap` ✅ — 20 screenshots, mobile + desktop, compare + single-pane

## Test plan

- [ ] CI passes
- [ ] Greptile review addressed
- [ ] Visual spot-check: open compare mode (default), confirm deltas render in green/red, ties don't show a delta, single-pane mode collapses cleanly
- [ ] Mobile spot-check: 375×667 portrait — confirm 3-col 2-row wrap with no stray vertical rules