### PR TITLE
feat(tui): add snapshot ring buffer and time scrubber

### DIFF
--- a/crates/elevator-tui/src/app.rs
+++ b/crates/elevator-tui/src/app.rs
@@ -538,8 +538,14 @@ fn handle_key_scrub_back(state: &mut AppState, sim: &mut Simulation) {
     let max_offset = state.snapshot_ring.len() - 1;
     let next_offset = match state.scrub_offset {
         None => {
-            // Entering scrub mode for the first time.
-            state.live_snapshot = Some(sim.snapshot());
+            // Entering scrub mode for the first time. Capture the
+            // *pre-scrub* pause state so `Esc` can restore it
+            // verbatim — a user who manually paused before scrubbing
+            // expects to stay paused after exiting.
+            state.live_snapshot = Some(crate::state::LiveSnapshot {
+                snapshot: sim.snapshot(),
+                was_paused: state.paused,
+            });
             state.paused = true;
             0
         }
@@ -567,16 +573,32 @@ fn handle_key_scrub_forward(state: &mut AppState, sim: &mut Simulation) {
 
 /// Exit scrub mode and restore the live snapshot taken on entry.
 /// `Esc` triggers this when scrubbing, mirroring how `>` would walk
-/// all the way forward.
+/// all the way forward. Preserves the pre-scrub pause state so a
+/// user who manually paused stays paused after exiting.
+///
+/// On restore failure (snapshot missing or `restore` errors) we
+/// flash the error and *don't* clear the scrub indicator — the sim
+/// would otherwise silently drift, with the user looking at a
+/// replayed past state but no REPLAY badge to flag it.
 fn handle_key_scrub_exit(state: &mut AppState, sim: &mut Simulation) {
-    if let Some(snap) = state.live_snapshot.take()
-        && let Ok(restored) = snap.restore(None)
-    {
-        *sim = restored;
-        state.flash(format!("live @ tick {}", sim.current_tick()));
+    let Some(live) = state.live_snapshot.take() else {
+        state.flash("scrub exit: no live snapshot to restore");
+        return;
+    };
+    // Clone the snapshot for `restore` so we can stash the original
+    // back on failure — no retry path otherwise.
+    match live.snapshot.clone().restore(None) {
+        Ok(restored) => {
+            *sim = restored;
+            state.scrub_offset = None;
+            state.paused = live.was_paused;
+            state.flash(format!("live @ tick {}", sim.current_tick()));
+        }
+        Err(e) => {
+            state.live_snapshot = Some(live);
+            state.flash(format!("scrub exit failed: {e}"));
+        }
     }
-    state.scrub_offset = None;
-    state.paused = false;
 }
 
 /// Restore the ring entry at `offset` (counted from newest) and
@@ -949,6 +971,23 @@ mod tests {
         assert!(sim.current_tick() <= live_tick);
         handle_key(&mut state, &mut sim, KeyCode::Char('<'), KeyModifiers::NONE);
         assert_eq!(state.scrub_offset, Some(1));
+    }
+
+    #[test]
+    fn scrub_exit_preserves_pre_scrub_pause() {
+        // Greptile P1: user-paused → scrub → exit must stay paused.
+        let mut state = AppState::new(1.0).without_welcome();
+        let mut sim = demo_sim();
+        for _ in 0..(crate::state::SNAPSHOT_INTERVAL_TICKS * 2) {
+            handle_key(&mut state, &mut sim, KeyCode::Char('.'), KeyModifiers::NONE);
+        }
+        // User pauses manually before scrubbing.
+        state.paused = true;
+        handle_key(&mut state, &mut sim, KeyCode::Char('<'), KeyModifiers::NONE);
+        assert!(state.scrub_offset.is_some());
+        handle_key(&mut state, &mut sim, KeyCode::Esc, KeyModifiers::NONE);
+        assert!(state.scrub_offset.is_none());
+        assert!(state.paused, "pre-scrub pause should survive scrub exit");
     }
 
     #[test]

--- a/crates/elevator-tui/src/app.rs
+++ b/crates/elevator-tui/src/app.rs
@@ -190,6 +190,20 @@ fn record_step(sim: &mut Simulation, state: &mut AppState) {
     let total_occupancy: usize = ui::shaft::cars_iter(sim).map(|car| car.riders.len()).sum();
     state.occupancy_sparkline.push(total_occupancy as u64);
     state.advance_spawn_bucket(tick, sim.time().ticks_per_second());
+
+    // Auto-snapshot for the time scrubber. Skipped while the user is
+    // *in* scrub mode — record_step still runs there if they manual-
+    // step `.` while paused, but we don't want to pollute the ring
+    // with replay-induced snapshots.
+    if state.scrub_offset.is_none() && tick.is_multiple_of(crate::state::SNAPSHOT_INTERVAL_TICKS) {
+        if state.snapshot_ring.len() == crate::state::SNAPSHOT_RING_CAP {
+            state.snapshot_ring.pop_front();
+        }
+        state.snapshot_ring.push_back(crate::state::RingEntry {
+            tick,
+            snapshot: sim.snapshot(),
+        });
+    }
 }
 
 /// Map a single keypress to a state transition (and possibly a sim
@@ -330,6 +344,10 @@ const fn handle_key_help(state: &mut AppState, code: KeyCode) {
 /// Main viewer handler — overview / drill-down / metrics share these
 /// bindings; the right-panel toggle (Enter / Esc) flips between
 /// `Overview` and `DrillDown` without changing the keymap.
+///
+/// Long because every binding is a one-arm match; splitting across
+/// helpers loses scannability without separating concerns.
+#[allow(clippy::too_many_lines)]
 fn handle_key_main(
     state: &mut AppState,
     sim: &mut Simulation,
@@ -438,13 +456,26 @@ fn handle_key_main(
             };
         }
         KeyCode::Esc => {
-            state.right_panel = RightPanel::Overview;
+            // Exit scrub mode first (the user's "go back to live"
+            // gesture); fall through to close drilldown only when
+            // not scrubbing.
+            if state.scrub_offset.is_some() {
+                handle_key_scrub_exit(state, sim);
+            } else {
+                state.right_panel = RightPanel::Overview;
+            }
         }
         KeyCode::Char('s') => {
             state.snapshot_slot = Some(sim.snapshot());
             state.flash(format!("snapshot saved @ tick {}", sim.current_tick()));
         }
         KeyCode::Char('l') => handle_key_main_load_snapshot(state, sim),
+        // `<` / `>` step the time scrubber. The first `<` snapshots
+        // the live state, pauses, and restores the newest ring entry;
+        // subsequent `<` go further back. `>` walks toward live; `Esc`
+        // jumps back to live in one go.
+        KeyCode::Char('<') => handle_key_scrub_back(state, sim),
+        KeyCode::Char('>') => handle_key_scrub_forward(state, sim),
         _ => {}
     }
 }
@@ -492,6 +523,80 @@ const fn handle_events_scroll(
             true
         }
         _ => false,
+    }
+}
+
+/// Step the time scrubber backward by one ring entry. The first
+/// press snapshots the live state (so `Esc` can restore it),
+/// pauses, and lands on the newest ring entry. Subsequent presses
+/// walk further back until the ring is exhausted.
+fn handle_key_scrub_back(state: &mut AppState, sim: &mut Simulation) {
+    if state.snapshot_ring.is_empty() {
+        state.flash("no history yet — keep stepping");
+        return;
+    }
+    let max_offset = state.snapshot_ring.len() - 1;
+    let next_offset = match state.scrub_offset {
+        None => {
+            // Entering scrub mode for the first time.
+            state.live_snapshot = Some(sim.snapshot());
+            state.paused = true;
+            0
+        }
+        Some(o) if o < max_offset => o + 1,
+        Some(_) => {
+            state.flash("at oldest snapshot");
+            return;
+        }
+    };
+    apply_scrub_offset(state, sim, next_offset);
+}
+
+/// Step the scrubber forward by one entry. At offset 0, exits scrub
+/// mode and restores the live snapshot.
+fn handle_key_scrub_forward(state: &mut AppState, sim: &mut Simulation) {
+    let Some(o) = state.scrub_offset else {
+        return;
+    };
+    if o == 0 {
+        handle_key_scrub_exit(state, sim);
+    } else {
+        apply_scrub_offset(state, sim, o - 1);
+    }
+}
+
+/// Exit scrub mode and restore the live snapshot taken on entry.
+/// `Esc` triggers this when scrubbing, mirroring how `>` would walk
+/// all the way forward.
+fn handle_key_scrub_exit(state: &mut AppState, sim: &mut Simulation) {
+    if let Some(snap) = state.live_snapshot.take()
+        && let Ok(restored) = snap.restore(None)
+    {
+        *sim = restored;
+        state.flash(format!("live @ tick {}", sim.current_tick()));
+    }
+    state.scrub_offset = None;
+    state.paused = false;
+}
+
+/// Restore the ring entry at `offset` (counted from newest) and
+/// update the scrub indicator. Helper used by both `<` and `>`.
+fn apply_scrub_offset(state: &mut AppState, sim: &mut Simulation, offset: usize) {
+    let idx = state
+        .snapshot_ring
+        .len()
+        .saturating_sub(1)
+        .saturating_sub(offset);
+    let Some(entry) = state.snapshot_ring.get(idx) else {
+        return;
+    };
+    match entry.snapshot.clone().restore(None) {
+        Ok(restored) => {
+            *sim = restored;
+            state.scrub_offset = Some(offset);
+            state.flash(format!("replay -{offset} @ tick {tick}", tick = entry.tick));
+        }
+        Err(e) => state.flash(format!("scrub failed: {e}")),
     }
 }
 
@@ -824,6 +929,42 @@ mod tests {
         handle_key(&mut state, &mut sim, KeyCode::Esc, KeyModifiers::NONE);
         assert!(state.pending_command.is_none());
         assert!(!state.quit);
+    }
+
+    #[test]
+    fn scrub_back_pauses_and_walks_history() {
+        let mut state = AppState::new(1.0).without_welcome();
+        let mut sim = demo_sim();
+        // Build up a small snapshot ring so the scrubber has somewhere
+        // to go. Three intervals → three ring entries.
+        for _ in 0..(crate::state::SNAPSHOT_INTERVAL_TICKS * 3) {
+            handle_key(&mut state, &mut sim, KeyCode::Char('.'), KeyModifiers::NONE);
+        }
+        assert_eq!(state.snapshot_ring.len(), 3);
+        let live_tick = sim.current_tick();
+        handle_key(&mut state, &mut sim, KeyCode::Char('<'), KeyModifiers::NONE);
+        assert_eq!(state.scrub_offset, Some(0));
+        assert!(state.paused);
+        assert!(state.live_snapshot.is_some());
+        assert!(sim.current_tick() <= live_tick);
+        handle_key(&mut state, &mut sim, KeyCode::Char('<'), KeyModifiers::NONE);
+        assert_eq!(state.scrub_offset, Some(1));
+    }
+
+    #[test]
+    fn esc_while_scrubbing_returns_to_live() {
+        let mut state = AppState::new(1.0).without_welcome();
+        let mut sim = demo_sim();
+        for _ in 0..(crate::state::SNAPSHOT_INTERVAL_TICKS * 2) {
+            handle_key(&mut state, &mut sim, KeyCode::Char('.'), KeyModifiers::NONE);
+        }
+        let live_tick = sim.current_tick();
+        handle_key(&mut state, &mut sim, KeyCode::Char('<'), KeyModifiers::NONE);
+        assert!(state.scrub_offset.is_some());
+        handle_key(&mut state, &mut sim, KeyCode::Esc, KeyModifiers::NONE);
+        assert!(state.scrub_offset.is_none());
+        assert!(!state.paused);
+        assert_eq!(sim.current_tick(), live_tick);
     }
 
     #[test]

--- a/crates/elevator-tui/src/app.rs
+++ b/crates/elevator-tui/src/app.rs
@@ -530,32 +530,40 @@ const fn handle_events_scroll(
 /// press snapshots the live state (so `Esc` can restore it),
 /// pauses, and lands on the newest ring entry. Subsequent presses
 /// walk further back until the ring is exhausted.
+///
+/// The scrub-entry mutations (`live_snapshot`, `paused`,
+/// `scrub_offset`) are committed only *after* the ring restore
+/// succeeds, so a failed restore leaves the user in their original
+/// state — no orphan `live_snapshot`, no silent pause without the
+/// REPLAY badge.
 fn handle_key_scrub_back(state: &mut AppState, sim: &mut Simulation) {
     if state.snapshot_ring.is_empty() {
         state.flash("no history yet — keep stepping");
         return;
     }
     let max_offset = state.snapshot_ring.len() - 1;
-    let next_offset = match state.scrub_offset {
-        None => {
-            // Entering scrub mode for the first time. Capture the
-            // *pre-scrub* pause state so `Esc` can restore it
-            // verbatim — a user who manually paused before scrubbing
-            // expects to stay paused after exiting.
-            state.live_snapshot = Some(crate::state::LiveSnapshot {
-                snapshot: sim.snapshot(),
-                was_paused: state.paused,
-            });
-            state.paused = true;
-            0
-        }
-        Some(o) if o < max_offset => o + 1,
+    let (next_offset, is_entry) = match state.scrub_offset {
+        None => (0, true),
+        Some(o) if o < max_offset => (o + 1, false),
         Some(_) => {
             state.flash("at oldest snapshot");
             return;
         }
     };
-    apply_scrub_offset(state, sim, next_offset);
+    let live_to_capture = is_entry.then(|| crate::state::LiveSnapshot {
+        snapshot: sim.snapshot(),
+        was_paused: state.paused,
+    });
+    if apply_scrub_offset(state, sim, next_offset).is_err() {
+        // Restore failed — apply_scrub_offset already flashed the
+        // error and left scrub_offset alone. Drop our staged live
+        // snapshot too so we don't carry it back to a future call.
+        return;
+    }
+    if let Some(live) = live_to_capture {
+        state.live_snapshot = Some(live);
+        state.paused = true;
+    }
 }
 
 /// Step the scrubber forward by one entry. At offset 0, exits scrub
@@ -567,7 +575,10 @@ fn handle_key_scrub_forward(state: &mut AppState, sim: &mut Simulation) {
     if o == 0 {
         handle_key_scrub_exit(state, sim);
     } else {
-        apply_scrub_offset(state, sim, o - 1);
+        // Failure here leaves scrub_offset on the prior step, which
+        // is the right behavior — user just sees the flash and can
+        // try `>` again or `Esc` out.
+        let _ = apply_scrub_offset(state, sim, o - 1);
     }
 }
 
@@ -603,22 +614,31 @@ fn handle_key_scrub_exit(state: &mut AppState, sim: &mut Simulation) {
 
 /// Restore the ring entry at `offset` (counted from newest) and
 /// update the scrub indicator. Helper used by both `<` and `>`.
-fn apply_scrub_offset(state: &mut AppState, sim: &mut Simulation, offset: usize) {
+/// Returns `Ok` after a successful restore (with `scrub_offset`
+/// committed), `Err(())` on either a missing entry or a restore
+/// failure (in which case the indicator is *not* mutated, so the
+/// caller can leave the user's prior state intact).
+fn apply_scrub_offset(state: &mut AppState, sim: &mut Simulation, offset: usize) -> Result<(), ()> {
     let idx = state
         .snapshot_ring
         .len()
         .saturating_sub(1)
         .saturating_sub(offset);
     let Some(entry) = state.snapshot_ring.get(idx) else {
-        return;
+        state.flash("scrub: snapshot ring entry missing");
+        return Err(());
     };
     match entry.snapshot.clone().restore(None) {
         Ok(restored) => {
             *sim = restored;
             state.scrub_offset = Some(offset);
             state.flash(format!("replay -{offset} @ tick {tick}", tick = entry.tick));
+            Ok(())
         }
-        Err(e) => state.flash(format!("scrub failed: {e}")),
+        Err(e) => {
+            state.flash(format!("scrub failed: {e}"));
+            Err(())
+        }
     }
 }
 

--- a/crates/elevator-tui/src/state.rs
+++ b/crates/elevator-tui/src/state.rs
@@ -157,6 +157,19 @@ pub struct RingEntry {
     pub snapshot: elevator_core::snapshot::WorldSnapshot,
 }
 
+/// Snapshot of the live sim plus the pre-scrub pause state.
+///
+/// Captured when the user first enters scrub mode. Restoring both
+/// fields on `Esc` returns the user exactly to the moment they
+/// started inspecting — the pause state isn't silently un-paused.
+#[derive(Debug, Clone)]
+pub struct LiveSnapshot {
+    /// The live sim snapshot.
+    pub snapshot: elevator_core::snapshot::WorldSnapshot,
+    /// Whether the sim was paused before scrub mode entered.
+    pub was_paused: bool,
+}
+
 /// Take an auto-snapshot every N ticks.
 ///
 /// Tuned so that 30 entries (`SNAPSHOT_RING_CAP`) covers roughly 15
@@ -254,10 +267,11 @@ pub struct AppState {
     /// [`SNAPSHOT_INTERVAL_TICKS`] ticks. Drives the time scrubber:
     /// `<` steps back, `>` steps forward, `Esc` resumes live.
     pub snapshot_ring: std::collections::VecDeque<RingEntry>,
-    /// Snapshot taken on entry into scrub mode so `Esc` can restore
-    /// the user to the moment they started inspecting. `None` outside
-    /// scrub mode.
-    pub live_snapshot: Option<elevator_core::snapshot::WorldSnapshot>,
+    /// Context captured on entry into scrub mode so `Esc` can fully
+    /// restore the user to the moment they started inspecting —
+    /// including their pre-scrub pause state. `None` outside scrub
+    /// mode.
+    pub live_snapshot: Option<LiveSnapshot>,
     /// Position in `snapshot_ring` currently being viewed. `None` =
     /// live (not scrubbing); `Some(N)` = `N` entries back from the
     /// newest auto-snapshot. Bounded by `snapshot_ring.len() - 1`.

--- a/crates/elevator-tui/src/state.rs
+++ b/crates/elevator-tui/src/state.rs
@@ -148,6 +148,26 @@ impl Sparkline {
     }
 }
 
+/// One entry in the rolling auto-snapshot ring used by the scrubber.
+#[derive(Debug, Clone)]
+pub struct RingEntry {
+    /// Tick at which the snapshot was taken.
+    pub tick: u64,
+    /// The world snapshot itself.
+    pub snapshot: elevator_core::snapshot::WorldSnapshot,
+}
+
+/// Take an auto-snapshot every N ticks.
+///
+/// Tuned so that 30 entries (`SNAPSHOT_RING_CAP`) covers roughly 15
+/// seconds of sim time at the default 60 t/s — enough history to
+/// step back and watch what just happened without burning memory on
+/// every tick.
+pub const SNAPSHOT_INTERVAL_TICKS: u64 = 30;
+
+/// Capacity of the ring; oldest entries drop when full.
+pub const SNAPSHOT_RING_CAP: usize = 30;
+
 /// Vim-style scroll motions the events pane responds to.
 ///
 /// The motions are intentionally pane-agnostic — once the metrics
@@ -230,6 +250,18 @@ pub struct AppState {
     pub bucket_started_at: u64,
     /// In-memory snapshot slot (`s` saves, `l` restores).
     pub snapshot_slot: Option<elevator_core::snapshot::WorldSnapshot>,
+    /// Rolling ring of auto-snapshots taken every
+    /// [`SNAPSHOT_INTERVAL_TICKS`] ticks. Drives the time scrubber:
+    /// `<` steps back, `>` steps forward, `Esc` resumes live.
+    pub snapshot_ring: std::collections::VecDeque<RingEntry>,
+    /// Snapshot taken on entry into scrub mode so `Esc` can restore
+    /// the user to the moment they started inspecting. `None` outside
+    /// scrub mode.
+    pub live_snapshot: Option<elevator_core::snapshot::WorldSnapshot>,
+    /// Position in `snapshot_ring` currently being viewed. `None` =
+    /// live (not scrubbing); `Some(N)` = `N` entries back from the
+    /// newest auto-snapshot. Bounded by `snapshot_ring.len() - 1`.
+    pub scrub_offset: Option<usize>,
     /// Status banner (transient feedback after a hotkey action).
     pub status: Option<String>,
     /// Monotonically incrementing counter bumped each time [`flash`] is
@@ -295,6 +327,9 @@ impl AppState {
             spawn_bucket: 0,
             bucket_started_at: 0,
             snapshot_slot: None,
+            snapshot_ring: std::collections::VecDeque::with_capacity(SNAPSHOT_RING_CAP),
+            live_snapshot: None,
+            scrub_offset: None,
             status: None,
             status_seq: 0,
             overlay: Some(UiOverlay::Welcome),

--- a/crates/elevator-tui/src/ui/mod.rs
+++ b/crates/elevator-tui/src/ui/mod.rs
@@ -73,7 +73,7 @@ fn draw_title(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulat
     } else {
         Style::default().fg(palette::SUCCESS)
     };
-    let spans = vec![
+    let mut spans = vec![
         Span::styled(
             " elevator-tui ",
             Style::default()
@@ -85,6 +85,21 @@ fn draw_title(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulat
             format!("tick {}", sim.current_tick()),
             Style::default().fg(palette::DIM_STRONG),
         ),
+    ];
+    // Scrub-mode badge — accent-colored so it visually leaps off the
+    // title row, paired with the offset so the user knows how far
+    // back they've stepped.
+    if let Some(offset) = state.scrub_offset {
+        spans.push(Span::styled(" · ", Style::default().fg(palette::DIM)));
+        spans.push(Span::styled(
+            format!(" REPLAY -{offset} "),
+            Style::default()
+                .fg(palette::WARN)
+                .add_modifier(Modifier::BOLD)
+                .add_modifier(Modifier::REVERSED),
+        ));
+    }
+    spans.extend([
         Span::styled(" · ", Style::default().fg(palette::DIM)),
         Span::styled(run_glyph.to_string(), run_style),
         Span::styled(
@@ -101,7 +116,7 @@ fn draw_title(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulat
             format!("{:?}", state.right_panel).to_lowercase(),
             Style::default().fg(palette::DIM_STRONG),
         ),
-    ];
+    ]);
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 


### PR DESCRIPTION
## Summary

Fifth PR in the TUI overhaul. Auto-snapshots the sim every \`SNAPSHOT_INTERVAL_TICKS\` (=30) ticks into a 30-slot ring; \`<\` and \`>\` walk that ring backward and forward so the user can replay what just happened without manual \`s\`/\`l\` save and restore.

- **Auto-snapshot.** \`record_step\` pushes a fresh \`WorldSnapshot\` every 30 ticks (oldest dropped at cap 30 → ~15s of history at 60 t/s). Skipped while in scrub mode so replay-induced state doesn't poison the ring.
- **\`<\` enters scrub mode** by stashing the current sim as \`live_snapshot\`, pausing, and restoring the newest ring entry. Subsequent \`<\` walk further back; \`>\` walks toward live.
- **\`Esc\` exits scrub mode**, restoring \`live_snapshot\` so the user resumes exactly where they were when they started replaying.
- **Title bar** shows a \`REPLAY -N\` badge while scrubbing — accent-warn-reversed so it visually leaps off the row.
- **Tests.** Two new unit tests cover ring growth, the pause-on-entry, and the live-restore on exit.

## Test plan

- [x] \`cargo test -p elevator-tui --all-targets\` (33 lib + 9 snapshot passing)
- [x] \`cargo clippy -p elevator-tui --all-targets -- -D warnings\`
- [x] Pre-commit hook green
- [ ] Manual: let sim run ~30 s, press \`<\` — REPLAY badge appears, sim jumps back; \`>\` walks forward; Esc returns to live