### PR TITLE
feat(playground): replace dot tweens with silhouette walk animations

### DIFF
--- a/playground/src/__tests__/color-utils.test.ts
+++ b/playground/src/__tests__/color-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { arcPoint, easeOutNorm, hexWithAlpha, shade, withAlpha } from "../render/color-utils";
+import { easeOutNorm, hexWithAlpha, shade, withAlpha } from "../render/color-utils";
 
 describe("shade", () => {
   it("positive amount lightens a color", () => {
@@ -80,36 +80,6 @@ describe("withAlpha", () => {
     // 3-char shorthand doesn't match the /^#[0-9a-f]{6}$/i guard;
     // hexWithAlpha also can't parse it, so the value is returned as-is.
     expect(withAlpha("#f00", 0.5)).toBe("#f00");
-  });
-});
-
-describe("arcPoint", () => {
-  it("at t=0 returns the start point", () => {
-    const [x, y] = arcPoint(10, 20, 100, 80, 0);
-    expect(x).toBeCloseTo(10, 5);
-    expect(y).toBeCloseTo(20, 5);
-  });
-
-  it("at t=1 returns the end point", () => {
-    const [x, y] = arcPoint(10, 20, 100, 80, 1);
-    expect(x).toBeCloseTo(100, 5);
-    expect(y).toBeCloseTo(80, 5);
-  });
-
-  it("at t=0.5 returns a point off the straight midpoint (has perpendicular arc)", () => {
-    // Straight midpoint of (0,0)→(100,0) is (50,0).
-    // The perpendicular offset on a horizontal segment is vertical,
-    // so the arc midpoint should have y != 0.
-    const [x, y] = arcPoint(0, 0, 100, 0, 0.5);
-    expect(x).toBeCloseTo(50, 0);
-    expect(y).not.toBeCloseTo(0, 1);
-  });
-
-  it("start === end still returns a valid point (zero-length segment guard)", () => {
-    const [x, y] = arcPoint(50, 50, 50, 50, 0.5);
-    // Should not throw or return NaN
-    expect(Number.isFinite(x)).toBe(true);
-    expect(Number.isFinite(y)).toBe(true);
   });
 });
 

--- a/playground/src/__tests__/tweens.test.ts
+++ b/playground/src/__tests__/tweens.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { type Tween, emitAbandonWalks, emitAlightWalks, emitBoardWalks } from "../render/tweens";
+
+const baseSpec = {
+  now: 1_000,
+  stagger: 80,
+  duration: 260,
+  floorY: 200,
+  color: "#abc",
+};
+
+describe("emitBoardWalks", () => {
+  it("emits one tween per boarder up to count, in single-file when pairs disabled", () => {
+    const out: Tween[] = [];
+    emitBoardWalks(out, {
+      ...baseSpec,
+      count: 3,
+      enablePairs: false,
+      halfPairW: 2,
+      originX: 50,
+      endX: 100,
+      stopId: 7,
+      dirOffset: 0,
+    });
+    expect(out).toHaveLength(3);
+    expect(out.every((t) => t.kind === "board")).toBe(true);
+    // No pair offset in single-file mode.
+    expect(out.map((t) => t.startX)).toEqual([50, 50, 50]);
+    expect(out.map((t) => t.endX)).toEqual([100, 100, 100]);
+    // Variants vary across slots.
+    expect(new Set(out.map((t) => t.variant)).size).toBeGreaterThanOrEqual(1);
+  });
+
+  it("staggers waves, with pair-mates sharing the same bornAt", () => {
+    const out: Tween[] = [];
+    emitBoardWalks(out, {
+      ...baseSpec,
+      count: 4,
+      enablePairs: true,
+      halfPairW: 2,
+      originX: 50,
+      endX: 100,
+      stopId: 7,
+      dirOffset: 0,
+    });
+    expect(out).toHaveLength(4);
+    expect(out[0]?.bornAt).toBe(out[1]?.bornAt);
+    expect(out[2]?.bornAt).toBe(out[3]?.bornAt);
+    expect(out[2]?.bornAt).toBe((out[0]?.bornAt ?? 0) + 80);
+  });
+
+  it("pair m=0 trails (-halfPairW); m=1 leads (+halfPairW)", () => {
+    const out: Tween[] = [];
+    emitBoardWalks(out, {
+      ...baseSpec,
+      count: 2,
+      enablePairs: true,
+      halfPairW: 2,
+      originX: 50,
+      endX: 100,
+      stopId: 7,
+      dirOffset: 0,
+    });
+    expect(out[0]?.startX).toBe(48);
+    expect(out[1]?.startX).toBe(52);
+    expect(out[0]?.endX).toBe(98);
+    expect(out[1]?.endX).toBe(102);
+  });
+
+  it("falls back to single-file when pair would exceed count (odd remainder)", () => {
+    const out: Tween[] = [];
+    emitBoardWalks(out, {
+      ...baseSpec,
+      count: 3,
+      enablePairs: true,
+      halfPairW: 2,
+      originX: 50,
+      endX: 100,
+      stopId: 7,
+      dirOffset: 0,
+    });
+    expect(out).toHaveLength(3);
+    // Last rider runs solo (no offset).
+    expect(out[2]?.startX).toBe(50);
+    expect(out[2]?.endX).toBe(100);
+  });
+});
+
+describe("emitAlightWalks", () => {
+  it("uses LIFO from the variants slice, with pair m=0 trailing on right-bound walk", () => {
+    const out: Tween[] = [];
+    emitAlightWalks(out, {
+      ...baseSpec,
+      count: 2,
+      enablePairs: true,
+      halfPairW: 2,
+      startX: 100,
+      endX: 140,
+      color: "#def",
+      variants: ["short", "tall", "briefcase", "bag"],
+      carId: 9,
+    });
+    expect(out).toHaveLength(2);
+    expect(out[0]?.kind).toBe("alight");
+    // LIFO: last variant exits first.
+    expect(out[0]?.variant).toBe("bag");
+    expect(out[1]?.variant).toBe("briefcase");
+    // m=0 trails (left of m=1) on a rightward walk.
+    expect(out[0]?.startX).toBeLessThan(out[1]?.startX ?? 0);
+  });
+
+  it("falls back to deterministic carId hash when variants slice runs short", () => {
+    const out: Tween[] = [];
+    emitAlightWalks(out, {
+      ...baseSpec,
+      count: 2,
+      enablePairs: false,
+      halfPairW: 2,
+      startX: 100,
+      endX: 140,
+      color: "#def",
+      variants: [],
+      carId: 9,
+    });
+    expect(out).toHaveLength(2);
+    expect(out.every((t) => typeof t.variant === "string")).toBe(true);
+  });
+});
+
+describe("emitAbandonWalks", () => {
+  it("emits single-file tweens with consecutive bornAts", () => {
+    const out: Tween[] = [];
+    emitAbandonWalks(out, {
+      ...baseSpec,
+      count: 3,
+      startX: 60,
+      endX: 24,
+      color: "#f55",
+      stopId: 11,
+    });
+    expect(out).toHaveLength(3);
+    expect(out.every((t) => t.kind === "abandon")).toBe(true);
+    expect(out[1]?.bornAt).toBe((out[0]?.bornAt ?? 0) + 80);
+    expect(out[2]?.bornAt).toBe((out[0]?.bornAt ?? 0) + 160);
+    // No pair offset on abandons (single-file).
+    expect(out[0]?.startX).toBe(60);
+  });
+});

--- a/playground/src/render/color-utils.ts
+++ b/playground/src/render/color-utils.ts
@@ -58,38 +58,6 @@ export function withAlpha(hex: string, alpha: number): string {
   return hexWithAlpha(hex, alpha);
 }
 
-/**
- * Compute a curved-arc position along a tween at progress `t` (0..1).
- * The control point is offset perpendicular to the (start->end) segment so
- * dots arc above or below the straight path -- "above" for left-to-right
- * motion, which reads as a small airlock lift.
- */
-export function arcPoint(
-  startX: number,
-  startY: number,
-  endX: number,
-  endY: number,
-  t: number,
-): [number, number] {
-  const mx = (startX + endX) / 2;
-  const my = (startY + endY) / 2;
-  const dx = endX - startX;
-  const dy = endY - startY;
-  const len = Math.max(Math.hypot(dx, dy), 1);
-  // Perpendicular offset (-dy, dx) normalized, scaled by a fraction of length.
-  const perpX = -dy / len;
-  const perpY = dx / len;
-  const arc = Math.min(len * 0.25, 22);
-  const cx = mx + perpX * arc;
-  const cy = my + perpY * arc;
-  // Quadratic bezier at `t`.
-  const u = 1 - t;
-  return [
-    u * u * startX + 2 * u * t * cx + t * t * endX,
-    u * u * startY + 2 * u * t * cy + t * t * endY,
-  ];
-}
-
 /** Cubic-bezier(0.2, 0.6, 0.2, 1) evaluated at x -> y, good-enough via Newton. */
 export function easeOutNorm(tx: number): number {
   // Approximation: two-iteration Newton solver on the x curve, then evaluate y.

--- a/playground/src/render/draw-cars.ts
+++ b/playground/src/render/draw-cars.ts
@@ -122,7 +122,7 @@ export function drawCar(
   // loading-related phases, suggesting an open door without painting
   // sliding panels. Drawn last so it sits on top of the dark border.
   if (car.phase === "door-opening" || car.phase === "loading" || car.phase === "door-closing") {
-    const notchW = Math.max(4, Math.min(carW * 0.4, 8));
+    const notchW = Math.max(carW * 0.2, Math.min(carW * 0.4, 8));
     ctx.strokeStyle = "rgba(250, 250, 250, 0.85)";
     ctx.lineWidth = 1.5;
     ctx.beginPath();

--- a/playground/src/render/draw-cars.ts
+++ b/playground/src/render/draw-cars.ts
@@ -117,6 +117,19 @@ export function drawCar(
   if (car.riders > 0 || isFull) {
     drawRidersInCar(ctx, cx, bottom, carW, carH, car.riders, riderColor, s, roster, isFull);
   }
+
+  // Door notch: a small bright segment at the cabin's bottom edge during
+  // loading-related phases, suggesting an open door without painting
+  // sliding panels. Drawn last so it sits on top of the dark border.
+  if (car.phase === "door-opening" || car.phase === "loading" || car.phase === "door-closing") {
+    const notchW = Math.max(4, Math.min(carW * 0.4, 8));
+    ctx.strokeStyle = "rgba(250, 250, 250, 0.85)";
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.moveTo(cx - notchW / 2, bottom - 0.5);
+    ctx.lineTo(cx + notchW / 2, bottom - 0.5);
+    ctx.stroke();
+  }
 }
 
 // Layout + style constants for the speech bubbles. Tuned for a tight,

--- a/playground/src/render/renderer.ts
+++ b/playground/src/render/renderer.ts
@@ -20,7 +20,15 @@ import {
 } from "./frame-buffers";
 import type { Scale } from "./layout";
 import { findNearestStop, scaleFor } from "./layout";
-import { type CarState, type StopState, type Tween, drawTweens } from "./tweens";
+import {
+  type CarState,
+  type StopState,
+  type Tween,
+  drawTweens,
+  emitAbandonWalks,
+  emitAlightWalks,
+  emitBoardWalks,
+} from "./tweens";
 import {
   CAR_DOT_COLOR,
   DOWN_COLOR,
@@ -525,7 +533,7 @@ export class CanvasRenderer {
     this.#firstDrawAt = state.firstDrawAt;
   }
 
-  // ── Flying-dot animations ─────────────────────────────────────────
+  // ── Rider walk animations ─────────────────────────────────────────
 
   #computeTweens(
     snap: Snapshot,
@@ -538,39 +546,37 @@ export class CanvasRenderer {
     const now = performance.now();
     const scale = Math.max(1, speedMultiplier);
     const duration = TWEEN_BASE_MS / scale;
-    const stagger = 30 / scale;
+    const stagger = 80 / scale;
+    const halfPairW = Math.max(1.5, Math.min(2.5, s.figureStride * 0.45));
 
     const boardsAtStop = this.#boardsAtStop;
     boardsAtStop.clear();
     for (const car of snap.cars) {
       const prev = this.#carStates.get(car.id);
-      const riders = car.riders;
       const cx = carX.get(car.id);
-
       const nearest = findNearestStop(snap.stops, car.y);
       const loadStop =
         car.phase === "loading" && nearest !== undefined && nearest.dist < 0.5
           ? nearest.stop
           : undefined;
 
+      const useUp = loadStop !== undefined && loadStop.waiting_up >= loadStop.waiting_down;
+      const dirOffset = useUp ? 0 : 10_000;
+
       if (prev && cx !== undefined && loadStop !== undefined) {
-        const delta = riders - prev.riders;
+        const delta = car.riders - prev.riders;
         if (delta > 0) {
           boardsAtStop.set(loadStop.entity_id, (boardsAtStop.get(loadStop.entity_id) ?? 0) + delta);
         }
         if (delta !== 0) {
           const stopY = toScreenY(loadStop.y);
-          const cabinCenterY = toScreenY(car.y) - s.carH / 2;
+          const carWHere = this.#carWPerCar.get(car.id) ?? s.carW;
+          const enablePairs = carWHere >= s.figureStride * 3;
           const count = Math.min(Math.abs(delta), 6);
           if (delta > 0) {
-            const useUp = loadStop.waiting_up >= loadStop.waiting_down;
             const qr = carQueueRegion.get(car.id);
-            let originX = cx - 20;
-            if (qr !== undefined) {
-              const qs: number = qr.start;
-              const qe: number = qr.end;
-              originX = (qs + qe) / 2;
-            }
+            // qr.end - 2 matches the gutter row's leading-figure anchor.
+            const originX = qr !== undefined ? qr.end - 2 : cx - 20;
             const color = useUp ? UP_COLOR : DOWN_COLOR;
             // Clear just this car's line entry; other lines at the same
             // stop (e.g. a VIP still en route for an exec-only rider)
@@ -580,31 +586,39 @@ export class CanvasRenderer {
               byLine.delete(car.line);
               if (byLine.size === 0) this.#stopAssignments.delete(loadStop.entity_id);
             }
-            for (let k = 0; k < count; k++) {
-              this.#tweens.push({
-                kind: "board",
-                bornAt: now + k * stagger,
-                duration,
-                startX: originX,
-                startY: stopY,
-                endX: cx,
-                endY: cabinCenterY,
-                color,
-              });
-            }
+            emitBoardWalks(this.#tweens, {
+              count,
+              enablePairs,
+              halfPairW,
+              now,
+              stagger,
+              duration,
+              originX,
+              endX: cx,
+              floorY: stopY,
+              color,
+              stopId: loadStop.entity_id,
+              dirOffset,
+            });
           } else {
-            for (let k = 0; k < count; k++) {
-              this.#tweens.push({
-                kind: "alight",
-                bornAt: now + k * stagger,
-                duration,
-                startX: cx,
-                startY: cabinCenterY,
-                endX: cx + 18,
-                endY: cabinCenterY + 10,
-                color: CAR_DOT_COLOR,
-              });
-            }
+            const carColor = this.#riderColorPerCar.get(car.id) ?? CAR_DOT_COLOR;
+            // Exit right since boards enter from the left gutter.
+            const exitEndX = cx + carWHere / 2 + 14;
+            const variants = prev.roster.slice(Math.max(0, prev.roster.length - count));
+            emitAlightWalks(this.#tweens, {
+              count,
+              enablePairs,
+              halfPairW,
+              now,
+              stagger,
+              duration,
+              startX: cx,
+              endX: exitEndX,
+              floorY: stopY,
+              color: carColor,
+              variants,
+              carId: car.id,
+            });
           }
         }
       }
@@ -614,46 +628,36 @@ export class CanvasRenderer {
       if (!prev) {
         // First frame for this car — seed the roster from the car's own id.
         roster = [];
-        for (let i = 0; i < riders; i++) {
+        for (let i = 0; i < car.riders; i++) {
           roster.push(pickRiderVariant(car.id, i));
         }
       } else {
-        const delta = riders - prev.riders;
-        // When delta is zero we can keep the previous roster reference
-        // — the trailing length-correction loops are no-ops in steady
-        // state, and overwriting `#carStates` with the same array below
-        // is harmless.
+        const delta = car.riders - prev.riders;
         if (delta === 0) {
           roster = prev.roster;
         } else {
           roster = prev.roster.slice();
           if (delta > 0 && loadStop !== undefined) {
-            // Riders boarded from this stop. Replicate the gutter's variant
-            // picks so the silhouettes visually match who was waiting.
-            const isUp = loadStop.waiting_up >= loadStop.waiting_down;
-            const dirOffset = isUp ? 0 : 10_000;
-            // The gutter's nearest-shaft figures are at low slot indices —
-            // those are the ones who board first.
+            // Match the gutter's variant picks so boarding silhouettes
+            // visually correspond to who was waiting.
             for (let k = 0; k < delta; k++) {
               roster.push(pickRiderVariant(loadStop.entity_id, k + dirOffset));
             }
           } else if (delta > 0) {
-            // Riders appeared but no load stop (e.g., first snapshot or
-            // teleport). Fall back to car-id hashing.
             for (let k = 0; k < delta; k++) {
               roster.push(pickRiderVariant(car.id, roster.length + k));
             }
           } else {
-            // Riders alighted — remove from end (LIFO).
+            // LIFO: alighters are popped from the end.
             roster.splice(roster.length + delta, -delta);
           }
         }
       }
       // Correct any length drift from accumulated rounding.
-      while (roster.length > riders) roster.pop();
-      while (roster.length < riders) roster.push(pickRiderVariant(car.id, roster.length));
+      while (roster.length > car.riders) roster.pop();
+      while (roster.length < car.riders) roster.push(pickRiderVariant(car.id, roster.length));
 
-      this.#carStates.set(car.id, { riders, roster });
+      this.#carStates.set(car.id, { riders: car.riders, roster });
     }
 
     for (const stop of snap.stops) {
@@ -664,29 +668,23 @@ export class CanvasRenderer {
         const boards = boardsAtStop.get(stop.entity_id) ?? 0;
         const abandons = Math.max(0, dropped - boards);
         if (abandons > 0) {
-          const stopY = toScreenY(stop.y);
-          const startX = s.padX + s.labelW + 20;
-          const count = Math.min(abandons, 4);
-          for (let k = 0; k < count; k++) {
-            this.#tweens.push({
-              kind: "abandon",
-              bornAt: now + k * stagger,
-              duration: duration * 1.5,
-              startX,
-              startY: stopY,
-              endX: startX - 26,
-              endY: stopY - 6,
-              color: OVERFLOW_COLOR,
-            });
-          }
+          emitAbandonWalks(this.#tweens, {
+            count: Math.min(abandons, 4),
+            now,
+            stagger,
+            duration: duration * 2.2,
+            startX: s.padX + s.labelW + 20,
+            endX: s.padX + s.labelW - 16,
+            floorY: toScreenY(stop.y),
+            color: OVERFLOW_COLOR,
+            stopId: stop.entity_id,
+          });
         }
       }
       this.#stopStates.set(stop.entity_id, { waiting });
     }
 
-    // Reap completed tweens via in-place compaction. The previous
-    // `splice(i, 1)` per expired tween was O(n) per removal — this is
-    // O(n) total for the pass and writes survivors forward in place.
+    // Reap completed tweens via in-place compaction.
     {
       let writeIdx = 0;
       for (let i = 0; i < this.#tweens.length; i++) {
@@ -699,9 +697,6 @@ export class CanvasRenderer {
       this.#tweens.length = writeIdx;
     }
 
-    // Drop state for cars no longer in the snapshot. Reuse the
-    // `#carById` map populated at the top of `draw()` so we don't have
-    // to allocate a fresh `Set` of live ids per frame.
     if (this.#carStates.size > snap.cars.length) {
       for (const id of this.#carStates.keys()) {
         if (!this.#carById.has(id)) this.#carStates.delete(id);

--- a/playground/src/render/tweens.ts
+++ b/playground/src/render/tweens.ts
@@ -1,17 +1,22 @@
-import type { RiderVariant } from "./figures/rider";
+import { type RiderVariant, drawRider, pickRiderVariant } from "./figures/rider";
 import type { Scale } from "./layout";
-import { arcPoint, easeOutNorm, hexWithAlpha } from "./color-utils";
+import { easeOutNorm } from "./color-utils";
 
-/** One-shot animation tween — board into a car, alight out, or abandon the queue. */
+/**
+ * One-shot rider animation. Riders walk horizontally along `floorY`
+ * with a small sinusoidal head bob; per-kind alpha schedules sell the
+ * threshold-crossing (board fades into the cabin, alight fades out of
+ * it, abandon walks away dejectedly).
+ */
 export interface Tween {
   kind: "board" | "alight" | "abandon";
   bornAt: number;
   duration: number;
   startX: number;
-  startY: number;
   endX: number;
-  endY: number;
+  floorY: number;
   color: string;
+  variant: RiderVariant;
 }
 
 /** Per-car frame-to-frame memory used to detect board/alight transitions. */
@@ -25,7 +30,9 @@ export interface StopState {
   waiting: number;
 }
 
-/** Render every active tween at its eased position, fading by remaining lifetime. */
+const BOB_AMPLITUDE = 0.8;
+const BOB_CYCLES = 2;
+
 export function drawTweens(
   ctx: CanvasRenderingContext2D,
   tweens: readonly Tween[],
@@ -37,15 +44,158 @@ export function drawTweens(
     if (age < 0) continue;
     const tx = Math.min(1, Math.max(0, age / t.duration));
     const eased = easeOutNorm(tx);
-    const [x, y] =
-      t.kind === "board"
-        ? arcPoint(t.startX, t.startY, t.endX, t.endY, eased)
-        : [t.startX + (t.endX - t.startX) * eased, t.startY + (t.endY - t.startY) * eased];
-    const alpha = t.kind === "board" ? 0.9 : t.kind === "abandon" ? (1 - eased) ** 1.5 : 1 - eased;
-    const radius = t.kind === "abandon" ? s.carDotR * 0.85 : s.carDotR;
-    ctx.fillStyle = hexWithAlpha(t.color, alpha);
-    ctx.beginPath();
-    ctx.arc(x, y, radius, 0, Math.PI * 2);
-    ctx.fill();
+    const x = t.startX + (t.endX - t.startX) * eased;
+    const bob = Math.sin(eased * Math.PI * BOB_CYCLES * 2) * BOB_AMPLITUDE;
+    const floorY = t.floorY + bob;
+    const alpha = alphaFor(t.kind, tx, eased);
+    if (alpha <= 0) continue;
+    ctx.save();
+    ctx.globalAlpha = alpha;
+    drawRider(ctx, x, floorY, s.figureHeadR, t.color, t.variant);
+    ctx.restore();
+  }
+}
+
+function alphaFor(kind: Tween["kind"], tx: number, eased: number): number {
+  if (kind === "board") {
+    // Full alpha through the walk; fade the last 25% as they cross the door.
+    return tx < 0.75 ? 1 : Math.max(0, 1 - (tx - 0.75) / 0.25);
+  }
+  if (kind === "alight") {
+    // Fade in over the first 20% (emerging from the cabin), full while
+    // crossing the gutter, fade out over the last 40%.
+    if (tx < 0.2) return tx / 0.2;
+    if (tx > 0.6) return Math.max(0, 1 - (tx - 0.6) / 0.4);
+    return 1;
+  }
+  // abandon: lower base alpha that decays with a slight curve.
+  return 0.7 * (1 - eased) ** 1.2;
+}
+
+interface BoardWalkSpec {
+  count: number;
+  enablePairs: boolean;
+  halfPairW: number;
+  now: number;
+  stagger: number;
+  duration: number;
+  originX: number;
+  endX: number;
+  floorY: number;
+  color: string;
+  stopId: number;
+  dirOffset: number;
+}
+
+interface AlightWalkSpec {
+  count: number;
+  enablePairs: boolean;
+  halfPairW: number;
+  now: number;
+  stagger: number;
+  duration: number;
+  startX: number;
+  endX: number;
+  floorY: number;
+  color: string;
+  variants: readonly RiderVariant[];
+  carId: number;
+}
+
+/**
+ * Emit board walks: pairs (when the door is wide enough) walk side-by-side
+ * from the gutter slot nearest the shaft to the cabin door. Each rider's
+ * variant is hashed from the gutter's slot seed so the silhouette that
+ * boards visually matches who was waiting.
+ */
+export function emitBoardWalks(out: Tween[], spec: BoardWalkSpec): void {
+  const { count, enablePairs, halfPairW, now, stagger, duration, originX, endX, floorY, color } =
+    spec;
+  let k = 0;
+  let waveIdx = 0;
+  while (k < count) {
+    const pairCount = enablePairs && k + 1 < count ? 2 : 1;
+    for (let m = 0; m < pairCount; m++) {
+      const off = pairCount === 2 ? (m === 0 ? -halfPairW : halfPairW) : 0;
+      out.push({
+        kind: "board",
+        bornAt: now + waveIdx * stagger,
+        duration,
+        startX: originX + off,
+        endX: endX + off,
+        floorY,
+        color,
+        variant: pickRiderVariant(spec.stopId, k + m + spec.dirOffset),
+      });
+    }
+    k += pairCount;
+    waveIdx++;
+  }
+}
+
+interface AbandonWalkSpec {
+  count: number;
+  now: number;
+  stagger: number;
+  duration: number;
+  startX: number;
+  endX: number;
+  floorY: number;
+  color: string;
+  stopId: number;
+}
+
+/**
+ * Emit single-file abandon walks: dejected silhouettes drift away from
+ * the queue area at the stop. Lower base alpha (in `alphaFor`) plus a
+ * stretched duration sells the "gave up waiting" read.
+ */
+export function emitAbandonWalks(out: Tween[], spec: AbandonWalkSpec): void {
+  const { count, now, stagger, duration, startX, endX, floorY, color, stopId } = spec;
+  for (let k = 0; k < count; k++) {
+    out.push({
+      kind: "abandon",
+      bornAt: now + k * stagger,
+      duration,
+      startX,
+      endX,
+      floorY,
+      color,
+      variant: pickRiderVariant(stopId, 20_000 + k),
+    });
+  }
+}
+
+/**
+ * Emit alight walks: pairs (or singles) emerge from the cabin door and
+ * walk out into the gutter, fading out. Variants are taken from the
+ * cabin's roster in LIFO order so the silhouettes match who was aboard.
+ */
+export function emitAlightWalks(out: Tween[], spec: AlightWalkSpec): void {
+  const { count, enablePairs, halfPairW, now, stagger, duration, startX, endX, floorY, color } =
+    spec;
+  let k = 0;
+  let waveIdx = 0;
+  while (k < count) {
+    const pairCount = enablePairs && k + 1 < count ? 2 : 1;
+    for (let m = 0; m < pairCount; m++) {
+      const slotIdx = k + m;
+      // m=0 trails (matches board convention: -halfPairW behind in walking direction).
+      const off = pairCount === 2 ? (m === 0 ? -halfPairW : halfPairW) : 0;
+      out.push({
+        kind: "alight",
+        bornAt: now + waveIdx * stagger,
+        duration,
+        startX: startX + off,
+        endX: endX + off,
+        floorY,
+        color,
+        variant:
+          spec.variants[spec.variants.length - 1 - slotIdx] ??
+          pickRiderVariant(spec.carId, slotIdx),
+      });
+    }
+    k += pairCount;
+    waveIdx++;
   }
 }

--- a/playground/src/render/tweens.ts
+++ b/playground/src/render/tweens.ts
@@ -46,13 +46,13 @@ export function drawTweens(
     const eased = easeOutNorm(tx);
     const x = t.startX + (t.endX - t.startX) * eased;
     const bob = Math.sin(eased * Math.PI * BOB_CYCLES * 2) * BOB_AMPLITUDE;
-    const floorY = t.floorY + bob;
+    const drawY = t.floorY + bob;
     const alpha = alphaFor(t.kind, tx, eased);
     if (alpha <= 0) continue;
-    ctx.save();
+    const prevAlpha = ctx.globalAlpha;
     ctx.globalAlpha = alpha;
-    drawRider(ctx, x, floorY, s.figureHeadR, t.color, t.variant);
-    ctx.restore();
+    drawRider(ctx, x, drawY, s.figureHeadR, t.color, t.variant);
+    ctx.globalAlpha = prevAlpha;
   }
 }
 


### PR DESCRIPTION
## Summary
- Riders now board, alight, and abandon as full silhouettes walking horizontally with a subtle 1px head bob, instead of small flying colored dots. Variants (briefcase / bag / short / tall / standard) carry through gutter → cabin → exit, so the same silhouette that waits also boards and (LIFO) alights.
- Boards enter from the left gutter and exit out the **right** side of the cabin (clean push-through that doesn't backtrack through waiters). Abandons walk away dejectedly with reduced base alpha and a 2.2× duration.
- Pair-mode (two-abreast through the doorway) when the cabin is wide enough; falls back to single-file on narrow shafts.
- Subtle lit notch at the cabin floor center signals the door during `door-opening` / `loading` / `door-closing`.
- Building mode only — tether scene unchanged.
- Unused `arcPoint` and its 4 tests removed.

## Design decisions locked in via a brainstorming pass
| Question | Choice |
|---|---|
| Animated form | Same silhouette as static figures, full size |
| Boarding path | Walk along floor → door (cabin floor flush during loading) |
| Exit path | Walk out the **right**, then fade |
| Doors | Thin lit notch at cabin floor center during loading phases |
| Group flow | Two-at-a-time pairs (clamp to single-file on narrow doors) |
| Timing | Fixed duration scaled by speed multiplier (existing pattern) |
| Abandon | Walk dejectedly, slower + lower opacity |
| Walk cycle | Sinusoidal vertical head-bob (~0.8 px) |
| Color source | Boards = directional UP/DOWN; alights = cabin's rider color; abandons = OVERFLOW_COLOR |

## Files
- `playground/src/render/tweens.ts` — Tween reshape (added `floorY`, `variant`; removed `startY`/`endY`); per-kind alpha schedules; new `emit{Board,Alight,Abandon}Walks` helpers.
- `playground/src/render/renderer.ts` — `#computeTweens` rewired to emit silhouette tweens with variants + pairs; alight exits right (`cx + carW/2 + 14`).
- `playground/src/render/draw-cars.ts` — door notch in `drawCar` during loading-related phases.
- `playground/src/render/color-utils.ts` — removed unused `arcPoint`.
- `playground/src/__tests__/tweens.test.ts` — new regression tests for emitter pair-offset, LIFO variant indexing, and stagger geometry.

## Known minor visual artifact (deferred)
Under low `globalAlpha` during alight fade-out, the `bag` variant's strap stroke compounds with the body fill (both same color) and reads as a faint glowing diagonal. Cheap fix lives in `figures/rider.ts` (offscreen-canvas composite, or shorten strap so it stops at the body edge) — held back to avoid touching shared silhouette rendering in this PR.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test --run` — 344 / 344 pass (added 7 new tween tests)
- [x] `pnpm build` succeeds
- [ ] Visual smoke: load `localhost:5173`, drive a busy scenario, verify silhouettes walk in / out / give up at the right floor cleanly
- [ ] Mobile portrait: confirm pair-mode falls back to single-file at narrow widths