### PR TITLE
feat(playground): refine speech-bubble visual treatment

### DIFF
--- a/playground/src/features/compare-pane/bubbles.ts
+++ b/playground/src/features/compare-pane/bubbles.ts
@@ -31,39 +31,48 @@ export function updateBubbles(pane: Pane, events: EventDto[], snap: Snapshot): v
   const bornAt = performance.now();
   const stopName = (id: number): string => resolveStopName(snap, id);
   for (const ev of events) {
-    const text = bubbleTextFor(ev, stopName);
-    if (text === null) continue;
+    const content = bubbleTextFor(ev, stopName);
+    if (content === null) continue;
     // Some events are rider-scoped rather than car-scoped (spawn,
     // abandon). bubbleTextFor returns `null` for those, so we only
     // get here when `ev` carries an `elevator` field.
     const carId = (ev as { elevator?: number }).elevator;
     if (carId === undefined) continue;
     const ttl = BUBBLE_TTL_BY_KIND[ev.kind] ?? BUBBLE_TTL_DEFAULT_MS;
-    pane.bubbles.set(carId, { text, bornAt, expiresAt: bornAt + ttl });
+    pane.bubbles.set(carId, {
+      glyph: content.glyph,
+      text: content.text,
+      bornAt,
+      expiresAt: bornAt + ttl,
+    });
   }
 }
 
-/** Map an event to a short bubble string (icon glyph + phrase), or
+/** Map an event to a leading icon glyph plus the body phrase, or
  *  `null` when the event has no car to attach to, or when emitting a
  *  bubble for it would add more noise than signal. `elevator-departed`
  *  and `door-closed` are intentionally suppressed because the prior
  *  bubble ("Arrived at X", "Doors open") already narrates the context
  *  and re-firing on closure makes the car feel chatty without adding
- *  information. */
-function bubbleTextFor(ev: EventDto, stopName: (id: number) => string): string | null {
+ *  information. The renderer paints the glyph in the pane accent and
+ *  the body in a neutral off-white. */
+function bubbleTextFor(
+  ev: EventDto,
+  stopName: (id: number) => string,
+): { glyph: string; text: string } | null {
   switch (ev.kind) {
     case "elevator-assigned":
-      return `\u203a To ${stopName(ev.stop)}`;
+      return { glyph: "›", text: `To ${stopName(ev.stop)}` };
     case "elevator-repositioning":
-      return `\u21BB Reposition to ${stopName(ev.stop)}`;
+      return { glyph: "↻", text: `Reposition to ${stopName(ev.stop)}` };
     case "elevator-arrived":
-      return `\u25cf At ${stopName(ev.stop)}`;
+      return { glyph: "●", text: `At ${stopName(ev.stop)}` };
     case "door-opened":
-      return "\u25cc Doors open";
+      return { glyph: "◌", text: "Doors open" };
     case "rider-boarded":
-      return "\u002b Boarding";
+      return { glyph: "+", text: "Boarding" };
     case "rider-exited":
-      return `\u2193 Off at ${stopName(ev.stop)}`;
+      return { glyph: "↓", text: `Off at ${stopName(ev.stop)}` };
     default:
       return null;
   }

--- a/playground/src/render/draw-cars.ts
+++ b/playground/src/render/draw-cars.ts
@@ -1,9 +1,8 @@
-import { hexWithAlpha, shade, withAlpha } from "./color-utils";
+import { easeOutNorm, hexWithAlpha, shade, withAlpha } from "./color-utils";
 import type { RiderVariant } from "./figures/rider";
 import { drawRidersInCar } from "./figures/riders-in-car";
 import type { Scale } from "./layout";
 import { CANVAS_FONT_SANS, PHASE_COLORS, TARGET_FILL, TRAIL_DT, TRAIL_STEPS } from "./palette";
-import { roundedRect } from "./primitives";
 import type { CarDto, CarBubble, Snapshot } from "../types";
 
 export function drawTargetMarkers(
@@ -107,9 +106,51 @@ export function drawCar(
   }
 }
 
+// Layout + style constants for the speech bubbles. Tuned for a tight,
+// warm-dark surface aesthetic that matches the broader playground:
+// translucent fill anchored to `--bg-elevated`, hairline accent stroke,
+// soft accent halo, and a small integrated tail. Padding is asymmetric
+// because the body text sits between a dim accent glyph and a neutral
+// off-white run, and we want the row to read as one tight chip.
+const BUBBLE_PAD_X = 6;
+const BUBBLE_PAD_Y = 3;
+const BUBBLE_RADIUS = 4;
+const BUBBLE_TAIL_W = 3;
+const BUBBLE_TAIL_H = 2.5;
+const BUBBLE_GAP = 2;
+const BUBBLE_HALO_BLUR = 12;
+const BUBBLE_FILL = "rgba(37, 37, 48, 0.80)"; // --bg-elevated (#252530) at 0.80
+const BUBBLE_TEXT_COLOR = "#ECECEE"; // warm off-white
+const BUBBLE_GLYPH_TEXT_GAP = 3;
+const BUBBLE_LIFETIME_FADE_FRAC = 0.3;
+const BUBBLE_ENTRANCE_MS = 140;
+const BUBBLE_ENTRANCE_SCALE_FROM = 0.85;
+const BUBBLE_ENTRANCE_DRIFT_PX = 2.5;
+
+interface BubblePlacement {
+  bubble: CarBubble;
+  glyphW: number;
+  textW: number;
+  alpha: number;
+  cx: number;
+  carTop: number;
+  carBottom: number;
+  bubbleW: number;
+  bubbleH: number;
+  side: "above" | "below";
+  bx: number;
+  by: number;
+  entrance: number;
+}
+
 /**
- * Draw a small rounded speech-bubble with a tail pointing down (or
- * up) to each car with a fresh action.
+ * Draw a small rounded speech-bubble with a tail pointing down (or up)
+ * to each car with a fresh action.
+ *
+ * Visual: translucent warm-dark fill, hairline pane-accent stroke, soft
+ * accent halo, leading glyph tinted with the pane accent, body text in
+ * a neutral off-white. Each bubble does a 140 ms ease-out entrance
+ * (opacity, scale, slight upward drift) when it first appears.
  */
 export function drawBubbles(
   ctx: CanvasRenderingContext2D,
@@ -121,31 +162,19 @@ export function drawBubbles(
   s: Scale,
   canvasWidth: number,
 ): void {
-  const padX = 7;
-  const padY = 4;
-  const tailW = 5;
-  const tailH = 4;
-  const radius = 6;
-  const gap = 2;
-  ctx.font = `600 ${s.fontSmall + 0.5}px ${CANVAS_FONT_SANS}`;
+  const fontSize = s.fontSmall + 0.5;
+  ctx.font = `500 ${fontSize}px ${CANVAS_FONT_SANS}`;
   ctx.textBaseline = "middle";
-  const FADE_FRAC = 0.3;
+  // Slight negative tracking so the chip stays compact at small sizes.
+  // Property is ignored on browsers without Canvas letterSpacing support
+  // (Safari < 17.2). measureText reflects the active spacing on engines
+  // that do honour it, which keeps width math accurate.
+  setLetterSpacing(ctx, "-0.1px");
   const now = performance.now();
-  const strokeBase = accent;
-
-  interface Placement {
-    bubble: CarBubble;
-    alpha: number;
-    cx: number;
-    carTop: number;
-    carBottom: number;
-    bubbleW: number;
-    bubbleH: number;
-    side: "above" | "below";
-    bx: number;
-    by: number;
-  }
-  const placements: Placement[] = [];
+  const strokeColor = withAlpha(accent, 0.45);
+  const haloColor = withAlpha(accent, 0.5);
+  const glyphColor = withAlpha(accent, 0.75);
+  const placements: BubblePlacement[] = [];
   // Iterate the (typically small) bubbles map directly — looking up the
   // car via the prepared id map skips a full pass over `snap.cars` per
   // frame when only a handful of cars have active bubbles.
@@ -159,17 +188,27 @@ export function drawBubbles(
 
     const ttl = Math.max(1, bubble.expiresAt - bubble.bornAt);
     const remaining = bubble.expiresAt - now;
-    const alpha = remaining > ttl * FADE_FRAC ? 1 : Math.max(0, remaining / (ttl * FADE_FRAC));
+    const lifetimeFade =
+      remaining > ttl * BUBBLE_LIFETIME_FADE_FRAC
+        ? 1
+        : Math.max(0, remaining / (ttl * BUBBLE_LIFETIME_FADE_FRAC));
+    const age = Math.max(0, now - bubble.bornAt);
+    const entrance = Math.min(1, age / BUBBLE_ENTRANCE_MS);
+    const alpha = lifetimeFade * entrance;
     if (alpha <= 0) continue;
 
+    const glyphW = ctx.measureText(bubble.glyph).width;
     const textW = ctx.measureText(bubble.text).width;
-    const bubbleW = textW + padX * 2;
-    const bubbleH = s.fontSmall + padY * 2 + 2;
+    const bubbleW = glyphW + BUBBLE_GLYPH_TEXT_GAP + textW + BUBBLE_PAD_X * 2;
+    const bubbleH = fontSize + BUBBLE_PAD_Y * 2 + 2;
 
-    const aboveTop = carTop - gap - tailH - bubbleH;
-    const belowOverflow = carBottom + gap + tailH + bubbleH > canvasWidth;
+    const aboveTop = carTop - BUBBLE_GAP - BUBBLE_TAIL_H - bubbleH;
+    const belowOverflow = carBottom + BUBBLE_GAP + BUBBLE_TAIL_H + bubbleH > canvasWidth;
     const initialSide: "above" | "below" = aboveTop < 2 && !belowOverflow ? "below" : "above";
-    const by = initialSide === "above" ? carTop - gap - tailH - bubbleH : carBottom + gap + tailH;
+    const by =
+      initialSide === "above"
+        ? carTop - BUBBLE_GAP - BUBBLE_TAIL_H - bubbleH
+        : carBottom + BUBBLE_GAP + BUBBLE_TAIL_H;
     let bx = cx - bubbleW / 2;
     const minX = 2;
     const maxX = canvasWidth - bubbleW - 2;
@@ -177,6 +216,8 @@ export function drawBubbles(
     if (bx > maxX) bx = maxX;
     placements.push({
       bubble,
+      glyphW,
+      textW,
       alpha,
       cx,
       carTop,
@@ -186,11 +227,12 @@ export function drawBubbles(
       side: initialSide,
       bx,
       by,
+      entrance,
     });
   }
 
-  // Collision pass.
-  const rectsIntersect = (a: Placement, b: Placement): boolean =>
+  // Collision pass — flip side when overlapping a previously-placed bubble.
+  const rectsIntersect = (a: BubblePlacement, b: BubblePlacement): boolean =>
     !(
       a.bx + a.bubbleW <= b.bx ||
       b.bx + b.bubbleW <= a.bx ||
@@ -212,8 +254,10 @@ export function drawBubbles(
     if (!collides) continue;
     const flipSide: "above" | "below" = p.side === "above" ? "below" : "above";
     const flipBy =
-      flipSide === "above" ? p.carTop - gap - tailH - p.bubbleH : p.carBottom + gap + tailH;
-    const flipped: Placement = { ...p, side: flipSide, by: flipBy };
+      flipSide === "above"
+        ? p.carTop - BUBBLE_GAP - BUBBLE_TAIL_H - p.bubbleH
+        : p.carBottom + BUBBLE_GAP + BUBBLE_TAIL_H;
+    const flipped: BubblePlacement = { ...p, side: flipSide, by: flipBy };
     let flipClears = true;
     for (let j = 0; j < i; j++) {
       const pj = placements[j];
@@ -229,42 +273,120 @@ export function drawBubbles(
   }
 
   for (const p of placements) {
-    const { bubble, alpha, cx, carTop, carBottom, bubbleW, bubbleH, side, bx, by } = p;
-    const tipY = side === "above" ? carTop - gap : carBottom + gap;
-    const baseY = side === "above" ? by + bubbleH : by;
+    const {
+      bubble,
+      glyphW,
+      alpha,
+      cx,
+      carTop,
+      carBottom,
+      bubbleW,
+      bubbleH,
+      side,
+      bx,
+      by,
+      entrance,
+    } = p;
+    const tipY = side === "above" ? carTop - BUBBLE_GAP : carBottom + BUBBLE_GAP;
     const tailCenter = Math.min(
-      Math.max(cx, bx + radius + tailW / 2),
-      bx + bubbleW - radius - tailW / 2,
+      Math.max(cx, bx + BUBBLE_RADIUS + BUBBLE_TAIL_W / 2),
+      bx + bubbleW - BUBBLE_RADIUS - BUBBLE_TAIL_W / 2,
     );
+
+    const ease = easeOutNorm(entrance);
+    const scale = BUBBLE_ENTRANCE_SCALE_FROM + (1 - BUBBLE_ENTRANCE_SCALE_FROM) * ease;
+    const driftY = (1 - ease) * BUBBLE_ENTRANCE_DRIFT_PX;
+    const centerX = bx + bubbleW / 2;
+    const centerY = by + bubbleH / 2;
 
     ctx.save();
     ctx.globalAlpha = alpha;
+    ctx.translate(centerX, centerY + driftY);
+    ctx.scale(scale, scale);
+    ctx.translate(-centerX, -centerY);
 
-    ctx.shadowColor = strokeBase;
-    ctx.shadowBlur = 8;
-    ctx.fillStyle = "rgba(16, 19, 26, 0.94)";
-    roundedRect(ctx, bx, by, bubbleW, bubbleH, radius);
+    // Single combined path: rounded body + integrated tail. Filling and
+    // stroking once eliminates the seam where the old separate-tail
+    // implementation overlapped its strokes against the body edge.
+    bubblePath(ctx, bx, by, bubbleW, bubbleH, BUBBLE_RADIUS, side, tailCenter, tipY);
+
+    ctx.shadowColor = haloColor;
+    ctx.shadowBlur = BUBBLE_HALO_BLUR;
+    ctx.fillStyle = BUBBLE_FILL;
     ctx.fill();
     ctx.shadowBlur = 0;
+    ctx.shadowColor = "transparent";
 
-    ctx.strokeStyle = withAlpha(strokeBase, 0.65);
+    ctx.strokeStyle = strokeColor;
     ctx.lineWidth = 1;
-    roundedRect(ctx, bx, by, bubbleW, bubbleH, radius);
     ctx.stroke();
 
-    ctx.beginPath();
-    ctx.moveTo(tailCenter - tailW / 2, baseY);
-    ctx.lineTo(tailCenter + tailW / 2, baseY);
-    ctx.lineTo(tailCenter, tipY);
-    ctx.closePath();
-    ctx.fillStyle = "rgba(16, 19, 26, 0.94)";
-    ctx.fill();
-    ctx.stroke();
-
-    ctx.fillStyle = "#f0f3fb";
-    ctx.textAlign = "center";
-    ctx.fillText(bubble.text, bx + bubbleW / 2, by + bubbleH / 2);
+    // Glyph + text run. We left-align both on the same baseline; the
+    // glyph leads in dim accent, then the body in warm off-white.
+    const textY = by + bubbleH / 2;
+    const runStartX = bx + BUBBLE_PAD_X;
+    ctx.textAlign = "left";
+    ctx.fillStyle = glyphColor;
+    ctx.fillText(bubble.glyph, runStartX, textY);
+    ctx.fillStyle = BUBBLE_TEXT_COLOR;
+    ctx.fillText(bubble.text, runStartX + glyphW + BUBBLE_GLYPH_TEXT_GAP, textY);
 
     ctx.restore();
   }
+
+  // Reset letterSpacing so we don't leak the tighter tracking onto the
+  // next pane's draw pass. Other text in the renderer assumes default.
+  setLetterSpacing(ctx, "0px");
+}
+
+/**
+ * Build a single closed path for the bubble body with the tail
+ * integrated into either the bottom (above-mode) or top (below-mode)
+ * edge. Drawn clockwise from `(bx + radius, by)`.
+ */
+function bubblePath(
+  ctx: CanvasRenderingContext2D,
+  bx: number,
+  by: number,
+  w: number,
+  h: number,
+  radius: number,
+  side: "above" | "below",
+  tailCenter: number,
+  tipY: number,
+): void {
+  const r = Math.min(radius, w / 2, h / 2);
+  ctx.beginPath();
+  ctx.moveTo(bx + r, by);
+  if (side === "below") {
+    // Tail on the top edge, pointing up to the car above.
+    ctx.lineTo(tailCenter - BUBBLE_TAIL_W / 2, by);
+    ctx.lineTo(tailCenter, tipY);
+    ctx.lineTo(tailCenter + BUBBLE_TAIL_W / 2, by);
+  }
+  ctx.lineTo(bx + w - r, by);
+  ctx.arcTo(bx + w, by, bx + w, by + r, r);
+  ctx.lineTo(bx + w, by + h - r);
+  ctx.arcTo(bx + w, by + h, bx + w - r, by + h, r);
+  if (side === "above") {
+    // Tail on the bottom edge, pointing down to the car below.
+    ctx.lineTo(tailCenter + BUBBLE_TAIL_W / 2, by + h);
+    ctx.lineTo(tailCenter, tipY);
+    ctx.lineTo(tailCenter - BUBBLE_TAIL_W / 2, by + h);
+  }
+  ctx.lineTo(bx + r, by + h);
+  ctx.arcTo(bx, by + h, bx, by + h - r, r);
+  ctx.lineTo(bx, by + r);
+  ctx.arcTo(bx, by, bx + r, by, r);
+  ctx.closePath();
+}
+
+/**
+ * Apply Canvas letterSpacing without typing the experimental property
+ * across all tsconfig targets. The property write is silently ignored
+ * on browsers that don't implement it, and the slightly tighter run is
+ * a polish, not a correctness concern.
+ */
+function setLetterSpacing(ctx: CanvasRenderingContext2D, value: string): void {
+  (ctx as unknown as { letterSpacing?: string }).letterSpacing = value;
 }

--- a/playground/src/render/draw-cars.ts
+++ b/playground/src/render/draw-cars.ts
@@ -125,12 +125,9 @@ const BUBBLE_GLYPH_TEXT_GAP = 3;
 const BUBBLE_LIFETIME_FADE_FRAC = 0.3;
 const BUBBLE_ENTRANCE_MS = 140;
 const BUBBLE_ENTRANCE_SCALE_FROM = 0.85;
-const BUBBLE_ENTRANCE_DRIFT_PX = 2.5;
-
 interface BubblePlacement {
   bubble: CarBubble;
   glyphW: number;
-  textW: number;
   alpha: number;
   cx: number;
   carTop: number;
@@ -198,8 +195,8 @@ export function drawBubbles(
     if (alpha <= 0) continue;
 
     const glyphW = ctx.measureText(bubble.glyph).width;
-    const textW = ctx.measureText(bubble.text).width;
-    const bubbleW = glyphW + BUBBLE_GLYPH_TEXT_GAP + textW + BUBBLE_PAD_X * 2;
+    const bubbleW =
+      glyphW + BUBBLE_GLYPH_TEXT_GAP + ctx.measureText(bubble.text).width + BUBBLE_PAD_X * 2;
     const bubbleH = fontSize + BUBBLE_PAD_Y * 2 + 2;
 
     const aboveTop = carTop - BUBBLE_GAP - BUBBLE_TAIL_H - bubbleH;
@@ -217,7 +214,6 @@ export function drawBubbles(
     placements.push({
       bubble,
       glyphW,
-      textW,
       alpha,
       cx,
       carTop,
@@ -295,15 +291,17 @@ export function drawBubbles(
 
     const ease = easeOutNorm(entrance);
     const scale = BUBBLE_ENTRANCE_SCALE_FROM + (1 - BUBBLE_ENTRANCE_SCALE_FROM) * ease;
-    const driftY = (1 - ease) * BUBBLE_ENTRANCE_DRIFT_PX;
-    const centerX = bx + bubbleW / 2;
-    const centerY = by + bubbleH / 2;
 
     ctx.save();
     ctx.globalAlpha = alpha;
-    ctx.translate(centerX, centerY + driftY);
+    // Anchor the entrance scale at the tail tip so the tip stays glued
+    // to the car for the full 140 ms — the body grows away from the
+    // car instead of floating in. This produces the same visual rise
+    // the previous explicit drift was trying to fake, without leaving a
+    // visible gap between the tail and the cabin while scale < 1.
+    ctx.translate(tailCenter, tipY);
     ctx.scale(scale, scale);
-    ctx.translate(-centerX, -centerY);
+    ctx.translate(-tailCenter, -tipY);
 
     // Single combined path: rounded body + integrated tail. Filling and
     // stroking once eliminates the seam where the old separate-tail

--- a/playground/src/types/bubble.ts
+++ b/playground/src/types/bubble.ts
@@ -2,8 +2,12 @@
  * Per-car speech-bubble state, keyed by car entity id. Timestamps use
  * `performance.now()` wall-clock ms — not sim ticks — so the bubble
  * fades predictably even when the sim races ahead.
+ *
+ * `glyph` is rendered separately from `text` so the renderer can paint
+ * it in the pane accent while the body stays neutral off-white.
  */
 export interface CarBubble {
+  glyph: string;
   text: string;
   bornAt: number;
   expiresAt: number;


### PR DESCRIPTION
## Summary

Restyles the per-car speech bubbles to align with the warm-dark playground aesthetic. Visual change only — bubble lifecycle, placement, and collision-flip logic are unchanged.

**Surface**
- Translucent fill anchored on `--bg-elevated` (`#252530`) at 0.80 alpha — the building hints through behind the chip
- 1px hairline stroke in pane accent at 45% alpha, 4px corner radius
- Soft accent halo (12px blur, ~50% alpha) for separation from the busy backdrop
- Tighter density: 6×3 padding, smaller 3×2.5 tail integrated into the body path so fill + stroke run as a single shape (no seam where the tail meets the body)

**Type**
- Geist 500 (down from 600)
- Slight negative tracking via Canvas `letterSpacing` (silently ignored on engines without support)
- Body text in warm off-white `#ECECEE`
- Leading event glyph rendered separately in pane accent at 75% alpha, then a small gap, then the body run — the glyph carries the A/B color cue while the body stays neutral

**Animation**
- 140ms ease-out entrance per bubble: opacity 0→1, scale 0.85→1, with a 2.5px upward drift
- Existing lifetime fade (last 30%) preserved

## Implementation notes

- `CarBubble` now carries `glyph` and `text` separately so the renderer can paint each in its own fill style. `bubbleTextFor` returns `{ glyph, text } | null`.
- The bubble + tail is drawn as a single closed path (`bubblePath`) instead of overlapping a separate triangle on the body's stroke, so the joint reads as one shape under the hairline stroke.
- A small `setLetterSpacing` shim writes the experimental Canvas property without leaking the type onto the rest of the renderer; the value is reset to `0px` after the bubble pass so other text in the renderer keeps its default tracking.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — 340/340 passing
- [x] Vite dev server boots clean
- [ ] Manual visual check: default scenario, space elevator, compare mode (A vs B accent differentiation legible)
- [ ] Manual visual check: mobile portrait + landscape (P0)