### PR TITLE
fix(playground): bump rider walk duration so the animation is legible

### DIFF
--- a/playground/src/render/palette.ts
+++ b/playground/src/render/palette.ts
@@ -92,9 +92,11 @@ export const OVERFLOW_COLOR = "#8b8c92"; // --text-tertiary
 // using it for the target dot added false semantic overlap.
 export const TARGET_FILL = "rgba(250, 250, 250, 0.95)"; // --text-primary at alpha
 
-// Board/alight animation baseline. Effective duration is divided by the sim
-// speed multiplier so fast-forwarded runs don't queue stale tweens.
-export const TWEEN_BASE_MS = 260;
+// Board/alight animation baseline at 1× sim speed. Effective duration is
+// divided by the speed multiplier so fast-forwarded runs don't queue stale
+// tweens. ~700ms reads as a believable doorway-cross while staying well
+// inside the typical loading dwell (`door_open_ticks: 300` ≈ 5 s at 60 Hz).
+export const TWEEN_BASE_MS = 700;
 
 // Cars in `moving` phase leave a short fading ghost strip behind them so
 // velocity is visible at a glance without a text indicator.


### PR DESCRIPTION
## Summary
- Followup to #795. The new silhouette walk tweens were 260 ms at 1× speed — only ~5% of the typical 5 s loading dwell (`door_open_ticks: 300` at 60 Hz) — so the walk vanished almost as soon as it started.
- Bumped `TWEEN_BASE_MS` to 700 ms. At 1× speed the walk now reads as a believable doorway cross; at higher speeds it continues to scale with `speedMultiplier`, so fast-forwarded runs don't queue stale tweens.

## Why not change door ticks?
The default scenarios already use realistic dwell timing (`door_open_ticks: 300` ≈ 5 s, `door_transition_ticks: 60` ≈ 1 s per transition). The animation was simply much shorter than the dwell window. Quest stages use compressed ticks intentionally (tutorials), and don't need to be slowed down.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test --run` — 344 / 344 pass
- [ ] Visual smoke: open `localhost:5173`, drive a busy scenario at 1× speed and verify riders are visible boarding/alighting. Bump speed to 4× and confirm walk still reads but is proportionally faster.