### PR TITLE
refactor(hooks): collapse four parallel HashMaps into one keyed map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/hooks.rs
+++ b/crates/elevator-core/src/hooks.rs
@@ -68,41 +68,58 @@ impl std::fmt::Display for Phase {
     }
 }
 
+/// Whether a hook fires before or after its phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum When {
+    /// Fires immediately before the phase body runs.
+    Before,
+    /// Fires immediately after the phase body completes.
+    After,
+}
+
 /// A boxed closure that receives mutable world access during a phase hook.
 pub(crate) type PhaseHook = Box<dyn Fn(&mut World) + Send + Sync>;
 
-/// Storage for before/after hooks keyed by phase.
+/// Storage for hooks keyed by `(phase, when, optional group)`.
+///
+/// Collapses what used to be four parallel `HashMap`s — `before`,
+/// `after`, `before_group`, `after_group` — into a single map keyed
+/// on the full hook scope. The four `add_*` / `run_*` methods are
+/// thin wrappers preserved for the `SimulationBuilder` shape.
 #[derive(Default)]
 pub(crate) struct PhaseHooks {
-    /// Hooks to run before each phase.
-    before: HashMap<Phase, Vec<PhaseHook>>,
-    /// Hooks to run after each phase.
-    after: HashMap<Phase, Vec<PhaseHook>>,
-    /// Hooks to run before a phase for a specific group.
-    before_group: HashMap<(Phase, GroupId), Vec<PhaseHook>>,
-    /// Hooks to run after a phase for a specific group.
-    after_group: HashMap<(Phase, GroupId), Vec<PhaseHook>>,
+    /// All registered hooks keyed on `(phase, when, optional group)`.
+    hooks: HashMap<(Phase, When, Option<GroupId>), Vec<PhaseHook>>,
 }
 
 impl PhaseHooks {
-    /// Run all before-hooks for the given phase.
-    pub(crate) fn run_before(&self, phase: Phase, world: &mut World) {
-        if let Some(hooks) = self.before.get(&phase) {
+    /// Append `hook` to the bucket identified by `(phase, when, group)`.
+    fn add(&mut self, phase: Phase, when: When, group: Option<GroupId>, hook: PhaseHook) {
+        self.hooks
+            .entry((phase, when, group))
+            .or_default()
+            .push(hook);
+    }
+
+    /// Invoke every hook registered for the given scope, in registration order.
+    fn run(&self, phase: Phase, when: When, group: Option<GroupId>, world: &mut World) {
+        if let Some(hooks) = self.hooks.get(&(phase, when, group)) {
             for hook in hooks {
                 hook(world);
             }
-            Self::debug_check_invariants(phase, world);
         }
+    }
+
+    /// Run all before-hooks for the given phase.
+    pub(crate) fn run_before(&self, phase: Phase, world: &mut World) {
+        self.run(phase, When::Before, None, world);
+        Self::debug_check_invariants(phase, world);
     }
 
     /// Run all after-hooks for the given phase.
     pub(crate) fn run_after(&self, phase: Phase, world: &mut World) {
-        if let Some(hooks) = self.after.get(&phase) {
-            for hook in hooks {
-                hook(world);
-            }
-            Self::debug_check_invariants(phase, world);
-        }
+        self.run(phase, When::After, None, world);
+        Self::debug_check_invariants(phase, world);
     }
 
     /// In debug builds, verify that hooks did not break core invariants.
@@ -123,45 +140,31 @@ impl PhaseHooks {
 
     /// Register a hook to run before a phase.
     pub(crate) fn add_before(&mut self, phase: Phase, hook: PhaseHook) {
-        self.before.entry(phase).or_default().push(hook);
+        self.add(phase, When::Before, None, hook);
     }
 
     /// Register a hook to run after a phase.
     pub(crate) fn add_after(&mut self, phase: Phase, hook: PhaseHook) {
-        self.after.entry(phase).or_default().push(hook);
+        self.add(phase, When::After, None, hook);
     }
 
     /// Run all before-hooks for the given phase and group.
     pub(crate) fn run_before_group(&self, phase: Phase, group: GroupId, world: &mut World) {
-        if let Some(hooks) = self.before_group.get(&(phase, group)) {
-            for hook in hooks {
-                hook(world);
-            }
-        }
+        self.run(phase, When::Before, Some(group), world);
     }
 
     /// Run all after-hooks for the given phase and group.
     pub(crate) fn run_after_group(&self, phase: Phase, group: GroupId, world: &mut World) {
-        if let Some(hooks) = self.after_group.get(&(phase, group)) {
-            for hook in hooks {
-                hook(world);
-            }
-        }
+        self.run(phase, When::After, Some(group), world);
     }
 
     /// Register a hook to run before a phase for a specific group.
     pub(crate) fn add_before_group(&mut self, phase: Phase, group: GroupId, hook: PhaseHook) {
-        self.before_group
-            .entry((phase, group))
-            .or_default()
-            .push(hook);
+        self.add(phase, When::Before, Some(group), hook);
     }
 
     /// Register a hook to run after a phase for a specific group.
     pub(crate) fn add_after_group(&mut self, phase: Phase, group: GroupId, hook: PhaseHook) {
-        self.after_group
-            .entry((phase, group))
-            .or_default()
-            .push(hook);
+        self.add(phase, When::After, Some(group), hook);
     }
 }

--- a/crates/elevator-core/src/hooks.rs
+++ b/crates/elevator-core/src/hooks.rs
@@ -101,25 +101,33 @@ impl PhaseHooks {
             .push(hook);
     }
 
-    /// Invoke every hook registered for the given scope, in registration order.
-    fn run(&self, phase: Phase, when: When, group: Option<GroupId>, world: &mut World) {
-        if let Some(hooks) = self.hooks.get(&(phase, when, group)) {
-            for hook in hooks {
-                hook(world);
-            }
+    /// Invoke every hook registered for the given scope, in
+    /// registration order. Returns `true` when at least one hook ran;
+    /// the ungrouped wrappers use this to scope the debug invariant
+    /// check, preserving the original semantic of "only check when a
+    /// hook actually touched the world".
+    fn run(&self, phase: Phase, when: When, group: Option<GroupId>, world: &mut World) -> bool {
+        let Some(hooks) = self.hooks.get(&(phase, when, group)) else {
+            return false;
+        };
+        for hook in hooks {
+            hook(world);
         }
+        true
     }
 
     /// Run all before-hooks for the given phase.
     pub(crate) fn run_before(&self, phase: Phase, world: &mut World) {
-        self.run(phase, When::Before, None, world);
-        Self::debug_check_invariants(phase, world);
+        if self.run(phase, When::Before, None, world) {
+            Self::debug_check_invariants(phase, world);
+        }
     }
 
     /// Run all after-hooks for the given phase.
     pub(crate) fn run_after(&self, phase: Phase, world: &mut World) {
-        self.run(phase, When::After, None, world);
-        Self::debug_check_invariants(phase, world);
+        if self.run(phase, When::After, None, world) {
+            Self::debug_check_invariants(phase, world);
+        }
     }
 
     /// In debug builds, verify that hooks did not break core invariants.


### PR DESCRIPTION
## Summary

`PhaseHooks` used to keep four separate `HashMap`s — `before`,
`after`, `before_group`, `after_group` — each handling a slice of the
hook scope. Collapse them into a single
`HashMap<(Phase, When, Option<GroupId>), Vec<PhaseHook>>` and route
the four `add_*` / `run_*` wrappers through a shared `add` / `run`
helper pair.

Pure internal refactor:

- `SimulationBuilder` keeps its `.before` / `.after` / `.before_group`
  / `.after_group` builder methods — public API unchanged.
- New private `When` enum captures the before/after axis as data; the
  fourth scope axis (group vs no group) is `Option<GroupId>`.
- `PhaseHook` storage shrinks from 4 maps to 1; `add_*` / `run_*`
  become 1-line wrappers.

From `.research/elevator-core-audit-2026-05-08.md` §14 (audit
recommended collapsing the 4-method API; this PR keeps the public
shape but consolidates the storage, which is the part that actually
matters for maintenance).

## Test plan

- [x] `cargo test -p elevator-core --all-features --lib hooks_tests`
      — all 6 pass
- [x] `cargo test -p elevator-core --all-features --lib` — 985 pass
- [x] `cargo clippy -p elevator-core --all-features --all-targets` clean
- [x] full pre-commit green