### PR TITLE
perf(playground): cache hex parsing and hoist tether render allocations

### DIFF
--- a/playground/src/features/compare-pane/bubbles.ts
+++ b/playground/src/features/compare-pane/bubbles.ts
@@ -23,13 +23,15 @@ const BUBBLE_TTL_DEFAULT_MS = 1000;
  * contain many events per car, and keeping just the last keeps the
  * UI readable without pathologically long message queues.
  *
- * Uses stop name/id lookups from the pane's latest snapshot via
- * [`resolveStopName`]; unresolved stop ids fall back to the numeric
- * id rather than dropping the bubble.
+ * Builds a single id→name map from the snapshot up front so resolving
+ * stop names per event is an O(1) Map lookup instead of an
+ * O(stops × events) linear scan.
  */
 export function updateBubbles(pane: Pane, events: EventDto[], snap: Snapshot): void {
   const bornAt = performance.now();
-  const stopName = (id: number): string => resolveStopName(snap, id);
+  const nameById = new Map<number, string>();
+  for (const stop of snap.stops) nameById.set(stop.entity_id, stop.name);
+  const stopName = (id: number): string => nameById.get(id) ?? `stop #${id}`;
   for (const ev of events) {
     const content = bubbleTextFor(ev, stopName);
     if (content === null) continue;

--- a/playground/src/render/color-utils.ts
+++ b/playground/src/render/color-utils.ts
@@ -1,11 +1,33 @@
+// Per-frame draw paths feed the same handful of hex colours into shade()
+// and hexWithAlpha() over and over. Memoise the regex match + parseInt
+// (the dominant cost) so the hot path is just an object-property read
+// plus the rgba/rgb string format.
+//
+// The cache keyed on the input hex returns the parsed (r, g, b) triple;
+// callers that need a pure shade or alpha variant compose their own
+// output string. `null` marks "unparseable" so we don't re-run the
+// regex on a colour we already classified as non-hex.
+const PARSED_HEX = new Map<string, readonly [number, number, number] | null>();
+
+function parseHex(color: string): readonly [number, number, number] | null {
+  const cached = PARSED_HEX.get(color);
+  if (cached !== undefined) return cached;
+  const m = color.match(/^#?([0-9a-f]{6})$/i);
+  if (!m || m[1] === undefined) {
+    PARSED_HEX.set(color, null);
+    return null;
+  }
+  const n = parseInt(m[1], 16);
+  const triple: readonly [number, number, number] = [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
+  PARSED_HEX.set(color, triple);
+  return triple;
+}
+
 /** Lighten (`amount > 0`) or darken (`amount < 0`) a hex color by a fraction [-1, 1]. */
 export function shade(hex: string, amount: number): string {
-  const m = hex.match(/^#?([0-9a-f]{6})$/i);
-  if (!m || m[1] === undefined) return hex;
-  const n = parseInt(m[1], 16);
-  const r = (n >> 16) & 0xff;
-  const g = (n >> 8) & 0xff;
-  const b = n & 0xff;
+  const triple = parseHex(hex);
+  if (triple === null) return hex;
+  const [r, g, b] = triple;
   const f = (c: number): number =>
     amount >= 0 ? Math.round(c + (255 - c) * amount) : Math.round(c * (1 + amount));
   return `rgb(${f(r)}, ${f(g)}, ${f(b)})`;
@@ -13,12 +35,9 @@ export function shade(hex: string, amount: number): string {
 
 /** `#rrggbb` -> `rgba(r, g, b, a)`, no-op on other color forms. */
 export function hexWithAlpha(color: string, alpha: number): string {
-  const m = color.match(/^#?([0-9a-f]{6})$/i);
-  if (!m || m[1] === undefined) return color;
-  const n = parseInt(m[1], 16);
-  const r = (n >> 16) & 0xff;
-  const g = (n >> 8) & 0xff;
-  const b = n & 0xff;
+  const triple = parseHex(color);
+  if (triple === null) return color;
+  const [r, g, b] = triple;
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
@@ -30,7 +49,9 @@ export function hexWithAlpha(color: string, alpha: number): string {
  *  strictly `#RRGGBB` -- cheap safety net so a future caller passing
  *  shorthand or a CSS variable doesn't silently drop alpha. */
 export function withAlpha(hex: string, alpha: number): string {
-  if (/^#[0-9a-f]{6}$/i.test(hex)) {
+  // parseHex memoises the regex check, so the per-frame call cost is a
+  // Map lookup + the small alpha-byte formatting.
+  if (parseHex(hex) !== null && hex.startsWith("#")) {
     const a = Math.round(Math.max(0, Math.min(1, alpha)) * 255);
     return `${hex}${a.toString(16).padStart(2, "0")}`;
   }

--- a/playground/src/render/draw-cars.ts
+++ b/playground/src/render/draw-cars.ts
@@ -5,6 +5,21 @@ import type { Scale } from "./layout";
 import { CANVAS_FONT_SANS, PHASE_COLORS, TARGET_FILL, TRAIL_DT, TRAIL_STEPS } from "./palette";
 import type { CarDto, CarBubble, Snapshot } from "../types";
 
+// Trail colours are a fixed function of the moving phase + step index,
+// so we resolve them once at module load instead of paying for a
+// regex-match + rgba string allocation per ghost step per moving car
+// per frame (TRAIL_STEPS × moving_cars allocations otherwise).
+const TRAIL_COLORS: readonly string[] = Array.from({ length: TRAIL_STEPS }, (_, i) =>
+  hexWithAlpha(PHASE_COLORS["moving"], 0.18 * (1 - i / TRAIL_STEPS)),
+);
+
+// Each PHASE_COLORS entry resolves to a single shade value used as the
+// car's inset highlight; precompute so the per-car draw loop is a map
+// lookup instead of a regex-match + rgb() string allocation per frame.
+const SHADE_HIGHLIGHT: Record<CarDto["phase"], string> = Object.fromEntries(
+  Object.entries(PHASE_COLORS).map(([phase, color]) => [phase, shade(color, 0.18)]),
+) as Record<CarDto["phase"], string>;
+
 export function drawTargetMarkers(
   ctx: CanvasRenderingContext2D,
   snap: Snapshot,
@@ -49,13 +64,10 @@ export function drawCarTrail(
   toScreenY: (y: number) => number,
 ): void {
   if (car.phase !== "moving" || Math.abs(car.v) < 0.1) return;
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- wasm boundary: phase may hold a variant the TS union hasn't caught up with
-  const base = PHASE_COLORS[car.phase] ?? "#6b6b75";
   const halfW = carW / 2;
   for (let i = 1; i <= TRAIL_STEPS; i++) {
     const behindBottom = toScreenY(car.y - car.v * TRAIL_DT * i);
-    const alpha = 0.18 * (1 - (i - 1) / TRAIL_STEPS);
-    ctx.fillStyle = hexWithAlpha(base, alpha);
+    ctx.fillStyle = TRAIL_COLORS[i - 1] ?? "rgba(107, 107, 117, 0.06)";
     ctx.fillRect(cx - halfW, behindBottom - carH, carW, carH);
   }
 }
@@ -92,7 +104,8 @@ export function drawCar(
   // 1 px inset highlight one row below the dark border — gives the
   // cabin a subtle sense of depth without painting a gradient over
   // the whole body.
-  ctx.strokeStyle = shade(base, 0.18);
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- wasm boundary: phase may hold a variant the TS union hasn't caught up with
+  ctx.strokeStyle = SHADE_HIGHLIGHT[car.phase] ?? SHADE_HIGHLIGHT["unknown"];
   ctx.beginPath();
   ctx.moveTo(cx - halfW + 1, top + 1.5);
   ctx.lineTo(cx + halfW - 1, top + 1.5);

--- a/playground/src/render/draw-tether-hud.ts
+++ b/playground/src/render/draw-tether-hud.ts
@@ -303,15 +303,24 @@ export function buildHudList(
   stopIdxById: ReadonlyMap<number, number>,
   outBuf: ClimberHud[],
   idSortBuf: number[],
+  idRankBuf: Map<number, number>,
 ): ClimberHud[] {
   // Stable A/B/C labels are assigned by id rank — sort a tiny scratch
-  // buffer instead of cloning + sorting `snap.cars` itself.
+  // buffer instead of cloning + sorting `snap.cars` itself, then build
+  // a reverse-lookup so the per-car label resolves in O(1) instead of
+  // O(n) via `indexOf` (matters for consistency with the rest of the
+  // hot path, even though n is tiny).
   idSortBuf.length = snap.cars.length;
   for (let i = 0; i < snap.cars.length; i++) {
     const car = snap.cars[i];
     if (car !== undefined) idSortBuf[i] = car.id;
   }
   idSortBuf.sort((a, b) => a - b);
+  idRankBuf.clear();
+  for (let i = 0; i < idSortBuf.length; i++) {
+    const id = idSortBuf[i];
+    if (id !== undefined) idRankBuf.set(id, i);
+  }
 
   outBuf.length = snap.cars.length;
   for (let i = 0; i < snap.cars.length; i++) {
@@ -325,7 +334,7 @@ export function buildHudList(
     const etaSeconds = targetStop
       ? tetherEta(altitudeM, targetStop.y, car.v, maxSpeed, acceleration, deceleration)
       : undefined;
-    const labelIdx = idSortBuf.indexOf(car.id);
+    const labelIdx = idRankBuf.get(car.id) ?? 0;
     const slot = outBuf[i];
     if (slot === undefined) {
       outBuf[i] = {

--- a/playground/src/render/draw-tether-hud.ts
+++ b/playground/src/render/draw-tether-hud.ts
@@ -298,28 +298,60 @@ export function buildHudList(
   maxSpeed: number,
   acceleration: number,
   deceleration: number,
+  // Reusable scratch supplied by the renderer so we can reach steady
+  // state with zero per-frame allocations.
+  stopIdxById: ReadonlyMap<number, number>,
+  outBuf: ClimberHud[],
+  idSortBuf: number[],
 ): ClimberHud[] {
-  // Snapshot order is stable across frames, so deriving "Climber A/B/…"
-  // from the car's index in the sorted snapshot keeps the label tied
-  // to the same cabin even though the engine's entity id is opaque.
-  const cars = [...snap.cars].sort((a, b) => a.id - b.id);
-  return cars.map((car, idx) => {
+  // Stable A/B/C labels are assigned by id rank — sort a tiny scratch
+  // buffer instead of cloning + sorting `snap.cars` itself.
+  idSortBuf.length = snap.cars.length;
+  for (let i = 0; i < snap.cars.length; i++) {
+    const car = snap.cars[i];
+    if (car !== undefined) idSortBuf[i] = car.id;
+  }
+  idSortBuf.sort((a, b) => a - b);
+
+  outBuf.length = snap.cars.length;
+  for (let i = 0; i < snap.cars.length; i++) {
+    const car = snap.cars[i];
+    if (car === undefined) continue;
     const altitudeM = car.y;
-    const targetStop =
-      car.target !== undefined ? snap.stops.find((s) => s.entity_id === car.target) : undefined;
+    // Map lookup beats the previous O(stops × cars) `snap.stops.find()` —
+    // matters once a scenario adds platforms past the lobby/GEO pair.
+    const targetIdx = car.target !== undefined ? stopIdxById.get(car.target) : undefined;
+    const targetStop = targetIdx !== undefined ? snap.stops[targetIdx] : undefined;
     const etaSeconds = targetStop
       ? tetherEta(altitudeM, targetStop.y, car.v, maxSpeed, acceleration, deceleration)
       : undefined;
-    return {
-      cx,
-      cy: axis.toScreenAlt(altitudeM),
-      altitudeM,
-      velocity: car.v,
-      phase: classifyKinematicPhase(car.v, prevVelocity.get(car.id) ?? 0, maxSpeed),
-      layer: atmosphericLayer(altitudeM),
-      carName: `Climber ${String.fromCharCode(65 + idx)}`,
-      destinationName: targetStop?.name,
-      etaSeconds,
-    };
-  });
+    const labelIdx = idSortBuf.indexOf(car.id);
+    const slot = outBuf[i];
+    if (slot === undefined) {
+      outBuf[i] = {
+        cx,
+        cy: axis.toScreenAlt(altitudeM),
+        altitudeM,
+        velocity: car.v,
+        phase: classifyKinematicPhase(car.v, prevVelocity.get(car.id) ?? 0, maxSpeed),
+        layer: atmosphericLayer(altitudeM),
+        carName: `Climber ${String.fromCharCode(65 + labelIdx)}`,
+        destinationName: targetStop?.name,
+        etaSeconds,
+      };
+    } else {
+      // Mutate the pooled object in place so the per-frame steady state
+      // is zero ClimberHud allocations once the buffer has been seeded.
+      slot.cx = cx;
+      slot.cy = axis.toScreenAlt(altitudeM);
+      slot.altitudeM = altitudeM;
+      slot.velocity = car.v;
+      slot.phase = classifyKinematicPhase(car.v, prevVelocity.get(car.id) ?? 0, maxSpeed);
+      slot.layer = atmosphericLayer(altitudeM);
+      slot.carName = `Climber ${String.fromCharCode(65 + labelIdx)}`;
+      slot.destinationName = targetStop?.name;
+      slot.etaSeconds = etaSeconds;
+    }
+  }
+  return outBuf;
 }

--- a/playground/src/render/draw-tether.ts
+++ b/playground/src/render/draw-tether.ts
@@ -5,6 +5,7 @@ import {
   drawClimberHuds,
   drawTetherSideCard,
   type AltitudeAxis,
+  type ClimberHud,
 } from "./draw-tether-hud";
 import type { Scale } from "./layout";
 import { TARGET_FILL } from "./palette";
@@ -359,7 +360,9 @@ function applyDayPhase(elapsedSec: number): number {
 /**
  * Mutable per-frame state the renderer threads through tether mode:
  * carries velocity history (for kinematic-phase classification), the
- * active physics knobs, and the day/night cycle baseline.
+ * active physics knobs, the day/night cycle baseline, and reusable
+ * scratch buffers so the per-frame draw doesn't churn fresh Maps and
+ * Arrays for the GC.
  */
 export interface TetherRenderState {
   prevVelocity: Map<number, number>;
@@ -368,6 +371,14 @@ export interface TetherRenderState {
   deceleration: number;
   /** Performance-now timestamp of the first tether draw (0 if uninitialized). */
   firstDrawAt: number;
+  /** Reusable car-id → cabin screen-y map; cleared and refilled per frame. */
+  carCenters: Map<number, number>;
+  /** Reusable stop entity-id → snap.stops index; cleared and refilled per frame. */
+  stopIdxById: Map<number, number>;
+  /** Reusable HUD-list buffer; truncated and refilled per frame. */
+  hudBuf: ClimberHud[];
+  /** Reusable car-id buffer used to assign stable A/B/C labels by id rank. */
+  idSortBuf: number[];
 }
 
 /**
@@ -421,9 +432,14 @@ export function drawTetherScene(
   s.carH = carH;
   s.carW = carW;
 
-  const carCenters = new Map<number, number>();
-  const stopIdxById = new Map<number, number>();
-  snap.stops.forEach((st, i) => stopIdxById.set(st.entity_id, i));
+  const carCenters = state.carCenters;
+  const stopIdxById = state.stopIdxById;
+  carCenters.clear();
+  stopIdxById.clear();
+  for (let i = 0; i < snap.stops.length; i++) {
+    const st = snap.stops[i];
+    if (st !== undefined) stopIdxById.set(st.entity_id, i);
+  }
   for (const car of snap.cars) {
     carCenters.set(car.id, axis.toScreenAlt(car.y));
   }
@@ -443,12 +459,17 @@ export function drawTetherScene(
     state.maxSpeed,
     state.acceleration,
     state.deceleration,
+    stopIdxById,
+    state.hudBuf,
+    state.idSortBuf,
   );
-  const sortedHud = [...hudList].sort((a, b) => b.altitudeM - a.altitudeM);
-  drawClimberHuds(ctx, sortedHud, carW, w - cardW - cardGap, s);
+  // Sort the same buffer in-place for altitude order; `drawClimberHuds`
+  // and `drawTetherSideCard` both consume it sorted top-to-bottom.
+  hudList.sort((a, b) => b.altitudeM - a.altitudeM);
+  drawClimberHuds(ctx, hudList, carW, w - cardW - cardGap, s);
 
   if (wantsCard) {
-    drawTetherSideCard(ctx, sortedHud, w - s.padX - cardW, cardW, shaftTop, s);
+    drawTetherSideCard(ctx, hudList, w - s.padX - cardW, cardW, shaftTop, s);
   }
 
   // Refresh per-car velocity history for next frame's phase classifier.
@@ -456,9 +477,10 @@ export function drawTetherScene(
     state.prevVelocity.set(car.id, car.v);
   }
   if (state.prevVelocity.size > snap.cars.length) {
-    const live = new Set(snap.cars.map((c) => c.id));
+    // Reuse `carCenters` (already keyed by live car id) instead of
+    // allocating a fresh Set just to test membership.
     for (const id of state.prevVelocity.keys()) {
-      if (!live.has(id)) state.prevVelocity.delete(id);
+      if (!carCenters.has(id)) state.prevVelocity.delete(id);
     }
   }
 }

--- a/playground/src/render/draw-tether.ts
+++ b/playground/src/render/draw-tether.ts
@@ -379,6 +379,9 @@ export interface TetherRenderState {
   hudBuf: ClimberHud[];
   /** Reusable car-id buffer used to assign stable A/B/C labels by id rank. */
   idSortBuf: number[];
+  /** Reverse-lookup of `idSortBuf` (id → rank) so label assignment is
+   *  O(1) per car instead of O(n) via `indexOf`. */
+  idRankBuf: Map<number, number>;
 }
 
 /**
@@ -462,6 +465,7 @@ export function drawTetherScene(
     stopIdxById,
     state.hudBuf,
     state.idSortBuf,
+    state.idRankBuf,
   );
   // Sort the same buffer in-place for altitude order; `drawClimberHuds`
   // and `drawTetherSideCard` both consume it sorted top-to-bottom.

--- a/playground/src/render/renderer.ts
+++ b/playground/src/render/renderer.ts
@@ -7,6 +7,7 @@ import {
 } from "./draw-building";
 import { drawBubbles, drawCar, drawCarTrail, drawTargetMarkers } from "./draw-cars";
 import { drawTetherScene, type TetherRenderState } from "./draw-tether";
+import type { ClimberHud } from "./draw-tether-hud";
 import type { RiderVariant } from "./figures/rider";
 import { pickRiderVariant } from "./figures/rider";
 import {
@@ -55,6 +56,12 @@ export class CanvasRenderer {
   #tether: TetherMeta | null = null;
   /** Per-car previous-frame velocity, used to classify trapezoidal phase. */
   readonly #prevVelocity: Map<number, number> = new Map();
+  // Tether-mode scratch reused across frames so the per-frame draw
+  // reaches steady state with zero Map / Array / ClimberHud allocations.
+  readonly #tetherCarCenters: Map<number, number> = new Map();
+  readonly #tetherStopIdxById: Map<number, number> = new Map();
+  readonly #tetherHudBuf: ClimberHud[] = [];
+  readonly #tetherIdSortBuf: number[] = [];
   /** Active `max_speed` for HUD/ETA math; updated from the snapshot's max served range. */
   #activeMaxSpeed = 1;
   #activeAcceleration = 1;
@@ -502,6 +509,10 @@ export class CanvasRenderer {
       acceleration: this.#activeAcceleration,
       deceleration: this.#activeDeceleration,
       firstDrawAt: this.#firstDrawAt,
+      carCenters: this.#tetherCarCenters,
+      stopIdxById: this.#tetherStopIdxById,
+      hudBuf: this.#tetherHudBuf,
+      idSortBuf: this.#tetherIdSortBuf,
     };
     drawTetherScene(this.#ctx, snap, w, h, s, tether, state);
     this.#firstDrawAt = state.firstDrawAt;

--- a/playground/src/render/renderer.ts
+++ b/playground/src/render/renderer.ts
@@ -62,6 +62,7 @@ export class CanvasRenderer {
   readonly #tetherStopIdxById: Map<number, number> = new Map();
   readonly #tetherHudBuf: ClimberHud[] = [];
   readonly #tetherIdSortBuf: number[] = [];
+  readonly #tetherIdRankBuf: Map<number, number> = new Map();
   /** Active `max_speed` for HUD/ETA math; updated from the snapshot's max served range. */
   #activeMaxSpeed = 1;
   #activeAcceleration = 1;
@@ -513,6 +514,7 @@ export class CanvasRenderer {
       stopIdxById: this.#tetherStopIdxById,
       hudBuf: this.#tetherHudBuf,
       idSortBuf: this.#tetherIdSortBuf,
+      idRankBuf: this.#tetherIdRankBuf,
     };
     drawTetherScene(this.#ctx, snap, w, h, s, tether, state);
     this.#firstDrawAt = state.firstDrawAt;


### PR DESCRIPTION
## Summary

Targets remaining per-frame churn after #726.

- **Color parsing memoised.** `shade()`, `hexWithAlpha()`, and `withAlpha()` share a `parseHex` cache so the regex match + `parseInt` only run on cache miss. The palette has ~8 distinct hex inputs flowing into these on every frame, so cache hit rate is ~100% after warmup.
- **Trail + highlight colors precomputed.** `drawCarTrail` always uses `PHASE_COLORS[\"moving\"]` with fixed step alphas, so the 3 trail colours resolve once at module load. `drawCar`'s inset-highlight `shade(base, 0.18)` is bounded by the small phase set, so we precompute a `Record<phase, string>`. Removes ~20 string allocations per frame in steady state (5 cars × 3 trail steps + 5 highlights).
- **Tether mode allocations hoisted.** `carCenters`, `stopIdxById`, `hudBuf`, and `idSortBuf` are now renderer-owned reusable buffers. `ClimberHud` slots are pooled and mutated in place after the buffer is seeded. The live-set check that previously allocated `new Set(snap.cars.map(...))` per frame now reuses `carCenters`.
- **`buildHudList` indexes via `stopIdxById`.** Replaces an O(stops × cars) `snap.stops.find()` per car with an O(1) Map lookup.
- **`updateBubbles` builds a stop-name map once per frame.** Was running `snap.stops.find()` per event; at 16x speed with many events per frame this was O(events × stops), now O(events + stops). Public `resolveStopName` export is preserved for tests.

Behaviour preserved — visual output identical, only the per-frame allocation count and parse cost change.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` 0 errors / 0 warnings
- [x] \`pnpm test\` 341/341 passing
- [ ] Manual: default scenario, space-elevator scenario, compare mode (A vs B) on desktop
- [ ] Manual: mobile portrait + landscape (P0)