### PR TITLE
docs(tui): separate event_elevator and event_touches docstrings

### DIFF
--- a/crates/elevator-tui/src/state.rs
+++ b/crates/elevator-tui/src/state.rs
@@ -635,16 +635,11 @@ pub fn all_categories() -> HashSet<EventCategory> {
     ])
 }
 
-/// True when an event references the given entity in any of its
-/// commonly-named slots.
+/// Extract the elevator entity an event most directly concerns,
+/// if any.
 ///
-/// Cheap structural match; we don't reflect every variant — only the
-/// ones a follow filter would care about (cars and riders). Stops
-/// aren't followed today, so `at_stop`/`from_stop` are not consulted
-/// here.
-/// Extract the elevator entity an event most directly concerns, if
-/// any. Used by mouse click-on-event-row to map the clicked event
-/// back to a focusable car. Rider-only events return `None` — the
+/// Used by mouse click-on-event-row to map the clicked event back
+/// to a focusable car. Rider-only events return `None` — the
 /// follow target is keyed off cars in the current UI.
 #[must_use]
 pub const fn event_elevator(event: &Event) -> Option<elevator_core::entity::EntityId> {


### PR DESCRIPTION
Greptile P2 follow-up to #746. The original PR landed with the leftover \`event_touches\` doc block between functions — without a blank separator, rustdoc parsed lines 638–644 as part of \`event_elevator\`'s docs, so the rendered docs led with the wrong description.

\`event_touches\` already grew its own correct doc block in the original PR; the leftover lines were dead weight. This PR just deletes them.