### PR TITLE
feat(tui): add mouse support (wheel scroll + click-to-focus pane)

### DIFF
--- a/crates/elevator-tui/src/app.rs
+++ b/crates/elevator-tui/src/app.rs
@@ -5,7 +5,10 @@ use std::io::{self, Stdout};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context as _, Result};
-use crossterm::event::{self, Event as TermEvent, KeyCode, KeyEventKind, KeyModifiers};
+use crossterm::event::{
+    self, DisableMouseCapture, EnableMouseCapture, Event as TermEvent, KeyCode, KeyEventKind,
+    KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+};
 use crossterm::execute;
 use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen};
 use elevator_core::config::SimConfig;
@@ -86,10 +89,12 @@ fn event_loop(
             if !event::poll(remaining).context("polling input")? {
                 break;
             }
-            if let TermEvent::Key(key) = event::read().context("reading input")?
-                && key.kind == KeyEventKind::Press
-            {
-                handle_key(&mut state, &mut sim, key.code, key.modifiers);
+            match event::read().context("reading input")? {
+                TermEvent::Key(key) if key.kind == KeyEventKind::Press => {
+                    handle_key(&mut state, &mut sim, key.code, key.modifiers);
+                }
+                TermEvent::Mouse(mouse) => handle_mouse(&mut state, &mut sim, mouse),
+                _ => {}
             }
             if state.quit {
                 return Ok(());
@@ -243,6 +248,36 @@ fn handle_key(state: &mut AppState, sim: &mut Simulation, code: KeyCode, modifie
         return;
     }
     handle_key_main(state, sim, code, modifiers);
+}
+
+/// Mouse handler — wheel scrolls the events pane (when focused),
+/// left-click on a tracked pane refocuses it, scroll over a pane
+/// also refocuses it as a side effect of the wheel motion. Click
+/// on a car or event row is deferred to a follow-up PR.
+fn handle_mouse(state: &mut AppState, _sim: &mut Simulation, mouse: MouseEvent) {
+    let rects = state.pane_rects.get();
+    let (col, row) = (mouse.column, mouse.row);
+    match mouse.kind {
+        MouseEventKind::Down(MouseButton::Left) => {
+            if let Some(pane) = rects.hit(col, row) {
+                state.focused_pane = pane;
+                state.flash(format!("focus → {}", pane.label()));
+            }
+        }
+        MouseEventKind::ScrollUp
+            if rects.events.is_some_and(|b| b.contains(col, row))
+                || state.focused_pane == FocusedPane::Events =>
+        {
+            state.scroll_events(crate::state::ScrollMotion::Up);
+        }
+        MouseEventKind::ScrollDown
+            if rects.events.is_some_and(|b| b.contains(col, row))
+                || state.focused_pane == FocusedPane::Events =>
+        {
+            state.scroll_events(crate::state::ScrollMotion::Down);
+        }
+        _ => {}
+    }
 }
 
 /// Filter-input handler — keys flow into `state.pending_filter`
@@ -679,12 +714,13 @@ const fn digit_to_category(d: char) -> Option<EventCategory> {
     })
 }
 
-/// Switch the terminal into raw mode + alternate screen and wrap it
-/// in a [`Terminal`] backed by [`CrosstermBackend`].
+/// Switch the terminal into raw mode + alternate screen, enable
+/// mouse capture, and wrap stdout in a [`Terminal`] backed by
+/// [`CrosstermBackend`].
 fn setup_terminal() -> io::Result<Terminal<CrosstermBackend<Stdout>>> {
     crossterm::terminal::enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen)?;
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
     Terminal::new(CrosstermBackend::new(stdout))
 }
 
@@ -695,7 +731,7 @@ struct TerminalGuard;
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
         let _ = crossterm::terminal::disable_raw_mode();
-        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+        let _ = execute!(io::stdout(), DisableMouseCapture, LeaveAlternateScreen);
     }
 }
 

--- a/crates/elevator-tui/src/app.rs
+++ b/crates/elevator-tui/src/app.rs
@@ -255,10 +255,16 @@ fn handle_key(state: &mut AppState, sim: &mut Simulation, code: KeyCode, modifie
 /// also refocuses it as a side effect of the wheel motion. Click
 /// on a car or event row is deferred to a follow-up PR.
 fn handle_mouse(state: &mut AppState, _sim: &mut Simulation, mouse: MouseEvent) {
+    // While the drilldown popup is up it overlays parts of the right
+    // column. `pane_rects` still tracks the panes underneath, so a
+    // click landing inside the popup that happens to fall over the
+    // events / metrics rect would silently change focus on hidden
+    // content. Skip click-to-focus entirely until the popup closes.
+    let popup_active = state.right_panel == RightPanel::DrillDown;
     let rects = state.pane_rects.get();
     let (col, row) = (mouse.column, mouse.row);
     match mouse.kind {
-        MouseEventKind::Down(MouseButton::Left) => {
+        MouseEventKind::Down(MouseButton::Left) if !popup_active => {
             if let Some(pane) = rects.hit(col, row) {
                 state.focused_pane = pane;
                 state.flash(format!("focus → {}", pane.label()));

--- a/crates/elevator-tui/src/state.rs
+++ b/crates/elevator-tui/src/state.rs
@@ -181,6 +181,69 @@ pub const SNAPSHOT_INTERVAL_TICKS: u64 = 30;
 /// Capacity of the ring; oldest entries drop when full.
 pub const SNAPSHOT_RING_CAP: usize = 30;
 
+/// Last-rendered bounding box for one pane, in terminal cells.
+/// State holds a plain tuple so it doesn't need a ratatui dep — the
+/// renderer is the only place that constructs these.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct PaneBox {
+    /// Inclusive left column.
+    pub x: u16,
+    /// Inclusive top row.
+    pub y: u16,
+    /// Width in cells (border-inclusive).
+    pub w: u16,
+    /// Height in cells (border-inclusive).
+    pub h: u16,
+}
+
+impl PaneBox {
+    /// `true` when the cell at `(col, row)` lies inside this box.
+    #[must_use]
+    pub const fn contains(&self, col: u16, row: u16) -> bool {
+        col >= self.x
+            && col < self.x.saturating_add(self.w)
+            && row >= self.y
+            && row < self.y.saturating_add(self.h)
+    }
+}
+
+/// Most recently rendered bounding boxes for each focusable pane.
+/// `None` for a pane means it wasn't on screen this frame.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PaneRects {
+    /// Left-column shaft view bounds.
+    pub shaft: Option<PaneBox>,
+    /// Dispatch panel bounds (right column).
+    pub dispatch: Option<PaneBox>,
+    /// Events panel bounds (right column).
+    pub events: Option<PaneBox>,
+    /// Metrics panel bounds (right column).
+    pub metrics: Option<PaneBox>,
+    /// Traffic panel bounds (right column).
+    pub traffic: Option<PaneBox>,
+}
+
+impl PaneRects {
+    /// Hit-test a `(col, row)` against every recorded pane and return
+    /// the matching `FocusedPane`. `None` if the click landed in a
+    /// gap or outside any tracked pane (footer, title bar, popup).
+    #[must_use]
+    pub fn hit(&self, col: u16, row: u16) -> Option<FocusedPane> {
+        for (pane, b) in [
+            (FocusedPane::Shaft, &self.shaft),
+            (FocusedPane::Dispatch, &self.dispatch),
+            (FocusedPane::Events, &self.events),
+            (FocusedPane::Metrics, &self.metrics),
+            (FocusedPane::Traffic, &self.traffic),
+        ] {
+            if b.is_some_and(|b| b.contains(col, row)) {
+                return Some(pane);
+            }
+        }
+        None
+    }
+}
+
 /// Vim-style scroll motions the events pane responds to.
 ///
 /// The motions are intentionally pane-agnostic — once the metrics
@@ -316,6 +379,16 @@ pub struct AppState {
     /// `Esc` cancels. Mutually exclusive with `pending_filter` —
     /// the dispatcher checks both.
     pub pending_command: Option<String>,
+    /// Most recently rendered panel bounding boxes, keyed by pane.
+    /// Populated each frame by `ui::draw` and consumed by the mouse
+    /// handler to map a click to a focus target. `None` (default)
+    /// values mean the pane wasn't on screen this frame.
+    ///
+    /// Wrapped in [`std::cell::Cell`] so the renderer can write to it
+    /// through a `&AppState` borrow without cascading `&mut` through
+    /// every panel's `draw` signature; `PaneRects: Copy` makes
+    /// `Cell::set` / `Cell::get` cheap.
+    pub pane_rects: std::cell::Cell<PaneRects>,
     /// User has requested a clean exit.
     pub quit: bool,
 }
@@ -352,6 +425,7 @@ impl AppState {
             pending_filter: None,
             gg_pending: false,
             pending_command: None,
+            pane_rects: std::cell::Cell::default(),
             quit: false,
         }
     }

--- a/crates/elevator-tui/src/ui/mod.rs
+++ b/crates/elevator-tui/src/ui/mod.rs
@@ -8,7 +8,7 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
-use crate::state::{AppState, FocusedPane, RightPanel, UiOverlay};
+use crate::state::{AppState, FocusedPane, PaneBox, PaneRects, RightPanel, UiOverlay};
 
 pub mod dispatch;
 pub mod drilldown;
@@ -46,7 +46,19 @@ pub fn draw(frame: &mut Frame<'_>, state: &AppState, sim: &Simulation) {
     // a centered popup overlaid on top, not a panel that steals the
     // column. Preserves spatial context (you can still see where the
     // car sits in the shaft behind the popup).
-    draw_overview(frame, body[1], state, sim);
+    let right_rects = draw_overview(frame, body[1], state, sim);
+
+    // Track the bounding boxes of every focusable pane so the mouse
+    // handler can map a click back to a `FocusedPane`. Cell-based
+    // interior mutability lets us write through `&AppState` without
+    // cascading `&mut` through every panel's `draw` signature.
+    state.pane_rects.set(PaneRects {
+        shaft: Some(rect_to_box(body[0])),
+        dispatch: right_rects.dispatch,
+        events: right_rects.events,
+        metrics: right_rects.metrics,
+        traffic: right_rects.traffic,
+    });
 
     draw_footer(frame, outer[2], state);
 
@@ -275,8 +287,39 @@ fn extend_with_key_hints(
     }
 }
 
+/// Convert a ratatui `Rect` to the state-side `PaneBox` (which lives
+/// in `state.rs` to keep that module dep-free of ratatui).
+const fn rect_to_box(r: Rect) -> PaneBox {
+    PaneBox {
+        x: r.x,
+        y: r.y,
+        w: r.width,
+        h: r.height,
+    }
+}
+
+/// Bounding boxes for the four right-column panes, returned from
+/// `draw_overview` so the top-level draw can stitch them into
+/// `state.pane_rects` for mouse hit-testing.
+#[derive(Debug, Default, Clone, Copy)]
+struct OverviewRects {
+    /// Dispatch panel bounds (right column, top).
+    dispatch: Option<PaneBox>,
+    /// Events panel bounds (right column, fills slack).
+    events: Option<PaneBox>,
+    /// Traffic panel bounds (right column).
+    traffic: Option<PaneBox>,
+    /// Metrics panel bounds (right column, bottom).
+    metrics: Option<PaneBox>,
+}
+
 /// Right column = Dispatch / Events / Traffic / Metrics stacked.
-fn draw_overview(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulation) {
+fn draw_overview(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    state: &AppState,
+    sim: &Simulation,
+) -> OverviewRects {
     // Dispatch fills proportionally to the car count so the panel keeps
     // every car visible even on busier configs (group line + 1 row/car
     // + a 2-row title border = `cars + 3`). Traffic is one sparkline
@@ -300,6 +343,12 @@ fn draw_overview(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simu
     events::draw(frame, chunks[1], state, sim);
     traffic::draw(frame, chunks[2], state, sim);
     metrics::draw(frame, chunks[3], state, sim);
+    OverviewRects {
+        dispatch: Some(rect_to_box(chunks[0])),
+        events: Some(rect_to_box(chunks[1])),
+        traffic: Some(rect_to_box(chunks[2])),
+        metrics: Some(rect_to_box(chunks[3])),
+    }
 }
 
 /// Center a fixed-size rectangle inside `area`. If `area` is smaller


### PR DESCRIPTION
## Summary

Sixth PR in the TUI overhaul. Brings the TUI in line with the 2026 expectation that wheel + click work alongside the keyboard.

- **Mouse capture.** \`setup_terminal\` enables \`EnableMouseCapture\`; the \`TerminalGuard\` drop disables it on exit so the terminal doesn't leak escape-sequence reporting.
- **\`PaneRects\` tracking.** New state-side \`PaneBox\` / \`PaneRects\` types record the bounding box of every focusable pane each frame, populated in \`ui::draw\` and threaded out of \`draw_overview\`. Wrapped in a \`Cell\` so the renderer writes through \`&AppState\` without cascading \`&mut\` through every panel's draw signature.
- **Click on a pane focuses it.** \`handle_mouse(MouseEventKind::Down(Left))\` hit-tests the click against \`pane_rects\` and updates \`state.focused_pane\`, with a flash for feedback.
- **Wheel scrolls the events pane.** Wheel up/down on the events rect (or anywhere when the events pane is already focused) walks \`events_scroll\` via the same \`ScrollMotion\` helper used by \`j\`/\`k\`.

Click-on-car (shaft hit-testing per row → \`focused_car_idx\`) and click-on-event-row (set follow target) are deferred to a follow-up to keep this PR small.