### PR TITLE
feat(events): add EventKind projection and drain_events_by_kind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "19.0.0"
+version = "19.2.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/bindings.toml
+++ b/bindings.toml
@@ -520,6 +520,16 @@ gdext = "todo:future-binding"
 bevy = "todo:plugin-layer"
 
 [[methods]]
+name = "drain_events_by_kind"
+category = "events"
+wasm = "todo:future-binding"
+ffi  = "todo:future-binding"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "todo:future-binding"
+gdext = "todo:future-binding"
+bevy = "todo:plugin-layer"
+
+[[methods]]
 name = "pending_events"
 category = "events"
 wasm = "pendingEvents"

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -678,6 +678,194 @@ pub enum Event {
     },
 }
 
+/// Discriminant for [`Event`] — the unit-variant projection of the
+/// payload-carrying enum.
+///
+/// Strategies, hosts, and FFI consumers use [`EventKind`] to filter
+/// events without pattern-matching against payload-laden variants.
+/// Filtering is the primary use case;
+/// [`Simulation::drain_events_by_kind`](crate::sim::Simulation::drain_events_by_kind)
+/// takes a `&[EventKind]` so closure-free filtering crosses the
+/// FFI/wasm/gdext boundary that closure-based
+/// [`drain_events_where`](crate::sim::Simulation::drain_events_where)
+/// can't.
+///
+/// One-to-one with [`Event`] variants. Mirrors the same `#[non_exhaustive]`
+/// and `#[cfg(feature = "energy")]` gates so hosts compiled without the
+/// `energy` feature don't see [`EventKind::EnergyConsumed`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum EventKind {
+    /// See [`Event::ElevatorDeparted`].
+    ElevatorDeparted,
+    /// See [`Event::ElevatorArrived`].
+    ElevatorArrived,
+    /// See [`Event::DoorOpened`].
+    DoorOpened,
+    /// See [`Event::DoorClosed`].
+    DoorClosed,
+    /// See [`Event::PassingFloor`].
+    PassingFloor,
+    /// See [`Event::MovementAborted`].
+    MovementAborted,
+    /// See [`Event::RiderSpawned`].
+    RiderSpawned,
+    /// See [`Event::RiderBoarded`].
+    RiderBoarded,
+    /// See [`Event::RiderExited`].
+    RiderExited,
+    /// See [`Event::RiderRejected`].
+    RiderRejected,
+    /// See [`Event::RiderAbandoned`].
+    RiderAbandoned,
+    /// See [`Event::RiderEjected`].
+    RiderEjected,
+    /// See [`Event::ElevatorAssigned`].
+    ElevatorAssigned,
+    /// See [`Event::StopAdded`].
+    StopAdded,
+    /// See [`Event::ElevatorAdded`].
+    ElevatorAdded,
+    /// See [`Event::EntityDisabled`].
+    EntityDisabled,
+    /// See [`Event::EntityEnabled`].
+    EntityEnabled,
+    /// See [`Event::RouteInvalidated`].
+    RouteInvalidated,
+    /// See [`Event::RiderRerouted`].
+    RiderRerouted,
+    /// See [`Event::RiderSettled`].
+    RiderSettled,
+    /// See [`Event::RiderDespawned`].
+    RiderDespawned,
+    /// See [`Event::LineAdded`].
+    LineAdded,
+    /// See [`Event::LineRemoved`].
+    LineRemoved,
+    /// See [`Event::LineReassigned`].
+    LineReassigned,
+    /// See [`Event::ElevatorReassigned`].
+    ElevatorReassigned,
+    /// See [`Event::ElevatorRepositioning`].
+    ElevatorRepositioning,
+    /// See [`Event::ElevatorRepositioned`].
+    ElevatorRepositioned,
+    /// See [`Event::ElevatorRecalled`].
+    ElevatorRecalled,
+    /// See [`Event::ServiceModeChanged`].
+    ServiceModeChanged,
+    /// See [`Event::EnergyConsumed`].
+    #[cfg(feature = "energy")]
+    EnergyConsumed,
+    /// See [`Event::CapacityChanged`].
+    CapacityChanged,
+    /// See [`Event::ElevatorIdle`].
+    ElevatorIdle,
+    /// See [`Event::DirectionIndicatorChanged`].
+    DirectionIndicatorChanged,
+    /// See [`Event::ElevatorRemoved`].
+    ElevatorRemoved,
+    /// See [`Event::DestinationQueued`].
+    DestinationQueued,
+    /// See [`Event::StopRemoved`].
+    StopRemoved,
+    /// See [`Event::DoorCommandQueued`].
+    DoorCommandQueued,
+    /// See [`Event::DoorCommandApplied`].
+    DoorCommandApplied,
+    /// See [`Event::ElevatorUpgraded`].
+    ElevatorUpgraded,
+    /// See [`Event::ManualVelocityCommanded`].
+    ManualVelocityCommanded,
+    /// See [`Event::HallButtonPressed`].
+    HallButtonPressed,
+    /// See [`Event::HallCallAcknowledged`].
+    HallCallAcknowledged,
+    /// See [`Event::HallCallCleared`].
+    HallCallCleared,
+    /// See [`Event::CarButtonPressed`].
+    CarButtonPressed,
+    /// See [`Event::RiderSkipped`].
+    RiderSkipped,
+    /// See [`Event::SnapshotDanglingReference`].
+    SnapshotDanglingReference,
+    /// See [`Event::RepositionStrategyNotRestored`].
+    RepositionStrategyNotRestored,
+    /// See [`Event::DispatchConfigNotRestored`].
+    DispatchConfigNotRestored,
+    /// See [`Event::ResidentsAtRemovedStop`].
+    ResidentsAtRemovedStop,
+}
+
+impl Event {
+    /// Project this [`Event`] to its [`EventKind`] discriminant.
+    ///
+    /// ```
+    /// # use elevator_core::events::{Event, EventKind};
+    /// # use elevator_core::entity::EntityId;
+    /// let e = Event::DoorOpened {
+    ///     elevator: EntityId::default(),
+    ///     tick: 0,
+    /// };
+    /// assert_eq!(e.kind(), EventKind::DoorOpened);
+    /// ```
+    #[must_use]
+    pub const fn kind(&self) -> EventKind {
+        match self {
+            Self::ElevatorDeparted { .. } => EventKind::ElevatorDeparted,
+            Self::ElevatorArrived { .. } => EventKind::ElevatorArrived,
+            Self::DoorOpened { .. } => EventKind::DoorOpened,
+            Self::DoorClosed { .. } => EventKind::DoorClosed,
+            Self::PassingFloor { .. } => EventKind::PassingFloor,
+            Self::MovementAborted { .. } => EventKind::MovementAborted,
+            Self::RiderSpawned { .. } => EventKind::RiderSpawned,
+            Self::RiderBoarded { .. } => EventKind::RiderBoarded,
+            Self::RiderExited { .. } => EventKind::RiderExited,
+            Self::RiderRejected { .. } => EventKind::RiderRejected,
+            Self::RiderAbandoned { .. } => EventKind::RiderAbandoned,
+            Self::RiderEjected { .. } => EventKind::RiderEjected,
+            Self::ElevatorAssigned { .. } => EventKind::ElevatorAssigned,
+            Self::StopAdded { .. } => EventKind::StopAdded,
+            Self::ElevatorAdded { .. } => EventKind::ElevatorAdded,
+            Self::EntityDisabled { .. } => EventKind::EntityDisabled,
+            Self::EntityEnabled { .. } => EventKind::EntityEnabled,
+            Self::RouteInvalidated { .. } => EventKind::RouteInvalidated,
+            Self::RiderRerouted { .. } => EventKind::RiderRerouted,
+            Self::RiderSettled { .. } => EventKind::RiderSettled,
+            Self::RiderDespawned { .. } => EventKind::RiderDespawned,
+            Self::LineAdded { .. } => EventKind::LineAdded,
+            Self::LineRemoved { .. } => EventKind::LineRemoved,
+            Self::LineReassigned { .. } => EventKind::LineReassigned,
+            Self::ElevatorReassigned { .. } => EventKind::ElevatorReassigned,
+            Self::ElevatorRepositioning { .. } => EventKind::ElevatorRepositioning,
+            Self::ElevatorRepositioned { .. } => EventKind::ElevatorRepositioned,
+            Self::ElevatorRecalled { .. } => EventKind::ElevatorRecalled,
+            Self::ServiceModeChanged { .. } => EventKind::ServiceModeChanged,
+            #[cfg(feature = "energy")]
+            Self::EnergyConsumed { .. } => EventKind::EnergyConsumed,
+            Self::CapacityChanged { .. } => EventKind::CapacityChanged,
+            Self::ElevatorIdle { .. } => EventKind::ElevatorIdle,
+            Self::DirectionIndicatorChanged { .. } => EventKind::DirectionIndicatorChanged,
+            Self::ElevatorRemoved { .. } => EventKind::ElevatorRemoved,
+            Self::DestinationQueued { .. } => EventKind::DestinationQueued,
+            Self::StopRemoved { .. } => EventKind::StopRemoved,
+            Self::DoorCommandQueued { .. } => EventKind::DoorCommandQueued,
+            Self::DoorCommandApplied { .. } => EventKind::DoorCommandApplied,
+            Self::ElevatorUpgraded { .. } => EventKind::ElevatorUpgraded,
+            Self::ManualVelocityCommanded { .. } => EventKind::ManualVelocityCommanded,
+            Self::HallButtonPressed { .. } => EventKind::HallButtonPressed,
+            Self::HallCallAcknowledged { .. } => EventKind::HallCallAcknowledged,
+            Self::HallCallCleared { .. } => EventKind::HallCallCleared,
+            Self::CarButtonPressed { .. } => EventKind::CarButtonPressed,
+            Self::RiderSkipped { .. } => EventKind::RiderSkipped,
+            Self::SnapshotDanglingReference { .. } => EventKind::SnapshotDanglingReference,
+            Self::RepositionStrategyNotRestored { .. } => EventKind::RepositionStrategyNotRestored,
+            Self::DispatchConfigNotRestored { .. } => EventKind::DispatchConfigNotRestored,
+            Self::ResidentsAtRemovedStop { .. } => EventKind::ResidentsAtRemovedStop,
+        }
+    }
+}
+
 /// Identifies which elevator parameter was changed in an
 /// [`Event::ElevatorUpgraded`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -537,7 +537,7 @@ pub mod prelude {
     pub use crate::dispatch::{BuiltinReposition, BuiltinStrategy, DispatchStrategy};
     pub use crate::entity::{ElevatorId, EntityId, RiderId};
     pub use crate::error::{RejectionReason, SimError};
-    pub use crate::events::Event;
+    pub use crate::events::{Event, EventKind};
     pub use crate::ids::GroupId;
     pub use crate::metrics::Metrics;
     pub use crate::sim::{RiderBuilder, Simulation};

--- a/crates/elevator-core/src/sim/rider.rs
+++ b/crates/elevator-core/src/sim/rider.rs
@@ -285,6 +285,32 @@ impl super::Simulation {
         matched
     }
 
+    /// Drain events whose [`kind`](Event::kind) is in `kinds`.
+    ///
+    /// Closure-free counterpart to
+    /// [`drain_events_where`](Self::drain_events_where) — useful from
+    /// FFI / wasm / gdext call sites that can't marshal a Rust closure
+    /// across the language boundary. `kinds` is treated as a small
+    /// set; for very large filter sets prefer the closure form.
+    ///
+    /// Events whose kind is not in the set remain in the buffer and
+    /// will be returned by future `drain_events*` calls.
+    ///
+    /// ```
+    /// use elevator_core::events::EventKind;
+    /// use elevator_core::prelude::*;
+    ///
+    /// let mut sim = SimulationBuilder::demo().build().unwrap();
+    /// sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
+    /// sim.step();
+    ///
+    /// let spawns = sim.drain_events_by_kind(&[EventKind::RiderSpawned]);
+    /// assert!(spawns.iter().all(|e| matches!(e, Event::RiderSpawned { .. })));
+    /// ```
+    pub fn drain_events_by_kind(&mut self, kinds: &[crate::events::EventKind]) -> Vec<Event> {
+        self.drain_events_where(|e| kinds.contains(&e.kind()))
+    }
+
     // ── Rider tag (opaque consumer-attached id) ──────────────────────
 
     /// Read the opaque tag attached to a rider.

--- a/crates/elevator-core/src/sim/rider.rs
+++ b/crates/elevator-core/src/sim/rider.rs
@@ -297,7 +297,6 @@ impl super::Simulation {
     /// will be returned by future `drain_events*` calls.
     ///
     /// ```
-    /// use elevator_core::events::EventKind;
     /// use elevator_core::prelude::*;
     ///
     /// let mut sim = SimulationBuilder::demo().build().unwrap();


### PR DESCRIPTION
## Summary

Adds `EventKind` — the unit-variant projection of `Event`. Mirrors all
49 variants with the same `#[non_exhaustive]` annotation and the same
`#[cfg(feature = \"energy\")]` gate so feature-disabled hosts don't see
`EnergyConsumed`.

\`\`\`rust
let e = Event::DoorOpened { elevator, tick };
assert_eq!(e.kind(), EventKind::DoorOpened);
\`\`\`

Adds `Simulation::drain_events_by_kind(&[EventKind]) -> Vec<Event>` —
a closure-free counterpart to `drain_events_where`, callable from FFI
/ wasm / gdext that can't marshal a Rust closure across the language
boundary. Internally just delegates to `drain_events_where` with an
explicit `kinds.contains` check.

This unblocks the audit's §10: hosts that need filtered event streams
no longer have to drain everything and filter on their own side.

`bindings.toml` updated: `drain_events_where` stays
`skip:closure-marshaling` (it genuinely can't cross the FFI line),
`drain_events_by_kind` is `todo:future-binding` ready for downstream
wiring as each host needs it.

## Test plan

- [x] new doctest on `Event::kind` and `drain_events_by_kind` pass
- [x] `cargo test -p elevator-core --all-features --lib` — 990 pass
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean
- [x] `scripts/check-bindings.sh` — manifest in sync