### PR TITLE
docs: rewrite stability page, rename integration-gallery, tighten parity doc

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -55,5 +55,5 @@
 - [Using the Bindings](using-the-bindings.md)
 - [Binding Coverage Manifest](binding-coverage.md)
 - [Host Binding Parity](host-binding-parity.md)
-- [Integration Gallery](integration-gallery.md)
+- [Supporting Crates](supporting-crates.md)
 - [Performance](performance.md)

--- a/docs/src/host-binding-parity.md
+++ b/docs/src/host-binding-parity.md
@@ -1,41 +1,6 @@
 # Host Binding Parity
 
-This page documents the *cross-host* contract: the surfaces that every
-binding crate (FFI, wasm, gdext, Bevy, GameMaker) is expected to
-expose, the agreed semantics, and the per-host status. It is the
-counterpart to [Binding Coverage Manifest](binding-coverage.md) — the
-manifest tracks every `Simulation::*` method one-by-one, while this
-page tracks the *non-method* concerns that nonetheless need to behave
-consistently across hosts.
-
-This is the foundation referenced in issue #655: "Add HostBinding
-abstraction trait shared across binding crates". The work itself is
-incremental — the *contract* lives here, while individual host
-crates migrate at their own pace as new PRs land.
-
-## Why a separate parity document
-
-`bindings.toml` enumerates `pub fn` on `impl Simulation`. But several
-host concerns aren't `Simulation` methods:
-
-- **Snapshot encode/decode** — each host shapes its own DTO from the
-  shared `Simulation::snapshot` data; the *fields* should match
-  even though the *envelope* differs (`#[repr(C)]` for FFI,
-  `Tsify` for wasm, Godot `Variant` dict for gdext).
-- **Event drain** — the *core* method is `drain_events()`, but the
-  host wrappers around it (lazy buffering, severity classification,
-  borrowed-pointer lifetimes) live entirely in each host crate.
-- **Error marshalling** — `EvStatus`, `JsValue`, Godot exceptions,
-  Bevy panics; same failure modes, different wire shapes.
-- **ABI version** — the FFI `EV_ABI_VERSION` constant has no direct
-  analogue in wasm/gdext, but consumers still need *something* to
-  pin against.
-- **Log drain** — convenience surface on top of the event stream;
-  parity work landed in #656.
-
-These cross-host concerns previously had no canonical home. Without
-one, "fully supported in language X" drifts silently — exactly the
-risk that motivated `bindings.toml` for the per-method surface.
+This page is the cross-host contract for `elevator-core`'s binding crates: the non-method surfaces that every host (FFI, wasm, gdext, Bevy, GameMaker) is expected to expose, and the agreed semantics for each. It is the counterpart to the [Binding Coverage Manifest](binding-coverage.md) — the manifest tracks every `Simulation::*` method one-by-one; this page tracks the snapshot, event, error, and ABI-version concerns that don't live on `Simulation` but still have to align across hosts.
 
 ## The parity surface
 
@@ -70,119 +35,54 @@ PRs will lift these to a shared module so wasm / gdext error
 constructors map their underlying language errors onto the same
 classification.
 
-## Migration plan (multi-PR)
-
-The work below is intentionally incremental — each step is small,
-ships independently, and keeps every host runnable.
-
-1. ✅ **Shared log severity constants** (this PR) — `LEVEL_TRACE`
-   … `LEVEL_ERROR` lifted from FFI's hardcoded values into
-   `elevator_core::events::log_format`. Hosts that surface
-   formatted log records reference the constants instead of
-   knowing "1 means debug" out-of-band.
-2. ✅ **Cross-host log drain** (#656) — wasm and gdext expose
-   `peekLogMessages` / `peek_log_messages` mirroring FFI's
-   `ev_drain_log_messages`. Bevy is intentionally skipped because
-   it has native `tracing`.
-3. ✅ **Shared error classification** —
-   `elevator_core::host_error::ErrorKind` is the cross-host failure
-   vocabulary (`NullArg`, `InvalidUtf8`, `ConfigLoad`,
-   `ConfigParse`, `BuildFailed`, `NotFound`, `InvalidArg`,
-   `Panic`). FFI provides `impl From<ErrorKind> for EvStatus`; new
-   FFI / wasm / gdext call sites should produce errors via the
-   shared kind so the integer / string / Variant representations
-   stay aligned. Adoption across existing call sites is
-   intentionally incremental — the shared enum is the foothold,
-   not a flag-day migration.
-4. ✅ **Snapshot field-set guard** — a tripwire test
-   (`elevator_ffi::tests::snapshot_dto_field_names_locked`) locks
-   the field names on every snapshot DTO (`EvElevatorView`,
-   `EvStopView`, `EvRiderView`, `EvMetricsView`, `EvFrame`) using
-   the existing `MultiHostLayout::fields()` registry. When a field
-   is added, removed, or renamed, the test fails and walks the
-   developer through the parity update sequence (wasm DTO → gdext
-   dict → bump `HOST_PROTOCOL_VERSION` if breaking → update the
-   locked list). Catches the silent-drift failure mode without
-   requiring CI access to wasm / gdext crate internals.
-5. ✅ **Wire-version constant** — `elevator_core::HOST_PROTOCOL_VERSION`
-   is the single source of truth. wasm's `ABI_VERSION` and gdext's
-   `ABI_VERSION` reference it directly at compile time; FFI keeps a
-   literal `EV_ABI_VERSION` (so cbindgen can resolve it into the
-   generated C header) plus a `const _: () = assert!(...)` guard
-   that traps any drift. `scripts/check-abi-pins.sh` was extended to
-   verify both literal and reference shapes.
-6. ✅ **`HostBinding` pattern (closing decision: documented
-   contract, no Rust trait)** — see [Close-out](#close-out-trait-or-pattern)
-   below. The trait shape was rejected after steps 3-5 made the
-   per-host divergence concrete; the pattern landed instead is
-   *this document plus per-host adapter modules in core*
-   (`events::log_format`, `host_error::ErrorKind`, the
-   `HOST_PROTOCOL_VERSION` constant), backed by tripwire tests
-   in the FFI crate.
-
-All six steps are complete. Future per-method coverage continues
-to land via [`bindings.toml`](binding-coverage.md); cross-host
-concerns track in the parity table above.
-
-## Close-out: trait or pattern?
-
-Steps 3-5 deliberately exercised the cross-host vocabulary by
-landing real, observable changes in three host crates. With those
-in main, the trait-vs-pattern question that step 6 deferred has
-a clear answer: **shared types in `elevator-core`, hand-written
-per-host adapters, no Rust trait**. The reasoning, in plain
-terms:
-
-1. **The host I/O types are too divergent for a useful trait.**
-   FFI returns `EvStatus` integers and `*const T` slice pointers.
-   wasm returns `tsify`-derived discriminated unions over
-   `JsValue`. gdext returns Godot `Variant` dictionaries. Bevy
-   emits ECS messages. A trait abstracting these would need
-   associated types for *every* return shape — at which point
-   each host's `impl` is a thicker translation layer than the
-   direct hand-written adapter it replaces.
-
-2. **The actual sharing happens at the data layer, not the
-   method layer.** `events::log_format::format_event`,
-   `host_error::ErrorKind`, and `HOST_PROTOCOL_VERSION` are
-   plain values / enums — every host already references them
-   directly. There is no place a `trait HostBinding { fn
-   ev_status(...) }` would slot in without re-introducing the
-   per-host divergence we just removed.
-
-3. **The tripwire pattern (step 4) covers the drift risk a
-   trait would have caught.** `snapshot_dto_field_names_locked`
-   forces a deliberate sync when a snapshot DTO changes, with
-   the parity-update sequence spelled out in the test's doc
-   comment. That achieves the trait's main value (preventing
-   silent drift) without the type gymnastics.
-
-So `HostBinding` lands as: this document + the shared types in
-core + tripwire tests. Adding a Rust trait later is still
-possible if a concrete need surfaces, but speculatively
-introducing one would constrain future host evolution without
-buying real safety.
-
 ## Next steps
 
-- Read [Binding Coverage Manifest](binding-coverage.md) for the
-  per-method coverage view that complements this page.
-- Pick a host you ship against in [Using the Bindings](using-the-bindings.md)
-  and check the relevant column above for known gaps.
-- The umbrella issue [#655] is closed; this document is the
-  ongoing tracker for cross-host parity changes. Edit it directly
-  when a new concern appears or an existing one shifts.
+- [Binding Coverage Manifest](binding-coverage.md) — the per-method coverage view that complements this page.
+- [Using the Bindings](using-the-bindings.md) — host-by-host consumer guide; cross-reference the parity table above for known gaps in the host you ship against.
+- [Supporting Crates](supporting-crates.md) — the build-time crates (`elevator-layout-*`, `elevator-contract`) that enforce the parity contract in CI.
 
-## Cross-references
+## History
 
-- [Binding Coverage Manifest](binding-coverage.md) — per-method
-  coverage in `bindings.toml`.
-- [Using the Bindings](using-the-bindings.md) — host-by-host
-  consumer guide.
-- Issue [#655] — the umbrella issue, closed by this document's
-  step 6. Future cross-host parity work edits this page directly
-  instead of opening a new umbrella.
-- Issue [#656] — log-drain parity, completed.
+The contract above is the result of incremental work across several
+PRs, originally tracked under issue [#655] ("Add HostBinding
+abstraction trait shared across binding crates"). The umbrella issue
+is closed; further cross-host parity changes edit this page directly
+instead of opening a new umbrella.
+
+<details>
+<summary>Migration plan (all complete)</summary>
+
+The work was intentionally incremental — each step shipped
+independently and kept every host runnable.
+
+1. **Shared log severity constants** — `LEVEL_TRACE` … `LEVEL_ERROR` lifted from FFI's hardcoded values into `elevator_core::events::log_format`. Hosts that surface formatted log records reference the constants instead of knowing "1 means debug" out-of-band.
+2. **Cross-host log drain** ([#656]) — wasm and gdext expose `peekLogMessages` / `peek_log_messages` mirroring FFI's `ev_drain_log_messages`. Bevy is intentionally skipped because it has native `tracing`.
+3. **Shared error classification** — `elevator_core::host_error::ErrorKind` is the cross-host failure vocabulary (`NullArg`, `InvalidUtf8`, `ConfigLoad`, `ConfigParse`, `BuildFailed`, `NotFound`, `InvalidArg`, `Panic`). FFI provides `impl From<ErrorKind> for EvStatus`; new FFI / wasm / gdext call sites should produce errors via the shared kind so the integer / string / Variant representations stay aligned. Adoption across existing call sites is intentionally incremental — the shared enum is the foothold, not a flag-day migration.
+4. **Snapshot field-set guard** — a tripwire test (`elevator_ffi::tests::snapshot_dto_field_names_locked`) locks the field names on every snapshot DTO (`EvElevatorView`, `EvStopView`, `EvRiderView`, `EvMetricsView`, `EvFrame`) using the existing `MultiHostLayout::fields()` registry. When a field is added, removed, or renamed, the test fails and walks the developer through the parity update sequence (wasm DTO → gdext dict → bump `HOST_PROTOCOL_VERSION` if breaking → update the locked list). Catches the silent-drift failure mode without requiring CI access to wasm / gdext crate internals.
+5. **Wire-version constant** — `elevator_core::HOST_PROTOCOL_VERSION` is the single source of truth. wasm's `ABI_VERSION` and gdext's `ABI_VERSION` reference it directly at compile time; FFI keeps a literal `EV_ABI_VERSION` (so cbindgen can resolve it into the generated C header) plus a `const _: () = assert!(...)` guard that traps any drift. `scripts/check-abi-pins.sh` verifies both literal and reference shapes.
+6. **`HostBinding` pattern** — see the close-out section below.
+
+</details>
+
+<details>
+<summary>Close-out: documented contract, no Rust trait</summary>
+
+Steps 3–5 deliberately exercised the cross-host vocabulary by landing
+real, observable changes in three host crates. With those in main,
+the trait-vs-pattern question that step 6 deferred had a clear
+answer: **shared types in `elevator-core`, hand-written per-host
+adapters, no Rust trait**. The reasoning:
+
+1. **The host I/O types are too divergent for a useful trait.** FFI returns `EvStatus` integers and `*const T` slice pointers. wasm returns `tsify`-derived discriminated unions over `JsValue`. gdext returns Godot `Variant` dictionaries. Bevy emits ECS messages. A trait abstracting these would need associated types for *every* return shape — at which point each host's `impl` is a thicker translation layer than the direct hand-written adapter it replaces.
+2. **The actual sharing happens at the data layer, not the method layer.** `events::log_format::format_event`, `host_error::ErrorKind`, and `HOST_PROTOCOL_VERSION` are plain values / enums — every host already references them directly. There is no place a `trait HostBinding { fn ev_status(...) }` would slot in without re-introducing the per-host divergence we just removed.
+3. **The tripwire pattern (step 4) covers the drift risk a trait would have caught.** `snapshot_dto_field_names_locked` forces a deliberate sync when a snapshot DTO changes, with the parity-update sequence spelled out in the test's doc comment. That achieves the trait's main value (preventing silent drift) without the type gymnastics.
+
+So `HostBinding` landed as: this document + the shared types in core
++ tripwire tests. Adding a Rust trait later is still possible if a
+concrete need surfaces, but speculatively introducing one would
+constrain future host evolution without buying real safety.
+
+</details>
 
 [#655]: https://github.com/andymai/elevator-core/issues/655
 [#656]: https://github.com/andymai/elevator-core/issues/656

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -59,4 +59,4 @@ The repository is a Cargo workspace grouped by role:
 
 - [Quick Start](quick-start.md) — build your first simulation in under 30 lines.
 - [Stops, Lines, and Groups](stops-lines-groups.md) — the topology model that lets the same engine run an office or a 1,000-unit space tether.
-- [Integration Gallery](integration-gallery.md) — supporting crates that keep the host bindings honest.
+- [Supporting Crates](supporting-crates.md) — supporting crates that keep the host bindings honest.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -45,7 +45,7 @@ The repository is a Cargo workspace grouped by role:
 |---|---|---|
 | **Core** | `elevator-core` | The simulation library. Pure Rust, no engine dependencies. This is what you add to your project. |
 | **Hosts** | `elevator-bevy`, `elevator-ffi`, `elevator-wasm`, `elevator-gdext`, `elevator-tui` | Engine wrappers: a Bevy 0.18 visual frontend, a C ABI wrapper for Unity / .NET / GameMaker, a wasm-bindgen surface for the browser playground, a Godot (gdext) extension, and a terminal viewer / smoke runner. |
-| **Supporting** | `elevator-contract`, `elevator-layout-derive`, `elevator-layout-runtime`, `elevator-layout-codegen` | Build-time and test-only crates that keep host bindings in sync and validate cross-process snapshot determinism. See [Integration Gallery](integration-gallery.md). |
+| **Supporting** | `elevator-contract`, `elevator-layout-derive`, `elevator-layout-runtime`, `elevator-layout-codegen` | Build-time and test-only crates that keep host bindings in sync and validate cross-process snapshot determinism. See [Supporting Crates](supporting-crates.md). |
 
 `elevator-core` is the only crate published to crates.io. The host crates set `publish = false` and ship through their target ecosystems instead — pulled directly from this repo, vendored into a Unity package, packaged as a Godot extension, or distributed as a GameMaker extension.
 

--- a/docs/src/stability.md
+++ b/docs/src/stability.md
@@ -1,36 +1,61 @@
 # Stability and Versioning
 
-`elevator-core` classifies every public item as **stable**, **experimental**, or **internal**, and the crate makes a specific promise about how quickly each kind can break. This chapter summarises the rules; the repo's [`STABILITY.md`](https://github.com/andymai/elevator-core/blob/main/STABILITY.md) is the authoritative source.
+`elevator-core` classifies every public item as **stable**, **experimental**, or **internal**. Each level has a different break-rate guarantee. This page covers what those guarantees mean and how to work with them; the repo's [`STABILITY.md`](https://github.com/andymai/elevator-core/blob/main/STABILITY.md) is the authoritative source for the per-item classification.
 
-## Three status levels
+## The three status levels
 
-**Stable.** Breaking changes ship only in planned major versions. Majors that touch a stable API are announced in a GitHub issue at least 60 days before the release, with a CHANGELOG migration note. `#[deprecated]` precedes removal by at least one major.
+### Stable
 
-**Experimental.** The shape is still being discovered. May break in any minor version with no deprecation cycle. The API is real — fully implemented and tested — but the contract can shift as the design matures.
+A stable API ships breaking changes **only in planned major versions**. Three rules back the guarantee:
 
-**Internal.** `pub(crate)` or `#[doc(hidden)]`. Not supported for use outside the crate.
+- **Majors are announced.** A major bump that touches a stable API opens a GitHub issue at least 60 days before the release, with a migration note staged in the CHANGELOG preamble.
+- **Deprecation precedes removal.** A stable API on its way out is marked `#[deprecated]` for at least one major before deletion. Compiler warnings point you at the replacement.
+- **Semver is honoured strictly.** Bug fixes that change behaviour either land behind a new function or wait for the next major.
 
-## Where to find the current classification
+The current stable surface includes `Simulation`, `SimulationBuilder`, `Event`, `SimError`, `Metrics`, the typed IDs (`StopId`, `RiderId`, `ElevatorId`), `WorldSnapshot`, and the `DispatchStrategy` trait with all built-in strategies. See `STABILITY.md` for the full enumeration.
 
-The module table at the top of the [`elevator-core` crate docs](https://docs.rs/elevator-core) has a Stability column for every row and is the canonical list. `STABILITY.md` lists the per-item day-one classification — check it before taking a dependency on a specific module.
+### Experimental
 
-## Depending on experimental APIs
+Experimental APIs signal *the shape is still being discovered*. They may break in any minor version with no deprecation cycle. The API is real — fully implemented and tested — but the contract can shift as the design matures.
 
-Pin to an exact minor version:
+Currently experimental: `hooks::*`, `topology::*`, `tagged_metrics::*`, `scenario::*`, `traffic::*`, `query::*`, the extension-component APIs on `World`, the RON `config::*` surface, `movement::*` primitives, `energy::*`, `time::TimeAdapter`, and `ids::*`.
+
+If you depend on one of these, pin the minor version:
 
 ```toml
-# Use this if you touch hooks, topology, traffic, extensions, or any
-# other experimental area. Replace X.Y with the minor you are targeting.
+# Replace X.Y with the minor you are targeting.
 elevator-core = "=X.Y"
 ```
 
-When you bump the minor, expect a short migration task. The CHANGELOG will call out what changed.
+When you bump the pin, expect a short migration. The CHANGELOG calls out what moved.
+
+### Internal
+
+Items marked `pub(crate)` or `#[doc(hidden)]` are not part of the supported surface. Anything in `systems::*`, low-level door/ETA primitives, and `#[doc(hidden)]` re-exports falls here. Using these from outside the crate (via reflection, macros, or forks) is unsupported.
+
+## Non-breaking changes you should expect
+
+Several kinds of change look like API breaks but are deliberately *not* covered by the stability policy:
+
+- **Adding variants to `#[non_exhaustive]` enums.** `Event` and `SimError` are non-exhaustive; new variants ship in `feat:` commits, not `feat!:`.
+- **Adding fields with `#[serde(default)]`.** RON config additions are gated by serde defaults whenever possible; older configs continue to load.
+- **Adding optional builder methods.** `SimulationBuilder` and `RiderBuilder` accept new methods without breaking existing call sites.
+
+These appear in the CHANGELOG under feature additions, not migrations.
 
 ## Cadence commitment
 
-The stable surface has a bounded break rate; planned majors bundle changes together. Experimental surface has no such cap. See [`STABILITY.md`](https://github.com/andymai/elevator-core/blob/main/STABILITY.md) for the specific bound and the retroactivity note that scopes when the commitment took effect.
+The stable surface has a bounded break rate; planned majors bundle changes to minimise consumer-side churn. The experimental surface has no such cap. The bound and its scope are spelled out in [`STABILITY.md` § Cadence commitment](https://github.com/andymai/elevator-core/blob/main/STABILITY.md#cadence-commitment).
+
+## Where to look up an item's status
+
+Two sources, in order of recency:
+
+1. **The crate-root module table** in the [`elevator-core` rustdoc](https://docs.rs/elevator-core). Every module row carries a Stability column; this is the live snapshot.
+2. **`STABILITY.md`** in the repo. The History section there records when items graduated from experimental to stable, which the rustdoc table does not.
 
 ## Next steps
 
-- [`STABILITY.md`](https://github.com/andymai/elevator-core/blob/main/STABILITY.md) — full policy text, deprecation rules, and per-item classification.
+- [`STABILITY.md`](https://github.com/andymai/elevator-core/blob/main/STABILITY.md) — full policy text, deprecation rules, graduation history.
 - [Testing Your Simulation](testing.md) — the invariants you can rely on under the stability policy.
+- [Snapshots and Determinism](snapshots-determinism.md) — the determinism contract that anchors what "stable behaviour" means.

--- a/docs/src/stability.md
+++ b/docs/src/stability.md
@@ -12,13 +12,13 @@ A stable API ships breaking changes **only in planned major versions**. Three ru
 - **Deprecation precedes removal.** A stable API on its way out is marked `#[deprecated]` for at least one major before deletion. Compiler warnings point you at the replacement.
 - **Semver is honoured strictly.** Bug fixes that change behaviour either land behind a new function or wait for the next major.
 
-The current stable surface includes `Simulation`, `SimulationBuilder`, `Event`, `SimError`, `Metrics`, the typed IDs (`StopId`, `RiderId`, `ElevatorId`), `WorldSnapshot`, and the `DispatchStrategy` trait with all built-in strategies. See `STABILITY.md` for the full enumeration.
+The current stable surface includes `Simulation`, `SimulationBuilder`, `Event`, `SimError`, `Metrics`, the entity IDs (`StopId`, `RiderId`, `ElevatorId` — declared in `entity::` and `stop::`), `WorldSnapshot`, and the `DispatchStrategy` trait with all built-in strategies. See `STABILITY.md` for the full enumeration.
 
 ### Experimental
 
 Experimental APIs signal *the shape is still being discovered*. They may break in any minor version with no deprecation cycle. The API is real — fully implemented and tested — but the contract can shift as the design matures.
 
-Currently experimental: `hooks::*`, `topology::*`, `tagged_metrics::*`, `scenario::*`, `traffic::*`, `query::*`, the extension-component APIs on `World`, the RON `config::*` surface, `movement::*` primitives, `energy::*`, `time::TimeAdapter`, and `ids::*`.
+Currently experimental: `hooks::*`, `topology::*`, `tagged_metrics::*`, `scenario::*`, `traffic::*`, `query::*`, the extension-component APIs on `World`, the RON `config::*` surface, `movement::*` primitives, `energy::*`, `time::TimeAdapter`, and `ids::*` (config-level identifiers like `GroupId` — distinct from the entity IDs above, which are stable).
 
 If you depend on one of these, pin the minor version:
 

--- a/docs/src/supporting-crates.md
+++ b/docs/src/supporting-crates.md
@@ -52,12 +52,6 @@ cargo run -p elevator-layout-codegen
 
 CI runs this in dry-run mode and fails if the output drifts from what's checked in, so a Rust-side struct edit can't ship without the host bindings being regenerated in the same PR.
 
-## See also
-
-- [Binding Coverage Manifest](binding-coverage.md) — `bindings.toml` policy.
-- [Using the Bindings](using-the-bindings.md) — host-facing usage docs for wasm / FFI / gdext / GameMaker.
-- [Stability and Versioning](stability.md) — how API breaks are signalled across these crates.
-
 ## Next steps
 
 - [Using the Bindings](using-the-bindings.md) — host-language integration with a runtime API surface (the page that complements this one).

--- a/docs/src/supporting-crates.md
+++ b/docs/src/supporting-crates.md
@@ -1,6 +1,8 @@
-# Integration Gallery
+# Supporting Crates
 
-`elevator-core` ships several supporting crates that don't surface a runtime API of their own — they exist to keep the binding crates honest, to drive cross-host code generation, or to validate snapshot determinism. This page is the narrative index for those crates; for hands-on integration with a host language see [Using the Bindings](using-the-bindings.md).
+The workspace ships a handful of crates that don't surface a runtime API to consumers — they exist to keep the host bindings in sync, to drive cross-host code generation, or to validate snapshot determinism. This page is the narrative index for those crates.
+
+> Looking for a host crate (Bevy, wasm, FFI, gdext) you can actually depend on? See [Using the Bindings](using-the-bindings.md). The crates below are about *building and validating* those hosts, not consuming them.
 
 ## elevator-tui
 
@@ -58,8 +60,6 @@ CI runs this in dry-run mode and fails if the output drifts from what's checked 
 
 ## Next steps
 
-- For host-language integration with a runtime API surface, head to
-  [Using the Bindings](using-the-bindings.md) — the gallery covers the
-  *supporting* crates rather than the binding crates themselves.
-- For the determinism contract that `elevator-contract` checksums
-  enforce, read [Snapshots and Determinism](snapshots-determinism.md).
+- [Using the Bindings](using-the-bindings.md) — host-language integration with a runtime API surface (the page that complements this one).
+- [Snapshots and Determinism](snapshots-determinism.md) — the determinism contract that `elevator-contract` checksums enforce.
+- [Binding Coverage Manifest](binding-coverage.md) — the per-method `bindings.toml` policy these crates help enforce.


### PR DESCRIPTION
## Summary

PR 3b of 4 in the docs accuracy + structure pass. Stacked on #735 (PR 1 — factual fixes); file-disjoint from PR 2 (#736), so the two can land in either order after PR 1.

Three internals-cleanup fixes that share a theme: each page was harder to get value out of than it needed to be.

### `stability.md` — full rewrite

The old page was a 37-line pointer that mostly said "go read STABILITY.md". Replaced with a self-contained chapter:
- The three status levels (Stable / Experimental / Internal), each with the actual API surfaces that fall under it.
- The deliberate non-breaking-change categories: `#[non_exhaustive]` enum additions, `#[serde(default)]` fields, optional builder methods. CLAUDE.md flags these as policy; readers should not have to learn them by surprise.
- The cadence commitment (with link to the authoritative `STABILITY.md` for the bound itself).
- Two clear pointers for looking up an item's current status (rustdoc module table; `STABILITY.md` history).

### `integration-gallery.md` → `supporting-crates.md` (rename + light rewrite)

The old title implied this was the index of *integration hosts* (Bevy / wasm / FFI / gdext). In fact the page only covers the *supporting* crates — `elevator-tui`, `elevator-contract`, the three `elevator-layout-*` crates. Renamed to match the actual content. Reworked the lede so anyone arriving from the SUMMARY's "Integration" section gets redirected to `using-the-bindings.md` immediately if that's what they wanted. Inbound links in `SUMMARY.md` and `introduction.md` updated.

### `host-binding-parity.md` — tighten

High-quality parity-table content was buried under: a "Why a separate parity document" preamble, a six-step migration plan that's 100% complete, and a trait-vs-pattern close-out. Lifted the parity table to right after a one-paragraph framing. Folded the migration plan and close-out into `<details>` blocks under a History section. Content preserved for anyone who wants the archaeology; readers who came for the parity contract now hit it on the first scroll.

## Test plan

- [x] `bash scripts/lint-docs.sh --quick` passes
- [x] Pre-commit hook (workspace tests + doc tests + workspace check + lint-docs) all green
- [x] Verified internal links: `introduction.md` → `supporting-crates.md`, `SUMMARY.md` → `supporting-crates.md`
- [ ] Greptile review

## Stack

- #735 (PR 1) ← merge target for this PR
- #736 (PR 2) ← independent of this PR; can land in either order after #735
- After both internal cleanups land, PR 3a follows: front-door rewrite (`introduction.md`) and 3 new Mermaid diagrams (host architecture, dispatch flow, snapshot round-trip).