### PR TITLE
feat(world): add non-allocating iter_elevator_ids / iter_rider_ids / iter_stop_ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "18.2.0"
+version = "18.1.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/tests/world_tests.rs
+++ b/crates/elevator-core/src/tests/world_tests.rs
@@ -336,3 +336,67 @@ fn despawn_cleans_up_hall_and_car_calls() {
         "car_calls should be cleaned up after despawn"
     );
 }
+
+#[test]
+fn iter_id_methods_match_allocating_forms() {
+    let mut world = World::new();
+    let elev = world.spawn();
+    world.set_elevator(
+        elev,
+        Elevator {
+            phase: ElevatorPhase::Idle,
+            door: DoorState::Closed,
+            max_speed: Speed::from(2.0),
+            acceleration: Accel::from(1.5),
+            deceleration: Accel::from(2.0),
+            weight_capacity: Weight::from(800.0),
+            current_load: Weight::from(0.0),
+            riders: vec![],
+            target_stop: None,
+            door_transition_ticks: 15,
+            door_open_ticks: 60,
+            line: crate::entity::EntityId::default(),
+            repositioning: false,
+            restricted_stops: HashSet::new(),
+            inspection_speed_factor: 0.25,
+            going_up: true,
+            going_down: true,
+            move_count: 0,
+            door_command_queue: Vec::new(),
+            manual_target_velocity: None,
+            bypass_load_up_pct: None,
+            bypass_load_down_pct: None,
+            home_stop: None,
+        },
+    );
+    let stop = world.spawn();
+    world.set_stop(
+        stop,
+        Stop {
+            name: "S".into(),
+            position: 0.0,
+        },
+    );
+    let rider = world.spawn();
+    world.set_rider(
+        rider,
+        Rider {
+            weight: Weight::from(70.0),
+            phase: RiderPhase::Waiting,
+            current_stop: Some(stop),
+            spawn_tick: 0,
+            tag: 0,
+            board_tick: None,
+        },
+    );
+
+    assert_eq!(
+        world.iter_elevator_ids().collect::<Vec<_>>(),
+        world.elevator_ids()
+    );
+    assert_eq!(
+        world.iter_rider_ids().collect::<Vec<_>>(),
+        world.rider_ids()
+    );
+    assert_eq!(world.iter_stop_ids().collect::<Vec<_>>(), world.stop_ids());
+}

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -643,6 +643,16 @@ impl World {
             .filter_map(|(id, car)| self.positions.get(id).map(|pos| (id, pos, car)))
     }
 
+    /// Iterate all elevator entity IDs without allocating.
+    ///
+    /// Prefer this over [`elevator_ids`](Self::elevator_ids) in tight
+    /// per-tick paths where the result is consumed immediately. The
+    /// allocating form remains for callers that genuinely need indexed
+    /// access (e.g. gdext mapping integer indices from `GDScript`).
+    pub fn iter_elevator_ids(&self) -> impl Iterator<Item = EntityId> + '_ {
+        self.elevators.keys()
+    }
+
     /// Iterate all elevator entity IDs (allocates).
     #[must_use]
     pub fn elevator_ids(&self) -> Vec<EntityId> {
@@ -665,6 +675,14 @@ impl World {
         self.riders.iter_mut()
     }
 
+    /// Iterate all rider entity IDs without allocating.
+    ///
+    /// Companion to [`iter_riders`](Self::iter_riders) when only the IDs
+    /// are needed.
+    pub fn iter_rider_ids(&self) -> impl Iterator<Item = EntityId> + '_ {
+        self.riders.keys()
+    }
+
     /// Iterate all rider entity IDs (allocates).
     #[must_use]
     pub fn rider_ids(&self) -> Vec<EntityId> {
@@ -674,6 +692,14 @@ impl World {
     /// Iterate all stop entities.
     pub fn iter_stops(&self) -> impl Iterator<Item = (EntityId, &Stop)> {
         self.stops.iter()
+    }
+
+    /// Iterate all stop entity IDs without allocating.
+    ///
+    /// Companion to [`iter_stops`](Self::iter_stops) when only the IDs
+    /// are needed.
+    pub fn iter_stop_ids(&self) -> impl Iterator<Item = EntityId> + '_ {
+        self.stops.keys()
     }
 
     /// Iterate all stop entity IDs (allocates).

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -649,6 +649,14 @@ impl World {
     /// per-tick paths where the result is consumed immediately. The
     /// allocating form remains for callers that genuinely need indexed
     /// access (e.g. gdext mapping integer indices from `GDScript`).
+    ///
+    /// Yields `EntityId` rather than the typed [`ElevatorId`] newtype to
+    /// match the rest of the `World`-keyed accessor surface (`elevator`,
+    /// `iter_elevators`, `elevator_ids`). Callers crossing the
+    /// `Simulation` boundary should wrap with `ElevatorId::wrap_unchecked`
+    /// per the project ID-type convention.
+    ///
+    /// [`ElevatorId`]: crate::entity::ElevatorId
     pub fn iter_elevator_ids(&self) -> impl Iterator<Item = EntityId> + '_ {
         self.elevators.keys()
     }


### PR DESCRIPTION
## Summary

Companion non-allocating iterators alongside `elevator_ids` /
`rider_ids` / `stop_ids`:

- `iter_elevator_ids() -> impl Iterator<Item = EntityId>`
- `iter_rider_ids() -> impl Iterator<Item = EntityId>`
- `iter_stop_ids() -> impl Iterator<Item = EntityId>`

Per-tick code can walk IDs without a fresh `Vec` allocation now. The
`Vec`-returning forms remain because gdext's `spawn_rider` / `set_*`
paths take an integer stop index from GDScript and genuinely need
indexed access; those callers don't benefit from the iterator form.

Pure addition — no internal callers migrated in this PR. Follow-up
work can audit `systems/advance_transient.rs:348` and any other
per-tick allocator sites once a borrow-checker-friendly migration
pattern is settled.

From `.research/elevator-core-audit-2026-05-08.md` §5 (re-scoped from
"deprecate Vec forms" after auditing call sites).

## Test plan

- [x] `cargo test -p elevator-core --all-features --lib world_tests`
- [x] `cargo clippy -p elevator-core --all-features --all-targets` clean
- [x] full pre-commit green (fmt, clippy, core tests, doc tests,
      workspace check, ABI pin guard)