### PR TITLE
feat(dispatch): add PrepareScratch helper for custom strategies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/examples/custom_dispatch.rs
+++ b/crates/elevator-core/examples/custom_dispatch.rs
@@ -29,17 +29,27 @@
     clippy::missing_const_for_fn
 )]
 
-use std::collections::HashMap;
-
 use elevator_core::components::CallDirection;
 use elevator_core::dispatch::{
-    BuiltinStrategy, DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext,
+    BuiltinStrategy, DispatchManifest, DispatchStrategy, ElevatorGroup, PrepareScratch, RankContext,
 };
 use elevator_core::entity::EntityId;
 use elevator_core::ids::GroupId;
 use elevator_core::prelude::*;
 use elevator_core::stop::StopConfig;
 use elevator_core::world::World;
+
+/// Per-car bookkeeping for the idle-penalty heuristic. Bundling the two
+/// related fields means `notify_removed` only needs to drop one entry,
+/// not remember to clean both — an easy class of bug to introduce when
+/// each piece of state lives in its own `HashMap`.
+#[derive(Default)]
+struct CarStats {
+    /// Tick of the last call this car was assigned to.
+    last_served_tick: u64,
+    /// Idle ticks resolved once per car in `prepare_car` and read by `rank`.
+    idle_for: f64,
+}
 
 /// Weighted nearest-car: distance plus a penalty proportional to how
 /// many ticks this car has been idle since it last served a call.
@@ -49,12 +59,9 @@ use elevator_core::world::World;
 /// so two cars are never sent to the same hall call.
 #[derive(Default)]
 struct IdlePenaltyDispatch {
-    /// Tick of the last call each car was assigned to. Used to penalize
-    /// cars that have sat unused for a while so the fleet rotates fairly.
-    last_served_tick: HashMap<EntityId, u64>,
-    /// Idle ticks resolved once per car in `prepare_car` and read by `rank`.
-    /// Keeping mutation out of `rank` keeps the cost matrix order-independent.
-    idle_for: HashMap<EntityId, f64>,
+    /// Per-car scratch: managed by `PrepareScratch` so a single
+    /// `notify_removed` call drops every per-car field at once.
+    stats: PrepareScratch<CarStats>,
     /// Current tick, refreshed once per group pass via `pre_dispatch`.
     tick: u64,
 }
@@ -81,10 +88,9 @@ impl DispatchStrategy for IdlePenaltyDispatch {
         _manifest: &DispatchManifest,
         _world: &World,
     ) {
-        let last = self.last_served_tick.get(&car).copied().unwrap_or(0);
-        let idle = self.tick.saturating_sub(last) as f64;
-        self.idle_for.insert(car, idle);
-        self.last_served_tick.insert(car, self.tick);
+        let stats = self.stats.entry(car);
+        stats.idle_for = self.tick.saturating_sub(stats.last_served_tick) as f64;
+        stats.last_served_tick = self.tick;
     }
 
     /// Cost is distance minus a small bonus for cars that haven't been
@@ -92,17 +98,17 @@ impl DispatchStrategy for IdlePenaltyDispatch {
     /// pair entirely — useful for capacity limits or restricted stops.
     fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
         let distance = (ctx.car_position() - ctx.stop_position()).abs();
-        let idle_for = self.idle_for.get(&ctx.car).copied().unwrap_or(0.0);
+        let idle_for = self.stats.get(ctx.car).map_or(0.0, |s| s.idle_for);
         // Bias toward long-idle cars; clamp so cost stays non-negative.
         Some(0.01f64.mul_add(-idle_for, distance).max(0.0))
     }
 
     /// The framework calls this when an elevator leaves the group — via
-    /// `Simulation::remove_elevator` or cross-group reassignment. Drop
-    /// per-elevator state here to prevent unbounded growth.
+    /// `Simulation::remove_elevator` or cross-group reassignment. The
+    /// `PrepareScratch` wrapper means one drop covers every per-car
+    /// field; with hand-rolled `HashMap`s this is where bugs hide.
     fn notify_removed(&mut self, elevator: EntityId) {
-        self.last_served_tick.remove(&elevator);
-        self.idle_for.remove(&elevator);
+        self.stats.remove(elevator);
     }
 }
 

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -47,6 +47,8 @@ pub mod reposition;
 pub mod rsr;
 /// SCAN dispatch algorithm.
 pub mod scan;
+/// Per-elevator scratch helper for custom strategies.
+pub mod scratch;
 /// Shared sweep-direction logic used by SCAN and LOOK.
 pub(crate) mod sweep;
 
@@ -56,6 +58,7 @@ pub use look::LookDispatch;
 pub use nearest_car::NearestCarDispatch;
 pub use rsr::RsrDispatch;
 pub use scan::ScanDispatch;
+pub use scratch::PrepareScratch;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/elevator-core/src/dispatch/scratch.rs
+++ b/crates/elevator-core/src/dispatch/scratch.rs
@@ -1,0 +1,159 @@
+//! Per-elevator scratch helper for custom dispatch strategies.
+//!
+//! Custom strategies that carry per-car state (idle counters, last-served
+//! ticks, learned weights, ...) typically reach for a
+//! `HashMap<EntityId, T>`. Each one then has to remember to drop the
+//! entry from `notify_removed`, or per-car state leaks every time an
+//! elevator is removed or reassigned.
+//!
+//! [`PrepareScratch`] is a typed wrapper around that pattern with
+//! batteries — `entry`, `get`, `get_mut`, `insert`, `remove`, `clear` —
+//! and a clear name so a strategy carrying multiple buckets reads as
+//! "the per-car scratch for X" rather than "another HashMap".
+
+use std::collections::HashMap;
+
+use crate::entity::EntityId;
+
+/// Per-elevator scratch storage, keyed by `EntityId`.
+///
+/// Custom strategies use `PrepareScratch<T>` to hold per-car state that
+/// is computed in `prepare_car` and read in `rank`. Drop entries from
+/// `notify_removed` so an elevator leaving the group doesn't leak.
+///
+/// # Example
+///
+/// ```
+/// use elevator_core::dispatch::{
+///     DispatchStrategy, PrepareScratch, RankContext, ElevatorGroup, DispatchManifest,
+/// };
+/// use elevator_core::entity::EntityId;
+/// use elevator_core::world::World;
+///
+/// #[derive(Default)]
+/// struct CarStats { idle_for: f64 }
+///
+/// #[derive(Default)]
+/// struct IdleAware {
+///     stats: PrepareScratch<CarStats>,
+/// }
+///
+/// impl DispatchStrategy for IdleAware {
+///     fn prepare_car(
+///         &mut self,
+///         car: EntityId,
+///         _car_position: f64,
+///         _group: &ElevatorGroup,
+///         _manifest: &DispatchManifest,
+///         _world: &World,
+///     ) {
+///         self.stats.entry(car).idle_for += 1.0;
+///     }
+///
+///     fn rank(&self, ctx: &RankContext<'_>) -> Option<f64> {
+///         let idle = self.stats.get(ctx.car).map_or(0.0, |s| s.idle_for);
+///         Some((ctx.car_position() - ctx.stop_position()).abs() - 0.01 * idle)
+///     }
+///
+///     fn notify_removed(&mut self, eid: EntityId) {
+///         self.stats.remove(eid);
+///     }
+/// }
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct PrepareScratch<T: Default> {
+    /// The underlying per-entity bucket.
+    inner: HashMap<EntityId, T>,
+}
+
+impl<T: Default> PrepareScratch<T> {
+    /// Empty scratch.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: HashMap::new(),
+        }
+    }
+
+    /// Read-only access to `eid`'s scratch slot.
+    #[must_use]
+    pub fn get(&self, eid: EntityId) -> Option<&T> {
+        self.inner.get(&eid)
+    }
+
+    /// Mutable access to `eid`'s scratch slot, if it exists.
+    pub fn get_mut(&mut self, eid: EntityId) -> Option<&mut T> {
+        self.inner.get_mut(&eid)
+    }
+
+    /// Mutable access to `eid`'s scratch slot, inserting `T::default()`
+    /// if absent. Mirrors `HashMap::entry(...).or_default()` but takes
+    /// the typed `EntityId` directly and returns `&mut T` so callers can
+    /// chain field updates (`scratch.entry(car).field = …`).
+    pub fn entry(&mut self, eid: EntityId) -> &mut T {
+        self.inner.entry(eid).or_default()
+    }
+
+    /// Replace the scratch value for `eid`, returning the previous value
+    /// if any.
+    pub fn insert(&mut self, eid: EntityId, value: T) -> Option<T> {
+        self.inner.insert(eid, value)
+    }
+
+    /// Drop the scratch entry for `eid`. Call from `notify_removed` so
+    /// the scratch doesn't outlive the elevator.
+    pub fn remove(&mut self, eid: EntityId) -> Option<T> {
+        self.inner.remove(&eid)
+    }
+
+    /// Drop every scratch entry.
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+
+    /// Number of scratch entries.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Whether the scratch is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use slotmap::KeyData;
+
+    fn fake_id(idx: u64) -> EntityId {
+        EntityId::from(KeyData::from_ffi(idx))
+    }
+
+    #[test]
+    fn entry_inserts_default_then_returns_mut() {
+        #[derive(Default, Debug, PartialEq)]
+        struct CarStats {
+            counter: u32,
+        }
+        let mut scratch: PrepareScratch<CarStats> = PrepareScratch::new();
+        let id = fake_id(0x4242_0000_0000_0001);
+        scratch.entry(id).counter = 7;
+        assert_eq!(scratch.get(id).map(|s| s.counter), Some(7));
+        scratch.entry(id).counter += 5;
+        assert_eq!(scratch.get(id).map(|s| s.counter), Some(12));
+    }
+
+    #[test]
+    fn remove_returns_old_value_and_drops_entry() {
+        let mut scratch: PrepareScratch<u32> = PrepareScratch::new();
+        let id = fake_id(0x1234_0000_0000_0001);
+        scratch.insert(id, 99);
+        assert_eq!(scratch.remove(id), Some(99));
+        assert!(scratch.get(id).is_none());
+        assert!(scratch.is_empty());
+    }
+}

--- a/crates/elevator-core/src/dispatch/scratch.rs
+++ b/crates/elevator-core/src/dispatch/scratch.rs
@@ -90,8 +90,39 @@ impl<T: Default> PrepareScratch<T> {
     /// if absent. Mirrors `HashMap::entry(...).or_default()` but takes
     /// the typed `EntityId` directly and returns `&mut T` so callers can
     /// chain field updates (`scratch.entry(car).field = …`).
+    ///
+    /// Intended for use inside `prepare_car`, where the framework
+    /// guarantees the elevator exists. Calling this from other
+    /// `&mut self` hooks (e.g. `pre_dispatch`) on an `eid` that has
+    /// not yet been through `prepare_car` will silently insert a
+    /// `T::default()` entry; prefer [`get`](Self::get) or
+    /// [`get_mut`](Self::get_mut) there.
     pub fn entry(&mut self, eid: EntityId) -> &mut T {
         self.inner.entry(eid).or_default()
+    }
+
+    /// Iterate `(EntityId, &T)` for every populated slot.
+    ///
+    /// Useful from `pre_dispatch` for fleet-wide scans (aging, decay,
+    /// tick-bound counters) without keeping a side-channel
+    /// `Vec<EntityId>` to track the populated set.
+    pub fn iter(&self) -> impl Iterator<Item = (EntityId, &T)> + '_ {
+        self.inner.iter().map(|(id, t)| (*id, t))
+    }
+
+    /// Iterate `(EntityId, &mut T)` for every populated slot.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (EntityId, &mut T)> + '_ {
+        self.inner.iter_mut().map(|(id, t)| (*id, t))
+    }
+
+    /// Iterate `&T` over every populated slot.
+    pub fn values(&self) -> impl Iterator<Item = &T> + '_ {
+        self.inner.values()
+    }
+
+    /// Iterate `&mut T` over every populated slot.
+    pub fn values_mut(&mut self) -> impl Iterator<Item = &mut T> + '_ {
+        self.inner.values_mut()
     }
 
     /// Replace the scratch value for `eid`, returning the previous value


### PR DESCRIPTION
## Summary

Adds `PrepareScratch<T>` — a typed wrapper around the
`HashMap<EntityId, T>` pattern that custom dispatch strategies use to
hold per-car state computed in `prepare_car` and read in `rank`.

The friction this addresses: strategies that hand-roll per-car state
into multiple parallel `HashMap`s have to remember to drop each one
from `notify_removed`. Forgetting half is a class of bug
`PrepareScratch` removes by encouraging a single `Default` bundle
type per strategy:

\`\`\`rust
#[derive(Default)]
struct CarStats { last_served_tick: u64, idle_for: f64 }

#[derive(Default)]
struct IdlePenalty {
    stats: PrepareScratch<CarStats>,
}

impl DispatchStrategy for IdlePenalty {
    fn prepare_car(&mut self, car: EntityId, ...) {
        let s = self.stats.entry(car);
        s.idle_for = ...;
    }
    fn notify_removed(&mut self, eid: EntityId) {
        self.stats.remove(eid); // one call, all per-car fields gone
    }
}
\`\`\`

`examples/custom_dispatch.rs` is updated to use the bundled shape;
the prior version held two parallel `HashMap`s.

From `.research/elevator-core-audit-2026-05-08.md` §28.

## Test plan

- [x] `cargo test -p elevator-core --all-features --lib` — 988 pass
- [x] `cargo build --example custom_dispatch -p elevator-core
      --all-features` builds the updated example
- [x] new doctest on `PrepareScratch` passes (159 doctests total)
- [x] `cargo clippy -p elevator-core --all-features --all-targets` clean
- [x] full pre-commit green