### PR TITLE
docs(query): clarify query/ as extension-author surface

### DIFF
--- a/crates/elevator-core/src/query/mod.rs
+++ b/crates/elevator-core/src/query/mod.rs
@@ -1,5 +1,30 @@
 //! ECS-style query builder for iterating entities by component composition.
 //!
+//! # Audience
+//!
+//! This module is the **extension-author surface**: the generic
+//! builder for iterating over arbitrary component combinations,
+//! including [`Ext<T>`](crate::query::Ext) game-defined components.
+//! Use it when:
+//!
+//! - You're filtering on a combination of components
+//!   ([`With`](crate::query::With) / [`Without`](crate::query::Without)
+//!   / multiple `&T` slots) — e.g. "all riders with a `VipTag`
+//!   extension and a position".
+//! - You're operating on game-defined [`Ext<T>`](crate::query::Ext)
+//!   components that don't have hand-written iterators on
+//!   [`World`](crate::world::World).
+//!
+//! Core's per-tick hot paths intentionally use the typed
+//! [`World::iter_riders`](crate::world::World::iter_riders),
+//! [`World::iter_elevators`](crate::world::World::iter_elevators),
+//! [`World::iter_stops`](crate::world::World::iter_stops), etc. —
+//! direct accessors over the `SoA` storage that skip the generic
+//! dispatch layer. The builder is for the cases those don't cover.
+//! `query_bench` shows the builder is fast (linear in entity count
+//! with a small constant), but for known component types the typed
+//! accessor is still preferred.
+//!
 //! # Examples
 //!
 //! ```


### PR DESCRIPTION
## Summary

Audit §31 framed \`query/\` as "~zero adoption inside the crate" and asked it be marked experimental. The framing was off — \`query/\` is the public ECS-style query path used externally; core just prefers the faster typed \`iter_*\` accessors on hot paths because they skip the generic dispatch layer and operate directly on SoA storage.

Add an \`# Audience\` section to the module docstring recording the split:
- **\`query_bench\` shows the builder is fast** (linear in entity count with a small constant). Performance isn't the reason to skip it.
- **The builder is for the generic case**: arbitrary component combinations (\`With\` / \`Without\` / multiple \`&T\` slots), \`Ext<T>\` game-defined components.
- **The typed iterators are for the specific case**: known types in core's per-tick hot paths.

This clarifies the design choice for future readers and counters the audit's "experimental, mark for kill" framing.

## Test plan
- [x] \`cargo test -p elevator-core --all-features --doc query\` — passes
- [x] \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps -p elevator-core --all-features\` clean