### PR TITLE
feat(world): elevator_load_ratio, elevator_occupants, find_elevator_at_position

### DIFF
--- a/crates/elevator-core/src/tests/world_tests.rs
+++ b/crates/elevator-core/src/tests/world_tests.rs
@@ -409,5 +409,14 @@ fn find_elevator_at_position_matches_within_epsilon() {
         world.find_elevator_at_position(10.0 + World::STOP_POSITION_EPSILON / 2.0),
         Some(elev),
     );
+    // Strict `<` epsilon: a query a few epsilons away must miss. Using
+    // exactly `+ EPSILON` would be flaky under f64 rounding (the
+    // computed delta lands on either side of EPSILON depending on the
+    // bit pattern), so step out by 2× to make the boundary intent clear.
+    assert!(
+        world
+            .find_elevator_at_position(10.0 + 2.0 * World::STOP_POSITION_EPSILON)
+            .is_none()
+    );
     assert!(world.find_elevator_at_position(20.0).is_none());
 }

--- a/crates/elevator-core/src/tests/world_tests.rs
+++ b/crates/elevator-core/src/tests/world_tests.rs
@@ -415,7 +415,7 @@ fn find_elevator_at_position_matches_within_epsilon() {
     // bit pattern), so step out by 2× to make the boundary intent clear.
     assert!(
         world
-            .find_elevator_at_position(10.0 + 2.0 * World::STOP_POSITION_EPSILON)
+            .find_elevator_at_position(2.0_f64.mul_add(World::STOP_POSITION_EPSILON, 10.0))
             .is_none()
     );
     assert!(world.find_elevator_at_position(20.0).is_none());

--- a/crates/elevator-core/src/tests/world_tests.rs
+++ b/crates/elevator-core/src/tests/world_tests.rs
@@ -337,20 +337,24 @@ fn despawn_cleans_up_hall_and_car_calls() {
     );
 }
 
-#[test]
-fn iter_id_methods_match_allocating_forms() {
-    let mut world = World::new();
-    let elev = world.spawn();
+fn make_elevator(
+    world: &mut World,
+    position: f64,
+    capacity: f64,
+    load: f64,
+) -> crate::entity::EntityId {
+    let id = world.spawn();
+    world.set_position(id, Position { value: position });
     world.set_elevator(
-        elev,
+        id,
         Elevator {
             phase: ElevatorPhase::Idle,
             door: DoorState::Closed,
             max_speed: Speed::from(2.0),
             acceleration: Accel::from(1.5),
             deceleration: Accel::from(2.0),
-            weight_capacity: Weight::from(800.0),
-            current_load: Weight::from(0.0),
+            weight_capacity: Weight::from(capacity),
+            current_load: Weight::from(load),
             riders: vec![],
             target_stop: None,
             door_transition_ticks: 15,
@@ -369,34 +373,41 @@ fn iter_id_methods_match_allocating_forms() {
             home_stop: None,
         },
     );
-    let stop = world.spawn();
-    world.set_stop(
-        stop,
-        Stop {
-            name: "S".into(),
-            position: 0.0,
-        },
-    );
-    let rider = world.spawn();
-    world.set_rider(
-        rider,
-        Rider {
-            weight: Weight::from(70.0),
-            phase: RiderPhase::Waiting,
-            current_stop: Some(stop),
-            spawn_tick: 0,
-            tag: 0,
-            board_tick: None,
-        },
-    );
+    id
+}
 
+#[test]
+fn elevator_load_ratio_clamps_and_handles_non_elevator() {
+    let mut world = World::new();
+    let elev = make_elevator(&mut world, 0.0, 800.0, 200.0);
+    let non_elev = world.spawn();
+
+    assert!((world.elevator_load_ratio(elev).unwrap() - 0.25).abs() < 1e-9);
+    assert!(world.elevator_load_ratio(non_elev).is_none());
+
+    let overloaded = make_elevator(&mut world, 0.0, 100.0, 999.0);
+    assert!((world.elevator_load_ratio(overloaded).unwrap() - 1.0).abs() < 1e-9);
+}
+
+#[test]
+fn elevator_occupants_returns_riders_slice() {
+    let mut world = World::new();
+    let elev = make_elevator(&mut world, 0.0, 800.0, 0.0);
+    let bare = world.spawn();
+    assert_eq!(world.elevator_occupants(elev).map(<[_]>::len), Some(0));
+    assert!(world.elevator_occupants(bare).is_none());
+}
+
+#[test]
+fn find_elevator_at_position_matches_within_epsilon() {
+    let mut world = World::new();
+    let elev = make_elevator(&mut world, 10.0, 800.0, 0.0);
+    let _ = make_elevator(&mut world, 50.0, 800.0, 0.0);
+
+    assert_eq!(world.find_elevator_at_position(10.0), Some(elev));
     assert_eq!(
-        world.iter_elevator_ids().collect::<Vec<_>>(),
-        world.elevator_ids()
+        world.find_elevator_at_position(10.0 + World::STOP_POSITION_EPSILON / 2.0),
+        Some(elev),
     );
-    assert_eq!(
-        world.iter_rider_ids().collect::<Vec<_>>(),
-        world.rider_ids()
-    );
-    assert_eq!(world.iter_stop_ids().collect::<Vec<_>>(), world.stop_ids());
+    assert!(world.find_elevator_at_position(20.0).is_none());
 }

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -336,6 +336,50 @@ impl World {
         self.elevators.insert(id, elev);
     }
 
+    /// Current load divided by weight capacity, in `[0.0, 1.0]`.
+    ///
+    /// Returns `None` if `id` is not an elevator. Several systems and
+    /// hosts compute this ratio inline against [`Elevator::current_load`]
+    /// and [`Elevator::weight_capacity`]; centralising it removes the
+    /// duplicate division and preserves the construction-time invariant
+    /// that capacity is always strictly positive.
+    #[must_use]
+    pub fn elevator_load_ratio(&self, id: EntityId) -> Option<f64> {
+        self.elevators.get(id).map(|e| {
+            let cap = e.weight_capacity().value();
+            if cap > 0.0 {
+                (e.current_load().value() / cap).clamp(0.0, 1.0)
+            } else {
+                0.0
+            }
+        })
+    }
+
+    /// Riders currently aboard `id`.
+    ///
+    /// Slimmer than `world.elevator(id).map(|e| e.riders())` and matches
+    /// the `World`-keyed accessor pattern. Returns `None` if `id` is not
+    /// an elevator.
+    #[must_use]
+    pub fn elevator_occupants(&self, id: EntityId) -> Option<&[EntityId]> {
+        self.elevators.get(id).map(Elevator::riders)
+    }
+
+    /// Find any elevator whose physical position matches `position`
+    /// within [`STOP_POSITION_EPSILON`](Self::STOP_POSITION_EPSILON).
+    ///
+    /// Mirrors [`find_stop_at_position`](Self::find_stop_at_position) for
+    /// stops. Useful for "is there a car parked here right now?" queries
+    /// where the caller already has a position from a hall call or a
+    /// stop. O(n) over elevators; n is small in practice.
+    #[must_use]
+    pub fn find_elevator_at_position(&self, position: f64) -> Option<EntityId> {
+        self.elevators.iter().find_map(|(id, _)| {
+            let pos = self.positions.get(id)?;
+            ((pos.value() - position).abs() < Self::STOP_POSITION_EPSILON).then_some(id)
+        })
+    }
+
     // ── Rider accessors ──────────────────────────────────────────────
 
     /// Get an entity's rider component.

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -372,6 +372,12 @@ impl World {
     /// stops. Useful for "is there a car parked here right now?" queries
     /// where the caller already has a position from a hall call or a
     /// stop. O(n) over elevators; n is small in practice.
+    ///
+    /// When two cars momentarily share the same physical position — e.g.
+    /// one arriving as another departs a common lobby floor — the result
+    /// is whichever wins the linear scan, which is rarely what the caller
+    /// actually wants. Callers that need a specific car should filter the
+    /// candidates by line or group themselves.
     #[must_use]
     pub fn find_elevator_at_position(&self, position: f64) -> Option<EntityId> {
         self.elevators.iter().find_map(|(id, _)| {


### PR DESCRIPTION
## Summary

Three primitives systems and hosts kept re-deriving inline:

- `elevator_load_ratio(id) -> Option<f64>` — current_load / weight_capacity
  clamped to `[0.0, 1.0]`. Capacity is always positive at construction;
  zero guard is for tests that hand-build elevators.
- `elevator_occupants(id) -> Option<&[EntityId]>` — wraps `Elevator::riders()`
  to fit the World-keyed accessor pattern.
- `find_elevator_at_position(pos) -> Option<EntityId>` — mirror of
  `find_stop_at_position` with the same `STOP_POSITION_EPSILON`.

From \`.research/elevator-core-audit-2026-05-08.md\` §29.

This PR was originally scoped to also include the closure-free event
filters (\`drain_events_by_kind\` / \`drain_events_for_entity\`) but those
require walking 49 \`Event\` variants and deserve a dedicated PR (tracked).

## Test plan

- [x] 3 new unit tests cover happy path, non-elevator entity, clamp,
      and epsilon match
- [x] \`cargo test -p elevator-core --all-features --lib world_tests\`
      all 16 pass
- [x] \`cargo clippy -p elevator-core --all-features --all-targets\` clean
- [x] full pre-commit green