### PR TITLE
refactor(sim): encapsulate dispatcher/repositioner pairs behind a set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "19.3.0"
+version = "19.4.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -75,16 +75,19 @@ mod lifecycle;
 mod manual;
 mod rider;
 mod runtime;
+pub(crate) mod strategy_set;
 mod substep;
 mod tagging;
 mod topology;
+
+pub(crate) use strategy_set::{DispatcherSet, RepositionerSet};
 #[allow(clippy::redundant_pub_crate)]
 pub(crate) mod transition;
 
 use crate::components::{
     Accel, AccessControl, Orientation, Patience, Preferences, Route, SpatialPosition, Speed, Weight,
 };
-use crate::dispatch::{BuiltinReposition, DispatchStrategy, ElevatorGroup, RepositionStrategy};
+use crate::dispatch::ElevatorGroup;
 use crate::entity::{EntityId, RiderId};
 use crate::error::SimError;
 use crate::events::{Event, EventBus};
@@ -96,7 +99,7 @@ use crate::stop::StopId;
 use crate::time::TimeAdapter;
 use crate::topology::TopologyGraph;
 use crate::world::World;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::sync::Mutex;
 
@@ -364,14 +367,13 @@ pub struct Simulation {
     groups: Vec<ElevatorGroup>,
     /// Config `StopId` to `EntityId` mapping for spawn helpers.
     stop_lookup: HashMap<StopId, EntityId>,
-    /// Dispatch strategies keyed by group.
-    dispatchers: BTreeMap<GroupId, Box<dyn DispatchStrategy>>,
-    /// Serializable strategy identifiers (for snapshot).
-    strategy_ids: BTreeMap<GroupId, crate::dispatch::BuiltinStrategy>,
-    /// Reposition strategies keyed by group (optional per group).
-    repositioners: BTreeMap<GroupId, Box<dyn RepositionStrategy>>,
-    /// Serializable reposition strategy identifiers (for snapshot).
-    reposition_ids: BTreeMap<GroupId, BuiltinReposition>,
+    /// Dispatch strategies + their snapshot identities, keyed by group.
+    /// Owns both halves so insert/remove stay atomic — see
+    /// [`DispatcherSet`].
+    dispatcher_set: DispatcherSet,
+    /// Reposition strategies + their snapshot identities, keyed by group.
+    /// Empty when no group opts into the reposition phase.
+    repositioner_set: RepositionerSet,
     /// Aggregated metrics.
     metrics: Metrics,
     /// Time conversion utility.

--- a/crates/elevator-core/src/sim/accessors.rs
+++ b/crates/elevator-core/src/sim/accessors.rs
@@ -179,7 +179,7 @@ impl super::Simulation {
     /// Get the strategy identifier for a group.
     #[must_use]
     pub fn strategy_id(&self, group: GroupId) -> Option<&crate::dispatch::BuiltinStrategy> {
-        self.strategy_ids.get(&group)
+        self.dispatcher_set.id_for(group)
     }
 
     /// Iterate over the stop ID → entity ID mapping.

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -304,10 +304,8 @@ impl Simulation {
             dt,
             groups,
             stop_lookup,
-            dispatchers,
-            strategy_ids,
-            repositioners,
-            reposition_ids,
+            dispatcher_set: super::DispatcherSet::from_parts(dispatchers, strategy_ids),
+            repositioner_set: super::RepositionerSet::from_parts(repositioners, reposition_ids),
             metrics: Metrics::new(),
             time: TimeAdapter::new(config.simulation.ticks_per_second),
             hooks,
@@ -697,10 +695,8 @@ impl Simulation {
             dt,
             groups,
             stop_lookup,
-            dispatchers,
-            strategy_ids,
-            repositioners: BTreeMap::new(),
-            reposition_ids: BTreeMap::new(),
+            dispatcher_set: super::DispatcherSet::from_parts(dispatchers, strategy_ids),
+            repositioner_set: super::RepositionerSet::new(),
             metrics,
             time: TimeAdapter::new(ticks_per_second),
             hooks: PhaseHooks::default(),
@@ -1028,8 +1024,7 @@ impl Simulation {
         {
             g.set_hall_call_mode(mode);
         }
-        self.dispatchers.insert(group, strategy);
-        self.strategy_ids.insert(group, resolved_id);
+        self.dispatcher_set.insert(group, strategy, resolved_id);
     }
 
     // ── Reposition management ─────────────────────────────────────────
@@ -1070,8 +1065,7 @@ impl Simulation {
     ) {
         let resolved_id = strategy.builtin_id().unwrap_or(id);
         let needed_window = strategy.min_arrival_log_window();
-        self.repositioners.insert(group, strategy);
-        self.reposition_ids.insert(group, resolved_id);
+        self.repositioner_set.insert(group, strategy, resolved_id);
         // Widen the arrival-log retention if the freshly installed
         // strategy queries a window the pruner would otherwise truncate
         // under it. Without this, `PredictiveParking::with_window_ticks`
@@ -1098,14 +1092,13 @@ impl Simulation {
     /// explicitly to shrink retention after removing a wide-window
     /// strategy.
     pub fn remove_reposition(&mut self, group: GroupId) {
-        self.repositioners.remove(&group);
-        self.reposition_ids.remove(&group);
+        self.repositioner_set.remove(group);
     }
 
     /// Get the reposition strategy identifier for a group.
     #[must_use]
     pub fn reposition_id(&self, group: GroupId) -> Option<&BuiltinReposition> {
-        self.reposition_ids.get(&group)
+        self.repositioner_set.id_for(group)
     }
 
     // ── Hooks ────────────────────────────────────────────────────────

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -613,7 +613,7 @@ impl Simulation {
                 .find(|g| g.elevator_entities().contains(&id))
                 .map(ElevatorGroup::id);
             if let Some(gid) = group_id
-                && let Some(dispatcher) = self.dispatchers.get_mut(&gid)
+                && let Some(dispatcher) = self.dispatcher_set.strategies_mut().get_mut(&gid)
             {
                 dispatcher.notify_removed(id);
             }

--- a/crates/elevator-core/src/sim/strategy_set.rs
+++ b/crates/elevator-core/src/sim/strategy_set.rs
@@ -42,10 +42,17 @@ impl DispatcherSet {
     ///
     /// Callers that already produced the two maps in lockstep — snapshot
     /// restore and the legacy builder ctor — hand them in directly.
-    pub const fn from_parts(
+    /// Asserts in debug builds that the two halves agree on key set so a
+    /// future caller bypassing the encapsulation can't silently smuggle
+    /// in mismatched maps.
+    pub fn from_parts(
         strategies: BTreeMap<GroupId, Box<dyn DispatchStrategy>>,
         ids: BTreeMap<GroupId, BuiltinStrategy>,
     ) -> Self {
+        debug_assert!(
+            strategies.keys().eq(ids.keys()),
+            "DispatcherSet::from_parts: strategies and ids must have identical key sets"
+        );
         Self { strategies, ids }
     }
 
@@ -96,6 +103,12 @@ pub struct RepositionerSet {
     ids: BTreeMap<GroupId, BuiltinReposition>,
 }
 
+impl Default for RepositionerSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RepositionerSet {
     /// An empty set with no groups registered.
     pub const fn new() -> Self {
@@ -106,10 +119,17 @@ impl RepositionerSet {
     }
 
     /// Construct from pre-built map halves.
-    pub const fn from_parts(
+    ///
+    /// Asserts in debug builds that the two halves agree on key set,
+    /// matching [`DispatcherSet::from_parts`].
+    pub fn from_parts(
         strategies: BTreeMap<GroupId, Box<dyn RepositionStrategy>>,
         ids: BTreeMap<GroupId, BuiltinReposition>,
     ) -> Self {
+        debug_assert!(
+            strategies.keys().eq(ids.keys()),
+            "RepositionerSet::from_parts: strategies and ids must have identical key sets"
+        );
         Self { strategies, ids }
     }
 

--- a/crates/elevator-core/src/sim/strategy_set.rs
+++ b/crates/elevator-core/src/sim/strategy_set.rs
@@ -1,0 +1,154 @@
+//! Encapsulated strategy + identity pairs for [`Simulation`].
+//!
+//! Every elevator group carries both a live strategy trait object and a
+//! tagged identity ([`BuiltinStrategy`] / [`BuiltinReposition`]). The
+//! identity rides along into snapshots so a restored sim can re-instantiate
+//! the right built-in (or look up a custom factory by name) without
+//! serialising the trait object itself.
+//!
+//! Pre-encapsulation, the two halves lived in parallel `BTreeMap`s on
+//! [`Simulation`] and every insert / remove site had to update both by
+//! hand — a class of footguns the hot-swap and reassign paths kept hitting.
+//! [`DispatcherSet`] / [`RepositionerSet`] own both maps and expose a
+//! single atomic [`insert`](DispatcherSet::insert) /
+//! [`remove`](RepositionerSet::remove) so the strategy and its identity
+//! can never drift apart.
+//!
+//! [`Simulation`]: super::Simulation
+
+use crate::dispatch::{BuiltinReposition, BuiltinStrategy, DispatchStrategy, RepositionStrategy};
+use crate::ids::GroupId;
+use std::collections::BTreeMap;
+
+/// Per-group dispatch strategies paired with their snapshot identity.
+///
+/// The two halves move together: every [`insert`](Self::insert) writes
+/// both, every [`remove`](Self::remove) clears both. Pre-encapsulation
+/// the two maps lived as separate `BTreeMap` fields on
+/// [`Simulation`](super::Simulation) and a class of bugs came from updating
+/// one without the other (snapshot replay would lose the identity, hot-swap
+/// would orphan an id, etc.).
+pub struct DispatcherSet {
+    /// Live trait objects, one per group, queried each tick by the
+    /// dispatch system.
+    strategies: BTreeMap<GroupId, Box<dyn DispatchStrategy>>,
+    /// Snapshot identity per group — the variant of [`BuiltinStrategy`]
+    /// that re-instantiates the strategy on snapshot restore.
+    ids: BTreeMap<GroupId, BuiltinStrategy>,
+}
+
+impl DispatcherSet {
+    /// Construct from pre-built map halves (snapshot + builder paths).
+    ///
+    /// Callers that already produced the two maps in lockstep — snapshot
+    /// restore and the legacy builder ctor — hand them in directly.
+    pub const fn from_parts(
+        strategies: BTreeMap<GroupId, Box<dyn DispatchStrategy>>,
+        ids: BTreeMap<GroupId, BuiltinStrategy>,
+    ) -> Self {
+        Self { strategies, ids }
+    }
+
+    /// Insert (or replace) the dispatch strategy and its snapshot
+    /// identity for `group` atomically.
+    pub fn insert(
+        &mut self,
+        group: GroupId,
+        strategy: Box<dyn DispatchStrategy>,
+        id: BuiltinStrategy,
+    ) {
+        self.strategies.insert(group, strategy);
+        self.ids.insert(group, id);
+    }
+
+    /// Look up the snapshot identity for `group`.
+    pub fn id_for(&self, group: GroupId) -> Option<&BuiltinStrategy> {
+        self.ids.get(&group)
+    }
+
+    /// Strategy map for systems that take `&BTreeMap<GroupId, Box<dyn ..>>`
+    /// (dispatch phase, FFI / wasm key iteration, snapshot serialization).
+    pub const fn strategies(&self) -> &BTreeMap<GroupId, Box<dyn DispatchStrategy>> {
+        &self.strategies
+    }
+
+    /// Mutable strategy map. Use sparingly — direct insertion bypasses
+    /// the [`insert`](Self::insert) atomicity, leaving `ids` stale.
+    /// Callers that swap a strategy at a known group should round-trip
+    /// through [`insert`](Self::insert); use this only when a system
+    /// needs to mutate an already-installed trait object in place.
+    pub const fn strategies_mut(&mut self) -> &mut BTreeMap<GroupId, Box<dyn DispatchStrategy>> {
+        &mut self.strategies
+    }
+}
+
+/// Per-group reposition strategies paired with their snapshot identity.
+///
+/// Mirrors [`DispatcherSet`] for the optional reposition phase; the same
+/// atomicity guarantees apply.
+pub struct RepositionerSet {
+    /// Live trait objects, one per group, queried by the reposition
+    /// phase. Empty when no group opts in.
+    strategies: BTreeMap<GroupId, Box<dyn RepositionStrategy>>,
+    /// Snapshot identity per group — the variant of
+    /// [`BuiltinReposition`] that re-instantiates the strategy on
+    /// snapshot restore.
+    ids: BTreeMap<GroupId, BuiltinReposition>,
+}
+
+impl RepositionerSet {
+    /// An empty set with no groups registered.
+    pub const fn new() -> Self {
+        Self {
+            strategies: BTreeMap::new(),
+            ids: BTreeMap::new(),
+        }
+    }
+
+    /// Construct from pre-built map halves.
+    pub const fn from_parts(
+        strategies: BTreeMap<GroupId, Box<dyn RepositionStrategy>>,
+        ids: BTreeMap<GroupId, BuiltinReposition>,
+    ) -> Self {
+        Self { strategies, ids }
+    }
+
+    /// Insert (or replace) the reposition strategy and its snapshot
+    /// identity for `group` atomically.
+    pub fn insert(
+        &mut self,
+        group: GroupId,
+        strategy: Box<dyn RepositionStrategy>,
+        id: BuiltinReposition,
+    ) {
+        self.strategies.insert(group, strategy);
+        self.ids.insert(group, id);
+    }
+
+    /// Remove both halves for `group` atomically.
+    pub fn remove(&mut self, group: GroupId) {
+        self.strategies.remove(&group);
+        self.ids.remove(&group);
+    }
+
+    /// Look up the snapshot identity for `group`.
+    pub fn id_for(&self, group: GroupId) -> Option<&BuiltinReposition> {
+        self.ids.get(&group)
+    }
+
+    /// True when no group has a reposition strategy installed; the
+    /// reposition phase is skipped entirely in that case.
+    pub fn is_empty(&self) -> bool {
+        self.strategies.is_empty()
+    }
+
+    /// Whether `group` has a reposition strategy installed.
+    pub fn contains_key(&self, group: GroupId) -> bool {
+        self.strategies.contains_key(&group)
+    }
+
+    /// Mutable strategy map for the reposition phase.
+    pub const fn strategies_mut(&mut self) -> &mut BTreeMap<GroupId, Box<dyn RepositionStrategy>> {
+        &mut self.strategies
+    }
+}

--- a/crates/elevator-core/src/sim/substep.rs
+++ b/crates/elevator-core/src/sim/substep.rs
@@ -16,14 +16,26 @@ impl super::Simulation {
     // ── Sub-stepping ────────────────────────────────────────────────
 
     /// Get the dispatch strategies map (for advanced sub-stepping).
+    ///
+    /// Returns the strategy half of the encapsulated
+    /// [`DispatcherSet`](super::DispatcherSet) — the snapshot identity
+    /// half is only readable through
+    /// [`strategy_id`](Self::strategy_id) so callers can't accidentally
+    /// drift the two halves out of sync via this accessor.
     #[must_use]
     pub fn dispatchers(&self) -> &BTreeMap<GroupId, Box<dyn DispatchStrategy>> {
-        &self.dispatchers
+        self.dispatcher_set.strategies()
     }
 
     /// Get the dispatch strategies map mutably (for advanced sub-stepping).
+    ///
+    /// Direct insertion via this map bypasses the
+    /// [`DispatcherSet`](super::DispatcherSet) atomicity, leaving the
+    /// snapshot identity stale. Prefer [`set_dispatch`](Self::set_dispatch)
+    /// for swaps; reach for this only when a system needs to mutate an
+    /// already-installed trait object in place (e.g. `restore_config`).
     pub fn dispatchers_mut(&mut self) -> &mut BTreeMap<GroupId, Box<dyn DispatchStrategy>> {
-        &mut self.dispatchers
+        self.dispatcher_set.strategies_mut()
     }
 
     /// Get a mutable reference to the event bus.
@@ -102,7 +114,7 @@ impl super::Simulation {
             &mut self.events,
             &ctx,
             &self.groups,
-            &mut self.dispatchers,
+            self.dispatcher_set.strategies_mut(),
             &self.rider_index,
             &mut self.dispatch_scratch,
         );
@@ -220,10 +232,10 @@ impl super::Simulation {
     pub fn run_reposition(&mut self) {
         self.sync_world_tick();
         self.hooks.run_before(Phase::Reposition, &mut self.world);
-        if !self.repositioners.is_empty() {
+        if !self.repositioner_set.is_empty() {
             // Only run per-group hooks for groups that have a repositioner.
             for group in &self.groups {
-                if self.repositioners.contains_key(&group.id()) {
+                if self.repositioner_set.contains_key(group.id()) {
                     self.hooks
                         .run_before_group(Phase::Reposition, group.id(), &mut self.world);
                 }
@@ -234,11 +246,11 @@ impl super::Simulation {
                 &mut self.events,
                 &ctx,
                 &self.groups,
-                &mut self.repositioners,
+                self.repositioner_set.strategies_mut(),
                 &mut self.reposition_buf,
             );
             for group in &self.groups {
-                if self.repositioners.contains_key(&group.id()) {
+                if self.repositioner_set.contains_key(group.id()) {
                     self.hooks
                         .run_after_group(Phase::Reposition, group.id(), &mut self.world);
                 }

--- a/crates/elevator-core/src/sim/substep.rs
+++ b/crates/elevator-core/src/sim/substep.rs
@@ -17,11 +17,10 @@ impl super::Simulation {
 
     /// Get the dispatch strategies map (for advanced sub-stepping).
     ///
-    /// Returns the strategy half of the encapsulated
-    /// [`DispatcherSet`](super::DispatcherSet) — the snapshot identity
-    /// half is only readable through
-    /// [`strategy_id`](Self::strategy_id) so callers can't accidentally
-    /// drift the two halves out of sync via this accessor.
+    /// Returns the strategy half of the internally-encapsulated
+    /// dispatcher set — the snapshot identity half is only readable
+    /// through [`strategy_id`](Self::strategy_id) so callers can't
+    /// accidentally drift the two halves out of sync via this accessor.
     #[must_use]
     pub fn dispatchers(&self) -> &BTreeMap<GroupId, Box<dyn DispatchStrategy>> {
         self.dispatcher_set.strategies()
@@ -29,10 +28,10 @@ impl super::Simulation {
 
     /// Get the dispatch strategies map mutably (for advanced sub-stepping).
     ///
-    /// Direct insertion via this map bypasses the
-    /// [`DispatcherSet`](super::DispatcherSet) atomicity, leaving the
-    /// snapshot identity stale. Prefer [`set_dispatch`](Self::set_dispatch)
-    /// for swaps; reach for this only when a system needs to mutate an
+    /// Direct insertion via this map bypasses the internally-enforced
+    /// strategy/identity atomicity, leaving the snapshot identity
+    /// stale. Prefer [`set_dispatch`](Self::set_dispatch) for swaps;
+    /// reach for this only when a system needs to mutate an
     /// already-installed trait object in place (e.g. `restore_config`).
     pub fn dispatchers_mut(&mut self) -> &mut BTreeMap<GroupId, Box<dyn DispatchStrategy>> {
         self.dispatcher_set.strategies_mut()

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -556,8 +556,8 @@ impl Simulation {
         self.groups
             .push(ElevatorGroup::new(group_id, name.into(), Vec::new()));
 
-        self.dispatchers.insert(group_id, Box::new(dispatch));
-        self.strategy_ids.insert(group_id, BuiltinStrategy::Scan);
+        self.dispatcher_set
+            .insert(group_id, Box::new(dispatch), BuiltinStrategy::Scan);
         self.mark_topo_dirty();
         group_id
     }
@@ -597,7 +597,7 @@ impl Simulation {
         let elevators_to_notify: Vec<EntityId> = self.groups[old_group_idx].lines()[line_idx]
             .elevators()
             .to_vec();
-        if let Some(dispatcher) = self.dispatchers.get_mut(&old_group_id) {
+        if let Some(dispatcher) = self.dispatcher_set.strategies_mut().get_mut(&old_group_id) {
             for eid in &elevators_to_notify {
                 dispatcher.notify_removed(*eid);
             }
@@ -694,7 +694,9 @@ impl Simulation {
             // Notify the old group's dispatcher so it clears per-elevator
             // state (ScanDispatch/LookDispatch track direction by
             // EntityId). Matches the symmetry with `remove_elevator`.
-            if let Some(old_dispatcher) = self.dispatchers.get_mut(&old_group_id) {
+            if let Some(old_dispatcher) =
+                self.dispatcher_set.strategies_mut().get_mut(&old_group_id)
+            {
                 old_dispatcher.notify_removed(elevator);
             }
         }


### PR DESCRIPTION
## Summary

- New \`pub(crate) DispatcherSet\` / \`RepositionerSet\` in \`crates/elevator-core/src/sim/strategy_set.rs\` own both halves of each pair and expose a single atomic \`insert(group, strategy, id)\` so the trait object and its snapshot identity can never drift apart
- All call sites that previously did \`self.dispatchers.insert(...) + self.strategy_ids.insert(...)\` (and the reposition equivalents) collapse to one set call. Mutating get_mut access goes through \`set.strategies_mut()\` for the cases (dispatch system, snapshot \`restore_config\`) where systems still want to mutate an installed trait object in place
- Public API is preserved: \`dispatchers()\`, \`dispatchers_mut()\`, \`strategy_id()\`, \`reposition_id()\` retain their existing return types — only internal storage changes, so wasm / FFI / tests continue to work unchanged

Audit §15. The two parallel maps were a class of footguns the audit flagged: every snapshot restore, hot-swap, topology reassignment, and ctor path had to update both halves by hand.

## Test plan
- [x] \`cargo test -p elevator-core --all-features\` — 992 unit + 169 doc tests pass
- [x] \`cargo clippy -p elevator-core --all-features --all-targets\` clean
- [x] \`cargo check --workspace --all-features --all-targets\` clean (wasm / FFI / gdext / tui all unchanged)
- [x] \`scripts/check-bindings.sh\` clean (no public method signatures changed)