### PR TITLE
docs: tighten ExtKey snapshot-stability + DCS queue-probe invariant

### DIFF
--- a/crates/elevator-core/src/dispatch/destination.rs
+++ b/crates/elevator-core/src/dispatch/destination.rs
@@ -354,6 +354,14 @@ impl DestinationDispatch {
         // (car, candidate-rider) pair each DCS tick, and at the scale of a
         // busy commercial group the Vec clone was the dominant allocation
         // in `pre_dispatch`.
+        //
+        // Invariant: the destination queue must be immutable for the
+        // duration of one DCS pass. `pre_dispatch` calls `rebuild_car_queue`
+        // before any `compute_cost` runs, then leaves the queue alone
+        // until the next pass. Concurrent mutation here would race with
+        // these probes; if you ever need to write to the queue from
+        // inside a `compute_cost` call site, snapshot the relevant
+        // entries into a `SmallVec` at the top of `pre_dispatch` instead.
         let queue_contains = |s: EntityId| {
             world
                 .destination_queue(eid)

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -19,6 +19,22 @@ use crate::query::storage::AnyExtMap;
 ///
 /// Constructed via [`ExtKey::new`] with an explicit name, or
 /// [`ExtKey::from_type_name`] which uses `std::any::type_name::<T>()`.
+///
+/// # Snapshot stability
+///
+/// The `name` is the wire-format key for snapshot extension storage.
+/// **Prefer [`ExtKey::new`] with an explicit string for any production
+/// or persisted scenario** — `std::any::type_name::<T>()` is documented
+/// as not guaranteed stable across compilations and can drift in
+/// practice (renamed crates, generic monomorphization choices, future
+/// compiler releases). A snapshot saved on one build profile and
+/// restored on another whose `type_name<T>()` differs will silently
+/// drop the extension data.
+///
+/// `assert_ext_name_unique` (called by `register_ext` and
+/// `insert_ext`) panics on in-process collisions, so in-memory drift
+/// is loud; the silent failure mode is purely a snapshot-restore-on-a
+/// different-build issue.
 #[derive(Debug)]
 pub struct ExtKey<T> {
     /// Human-readable storage name, used for serialization roundtrips.
@@ -45,6 +61,11 @@ impl<T> ExtKey<T> {
     }
 
     /// Create a key using `std::any::type_name::<T>()` as the storage name.
+    ///
+    /// Convenient for prototyping and tests, but the resulting `name`
+    /// is **not snapshot-stable across builds** — see the type-level
+    /// "Snapshot stability" note. Production code that persists
+    /// snapshots should use [`ExtKey::new`] with an explicit name.
     #[must_use]
     pub fn from_type_name() -> Self {
         Self {


### PR DESCRIPTION
## Summary

Two documentation-tightening items the audit flagged as hazards
waiting to bite a future contributor (§26, §27). Pure docs / comments
— no behavior change.

**ExtKey snapshot-stability (§26).** `ExtKey::from_type_name` uses
`std::any::type_name::<T>()`, which is not guaranteed stable across
builds. Different debug/release profiles, crate renames, or generic
monomorphization choices can produce different names. A snapshot
saved on one build profile and restored on another with a divergent
`type_name` silently drops the extension data. The in-process
collision case is loud (asserted via `assert_ext_name_unique`); this
cross-build silent failure is what matters. Adds a type-level
"Snapshot stability" doc block plus a pointer on `from_type_name()`
so the warning surfaces in the rustdoc summary.

**DCS queue-probe invariant (§27).** The `compute_cost` queue probe
at `destination.rs:354` already had a comment explaining why we don't
clone, but didn't pin the invariant the optimization relies on: the
destination queue must be immutable for the duration of one DCS
pass. Document it explicitly so a future "let me write to the queue
here too" change surfaces the conflict at review time instead of as
flaky behavior at runtime.

## Test plan

- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean
- [x] full pre-commit green