### PR TITLE
refactor(snapshot)!: replace restore(Option<&Fn>) with RestoreOptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "19.3.0"
+version = "19.4.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -181,7 +181,7 @@
 //!
 //! 1. Capture: `sim.snapshot()` → [`WorldSnapshot`](snapshot::WorldSnapshot)
 //! 2. Serialize: serde (RON, JSON, bincode, etc.)
-//! 3. Deserialize + restore: `snapshot.restore(factory)` → new `Simulation`
+//! 3. Deserialize + restore: `snapshot.restore(RestoreOptions::default())` → new `Simulation`
 //! 4. Re-register extensions: `world.register_ext::<T>(key)` per type
 //! 5. Load extension data: `sim.load_extensions()`
 //!

--- a/crates/elevator-core/src/sim/lifecycle.rs
+++ b/crates/elevator-core/src/sim/lifecycle.rs
@@ -59,16 +59,18 @@ impl Simulation {
     /// # #[derive(Clone, Serialize, Deserialize)] struct VipTag;
     /// # #[derive(Clone, Serialize, Deserialize)] struct TeamId;
     /// # fn before(snapshot: WorldSnapshot) -> Result<(), SimError> {
+    /// # use elevator_core::snapshot::RestoreOptions;
     /// // Before (3-step ceremony):
-    /// let mut sim = snapshot.restore(None)?;
+    /// let mut sim = snapshot.restore(RestoreOptions::default())?;
     /// sim.world_mut().register_ext::<VipTag>(ExtKey::from_type_name());
     /// sim.world_mut().register_ext::<TeamId>(ExtKey::from_type_name());
     /// sim.load_extensions();
     /// # Ok(()) }
     /// # fn after(snapshot: WorldSnapshot) -> Result<(), SimError> {
+    /// # use elevator_core::snapshot::RestoreOptions;
     ///
     /// // After:
-    /// let mut sim = snapshot.restore(None)?;
+    /// let mut sim = snapshot.restore(RestoreOptions::default())?;
     /// let unregistered = sim.load_extensions_with(|world| {
     ///     register_extensions!(world, VipTag, TeamId);
     /// });

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -214,6 +214,51 @@ pub(crate) struct PendingExtensions(pub(crate) BTreeMap<String, BTreeMap<EntityI
 type CustomStrategyFactory<'a> =
     Option<&'a dyn Fn(&str) -> Option<Box<dyn crate::dispatch::DispatchStrategy>>>;
 
+/// Options for [`WorldSnapshot::restore`] and
+/// [`Simulation::restore_bytes`](crate::sim::Simulation::restore_bytes).
+///
+/// Construct via [`Default::default`] when the snapshot only uses
+/// built-in strategies, or via [`with_factory`](Self::with_factory)
+/// when groups in the snapshot reference [`Custom`] dispatch strategies
+/// that need to be re-instantiated by name. The struct is
+/// `#[non_exhaustive]` so future restore knobs can land without an API
+/// break.
+///
+/// [`Custom`]: crate::dispatch::BuiltinStrategy::Custom
+///
+/// ```no_run
+/// # use elevator_core::snapshot::{RestoreOptions, WorldSnapshot};
+/// # fn doit(snap: WorldSnapshot) -> Result<(), elevator_core::error::SimError> {
+/// // Built-ins only:
+/// let _sim = snap.restore(RestoreOptions::default())?;
+/// # Ok(()) }
+/// ```
+#[derive(Default)]
+#[non_exhaustive]
+pub struct RestoreOptions<'a> {
+    /// Factory mapping [`Custom`](crate::dispatch::BuiltinStrategy::Custom)
+    /// strategy names to fresh trait-object instances. `None` when the
+    /// snapshot only uses built-in strategies — restore returns
+    /// [`SimError::UnresolvedCustomStrategy`](crate::error::SimError::UnresolvedCustomStrategy)
+    /// if a snapshot group needs a custom strategy and the factory isn't
+    /// supplied (or returns `None`).
+    pub custom_strategy_factory: CustomStrategyFactory<'a>,
+}
+
+impl<'a> RestoreOptions<'a> {
+    /// Build a [`RestoreOptions`] with a custom-strategy factory wired
+    /// up. Use [`Default::default`] when no custom strategies are in
+    /// play.
+    #[must_use]
+    pub fn with_factory(
+        factory: &'a dyn Fn(&str) -> Option<Box<dyn crate::dispatch::DispatchStrategy>>,
+    ) -> Self {
+        Self {
+            custom_strategy_factory: Some(factory),
+        }
+    }
+}
+
 impl WorldSnapshot {
     /// Schema version this build of `elevator-core` writes and accepts.
     ///
@@ -230,9 +275,9 @@ impl WorldSnapshot {
     /// first:
     ///
     /// ```no_run
-    /// # use elevator_core::snapshot::WorldSnapshot;
+    /// # use elevator_core::snapshot::{RestoreOptions, WorldSnapshot};
     /// # fn load(snap: WorldSnapshot) -> Result<(), elevator_core::error::SimError> {
-    /// let sim = snap.migrate()?.restore(None)?;
+    /// let sim = snap.migrate()?.restore(RestoreOptions::default())?;
     /// # let _ = sim;
     /// # Ok(()) }
     /// ```
@@ -284,22 +329,34 @@ impl WorldSnapshot {
 
     /// Restore a simulation from this snapshot.
     ///
-    /// Built-in strategies (Scan, Look, `NearestCar`, ETD) are auto-restored.
-    /// For `Custom` strategies, provide a factory function that maps strategy
-    /// names to instances. Pass `None` if only using built-in strategies.
+    /// Built-in strategies (Scan, Look, `NearestCar`, ETD, RSR,
+    /// Destination) are auto-restored. For [`Custom`] strategies,
+    /// configure [`RestoreOptions`] with a factory; pass
+    /// [`RestoreOptions::default()`] when only built-in strategies are
+    /// in play. The struct is `#[non_exhaustive]` so future restore
+    /// knobs land without an API break.
+    ///
+    /// [`Custom`]: crate::dispatch::BuiltinStrategy::Custom
     ///
     /// # Errors
     /// Returns [`SimError::UnresolvedCustomStrategy`](crate::error::SimError::UnresolvedCustomStrategy)
-    /// if a snapshot group uses a `Custom` strategy and the factory returns `None`.
+    /// if a snapshot group uses a `Custom` strategy and the factory
+    /// returns `None` (or no factory was supplied).
     ///
     /// To restore extension components, call
     /// [`Simulation::load_extensions_with`](crate::sim::Simulation::load_extensions_with)
     /// on the returned simulation.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn restore(
         self,
-        custom_strategy_factory: CustomStrategyFactory<'_>,
+        options: RestoreOptions<'_>,
     ) -> Result<crate::sim::Simulation, crate::error::SimError> {
         use crate::world::{SortedStops, World};
+
+        let RestoreOptions {
+            custom_strategy_factory,
+            ..
+        } = options;
 
         // Reject snapshots from incompatible schema versions. Without this
         // guard, `#[serde(default)]` on newly-added fields would silently
@@ -1179,7 +1236,9 @@ impl crate::sim::Simulation {
     ///
     /// Built-in dispatch strategies are auto-restored. For groups using
     /// [`BuiltinStrategy::Custom`](crate::dispatch::BuiltinStrategy::Custom),
-    /// provide a factory; pass `None` otherwise.
+    /// configure [`RestoreOptions`] with a factory; pass
+    /// [`RestoreOptions::default()`] when the snapshot only carries
+    /// built-in strategies.
     ///
     /// # Errors
     /// - [`SimError::SnapshotFormat`](crate::error::SimError::SnapshotFormat)
@@ -1191,7 +1250,7 @@ impl crate::sim::Simulation {
     ///   if a group uses a custom strategy that the factory cannot resolve.
     pub fn restore_bytes(
         bytes: &[u8],
-        custom_strategy_factory: CustomStrategyFactory<'_>,
+        options: RestoreOptions<'_>,
     ) -> Result<Self, crate::error::SimError> {
         let (envelope, tail): (SnapshotEnvelope, &[u8]) = postcard::take_from_bytes(bytes)
             .map_err(|e| crate::error::SimError::SnapshotFormat(e.to_string()))?;
@@ -1214,6 +1273,6 @@ impl crate::sim::Simulation {
                 current: current.to_owned(),
             });
         }
-        envelope.payload.restore(custom_strategy_factory)
+        envelope.payload.restore(options)
     }
 }

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -211,7 +211,14 @@ pub struct GroupSnapshot {
 pub(crate) struct PendingExtensions(pub(crate) BTreeMap<String, BTreeMap<EntityId, String>>);
 
 /// Factory function type for instantiating custom dispatch strategies by name.
-type CustomStrategyFactory<'a> =
+///
+/// Wired into [`RestoreOptions::custom_strategy_factory`] and used
+/// internally by [`WorldSnapshot::restore`] /
+/// [`Simulation::restore_bytes`](crate::sim::Simulation::restore_bytes)
+/// to look up dispatch strategies that aren't built-ins. Callers that
+/// need to hold or pass the factory by value can name this alias
+/// directly instead of repeating the trait-object spelling.
+pub type CustomStrategyFactory<'a> =
     Option<&'a dyn Fn(&str) -> Option<Box<dyn crate::dispatch::DispatchStrategy>>>;
 
 /// Options for [`WorldSnapshot::restore`] and
@@ -233,7 +240,7 @@ type CustomStrategyFactory<'a> =
 /// let _sim = snap.restore(RestoreOptions::default())?;
 /// # Ok(()) }
 /// ```
-#[derive(Default)]
+#[derive(Clone, Copy, Default)]
 #[non_exhaustive]
 pub struct RestoreOptions<'a> {
     /// Factory mapping [`Custom`](crate::dispatch::BuiltinStrategy::Custom)
@@ -346,7 +353,6 @@ impl WorldSnapshot {
     /// To restore extension components, call
     /// [`Simulation::load_extensions_with`](crate::sim::Simulation::load_extensions_with)
     /// on the returned simulation.
-    #[allow(clippy::needless_pass_by_value)]
     pub fn restore(
         self,
         options: RestoreOptions<'_>,

--- a/crates/elevator-core/src/tests/arrival_log_tests.rs
+++ b/crates/elevator-core/src/tests/arrival_log_tests.rs
@@ -91,7 +91,9 @@ fn arrival_log_survives_snapshot_round_trip() {
     assert!(before >= 2, "precondition: snapshot source has arrivals");
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None).unwrap();
+    let restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
 
     let origin_after = restored.stop_entity(StopId(0)).unwrap();
     let log_after = restored

--- a/crates/elevator-core/src/tests/destination_queue_tests.rs
+++ b/crates/elevator-core/src/tests/destination_queue_tests.rs
@@ -254,7 +254,9 @@ fn snapshot_roundtrip_preserves_queue() {
     sim.push_destination(elev, s0).unwrap();
 
     let snapshot = sim.snapshot();
-    let restored = snapshot.restore(None).unwrap();
+    let restored = snapshot
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
     let new_elev = ElevatorId::from(restored.world().elevator_ids()[0]);
 
     let restored_queue = restored.destination_queue(new_elev).unwrap();

--- a/crates/elevator-core/src/tests/direction_indicator_tests.rs
+++ b/crates/elevator-core/src/tests/direction_indicator_tests.rs
@@ -333,7 +333,9 @@ fn snapshot_roundtrip_preserves_indicators() {
     assert_eq!(sim.elevator_going_down(elev), Some(false));
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None).unwrap();
+    let restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
     let restored_elev = ElevatorId::from(restored.world().elevator_ids()[0]);
 
     assert_eq!(restored.elevator_going_up(restored_elev), Some(true));

--- a/crates/elevator-core/src/tests/home_stop_tests.rs
+++ b/crates/elevator-core/src/tests/home_stop_tests.rs
@@ -288,7 +288,8 @@ fn home_stop_survives_snapshot_round_trip() {
     let target = stop_entity(&sim, StopId(2));
 
     let bytes = sim.snapshot_bytes().expect("snapshot");
-    let restored = Simulation::restore_bytes(&bytes, None).expect("restore");
+    let restored = Simulation::restore_bytes(&bytes, crate::snapshot::RestoreOptions::default())
+        .expect("restore");
 
     assert_eq!(restored.elevator_home_stop(elev).unwrap(), Some(target));
 }

--- a/crates/elevator-core/src/tests/invariants_tests.rs
+++ b/crates/elevator-core/src/tests/invariants_tests.rs
@@ -641,7 +641,7 @@ proptest! {
         }
 
         let snap = sim_a.snapshot();
-        let mut sim_b = snap.restore(None).expect("restore");
+        let mut sim_b = snap.restore(crate::snapshot::RestoreOptions::default()).expect("restore");
 
         for tick in 0..COMPARE_TICKS {
             sim_a.step();

--- a/crates/elevator-core/src/tests/move_count_tests.rs
+++ b/crates/elevator-core/src/tests/move_count_tests.rs
@@ -265,7 +265,9 @@ fn move_count_persists_across_snapshot() {
     let per_elev_before = sim.elevator_move_count(elev.into()).unwrap();
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None).unwrap();
+    let restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
 
     assert_eq!(restored.metrics().total_moves(), moves_before);
     let restored_elev = restored

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -2672,7 +2672,9 @@ fn snapshot_roundtrip_preserves_multi_group_topology() {
     let sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None).unwrap();
+    let restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
 
     // Both groups must survive.
     assert_eq!(
@@ -2713,7 +2715,9 @@ fn snapshot_roundtrip_elevator_line_reference_is_valid() {
     let orig_g1_line = sim.world().elevator(orig_g1_elev).unwrap().line();
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None).unwrap();
+    let restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
 
     // In the restored sim, each elevator's line reference must still point to a
     // valid line entity (even though EntityIds are remapped).

--- a/crates/elevator-core/src/tests/resident_tests.rs
+++ b/crates/elevator-core/src/tests/resident_tests.rs
@@ -397,7 +397,9 @@ fn snapshot_roundtrip_preserves_residents() {
 
     // Snapshot and restore.
     let snapshot = sim.snapshot();
-    let restored = snapshot.restore(None).unwrap();
+    let restored = snapshot
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
 
     // Verify residents are in the index after restore.
     // Entity IDs may be remapped, so find the resident rider.

--- a/crates/elevator-core/src/tests/rider_tag_tests.rs
+++ b/crates/elevator-core/src/tests/rider_tag_tests.rs
@@ -88,7 +88,8 @@ fn round_trips_through_snapshot_bytes() {
     sim.set_rider_tag(rider, 0x1122_3344_5566_7788).unwrap();
 
     let bytes = sim.snapshot_bytes().expect("snapshot");
-    let restored = Simulation::restore_bytes(&bytes, None).expect("restore from bytes");
+    let restored = Simulation::restore_bytes(&bytes, crate::snapshot::RestoreOptions::default())
+        .expect("restore from bytes");
 
     assert_eq!(
         restored.rider_tag(rider).unwrap(),

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -19,7 +19,9 @@ fn snapshot_roundtrip_preserves_tick() {
     let snap = sim.snapshot();
     assert_eq!(snap.tick, 100);
 
-    let restored = snap.restore(None).unwrap();
+    let restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
     assert_eq!(restored.current_tick(), 100);
 }
 
@@ -39,7 +41,9 @@ fn snapshot_roundtrip_preserves_riders() {
     }
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None).unwrap();
+    let restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
 
     // Rider count should match.
     let original_count = sim.world().iter_riders().count();
@@ -53,7 +57,9 @@ fn snapshot_roundtrip_preserves_stop_lookup() {
     let sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None).unwrap();
+    let restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
 
     // All stop IDs should resolve.
     assert!(restored.stop_entity(StopId(0)).is_some());
@@ -73,7 +79,9 @@ fn snapshot_roundtrip_preserves_metrics() {
 
     let original_delivered = sim.metrics().total_delivered();
     let snap = sim.snapshot();
-    let restored = snap.restore(None).unwrap();
+    let restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
 
     assert_eq!(restored.metrics().total_delivered(), original_delivered);
 }
@@ -109,7 +117,9 @@ fn restored_sim_can_continue_stepping() {
     }
 
     let snap = sim.snapshot();
-    let mut restored = snap.restore(None).unwrap();
+    let mut restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
 
     // Should be able to keep stepping without panics.
     for _ in 0..200 {
@@ -132,7 +142,9 @@ fn snapshot_remaps_entity_ids_for_mid_route_riders() {
     }
 
     let snap = sim.snapshot();
-    let mut restored = snap.restore(None).unwrap();
+    let mut restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
 
     // Riders should still have valid routes pointing to real stops.
     for (_, rider) in restored.world().iter_riders() {
@@ -174,7 +186,9 @@ fn snapshot_roundtrip_via_ron_preserves_cross_references() {
     let snap = sim.snapshot();
     let ron_str = ron::to_string(&snap).unwrap();
     let deserialized: crate::snapshot::WorldSnapshot = ron::from_str(&ron_str).unwrap();
-    let mut restored = deserialized.restore(None).unwrap();
+    let mut restored = deserialized
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
 
     // Should complete without panics and deliver riders.
     for _ in 0..2000 {
@@ -203,7 +217,9 @@ fn snapshot_preserves_metric_tags() {
     assert!(original_spawned > 0);
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None).unwrap();
+    let restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
 
     let restored_spawned = restored
         .metrics_for_tag("zone:lobby")
@@ -230,7 +246,9 @@ fn snapshot_preserves_extension_components() {
     );
 
     let snap = sim.snapshot();
-    let mut restored = snap.restore(None).unwrap();
+    let mut restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
 
     // Register the extension type on the restored world, then load.
     restored
@@ -267,7 +285,9 @@ fn load_extensions_with_convenience() {
     );
 
     let snap = sim.snapshot();
-    let mut restored = snap.restore(None).unwrap();
+    let mut restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
 
     let unregistered = restored.load_extensions_with(|world| {
         world.register_ext::<VipTag>(ExtKey::from_type_name());
@@ -307,7 +327,9 @@ fn load_extensions_reports_unregistered_types() {
     );
 
     let snap = sim.snapshot();
-    let mut restored = snap.restore(None).unwrap();
+    let mut restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
 
     // Load without registering VipTag — should report it as unregistered.
     let unregistered = restored.load_extensions();
@@ -326,7 +348,9 @@ fn snapshot_bytes_roundtrip() {
 
     let bytes = sim.snapshot_bytes().unwrap();
     assert!(!bytes.is_empty());
-    let restored = crate::sim::Simulation::restore_bytes(&bytes, None).unwrap();
+    let restored =
+        crate::sim::Simulation::restore_bytes(&bytes, crate::snapshot::RestoreOptions::default())
+            .unwrap();
     assert_eq!(restored.current_tick(), sim.current_tick());
     assert_eq!(
         restored.metrics().total_delivered(),
@@ -341,7 +365,9 @@ fn snapshot_bytes_rejects_wrong_magic() {
     let mut bytes = sim.snapshot_bytes().unwrap();
     // The magic is serialized first — flip a byte inside the first 8.
     bytes[0] ^= 0xFF;
-    let err = crate::sim::Simulation::restore_bytes(&bytes, None).unwrap_err();
+    let err =
+        crate::sim::Simulation::restore_bytes(&bytes, crate::snapshot::RestoreOptions::default())
+            .unwrap_err();
     assert!(
         matches!(err, crate::error::SimError::SnapshotFormat(_)),
         "expected SnapshotFormat, got {err:?}",
@@ -368,7 +394,9 @@ fn snapshot_bytes_rejects_wrong_version() {
     };
     let bytes = postcard::to_allocvec(&fake).unwrap();
 
-    let err = crate::sim::Simulation::restore_bytes(&bytes, None).unwrap_err();
+    let err =
+        crate::sim::Simulation::restore_bytes(&bytes, crate::snapshot::RestoreOptions::default())
+            .unwrap_err();
     match err {
         crate::error::SimError::SnapshotVersion { saved, current } => {
             assert_eq!(saved, "0.0.0-definitely-not-real");
@@ -387,7 +415,9 @@ fn snapshot_bytes_rejects_trailing_bytes() {
     let sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
     let mut bytes = sim.snapshot_bytes().unwrap();
     bytes.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
-    let err = crate::sim::Simulation::restore_bytes(&bytes, None).unwrap_err();
+    let err =
+        crate::sim::Simulation::restore_bytes(&bytes, crate::snapshot::RestoreOptions::default())
+            .unwrap_err();
     match err {
         crate::error::SimError::SnapshotFormat(msg) => {
             assert!(
@@ -401,7 +431,11 @@ fn snapshot_bytes_rejects_trailing_bytes() {
 
 #[test]
 fn snapshot_bytes_rejects_garbage() {
-    let err = crate::sim::Simulation::restore_bytes(&[1, 2, 3, 4], None).unwrap_err();
+    let err = crate::sim::Simulation::restore_bytes(
+        &[1, 2, 3, 4],
+        crate::snapshot::RestoreOptions::default(),
+    )
+    .unwrap_err();
     assert!(matches!(err, crate::error::SimError::SnapshotFormat(_)));
 }
 
@@ -430,7 +464,9 @@ fn snapshot_bytes_midrun_determinism() {
         via_snapshot.step();
     }
     let bytes = via_snapshot.snapshot_bytes().unwrap();
-    let mut via_snapshot = crate::sim::Simulation::restore_bytes(&bytes, None).unwrap();
+    let mut via_snapshot =
+        crate::sim::Simulation::restore_bytes(&bytes, crate::snapshot::RestoreOptions::default())
+            .unwrap();
 
     for _ in 0..250 {
         fresh.step();
@@ -461,7 +497,9 @@ fn snapshot_preserves_hall_calls_and_pinning() {
     sim.pin_assignment(car, stop, CallDirection::Up).unwrap();
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None).unwrap();
+    let restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
 
     let restored_stop = restored.stop_entity(StopId(1)).unwrap();
     let call = restored
@@ -492,7 +530,9 @@ fn snapshot_preserves_car_calls() {
     assert_eq!(sim.car_calls(car).len(), 1);
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None).unwrap();
+    let restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
 
     let restored_car = ElevatorId::from(restored.world().elevator_ids()[0]);
     let calls = restored.car_calls(restored_car);
@@ -511,7 +551,9 @@ fn snapshot_preserves_group_hall_mode_and_ack_latency() {
     sim.groups_mut()[0].set_ack_latency_ticks(12);
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None).unwrap();
+    let restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
 
     assert_eq!(
         restored.groups()[0].hall_call_mode(),
@@ -544,7 +586,9 @@ fn snapshot_preserves_hall_call_ack_state_under_latency() {
         .press_tick;
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None).unwrap();
+    let restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
 
     let restored_stop = restored.stop_entity(StopId(1)).unwrap();
     let call = restored
@@ -571,7 +615,7 @@ fn restore_rejects_mismatched_schema_version() {
     let sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
     let mut snap = sim.snapshot();
     snap.version = u32::MAX;
-    let result = snap.restore(None);
+    let result = snap.restore(crate::snapshot::RestoreOptions::default());
     assert!(
         matches!(result, Err(SimError::SnapshotVersion { .. })),
         "mismatched schema version must be rejected, got {result:?}"
@@ -589,7 +633,7 @@ fn restore_rejects_legacy_zero_version() {
     let sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
     let mut snap = sim.snapshot();
     snap.version = 0;
-    let result = snap.restore(None);
+    let result = snap.restore(crate::snapshot::RestoreOptions::default());
     assert!(matches!(result, Err(SimError::SnapshotVersion { .. })));
 }
 
@@ -606,7 +650,9 @@ fn snapshot_roundtrip_emits_no_dangling_warnings() {
     sim.drain_events();
 
     let snap = sim.snapshot();
-    let mut restored = snap.restore(None).unwrap();
+    let mut restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
     let events = restored.drain_events();
     let dangling = events
         .iter()
@@ -710,7 +756,9 @@ fn etd_tuned_weights_survive_snapshot_round_trip() {
     }
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None).expect("restore");
+    let restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .expect("restore");
 
     let dispatcher = restored
         .dispatchers()
@@ -750,7 +798,9 @@ fn rsr_tuned_weights_survive_snapshot_round_trip() {
     }
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None).expect("restore");
+    let restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .expect("restore");
     let dispatcher = restored.dispatchers().values().next().unwrap();
     let serialized = dispatcher.snapshot_config().unwrap();
     let parsed: RsrDispatch = ron::from_str(&serialized).expect("round-trip parse");
@@ -812,7 +862,9 @@ fn destination_tuned_config_survives_snapshot_round_trip() {
     }
 
     let snap = sim.snapshot();
-    let restored = snap.restore(None).expect("restore");
+    let restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .expect("restore");
     let dispatcher = restored.dispatchers().values().next().unwrap();
     let serialized = dispatcher.snapshot_config().unwrap();
     // DestinationDispatch's config fields are `pub(crate)`, so
@@ -927,8 +979,11 @@ fn snapshot_bytes_roundtrip_is_byte_stable() {
     let sim = diverse_phase_sim();
     let bytes_before = sim.snapshot_bytes().expect("initial snapshot_bytes");
 
-    let restored =
-        crate::sim::Simulation::restore_bytes(&bytes_before, None).expect("restore_bytes");
+    let restored = crate::sim::Simulation::restore_bytes(
+        &bytes_before,
+        crate::snapshot::RestoreOptions::default(),
+    )
+    .expect("restore_bytes");
     let bytes_after = restored
         .snapshot_bytes()
         .expect("post-restore snapshot_bytes");
@@ -1008,8 +1063,11 @@ fn snapshot_bytes_with_reposition_cooldowns_roundtrip_is_stable() {
     sim.world_mut().insert_resource(cooldowns);
 
     let bytes_before = sim.snapshot_bytes().expect("initial snapshot_bytes");
-    let restored =
-        crate::sim::Simulation::restore_bytes(&bytes_before, None).expect("restore_bytes");
+    let restored = crate::sim::Simulation::restore_bytes(
+        &bytes_before,
+        crate::snapshot::RestoreOptions::default(),
+    )
+    .expect("restore_bytes");
     let bytes_after = restored
         .snapshot_bytes()
         .expect("post-restore snapshot_bytes");

--- a/crates/elevator-core/tests/scenarios/snapshot_roundtrip.rs
+++ b/crates/elevator-core/tests/scenarios/snapshot_roundtrip.rs
@@ -7,7 +7,7 @@ use elevator_core::dispatch::BuiltinReposition;
 use elevator_core::dispatch::reposition::{AdaptiveParking, ReturnToLobby};
 use elevator_core::ids::GroupId;
 use elevator_core::prelude::*;
-use elevator_core::snapshot::WorldSnapshot;
+use elevator_core::snapshot::{RestoreOptions, WorldSnapshot};
 use elevator_core::traffic_detector::TrafficDetector;
 
 #[test]
@@ -29,7 +29,7 @@ fn snapshot_roundtrip_preserves_state() {
     let snap = sim.snapshot();
     let ron_str = ron::to_string(&snap).unwrap();
     let snap2: WorldSnapshot = ron::from_str(&ron_str).unwrap();
-    let restored = snap2.restore(None).unwrap();
+    let restored = snap2.restore(RestoreOptions::default()).unwrap();
 
     assert_eq!(restored.current_tick(), original_tick);
     assert_eq!(restored.metrics().total_delivered(), original_delivered);
@@ -73,7 +73,7 @@ fn snapshot_roundtrip_remaps_repositioning_phase() {
     let snap = sim.snapshot();
     let ron_str = ron::to_string(&snap).unwrap();
     let snap2: WorldSnapshot = ron::from_str(&ron_str).unwrap();
-    let restored = snap2.restore(None).unwrap();
+    let restored = snap2.restore(RestoreOptions::default()).unwrap();
 
     // The elevator must still be in Repositioning, and its target stop
     // entity must resolve to a real stop in the restored world.
@@ -113,7 +113,7 @@ fn snapshot_roundtrip_preserves_adaptive_repositioner() {
     let snap = sim.snapshot();
     let ron_str = ron::to_string(&snap).unwrap();
     let snap2: WorldSnapshot = ron::from_str(&ron_str).unwrap();
-    let restored = snap2.restore(None).unwrap();
+    let restored = snap2.restore(RestoreOptions::default()).unwrap();
 
     assert_eq!(
         restored.reposition_id(GroupId(0)),
@@ -151,7 +151,7 @@ fn snapshot_roundtrip_preserves_arrival_and_destination_logs() {
     let snap = sim.snapshot();
     let ron_str = ron::to_string(&snap).unwrap();
     let snap2: WorldSnapshot = ron::from_str(&ron_str).unwrap();
-    let restored = snap2.restore(None).unwrap();
+    let restored = snap2.restore(RestoreOptions::default()).unwrap();
 
     assert_eq!(
         restored.world().resource::<ArrivalLog>().unwrap().len(),
@@ -186,7 +186,7 @@ fn snapshot_roundtrip_preserves_traffic_detector_state() {
     let snap = sim.snapshot();
     let ron_str = ron::to_string(&snap).unwrap();
     let snap2: WorldSnapshot = ron::from_str(&ron_str).unwrap();
-    let restored = snap2.restore(None).unwrap();
+    let restored = snap2.restore(RestoreOptions::default()).unwrap();
 
     let restored_detector = restored.world().resource::<TrafficDetector>().unwrap();
     assert_eq!(

--- a/crates/elevator-tui/src/app.rs
+++ b/crates/elevator-tui/src/app.rs
@@ -745,7 +745,11 @@ fn handle_key_scrub_exit(state: &mut AppState, sim: &mut Simulation) {
     };
     // Clone the snapshot for `restore` so we can stash the original
     // back on failure — no retry path otherwise.
-    match live.snapshot.clone().restore(None) {
+    match live
+        .snapshot
+        .clone()
+        .restore(elevator_core::snapshot::RestoreOptions::default())
+    {
         Ok(restored) => {
             *sim = restored;
             state.scrub_offset = None;
@@ -775,7 +779,11 @@ fn apply_scrub_offset(state: &mut AppState, sim: &mut Simulation, offset: usize)
         state.flash("scrub: snapshot ring entry missing");
         return Err(());
     };
-    match entry.snapshot.clone().restore(None) {
+    match entry
+        .snapshot
+        .clone()
+        .restore(elevator_core::snapshot::RestoreOptions::default())
+    {
         Ok(restored) => {
             *sim = restored;
             state.scrub_offset = Some(offset);
@@ -797,7 +805,7 @@ fn handle_key_main_load_snapshot(state: &mut AppState, sim: &mut Simulation) {
         state.flash("no snapshot saved");
         return;
     };
-    match snap.restore(None) {
+    match snap.restore(elevator_core::snapshot::RestoreOptions::default()) {
         Ok(restored) => {
             *sim = restored;
             state.event_log.clear();

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -595,8 +595,9 @@ impl WasmSim {
         if strategy_id(&strategy).is_none() {
             return Err(JsError::new(&format!("unknown strategy: {strategy}")));
         }
-        let inner = Simulation::restore_bytes(bytes, None)
-            .map_err(|e| JsError::new(&format!("restore: {e}")))?;
+        let inner =
+            Simulation::restore_bytes(bytes, elevator_core::snapshot::RestoreOptions::default())
+                .map_err(|e| JsError::new(&format!("restore: {e}")))?;
         let reposition_name = reposition
             .as_deref()
             .map_or("adaptive", |s| if s.is_empty() { "adaptive" } else { s })

--- a/docs/src/custom-dispatch.md
+++ b/docs/src/custom-dispatch.md
@@ -264,7 +264,8 @@ fn run(snapshot: WorldSnapshot) -> Result<(), SimError> {
 
     // When restoring, the factory maps names back to strategy instances.
     // `restore_config` replays `urgency_boost` onto the new instance.
-    let sim = snapshot.restore(Some(&|name: &str| -> Option<Box<dyn DispatchStrategy>> {
+    use elevator_core::snapshot::RestoreOptions;
+    let sim = snapshot.restore(RestoreOptions::with_factory(&|name: &str| -> Option<Box<dyn DispatchStrategy>> {
         match name {
             PRIORITY_NAME => Some(Box::new(PriorityDispatch::default())),
             // Return `None` for unknown names -- the restore records a

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -174,8 +174,9 @@ Extension components are serialized by their registered type name into the `Worl
 # use elevator_core::snapshot::WorldSnapshot;
 # use serde::{Serialize, Deserialize};
 # #[derive(Clone, Serialize, Deserialize)] struct GuestPriority { priority_class: u8, suite_floor: u32 }
+# use elevator_core::snapshot::RestoreOptions;
 # fn run(snapshot: WorldSnapshot) {
-let mut sim = snapshot.restore(None).unwrap();
+let mut sim = snapshot.restore(RestoreOptions::default()).unwrap();
 sim.world_mut().register_ext::<GuestPriority>(ExtKey::from_type_name());
 sim.load_extensions();
 # }

--- a/docs/src/snapshots-determinism.md
+++ b/docs/src/snapshots-determinism.md
@@ -67,13 +67,15 @@ The snapshot struct is `Serialize + Deserialize` -- choose any serde format (RON
 # use elevator_core::prelude::*;
 # use elevator_core::__doctest_prelude::*;
 # use elevator_core::snapshot::WorldSnapshot;
+# use elevator_core::snapshot::RestoreOptions;
 # fn main() -> Result<(), SimError> {
 let bytes = std::fs::read_to_string("save.ron").unwrap();
 let snapshot: WorldSnapshot = ron::from_str(&bytes).unwrap();
 
-// `None` means "only built-in dispatch strategies"; pass a closure to
-// resurrect custom strategies registered by name.
-let sim = snapshot.restore(None)?;
+// `RestoreOptions::default()` means "only built-in dispatch strategies";
+// use `RestoreOptions::with_factory(...)` to resurrect custom strategies
+// registered by name.
+let sim = snapshot.restore(RestoreOptions::default())?;
 # Ok(())
 # }
 ```
@@ -94,9 +96,10 @@ Built-in strategies (`Scan`, `Look`, `NearestCar`, `Etd`, `Rsr`, `Destination`) 
 # impl DispatchStrategy for HighestFirstDispatch {
 #   fn rank(&self, _ctx: &RankContext<'_>) -> Option<f64> { Some(0.0) }
 # }
+# use elevator_core::snapshot::RestoreOptions;
 # fn run(snapshot: WorldSnapshot) {
-let sim = snapshot.restore(Some(&|name: &str| match name {
-    "HighestFirst" => Some(Box::new(HighestFirstDispatch)),
+let sim = snapshot.restore(RestoreOptions::with_factory(&|name: &str| match name {
+    "HighestFirst" => Some(Box::new(HighestFirstDispatch) as Box<dyn DispatchStrategy>),
     _ => None,
 }));
 # }
@@ -114,8 +117,9 @@ Extensions are serialized by their registered name. Dispatch-internal extensions
 # use elevator_core::snapshot::WorldSnapshot;
 # use serde::{Serialize, Deserialize};
 # #[derive(Clone, Serialize, Deserialize)] struct VipTag;
+# use elevator_core::snapshot::RestoreOptions;
 # fn run(snapshot: WorldSnapshot) {
-let mut sim = snapshot.restore(None).unwrap();
+let mut sim = snapshot.restore(RestoreOptions::default()).unwrap();
 sim.world_mut().register_ext::<VipTag>(ExtKey::from_type_name());
 sim.load_extensions();
 # }

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -98,7 +98,7 @@ fn snapshot_roundtrip_preserves_state() {
     let snap = sim.snapshot();
     let ron_str = ron::to_string(&snap).unwrap();
     let snap2: WorldSnapshot = ron::from_str(&ron_str).unwrap();
-    let restored = snap2.restore(None).unwrap();
+    let restored = snap2.restore(elevator_core::snapshot::RestoreOptions::default()).unwrap();
 
     assert_eq!(restored.current_tick(), original_tick);
     assert_eq!(restored.metrics().total_delivered(), original_delivered);


### PR DESCRIPTION
## Summary

\`WorldSnapshot::restore\` and \`Simulation::restore_bytes\` used to take an opaque \`Option<&dyn Fn(&str) -> Option<Box<dyn DispatchStrategy>>>\` for the custom-strategy factory. \`snap.restore(None)\` was unrevealing at the call site, and adding any other restore knob (extension auto-load policy, dangling-ref behaviour, …) would have been an API break.

Replace with a \`#[non_exhaustive]\` \`RestoreOptions\` struct:

\`\`\`rust
snap.restore(RestoreOptions::default())                 // built-ins only
snap.restore(RestoreOptions::with_factory(&factory))    // with custom
\`\`\`

Future restore knobs land as additive \`RestoreOptions\` fields without changing signatures.

Audit §39. **Breaking change** — every caller of \`restore\` / \`restore_bytes\` updates to the new options form. Updated within this repo:

- \`elevator-core\` lib + tests (~30 sites) + scenarios harness
- \`elevator-tui\` app (replay swap path)
- \`elevator-wasm\` (\`restore_bytes\` call)
- mdBook docs (\`snapshots-determinism\`, \`custom-dispatch\`, \`extensions\`, \`testing\`)
- \`lifecycle.rs\` doc-comment example

## Test plan
- [x] \`cargo test -p elevator-core --all-features\` — 992 unit + 170 doc tests pass
- [x] \`cargo clippy -p elevator-core --all-features --all-targets\` clean
- [x] \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps --workspace --all-features\` clean
- [x] \`cargo check --workspace --all-features --all-targets\` clean (wasm + tui consumers updated)
- [x] \`scripts/check-bindings.sh\` clean