### PR TITLE
docs: strip drift-prone counts and tighten weak footers

### DIFF
--- a/docs/src/custom-dispatch.md
+++ b/docs/src/custom-dispatch.md
@@ -286,7 +286,7 @@ Two levels of test coverage work well:
 
 **Unit-test through `dispatch::assign` in isolation.** Construct a minimal `World`, an `ElevatorGroup`, and a `DispatchManifest`, then run one assignment pass. This exercises the Hungarian matching and `fallback` path end-to-end, so the test reflects real runtime behavior. See `crates/elevator-core/src/tests/dispatch_tests.rs` for the helper pattern (`test_world()`, `test_group()`, `spawn_elevator()`, `add_demand()`).
 
-**Integration-test via a full `Simulation`.** Spawn riders, step the loop, assert on events (`ElevatorAssigned`, `RiderBoarded`, etc.). This catches bugs that only surface through the 8-phase interaction -- e.g., a strategy that excludes every `(car, stop)` pair it shouldn't, or one whose `prepare_car` mutation leaves stale state between passes.
+**Integration-test via a full `Simulation`.** Spawn riders, step the loop, assert on events (`ElevatorAssigned`, `RiderBoarded`, etc.). This catches bugs that only surface through the full [tick loop](simulation-loop.md) -- e.g., a strategy that excludes every `(car, stop)` pair it shouldn't, or one whose `prepare_car` mutation leaves stale state between passes.
 
 ```rust,no_run
 # use elevator_core::prelude::*;

--- a/docs/src/dispatch-strategies.md
+++ b/docs/src/dispatch-strategies.md
@@ -1,6 +1,6 @@
 # Dispatch Strategies
 
-Dispatch is the brain of an elevator system -- it decides which elevator goes where. This chapter covers imperative dispatch, the six built-in strategies, and how to choose between them.
+Dispatch is the brain of an elevator system -- it decides which elevator goes where. This chapter covers imperative dispatch, the built-in strategies, and how to choose between them.
 
 ## How dispatch works
 
@@ -92,7 +92,7 @@ fn main() -> Result<(), SimError> {
 }
 ```
 
-All six strategies live in their respective modules:
+Each built-in lives in its own module:
 
 ```rust,no_run
 use elevator_core::dispatch::scan::ScanDispatch;

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -57,4 +57,6 @@ The repository is a Cargo workspace grouped by role:
 
 ## Next steps
 
-Head to [Quick Start](quick-start.md) to build your first simulation in under 30 lines of Rust.
+- [Quick Start](quick-start.md) — build your first simulation in under 30 lines.
+- [Stops, Lines, and Groups](stops-lines-groups.md) — the topology model that lets the same engine run an office or a 1,000-unit space tether.
+- [Integration Gallery](integration-gallery.md) — supporting crates that keep the host bindings honest.

--- a/docs/src/quick-start.md
+++ b/docs/src/quick-start.md
@@ -10,7 +10,7 @@ cargo add elevator-core
 
 ## Import the prelude
 
-The prelude re-exports the 22 names that cover most usage — building a simulation, stepping it, querying world state, writing custom dispatch, and reading aggregate metrics:
+The prelude re-exports the names that cover most usage — building a simulation, stepping it, querying world state, writing custom dispatch, and reading aggregate metrics:
 
 ```rust
 use elevator_core::prelude::*;
@@ -76,7 +76,7 @@ let rider_id = sim.spawn_rider(
 
 ## Run the simulation loop
 
-Each call to `sim.step()` advances the simulation by one tick, running all [eight phases](simulation-loop.md) of the tick loop. After stepping, drain events to see what happened:
+Each call to `sim.step()` advances the simulation by one tick, running every phase of the [tick loop](simulation-loop.md). After stepping, drain events to see what happened:
 
 ```rust,no_run
 # use elevator_core::prelude::*;
@@ -175,7 +175,7 @@ fn main() -> Result<(), SimError> {
 
 1. The **builder** created a `Simulation` containing a `World` with three stop entities and one elevator entity, plus a SCAN dispatch strategy (the default).
 2. `spawn_rider` created a rider entity at the Lobby with a route to Floor 3.
-3. Each `step()` ran the [eight-phase tick loop](simulation-loop.md). **Dispatch** noticed a waiting rider and sent the elevator to the Lobby. **Movement** moved the elevator using a trapezoidal velocity profile. **Doors** opened and closed. **Loading** boarded and exited the rider. **Metrics** updated aggregate stats.
+3. Each `step()` ran the [tick loop](simulation-loop.md). **Dispatch** noticed a waiting rider and sent the elevator to the Lobby. **Movement** moved the elevator using a trapezoidal velocity profile. **Doors** opened and closed. **Loading** boarded and exited the rider. **Metrics** updated aggregate stats.
 4. Events fired at each significant moment, and we pattern-matched on them to detect arrival.
 
 ## Next steps

--- a/docs/src/snapshots-determinism.md
+++ b/docs/src/snapshots-determinism.md
@@ -8,9 +8,9 @@ The simulation is deterministic given:
 
 1. The same initial `SimConfig` (same stops, elevators, groups, lines, dispatch strategy).
 2. The same sequence of API calls (`spawn_rider`, `despawn_rider`, `tag_entity`, hook mutations, etc.).
-3. A deterministic dispatch strategy. All six built-ins -- `ScanDispatch`, `LookDispatch`, `NearestCarDispatch`, `EtdDispatch`, `RsrDispatch`, `DestinationDispatch` -- are deterministic, and each one round-trips its identity, tunable weights, and internal per-car state through `WorldSnapshot` so `snapshot + restore` produces an indistinguishable simulation.
+3. A deterministic dispatch strategy. Every built-in (see [Dispatch Strategies](dispatch-strategies.md#built-in-strategies)) is deterministic, and each one round-trips its identity, tunable weights, and internal per-car state through `WorldSnapshot` so `snapshot + restore` produces an indistinguishable simulation.
 
-Under those conditions two runs produce byte-identical snapshots and event streams. The cross-strategy invariant harness in `crates/elevator-core/src/tests/invariants_tests.rs` pins this tick-for-tick for all six built-ins.
+Under those conditions two runs produce byte-identical snapshots and event streams. The cross-strategy invariant harness in `crates/elevator-core/src/tests/invariants_tests.rs` pins this tick-for-tick across all built-ins.
 
 Sources of *non*-determinism to watch for:
 

--- a/docs/src/stability.md
+++ b/docs/src/stability.md
@@ -32,6 +32,5 @@ The stable surface has a bounded break rate; planned majors bundle changes toget
 
 ## Next steps
 
-- [`STABILITY.md`](https://github.com/andymai/elevator-core/blob/main/STABILITY.md) — full policy text, deprecation rules, and per-item day-one classification.
-- [Introduction](introduction.md) — what the library does and doesn't do.
+- [`STABILITY.md`](https://github.com/andymai/elevator-core/blob/main/STABILITY.md) — full policy text, deprecation rules, and per-item classification.
 - [Testing Your Simulation](testing.md) — the invariants you can rely on under the stability policy.


### PR DESCRIPTION
## Summary

PR 2 of 4 in the docs accuracy + structure pass. Stacked on #735 (PR 1 — factual fixes).

Strips count phrases that will rot the next time a strategy or prelude export is added/removed, plus tightens two weak footers:

**Count strips** — every phrase below was either misleading or load-bearing on a number that drifts:
- `quick-start.md`: "the 22 names that cover most usage" → drop count.
- `dispatch-strategies.md`: "the six built-in strategies" / "All six strategies live…" → drop count (the table and module list below enumerate them).
- `snapshots-determinism.md`: "All six built-ins -- ScanDispatch, …" → "Every built-in (see Dispatch Strategies)" with a section anchor. Avoids enumerating strategies in two places.
- `quick-start.md` + `custom-dispatch.md`: "eight phases" / "8-phase interaction" → "tick loop" with a link. The phase count stays canonical to `simulation-loop.md`, which already has the diagram and per-phase breakdown.

**Footer tightening:**
- `introduction.md` had a one-line "Head to Quick Start" footer that duplicated the SUMMARY's sequential nav. Replaced with three steering bullets that each point to a non-obvious next read.
- `stability.md`'s footer included a back-link to `introduction.md` (regressive nav from a deeper page). Dropped. Also dropped the stale "day-one classification" wording in the STABILITY.md link description — that section was renamed in PR 1.

## Scope reduction vs. audit

The original audit estimated "trim ~half" of the 32 "Next steps" footers. After running `scripts/lint-docs.sh`, I found the doc lint enforces a `## Next steps` section on every page — so wholesale removal isn't viable, and most existing footers actually do steer to non-obvious next reads (≤3 bullets, taglines explaining each link). Surgical cleanup of the two genuinely weak ones is the right scope.

## Test plan

- [x] `bash scripts/lint-docs.sh --quick` passes
- [x] Pre-commit hook (workspace tests + doc tests + workspace check + lint-docs) all green
- [ ] Greptile review

## Stack

- #735 (PR 1) ← merge target for this PR
- After both merge, follow-ups: PR 3a (front-door rewrite + diagrams) and PR 3b (internals cleanup)