### PR TITLE
feat(playground): flat car bodies + lighter floor labels

### DIFF
--- a/playground/src/render/draw-building.ts
+++ b/playground/src/render/draw-building.ts
@@ -80,7 +80,9 @@ export function drawFloors(
   stopsTop: number,
   isTether: boolean,
 ): void {
-  ctx.font = `${s.fontMain.toFixed(0)}px ${CANVAS_FONT_SANS}`;
+  // Geist Sans at 500 reads cleaner than the default 600 here — heavier
+  // weight made the long stop-name strings feel chunky at small sizes.
+  ctx.font = `500 ${s.fontMain.toFixed(0)}px ${CANVAS_FONT_SANS}`;
   ctx.textBaseline = "middle";
   const labelX = s.padX;
   const slabLeft = s.padX + s.labelW;

--- a/playground/src/render/draw-cars.ts
+++ b/playground/src/render/draw-cars.ts
@@ -78,13 +78,21 @@ export function drawCar(
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- wasm boundary: phase may hold a variant the TS union hasn't caught up with
   const base = PHASE_COLORS[car.phase] ?? "#6b6b75";
 
-  const grad = ctx.createLinearGradient(cx, top, cx, bottom);
-  grad.addColorStop(0, shade(base, 0.14));
-  grad.addColorStop(1, shade(base, -0.18));
-  ctx.fillStyle = grad;
+  // Solid fill — the previous top→bottom gradient added bevel-style
+  // depth that read as fussy chrome. A flat phase colour keeps each
+  // car readable at a glance and lets the rider silhouettes inside
+  // carry the visual interest.
+  ctx.fillStyle = base;
   ctx.fillRect(cx - halfW, top, carW, carH);
-  ctx.strokeStyle = "rgba(10, 12, 16, 0.9)";
+  // 1 px inset highlight on the top edge gives the car a subtle
+  // sense of depth without painting a gradient on the whole body.
+  ctx.strokeStyle = shade(base, 0.18);
   ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(cx - halfW + 0.5, top + 0.5);
+  ctx.lineTo(cx + halfW - 0.5, top + 0.5);
+  ctx.stroke();
+  ctx.strokeStyle = "rgba(10, 12, 16, 0.9)";
   ctx.strokeRect(cx - halfW + 0.5, top + 0.5, carW - 1, carH - 1);
 
   // 0.95 = within one typical rider weight (~75 kg) of capacity; once

--- a/playground/src/render/draw-cars.ts
+++ b/playground/src/render/draw-cars.ts
@@ -84,16 +84,20 @@ export function drawCar(
   // carry the visual interest.
   ctx.fillStyle = base;
   ctx.fillRect(cx - halfW, top, carW, carH);
-  // 1 px inset highlight on the top edge gives the car a subtle
-  // sense of depth without painting a gradient on the whole body.
-  ctx.strokeStyle = shade(base, 0.18);
-  ctx.lineWidth = 1;
-  ctx.beginPath();
-  ctx.moveTo(cx - halfW + 0.5, top + 0.5);
-  ctx.lineTo(cx + halfW - 0.5, top + 0.5);
-  ctx.stroke();
+  // Dark outer border first so the inset highlight on the next row
+  // (`top + 1.5`) is not overwritten — painting both at `top + 0.5`
+  // would let the dark stroke win and erase the highlight.
   ctx.strokeStyle = "rgba(10, 12, 16, 0.9)";
+  ctx.lineWidth = 1;
   ctx.strokeRect(cx - halfW + 0.5, top + 0.5, carW - 1, carH - 1);
+  // 1 px inset highlight one row below the dark border — gives the
+  // cabin a subtle sense of depth without painting a gradient over
+  // the whole body.
+  ctx.strokeStyle = shade(base, 0.18);
+  ctx.beginPath();
+  ctx.moveTo(cx - halfW + 1, top + 1.5);
+  ctx.lineTo(cx + halfW - 1, top + 1.5);
+  ctx.stroke();
 
   // 0.95 = within one typical rider weight (~75 kg) of capacity; once
   // load is in this envelope no more riders can board.

--- a/playground/src/render/figures/riders-in-car.ts
+++ b/playground/src/render/figures/riders-in-car.ts
@@ -1,4 +1,5 @@
 import type { Scale } from "../layout";
+import { CANVAS_FONT_SANS } from "../palette";
 import { roundedRect } from "../primitives";
 import type { RiderVariant } from "./rider";
 import { drawRider, pickRiderVariant } from "./rider";
@@ -51,7 +52,7 @@ export function drawRidersInCar(
   if (count > visible) {
     const text = `+${count - visible}`;
     const fontSize = Math.max(8, s.fontSmall - 1);
-    ctx.font = `700 ${fontSize.toFixed(1)}px ui-sans-serif, system-ui, sans-serif`;
+    ctx.font = `700 ${fontSize.toFixed(1)}px ${CANVAS_FONT_SANS}`;
     ctx.textAlign = "right";
     ctx.textBaseline = "middle";
     const textW = ctx.measureText(text).width;
@@ -72,7 +73,7 @@ export function drawRidersInCar(
   // Drawn after silhouettes + pill so the F reads as the dominant signal.
   if (isFull) {
     const fSize = Math.max(10, Math.min(carH * 0.7, carW * 0.55));
-    ctx.font = `800 ${fSize.toFixed(0)}px ui-sans-serif, system-ui, sans-serif`;
+    ctx.font = `800 ${fSize.toFixed(0)}px ${CANVAS_FONT_SANS}`;
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
     const cy = carBottom - carH / 2;

--- a/playground/src/render/figures/riders-in-car.ts
+++ b/playground/src/render/figures/riders-in-car.ts
@@ -77,7 +77,7 @@ export function drawRidersInCar(
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
     const cy = carBottom - carH / 2;
-    // Soft halo so the glyph reads even against bright cabin gradients.
+    // Soft halo so the glyph reads even against bright phase-colour fills.
     ctx.fillStyle = "rgba(15, 15, 18, 0.6)";
     ctx.fillText("F", cx, cy + 1);
     ctx.fillStyle = "rgba(239, 68, 68, 0.92)"; // var(--bad) at high alpha


### PR DESCRIPTION
## Summary

PR 3 of the polish sequence — see \`playground/POLISH_PLAN.md\`.

The bevel-style top→bottom gradient on every cabin was the single loudest "AI-generated" element on the canvas. Every car was carrying its own faux-3D depth treatment. This PR replaces that with a flat phase-color fill + a single 1 px top-edge highlight. Cars now read as confident solid blocks; rider silhouettes inside carry the visual interest, not the chrome.

### What changes

- **\`drawCar\` (draw-cars.ts)** — remove \`createLinearGradient\` + colorStops, use solid \`base\` fill, add a 1 px top-edge highlight via \`shade(base, 0.18)\`. Outer dark border kept for separation against the shaft.
- **\`drawFloors\` (draw-building.ts)** — drop the implicit 600 weight, use 500. Geist Sans at medium reads cleaner at the 11–13 px sizes used for stop names and floor labels.
- **\`drawRidersInCar\` (figures/riders-in-car.ts)** — two \`ui-sans-serif\` hardcodes (the +N overflow pill and the F-for-full glyph) routed through \`CANVAS_FONT_SANS\` for consistency with the rest of the canvas. (PR 1 swept the obvious sites; these were under-the-fold and missed.)

### Deferred from the original plan

- **Door cycle ease, shaft chrome (vertical hairline grid)** — the existing shaft channels + floor-line treatment are already at hairline weight; adding a grid overlay would clutter without clear visual win, and the door animation lives across multiple files (renderer + tether). Those would be a meaningful follow-up but aren't necessary to land the polish goal here.
- **Cabin proportions, rider glyphs** — read cleanly against the new flat fills. No changes needed.

### Visual diff

Before: each cabin had a top-bright / bottom-dark gradient that made it look like a UI button. After: solid phase color, single hairline on the top edge.

### Rubric scorecard

| # | Item | Status |
|---|------|--------|
| 1 | Tabular-nums coverage | n/a (no new digits) |
| 2 | No spring on input feedback | n/a |
| 3 | Hover budget | n/a |
| 4 | Copy voice | n/a |
| 5 | Iconography weight | ✅ pass — no new icons; canvas-rendered "F" glyph now uses Geist |
| 6 | Accent reserved | ✅ pass — no accent changes |
| 7 | No new gradients / shadows | ✅ pass — net delta is **−1 gradient** (the cabin gradient is gone, none added) |
| 8 | Mobile parity | ✅ pass — desktop + iPhone SE / 14 / SE-landscape verified |
| 9 | No marketing copy | ✅ pass |
| 10 | Footer signature | n/a (PR 4) |

### Verification

- \`pnpm typecheck\` ✅
- \`pnpm test\` ✅ (340/340)
- \`pnpm lint\` ✅
- \`pnpm build\` ✅
- \`pnpm snap\` ✅ — 20 screenshots; cars visibly flat across all scenes

## Test plan

- [ ] CI passes
- [ ] Greptile review addressed
- [ ] Visual spot-check: open convention scenario (cars are largest there), confirm no top→bottom gradient on cabins; confirm 1px top-edge highlight gives subtle depth without bevel