### PR TITLE
fix(traffic-detector): use declaration order, not position, to identify the lobby

### DIFF
--- a/assets/config/annotated.ron
+++ b/assets/config/annotated.ron
@@ -15,6 +15,13 @@ SimConfig(
         // Stops along the elevator shaft. At least one required.
         // Positions are in arbitrary distance units from origin.
         // Stops need not be uniformly spaced — supports buildings and space elevators.
+        //
+        // Declare the lobby (or equivalent main entry stop) FIRST. The
+        // built-in TrafficDetector treats `stops[0]` as the lobby for
+        // UpPeak/DownPeak classification; listing a basement or other
+        // sub-grade stop first silently suppresses peak detection,
+        // which in turn disables RsrDispatch's peak-direction multiplier
+        // and AdaptiveParking's lobby-return branch.
         stops: [
             // id: unique StopId — referenced by elevator starting_stop and rider routes.
             // name: display label for the stop.

--- a/crates/elevator-core/src/systems/metrics.rs
+++ b/crates/elevator-core/src/systems/metrics.rs
@@ -154,12 +154,14 @@ fn refresh_traffic_detector(world: &mut World, tick: u64) {
     let destinations = world
         .resource::<crate::arrival_log::DestinationLog>()
         .unwrap_or(&destinations_fallback);
-    let mut stops: Vec<_> = world
-        .iter_stops()
-        .map(|(eid, s)| (eid, s.position))
-        .collect();
-    stops.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
-    let stop_ids: Vec<crate::entity::EntityId> = stops.into_iter().map(|(eid, _)| eid).collect();
+    // Stops in declaration order: `iter_stops()` walks the world's
+    // SecondaryMap by ascending `EntityId`, and `Simulation::new` spawns
+    // stops in the order they appear in `BuildingConfig::stops`. The
+    // detector treats `stops[0]` as the lobby; sorting by position would
+    // hand it whichever stop sits lowest on the shaft (a basement) in
+    // any building with below-grade floors, suppressing UpPeak/DownPeak
+    // detection entirely. The convention is "declare the lobby first."
+    let stop_ids: Vec<crate::entity::EntityId> = world.iter_stops().map(|(eid, _)| eid).collect();
     detector.update(arrivals, destinations, tick, &stop_ids);
     world.insert_resource(detector);
 }

--- a/crates/elevator-core/src/tests/traffic_detector_tests.rs
+++ b/crates/elevator-core/src/tests/traffic_detector_tests.rs
@@ -244,6 +244,114 @@ fn rider_spawn_appends_to_both_logs() {
     assert_eq!(destinations_len, 1, "destination log must carry 1 entry");
 }
 
+/// Buildings with below-grade stops must still classify a lobby-heavy
+/// rush as `UpPeak`. Regression for the position-sort bug in
+/// `refresh_traffic_detector`: sorting by position handed `stops[0]`
+/// to whichever stop sat lowest on the shaft (a basement), so an
+/// honest 76 %-Lobby morning rush registered ~0 % at the synthetic
+/// "lobby" and never tripped the threshold. The fix is to feed the
+/// detector stops in declaration order — `BuildingConfig` puts the
+/// lobby first by convention.
+#[test]
+fn up_peak_detected_in_building_with_basement() {
+    use crate::components::{Accel, Speed, Weight};
+    use crate::config::{
+        BuildingConfig, ElevatorConfig, PassengerSpawnConfig, SimConfig, SimulationParams,
+    };
+    use crate::stop::StopConfig;
+
+    // Lobby declared first; basements after the upper floor so the
+    // position sort would put `B1` at `stops[0]` if reintroduced. The
+    // upper floor exists only to give riders a destination — peak
+    // classification reads the origin distribution, not destinations.
+    let cfg = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
+        building: BuildingConfig {
+            name: "Basement-fronted tower".into(),
+            stops: vec![
+                StopConfig {
+                    id: StopId(0),
+                    name: "Lobby".into(),
+                    position: 0.0,
+                },
+                StopConfig {
+                    id: StopId(1),
+                    name: "Floor 2".into(),
+                    position: 4.0,
+                },
+                StopConfig {
+                    id: StopId(2),
+                    name: "B1".into(),
+                    position: -4.0,
+                },
+            ],
+            lines: None,
+            groups: None,
+        },
+        elevators: vec![ElevatorConfig {
+            id: 0,
+            name: "Main".into(),
+            max_speed: Speed::from(2.0),
+            acceleration: Accel::from(1.5),
+            deceleration: Accel::from(2.0),
+            weight_capacity: Weight::from(800.0),
+            starting_stop: StopId(0),
+            door_open_ticks: 10,
+            door_transition_ticks: 5,
+            restricted_stops: Vec::new(),
+            #[cfg(feature = "energy")]
+            energy_profile: None,
+            service_mode: None,
+            inspection_speed_factor: 0.25,
+            bypass_load_up_pct: None,
+            bypass_load_down_pct: None,
+        }],
+        simulation: SimulationParams {
+            ticks_per_second: 60.0,
+        },
+        passenger_spawning: PassengerSpawnConfig {
+            mean_interval_ticks: 120,
+            weight_range: (50.0, 100.0),
+        },
+    };
+    let mut sim = Simulation::new(&cfg, scan()).unwrap();
+
+    // Seed the arrival log directly — we want to test the classifier's
+    // reading of an existing distribution, not the spawn pipeline. 70
+    // arrivals at the lobby vs 0 elsewhere is a clean ≥60 % up-peak.
+    // Records are stamped at tick 0 so a single `step()` can see them
+    // all in its rolling window (the metrics phase reads
+    // `arrivals_in_window(..., now=1, ...)`, which only counts records
+    // with `tick <= now`).
+    let lobby = sim.stop_entity(StopId(0)).unwrap();
+    {
+        let log = sim
+            .world_mut()
+            .resource_mut::<ArrivalLog>()
+            .expect("arrival log auto-installed");
+        for _ in 0..70u64 {
+            log.record(0, lobby);
+        }
+    }
+
+    // One step is enough — the metrics phase runs every tick and reads
+    // the seeded log.
+    sim.step();
+
+    let mode = sim
+        .world()
+        .resource::<TrafficDetector>()
+        .expect("detector installed")
+        .current_mode();
+    assert_eq!(
+        mode,
+        TrafficMode::UpPeak,
+        "70/70 lobby-origin arrivals must trip UpPeak even when basement \
+         floors at negative positions exist (got {mode:?} — the position-sort \
+         bug would return InterFloor here)"
+    );
+}
+
 /// The metrics phase must refresh the detector each tick. After a
 /// burst of lobby-spawns and enough sim time for the window to fill,
 /// the detector's `last_update_tick` must be recent relative to the

--- a/crates/elevator-core/src/traffic_detector.rs
+++ b/crates/elevator-core/src/traffic_detector.rs
@@ -184,11 +184,15 @@ impl TrafficDetector {
 
     /// Re-classify using arrivals and destinations as of tick
     /// `now`. `stops` is the list of stop entities to aggregate
-    /// over; the *first* entry is treated as the lobby for both
-    /// up-peak and down-peak classification, so callers must pass
-    /// them in position order (lobby first). `destinations` may be
-    /// an empty (default-constructed) `DestinationLog` — in that
-    /// case down-peak detection silently no-ops and only the
+    /// over; `stops[0]` is treated as the lobby for both up-peak
+    /// and down-peak classification. The metrics phase passes
+    /// stops in declaration order (the order they appear in
+    /// `BuildingConfig::stops`), so the convention is **declare
+    /// the lobby first**. Sorting by position would silently swap
+    /// in the lowest below-grade stop on any building with
+    /// basements, suppressing peak detection. `destinations` may
+    /// be an empty (default-constructed) `DestinationLog` — in
+    /// that case down-peak detection silently no-ops and only the
     /// origin-driven modes fire.
     ///
     /// Precedence when both peaks meet their thresholds (rare —


### PR DESCRIPTION
## Summary

`refresh_traffic_detector` sorted stops by position before handing the list to the classifier, which treats `stops[0]` as the lobby. In any building with below-grade stops the basement floor sorts ahead of the lobby, so the detector watched ~0% lobby-origin arrivals and never tripped UpPeak / DownPeak — silently disabling RSR's `peak_direction_multiplier` and AdaptiveParking's `ReturnToLobby` branch on the playground's skyscraper scenario.

This was the user-visible cause of RSR + predictive parking underperforming SCAN + lobby on the skyscraper: RSR's wrong-direction penalty stayed at 15 instead of doubling to 30 during morning rush, so cars happily reversed off lobby-bound trips. SCAN doesn't depend on the detector and just kept sweeping.

## Fix

Pass stops in declaration order instead. `iter_stops()` walks the SecondaryMap by ascending `EntityId`, and `Simulation::new` spawns stops in `BuildingConfig::stops` order, so the convention becomes "declare the lobby first" — which the skyscraper RON already does and documents (`playground/src/domain/scenarios/scenarios.ts:327-333`), but the metrics-phase sort was overriding it.

`TrafficDetector::update`'s doc is also updated to make the convention explicit so future callers don't reintroduce the sort thinking it's safer.

## Test plan
- [x] `cargo test -p elevator-core --lib` — 985 passed, 0 failed
- [x] `cargo clippy -p elevator-core --all-features --all-targets` — clean
- [x] New regression test `up_peak_detected_in_building_with_basement` — verified to fail pre-fix (`InterFloor`) and pass post-fix (`UpPeak`)
- [ ] Smoke-test the playground's skyscraper scenario with RSR + AdaptiveParking against SCAN + ReturnToLobby — expect RSR to close the gap or pull ahead now that `peak_direction_multiplier` actually fires