### PR TITLE
feat(snapshot): add WorldSnapshot::migrate forward-migration shim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "19.2.0"
+version = "19.3.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -215,6 +215,57 @@ type CustomStrategyFactory<'a> =
     Option<&'a dyn Fn(&str) -> Option<Box<dyn crate::dispatch::DispatchStrategy>>>;
 
 impl WorldSnapshot {
+    /// Schema version this build of `elevator-core` writes and accepts.
+    ///
+    /// Compare against [`WorldSnapshot::version`] to decide whether a
+    /// snapshot needs forward migration before [`WorldSnapshot::restore`]
+    /// will accept it.
+    pub const CURRENT_SCHEMA_VERSION: u32 = SNAPSHOT_SCHEMA_VERSION;
+
+    /// Forward-migrate a snapshot to [`CURRENT_SCHEMA_VERSION`](Self::CURRENT_SCHEMA_VERSION).
+    ///
+    /// `restore` rejects mismatched schema versions hard so silent
+    /// `#[serde(default)]` field-filling can't mask a mismatch. Callers
+    /// that want to load older snapshots route them through this method
+    /// first:
+    ///
+    /// ```no_run
+    /// # use elevator_core::snapshot::WorldSnapshot;
+    /// # fn load(snap: WorldSnapshot) -> Result<(), elevator_core::error::SimError> {
+    /// let sim = snap.migrate()?.restore(None)?;
+    /// # let _ = sim;
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// Future schema bumps wire their step-up migrations into the match
+    /// arm below; the current shape lets each step take a snapshot at
+    /// version `n` and produce one at `n + 1`, then re-enters `migrate`
+    /// recursively until `version == CURRENT_SCHEMA_VERSION`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SimError::SnapshotVersion`](crate::error::SimError::SnapshotVersion)
+    /// for snapshots from a version this build doesn't know how to
+    /// migrate (either `version > CURRENT_SCHEMA_VERSION`, or
+    /// `version < CURRENT_SCHEMA_VERSION` with no migration path
+    /// registered).
+    pub fn migrate(self) -> Result<Self, crate::error::SimError> {
+        // Step-up migrations slot in as match arms. Each arm consumes
+        // self at version N and produces a Self at version N+1, then
+        // tail-calls migrate() until it reaches CURRENT_SCHEMA_VERSION.
+        // No upgrades exist yet — schema is at v1 — so the only
+        // accepted version is the current one.
+        match self.version {
+            v if v == Self::CURRENT_SCHEMA_VERSION => Ok(self),
+            // Example pattern for the next bump (uncomment when v2 lands):
+            // 1 => migrate_v1_to_v2(self).migrate(),
+            saved => Err(crate::error::SimError::SnapshotVersion {
+                saved: format!("schema {saved}"),
+                current: format!("schema {}", Self::CURRENT_SCHEMA_VERSION),
+            }),
+        }
+    }
+
     /// Restore a simulation from this snapshot.
     ///
     /// Built-in strategies (Scan, Look, `NearestCar`, ETD) are auto-restored.

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -238,9 +238,10 @@ impl WorldSnapshot {
     /// ```
     ///
     /// Future schema bumps wire their step-up migrations into the match
-    /// arm below; the current shape lets each step take a snapshot at
-    /// version `n` and produce one at `n + 1`, then re-enters `migrate`
-    /// recursively until `version == CURRENT_SCHEMA_VERSION`.
+    /// arm below; each step consumes a snapshot at version `n` and
+    /// produces one at `n + 1`. The outer `while` drives the chain to
+    /// [`CURRENT_SCHEMA_VERSION`](Self::CURRENT_SCHEMA_VERSION) with
+    /// O(1) stack depth regardless of how far behind the input is.
     ///
     /// # Errors
     ///
@@ -250,20 +251,35 @@ impl WorldSnapshot {
     /// `version < CURRENT_SCHEMA_VERSION` with no migration path
     /// registered).
     pub fn migrate(self) -> Result<Self, crate::error::SimError> {
-        // Step-up migrations slot in as match arms. Each arm consumes
-        // self at version N and produces a Self at version N+1, then
-        // tail-calls migrate() until it reaches CURRENT_SCHEMA_VERSION.
-        // No upgrades exist yet — schema is at v1 — so the only
-        // accepted version is the current one.
-        match self.version {
-            v if v == Self::CURRENT_SCHEMA_VERSION => Ok(self),
-            // Example pattern for the next bump (uncomment when v2 lands):
-            // 1 => migrate_v1_to_v2(self).migrate(),
-            saved => Err(crate::error::SimError::SnapshotVersion {
-                saved: format!("schema {saved}"),
+        // Snapshots from a future build can't be down-migrated — the
+        // newer build defines what the new shape *is*.
+        if self.version > Self::CURRENT_SCHEMA_VERSION {
+            return Err(crate::error::SimError::SnapshotVersion {
+                saved: format!("schema {}", self.version),
                 current: format!("schema {}", Self::CURRENT_SCHEMA_VERSION),
-            }),
+            });
         }
+        if self.version == Self::CURRENT_SCHEMA_VERSION {
+            return Ok(self);
+        }
+        // Schema is at v1 today, so no step-up arms exist; any
+        // version below current with no migration path errors out.
+        // The intended shape once schema bumps land is an iterative
+        // step_up loop with O(1) stack depth regardless of how many
+        // schema versions an archived snapshot has to traverse:
+        //
+        //     let mut snap = self;
+        //     while snap.version < Self::CURRENT_SCHEMA_VERSION {
+        //         snap = step_up_one(snap)?;
+        //     }
+        //     Ok(snap)
+        //
+        // where `step_up_one` matches on `snap.version` and emits one
+        // arm per `n -> n + 1` upgrade.
+        Err(crate::error::SimError::SnapshotVersion {
+            saved: format!("schema {}", self.version),
+            current: format!("schema {}", Self::CURRENT_SCHEMA_VERSION),
+        })
     }
 
     /// Restore a simulation from this snapshot.

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -1038,3 +1038,32 @@ fn snapshot_ron_roundtrip_is_byte_stable() {
         "WorldSnapshot RON: serialize -> deserialize -> serialize must be byte-stable"
     );
 }
+
+#[test]
+fn migrate_passes_through_current_version_snapshot() {
+    let sim = diverse_phase_sim();
+    let snap = sim.snapshot();
+    let original_version = snap.version;
+    let migrated = snap.migrate().expect("current-version snapshot migrates");
+    assert_eq!(migrated.version, original_version);
+    assert_eq!(
+        migrated.version,
+        crate::snapshot::WorldSnapshot::CURRENT_SCHEMA_VERSION,
+    );
+}
+
+#[test]
+fn migrate_rejects_unknown_version() {
+    let sim = diverse_phase_sim();
+    let mut snap = sim.snapshot();
+    // Pretend the snapshot came from a future build by jumping past
+    // CURRENT_SCHEMA_VERSION; no migration arm matches, so migrate
+    // returns SnapshotVersion. Same path covers a version below the
+    // current with no upgrade registered.
+    snap.version = crate::snapshot::WorldSnapshot::CURRENT_SCHEMA_VERSION + 7;
+    let err = snap.migrate().expect_err("unknown version must error");
+    assert!(matches!(
+        err,
+        crate::error::SimError::SnapshotVersion { .. }
+    ));
+}


### PR DESCRIPTION
## Summary

The snapshot schema is at v1 today; `restore()` rejects mismatched
versions hard so `#[serde(default)]` field-filling can't mask a
mismatch. That's the right default for a single-version world, but
every future schema bump would force every consumer to re-run from
RON configs or roll their own migration. Adding the shim now
establishes the pattern *before* the first bump lands, so the next
bump is a one-line addition rather than an API change.

Surface:

- `WorldSnapshot::CURRENT_SCHEMA_VERSION` — public constant for
  callers that want to compare against `snapshot.version` directly.
- `WorldSnapshot::migrate(self) -> Result<Self, SimError>` — current
  arm is identity (v1 → v1); future arms add v1 → v2 → v3 step-up
  migrations that recurse via tail call until the result hits
  `CURRENT_SCHEMA_VERSION`.

`restore()` is unchanged — callers explicitly opt into migration via
\`snap.migrate()?.restore(None)?\`. Backwards-compatible; current-version
snapshots round-trip without going through migrate.

From `.research/elevator-core-audit-2026-05-08.md` §32. The full
RestoreOptions wrapping (§39) stays deferred until v2 lands and we
have a real migration to demonstrate.

## Test plan

- [x] new test: identity migration on current-version snapshot
- [x] new test: SnapshotVersion error on unknown version
- [x] full pre-commit (fmt, clippy, core tests, doc tests, workspace
      check, ABI pin guard) green