### PR TITLE
feat(playground): mono wordmark + tabular scenario switcher + footer

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -434,11 +434,11 @@
     </main>
 
     <header
-      class="top relative bg-gradient-to-b from-surface-secondary to-surface px-5 pt-3 pb-2.5 max-md:px-3.5 max-md:pt-2.5 max-md:pb-2"
+      class="top relative bg-surface px-5 pt-3 pb-2.5 max-md:px-3.5 max-md:pt-2.5 max-md:pb-2"
     >
       <div class="flex flex-wrap items-center gap-y-1 gap-x-5 min-w-0 max-md:gap-x-3">
         <h1
-          class="m-0 text-[14px] font-semibold tracking-[-0.005em] inline-flex items-center gap-2.5 whitespace-nowrap min-w-0 before:content-[''] before:inline-block before:flex-none before:w-2 before:h-2 before:rounded-[2px] before:bg-accent before:shadow-[0_0_10px_color-mix(in_srgb,var(--accent)_50%,transparent)] max-md:text-[12.5px] max-md:gap-2 max-md:tracking-[-0.01em]"
+          class="m-0 text-[13px] font-mono font-medium tracking-[0] inline-flex items-center gap-2.5 whitespace-nowrap min-w-0 before:content-[''] before:inline-block before:flex-none before:w-2 before:h-2 before:rounded-[2px] before:bg-accent max-md:text-[12px] max-md:gap-2"
         >
           <span class="truncate"
             ><span class="text-content-tertiary max-md:hidden">elevator-core / </span
@@ -693,6 +693,13 @@
         </div>
       </section>
     </main>
+
+    <footer
+      class="text-content-disabled text-[10.5px] tracking-[0.04em] font-mono px-5 pb-2 pt-1 select-none max-md:hidden"
+      aria-label="Authorship"
+    >
+      engine: elevator-core (rust) · playground: vanilla ts · — a.m.
+    </footer>
 
     <!-- Bottom status bar — fixed, edge-to-edge, always visible. Hosts the
          phase indicator (with progress fill on the top edge) and the

--- a/playground/src/features/scenario-picker/cards.ts
+++ b/playground/src/features/scenario-picker/cards.ts
@@ -2,7 +2,7 @@ import { el } from "../../platform";
 import { SCENARIOS } from "../../domain";
 
 // Tabular switcher — replaces the previous card-pill chrome. Each
-// scenario is a flat text label with a 1px accent rule under the
+// scenario is a flat text label with a 2px accent rule under the
 // active one (no filled background), reserving the accent for the
 // "current scenario" signal alone (rubric #6).
 const SCENARIO_CARD_CLS =

--- a/playground/src/features/scenario-picker/cards.ts
+++ b/playground/src/features/scenario-picker/cards.ts
@@ -1,19 +1,17 @@
 import { el } from "../../platform";
 import { SCENARIOS } from "../../domain";
 
-// Compact pill tabs — used to be full-sized cards with a description
-// block; that was ~55 px of vertical chrome. Now a single row of
-// short buttons that show the scenario name and a numeric shortcut
-// badge. Description is accessible via the `title` tooltip so
-// nothing is lost, just de-weighted.
+// Tabular switcher — replaces the previous card-pill chrome. Each
+// scenario is a flat text label with a 1px accent rule under the
+// active one (no filled background), reserving the accent for the
+// "current scenario" signal alone (rubric #6).
 const SCENARIO_CARD_CLS =
-  "scenario-card inline-flex items-center gap-1.5 px-2.5 py-1 " +
-  "bg-surface-elevated border border-stroke-subtle rounded-md " +
-  "text-content-secondary text-[12px] font-medium cursor-pointer " +
+  "scenario-card inline-flex items-center gap-1.5 px-2 py-1 " +
+  "border-b-2 border-b-transparent " +
+  "text-content-tertiary text-[12px] font-medium cursor-pointer " +
   "transition-colors duration-fast select-none whitespace-nowrap " +
-  "hover:bg-surface-hover hover:border-stroke " +
-  "aria-pressed:bg-accent-muted aria-pressed:text-content " +
-  "aria-pressed:border-[color-mix(in_srgb,var(--accent)_55%,transparent)] " +
+  "hover:text-content " +
+  "aria-pressed:text-content aria-pressed:border-b-accent " +
   "max-md:flex-none max-md:snap-start";
 const SCENARIO_KBD_CLS =
   "inline-flex items-center justify-center min-w-[15px] h-[15px] px-1 " +

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -680,28 +680,6 @@
  * Tailwind provides `animate-spin` as a default so no custom spin
  * keyframe is needed. */
 
-  /* ── Scenario cards ─────────────────────────────────────────────────── */
-
-  /* .scenario-cards container background is a two-layer radial+solid
- * gradient that's awkward as a Tailwind arbitrary value; keep it here.
- * Layout (grid + mobile pill strip) moved to utilities on the HTML. */
-  .scenario-cards {
-    background:
-      radial-gradient(
-        700px 200px at 50% -40%,
-        color-mix(in srgb, var(--accent) 6%, transparent),
-        transparent 70%
-      ),
-      var(--bg-primary);
-  }
-  /* Scenario card hover/active/pressed base moved to Tailwind utilities in
- * `renderScenarioCards()` (src/main.ts). The accent ring below
- * supplements the aria-pressed background + border so the selected
- * scenario reads at a glance from across the strip — the muted-bg
- * alone was too quiet against the section's radial gradient. */
-  .scenario-card[aria-pressed="true"] {
-    box-shadow: 0 0 0 1.5px color-mix(in srgb, var(--accent) 70%, transparent);
-  }
   /* ── Seed shuffle button (inside the seed input) ───────────────────── */
 
   /* Global `button` styling (gradient + border + padding + hover


### PR DESCRIPTION
## Summary

PR 4 of the polish sequence — see \`playground/POLISH_PLAN.md\`.

Three header-band moves that bring the chrome to a level worthy of the cab silhouettes and metrics row that already shipped:

### What changes

- **Wordmark → mono lockup.** H1 switches from sans 14 px-semibold to **Geist Mono 13 px-medium**, and the accent dot's \`box-shadow: 0 0 10px color-mix(...)\` glow is dropped. The 8 px amber square stays as the visual mark; the mono lockup gives the title a confident engineer-tool feel.

- **Header gradient flattened.** \`bg-gradient-to-b from-surface-secondary to-surface\` → flat \`bg-surface\`. The scenario picker's existing \`border-b border-stroke-subtle\` separates header from content; the gradient was decoration, not elevation.

- **Scenario picker → tabular switcher.** Drop the card chrome (\`bg-surface-elevated border rounded-md\`), the \`aria-pressed:bg-accent-muted\` filled background, the \`box-shadow: 0 0 0 1.5px ...\` accent outline ring, and the radial-gradient on the strip container. Active scenario signals via a single **2 px \`border-b-accent\`** rule under the label. Accent reserved for the current scenario only — no other elements borrow it (rubric #6).

- **Footer signature.** New \`<footer>\`:

  > \`engine: elevator-core (rust) · playground: vanilla ts · — a.m.\`

  Mono, \`--text-disabled\`, 10.5 px. Mobile-hidden where the fixed controls bar already crowds the bottom edge.

### Visual diff

| | Before | After |
|---|---|---|
| Wordmark | sans semibold + amber dot with 10 px glow | mono medium + amber dot, no glow |
| Scenario picker | bordered cards on a radial-gradient strip | flat text labels, accent rule under the active one |
| Page bottom | nothing | \`engine: elevator-core (rust) · playground: vanilla ts · — a.m.\` |

### Rubric scorecard

| # | Item | Status |
|---|------|--------|
| 1 | Tabular-nums coverage | n/a (no new digits) |
| 2 | No spring on input feedback | n/a |
| 3 | Hover budget | n/a |
| 4 | Copy voice | ✅ pass — footer signature is engineering shorthand, no marketing tone |
| 5 | Iconography | n/a |
| 6 | Accent reserved | ✅ pass — accent now appears on **only** the active scenario rule and the wordmark dot, nowhere else in the header band |
| 7 | No new gradients / shadows | ✅ pass — diff is **−1 gradient (\`scenario-cards\` radial), −1 gradient (header), −1 box-shadow (\`scenario-card[aria-pressed=true]\`), −1 box-shadow (wordmark glow)** |
| 8 | Mobile parity | ✅ pass — wordmark collapses to "playground" only, scenario switcher snap-scrolls, footer hidden |
| 9 | No marketing copy | ✅ pass |
| 10 | Footer signature | ✅ pass — landed and locked in for future PRs |

### Verification

- \`pnpm typecheck\` ✅
- \`pnpm test\` ✅ (340/340)
- \`pnpm build\` ✅
- \`pnpm snap\` ✅ — desktop + iPhone SE / 14 / SE-landscape verified

## Test plan

- [ ] CI passes
- [ ] Greptile review addressed
- [ ] Visual spot-check: wordmark renders in Geist Mono; active scenario shows underline rule, not filled background; footer line visible at bottom on desktop