### PR TITLE
feat(playground): refine metric scoreboard layout and visual treatment

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -594,10 +594,7 @@
             class="pane-strategy-desc text-[11px] text-content-tertiary tracking-[0.01em] max-md:text-[10.5px] pl-[34px]"
           ></span>
         </header>
-        <div
-          id="metrics-a"
-          class="metric-strip grid grid-cols-5 tabular-nums border-y border-stroke-subtle py-1 max-md:grid-cols-3"
-        ></div>
+        <div id="metrics-a" class="metric-strip tabular-nums border-y border-stroke-subtle"></div>
         <div
           class="shaft-wrap relative bg-[radial-gradient(ellipse_at_50%_0%,var(--bg-hover)_0%,var(--bg-secondary)_80%)] border border-stroke-subtle rounded-md overflow-hidden shadow-[inset_0_1px_0_rgba(255,255,255,0.02)]"
         >
@@ -682,10 +679,7 @@
             class="pane-strategy-desc text-[11px] text-content-tertiary tracking-[0.01em] max-md:text-[10.5px] pl-[34px]"
           ></span>
         </header>
-        <div
-          id="metrics-b"
-          class="metric-strip grid grid-cols-5 tabular-nums border-y border-stroke-subtle py-1 max-md:grid-cols-3"
-        ></div>
+        <div id="metrics-b" class="metric-strip tabular-nums border-y border-stroke-subtle"></div>
         <div
           class="shaft-wrap relative bg-[radial-gradient(ellipse_at_50%_0%,var(--bg-hover)_0%,var(--bg-secondary)_80%)] border border-stroke-subtle rounded-md overflow-hidden shadow-[inset_0_1px_0_rgba(255,255,255,0.02)]"
         >

--- a/playground/src/__tests__/sparkline.test.ts
+++ b/playground/src/__tests__/sparkline.test.ts
@@ -1,37 +1,39 @@
 import { describe, expect, it } from "vitest";
-import { buildSparklinePath } from "../features/scoreboard/sparkline";
+import { buildSparkline } from "../features/scoreboard/sparkline";
 
-describe("buildSparklinePath", () => {
-  it("empty array → flat baseline at y=13", () => {
-    expect(buildSparklinePath([])).toBe("M 0 13 L 100 13");
+describe("buildSparkline", () => {
+  it("empty array → flat baseline at y=13, last point pinned right", () => {
+    const { d, lastX, lastY } = buildSparkline([]);
+    expect(d).toBe("M 0 13 L 100 13");
+    expect(lastX).toBe(100);
+    expect(lastY).toBe(13);
   });
 
-  it("single value → flat baseline at y=13", () => {
-    expect(buildSparklinePath([42])).toBe("M 0 13 L 100 13");
+  it("single value → flat baseline at y=13, last point pinned right", () => {
+    const { d, lastX, lastY } = buildSparkline([42]);
+    expect(d).toBe("M 0 13 L 100 13");
+    expect(lastX).toBe(100);
+    expect(lastY).toBe(13);
   });
 
   it("two values produce an M...L path with correct endpoints", () => {
-    const d = buildSparklinePath([0, 10]);
-    // First point at x=0, last at x=100
+    const { d } = buildSparkline([0, 10]);
     expect(d).toMatch(/^M 0\.00/);
     expect(d).toMatch(/L 100\.00/);
   });
 
   it("multiple values produce a valid M/L SVG path", () => {
-    const d = buildSparklinePath([1, 2, 3, 4, 5]);
-    // Must start with M and contain L segments
+    const { d } = buildSparkline([1, 2, 3, 4, 5]);
     expect(d).toMatch(/^M /);
     expect(d).toMatch(/L /);
-    // Should not be the flat baseline
     expect(d).not.toBe("M 0 13 L 100 13");
   });
 
   it("all same values → flat line at y=7 (midpoint)", () => {
-    const d = buildSparklinePath([5, 5, 5, 5]);
-    // span === 0 branch → y = 7 for all points
+    const { d, lastY } = buildSparkline([5, 5, 5, 5]);
     expect(d).toMatch(/M 0\.00 7\.00/);
     expect(d).toMatch(/L 100\.00 7\.00/);
-    // Every coordinate pair has the form "N.NN 7.00" — split on L/M and verify
+    expect(lastY).toBe(7);
     const coords = d
       .split(/[ML]/)
       .map((s) => s.trim())
@@ -45,21 +47,31 @@ describe("buildSparklinePath", () => {
     // With [0, 10]: min=0, max=10.
     // First point (0): y = 13 - (0/10)*12 = 13 (bottom)
     // Last point (10): y = 13 - (10/10)*12 = 1 (top)
-    const d = buildSparklinePath([0, 10]);
+    const { d, lastY } = buildSparkline([0, 10]);
     expect(d).toMatch(/M 0\.00 13\.00/);
     expect(d).toMatch(/L 100\.00 1\.00/);
+    expect(lastY).toBe(1);
   });
 
   it("x positions spread from 0 to 100 inclusive", () => {
-    const d = buildSparklinePath([1, 2, 3]);
+    const { d, lastX } = buildSparkline([1, 2, 3]);
     expect(d).toMatch(/M 0\.00/);
     expect(d).toMatch(/L 100\.00/);
-    // Middle point at x=50
     expect(d).toMatch(/L 50\.00/);
+    expect(lastX).toBe(100);
   });
 
-  it("result is trimmed (no trailing whitespace)", () => {
-    const d = buildSparklinePath([1, 2, 3]);
+  it("path is trimmed (no trailing whitespace)", () => {
+    const { d } = buildSparkline([1, 2, 3]);
     expect(d).toBe(d.trim());
+  });
+
+  it("returns last sample (x, y) tracking the final point", () => {
+    // Three samples [10, 0, 5]: indices 0, 1, 2 → x=0, 50, 100.
+    // min=0, max=10. y = 13 - ((v - 0) / 10) * 12.
+    // v=10 → y=1, v=0 → y=13, v=5 → y=7.
+    const { lastX, lastY } = buildSparkline([10, 0, 5]);
+    expect(lastX).toBe(100);
+    expect(lastY).toBe(7);
   });
 });

--- a/playground/src/features/scoreboard/metric-rows.ts
+++ b/playground/src/features/scoreboard/metric-rows.ts
@@ -1,6 +1,8 @@
 import { el } from "../../platform";
 import type { MetricKey, MetricsDto } from "../../types";
-import { buildSparklinePath } from "./sparkline";
+import { buildSparkline } from "./sparkline";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
 
 // Metric row layout: 5 fixed rows, always the same keys in the same order.
 // We build the DOM once and mutate text + verdict + sparkline + delta in
@@ -30,13 +32,18 @@ export function metricValue(m: MetricsDto, key: MetricKey): string {
 
 // Arithmetic delta from `self` to `other` for the cell's metric. Sign
 // reflects raw difference; the verdict (win/lose/tie) drives color
-// independently. Returned `text` is "▲ +0.3 s" / "▼ −2 %"; callers hide
+// independently. Returned text is "▴ +0.3 s" / "▾ −2 %"; callers hide
 // the element on tie to mirror the verdict's epsilon-based smoothing.
+//
+// Glyphs use the smaller `▴`/`▾` (U+25B4 / U+25BE) rather than the
+// chunkier `▲`/`▼`; under the mono family they line up vertically with
+// the sign character, and they read as a delta indicator without
+// dominating the delta row visually.
 function metricDelta(self: MetricsDto, other: MetricsDto, key: MetricKey): string {
   const sv = numericMetric(self, key);
   const ov = numericMetric(other, key);
   const diff = sv - ov;
-  const arrow = diff > 0 ? "▲" : "▼";
+  const arrow = diff > 0 ? "▴" : "▾";
   const sign = diff > 0 ? "+" : diff < 0 ? "−" : "";
   const mag = Math.abs(diff);
   switch (key) {
@@ -103,22 +110,31 @@ export function diffMetrics(
 export function initMetricRows(root: HTMLElement): void {
   const frag = document.createDocumentFragment();
   for (const [label] of METRIC_DEFS) {
-    // Hairline column rules between cells, no card chrome — the row
-    // floats on the surface. Column rules are grid-aware (CSS in
-    // style.css handles 5-col desktop vs 3-col mobile wrapping).
-    // data-verdict on the row drives delta + sparkline color via
+    // Layout flips between desktop (vertical stack inside each cell of
+    // a 5-col strip) and mobile (single-col list with the row laid out
+    // horizontally as label / value / delta / sparkline). The split is
+    // entirely CSS-driven via `.metric-strip` + `.metric-row` rules in
+    // style.css, so the DOM here is the same in both modes.
+    // `data-verdict` on the row drives delta + sparkline color via
     // attribute selectors in style.css.
-    const row = el("div", "metric-row flex flex-col gap-[2px] px-2 py-1 text-right");
+    const row = el("div", "metric-row");
     // SVG sparkline lives in the metric row and is mutated in place
     // each frame. SVG (not canvas) keeps it crisp at any DPR and lets
     // CSS drive the stroke colour via the `.metric-row[data-verdict]`
     // selectors in style.css (tertiary by default; --ok / --bad on
     // win / lose).
-    const spark = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const spark = document.createElementNS(SVG_NS, "svg");
     spark.classList.add("metric-spark");
     spark.setAttribute("viewBox", "0 0 100 14");
     spark.setAttribute("preserveAspectRatio", "none");
-    spark.appendChild(document.createElementNS("http://www.w3.org/2000/svg", "path"));
+    spark.appendChild(document.createElementNS(SVG_NS, "path"));
+    // Trailing-dot anchor at the latest sample. Sized in viewBox units
+    // (slight oval under the non-uniform 100×14 stretch is fine — at
+    // sparkline screen sizes it reads as a small "now" marker).
+    const dot = document.createElementNS(SVG_NS, "circle");
+    dot.classList.add("metric-spark-dot");
+    dot.setAttribute("r", "1.4");
+    spark.appendChild(dot);
     row.append(
       el("span", "metric-k", label),
       el("span", "metric-v"),
@@ -159,7 +175,10 @@ export function renderMetricRows(
     if (ds.textContent !== deltaText) ds.textContent = deltaText;
     const spark = row.children[3] as SVGSVGElement;
     const path = spark.firstElementChild as SVGPathElement;
-    const d = buildSparklinePath(history[key]);
-    if (path.getAttribute("d") !== d) path.setAttribute("d", d);
+    const dot = spark.children[1] as SVGCircleElement;
+    const sl = buildSparkline(history[key]);
+    if (path.getAttribute("d") !== sl.d) path.setAttribute("d", sl.d);
+    dot.setAttribute("cx", sl.lastX.toFixed(2));
+    dot.setAttribute("cy", sl.lastY.toFixed(2));
   }
 }

--- a/playground/src/features/scoreboard/metric-rows.ts
+++ b/playground/src/features/scoreboard/metric-rows.ts
@@ -178,7 +178,9 @@ export function renderMetricRows(
     const dot = spark.children[1] as SVGCircleElement;
     const sl = buildSparkline(history[key]);
     if (path.getAttribute("d") !== sl.d) path.setAttribute("d", sl.d);
-    dot.setAttribute("cx", sl.lastX.toFixed(2));
-    dot.setAttribute("cy", sl.lastY.toFixed(2));
+    const cx = sl.lastX.toFixed(2);
+    const cy = sl.lastY.toFixed(2);
+    if (dot.getAttribute("cx") !== cx) dot.setAttribute("cx", cx);
+    if (dot.getAttribute("cy") !== cy) dot.setAttribute("cy", cy);
   }
 }

--- a/playground/src/features/scoreboard/sparkline.ts
+++ b/playground/src/features/scoreboard/sparkline.ts
@@ -1,12 +1,22 @@
 /**
- * Build an SVG path `d` string sampling `values` across a 100x14
- * viewBox. The path uses the last up-to-`METRIC_HISTORY_LEN` samples
- * and auto-scales to the min/max within that window so the trace
- * always fills the vertical range regardless of absolute magnitude.
- * An empty or single-sample window draws a flat baseline.
+ * Build a sparkline path + the latest sample's (x, y) within the
+ * 100×14 viewBox. The path uses the last up-to-`METRIC_HISTORY_LEN`
+ * samples and auto-scales to the min/max within that window so the
+ * trace always fills the vertical range regardless of absolute
+ * magnitude. An empty or single-sample window draws a flat baseline
+ * with `lastX`/`lastY` pinned to the right edge so a trailing-dot
+ * marker still has a sensible anchor.
  */
-export function buildSparklinePath(values: number[]): string {
-  if (values.length < 2) return "M 0 13 L 100 13";
+export interface Sparkline {
+  d: string;
+  lastX: number;
+  lastY: number;
+}
+
+export function buildSparkline(values: number[]): Sparkline {
+  if (values.length < 2) {
+    return { d: "M 0 13 L 100 13", lastX: 100, lastY: 13 };
+  }
   let min = values[0] ?? 0;
   let max = values[0] ?? 0;
   for (let i = 1; i < values.length; i++) {
@@ -18,11 +28,15 @@ export function buildSparklinePath(values: number[]): string {
   const span = max - min;
   const n = values.length;
   let d = "";
+  let lastX = 0;
+  let lastY = 7;
   for (let i = 0; i < n; i++) {
     const x = (i / (n - 1)) * 100;
     // Inverted y-axis so higher values sit higher on the chart.
     const y = span > 0 ? 13 - (((values[i] ?? 0) - min) / span) * 12 : 7;
     d += `${i === 0 ? "M" : "L"} ${x.toFixed(2)} ${y.toFixed(2)} `;
+    lastX = x;
+    lastY = y;
   }
-  return d.trim();
+  return { d: d.trim(), lastX, lastY };
 }

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -975,29 +975,29 @@
     min-height: 1.35em;
   }
 
-  /* ── Metric row (Bloomberg-style) ──────────────────────────────────── */
+  /* ── Metric strip / row (Bloomberg-style instrument panel) ─────────── */
 
-  /* The row floats on the surface — no card bg, no border. Vertical
-   * column rules sit on every cell except the rightmost-of-its-visible-row
-   * (5 cols on desktop, 3 on mobile — the strip wraps the 5 cells into
-   * 2 mobile rows so we kill the 5n rule and gate by last-child instead).
+  /* Layout flips between desktop (5-cell horizontal strip with the row
+   * stacked vertically inside each cell) and mobile (single-column list
+   * with each row laid out horizontally as label / value / delta /
+   * sparkline). The DOM is identical in both modes; only CSS swaps.
    * Verdict drives delta + sparkline color; the row itself stays neutral. */
+  .metric-strip {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    padding: 4px 0;
+  }
   .metric-row {
     position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 4px 8px;
+    text-align: right;
     border-right: 1px solid var(--border-subtle);
   }
-  .metric-strip .metric-row:nth-child(5n),
   .metric-strip .metric-row:last-child {
     border-right: 0;
-  }
-  @media (max-width: 767px) {
-    .metric-strip .metric-row:nth-child(5n) {
-      border-right: 1px solid var(--border-subtle);
-    }
-    .metric-strip .metric-row:nth-child(3n),
-    .metric-strip .metric-row:last-child {
-      border-right: 0;
-    }
   }
   .metric-k {
     font-family: var(--font-stack-mono);
@@ -1008,10 +1008,12 @@
     color: var(--text-tertiary);
     line-height: 1;
   }
+  /* Hero of the cell — punchy mono with tabular figures so columns of
+   * numbers across panes line up at a glance. */
   .metric-v {
     font-family: var(--font-stack-mono);
-    font-size: 15px;
-    font-weight: 500;
+    font-size: 16px;
+    font-weight: 600;
     color: var(--text-primary);
     font-feature-settings:
       "tnum" 1,
@@ -1032,34 +1034,82 @@
     color: var(--text-tertiary);
     font-feature-settings: "tnum" 1;
   }
+  /* Verdict tints use a slightly desaturated mix of `--ok` / `--bad`
+   * with `--text-secondary` so a row of red deltas (which can happen
+   * after a bad strategy swap) doesn't read as a red alarm — the
+   * strip stays informational, not anxious. */
   .metric-row[data-verdict="win"] .metric-d {
-    color: var(--ok);
+    color: color-mix(in srgb, var(--ok) 85%, var(--text-secondary) 15%);
   }
   .metric-row[data-verdict="lose"] .metric-d {
-    color: var(--bad);
+    color: color-mix(in srgb, var(--bad) 85%, var(--text-secondary) 15%);
   }
   .metric-spark {
-    margin-top: 1px;
+    margin-top: 2px;
     width: 100%;
-    max-width: 56px;
-    height: 8px;
-    margin-left: auto;
+    height: 12px;
     display: block;
-    opacity: 0.7;
+    overflow: visible;
+    opacity: 0.95;
   }
   .metric-spark path {
     fill: none;
     stroke: var(--text-tertiary);
-    stroke-width: 1;
+    stroke-width: 1.25;
     stroke-linecap: round;
     stroke-linejoin: round;
     vector-effect: non-scaling-stroke;
   }
-  .metric-row[data-verdict="win"] .metric-spark path {
-    stroke: var(--ok);
+  .metric-spark-dot {
+    fill: var(--text-tertiary);
   }
-  .metric-row[data-verdict="lose"] .metric-spark path {
-    stroke: var(--bad);
+  .metric-row[data-verdict="win"] .metric-spark path,
+  .metric-row[data-verdict="win"] .metric-spark-dot {
+    stroke: color-mix(in srgb, var(--ok) 85%, var(--text-secondary) 15%);
+    fill: color-mix(in srgb, var(--ok) 85%, var(--text-secondary) 15%);
+  }
+  .metric-row[data-verdict="lose"] .metric-spark path,
+  .metric-row[data-verdict="lose"] .metric-spark-dot {
+    stroke: color-mix(in srgb, var(--bad) 85%, var(--text-secondary) 15%);
+    fill: color-mix(in srgb, var(--bad) 85%, var(--text-secondary) 15%);
+  }
+
+  /* Mobile (<768px): collapse the 5-cell strip into a single column
+   * where each row spreads its label, value, delta, and sparkline
+   * across the full width. Saves vertical space (one row per metric
+   * instead of four) and uses the available width for the sparkline. */
+  @media (max-width: 767px) {
+    .metric-strip {
+      grid-template-columns: 1fr;
+    }
+    .metric-row {
+      display: grid;
+      grid-template-columns: 78px max-content max-content 1fr;
+      align-items: baseline;
+      column-gap: 10px;
+      gap: 0;
+      padding: 5px 8px;
+      text-align: left;
+      border-right: 0;
+      border-bottom: 1px solid var(--border-subtle);
+    }
+    .metric-strip .metric-row:last-child {
+      border-bottom: 0;
+    }
+    .metric-k {
+      justify-self: start;
+    }
+    .metric-v {
+      justify-self: end;
+    }
+    .metric-d {
+      justify-self: start;
+    }
+    .metric-spark {
+      margin-top: 0;
+      align-self: center;
+      height: 14px;
+    }
   }
 
   /* ── Shortcut sheet overlay ─────────────────────────────────────────── */

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -1037,11 +1037,17 @@
   /* Verdict tints use a slightly desaturated mix of `--ok` / `--bad`
    * with `--text-secondary` so a row of red deltas (which can happen
    * after a bad strategy swap) doesn't read as a red alarm — the
-   * strip stays informational, not anxious. */
+   * strip stays informational, not anxious. The plain `color`
+   * declaration before each `color-mix()` is a graceful fallback for
+   * browsers older than Chrome 111 / Firefox 113 / Safari 16.2; they
+   * land on the unmixed `--ok` / `--bad` instead of an undefined
+   * value and show full-strength verdict color rather than nothing. */
   .metric-row[data-verdict="win"] .metric-d {
+    color: var(--ok);
     color: color-mix(in srgb, var(--ok) 85%, var(--text-secondary) 15%);
   }
   .metric-row[data-verdict="lose"] .metric-d {
+    color: var(--bad);
     color: color-mix(in srgb, var(--bad) 85%, var(--text-secondary) 15%);
   }
   .metric-spark {
@@ -1065,12 +1071,16 @@
   }
   .metric-row[data-verdict="win"] .metric-spark path,
   .metric-row[data-verdict="win"] .metric-spark-dot {
+    stroke: var(--ok);
     stroke: color-mix(in srgb, var(--ok) 85%, var(--text-secondary) 15%);
+    fill: var(--ok);
     fill: color-mix(in srgb, var(--ok) 85%, var(--text-secondary) 15%);
   }
   .metric-row[data-verdict="lose"] .metric-spark path,
   .metric-row[data-verdict="lose"] .metric-spark-dot {
+    stroke: var(--bad);
     stroke: color-mix(in srgb, var(--bad) 85%, var(--text-secondary) 15%);
+    fill: var(--bad);
     fill: color-mix(in srgb, var(--bad) 85%, var(--text-secondary) 15%);
   }
 


### PR DESCRIPTION
## Summary

Polishes the metric strip on desktop and reworks it for better mobile density. The DOM stays the same shape per row (label / value / delta / sparkline); the layout now flips between desktop (5-cell horizontal strip with the row stacked vertically) and mobile (single-column list with each row laid out horizontally).

### Desktop

- Value type: 15px / 500 → **16px / 600** mono. Numbers anchor each cell more confidently.
- Sparkline: drops the 56px max-width cap (now full cell width), grows from 8px → 12px tall, opacity 0.7 → 0.95, stroke 1 → 1.25.
- New trailing dot at the latest sample so "now" has an on-screen anchor.
- Verdict tints (`--ok` / `--bad`) now mix 85/15 with `--text-secondary` — a row of red deltas reads as informational, not alarming.
- Delta arrow glyphs swap from `▲`/`▼` to `▴`/`▾`. Smaller, line up with the sign character under the mono family without dominating.

### Mobile (<768px)

The previous layout was a 3-col wrap with an awkward empty slot in the bottom row, and each cell stacked four lines vertically.

Now: each metric is one full-width row with `LABEL  value  delta  sparkline` laid out horizontally. Border switches from per-cell vertical rules to a thin horizontal divider between rows.

```
WAIT AVG    12.4 s   ▴ +0.3 s   ∾∾∾∾∾∾∾∾∾∾∾•
WAIT MAX    58.7 s   ▾ −2.1 s   ∾∾∾∾∾∾∾∾∾∾∾•
DELIVERED   1,234    ▴ +18      ∾∾∾∾∾∾∾∾∾∾∾•
ABANDONED   42       ▾ −1       ∾∾∾∾∾∾∾∾∾∾∾•
UTIL        72%      ▴ +3%      ∾∾∾∾∾∾∾∾∾∾∾•
```

## Implementation

- `buildSparklinePath(values): string` becomes `buildSparkline(values): { d, lastX, lastY }` so the renderer can place the trailing dot without re-deriving the y-axis scaling. One consumer; tests updated.
- Layout moves entirely into `.metric-strip` / `.metric-row` CSS (was a mix of inline Tailwind utilities + CSS) — desktop and mobile are structurally different and need a media query anyway.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — 341/341 (one new test for the trailing-dot tracking)
- [x] Vite dev server boots clean
- [ ] Manual visual check: desktop 5-cell strip with new value type + sparkline
- [ ] Manual visual check: mobile portrait — single-column rows
- [ ] Manual visual check: compare mode — verdict colors look informational, not alarming