### PR TITLE
docs: fix stale crate count, version pins, and strategy enumeration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "18.0.0"
+version = "18.0.1"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -40,7 +40,8 @@ your `Cargo.toml` and expect a migration task when you upgrade:
 
 ```toml
 # Depending on an experimental API? Pin the minor, not the major.
-elevator-core = "=15.1"
+# Replace X.Y with the minor you are targeting.
+elevator-core = "=X.Y"
 ```
 
 Experimental APIs graduate to stable by explicit CHANGELOG entry. The
@@ -52,9 +53,9 @@ Internal items are `pub(crate)` or `#[doc(hidden)]`. They are not part
 of the supported surface; using them from outside the crate (via reflection,
 macros, or forks) is unsupported and subject to change without notice.
 
-## Day-one classification
+## Stable surface
 
-As of `elevator-core` v15.1.0, these items are **stable**:
+These items are **stable**:
 
 - `sim::Simulation::{new, step, spawn_rider, build_rider, drain_events,
   drain_events_where, metrics, snapshot, current_tick, dt, world,
@@ -67,11 +68,11 @@ As of `elevator-core` v15.1.0, these items are **stable**:
 - `entity::{ElevatorId, RiderId, EntityId}`
 - `components::{Weight, Speed, Accel}` and `components::units::UnitError`
 - `snapshot::WorldSnapshot`
-- `dispatch::DispatchStrategy` trait and the five built-in strategies
+- `dispatch::DispatchStrategy` trait and the built-in strategies
   (`ScanDispatch`, `LookDispatch`, `NearestCarDispatch`, `EtdDispatch`,
-  `DestinationDispatch`). Trait method signatures and built-in public
-  API are frozen; covered by the standard deprecation policy.
-  *(Graduated from experimental in v15.2.0 — see [History](#history).)*
+  `DestinationDispatch`, `RsrDispatch`). Trait method signatures and
+  built-in public API are frozen; covered by the standard deprecation
+  policy. See [History](#history) for graduations.
 
 These items are **experimental** and may change in any minor version:
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -39,13 +39,15 @@ The built-in `PoissonSource` traffic generator uses an OS-seeded RNG and is **no
 
 ## Project structure
 
-The repository is a Cargo workspace with three crates:
+The repository is a Cargo workspace grouped by role:
 
-| Crate | Purpose |
-|---|---|
-| `elevator-core` | The simulation library. Pure Rust, no engine dependencies. This is what you add to your project. |
-| `elevator-bevy` | A Bevy 0.18 binary that wraps the core sim with 2D rendering, a HUD, and keyboard controls. Useful as a reference implementation and visual debugger. |
-| `elevator-ffi` | C ABI wrapper for Unity, .NET, and other native consumers. Not published to crates.io. |
+| Group | Crates | Purpose |
+|---|---|---|
+| **Core** | `elevator-core` | The simulation library. Pure Rust, no engine dependencies. This is what you add to your project. |
+| **Hosts** | `elevator-bevy`, `elevator-ffi`, `elevator-wasm`, `elevator-gdext`, `elevator-tui` | Engine wrappers: a Bevy 0.18 visual frontend, a C ABI wrapper for Unity / .NET / GameMaker, a wasm-bindgen surface for the browser playground, a Godot (gdext) extension, and a terminal viewer / smoke runner. |
+| **Supporting** | `elevator-contract`, `elevator-layout-derive`, `elevator-layout-runtime`, `elevator-layout-codegen` | Build-time and test-only crates that keep host bindings in sync and validate cross-process snapshot determinism. See [Integration Gallery](integration-gallery.md). |
+
+The `elevator-core` crate is the only one published to crates.io as the library entry point; host crates ship via their target ecosystems (Bevy from crates.io, GameMaker from extension stores, etc.).
 
 ## Links
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -47,7 +47,7 @@ The repository is a Cargo workspace grouped by role:
 | **Hosts** | `elevator-bevy`, `elevator-ffi`, `elevator-wasm`, `elevator-gdext`, `elevator-tui` | Engine wrappers: a Bevy 0.18 visual frontend, a C ABI wrapper for Unity / .NET / GameMaker, a wasm-bindgen surface for the browser playground, a Godot (gdext) extension, and a terminal viewer / smoke runner. |
 | **Supporting** | `elevator-contract`, `elevator-layout-derive`, `elevator-layout-runtime`, `elevator-layout-codegen` | Build-time and test-only crates that keep host bindings in sync and validate cross-process snapshot determinism. See [Integration Gallery](integration-gallery.md). |
 
-The `elevator-core` crate is the only one published to crates.io as the library entry point; host crates ship via their target ecosystems (Bevy from crates.io, GameMaker from extension stores, etc.).
+`elevator-core` is the only crate published to crates.io. The host crates set `publish = false` and ship through their target ecosystems instead — pulled directly from this repo, vendored into a Unity package, packaged as a Godot extension, or distributed as a GameMaker extension.
 
 ## Links
 

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -94,10 +94,16 @@ Per `step()` cost at three scales, holding everything else constant:
 | 20e, 50s | 436 us | 395 us | 423 us | 413 us |
 | 50e, 200s | 2.18 ms | 2.00 ms | 2.04 ms | 1.96 ms |
 
-The four built-in strategies land within ~15 % of each other at every
+The strategies in the table land within ~15 % of each other at every
 scale. ETD is competitive despite its richer cost model because the
 other phases dominate wall-clock time. Pick the strategy that fits
 your dispatch *behavior* needs; they're all fast enough.
+
+`RsrDispatch` and `DestinationDispatch` are also covered by
+[`dispatch_bench`][bench] but are not yet captured in the numbers
+above. Run the bench locally for current values.
+
+[bench]: https://github.com/andymai/elevator-core/blob/main/crates/elevator-core/benches/dispatch_bench.rs
 
 #### Query surface (`query_bench`)
 

--- a/docs/src/stability.md
+++ b/docs/src/stability.md
@@ -20,15 +20,15 @@ Pin to an exact minor version:
 
 ```toml
 # Use this if you touch hooks, topology, traffic, extensions, or any
-# other experimental area:
-elevator-core = "=15.2"
+# other experimental area. Replace X.Y with the minor you are targeting.
+elevator-core = "=X.Y"
 ```
 
 When you bump the minor, expect a short migration task. The CHANGELOG will call out what changed.
 
 ## Cadence commitment
 
-The stable surface has a bounded break rate; planned majors bundle changes together. Experimental surface has no such cap. The commitment applies to releases after v15.1.0 — see [`STABILITY.md`](https://github.com/andymai/elevator-core/blob/main/STABILITY.md) for the specific bound and retroactivity note.
+The stable surface has a bounded break rate; planned majors bundle changes together. Experimental surface has no such cap. See [`STABILITY.md`](https://github.com/andymai/elevator-core/blob/main/STABILITY.md) for the specific bound and the retroactivity note that scopes when the commitment took effect.
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

PR 1 of 4 in a docs accuracy + structure pass. This one is the smallest and lowest-risk: surgical fixes to factual claims that have drifted from the codebase. No prose rewrites.

- **`docs/src/introduction.md`** — claimed a "Cargo workspace with three crates"; workspace has ten. Replaced the three-row table with a Core / Hosts / Supporting grouping that matches `CLAUDE.md`.
- **`docs/src/stability.md`** + **`STABILITY.md`** — pinned `=15.1` / `=15.2` example versions and anchored a section to "v15.1.0". Crate is at v18.0.1. Replaced the literal pins with `=X.Y` placeholder syntax and renamed `Day-one classification` → `Stable surface` so the listed APIs read as current state. History section preserved (it's a historical record of graduations).
- **`STABILITY.md`** — stable-strategy list said "the five built-in strategies" (Scan/Look/NearestCar/Etd/Destination); `RsrDispatch` was missing. Added it.
- **`docs/src/performance.md`** — said "the four built-in strategies land within ~15 %"; the bench table only has four columns but `dispatch_bench.rs` actually runs all six. Updated prose to reference the strategies in the table and link to the bench source for regenerating the missing columns.

## What this is *not*

Three follow-up PRs will address the rest of the docs audit (drift-prone counts in other pages, "Next steps" footer normalization, `introduction.md` rewrite + diagrams, `stability.md` rewrite, `integration-gallery.md` rename, `host-binding-parity.md` tightening). This PR keeps the surface area minimal so it can land first and unblock those.

## Test plan

- [x] `bash scripts/lint-docs.sh --quick` passes locally
- [x] Pre-commit hook runs full workspace test suite + doc tests + workspace check; all green
- [ ] Greptile review