### PR TITLE
feat(core): add step_many for batched ticks

### DIFF
--- a/bindings.toml
+++ b/bindings.toml
@@ -110,10 +110,20 @@ bevy = "todo:plugin-layer"
 [[methods]]
 name = "step"
 category = "lifecycle"
-wasm = "stepMany"  # exposes batched step, internally calls step in loop
+wasm = "skip:exposed via stepMany batch"
 ffi  = "ev_sim_step"
 tui  = "auto_tick_or_dot_hotkey"
 gms  = "ev_sim_step"
+gdext = "todo:future-binding"
+bevy = "todo:plugin-layer"
+
+[[methods]]
+name = "step_many"
+category = "lifecycle"
+wasm = "stepMany"
+ffi  = "todo:future-binding"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "todo:future-binding"
 gdext = "todo:future-binding"
 bevy = "todo:plugin-layer"
 

--- a/crates/elevator-core/src/sim/substep.rs
+++ b/crates/elevator-core/src/sim/substep.rs
@@ -357,6 +357,32 @@ impl super::Simulation {
         self.advance_tick();
     }
 
+    /// Advance the simulation by `n` ticks.
+    ///
+    /// Equivalent to calling [`step`](Self::step) `n` times. Hosts driving
+    /// the sim across an FFI / wasm boundary should prefer this over a
+    /// per-tick loop on their side: keeping the loop in Rust avoids
+    /// per-tick boundary crossings that add up at scale.
+    ///
+    /// Events from each tick accumulate in the internal queue; consumers
+    /// call [`drain_events`](Self::drain_events) once after the batch to
+    /// read the cumulative stream.
+    ///
+    /// `n == 0` is a no-op.
+    ///
+    /// ```
+    /// use elevator_core::prelude::*;
+    ///
+    /// let mut sim = SimulationBuilder::demo().build().unwrap();
+    /// sim.step_many(60);
+    /// assert_eq!(sim.current_tick(), 60);
+    /// ```
+    pub fn step_many(&mut self, n: u32) {
+        for _ in 0..n {
+            self.step();
+        }
+    }
+
     /// Step the simulation until every rider reaches a terminal phase
     /// (`Arrived`, `Abandoned`, or `Resident`), draining events each
     /// tick so event-driven metrics stay up to date.

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -277,9 +277,7 @@ impl WasmSim {
     /// Step the simulation forward `n` ticks.
     #[wasm_bindgen(js_name = stepMany)]
     pub fn step_many(&mut self, n: u32) {
-        for _ in 0..n {
-            self.inner.step();
-        }
+        self.inner.step_many(n);
     }
 
     /// Tick duration in seconds.


### PR DESCRIPTION
## Summary

- Add `Simulation::step_many(n: u32)` to core. Internally just a tight
  `for` loop over `step()`; the value is keeping the loop in Rust for
  hosts driving the sim across an FFI/wasm boundary.
- Wasm shim already had a local `step_many` loop — delegate to core
  instead.
- `bindings.toml` updated: new `step_many` entry, `step` row clarified
  (wasm only exposes `stepMany`).

From `.research/elevator-core-audit-2026-05-08.md` §1 — first item in
the ranked queue.

## Test plan

- [x] new doctest on `step_many` passes
- [x] `cargo clippy -p elevator-core --all-features --all-targets` clean
- [x] full pre-commit (fmt, clippy, core tests, doc tests, workspace
      check, ABI pin guard) green
- [x] `scripts/check-bindings.sh` reports manifest in sync (146 methods)