### PR TITLE
feat(core): add Display impls for public enums

### DIFF
--- a/crates/elevator-core/src/components/hall_call.rs
+++ b/crates/elevator-core/src/components/hall_call.rs
@@ -65,6 +65,20 @@ impl CallDirection {
     }
 }
 
+impl std::fmt::Display for CallDirection {
+    /// ```
+    /// # use elevator_core::components::CallDirection;
+    /// assert_eq!(format!("{}", CallDirection::Up), "up");
+    /// assert_eq!(format!("{}", CallDirection::Down), "down");
+    /// ```
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Up => f.write_str("up"),
+            Self::Down => f.write_str("down"),
+        }
+    }
+}
+
 /// A pressed hall button at `stop` requesting service in `direction`.
 ///
 /// Stored per `(stop, direction)` pair — at most two per stop. Built-in

--- a/crates/elevator-core/src/components/line.rs
+++ b/crates/elevator-core/src/components/line.rs
@@ -24,16 +24,24 @@ pub enum Orientation {
 }
 
 impl std::fmt::Display for Orientation {
+    /// Bounded precision keeps TUI/HUD output stable when `degrees` is the
+    /// result of a radians→degrees conversion that doesn't round-trip cleanly.
+    ///
     /// ```
     /// # use elevator_core::components::Orientation;
     /// assert_eq!(format!("{}", Orientation::Vertical), "vertical");
-    /// assert_eq!(format!("{}", Orientation::Angled { degrees: 30.0 }), "30°");
+    /// assert_eq!(format!("{}", Orientation::Horizontal), "horizontal");
+    /// assert_eq!(format!("{}", Orientation::Angled { degrees: 30.0 }), "30.0°");
+    /// assert_eq!(
+    ///     format!("{}", Orientation::Angled { degrees: 22.123_456_789 }),
+    ///     "22.1°",
+    /// );
     /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Vertical => f.write_str("vertical"),
             Self::Horizontal => f.write_str("horizontal"),
-            Self::Angled { degrees } => write!(f, "{degrees}°"),
+            Self::Angled { degrees } => write!(f, "{degrees:.1}°"),
         }
     }
 }

--- a/crates/elevator-core/src/components/line.rs
+++ b/crates/elevator-core/src/components/line.rs
@@ -23,6 +23,21 @@ pub enum Orientation {
     Horizontal,
 }
 
+impl std::fmt::Display for Orientation {
+    /// ```
+    /// # use elevator_core::components::Orientation;
+    /// assert_eq!(format!("{}", Orientation::Vertical), "vertical");
+    /// assert_eq!(format!("{}", Orientation::Angled { degrees: 30.0 }), "30°");
+    /// ```
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Vertical => f.write_str("vertical"),
+            Self::Horizontal => f.write_str("horizontal"),
+            Self::Angled { degrees } => write!(f, "{degrees}°"),
+        }
+    }
+}
+
 /// 2D position on a floor plan (for spatial queries and rendering).
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct SpatialPosition {

--- a/crates/elevator-core/src/components/route.rs
+++ b/crates/elevator-core/src/components/route.rs
@@ -19,11 +19,18 @@ pub enum TransportMode {
 }
 
 impl std::fmt::Display for TransportMode {
+    /// `Line` delegates to `EntityId`'s `Debug` since slotmap keys do not
+    /// implement `Display`; the doctest pins the prefix so the format is
+    /// observable even though the trailing key id is opaque.
+    ///
     /// ```
     /// # use elevator_core::components::TransportMode;
     /// # use elevator_core::ids::GroupId;
+    /// # use elevator_core::entity::EntityId;
     /// assert_eq!(format!("{}", TransportMode::Group(GroupId(0))), "group GroupId(0)");
     /// assert_eq!(format!("{}", TransportMode::Walk), "walk");
+    /// let line_str = format!("{}", TransportMode::Line(EntityId::default()));
+    /// assert!(line_str.starts_with("line "), "unexpected: {line_str}");
     /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/crates/elevator-core/src/components/route.rs
+++ b/crates/elevator-core/src/components/route.rs
@@ -18,6 +18,22 @@ pub enum TransportMode {
     Walk,
 }
 
+impl std::fmt::Display for TransportMode {
+    /// ```
+    /// # use elevator_core::components::TransportMode;
+    /// # use elevator_core::ids::GroupId;
+    /// assert_eq!(format!("{}", TransportMode::Group(GroupId(0))), "group GroupId(0)");
+    /// assert_eq!(format!("{}", TransportMode::Walk), "walk");
+    /// ```
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Group(g) => write!(f, "group {g}"),
+            Self::Line(eid) => write!(f, "line {eid:?}"),
+            Self::Walk => f.write_str("walk"),
+        }
+    }
+}
+
 /// One segment of a multi-leg route.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RouteLeg {

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -647,6 +647,20 @@ pub enum HallCallMode {
     Destination,
 }
 
+impl std::fmt::Display for HallCallMode {
+    /// ```
+    /// # use elevator_core::dispatch::HallCallMode;
+    /// assert_eq!(format!("{}", HallCallMode::Classic), "classic");
+    /// assert_eq!(format!("{}", HallCallMode::Destination), "destination");
+    /// ```
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Classic => f.write_str("classic"),
+            Self::Destination => f.write_str("destination"),
+        }
+    }
+}
+
 /// Runtime elevator group: a set of lines sharing a dispatch strategy.
 ///
 /// A group is the logical dispatch unit. It contains one or more

--- a/crates/elevator-core/src/hooks.rs
+++ b/crates/elevator-core/src/hooks.rs
@@ -47,6 +47,27 @@ pub enum Phase {
     Metrics,
 }
 
+impl std::fmt::Display for Phase {
+    /// ```
+    /// # use elevator_core::hooks::Phase;
+    /// assert_eq!(format!("{}", Phase::Dispatch), "dispatch");
+    /// assert_eq!(format!("{}", Phase::AdvanceTransient), "advance_transient");
+    /// ```
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::AdvanceTransient => "advance_transient",
+            Self::Dispatch => "dispatch",
+            Self::Movement => "movement",
+            Self::Doors => "doors",
+            Self::Loading => "loading",
+            Self::Reposition => "reposition",
+            Self::AdvanceQueue => "advance_queue",
+            Self::Metrics => "metrics",
+        };
+        f.write_str(s)
+    }
+}
+
 /// A boxed closure that receives mutable world access during a phase hook.
 pub(crate) type PhaseHook = Box<dyn Fn(&mut World) + Send + Sync>;
 


### PR DESCRIPTION
## Summary

Adds `Display` impls for public enums that hosts were formatting by
hand — TUI, Bevy HUD, playground all duplicate short status strings
the core enum should own.

- `components::CallDirection` — \"up\" / \"down\"
- `components::TransportMode` — \"group {g}\" / \"line {eid:?}\" / \"walk\"
- `components::Orientation` — \"vertical\" / \"horizontal\" / \"30°\"
- `dispatch::HallCallMode` — \"classic\" / \"destination\"
- `hooks::Phase` — \"dispatch\" / \"advance_transient\" / etc.

`ElevatorPhase`, `RiderPhase`, `Direction`, `RejectionReason`,
`ServiceMode`, units, and others already had Display — this finishes
the pattern.

`Event` (49 variants) is intentionally deferred to a follow-up.

From \`.research/elevator-core-audit-2026-05-08.md\` §2.

## Test plan

- [x] doctest on each new Display impl
- [x] full doctest suite green (164 passed)
- [x] \`cargo clippy -p elevator-core --all-features --all-targets\` clean
- [x] full pre-commit (fmt, clippy, core tests, doc tests, workspace
      check, ABI pin guard) green