### PR TITLE
feat(tui): add accent-flash decay on arrival and door-open

### DIFF
--- a/crates/elevator-tui/src/app.rs
+++ b/crates/elevator-tui/src/app.rs
@@ -1087,12 +1087,13 @@ mod tests {
         // by `record_step` rather than accumulating indefinitely.
         let mut state = AppState::new(1.0).without_welcome();
         let mut sim = demo_sim();
-        // Seed a flash that already expired.
-        let stale = elevator_core::entity::EntityId::from(slotmap::KeyData::from_ffi(99));
-        state.flash_until.insert(stale, 0);
+        // Seed a flash that already expired (key chosen to avoid
+        // colliding with `state` per clippy::similar_names).
+        let phantom_id = elevator_core::entity::EntityId::from(slotmap::KeyData::from_ffi(99));
+        state.flash_until.insert(phantom_id, 0);
         // Step once to trigger record_step's GC pass.
         handle_key(&mut state, &mut sim, KeyCode::Char('.'), KeyModifiers::NONE);
-        assert!(!state.flash_until.contains_key(&stale));
+        assert!(!state.flash_until.contains_key(&phantom_id));
     }
 
     #[test]

--- a/crates/elevator-tui/src/app.rs
+++ b/crates/elevator-tui/src/app.rs
@@ -182,13 +182,26 @@ fn step_no_traffic(sim: &mut Simulation, state: &mut AppState) {
 fn record_step(sim: &mut Simulation, state: &mut AppState) {
     let tick = sim.current_tick();
     let drained = sim.drain_events();
-    let spawned: u64 = drained
-        .iter()
-        .filter(|e| matches!(e, elevator_core::events::Event::RiderSpawned { .. }))
-        .count() as u64;
+    let mut spawned: u64 = 0;
+    let flash_expiry = tick + crate::state::FLASH_DURATION_TICKS;
+    for event in &drained {
+        match event {
+            elevator_core::events::Event::RiderSpawned { .. } => spawned += 1,
+            // Set / refresh the accent flash for the elevator that
+            // arrived or whose doors opened — the eye-catch readers
+            // rely on at-a-glance.
+            elevator_core::events::Event::ElevatorArrived { elevator, .. }
+            | elevator_core::events::Event::DoorOpened { elevator, .. } => {
+                state.flash_until.insert(*elevator, flash_expiry);
+            }
+            _ => {}
+        }
+    }
     for _ in 0..spawned {
         state.observe_spawn();
     }
+    // GC expired flashes so the map stays bounded by live entity count.
+    state.flash_until.retain(|_, exp| *exp > tick);
     state.push_events(tick, drained);
 
     state.wait_sparkline.push(sim.metrics().p95_wait_time());
@@ -1066,6 +1079,20 @@ mod tests {
         assert!(state.scrub_offset.is_none());
         assert!(!state.paused);
         assert_eq!(sim.current_tick(), live_tick);
+    }
+
+    #[test]
+    fn flash_until_gc_drops_expired_entries() {
+        // After enough ticks pass, expired flash entries are reaped
+        // by `record_step` rather than accumulating indefinitely.
+        let mut state = AppState::new(1.0).without_welcome();
+        let mut sim = demo_sim();
+        // Seed a flash that already expired.
+        let stale = elevator_core::entity::EntityId::from(slotmap::KeyData::from_ffi(99));
+        state.flash_until.insert(stale, 0);
+        // Step once to trigger record_step's GC pass.
+        handle_key(&mut state, &mut sim, KeyCode::Char('.'), KeyModifiers::NONE);
+        assert!(!state.flash_until.contains_key(&stale));
     }
 
     #[test]

--- a/crates/elevator-tui/src/state.rs
+++ b/crates/elevator-tui/src/state.rs
@@ -592,7 +592,14 @@ impl AppState {
     /// Take the in-progress command for execution. Returns the buffer
     /// (so the caller can parse + dispatch) and exits palette mode.
     /// `None` if the palette wasn't open.
-    pub const fn command_input_take(&mut self) -> Option<String> {
+    ///
+    /// `#[allow(clippy::missing_const_for_fn)]` keeps this consistent
+    /// with every other `&mut self` method on `AppState` — the
+    /// receiver type contains heap collections so this could never
+    /// actually be called in a const context, and marking it `const`
+    /// would mislead readers into thinking otherwise.
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn command_input_take(&mut self) -> Option<String> {
         self.pending_command.take()
     }
 

--- a/crates/elevator-tui/src/state.rs
+++ b/crates/elevator-tui/src/state.rs
@@ -170,6 +170,13 @@ pub struct LiveSnapshot {
     pub was_paused: bool,
 }
 
+/// How many sim ticks an accent flash on a car glyph stays bright.
+///
+/// Tuned for ~100 ms at 60 t/s — long enough to register
+/// peripherally but short enough that the panel doesn't strobe
+/// under heavy traffic.
+pub const FLASH_DURATION_TICKS: u64 = 6;
+
 /// Take an auto-snapshot every N ticks.
 ///
 /// Tuned so that 30 entries (`SNAPSHOT_RING_CAP`) covers roughly 15
@@ -389,6 +396,11 @@ pub struct AppState {
     /// every panel's `draw` signature; `PaneRects: Copy` makes
     /// `Cell::set` / `Cell::get` cheap.
     pub pane_rects: std::cell::Cell<PaneRects>,
+    /// Per-entity accent-flash expiry: entity → tick at which the
+    /// flash fades. `record_step` writes here on `ElevatorArrived`
+    /// and `DoorOpened`; the shaft renderer overlays an accent style
+    /// while `current_tick < expiry`.
+    pub flash_until: std::collections::HashMap<elevator_core::entity::EntityId, u64>,
     /// User has requested a clean exit.
     pub quit: bool,
 }
@@ -426,6 +438,7 @@ impl AppState {
             gg_pending: false,
             pending_command: None,
             pane_rects: std::cell::Cell::default(),
+            flash_until: std::collections::HashMap::new(),
             quit: false,
         }
     }

--- a/crates/elevator-tui/src/ui/palette.rs
+++ b/crates/elevator-tui/src/ui/palette.rs
@@ -61,6 +61,20 @@ pub fn focused_style() -> Style {
         .add_modifier(Modifier::REVERSED)
 }
 
+/// Brief accent flash overlay used for a few frames after a car
+/// arrives or its doors open.
+///
+/// Different shape from `focused_style` (warn-on-accent vs
+/// accent-reverse) so the two cues read distinctly when both are
+/// active on the same glyph.
+#[must_use]
+pub fn flash_style() -> Style {
+    Style::default()
+        .fg(WARN)
+        .bg(ACCENT)
+        .add_modifier(Modifier::BOLD)
+}
+
 /// Border style for a panel: accent-bold when focused, dim otherwise.
 ///
 /// Centralizing this means the focus visual lights up consistently

--- a/crates/elevator-tui/src/ui/shaft.rs
+++ b/crates/elevator-tui/src/ui/shaft.rs
@@ -149,12 +149,18 @@ pub fn draw(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulatio
         })
         .collect();
 
+    // Filter the flash-until map down to live entries for this tick.
+    // Carrying the whole map into row rendering would be fine but the
+    // closure capture is cleaner with a `Fn(EntityId) -> bool`.
+    let now = sim.current_tick();
+    let is_flashing = |id: EntityId| state.flash_until.get(&id).is_some_and(|&exp| exp > now);
     let ctx = RenderCtx {
         cars: &cars,
         nearest_stop_by_car: &nearest_stop_by_car,
         focused,
         hall_calls: &hall_calls,
         sim,
+        flashing: &is_flashing,
     };
     let lines: Vec<Line<'_>> = match state.shaft_mode {
         ShaftMode::Index => render_index_mode(&stops, &ctx, inner.height),
@@ -176,6 +182,8 @@ struct RenderCtx<'a> {
     hall_calls: &'a HashMap<EntityId, (bool, bool)>,
     /// Borrowed simulation, used for waiting-rider counts and stop lookups.
     sim: &'a Simulation,
+    /// `true` for entities whose accent flash is still live this frame.
+    flashing: &'a dyn Fn(EntityId) -> bool,
 }
 
 /// One row per stop. Stop list truncates to fit the available height.
@@ -282,7 +290,8 @@ fn stop_row<'a>(stop_id: EntityId, stop: &'a Stop, ctx: &RenderCtx<'a>) -> Line<
     ));
     for car in ctx.cars {
         let here = ctx.nearest_stop_by_car.get(&car.id) == Some(&stop_id);
-        spans.push(car_glyph_for_stop(car, here, ctx.focused));
+        let flashing = (ctx.flashing)(car.id);
+        spans.push(car_glyph_for_stop(car, here, ctx.focused, flashing));
         spans.push(Span::raw(" "));
     }
     Line::from(spans)
@@ -324,8 +333,16 @@ fn spacer_row<'a>(
     Line::from(spans)
 }
 
-/// Pick the glyph + style for a car at a given stop.
-fn car_glyph_for_stop<'a>(car: &CarView<'a>, here: bool, focused: Option<EntityId>) -> Span<'a> {
+/// Pick the glyph + style for a car at a given stop. `flashing`
+/// overlays an accent style when the car just arrived or its doors
+/// just opened — a per-frame visual cue that decays over
+/// `FLASH_DURATION_TICKS`.
+fn car_glyph_for_stop<'a>(
+    car: &CarView<'a>,
+    here: bool,
+    focused: Option<EntityId>,
+    flashing: bool,
+) -> Span<'a> {
     if !here {
         return Span::styled("·", Style::default().fg(palette::DIM));
     }
@@ -349,6 +366,8 @@ fn car_glyph_for_stop<'a>(car: &CarView<'a>, here: bool, focused: Option<EntityI
     };
     let style = if focused == Some(car.id) {
         palette::focused_style()
+    } else if flashing {
+        palette::flash_style()
     } else {
         Style::default().fg(color)
     };


### PR DESCRIPTION
## Summary

Seventh PR in the TUI overhaul. A short visual cue overlays the car glyph in the shaft when an \`ElevatorArrived\` or \`DoorOpened\` event fires, decaying after \`FLASH_DURATION_TICKS\` (=6, ~100 ms at 60 t/s). Helps the eye catch arrivals at a glance without being strobey under heavy traffic.

- **\`flash_until: HashMap<EntityId, u64>\`** on \`AppState\` records the expiry tick for each flashing entity. Updated in \`record_step\` when the relevant events drain; expired entries reaped each step so the map stays bounded by the live entity count.
- **\`palette::flash_style()\`** is the new overlay style (warn-on-accent + bold) — distinct from \`focused_style\` (accent-reverse) so both cues read clearly when active on the same glyph.
- **\`shaft::car_glyph_for_stop\`** takes a new \`flashing: bool\` flag and returns the flash style when true (and the entity isn't already focused — focus wins to keep selection visible).
- **\`RenderCtx\`** carries a \`flashing: &dyn Fn(EntityId) -> bool\` closure so each row can hit-test without rebuilding a HashSet.
- New unit test \`flash_until_gc_drops_expired_entries\` pins the GC.

Themes and responsive layout (originally bundled with this PR) are deferred to follow-up PRs to keep this small. Accent flashes alone are the highest-impact polish from the original PR7 plan.

## Series wrap

This is the last PR in the planned 7. With this merged the TUI ships with: focus model + mode-aware footer (#739), vim scroll + \`/\` filter (#740), \`:\` palette (#741), floating drilldown popup (#742), snapshot ring buffer + time scrubber (#743), mouse wheel + click-to-focus (#744), and accent flashes (this PR).

Deferred follow-ups (out of scope, can be picked up later): theme registry + responsive layout + scenario picker + sub-cell shaft motion + tui-big-text headline metric + click-on-car/event row.

## Test plan

- [x] \`cargo test -p elevator-tui --all-targets\` (35 lib + 9 snapshot passing)
- [x] \`cargo clippy -p elevator-tui --all-targets -- -D warnings\`
- [x] Pre-commit hook green
- [ ] Manual: watch a sim with traffic — cars flash briefly when arriving and when doors open