### PR TITLE
refactor(components)!: drop hardcoded unit suffixes; add Speed/Accel arith

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "19.3.0"
+version = "19.4.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/components/position.rs
+++ b/crates/elevator-core/src/components/position.rs
@@ -7,12 +7,13 @@ use std::fmt;
 ///
 /// # Display
 ///
-/// Formats as a compact distance string:
+/// Formats as a bare numeric value to two decimals; hosts suffix
+/// their own unit label (the engine doesn't pin a distance unit).
 ///
 /// ```
 /// # use elevator_core::components::Position;
 /// let pos = Position::from(4.5);
-/// assert_eq!(format!("{pos}"), "4.50m");
+/// assert_eq!(format!("{pos}"), "4.50");
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct Position {
@@ -39,7 +40,7 @@ impl Position {
 
 impl fmt::Display for Position {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:.2}m", self.value)
+        write!(f, "{:.2}", self.value)
     }
 }
 
@@ -57,14 +58,15 @@ impl From<f64> for Position {
 ///
 /// # Display
 ///
-/// Formats as a compact speed string:
+/// Formats as a bare numeric value to two decimals; hosts suffix
+/// their own unit label (the engine doesn't pin a distance unit).
 ///
 /// ```
 /// # use elevator_core::components::Velocity;
 /// let vel = Velocity::from(1.2);
-/// assert_eq!(format!("{vel}"), "1.20m/s");
+/// assert_eq!(format!("{vel}"), "1.20");
 /// let stopped = Velocity::from(0.0);
-/// assert_eq!(format!("{stopped}"), "0.00m/s");
+/// assert_eq!(format!("{stopped}"), "0.00");
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct Velocity {
@@ -91,7 +93,7 @@ impl Velocity {
 
 impl fmt::Display for Velocity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:.2}m/s", self.value)
+        write!(f, "{:.2}", self.value)
     }
 }
 

--- a/crates/elevator-core/src/components/units.rs
+++ b/crates/elevator-core/src/components/units.rs
@@ -59,6 +59,14 @@ macro_rules! impl_unit_from_f64 {
 /// tonnes). `Display` formats the bare numeric value to two decimals
 /// so hosts can suffix their own unit label.
 ///
+/// # Arithmetic
+///
+/// `Add` / `AddAssign` sum normally. `Sub` / `SubAssign` **saturate
+/// at zero** — `Weight(50.0) - Weight(80.0) == Weight(0.0)` rather
+/// than panicking or returning a negative value, since the type
+/// constructor rejects negatives. Same saturating contract applies
+/// to [`Speed`] and [`Accel`].
+///
 /// ```
 /// # use elevator_core::components::Weight;
 /// let w = Weight::from(75.0);
@@ -150,6 +158,12 @@ impl std::ops::SubAssign for Weight {
 /// the engine never converts. `Display` formats the bare numeric
 /// value to two decimals; hosts suffix their own unit label.
 ///
+/// # Arithmetic
+///
+/// Same saturating contract as [`Weight`]: `Sub` / `SubAssign`
+/// clamp underflow to zero rather than producing a negative value
+/// the constructor would reject.
+///
 /// ```
 /// # use elevator_core::components::Speed;
 /// let s = Speed::from(2.0);
@@ -234,6 +248,8 @@ impl std::ops::SubAssign for Speed {
 ///
 /// Same unit-agnostic convention as [`Speed`] — `Display` is the bare
 /// numeric value to two decimals; hosts label the unit downstream.
+/// `Sub` / `SubAssign` saturate at zero, matching the [`Weight`]
+/// and [`Speed`] arithmetic contract.
 ///
 /// ```
 /// # use elevator_core::components::Accel;

--- a/crates/elevator-core/src/components/units.rs
+++ b/crates/elevator-core/src/components/units.rs
@@ -53,13 +53,17 @@ macro_rules! impl_unit_from_f64 {
 
 /// Weight / mass (always non-negative).
 ///
-/// Used for rider weight, elevator load, and weight capacity.
+/// Used for rider weight, elevator load, and weight capacity. The
+/// crate is unit-agnostic — "kg" is a convention but the engine
+/// supports any consistent unit (the space-elevator config uses
+/// tonnes). `Display` formats the bare numeric value to two decimals
+/// so hosts can suffix their own unit label.
 ///
 /// ```
 /// # use elevator_core::components::Weight;
 /// let w = Weight::from(75.0);
 /// assert_eq!(w.value(), 75.0);
-/// assert_eq!(format!("{w}"), "75.00kg");
+/// assert_eq!(format!("{w}"), "75.00");
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -104,7 +108,7 @@ impl Weight {
 
 impl fmt::Display for Weight {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:.2}kg", self.value)
+        write!(f, "{:.2}", self.value)
     }
 }
 
@@ -142,10 +146,14 @@ impl std::ops::SubAssign for Weight {
 
 /// Maximum travel speed (always non-negative, distance units per second).
 ///
+/// Distance unit follows whatever the host chose for `Position` —
+/// the engine never converts. `Display` formats the bare numeric
+/// value to two decimals; hosts suffix their own unit label.
+///
 /// ```
 /// # use elevator_core::components::Speed;
 /// let s = Speed::from(2.0);
-/// assert_eq!(format!("{s}"), "2.00m/s");
+/// assert_eq!(format!("{s}"), "2.00");
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -186,18 +194,51 @@ impl Speed {
 
 impl fmt::Display for Speed {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:.2}m/s", self.value)
+        write!(f, "{:.2}", self.value)
     }
 }
 
 impl_unit_from_f64!(Speed);
 
+impl std::ops::Add for Speed {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self {
+        Self {
+            value: self.value + rhs.value,
+        }
+    }
+}
+
+impl std::ops::AddAssign for Speed {
+    fn add_assign(&mut self, rhs: Self) {
+        self.value += rhs.value;
+    }
+}
+
+impl std::ops::Sub for Speed {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self {
+        Self {
+            value: (self.value - rhs.value).max(0.0),
+        }
+    }
+}
+
+impl std::ops::SubAssign for Speed {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.value = (self.value - rhs.value).max(0.0);
+    }
+}
+
 /// Acceleration / deceleration rate (always non-negative, distance units per second²).
+///
+/// Same unit-agnostic convention as [`Speed`] — `Display` is the bare
+/// numeric value to two decimals; hosts label the unit downstream.
 ///
 /// ```
 /// # use elevator_core::components::Accel;
 /// let a = Accel::from(1.5);
-/// assert_eq!(format!("{a}"), "1.50m/s²");
+/// assert_eq!(format!("{a}"), "1.50");
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -238,8 +279,38 @@ impl Accel {
 
 impl fmt::Display for Accel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:.2}m/s²", self.value)
+        write!(f, "{:.2}", self.value)
     }
 }
 
 impl_unit_from_f64!(Accel);
+
+impl std::ops::Add for Accel {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self {
+        Self {
+            value: self.value + rhs.value,
+        }
+    }
+}
+
+impl std::ops::AddAssign for Accel {
+    fn add_assign(&mut self, rhs: Self) {
+        self.value += rhs.value;
+    }
+}
+
+impl std::ops::Sub for Accel {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self {
+        Self {
+            value: (self.value - rhs.value).max(0.0),
+        }
+    }
+}
+
+impl std::ops::SubAssign for Accel {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.value = (self.value - rhs.value).max(0.0);
+    }
+}

--- a/crates/elevator-core/src/error.rs
+++ b/crates/elevator-core/src/error.rs
@@ -333,7 +333,10 @@ pub struct RejectionContext {
 }
 
 impl fmt::Display for RejectionContext {
-    /// Compact summary for game feedback.
+    /// Compact summary for game feedback. The numeric values share the
+    /// same unit as [`Weight`](crate::components::Weight) — bare
+    /// numbers, no hardcoded suffix; hosts suffix their own unit label
+    /// downstream.
     ///
     /// ```
     /// # use elevator_core::error::RejectionContext;
@@ -343,20 +346,20 @@ impl fmt::Display for RejectionContext {
     ///     current_load: OrderedFloat(750.0),
     ///     capacity: OrderedFloat(800.0),
     /// };
-    /// assert_eq!(format!("{ctx}"), "over capacity by 30.0kg (750.0/800.0 + 80.0)");
+    /// assert_eq!(format!("{ctx}"), "over capacity by 30.0 (750.0/800.0 + 80.0)");
     /// ```
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let excess = (*self.current_load + *self.attempted_weight) - *self.capacity;
         if excess > 0.0 {
             write!(
                 f,
-                "over capacity by {excess:.1}kg ({:.1}/{:.1} + {:.1})",
+                "over capacity by {excess:.1} ({:.1}/{:.1} + {:.1})",
                 *self.current_load, *self.capacity, *self.attempted_weight,
             )
         } else {
             write!(
                 f,
-                "load {:.1}kg/{:.1}kg + {:.1}kg",
+                "load {:.1}/{:.1} + {:.1}",
                 *self.current_load, *self.capacity, *self.attempted_weight,
             )
         }

--- a/crates/elevator-tui/tests/snapshots/render_snapshot__drilldown_footer_overrides_pane_hints.snap
+++ b/crates/elevator-tui/tests/snapshots/render_snapshot__drilldown_footer_overrides_pane_hints.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/elevator-tui/tests/render_snapshot.rs
+assertion_line: 94
 expression: frame
 ---
  elevator-tui · tick 60 · ▶ 1.00× · index · drilldown                                               
@@ -8,8 +9,8 @@ expression: frame
 │  Ground      ╭┤ drill-down · EntityId(4v1) · Esc to close ├───────────────────────╮              │
 │              │phase     MovingToStop(EntityId(2v1))                               │              │
 │              │door      Closed                                                    │              │
-│              │load      75.00kg / 800.00kg                                        │──────────────╯
-│              │speed     max 2.00m/s / accel 1.50m/s² / decel 2.00m/s²             │──────────────╮
+│              │load      75.00 / 800.00                                            │──────────────╯
+│              │speed     max 2.00 / accel 1.50 / decel 2.00                        │──────────────╮
 │              │position  0.34                                                      │              │
 │              │                                                                    │              │
 │              │queue (1 stops)                                                     │              │


### PR DESCRIPTION
## Summary

\`Display\` impls on \`Weight\`, \`Speed\`, \`Accel\`, \`Position\`, \`Velocity\`, and the load-summary inside \`RejectionContext\` used to hardcode \`kg\` / \`m/s\` / \`m/s²\` / \`m\`. The crate is unit-agnostic — the same engine drives both kg-and-meters skyscrapers and tonne-and-kilometre space-elevator configs — so leaking the suffix into rejection messages, debug strings, and event-log surfaces forced consumers into the kg/m world they may not actually use.

\`Display\` now formats the bare numeric value to two decimals; hosts suffix their own unit label downstream. Doctests updated.

While the units module was open, this also adds \`Add\` / \`Sub\` / \`AddAssign\` / \`SubAssign\` impls on \`Speed\` and \`Accel\` to match the existing impls on \`Weight\` (audit's parity note in §17). Either all three need them or none do.

Audit §17 + §18 + §30. **Breaking change** — anyone whose UI relied on the hardcoded suffix needs to add their own. No in-tree consumers did (verified across \`elevator-tui\`, \`elevator-bevy\`, \`playground\`).

## Test plan
- [x] \`cargo test -p elevator-core --all-features\` — 992 unit + 169 doc tests pass
- [x] \`cargo clippy -p elevator-core --all-features --all-targets\` clean
- [x] \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps --workspace --all-features\` clean
- [x] \`cargo check --workspace --all-features --all-targets\` clean