### PR TITLE
feat(world): add iter_hall_calls_with_id for shape parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "19.4.0"
+version = "20.0.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -1057,3 +1057,31 @@ fn abandonment_scrubs_hall_call_pending_riders() {
         );
     }
 }
+
+#[test]
+fn iter_hall_calls_with_id_yields_stop_keyed_pairs() {
+    let mut sim = Simulation::new(&default_config(), scan()).unwrap();
+    sim.spawn_rider(StopId(0), StopId(2), 70.0).unwrap();
+    sim.spawn_rider(StopId(2), StopId(0), 80.0).unwrap();
+
+    // No-step: hall calls are registered at spawn time.
+    let pairs: Vec<(EntityId, &crate::components::HallCall)> =
+        sim.world().iter_hall_calls_with_id().collect();
+    assert!(
+        !pairs.is_empty(),
+        "two riders spawned with hall buttons should produce at least one pending call"
+    );
+    for (stop_id, call) in &pairs {
+        assert_eq!(
+            *stop_id, call.stop,
+            "iter_hall_calls_with_id must yield (call.stop, &call) — the SecondaryMap key is the call's stop"
+        );
+    }
+    // The unkeyed iterator must visit the same set of calls.
+    let unkeyed_count = sim.world().iter_hall_calls().count();
+    assert_eq!(
+        pairs.len(),
+        unkeyed_count,
+        "iter_hall_calls_with_id and iter_hall_calls must agree on count"
+    );
+}

--- a/crates/elevator-core/src/world.rs
+++ b/crates/elevator-core/src/world.rs
@@ -667,6 +667,20 @@ impl World {
         self.hall_calls.values().flat_map(StopCalls::iter)
     }
 
+    /// Iterate every active hall call paired with the stop entity it
+    /// originated at.
+    ///
+    /// Shape-parity companion to [`iter_riders`](Self::iter_riders) /
+    /// [`iter_stops`](Self::iter_stops) / [`iter_lines`](Self::iter_lines)
+    /// for callers that prefer a `(EntityId, &T)` cursor instead of
+    /// reading [`HallCall::stop`] off the value. The stop returned here
+    /// is always equal to `call.stop` for the yielded `&HallCall`.
+    pub fn iter_hall_calls_with_id(&self) -> impl Iterator<Item = (EntityId, &HallCall)> {
+        self.hall_calls
+            .iter()
+            .flat_map(|(stop, calls)| calls.iter().map(move |c| (stop, c)))
+    }
+
     /// Mutable iteration over every active hall call (crate-internal).
     pub(crate) fn iter_hall_calls_mut(&mut self) -> impl Iterator<Item = &mut HallCall> {
         self.hall_calls.values_mut().flat_map(StopCalls::iter_mut)
@@ -708,6 +722,14 @@ impl World {
     // ── Typed query helpers ──────────────────────────────────────────
 
     /// Iterate all elevator entities (have `Elevator` + `Position`).
+    ///
+    /// Yields `(EntityId, &Position, &Elevator)` rather than the
+    /// `(EntityId, &T)` shape of [`iter_riders`](Self::iter_riders) /
+    /// [`iter_stops`](Self::iter_stops) / [`iter_hall_calls_with_id`](Self::iter_hall_calls_with_id)
+    /// because every dispatch / movement / reposition hot path that
+    /// touches an elevator also touches its position, and bundling
+    /// avoids the second `SoA` lookup per car per tick. Callers that
+    /// only need IDs use [`iter_elevator_ids`](Self::iter_elevator_ids).
     pub fn iter_elevators(&self) -> impl Iterator<Item = (EntityId, &Position, &Elevator)> {
         self.elevators
             .iter()


### PR DESCRIPTION
## Summary

\`iter_hall_calls\` yields \`&HallCall\` while every other typed iterator on \`World\` yields \`(EntityId, &T)\`. Add \`iter_hall_calls_with_id\` that returns \`(stop_id, &HallCall)\` pairs so callers can use the same cursor shape for hall calls as for riders / stops / lines / elevator-ids — useful when threading hall calls through generic \`(id, value)\` consumers without manually projecting \`call.stop\`.

Also adds a doc paragraph on \`iter_elevators\` explaining why it remains the one iterator that bundles \`Position\` alongside the entity: every dispatch / movement / reposition hot path that touches an elevator also touches its position, and bundling avoids a second SoA lookup per car per tick.

Audit §33.

## Test plan
- [x] New \`iter_hall_calls_with_id_yields_stop_keyed_pairs\` test confirms \`(stop_id, call.stop)\` agreement and count parity with \`iter_hall_calls\`
- [x] \`cargo test -p elevator-core --all-features\` — all tests pass
- [x] \`cargo clippy -p elevator-core --all-features --all-targets\` clean