### PR TITLE
feat(tui): add vim scroll and / filter input to events pane

### DIFF
--- a/crates/elevator-tui/src/app.rs
+++ b/crates/elevator-tui/src/app.rs
@@ -15,7 +15,9 @@ use elevator_core::traffic::{PoissonSource, TrafficSource as _};
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 
-use crate::state::{AppState, RightPanel, ShaftMode, Sparkline, UiOverlay};
+use crate::state::{
+    AppState, FocusedPane, RightPanel, ScrollMotion, ShaftMode, Sparkline, UiOverlay,
+};
 use crate::ui;
 
 /// Run the interactive TUI until the user quits.
@@ -198,7 +200,7 @@ fn record_step(sim: &mut Simulation, state: &mut AppState) {
 /// each binding independently reviewable and lets new bindings land
 /// without affecting unrelated overlays.
 fn handle_key(state: &mut AppState, sim: &mut Simulation, code: KeyCode, modifiers: KeyModifiers) {
-    // Ctrl-C escapes every mode, including overlays.
+    // Ctrl-C escapes every mode, including overlays and filter input.
     if matches!(code, KeyCode::Char('c')) && modifiers.contains(KeyModifiers::CONTROL) {
         state.quit = true;
         return;
@@ -214,7 +216,27 @@ fn handle_key(state: &mut AppState, sim: &mut Simulation, code: KeyCode, modifie
         }
         None => {}
     }
-    handle_key_main(state, sim, code);
+    // Filter-input mode swallows most keys so the user can type a
+    // query containing `q`, `j`, `:`, etc. without firing the global
+    // bindings. Only Ctrl-C above and the four control keys below
+    // affect the input itself.
+    if state.pending_filter.is_some() {
+        handle_key_filter_input(state, code);
+        return;
+    }
+    handle_key_main(state, sim, code, modifiers);
+}
+
+/// Filter-input handler — keys flow into `state.pending_filter`
+/// until Enter commits or Esc cancels.
+fn handle_key_filter_input(state: &mut AppState, code: KeyCode) {
+    match code {
+        KeyCode::Esc => state.filter_input_cancel(),
+        KeyCode::Enter => state.filter_input_commit(),
+        KeyCode::Backspace => state.filter_input_backspace(),
+        KeyCode::Char(c) => state.filter_input_push(c),
+        _ => {}
+    }
 }
 
 /// Welcome overlay handler.
@@ -239,7 +261,23 @@ const fn handle_key_help(state: &mut AppState, code: KeyCode) {
 /// Main viewer handler — overview / drill-down / metrics share these
 /// bindings; the right-panel toggle (Enter / Esc) flips between
 /// `Overview` and `DrillDown` without changing the keymap.
-fn handle_key_main(state: &mut AppState, sim: &mut Simulation, code: KeyCode) {
+fn handle_key_main(
+    state: &mut AppState,
+    sim: &mut Simulation,
+    code: KeyCode,
+    modifiers: KeyModifiers,
+) {
+    // Vim scroll motions on the focused-events pane. Routed before the
+    // letter-key match so j/k/g/G never collide with global bindings.
+    // `gg_pending` is cleared inside `handle_events_scroll` regardless
+    // of whether the key was a scroll motion, so a stray `g` followed
+    // by an unrelated key doesn't leave the chord half-armed.
+    if state.focused_pane == FocusedPane::Events
+        && state.right_panel == RightPanel::Overview
+        && handle_events_scroll(state, code, modifiers)
+    {
+        return;
+    }
     match code {
         KeyCode::Char('?') => state.overlay = Some(UiOverlay::Help),
         KeyCode::Char('q') => state.quit = true,
@@ -298,6 +336,14 @@ fn handle_key_main(state: &mut AppState, sim: &mut Simulation, code: KeyCode) {
                 state.flash(format!("toggle {category:?}"));
             }
         }
+        // Filter input only meaningful for the events pane today.
+        // PR4 (popup drilldown) will widen this to the rider list.
+        KeyCode::Char('/')
+            if state.focused_pane == FocusedPane::Events
+                && state.right_panel == RightPanel::Overview =>
+        {
+            state.open_filter_input();
+        }
         // While DrillDown owns the right column the right-side panes
         // aren't on screen, so cycling focus would leave the user with a
         // flash announcing a change that nothing visible reflects (the
@@ -330,6 +376,52 @@ fn handle_key_main(state: &mut AppState, sim: &mut Simulation, code: KeyCode) {
     }
 }
 
+/// Vim-style scroll motions on the events pane. Returns `true` if the
+/// key was consumed; the caller skips the global binding match in that
+/// case. Always clears `gg_pending` on a non-`g` key so the chord
+/// can't get half-armed by a stray keypress.
+const fn handle_events_scroll(
+    state: &mut AppState,
+    code: KeyCode,
+    modifiers: KeyModifiers,
+) -> bool {
+    let ctrl = modifiers.contains(KeyModifiers::CONTROL);
+    let was_gg_pending = state.gg_pending;
+    state.gg_pending = false;
+    match code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            state.scroll_events(ScrollMotion::Down);
+            true
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            state.scroll_events(ScrollMotion::Up);
+            true
+        }
+        // Both Ctrl+f and Ctrl+d (helix / vim) — same outcome.
+        KeyCode::Char('f' | 'd') if ctrl => {
+            state.scroll_events(ScrollMotion::HalfPageDown);
+            true
+        }
+        KeyCode::Char('b' | 'u') if ctrl => {
+            state.scroll_events(ScrollMotion::HalfPageUp);
+            true
+        }
+        KeyCode::Char('g') => {
+            if was_gg_pending {
+                state.scroll_events(ScrollMotion::Top);
+            } else {
+                state.gg_pending = true;
+            }
+            true
+        }
+        KeyCode::Char('G') => {
+            state.scroll_events(ScrollMotion::Bottom);
+            true
+        }
+        _ => false,
+    }
+}
+
 /// Restore the last-saved snapshot, if any, and reset the derived
 /// view state (event log, sparklines, focused car). Extracted so the
 /// main keymap stays easy to scan.
@@ -345,6 +437,7 @@ fn handle_key_main_load_snapshot(state: &mut AppState, sim: &mut Simulation) {
             state.wait_sparkline = Sparkline::new(state.wait_sparkline.capacity);
             state.occupancy_sparkline = Sparkline::new(state.occupancy_sparkline.capacity);
             state.focused_car_idx = 0;
+            state.events_scroll = 0;
             state.flash(format!("restored @ tick {}", sim.current_tick()));
         }
         Err(e) => state.flash(format!("restore failed: {e}")),
@@ -514,6 +607,86 @@ mod tests {
         assert_eq!(state.focused_pane, FocusedPane::Traffic);
         handle_key(&mut state, &mut sim, KeyCode::BackTab, KeyModifiers::SHIFT);
         assert_eq!(state.focused_pane, FocusedPane::Metrics);
+    }
+
+    #[test]
+    fn slash_opens_filter_when_events_focused() {
+        let mut state = AppState::new(1.0).without_welcome();
+        let mut sim = demo_sim();
+        state.focused_pane = FocusedPane::Events;
+        handle_key(&mut state, &mut sim, KeyCode::Char('/'), KeyModifiers::NONE);
+        assert_eq!(state.pending_filter.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn slash_noop_when_other_pane_focused() {
+        let mut state = AppState::new(1.0).without_welcome();
+        let mut sim = demo_sim();
+        state.focused_pane = FocusedPane::Shaft;
+        handle_key(&mut state, &mut sim, KeyCode::Char('/'), KeyModifiers::NONE);
+        assert!(state.pending_filter.is_none());
+    }
+
+    #[test]
+    fn filter_input_typing_then_commit() {
+        let mut state = AppState::new(1.0).without_welcome();
+        let mut sim = demo_sim();
+        state.focused_pane = FocusedPane::Events;
+        handle_key(&mut state, &mut sim, KeyCode::Char('/'), KeyModifiers::NONE);
+        for c in "rider".chars() {
+            handle_key(&mut state, &mut sim, KeyCode::Char(c), KeyModifiers::NONE);
+        }
+        assert_eq!(state.pending_filter.as_deref(), Some("rider"));
+        handle_key(&mut state, &mut sim, KeyCode::Enter, KeyModifiers::NONE);
+        assert!(state.pending_filter.is_none());
+        assert_eq!(state.events_filter, "rider");
+    }
+
+    #[test]
+    fn filter_input_esc_cancels() {
+        let mut state = AppState::new(1.0).without_welcome();
+        let mut sim = demo_sim();
+        state.events_filter = "previous".into();
+        state.focused_pane = FocusedPane::Events;
+        handle_key(&mut state, &mut sim, KeyCode::Char('/'), KeyModifiers::NONE);
+        handle_key(&mut state, &mut sim, KeyCode::Char('x'), KeyModifiers::NONE);
+        handle_key(&mut state, &mut sim, KeyCode::Esc, KeyModifiers::NONE);
+        assert!(state.pending_filter.is_none());
+        // Esc keeps the previously committed filter intact.
+        assert_eq!(state.events_filter, "previous");
+    }
+
+    #[test]
+    fn vim_keys_scroll_events_pane() {
+        let mut state = AppState::new(1.0).without_welcome();
+        let mut sim = demo_sim();
+        state.focused_pane = FocusedPane::Events;
+        handle_key(&mut state, &mut sim, KeyCode::Char('j'), KeyModifiers::NONE);
+        handle_key(&mut state, &mut sim, KeyCode::Char('j'), KeyModifiers::NONE);
+        assert_eq!(state.events_scroll, 2);
+        handle_key(&mut state, &mut sim, KeyCode::Char('k'), KeyModifiers::NONE);
+        assert_eq!(state.events_scroll, 1);
+        handle_key(
+            &mut state,
+            &mut sim,
+            KeyCode::Char('f'),
+            KeyModifiers::CONTROL,
+        );
+        assert_eq!(state.events_scroll, 1 + AppState::EVENTS_HALF_PAGE);
+        handle_key(&mut state, &mut sim, KeyCode::Char('g'), KeyModifiers::NONE);
+        handle_key(&mut state, &mut sim, KeyCode::Char('g'), KeyModifiers::NONE);
+        assert_eq!(state.events_scroll, 0);
+    }
+
+    #[test]
+    fn vim_keys_inert_when_other_pane_focused() {
+        // The j/k scroll path is gated on focused_pane == Events. When
+        // shaft is focused, `j` should be ignored entirely.
+        let mut state = AppState::new(1.0).without_welcome();
+        let mut sim = demo_sim();
+        assert_eq!(state.focused_pane, FocusedPane::Shaft);
+        handle_key(&mut state, &mut sim, KeyCode::Char('j'), KeyModifiers::NONE);
+        assert_eq!(state.events_scroll, 0);
     }
 
     #[test]

--- a/crates/elevator-tui/src/state.rs
+++ b/crates/elevator-tui/src/state.rs
@@ -148,6 +148,27 @@ impl Sparkline {
     }
 }
 
+/// Vim-style scroll motions the events pane responds to.
+///
+/// The motions are intentionally pane-agnostic — once the metrics
+/// or drilldown panes pick up scrollable content (PR4) the same
+/// helper can drive their offsets too.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScrollMotion {
+    /// `j` / Down — one line older.
+    Down,
+    /// `k` / Up — one line newer.
+    Up,
+    /// `Ctrl+f` / `Ctrl+d` — half page older.
+    HalfPageDown,
+    /// `Ctrl+b` / `Ctrl+u` — half page newer.
+    HalfPageUp,
+    /// `gg` — newest event.
+    Top,
+    /// `G` — oldest visible event (clamped at render).
+    Bottom,
+}
+
 /// Mutually-exclusive UI overlays the viewer can show on top of the
 /// active panels.
 ///
@@ -164,7 +185,14 @@ pub enum UiOverlay {
 }
 
 /// Top-level interactive app state.
+///
+/// `clippy::struct_excessive_bools` triggers because `paused`,
+/// `follow_focused`, `gg_pending`, and `quit` are all distinct viewer
+/// modes — each is genuinely independent and refactoring into a
+/// bitflag struct would just add ceremony without making the state
+/// machine clearer.
 #[derive(Debug)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct AppState {
     /// Sim is paused (no auto-stepping). `space` toggles, `.` single-steps.
     pub paused: bool,
@@ -218,6 +246,24 @@ pub struct AppState {
     /// "never both `true`" invariant; the enum makes the contract
     /// explicit.
     pub overlay: Option<UiOverlay>,
+    /// Scroll offset (in events, newest-first) into the events panel.
+    /// `0` keeps the newest event glued to the top; positive values
+    /// scroll older events into view. Vim-style `j` / `k` step by one;
+    /// `Ctrl+f` / `Ctrl+b` step by `EVENTS_HALF_PAGE`; `gg` / `G` jump
+    /// to bounds.
+    pub events_scroll: usize,
+    /// Committed substring filter applied to the events log
+    /// (case-insensitive match against the rendered event body). Empty
+    /// = no filter. `/` opens an input that writes here on Enter.
+    pub events_filter: String,
+    /// In-progress filter input. `Some` means the user is typing a
+    /// filter (footer becomes a `/ {text}` prompt and most other keys
+    /// are routed to the input). `Enter` commits to `events_filter`,
+    /// `Esc` cancels.
+    pub pending_filter: Option<String>,
+    /// `gg` chord state — `true` after a `g` keypress, cleared on the
+    /// next key. The second `g` jumps the active scroll to the top.
+    pub gg_pending: bool,
     /// User has requested a clean exit.
     pub quit: bool,
 }
@@ -246,6 +292,10 @@ impl AppState {
             status: None,
             status_seq: 0,
             overlay: Some(UiOverlay::Welcome),
+            events_scroll: 0,
+            events_filter: String::new(),
+            pending_filter: None,
+            gg_pending: false,
             quit: false,
         }
     }
@@ -317,6 +367,59 @@ impl AppState {
             }
             follow.is_none_or(|target| event_touches(&logged.event, target))
         })
+    }
+
+    /// Half-page step used by `Ctrl+f` / `Ctrl+b`. Tuned to roughly
+    /// match a typical events-panel half-height; the renderer clamps
+    /// the resulting scroll offset to the available content.
+    pub const EVENTS_HALF_PAGE: usize = 5;
+
+    /// Apply a vim-style scroll motion to `events_scroll`. Clamping
+    /// against the live event count happens at render time; this
+    /// helper just performs the arithmetic so handlers can stay terse.
+    pub const fn scroll_events(&mut self, motion: ScrollMotion) {
+        self.events_scroll = match motion {
+            ScrollMotion::Down => self.events_scroll.saturating_add(1),
+            ScrollMotion::Up => self.events_scroll.saturating_sub(1),
+            ScrollMotion::HalfPageDown => self.events_scroll.saturating_add(Self::EVENTS_HALF_PAGE),
+            ScrollMotion::HalfPageUp => self.events_scroll.saturating_sub(Self::EVENTS_HALF_PAGE),
+            ScrollMotion::Top => 0,
+            ScrollMotion::Bottom => usize::MAX,
+        };
+    }
+
+    /// Begin filter-input mode, pre-filling the buffer with the
+    /// currently-committed filter so a user editing an existing query
+    /// doesn't have to retype it.
+    pub fn open_filter_input(&mut self) {
+        self.pending_filter = Some(self.events_filter.clone());
+    }
+
+    /// Append a typed character to the in-progress filter input.
+    pub fn filter_input_push(&mut self, c: char) {
+        if let Some(buf) = self.pending_filter.as_mut() {
+            buf.push(c);
+        }
+    }
+
+    /// Backspace one char from the in-progress filter input.
+    pub fn filter_input_backspace(&mut self) {
+        if let Some(buf) = self.pending_filter.as_mut() {
+            buf.pop();
+        }
+    }
+
+    /// Commit the in-progress filter, leaving filter-input mode.
+    pub fn filter_input_commit(&mut self) {
+        if let Some(text) = self.pending_filter.take() {
+            self.events_filter = text;
+        }
+    }
+
+    /// Cancel the in-progress filter, leaving filter-input mode and
+    /// keeping the previously-committed filter intact.
+    pub fn filter_input_cancel(&mut self) {
+        self.pending_filter = None;
     }
 
     /// Set a transient status banner.

--- a/crates/elevator-tui/src/ui/events.rs
+++ b/crates/elevator-tui/src/ui/events.rs
@@ -29,20 +29,32 @@ pub fn draw(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulatio
     frame.render_widget(block, area);
 
     let visible_height = inner.height as usize;
-    let items: Vec<ListItem<'_>> = state
+    // Pre-format each visible event so we can feed the body string both
+    // to the substring filter and to the rendered span without doing
+    // the work twice.
+    let needle = state.events_filter.to_lowercase();
+    let mut formatted: Vec<(u64, String, EventCategory)> = state
         .visible_events(focused)
-        .rev() // newest at the top
+        .rev() // newest first
+        .filter_map(|logged| {
+            let body = format_event_body(&logged.event);
+            if !needle.is_empty() && !body.to_lowercase().contains(&needle) {
+                return None;
+            }
+            Some((logged.tick, body, logged.event.category()))
+        })
+        .collect();
+    // `events_scroll` is in events; clamp here so the renderer never
+    // shows an empty pane when the user has scrolled past the end.
+    let max_scroll = formatted.len().saturating_sub(visible_height.max(1));
+    let scroll = state.events_scroll.min(max_scroll);
+    let items: Vec<ListItem<'_>> = formatted
+        .drain(scroll..)
         .take(visible_height)
-        .map(|logged| {
+        .map(|(tick, body, category)| {
             ListItem::new(Line::from(vec![
-                Span::styled(
-                    format!("t={:>6} ", logged.tick),
-                    Style::default().fg(palette::DIM),
-                ),
-                Span::styled(
-                    format_event_body(&logged.event),
-                    Style::default().fg(category_color(logged.event.category())),
-                ),
+                Span::styled(format!("t={tick:>6} "), Style::default().fg(palette::DIM)),
+                Span::styled(body, Style::default().fg(category_color(category))),
             ]))
         })
         .collect();
@@ -70,7 +82,17 @@ fn filter_summary(state: &AppState, focused: Option<elevator_core::entity::Entit
         (true, None) => " · follow=(no car)".to_string(),
         (false, _) => String::new(),
     };
-    format!("filter [{cats_str}]{follow}")
+    let needle = if state.events_filter.is_empty() {
+        String::new()
+    } else {
+        format!(" · /{}", state.events_filter)
+    };
+    let scroll = if state.events_scroll == 0 {
+        String::new()
+    } else {
+        format!(" · scroll {}", state.events_scroll)
+    };
+    format!("filter [{cats_str}]{follow}{needle}{scroll}")
 }
 
 /// Pick a tint per event category so the rolling log reads at a glance.

--- a/crates/elevator-tui/src/ui/help.rs
+++ b/crates/elevator-tui/src/ui/help.rs
@@ -15,7 +15,7 @@ use crate::ui::palette;
 
 /// Render a centered help modal over `area`.
 pub fn draw(frame: &mut Frame<'_>, area: Rect) {
-    let modal = super::centered_rect(area, 72, 30);
+    let modal = super::centered_rect(area, 72, 36);
     frame.render_widget(Clear, modal);
 
     let block = Block::default()
@@ -42,6 +42,12 @@ pub fn draw(frame: &mut Frame<'_>, area: Rect) {
         kv("Enter", "toggle right panel: overview ↔ drill-down"),
         kv("Esc", "close drill-down or this overlay"),
         kv("m", "toggle shaft layout: index ↔ distance"),
+        Line::from(""),
+        section("Events pane (when focused)"),
+        kv("j / k", "scroll one event older / newer"),
+        kv("C-f / C-b", "half-page scroll"),
+        kv("g g / G", "jump to newest / oldest event"),
+        kv("/", "filter events (Enter commit, Esc cancel)"),
         Line::from(""),
         section("Filters & Snapshots"),
         kv("1..7", "toggle event categories (1 Elev, 2 Rdr, 3 Dsp,"),

--- a/crates/elevator-tui/src/ui/mod.rs
+++ b/crates/elevator-tui/src/ui/mod.rs
@@ -138,7 +138,14 @@ fn draw_footer(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
         Span::styled(label, palette::title_style()),
         Span::styled("  │  ", Style::default().fg(palette::DIM)),
     ];
-    extend_with_key_hints(&mut spans, hints, include_tab);
+    // Filter-input mode replaces the normal hints with a `/ <text>█`
+    // prompt so the user sees their query as they type it. `Esc`
+    // cancels and `⏎` commits — both shown alongside.
+    if let Some(input) = state.pending_filter.as_deref() {
+        extend_with_filter_prompt(&mut spans, input);
+    } else {
+        extend_with_key_hints(&mut spans, hints, include_tab);
+    }
 
     if let Some(status) = &state.status {
         spans.push(Span::styled("   ◇ ", Style::default().fg(palette::DIM)));
@@ -150,6 +157,38 @@ fn draw_footer(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
         ));
     }
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+/// Render the in-progress filter as `/ <text>█  Esc cancel · ⏎ commit`.
+/// The trailing block (`█`) reverses to act as a faux text cursor —
+/// ratatui doesn't ship a real one and a styled glyph is cheap.
+fn extend_with_filter_prompt(spans: &mut Vec<Span<'static>>, input: &str) {
+    spans.push(Span::styled(
+        "/ ",
+        Style::default()
+            .fg(palette::ACCENT)
+            .add_modifier(Modifier::BOLD),
+    ));
+    spans.push(Span::styled(
+        input.to_string(),
+        Style::default().fg(palette::TITLE),
+    ));
+    spans.push(Span::styled(
+        "█",
+        Style::default()
+            .fg(palette::ACCENT)
+            .add_modifier(Modifier::BOLD),
+    ));
+    spans.push(Span::styled("  Esc", Style::default().fg(palette::ACCENT)));
+    spans.push(Span::styled(
+        " cancel · ",
+        Style::default().fg(palette::DIM_STRONG),
+    ));
+    spans.push(Span::styled("⏎", Style::default().fg(palette::ACCENT)));
+    spans.push(Span::styled(
+        " commit",
+        Style::default().fg(palette::DIM_STRONG),
+    ));
 }
 
 /// Verbs surfaced when `DrillDown` owns the right column. Same shape

--- a/crates/elevator-tui/tests/render_snapshot.rs
+++ b/crates/elevator-tui/tests/render_snapshot.rs
@@ -107,9 +107,38 @@ fn frame_with_events_pane_focused() {
 
 #[test]
 fn frame_with_help_overlay() {
+    // The help modal grew with the events-pane scroll/filter section
+    // landing in PR2. Render at a taller viewport so every binding is
+    // legible — most terminals are >= 30 rows in practice. PR7 will
+    // revisit the layout for ≤ 24-row terminals.
     let sim = demo_sim(60);
     let mut state = AppState::new(1.0).without_welcome();
     state.overlay = Some(elevator_tui::state::UiOverlay::Help);
-    let frame = render(&sim, &state, 100, 30);
+    let frame = render(&sim, &state, 100, 40);
     insta::assert_snapshot!("help_overlay", frame);
+}
+
+#[test]
+fn frame_with_filter_input_open() {
+    // Pins the / filter prompt visible in the footer while the user
+    // is typing.
+    let sim = demo_sim(120);
+    let mut state = AppState::new(1.0).without_welcome();
+    state.focused_pane = elevator_tui::state::FocusedPane::Events;
+    state.pending_filter = Some("rider".into());
+    let frame = render(&sim, &state, 100, 30);
+    insta::assert_snapshot!("filter_input_open", frame);
+}
+
+#[test]
+fn frame_with_committed_filter_and_scroll() {
+    // Pins the events-panel suffix updating when a filter is active
+    // and the user has scrolled into the log.
+    let sim = demo_sim(120);
+    let mut state = AppState::new(1.0).without_welcome();
+    state.focused_pane = elevator_tui::state::FocusedPane::Events;
+    state.events_filter = "rider".into();
+    state.events_scroll = 3;
+    let frame = render(&sim, &state, 100, 30);
+    insta::assert_snapshot!("filter_and_scroll", frame);
 }

--- a/crates/elevator-tui/tests/snapshots/render_snapshot__filter_and_scroll.snap
+++ b/crates/elevator-tui/tests/snapshots/render_snapshot__filter_and_scroll.snap
@@ -1,0 +1,34 @@
+---
+source: crates/elevator-tui/tests/render_snapshot.rs
+expression: frame
+---
+ elevator-tui · tick 120 · ▶ 1.00× · index · overview                                               
+╭┤ shaft · 1 cars · index ├──╮╭┤ dispatch · per-car state and load ├───────────────────────────────╮
+│  Top         10.0      │ · ││Default      strategy=Scan  cars=1  waiting=0                       │
+│  Ground       0.0      │ ▲ ││  car 1    movg →Top       [█░░░░░░░░░]   75/800  q=1               │
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            │╰────────────────────────────────────────────────────────────────────╯
+│                            │╭┤ events · filter [all] · /rider · scroll 3 ├───────────────────────╮
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            │╰────────────────────────────────────────────────────────────────────╯
+│                            │╭┤ traffic · arrivals/sec ├──────────────────────────────────────────╮
+│                            ││   0/s now   avg  0.0/s   total 1                                   │
+│                            ││                                                                    │
+│                            │╰────────────────────────────────────────────────────────────────────╯
+│                            │╭┤ metrics · aggregate health ├──────────────────────────────────────╮
+│                            ││spawned 1   delivered 0   abandoned 0 (0.0%)                        │
+│                            ││wait avg 4.0t   p95 4t   max 4t                                     │
+│                            ││ride avg 0.0t   throughput 0/3600t   util 100%                      │
+│                            ││p95 wait (ticks)                                                    │
+│                            ││                                                                    │
+│                            ││total occupancy                                                     │
+╰────────────────────────────╯╰────────────────────────────────────────────────────────────────────╯
+ RUNNING  events  │  Spc pause · 1-7 filter · f follow · Tab pane · ? help

--- a/crates/elevator-tui/tests/snapshots/render_snapshot__filter_input_open.snap
+++ b/crates/elevator-tui/tests/snapshots/render_snapshot__filter_input_open.snap
@@ -1,0 +1,34 @@
+---
+source: crates/elevator-tui/tests/render_snapshot.rs
+expression: frame
+---
+ elevator-tui · tick 120 · ▶ 1.00× · index · overview                                               
+╭┤ shaft · 1 cars · index ├──╮╭┤ dispatch · per-car state and load ├───────────────────────────────╮
+│  Top         10.0      │ · ││Default      strategy=Scan  cars=1  waiting=0                       │
+│  Ground       0.0      │ ▲ ││  car 1    movg →Top       [█░░░░░░░░░]   75/800  q=1               │
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            │╰────────────────────────────────────────────────────────────────────╯
+│                            │╭┤ events · filter [all] ├───────────────────────────────────────────╮
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            ││                                                                    │
+│                            │╰────────────────────────────────────────────────────────────────────╯
+│                            │╭┤ traffic · arrivals/sec ├──────────────────────────────────────────╮
+│                            ││   0/s now   avg  0.0/s   total 1                                   │
+│                            ││                                                                    │
+│                            │╰────────────────────────────────────────────────────────────────────╯
+│                            │╭┤ metrics · aggregate health ├──────────────────────────────────────╮
+│                            ││spawned 1   delivered 0   abandoned 0 (0.0%)                        │
+│                            ││wait avg 4.0t   p95 4t   max 4t                                     │
+│                            ││ride avg 0.0t   throughput 0/3600t   util 100%                      │
+│                            ││p95 wait (ticks)                                                    │
+│                            ││                                                                    │
+│                            ││total occupancy                                                     │
+╰────────────────────────────╯╰────────────────────────────────────────────────────────────────────╯
+ RUNNING  events  │  / rider█  Esc cancel · ⏎ commit

--- a/crates/elevator-tui/tests/snapshots/render_snapshot__help_overlay.snap
+++ b/crates/elevator-tui/tests/snapshots/render_snapshot__help_overlay.snap
@@ -2,14 +2,16 @@
 source: crates/elevator-tui/tests/render_snapshot.rs
 expression: frame
 ---
- elevator-tui ╭┤ help · press ? or Esc to close ├────────────────────────────────────╮              
-╭┤ shaft · 1 c│                                                                      │─────────────╮
-│  Top        │  Playback                                                            │             │
-│  Ground     │    space   pause / resume                                            │             │
-│             │    . / ,   step one tick / ten ticks                                 │             │
-│             │    + / -   halve or double tick rate (0.0625× – 64×)                 │             │
-│             │                                                                      │─────────────╯
-│             │  Navigation                                                          │─────────────╮
+ elevator-tui · tick 60 · ▶ 1.00× · index · overview                                                
+╭┤ shaft · 1 cars · index ├──╮╭┤ dispatch · per-car state and load ├───────────────────────────────╮
+│  Top        ╭┤ help · press ? or Esc to close ├────────────────────────────────────╮             │
+│  Ground     │                                                                      │             │
+│             │  Playback                                                            │             │
+│             │    space   pause / resume                                            │             │
+│             │    . / ,   step one tick / ten ticks                                 │─────────────╯
+│             │    + / -   halve or double tick rate (0.0625× – 64×)                 │─────────────╮
+│             │                                                                      │             │
+│             │  Navigation                                                          │             │
 │             │    Tab     focus next pane (Shift+Tab for previous)                  │             │
 │             │    [ / ]   focus previous / next car                                 │             │
 │             │    f       follow focused car (event filter)                         │             │
@@ -17,18 +19,26 @@ expression: frame
 │             │    Esc     close drill-down or this overlay                          │             │
 │             │    m       toggle shaft layout: index ↔ distance                     │             │
 │             │                                                                      │             │
-│             │  Filters & Snapshots                                                 │             │
-│             │    1..7    toggle event categories (1 Elev, 2 Rdr, 3 Dsp,            │─────────────╯
-│             │            4 Top, 5 Rep, 6 Dir, 7 Obs)                               │─────────────╮
-│             │    s / l   save / restore in-memory snapshot                         │             │
+│             │  Events pane (when focused)                                          │             │
+│             │    j / k   scroll one event older / newer                            │             │
+│             │    C-f / C-bhalf-page scroll                                         │             │
+│             │    g g / G jump to newest / oldest event                             │             │
+│             │    /       filter events (Enter commit, Esc cancel)                  │             │
 │             │                                                                      │             │
-│             │  Glyphs                                                              │─────────────╯
-│             │    ▲ ▼     going up / going down                                     │─────────────╮
-│             │    ■       stopped                                                   │             │
-│             │    L       loading riders                                            │             │
+│             │  Filters & Snapshots                                                 │             │
+│             │    1..7    toggle event categories (1 Elev, 2 Rdr, 3 Dsp,            │             │
+│             │            4 Top, 5 Rep, 6 Dir, 7 Obs)                               │             │
+│             │    s / l   save / restore in-memory snapshot                         │─────────────╯
+│             │                                                                      │─────────────╮
+│             │  Glyphs                                                              │             │
+│             │    ▲ ▼     going up / going down                                     │             │
+│             │    ■       stopped                                                   │─────────────╯
+│             │    L       loading riders                                            │─────────────╮
 │             │    O / C   doors opening / closing                                   │             │
 │             │    ↑↓      active hall call (up / down)                              │             │
 │             │    (n)     n riders waiting at this stop                             │             │
 │             │                                                                      │             │
-╰─────────────│                                                                      │─────────────╯
- RUNNING  shaf╰──────────────────────────────────────────────────────────────────────╯
+│             │                                                                      │             │
+│             ╰──────────────────────────────────────────────────────────────────────╯             │
+╰────────────────────────────╯╰────────────────────────────────────────────────────────────────────╯
+ RUNNING  shaft  │  Spc pause · [/] car · m mode · Tab pane · ? help


### PR DESCRIPTION
## Summary

Second PR in the TUI overhaul. Builds on PR1's focus model. Brings the Events pane up to lazygit / k9s usability — vim scroll motions and an inline filter input.

- **Vim scroll** (Events pane only when focused). `j/k` step one line, `Ctrl+f`/`Ctrl+d` and `Ctrl+b`/`Ctrl+u` half-page, `gg`/`G` jump to bounds. Routed through a new \`ScrollMotion\` enum + \`AppState::scroll_events\` helper so PR4's drilldown rider list can reuse the path. Render-time clamp keeps the panel populated when the user scrolls past the end.
- **\`/\` filter input** (Events pane only). Press \`/\` to open the prompt; the footer becomes \`/ <text>█  Esc cancel · ⏎ commit\`. Filter is a case-insensitive substring match against the rendered event body. Pre-fills with the existing committed filter on re-open. Events panel title carries \`/<text>\` and \`scroll N\` suffixes so the active state is always visible.
- **Filter-input dispatcher.** Captures most keys so a query containing \`q\`, \`j\`, \`:\` etc. doesn't fire global bindings; only Ctrl-C, Esc, Enter, Backspace, and Char reach the input.
- **Help & tests.** New "Events pane" section in \`?\`. Eight new unit tests cover the chord, half-page step, filter mode-routing, and Esc cancellation. Two new snapshot tests pin the prompt and committed-filter title.

## Subsequent PRs in the queue

PR3 \`:\` palette + scenario picker · PR4 floating drilldown popup + sub-cell motion + tui-big-text · PR5 snapshot ring buffer + scrubber · PR6 mouse · PR7 themes + responsive layout.

## Test plan

- [x] \`cargo test -p elevator-tui --all-targets\` (8 snapshot + unit tests passing)
- [x] \`cargo clippy -p elevator-tui --all-targets -- -D warnings\`
- [x] \`cargo check --workspace --all-features --all-targets\`
- [x] Pre-commit hook (fmt + clippy + tests + doc tests + workspace check) green
- [ ] Manual verification: focus events pane (Tab × 2 from default), press \`/\`, type \`elev\`, Enter — events filter to elevator-touching lines; \`j\`/\`k\` scroll; \`gg\`/\`G\` jump