### PR TITLE
refactor(dispatch): extract apply_fairness_bonus helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "19.3.0"
+version = "19.4.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/dispatch/etd.rs
+++ b/crates/elevator-core/src/dispatch/etd.rs
@@ -225,11 +225,11 @@ impl DispatchStrategy for EtdDispatch {
             self.compute_cost(ctx.car, ctx.car_position(), ctx.stop_position(), ctx.world);
         if self.wait_squared_weight > 0.0 {
             let wait_sq = super::wait_ticks_squared_sum(ctx.manifest.waiting_riders_at(ctx.stop));
-            cost = crate::fp::fma(self.wait_squared_weight, -wait_sq, cost).max(0.0);
+            cost = super::apply_fairness_bonus(cost, self.wait_squared_weight, wait_sq);
         }
         if self.age_linear_weight > 0.0 {
             let wait_sum = super::wait_ticks_sum(ctx.manifest.waiting_riders_at(ctx.stop));
-            cost = crate::fp::fma(self.age_linear_weight, -wait_sum, cost).max(0.0);
+            cost = super::apply_fairness_bonus(cost, self.age_linear_weight, wait_sum);
         }
         if cost.is_finite() { Some(cost) } else { None }
     }

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -216,6 +216,28 @@ pub(crate) fn wait_ticks_squared_sum(riders: &[RiderInfo]) -> f64 {
         .sum()
 }
 
+/// Apply a fairness bonus to a dispatch cost, clamping at zero.
+///
+/// Computes `(cost - weight * term).max(0.0)` via [`fp::fma`] for
+/// tighter rounding than the manual `cost - weight * term` form when
+/// the multiplier and product are both finite.
+///
+/// Both ETD's `age_linear` / `wait_squared` weights and RSR's
+/// `age_linear_weight` use this exact shape — a non-negative
+/// `weight` scaled against a non-negative aggregate (`wait_ticks_sum`
+/// / `wait_ticks_squared_sum`) subtracted from the running cost. The
+/// `.max(0.0)` floor is mandatory because the Hungarian assignment
+/// requires non-negative costs; without it, deeply-aged waits could
+/// underflow the cost into the negative territory, where the assigner's
+/// row-reduction step would produce a smaller-than-zero pseudo-cost
+/// and silently mis-rank.
+///
+/// [`fp::fma`]: crate::fp::fma
+#[must_use]
+pub(crate) fn apply_fairness_bonus(cost: f64, weight: f64, term: f64) -> f64 {
+    crate::fp::fma(weight, -term, cost).max(0.0)
+}
+
 /// Whether a waiting rider could actually board this car, matching the
 /// same filters the loading phase applies. Prevents `pair_is_useful`
 /// from approving a pickup whose only demand is direction-filtered or

--- a/crates/elevator-core/src/dispatch/rsr.rs
+++ b/crates/elevator-core/src/dispatch/rsr.rs
@@ -380,9 +380,14 @@ impl DispatchStrategy for RsrDispatch {
         // older upper-floor waiters. Mirrors ETD's `age_linear_weight`.
         if self.age_linear_weight > 0.0 {
             let wait_sum = super::wait_ticks_sum(ctx.manifest.waiting_riders_at(ctx.stop));
-            cost = crate::fp::fma(self.age_linear_weight, -wait_sum, cost);
+            cost = super::apply_fairness_bonus(cost, self.age_linear_weight, wait_sum);
         }
 
+        // Clamp the running cost to the Hungarian's non-negative floor.
+        // The fairness helper above already clamps, but the
+        // coincident-car-call bonus earlier subtracts unconditionally
+        // and can push the intermediate cost negative on a small-eta
+        // pairing.
         let cost = cost.max(0.0);
         if cost.is_finite() { Some(cost) } else { None }
     }

--- a/crates/elevator-core/src/dispatch/rsr.rs
+++ b/crates/elevator-core/src/dispatch/rsr.rs
@@ -384,10 +384,14 @@ impl DispatchStrategy for RsrDispatch {
         }
 
         // Clamp the running cost to the Hungarian's non-negative floor.
-        // The fairness helper above already clamps, but the
-        // coincident-car-call bonus earlier subtracts unconditionally
-        // and can push the intermediate cost negative on a small-eta
-        // pairing.
+        // Two paths reach here without a guaranteed prior clamp:
+        //   1. `age_linear_weight == 0.0` skips the fairness branch
+        //      entirely, leaving the coincident-car-call subtraction
+        //      unclamped.
+        //   2. Even when fairness runs, the coincident-call subtraction
+        //      happens before it on a small-eta pairing.
+        // Either way, this trailing clamp is the only floor the
+        // assigner sees.
         let cost = cost.max(0.0);
         if cost.is_finite() { Some(cost) } else { None }
     }


### PR DESCRIPTION
## Summary

Three sites — ETD's \`age_linear_weight\`, ETD's \`wait_squared_weight\`, and RSR's \`age_linear_weight\` — applied the same \`fma(weight, -term, cost).max(0.0)\` pattern by hand. Extract \`pub(crate) apply_fairness_bonus(cost, weight, term)\` in \`dispatch/mod.rs\` and call from all three.

For RSR, the fairness call now clamps internally where it previously did a single trailing \`.max(0.0)\`. The trailing clamp stays as the floor for the coincident-car-call bonus path, which subtracts unconditionally and could push the intermediate cost negative on a small-eta pairing. Final result is the same arithmetic.

Audit §3 (top-10 ROI), partial. The \`wait_ticks\` helpers shipped in #767; this finishes the fairness-application half. The audit also called for \`travel_cost_segments\` but the math diverges past the \`distance / max_speed\` guard (only ETD has intervening-stops + door overhead in its rank path), so that piece doesn't share a clean extraction.

## Test plan
- [x] \`cargo test -p elevator-core --all-features\` — 992 unit + 169 doc tests pass; ETD compute_cost mutation suite + RSR rank tests both green
- [x] \`cargo clippy -p elevator-core --all-features --all-targets\` clean
- [x] \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps -p elevator-core --all-features\` clean