### PR TITLE
refactor(error)!: drop From<EntityId/StopId/GroupId> for SimError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "18.0.1"
+version = "18.1.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-wasm"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "elevator-core",
  "getrandom 0.4.2",

--- a/crates/elevator-core/src/error.rs
+++ b/crates/elevator-core/src/error.rs
@@ -362,21 +362,3 @@ impl fmt::Display for RejectionContext {
         }
     }
 }
-
-impl From<EntityId> for SimError {
-    fn from(id: EntityId) -> Self {
-        Self::EntityNotFound(id)
-    }
-}
-
-impl From<StopId> for SimError {
-    fn from(id: StopId) -> Self {
-        Self::StopNotFound(id)
-    }
-}
-
-impl From<GroupId> for SimError {
-    fn from(id: GroupId) -> Self {
-        Self::GroupNotFound(id)
-    }
-}


### PR DESCRIPTION
## Summary

These three `From` impls silently coerced any stray `EntityId`,
`StopId`, or `GroupId` crossing a `?` or `.into()` into
`SimError::EntityNotFound` / `StopNotFound` / `GroupNotFound`, even
when the caller meant something more specific like `NotAnElevator`,
`NotAStop`, or `LineNotFound`. The cost was a class of subtle
miscategorisation bugs.

Confirmed zero callers across the workspace (`elevator-core`,
`-bevy`, `-wasm`, `-ffi`, `-tui`, `-gdext`) before deleting:

\`\`\`
$ rg \"From::<(EntityId|StopId|GroupId)>::from|<SimError>::from\" crates/
\`\`\`

returns nothing. Removing costs zero call-site changes inside the
repo; downstream users who relied on the implicit conversion will get
a clear compile error pointing at the exact construction.

Marked as a breaking change (`refactor(error)!:`) so release-please
bumps elevator-core's major. Cargo.lock catches up to the 18.0.1 →
18.1.0 bump from the prior release commit.

From \`.research/elevator-core-audit-2026-05-08.md\` §7.

## Test plan

- [x] `cargo build --workspace --all-features` clean
- [x] `cargo clippy --workspace --all-features --all-targets` clean
- [x] `cargo test -p elevator-core --all-features --lib` (985 passed)
- [x] full pre-commit (fmt, clippy, core tests, doc tests, workspace
      check, ABI pin guard) green