### PR TITLE
fix(playground): keep sparkline traces unfilled in win/lose verdicts

### DIFF
--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -1069,17 +1069,23 @@
   .metric-spark-dot {
     fill: var(--text-tertiary);
   }
-  .metric-row[data-verdict="win"] .metric-spark path,
-  .metric-row[data-verdict="win"] .metric-spark-dot {
+  /* Path is stroked-only (the base rule sets `fill: none`); only the
+   * trailing-dot circle picks up `fill`. The previous combined
+   * selector applied `fill: var(--ok|bad)` to both, which filled the
+   * area under the trace. */
+  .metric-row[data-verdict="win"] .metric-spark path {
     stroke: var(--ok);
     stroke: color-mix(in srgb, var(--ok) 85%, var(--text-secondary) 15%);
+  }
+  .metric-row[data-verdict="win"] .metric-spark-dot {
     fill: var(--ok);
     fill: color-mix(in srgb, var(--ok) 85%, var(--text-secondary) 15%);
   }
-  .metric-row[data-verdict="lose"] .metric-spark path,
-  .metric-row[data-verdict="lose"] .metric-spark-dot {
+  .metric-row[data-verdict="lose"] .metric-spark path {
     stroke: var(--bad);
     stroke: color-mix(in srgb, var(--bad) 85%, var(--text-secondary) 15%);
+  }
+  .metric-row[data-verdict="lose"] .metric-spark-dot {
     fill: var(--bad);
     fill: color-mix(in srgb, var(--bad) 85%, var(--text-secondary) 15%);
   }


### PR DESCRIPTION
## Summary

#728 combined the path + dot selectors for the win/lose verdict overrides and added `fill: var(--ok|bad)` so the trailing-dot would pick up the verdict colour. But the same `fill:` applies to the path element it's grouped with, which overrode the base rule's `fill: none` and filled the area under the trace.

This restores the unfilled trace by splitting the selectors so the path picks up only `stroke` and the dot picks up only `fill`.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` 0 errors / 0 warnings
- [x] \`pnpm test\` 341/341 passing
- [ ] Manual: trigger a win/lose verdict in compare mode and confirm sparkline is a stroked line, not a filled area