### PR TITLE
chore: drop unused deps flagged by cargo-machete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2659,7 +2659,6 @@ dependencies = [
  "elevator-core",
  "rand 0.10.1",
  "ron",
- "serde",
 ]
 
 [[package]]
@@ -2698,7 +2697,6 @@ dependencies = [
  "elevator-layout-runtime",
  "linkme",
  "ron",
- "serde",
  "slotmap",
 ]
 

--- a/crates/elevator-bevy/Cargo.toml
+++ b/crates/elevator-bevy/Cargo.toml
@@ -11,6 +11,5 @@ workspace = true
 [dependencies]
 elevator-core = { path = "../elevator-core" }
 bevy = { version = "0.18", default-features = false, features = ["2d"] }
-serde.workspace = true
 ron.workspace = true
 rand.workspace = true

--- a/crates/elevator-ffi/Cargo.toml
+++ b/crates/elevator-ffi/Cargo.toml
@@ -44,8 +44,12 @@ elevator-layout-derive = { path = "../elevator-layout-derive" }
 elevator-layout-runtime = { path = "../elevator-layout-runtime" }
 linkme = "0.3"
 ron = { workspace = true }
-serde = { workspace = true }
 slotmap = { workspace = true }
+
+# linkme is used via paths emitted by the MultiHostLayout derive macro
+# (`::linkme::distributed_slice`), so cargo-machete does not see it.
+[package.metadata.cargo-machete]
+ignored = ["linkme"]
 
 [build-dependencies]
 cbindgen = "0.29"


### PR DESCRIPTION
## Summary
- Tech-debt audit with `cargo machete` flagged three unused dependencies; this PR drops the genuinely-unused ones and pins the false positive
- Removes `serde` from `elevator-bevy` (no `Serialize`/`Deserialize` derives, no `serde::` paths anywhere in the crate)
- Removes `serde` from `elevator-ffi` (`events_encode` packs bytes manually; no serde usage in source or tests)
- Keeps `linkme` in `elevator-ffi` — its only references come through the `MultiHostLayout` derive macro emitting `::linkme::distributed_slice` paths, which machete's AST scan cannot see. Added a `[package.metadata.cargo-machete] ignored = ["linkme"]` block so future audits don't re-flag it.

## Audit context
A broader tech-debt sweep across the workspace was clean otherwise:
- No `TODO`/`FIXME`/`HACK` comments in source
- No `#[deprecated]` items, `#[ignore]`d tests, or commented-out tests
- All `clippy::expect_used` / `clippy::panic` allows in core have documented invariants (extension key collisions, unit `From<f64>` infallible contract, test modules)
- All `clippy::missing_const_for_fn` allows on `Simulation::world{,_mut}` already document why const is misleading there
- `bindings.toml` "todo" entries are intentional roadmap markers (`bevy = "todo:plugin-layer"`, `gdext/ffi = "todo:future-binding"`), not actionable debt

## Test plan
- [x] `cargo build --workspace --all-features --all-targets`
- [x] `cargo test -p elevator-core --all-features` (159 tests pass)
- [x] `cargo clippy --workspace --all-features --all-targets` (clean)
- [x] `cargo machete` (zero unused deps after change)
- [x] Pre-commit hook (985 core tests + 159 doctests + workspace check + ABI pins) — all green