### PR TITLE
docs(bench): explain cross_group_routing 1-group non-monotonicity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "19.4.0"
+version = "20.0.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/benches/multi_line_bench.rs
+++ b/crates/elevator-core/benches/multi_line_bench.rs
@@ -239,6 +239,18 @@ fn bench_multi_group_step(c: &mut Criterion) {
 // B) Cross-group routing: spawn_rider auto-detection overhead
 // ---------------------------------------------------------------------------
 
+/// 1000-spawn cross-group routing bench. Note that `1_groups` is
+/// expected to be *slower* than `5_groups` despite having fewer
+/// groups to walk in `auto_detect_group`: with fixed 1000 riders and
+/// `total_stops` driven by `(num_groups, stops_per_line, shared_stops)`,
+/// 1-group has 10 total stops vs 5-groups' 38. Per-(stop, direction)
+/// hall-call density is therefore ~4× higher in the 1-group case,
+/// and `HallCall::pending_riders` is a `Vec<EntityId>` whose
+/// `contains()` dedup-guard scales O(n²) when many riders aggregate
+/// onto a few calls (see `sim::calls::ensure_hall_call`). The 5/10/20
+/// rows monotonically grow as expected — the 1-row out-of-trend datum
+/// is hall-call density, not a routing fast path the multi-group
+/// path skips.
 fn bench_cross_group_routing(c: &mut Criterion) {
     let mut group = c.benchmark_group("cross_group_routing");
     group.sample_size(10);

--- a/crates/elevator-core/src/sim/calls.rs
+++ b/crates/elevator-core/src/sim/calls.rs
@@ -234,6 +234,10 @@ impl super::Simulation {
             self.world.set_hall_call(call);
             fresh_press = true;
         } else if let Some(existing) = self.world.hall_call_mut(stop, direction) {
+            // Dedup guard: a rider's auto-press at spawn plus a
+            // game-driven `press_hall_button` can target the same
+            // call. Without `contains`, both presses would push the
+            // rider into `pending_riders` twice and double-count.
             if let Some(rid) = rider
                 && !existing.pending_riders.contains(&rid)
             {


### PR DESCRIPTION
## Summary

Audit §41 flagged \`cross_group_routing/1_groups\` (342 µs) as a slower-than-\`5_groups\` (301 µs) outlier and asked whether 1-group "skips a fast path." Investigation says no:

- Bench's \`total_stops\` is driven by \`(num_groups, stops_per_line, shared_stops)\`. 1-group has 10 total stops; 5-groups has 38.
- All 1000 spawned riders land on \`(i % total_stops, (i+1) % total_stops)\` — so 1-group clusters ~50 riders onto each \`(stop, direction)\` call vs ~13 for 5-groups.
- \`HallCall::pending_riders\` is a \`Vec<EntityId>\` with an O(n) \`contains()\` dedup on each push (\`sim::calls::ensure_hall_call\`). Per-call aggregation cost is O(n²): ~50²/2 ≈ 1250 comparisons × 20 calls ≈ 25k for 1-group vs ~13²/2 × 76 ≈ 6.5k for 5-groups.
- 5 / 10 / 20 group rows are monotonic; the 1-row outlier is hall-call density, not routing.

This PR adds the rationale to the bench docstring and a focused doc-comment at the \`ensure_hall_call\` dedup site so the next person wondering "why a Vec, not a HashSet?" finds the correctness reason (rider auto-press at spawn + game-driven \`press_hall_button\` can target the same call) rather than reverse-engineering it.

No code change. If pending_riders aggregation later becomes a real bottleneck, the next move is a small-set inline storage or a sorted-Vec + binary-search variant — but that's a separate PR with measurable demand.

## Test plan
- [x] \`cargo check -p elevator-core --all-features --all-targets\` clean
- [x] \`cargo clippy -p elevator-core --all-features --all-targets\` clean