### PR TITLE
feat(events): add drain_events_for_entity and Event::involves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "19.3.0"
+version = "19.4.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/bindings.toml
+++ b/bindings.toml
@@ -530,6 +530,16 @@ gdext = "todo:future-binding"
 bevy = "todo:plugin-layer"
 
 [[methods]]
+name = "drain_events_for_entity"
+category = "events"
+wasm = "todo:future-binding"
+ffi  = "todo:future-binding"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "todo:future-binding"
+gdext = "todo:future-binding"
+bevy = "todo:plugin-layer"
+
+[[methods]]
 name = "pending_events"
 category = "events"
 wasm = "pendingEvents"

--- a/crates/elevator-core/src/events.rs
+++ b/crates/elevator-core/src/events.rs
@@ -864,6 +864,149 @@ impl Event {
             Self::ResidentsAtRemovedStop { .. } => EventKind::ResidentsAtRemovedStop,
         }
     }
+
+    /// Whether this event references the given entity in any of its
+    /// payload fields.
+    ///
+    /// Used by
+    /// [`Simulation::drain_events_for_entity`](crate::sim::Simulation::drain_events_for_entity)
+    /// to provide a closure-free filter that crosses the FFI / wasm /
+    /// gdext boundary. Returns `true` when `id` matches any [`EntityId`]
+    /// field on the variant — for example,
+    /// [`Event::RiderBoarded`] references both `rider` and `elevator`,
+    /// so a query for the elevator and a query for the rider both match
+    /// the same event.
+    ///
+    /// Variants whose only entity-shaped reference is a [`GroupId`]
+    /// (e.g. [`Event::RepositionStrategyNotRestored`]) never match —
+    /// [`GroupId`] is a separate identifier space from [`EntityId`].
+    ///
+    /// ```
+    /// # use elevator_core::events::Event;
+    /// # use elevator_core::entity::EntityId;
+    /// let car = EntityId::default();
+    /// let evt = Event::DoorOpened { elevator: car, tick: 0 };
+    /// assert!(evt.involves(car));
+    /// ```
+    #[must_use]
+    #[allow(clippy::too_many_lines)]
+    pub fn involves(&self, id: EntityId) -> bool {
+        match self {
+            Self::ElevatorDeparted {
+                elevator,
+                from_stop,
+                ..
+            } => *elevator == id || *from_stop == id,
+            Self::ElevatorArrived {
+                elevator, at_stop, ..
+            } => *elevator == id || *at_stop == id,
+            Self::DoorOpened { elevator, .. } | Self::DoorClosed { elevator, .. } => {
+                *elevator == id
+            }
+            Self::PassingFloor { elevator, stop, .. } => *elevator == id || *stop == id,
+            Self::MovementAborted {
+                elevator,
+                brake_target,
+                ..
+            } => *elevator == id || *brake_target == id,
+            Self::RiderSpawned {
+                rider,
+                origin,
+                destination,
+                ..
+            } => *rider == id || *origin == id || *destination == id,
+            Self::RiderBoarded {
+                rider, elevator, ..
+            } => *rider == id || *elevator == id,
+            Self::RiderExited {
+                rider,
+                elevator,
+                stop,
+                ..
+            } => *rider == id || *elevator == id || *stop == id,
+            Self::RiderRejected {
+                rider, elevator, ..
+            } => *rider == id || *elevator == id,
+            Self::RiderAbandoned { rider, stop, .. } => *rider == id || *stop == id,
+            Self::RiderEjected {
+                rider,
+                elevator,
+                stop,
+                ..
+            } => *rider == id || *elevator == id || *stop == id,
+            Self::ElevatorAssigned { elevator, stop, .. } => *elevator == id || *stop == id,
+            Self::StopAdded { stop, line, .. } => *stop == id || *line == id,
+            Self::ElevatorAdded { elevator, line, .. } => *elevator == id || *line == id,
+            Self::EntityDisabled { entity, .. } | Self::EntityEnabled { entity, .. } => {
+                *entity == id
+            }
+            Self::RouteInvalidated {
+                rider,
+                affected_stop,
+                ..
+            } => *rider == id || *affected_stop == id,
+            Self::RiderRerouted {
+                rider,
+                new_destination,
+                ..
+            } => *rider == id || *new_destination == id,
+            Self::RiderSettled { rider, stop, .. } => *rider == id || *stop == id,
+            Self::RiderDespawned { rider, .. } => *rider == id,
+            Self::LineAdded { line, .. } | Self::LineRemoved { line, .. } => *line == id,
+            Self::LineReassigned { line, .. } => *line == id,
+            Self::ElevatorReassigned {
+                elevator,
+                old_line,
+                new_line,
+                ..
+            } => *elevator == id || *old_line == id || *new_line == id,
+            Self::ElevatorRepositioning {
+                elevator, to_stop, ..
+            } => *elevator == id || *to_stop == id,
+            Self::ElevatorRepositioned {
+                elevator, at_stop, ..
+            } => *elevator == id || *at_stop == id,
+            Self::ElevatorRecalled {
+                elevator, to_stop, ..
+            } => *elevator == id || *to_stop == id,
+            Self::ServiceModeChanged { elevator, .. } => *elevator == id,
+            #[cfg(feature = "energy")]
+            Self::EnergyConsumed { elevator, .. } => *elevator == id,
+            Self::CapacityChanged { elevator, .. } => *elevator == id,
+            Self::ElevatorIdle {
+                elevator, at_stop, ..
+            } => *elevator == id || at_stop.is_some_and(|s| s == id),
+            Self::DirectionIndicatorChanged { elevator, .. } => *elevator == id,
+            Self::ElevatorRemoved { elevator, line, .. } => *elevator == id || *line == id,
+            Self::DestinationQueued { elevator, stop, .. } => *elevator == id || *stop == id,
+            Self::StopRemoved { stop, .. } => *stop == id,
+            Self::DoorCommandQueued { elevator, .. }
+            | Self::DoorCommandApplied { elevator, .. } => *elevator == id,
+            Self::ElevatorUpgraded { elevator, .. } => *elevator == id,
+            Self::ManualVelocityCommanded { elevator, .. } => *elevator == id,
+            Self::HallButtonPressed { stop, .. } | Self::HallCallAcknowledged { stop, .. } => {
+                *stop == id
+            }
+            Self::HallCallCleared { stop, car, .. } => *stop == id || *car == id,
+            Self::CarButtonPressed {
+                car, floor, rider, ..
+            } => *car == id || *floor == id || rider.is_some_and(|r| r == id),
+            Self::RiderSkipped {
+                rider,
+                elevator,
+                at_stop,
+                ..
+            } => *rider == id || *elevator == id || *at_stop == id,
+            Self::SnapshotDanglingReference { stale_id, .. } => *stale_id == id,
+            // GroupId-only payloads have no EntityId to match on.
+            Self::RepositionStrategyNotRestored { .. } | Self::DispatchConfigNotRestored { .. } => {
+                false
+            }
+            Self::ResidentsAtRemovedStop {
+                stop, residents, ..
+            } => *stop == id || residents.contains(&id),
+        }
+    }
 }
 
 /// Identifies which elevator parameter was changed in an

--- a/crates/elevator-core/src/sim/rider.rs
+++ b/crates/elevator-core/src/sim/rider.rs
@@ -310,6 +310,39 @@ impl super::Simulation {
         self.drain_events_where(|e| kinds.contains(&e.kind()))
     }
 
+    /// Drain events that reference `entity` in any of their fields.
+    ///
+    /// Closure-free counterpart to
+    /// [`drain_events_where`](Self::drain_events_where) for the common
+    /// "give me everything that happened to this rider / car / stop"
+    /// query — usable from FFI / wasm / gdext call sites that can't
+    /// marshal a Rust closure across the language boundary.
+    ///
+    /// Matching is delegated to [`Event::involves`]: an event matches
+    /// when any [`EntityId`](crate::entity::EntityId) field on the
+    /// payload equals `entity`. Multi-entity events (e.g.
+    /// [`RiderBoarded`](Event::RiderBoarded), which references both
+    /// rider and elevator) match when *either* role does, so a query
+    /// for a car returns the same event as a separate query for the
+    /// rider.
+    ///
+    /// Events that don't reference `entity` remain in the buffer and
+    /// will be returned by future `drain_events*` calls.
+    ///
+    /// ```
+    /// use elevator_core::prelude::*;
+    ///
+    /// let mut sim = SimulationBuilder::demo().build().unwrap();
+    /// let rider = sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
+    /// sim.step();
+    ///
+    /// let rider_events = sim.drain_events_for_entity(rider.entity());
+    /// assert!(rider_events.iter().all(|e| e.involves(rider.entity())));
+    /// ```
+    pub fn drain_events_for_entity(&mut self, entity: crate::entity::EntityId) -> Vec<Event> {
+        self.drain_events_where(|e| e.involves(entity))
+    }
+
     // ── Rider tag (opaque consumer-attached id) ──────────────────────
 
     /// Read the opaque tag attached to a rider.

--- a/crates/elevator-core/src/sim/rider.rs
+++ b/crates/elevator-core/src/sim/rider.rs
@@ -319,7 +319,7 @@ impl super::Simulation {
     /// marshal a Rust closure across the language boundary.
     ///
     /// Matching is delegated to [`Event::involves`]: an event matches
-    /// when any [`EntityId`](crate::entity::EntityId) field on the
+    /// when any [`EntityId`] field on the
     /// payload equals `entity`. Multi-entity events (e.g.
     /// [`RiderBoarded`](Event::RiderBoarded), which references both
     /// rider and elevator) match when *either* role does, so a query

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -579,6 +579,99 @@ fn drain_events_where_with_no_match_returns_empty_and_retains_all() {
     );
 }
 
+// ── drain_events_for_entity ───────────────────────────────────────────────────
+
+#[test]
+fn drain_events_for_entity_returns_only_matching_events() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let rider_id = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    for _ in 0..5 {
+        sim.step();
+    }
+
+    let rider_events = sim.drain_events_for_entity(rider_id.entity());
+    assert!(
+        !rider_events.is_empty(),
+        "rider must accumulate at least one event over 5 ticks"
+    );
+    for e in &rider_events {
+        assert!(
+            e.involves(rider_id.entity()),
+            "drain_events_for_entity returned an event that doesn't reference the queried id: {e:?}"
+        );
+    }
+}
+
+#[test]
+fn drain_events_for_entity_partitions_with_drain_events() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let rider_id = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    for _ in 0..5 {
+        sim.step();
+    }
+
+    let rider = sim.drain_events_for_entity(rider_id.entity());
+    let remaining = sim.drain_events();
+
+    // Filtered partition is disjoint: nothing in remaining references the rider.
+    for e in &remaining {
+        assert!(
+            !e.involves(rider_id.entity()),
+            "leftover event after drain_events_for_entity still references rider: {e:?}"
+        );
+    }
+    // Sanity: the union covers the events the rider participated in.
+    assert!(
+        rider
+            .iter()
+            .any(|e| matches!(e, Event::RiderSpawned { .. }))
+    );
+}
+
+#[test]
+fn drain_events_for_entity_matches_multi_role_events() {
+    // A RiderBoarded event references both rider and elevator. A query
+    // for either entity must return the same event.
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let rider_id = sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    let elevator_id = sim.groups()[0].elevator_entities()[0];
+
+    // Run until the rider has boarded — produces a RiderBoarded event.
+    for _ in 0..300 {
+        sim.step();
+        if matches!(
+            sim.world().rider(rider_id.entity()).unwrap().phase,
+            RiderPhase::Riding(_)
+        ) {
+            break;
+        }
+    }
+
+    // Drain everything to a buffer, then check the boarded event involves both.
+    let all = sim.drain_events();
+    let boarded: Vec<_> = all
+        .iter()
+        .filter(|e| matches!(e, Event::RiderBoarded { .. }))
+        .collect();
+    assert!(!boarded.is_empty(), "rider must have boarded");
+    for e in boarded {
+        assert!(
+            e.involves(rider_id.entity()),
+            "boarded event must involve rider"
+        );
+        assert!(
+            e.involves(elevator_id),
+            "boarded event must involve elevator"
+        );
+    }
+}
+
 // ── riders_on ─────────────────────────────────────────────────────────────────
 
 #[test]

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -624,7 +624,7 @@ fn drain_events_for_entity_partitions_with_drain_events() {
             "leftover event after drain_events_for_entity still references rider: {e:?}"
         );
     }
-    // Sanity: the union covers the events the rider participated in.
+    // Sanity: the rider-drain contains at least the spawn event.
     assert!(
         rider
             .iter()


### PR DESCRIPTION
## Summary

- Adds `Simulation::drain_events_for_entity(EntityId)` — closure-free counterpart to `drain_events_where` for the common "give me everything that happened to this rider / car / stop" query
- Adds `Event::involves(EntityId)` — exhaustive predicate matching any `EntityId` field on the variant. Multi-role events (e.g. `RiderBoarded`) match when *either* the rider or the elevator equals the queried id; `GroupId`-only payloads never match
- Updates \`bindings.toml\` with the new method (todo placeholders for hosts, mirroring \`drain_events_by_kind\`)

Audit §10 (top-10 ROI), second half. \`drain_events_by_kind\` shipped in #772; this completes the closure-free filter pair the FFI / wasm / gdext boundary needs.

## Test plan
- [x] 3 new unit tests in \`api_surface_tests\` — predicate-only return, partition with \`drain_events\`, multi-role match for \`RiderBoarded\`
- [x] 2 new doctests on \`Event::involves\` and \`drain_events_for_entity\`
- [x] \`cargo test -p elevator-core --all-features\` — 995 unit + 171 doc tests pass
- [x] \`cargo clippy -p elevator-core --all-features --all-targets\` clean
- [x] \`cargo check --workspace --all-features --all-targets\` clean
- [x] \`scripts/check-bindings.sh\` clean