### PR TITLE
refactor(sim): encapsulate tick_in_progress; document scratch's pub(crate)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "19.3.0"
+version = "19.4.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -386,6 +386,12 @@ pub struct Simulation {
     /// pending-stops list, servicing slice, pinned / committed /
     /// idle-elevator filters. Holding them on the sim means each
     /// dispatch pass reuses capacity instead of re-allocating.
+    ///
+    /// Stays `pub(crate)` rather than method-encapsulated because the
+    /// dispatch phase needs simultaneous disjoint mutable borrows of
+    /// `world`, `events`, and the scratch — a getter returning
+    /// `&mut DispatchScratch` would borrow all of `self`, conflicting
+    /// with `&mut self.world` in the same call.
     pub(crate) dispatch_scratch: crate::dispatch::DispatchScratch,
     /// Lazy-rebuilt connectivity graph for cross-line topology queries.
     topo_graph: Mutex<TopologyGraph>,
@@ -396,8 +402,31 @@ pub struct Simulation {
     /// reject mid-tick captures that would lose in-progress event-bus
     /// state. Always false outside the substep API path because
     /// [`step()`](Self::step) takes `&mut self` and snapshots take
-    /// `&self`. (#297)
-    pub(crate) tick_in_progress: bool,
+    /// `&self`. (#297) Read via [`tick_in_progress`](Self::tick_in_progress);
+    /// the substep loop owns the mutation through
+    /// [`set_tick_in_progress`](Self::set_tick_in_progress).
+    tick_in_progress: bool,
+}
+
+impl Simulation {
+    /// Whether the sim is between [`run_advance_transient`] and
+    /// [`advance_tick`] — i.e. mid-tick. Snapshot capture needs this
+    /// to reject mid-tick saves that would lose in-progress
+    /// event-bus state.
+    ///
+    /// [`run_advance_transient`]: Self::run_advance_transient
+    /// [`advance_tick`]: Self::advance_tick
+    #[must_use]
+    pub(crate) const fn tick_in_progress(&self) -> bool {
+        self.tick_in_progress
+    }
+
+    /// Set the mid-tick guard. Owned by the substep runner — only
+    /// `run_advance_transient` flips it on and `advance_tick` flips
+    /// it off.
+    pub(crate) const fn set_tick_in_progress(&mut self, in_progress: bool) {
+        self.tick_in_progress = in_progress;
+    }
 }
 
 impl fmt::Debug for Simulation {

--- a/crates/elevator-core/src/sim/substep.rs
+++ b/crates/elevator-core/src/sim/substep.rs
@@ -65,7 +65,7 @@ impl super::Simulation {
     /// elevators to move before dispatch, or transient states to persist
     /// across tick boundaries.
     pub fn run_advance_transient(&mut self) {
-        self.tick_in_progress = true;
+        self.set_tick_in_progress(true);
         self.sync_world_tick();
         self.hooks
             .run_before(Phase::AdvanceTransient, &mut self.world);
@@ -291,7 +291,7 @@ impl super::Simulation {
     pub fn advance_tick(&mut self) {
         self.pending_output.extend(self.events.drain());
         self.tick += 1;
-        self.tick_in_progress = false;
+        self.set_tick_in_progress(false);
         // Keep the `CurrentTick` world resource in lockstep after the tick
         // counter advances; substep consumers driving phases manually
         // will see the fresh value on their next call.

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -943,7 +943,7 @@ impl crate::sim::Simulation {
     /// when invoked between a `run_*` phase call and the matching
     /// `advance_tick`.
     pub fn try_snapshot(&self) -> Result<WorldSnapshot, crate::error::SimError> {
-        if self.tick_in_progress {
+        if self.tick_in_progress() {
             return Err(crate::error::SimError::MidTickSnapshot);
         }
         Ok(self.snapshot())


### PR DESCRIPTION
## Summary

\`tick_in_progress\` was a \`pub(crate)\` field touched at three sites (snapshot's mid-tick guard + substep's set/clear bookends). Hide the field and expose \`pub(crate) tick_in_progress() / set_tick_in_progress()\` so the contract reads at every call site.

\`dispatch_scratch\` **can't** be method-encapsulated the same way: the dispatch system needs simultaneous disjoint mutable borrows of \`world\`, \`events\`, and the scratch in one call. A getter returning \`&mut DispatchScratch\` borrows all of \`self\` and conflicts with \`&mut self.world\`. The field stays \`pub(crate)\` with a doc-comment that records why — so the next person attempting the encapsulation hits the explanation rather than the borrow-check wall.

Audit §36, partial.

## Test plan
- [x] \`cargo test -p elevator-core --all-features\` — 992 unit + 169 doc tests pass
- [x] \`cargo clippy -p elevator-core --all-features --all-targets\` clean