### PR TITLE
docs: rewrite introduction, polish README, add 3 mermaid diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,14 @@ fn main() -> Result<(), SimError> {
 }
 ```
 
+The README snippet above prints `Tick N: rider … delivered!` once the rider arrives. To run a slightly more elaborate example, with three riders and aggregate metrics:
+
 ```sh
-cargo run --example basic -p elevator-core   # try it now
-# Tick 89: rider RiderId(0) delivered!
+cargo run --example basic -p elevator-core
+# All riders arrived at tick 335!
+# Delivered: 3
+# Avg wait: 5.0 ticks
+# Avg ride: 328.0 ticks
 ```
 
 ## Use cases

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ cargo run --example basic -p elevator-core   # try it now
 |---|---|
 | Office building with 5 floors | Stops at 0, 4, 8, 12, 16 |
 | Skyscraper with sky lobbies | Multi-group dispatch, express zones |
-| Space elevator | Stops at 0 and 1,000,000 — same engine |
+| Space elevator | Stops at 0 and 1,000 — same engine |
 | Player-controlled car | `ServiceMode::Manual` + velocity commands |
 | Custom AI dispatch | Implement `DispatchStrategy::rank()` |
 | VIP passengers, cargo, robots | Extension storage — attach any data |

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ fn main() -> Result<(), SimError> {
 
 ```sh
 cargo run --example basic -p elevator-core   # try it now
+# Tick 89: rider RiderId(0) delivered!
 ```
 
 ## Use cases
@@ -87,11 +88,25 @@ cargo run --example basic -p elevator-core   # try it now
 - **Snapshot save/load:** serialize full simulation state for replays or networking
 - **Metrics:** wait times, ride times, throughput, delivered counts, all built-in
 
+## Hosts
+
+`elevator-core` itself is headless. Pick the host that matches your engine:
+
+| Host | Crate | Use it for |
+|---|---|---|
+| Bevy | [`elevator-bevy`](crates/elevator-bevy) | 2-D Rust game with HUD, mesh, and keyboard controls |
+| Browser | [`elevator-wasm`](crates/elevator-wasm) | wasm-bindgen surface; powers the live playground |
+| Unity / .NET / GameMaker | [`elevator-ffi`](crates/elevator-ffi) | C ABI wrapper for native consumers |
+| Godot | [`elevator-gdext`](crates/elevator-gdext) | gdext extension |
+| Terminal | [`elevator-tui`](crates/elevator-tui) | tick-by-tick debugger and headless smoke runner |
+
+Anything not on the list? Drive `Simulation::step()` yourself — the API is engine-agnostic.
+
 ## Non-goals
 
 This is a simulation library, not a game. It deliberately does **not** include:
 
-- Rendering or UI — wrap it with [Bevy](crates/elevator-bevy), Unity ([FFI](crates/elevator-ffi)), [Godot (gdext)](crates/elevator-gdext), or anything else
+- Rendering or UI — see the host crates above, or roll your own
 - AI passengers or traffic generation — use the optional `traffic` feature flag, or drive arrivals yourself
 - Building layout or 2-D floor plans — the sim is 1-D by design
 
@@ -122,7 +137,13 @@ cargo run -p elevator-tui -- assets/config/default.ron --headless --until 5000  
 
 ## Workspace
 
-The `crates/` directory ships a host crate per supported engine ([`elevator-bevy`](crates/elevator-bevy), [`elevator-ffi`](crates/elevator-ffi), [`elevator-wasm`](crates/elevator-wasm), [`elevator-gdext`](crates/elevator-gdext), [`elevator-tui`](crates/elevator-tui)) plus build-time / test-only supporting crates. See [CLAUDE.md](CLAUDE.md#project-structure) for the full breakdown.
+`elevator-core` is the simulation library. The hosts above wrap it. A handful of supporting crates (`elevator-contract`, `elevator-layout-derive`, `elevator-layout-runtime`, `elevator-layout-codegen`) are build-time / test-only and exist to keep the host bindings in sync. See [CLAUDE.md](CLAUDE.md#project-structure) for the full layout.
+
+## See also
+
+- [Stability and Versioning](STABILITY.md) — what counts as a breaking change and what doesn't.
+- [`elevator-core` changelog](crates/elevator-core/CHANGELOG.md) — release-please-managed.
+- [AI disclosure](AI-DISCLOSURE.md) — how AI tools are used in this repo.
 
 ## License
 

--- a/docs/src/dispatch-strategies.md
+++ b/docs/src/dispatch-strategies.md
@@ -6,6 +6,17 @@ Dispatch is the brain of an elevator system -- it decides which elevator goes wh
 
 Each tick, the Dispatch phase runs four steps:
 
+```mermaid
+flowchart LR
+    demand["per-stop demand<br/>(waiting riders,<br/>weights, wait times)"] --> manifest["DispatchManifest"]
+    riding["riding riders<br/>(per destination)"] --> manifest
+    cars["idle / stopped<br/>elevators per group"] --> rank
+    manifest --> rank["DispatchStrategy::rank()<br/>scores (car, stop) pairs"]
+    rank --> hungarian["Hungarian<br/>(Kuhn-Munkres)<br/>solver"]
+    hungarian --> decision["DispatchDecision<br/>per elevator:<br/>GoToStop(s) or Idle"]
+    decision --> phase["ElevatorPhase update<br/>+ direction indicator"]
+```
+
 1. **Build manifest.** The simulation collects per-stop demand (waiting riders, weights, wait times) and per-destination riding riders into a `DispatchManifest`.
 2. **Collect idle elevators.** Each group gathers its idle/stopped elevators and their current positions.
 3. **Rank and match.** The group's `DispatchStrategy` scores every `(car, stop)` pair via `rank()`. The dispatch system feeds all scores into a Hungarian (Kuhn-Munkres) solver to produce the globally optimal assignment -- one car per hall call, automatically.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,53 +1,83 @@
 # Introduction
 
-> **Try it live:** the [in-browser playground](./playground/index.html) runs the full simulation — race two dispatch strategies on the same traffic, side-by-side, without installing anything.
+**elevator-core** is an engine-agnostic elevator simulation library written in pure Rust. You define stops at arbitrary positions on a 1-D axis, spawn riders, and step the tick loop — the engine handles dispatch, trapezoidal motion, doors, boarding, and metrics. Your code reacts to a typed event stream.
 
-**elevator-core** is an engine-agnostic elevator simulation library written in pure Rust. It gives you a tick-based simulation with realistic trapezoidal motion profiles, pluggable dispatch algorithms, and a typed event bus -- everything you need to build elevator games, building management tools, or algorithm testbeds without coupling to any particular game engine or rendering framework.
+> **▶ Try it live:** the [in-browser playground](./playground/index.html) runs the full simulation. Race two dispatch strategies on the same traffic, side-by-side, no install.
 
-## Who is this for?
+## Who this is for
 
-- **Game developers** who want a ready-made elevator simulation they can drop into Bevy, macroquad, or any Rust game engine.
-- **Algorithm researchers** exploring dispatch strategies (SCAN, LOOK, ETD, or your own) on realistic elevator physics.
-- **Educators** looking for a visual, interactive way to teach scheduling and real-time systems concepts.
-- **Hobbyists** who just think elevators are neat.
+- **Game developers** dropping a ready-made elevator into Bevy, macroquad, Godot, Unity, or a homebrew engine.
+- **Algorithm researchers** prototyping dispatch strategies (SCAN, LOOK, ETD, RSR, or your own) on a deterministic, snapshot-able simulation.
+- **Educators** teaching scheduling, real-time systems, or queueing through a visual, interactive testbed.
+- **Hobbyists** who think elevators are neat. (You're correct.)
 
-## What can you build?
+## What you can build
 
-The library models **stops at arbitrary distances** along a shaft axis, not uniform floors. That means you can simulate a 5-story office where each floor is 4 metres apart, a 160-story skyscraper with sky lobbies and express zones, or a 2.4 km mine shaft where a single hoist serves the surface, a mid-level, and the working face. The engine doesn't enforce any particular unit -- positions are plain `f64` values, and the bundled `assets/config/space_elevator.ron` stretches that to 1,000 distance units between two stops as an upper-bound stress test.
+The library models stops at arbitrary distances along a shaft axis, not uniform floors. Position is a plain `f64`; the bundled `assets/config/space_elevator.ron` stretches the same engine to 1,000 distance units between two stops as a stress test. A few examples:
 
-The core crate provides primitives, not opinions. Riders are generic entities that ride elevators. Caller code decides whether they are office tenants, hotel guests, hospital patients, miners, or freight pallets. You attach semantics through the [extension storage system](extensions.md), and the simulation handles the physics and logistics.
+| Scenario | How |
+|---|---|
+| Office building with 5 floors | Stops at 0, 4, 8, 12, 16 |
+| Skyscraper with sky lobbies | Multi-group dispatch with express zones |
+| Space elevator / orbital tether | Stops at 0 and 1,000,000 — same engine |
+| Player-controlled car | `ServiceMode::Manual` + direct velocity commands |
+| Custom AI dispatch | Implement `DispatchStrategy::rank()` |
+| VIP passengers, cargo, robots | Extension storage — attach any typed data |
 
-## What elevator-core is *not*
+The core crate provides primitives, not opinions. A rider is anything that rides; you decide whether they are tenants, hotel guests, hospital patients, miners, or freight pallets, and attach the semantics through the [extension storage system](extensions.md).
 
-- **Not a renderer.** No graphics, no windowing, no audio. The core crate is headless; see [Bevy Integration](bevy-integration.md) for a 2D visual wrapper.
-- **Not real-time.** The tick loop runs as fast as you drive it. There is no wall-clock coupling -- a tick is whatever `ticks_per_second` says it is. Games layer real-time scheduling on top.
+## What it isn't
+
+- **Not a renderer.** No graphics, no windowing, no audio. The core crate is headless; see [Bevy Integration](bevy-integration.md) for a 2-D visual wrapper.
+- **Not real-time.** The tick loop runs as fast as you drive it. There is no wall-clock coupling — a tick is whatever `ticks_per_second` says it is. Games layer real-time scheduling on top.
 - **Not an ECS framework.** It uses an ECS-inspired internal layout but exposes a focused simulation API, not a general-purpose ECS.
 - **Not networked or multi-building.** One simulation per process. Federation, multiplayer, and cross-building routing are out of scope.
-- **Not an optimizer.** Built-in dispatch strategies (SCAN, LOOK, NearestCar, ETD, Destination) are reference implementations -- not tuned for any specific building. Bring your own algorithm if you need optimal performance.
+- **Not an optimizer.** Built-in dispatch strategies are reference implementations — fast enough for most consumers, but not tuned for any specific building. Bring your own algorithm if you need optimal performance.
 
-## Determinism
+## Workspace at a glance
 
-Given the same initial config and the same sequence of inputs (`spawn_rider`, hook mutations, etc.), the simulation is fully deterministic. The core loop contains no internal randomness -- every tick phase is pure over the world state.
+The simulation core sits at the centre. Host crates wrap it for a target engine; supporting crates exist only to keep the hosts in sync.
 
-The built-in `PoissonSource` traffic generator uses an OS-seeded RNG and is **not** deterministic across runs. For reproducible traffic, implement a custom [`TrafficSource`](traffic-generation.md) over a seeded RNG. See [Snapshots and Determinism](snapshots-determinism.md) for save/load, replay, and seeded traffic patterns.
+```mermaid
+flowchart TB
+    core["<b>elevator-core</b><br/>simulation library<br/>(pure Rust, no engine deps)"]
+
+    subgraph hosts ["Hosts"]
+        bevy["elevator-bevy<br/>2-D visual frontend"]
+        wasm["elevator-wasm<br/>browser playground"]
+        ffi["elevator-ffi<br/>C ABI: Unity, .NET, GameMaker"]
+        gdext["elevator-gdext<br/>Godot extension"]
+        tui["elevator-tui<br/>terminal viewer / smoke runner"]
+    end
+
+    subgraph supporting ["Supporting"]
+        contract["elevator-contract<br/>cross-host determinism harness"]
+        layout["elevator-layout-*<br/>repr(C) codegen for hosts"]
+    end
+
+    core --> bevy
+    core --> wasm
+    core --> ffi
+    core --> gdext
+    core --> tui
+
+    contract -.validates.-> ffi
+    contract -.validates.-> wasm
+    layout -.codegens for.-> ffi
+```
+
+`elevator-core` is the only crate published to crates.io as a library; the hosts ship through their target ecosystems. See [Supporting Crates](supporting-crates.md) for what each supporting crate does and [Using the Bindings](using-the-bindings.md) for host integration walkthroughs.
+
+## Determinism in one paragraph
+
+Given the same initial config and the same sequence of API calls, the simulation is byte-for-byte deterministic. The core loop contains no internal randomness; every tick phase is pure over the world state. The built-in `PoissonSource` traffic generator uses an OS-seeded RNG and is *not* deterministic — for reproducible traffic, plug in a seeded `TrafficSource`. See [Snapshots and Determinism](snapshots-determinism.md) for the contract, save/load, and replay patterns.
 
 ## Stability and MSRV
 
-- **MSRV:** Rust 1.88 (uses let-chains, which stabilized in 1.88; a CI job pinned to the exact MSRV keeps this honest).
-- **Versioning:** Semver. Breaking API changes bump the major version. Adding variants to `#[non_exhaustive]` enums (events, errors) is **not** considered breaking.
-- **Release cadence:** Managed via release-please; see `CHANGELOG.md` in the repo.
-
-## Project structure
-
-The repository is a Cargo workspace grouped by role:
-
-| Group | Crates | Purpose |
-|---|---|---|
-| **Core** | `elevator-core` | The simulation library. Pure Rust, no engine dependencies. This is what you add to your project. |
-| **Hosts** | `elevator-bevy`, `elevator-ffi`, `elevator-wasm`, `elevator-gdext`, `elevator-tui` | Engine wrappers: a Bevy 0.18 visual frontend, a C ABI wrapper for Unity / .NET / GameMaker, a wasm-bindgen surface for the browser playground, a Godot (gdext) extension, and a terminal viewer / smoke runner. |
-| **Supporting** | `elevator-contract`, `elevator-layout-derive`, `elevator-layout-runtime`, `elevator-layout-codegen` | Build-time and test-only crates that keep host bindings in sync and validate cross-process snapshot determinism. See [Supporting Crates](supporting-crates.md). |
-
-`elevator-core` is the only crate published to crates.io. The host crates set `publish = false` and ship through their target ecosystems instead — pulled directly from this repo, vendored into a Unity package, packaged as a Godot extension, or distributed as a GameMaker extension.
+- **MSRV:** Rust 1.88 (uses let-chains, stabilised in 1.88; a CI job pinned to the exact MSRV keeps this honest).
+- **Versioning:** Semver. Breaking changes bump the major version. Adding variants to `#[non_exhaustive]` enums (events, errors) is *not* breaking.
+- **Release cadence:** managed via release-please; see [`CHANGELOG.md`](https://github.com/andymai/elevator-core/blob/main/CHANGELOG.md).
+- **Per-item classification:** see [Stability and Versioning](stability.md).
 
 ## Links
 
@@ -58,5 +88,5 @@ The repository is a Cargo workspace grouped by role:
 ## Next steps
 
 - [Quick Start](quick-start.md) — build your first simulation in under 30 lines.
-- [Stops, Lines, and Groups](stops-lines-groups.md) — the topology model that lets the same engine run an office or a 1,000-unit space tether.
+- [Stops, Lines, and Groups](stops-lines-groups.md) — the topology model that lets one engine run an office, a skyscraper, or a space tether.
 - [Supporting Crates](supporting-crates.md) — supporting crates that keep the host bindings honest.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -76,7 +76,7 @@ Given the same initial config and the same sequence of API calls, the simulation
 
 - **MSRV:** Rust 1.88 (uses let-chains, stabilised in 1.88; a CI job pinned to the exact MSRV keeps this honest).
 - **Versioning:** Semver. Breaking changes bump the major version. Adding variants to `#[non_exhaustive]` enums (events, errors) is *not* breaking.
-- **Release cadence:** managed via release-please; see [`CHANGELOG.md`](https://github.com/andymai/elevator-core/blob/main/CHANGELOG.md).
+- **Release cadence:** managed via release-please; per-crate changelogs live under [`crates/*/CHANGELOG.md`](https://github.com/andymai/elevator-core/tree/main/crates).
 - **Per-item classification:** see [Stability and Versioning](stability.md).
 
 ## Links

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -19,7 +19,7 @@ The library models stops at arbitrary distances along a shaft axis, not uniform 
 |---|---|
 | Office building with 5 floors | Stops at 0, 4, 8, 12, 16 |
 | Skyscraper with sky lobbies | Multi-group dispatch with express zones |
-| Space elevator / orbital tether | Stops at 0 and 1,000,000 — same engine |
+| Space elevator / orbital tether | Stops at 0 and 1,000 — same engine |
 | Player-controlled car | `ServiceMode::Manual` + direct velocity commands |
 | Custom AI dispatch | Implement `DispatchStrategy::rank()` |
 | VIP passengers, cargo, robots | Extension storage — attach any typed data |

--- a/docs/src/snapshots-determinism.md
+++ b/docs/src/snapshots-determinism.md
@@ -22,6 +22,23 @@ Sources of *non*-determinism to watch for:
 
 A `WorldSnapshot` captures the full simulation state -- all entities, components, groups, lines, metrics, tagged metrics, tick counter -- in a serializable struct. Extension components are captured by type name and need a matching registration on restore. Resources and hooks are **not** captured.
 
+```mermaid
+flowchart LR
+    simA["Simulation A<br/>(at tick N)"] -->|sim.snapshot| ws1["WorldSnapshot"]
+    ws1 -->|serde<br/>(RON / JSON /<br/>bincode / …)| bytes["bytes"]
+    bytes -->|deserialize| ws2["WorldSnapshot"]
+    ws2 -->|Simulation::from_snapshot| simB["Simulation B<br/>(at tick N)"]
+
+    simA -.snapshot_checksum.-> chk["checksum"]
+    simB -.snapshot_checksum.-> chk
+    chk -.compared in.-> harness["elevator-contract<br/>vs. golden.txt"]
+
+    classDef artifact fill:#1c1c1c,stroke:#666,color:#eee
+    class ws1,ws2,bytes,chk artifact
+```
+
+Two simulations restored from the same bytes produce byte-identical snapshots forever after, given the same input sequence. The `elevator-contract` harness pins this across hosts: the core run and the wasm-bindgen run share a single `golden.txt` checksum.
+
 ### Saving
 
 ```rust,no_run


### PR DESCRIPTION
## Summary

PR 3a of 4 in the docs accuracy + structure pass. Stacked on #736 (PR 2 — counts and footers); depends on PR 1 (#735) transitively.

The "front-door" half of the rewrite: the pages a new reader hits first.

### `introduction.md` — full rewrite

Old shape: quoted playground link nobody clicks; dense prose for "What can you build?"; a "Project structure" table that PR 1 already corrected but that still framed the workspace as a small thing; a full Determinism subsection that duplicated the dedicated chapter.

New shape:
- Opens with a one-paragraph pitch and the playground call-to-action as the **lede**, not a footnote blockquote.
- Replaces "What can you build?" prose with a use-cases table mirroring the README — five concrete scenarios mapped to the API surface that powers them.
- Replaces the project-structure table with a **host-architecture Mermaid diagram**. Readers see the workspace topology at a glance: core in the centre, hosts as spokes, supporting crates as a validation cluster.
- Cuts "Determinism" from a full subsection to two sentences plus a link.

### `README.md` — polish

- Expected-output line under the basic example so readers know what success looks like.
- Replaces the buried "wrap it with Bevy, Unity (FFI), Godot, or anything else" sentence with a **Hosts table** surfacing all five host crates (Bevy / wasm / FFI / gdext / TUI) at the front door, each with one line on when to reach for it.
- Drops the "ten crates" count from the Workspace section (drift-prone) and inlines the supporting-crate names.
- Adds a "See also" section linking `STABILITY.md`, the per-crate `CHANGELOG.md`, and `AI-DISCLOSURE.md`.

### Three new Mermaid diagrams

- **Host architecture** in `introduction.md`.
- **Dispatch flow** in `dispatch-strategies.md` — visualises the manifest → rank → Hungarian → decision pipeline that the numbered list below walks through. The Hungarian step is easy to miss in prose.
- **Snapshot round-trip** in `snapshots-determinism.md` — Sim A → snapshot → bytes → Sim B, plus the checksum equality the `elevator-contract` harness pins against `golden.txt`. Sells determinism more concretely than the section's previous prose.

The audit had originally proposed four new diagrams; the fourth (rider lifecycle FSM) turned out to be redundant — `rider-lifecycle.md` already has one. The other diagrams already live in `simulation-loop.md`, `stops-lines-groups.md`, `door-control.md`, `movement-physics.md`, and `custom-dispatch.md`.

## Note: introduction.md conflict with PR 3b

PR 3b (#737) renames `integration-gallery.md` → `supporting-crates.md` and updates `introduction.md`'s link to it. This PR's full rewrite of `introduction.md` keeps the `[Integration Gallery]` link text — whichever PR merges second will rebase and update the one line. Trivial conflict by design.

## Test plan

- [x] `bash scripts/lint-docs.sh --quick` passes (mermaid node labels, internal links, code fences all green)
- [x] Pre-commit hook (workspace tests + doc tests + workspace check + lint-docs) all green
- [ ] Greptile review (memory: 3-4 review rounds expected at this size)

## Stack

- #735 (PR 1) → #736 (PR 2) → **#?? (this PR)**
- #737 (PR 3b) ← parallel-safe with this PR