### PR TITLE
fix(tui): clarify COMPACT_LAYOUT_THRESHOLD is body height not terminal

### DIFF
--- a/crates/elevator-tui/src/ui/mod.rs
+++ b/crates/elevator-tui/src/ui/mod.rs
@@ -313,12 +313,13 @@ struct OverviewRects {
     metrics: Option<PaneBox>,
 }
 
-/// Threshold (in rows) below which the metrics panel collapses its
-/// 4-row big-text headline into a single counter line, reclaiming
-/// 5 rows for the events panel above. 32 rows is roughly "average
-/// terminal" — anything shorter starts to feel cramped with the
-/// glyph headline taking a quarter of the right column.
-const COMPACT_LAYOUT_THRESHOLD: u16 = 32;
+/// Body-height threshold (in rows) below which the metrics panel
+/// collapses its 4-row big-text headline. The body excludes the
+/// 1-row title bar and 1-row footer, so this maps to a terminal
+/// height of 32 (= 30 body rows + 2 chrome). Anything shorter
+/// starts to feel cramped with the glyph headline taking a
+/// quarter of the right column.
+const COMPACT_LAYOUT_THRESHOLD: u16 = 30;
 
 /// Right column = Dispatch / Events / Traffic / Metrics stacked.
 fn draw_overview(


### PR DESCRIPTION
Greptile P2 follow-up to #754. The constant was compared against `area.height` — the body height after subtracting the 1-row title bar and 1-row footer — but the name and comments said "terminal height". Compact mode therefore actually fired at terminal heights below 34, not 32. Dropped the constant to 30 (= 32 terminal − 2 chrome) and clarified the docs.