### PR TITLE
refactor(dispatch): extract wait_ticks_sum / wait_ticks_squared_sum helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "18.1.0"
+version = "18.2.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/dispatch/etd.rs
+++ b/crates/elevator-core/src/dispatch/etd.rs
@@ -224,24 +224,11 @@ impl DispatchStrategy for EtdDispatch {
         let mut cost =
             self.compute_cost(ctx.car, ctx.car_position(), ctx.stop_position(), ctx.world);
         if self.wait_squared_weight > 0.0 {
-            let wait_sq: f64 = ctx
-                .manifest
-                .waiting_riders_at(ctx.stop)
-                .iter()
-                .map(|r| {
-                    let w = r.wait_ticks as f64;
-                    w * w
-                })
-                .sum();
+            let wait_sq = super::wait_ticks_squared_sum(ctx.manifest.waiting_riders_at(ctx.stop));
             cost = crate::fp::fma(self.wait_squared_weight, -wait_sq, cost).max(0.0);
         }
         if self.age_linear_weight > 0.0 {
-            let wait_sum: f64 = ctx
-                .manifest
-                .waiting_riders_at(ctx.stop)
-                .iter()
-                .map(|r| r.wait_ticks as f64)
-                .sum();
+            let wait_sum = super::wait_ticks_sum(ctx.manifest.waiting_riders_at(ctx.stop));
             cost = crate::fp::fma(self.age_linear_weight, -wait_sum, cost).max(0.0);
         }
         if cost.is_finite() { Some(cost) } else { None }

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -181,6 +181,32 @@ pub fn pair_is_useful(ctx: &RankContext<'_>, respect_aboard_path: bool) -> bool 
     })
 }
 
+/// Sum of `wait_ticks` across `riders`, as `f64`.
+///
+/// Helper used by ETD and RSR fairness terms — both compute the same
+/// `riders.iter().map(|r| r.wait_ticks as f64).sum()` and feed the
+/// result into a fused-multiply-add against a configured weight.
+#[must_use]
+pub(crate) fn wait_ticks_sum(riders: &[RiderInfo]) -> f64 {
+    riders.iter().map(|r| r.wait_ticks as f64).sum()
+}
+
+/// Sum of squared `wait_ticks` across `riders`, as `f64`.
+///
+/// Used by ETD's quadratic-fairness term to escalate cost as old
+/// waiters age. RSR has no quadratic fairness; the linear form lives
+/// in [`wait_ticks_sum`].
+#[must_use]
+pub(crate) fn wait_ticks_squared_sum(riders: &[RiderInfo]) -> f64 {
+    riders
+        .iter()
+        .map(|r| {
+            let w = r.wait_ticks as f64;
+            w * w
+        })
+        .sum()
+}
+
 /// Whether a waiting rider could actually board this car, matching the
 /// same filters the loading phase applies. Prevents `pair_is_useful`
 /// from approving a pickup whose only demand is direction-filtered or

--- a/crates/elevator-core/src/dispatch/rsr.rs
+++ b/crates/elevator-core/src/dispatch/rsr.rs
@@ -379,12 +379,7 @@ impl DispatchStrategy for RsrDispatch {
         // prevents fresh lobby-side demand from indefinitely preempting
         // older upper-floor waiters. Mirrors ETD's `age_linear_weight`.
         if self.age_linear_weight > 0.0 {
-            let wait_sum: f64 = ctx
-                .manifest
-                .waiting_riders_at(ctx.stop)
-                .iter()
-                .map(|r| r.wait_ticks as f64)
-                .sum();
+            let wait_sum = super::wait_ticks_sum(ctx.manifest.waiting_riders_at(ctx.stop));
             cost = crate::fp::fma(self.age_linear_weight, -wait_sum, cost);
         }
 


### PR DESCRIPTION
## Summary

ETD and RSR both compute the same `riders.iter().map(|r| r.wait_ticks
as f64).sum()` shape and feed the result into a fused-multiply-add
against a fairness weight. ETD also has a quadratic variant. Lift
both into `pub(crate)` helpers in `dispatch/mod.rs`.

- New `wait_ticks_sum(riders) -> f64` (used by ETD age-linear and RSR
  age-linear)
- New `wait_ticks_squared_sum(riders) -> f64` (used by ETD wait-squared)
- ETD and RSR call the helpers; the inline three-line iter-sum
  expression is gone

Smaller win than the audit suggested — the broader `compute_travel_cost`
extraction it called for would conflate ETD's intervening-stop /
direction-bonus structure with RSR's flat `eta_weight * travel_time`,
which are genuinely different and don't share enough structure to
unify cleanly. Sticking to the parts that *are* duplicated.

From `.research/elevator-core-audit-2026-05-08.md` §3 (re-scoped).

## Test plan

- [x] `cargo test -p elevator-core --all-features --lib` — 985 passed
- [x] all 11 scenario integration suites pass (dispatch_matrix included)
- [x] `cargo clippy -p elevator-core --all-features --all-targets` clean
- [x] full pre-commit green (fmt, clippy, core tests, doc tests,
      workspace check, ABI pin guard)