### PR TITLE
feat(playground): airport pedway scenario with horizontal-line rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "20.1.0"
+version = "20.2.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/tests/config_tests.rs
+++ b/crates/elevator-core/src/tests/config_tests.rs
@@ -324,6 +324,65 @@ fn ron_without_schema_version_field_deserializes_to_zero() {
 }
 
 #[test]
+fn ron_parses_horizontal_line_orientation() {
+    // Pedway-style scenario: explicitly declare `orientation: Horizontal`
+    // on a multi-line RON and confirm both the parser and the constructed
+    // `World` carry the orientation through to the `Line` component.
+    let ron_str = r#"
+        SimConfig(
+            schema_version: 1,
+            building: BuildingConfig(
+                name: "Pedway",
+                stops: [
+                    StopConfig(id: StopId(0), name: "A", position: 0.0),
+                    StopConfig(id: StopId(1), name: "B", position: 100.0),
+                ],
+                lines: Some([
+                    LineConfig(
+                        id: 0, name: "Outbound",
+                        serves: [StopId(0), StopId(1)],
+                        orientation: Horizontal,
+                        elevators: [
+                            ElevatorConfig(
+                                id: 0, name: "PT-1",
+                                max_speed: 10.0, acceleration: 1.0, deceleration: 1.0,
+                                weight_capacity: 1000.0,
+                                starting_stop: StopId(0),
+                                door_open_ticks: 60, door_transition_ticks: 30,
+                            ),
+                        ],
+                    ),
+                ]),
+                groups: Some([
+                    GroupConfig(id: 0, name: "G", lines: [0], dispatch: Scan),
+                ]),
+            ),
+            simulation: SimulationParams(ticks_per_second: 60.0),
+            passenger_spawning: PassengerSpawnConfig(
+                mean_interval_ticks: 60,
+                weight_range: (50.0, 100.0),
+            ),
+        )
+    "#;
+    let config: SimConfig = ron::from_str(ron_str).expect("horizontal RON parses");
+    let line = config
+        .building
+        .lines
+        .as_ref()
+        .and_then(|ls| ls.first())
+        .expect("one line declared");
+    assert!(matches!(line.orientation, Orientation::Horizontal));
+    let sim = crate::sim::Simulation::new(&config, super::helpers::scan())
+        .expect("horizontal line builds a Simulation");
+    let oriented = sim
+        .world()
+        .iter_lines()
+        .next()
+        .expect("simulation has one line");
+    assert!(matches!(oriented.1.orientation(), Orientation::Horizontal));
+}
+
+#[test]
 fn shipped_assets_pin_to_current_schema_version() {
     // Every config under assets/config/ must declare the current
     // version explicitly; otherwise the asset itself becomes a legacy

--- a/crates/elevator-wasm/src/dto.rs
+++ b/crates/elevator-wasm/src/dto.rs
@@ -50,6 +50,24 @@ pub struct CarDto {
     pub max_served_y: f64,
 }
 
+/// Per-line rendering snapshot. Lines are physical paths (shafts,
+/// tethers, tracks) and carry an orientation that renderers branch on
+/// to lay out vertical shafts vs horizontal pedways.
+#[derive(Serialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct LineDto {
+    /// Line entity id (matches `CarDto.line`).
+    pub id: u32,
+    /// Physical orientation. `"vertical"` is the default for buildings
+    /// and tethers; `"horizontal"` covers people-movers and transit
+    /// lines; `"angled"` carries an `angle_deg` payload.
+    #[tsify(type = r#""vertical" | "horizontal" | "angled""#)]
+    pub orientation: &'static str,
+    /// Angle in degrees from horizontal, set only when
+    /// `orientation == "angled"`. `None` for vertical/horizontal.
+    pub angle_deg: Option<f64>,
+}
+
 /// One line's share of a stop's waiting queue.
 #[derive(Serialize, Tsify)]
 #[tsify(into_wasm_abi)]
@@ -121,6 +139,9 @@ pub struct Snapshot {
     pub cars: Vec<CarDto>,
     /// Configured stops.
     pub stops: Vec<StopDto>,
+    /// Configured lines. Renderers branch on `orientation` to choose
+    /// vertical-shaft vs horizontal-pedway layout.
+    pub lines: Vec<LineDto>,
 }
 
 impl Snapshot {
@@ -215,11 +236,25 @@ impl Snapshot {
             })
             .collect();
 
+        let lines = sim
+            .world()
+            .iter_lines()
+            .map(|(id, line)| {
+                let (orientation, angle_deg) = orientation_label(line.orientation());
+                LineDto {
+                    id: entity_to_u32(id),
+                    orientation,
+                    angle_deg,
+                }
+            })
+            .collect();
+
         Self {
             tick: sim.current_tick(),
             dt: sim.dt(),
             cars,
             stops,
+            lines,
         }
     }
 }
@@ -1492,6 +1527,19 @@ impl From<Event> for EventDto {
                     .to_string(),
             },
         }
+    }
+}
+
+/// Map [`Orientation`] to its wire label and optional angle. The
+/// `#[non_exhaustive]` enum forces a fallback arm; future variants
+/// surface as `"vertical"` so the renderer falls back to its default
+/// layout instead of crashing.
+fn orientation_label(o: elevator_core::components::Orientation) -> (&'static str, Option<f64>) {
+    use elevator_core::components::Orientation;
+    match o {
+        Orientation::Horizontal => ("horizontal", None),
+        Orientation::Angled { degrees } => ("angled", Some(degrees)),
+        Orientation::Vertical | _ => ("vertical", None),
     }
 }
 

--- a/crates/elevator-wasm/src/dto.rs
+++ b/crates/elevator-wasm/src/dto.rs
@@ -50,25 +50,18 @@ pub struct CarDto {
     pub max_served_y: f64,
 }
 
-/// Per-line rendering snapshot. Lines are physical paths (shafts,
-/// tethers, tracks) and carry an orientation that renderers branch on
-/// to lay out vertical shafts vs horizontal pedways.
+/// Per-line rendering snapshot. Renderers branch on `orientation` to
+/// lay out vertical shafts vs horizontal pedways and read `name` for
+/// lane / shaft header copy.
 #[derive(Serialize, Tsify)]
 #[tsify(into_wasm_abi)]
 pub struct LineDto {
-    /// Line entity id (matches `CarDto.line`).
     pub id: u32,
-    /// Human-readable line name from the scenario config (e.g. "Low
-    /// bank", "Outbound"). Renderers use this for lane / shaft headers
-    /// instead of hardcoding scenario-specific strings.
     pub name: String,
-    /// Physical orientation. `"vertical"` is the default for buildings
-    /// and tethers; `"horizontal"` covers people-movers and transit
-    /// lines; `"angled"` carries an `angle_deg` payload.
     #[tsify(type = r#""vertical" | "horizontal" | "angled""#)]
     pub orientation: &'static str,
     /// Angle in degrees from horizontal, set only when
-    /// `orientation == "angled"`. `None` for vertical/horizontal.
+    /// `orientation == "angled"`.
     pub angle_deg: Option<f64>,
 }
 
@@ -143,8 +136,7 @@ pub struct Snapshot {
     pub cars: Vec<CarDto>,
     /// Configured stops.
     pub stops: Vec<StopDto>,
-    /// Configured lines. Renderers branch on `orientation` to choose
-    /// vertical-shaft vs horizontal-pedway layout.
+    /// Configured lines.
     pub lines: Vec<LineDto>,
 }
 

--- a/crates/elevator-wasm/src/dto.rs
+++ b/crates/elevator-wasm/src/dto.rs
@@ -58,6 +58,10 @@ pub struct CarDto {
 pub struct LineDto {
     /// Line entity id (matches `CarDto.line`).
     pub id: u32,
+    /// Human-readable line name from the scenario config (e.g. "Low
+    /// bank", "Outbound"). Renderers use this for lane / shaft headers
+    /// instead of hardcoding scenario-specific strings.
+    pub name: String,
     /// Physical orientation. `"vertical"` is the default for buildings
     /// and tethers; `"horizontal"` covers people-movers and transit
     /// lines; `"angled"` carries an `angle_deg` payload.
@@ -243,6 +247,7 @@ impl Snapshot {
                 let (orientation, angle_deg) = orientation_label(line.orientation());
                 LineDto {
                     id: entity_to_u32(id),
+                    name: line.name().to_string(),
                     orientation,
                     angle_deg,
                 }

--- a/playground/src/__tests__/bubbles.test.ts
+++ b/playground/src/__tests__/bubbles.test.ts
@@ -18,6 +18,7 @@ function makeSnapshot(stops: { entity_id: number; name: string }[]): Snapshot {
       waiting_by_line: [],
       residents: 0,
     })),
+    lines: [],
   };
 }
 

--- a/playground/src/__tests__/scenarios.test.ts
+++ b/playground/src/__tests__/scenarios.test.ts
@@ -73,4 +73,19 @@ describe("scenarios metadata", () => {
       expect(s.description.length, s.id).toBeGreaterThan(0);
     }
   });
+
+  it("airport-pedway declares two horizontal lines and six trains", () => {
+    const airport = SCENARIOS.find((s) => s.id === "airport-pedway");
+    expect(airport).toBeDefined();
+    if (airport === undefined) return;
+    expect(airport.disableCompare).toBe(true);
+    expect(airport.defaultCars).toBe(6);
+    // RON sanity: both LineConfig blocks must opt into Horizontal so
+    // the renderer's pedway path actually fires.
+    const horizontalCount = (airport.ron.match(/orientation:\s*Horizontal/g) ?? []).length;
+    expect(horizontalCount).toBe(2);
+    // Six elevator entries, three per line.
+    const elevatorCount = (airport.ron.match(/ElevatorConfig\s*\(/g) ?? []).length;
+    expect(elevatorCount).toBe(6);
+  });
 });

--- a/playground/src/__tests__/scenarios.test.ts
+++ b/playground/src/__tests__/scenarios.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { SCENARIOS, scenarioById } from "../domain/scenarios";
 
 describe("scenarios metadata", () => {
-  it("ships exactly 3 scenarios", () => {
-    expect(SCENARIOS).toHaveLength(3);
+  it("ships exactly 4 scenarios", () => {
+    expect(SCENARIOS).toHaveLength(4);
   });
 
   it("every id is unique", () => {

--- a/playground/src/__tests__/traffic.test.ts
+++ b/playground/src/__tests__/traffic.test.ts
@@ -21,6 +21,7 @@ function snapshotWithStops(n: number): Snapshot {
       waiting_by_line: [],
       residents: 0,
     })),
+    lines: [],
   };
 }
 

--- a/playground/src/domain/index.ts
+++ b/playground/src/domain/index.ts
@@ -19,7 +19,7 @@ export {
   type Overrides,
   type ParamKey,
 } from "./params";
-export { SCENARIOS, scenarioById } from "./scenarios";
+export { SCENARIOS, effectiveCompare, scenarioById } from "./scenarios";
 export {
   UI_STRATEGIES,
   STRATEGY_LABELS,

--- a/playground/src/domain/scenarios/airport-pedway.ts
+++ b/playground/src/domain/scenarios/airport-pedway.ts
@@ -1,19 +1,19 @@
 import type { Phase, ScenarioMeta } from "../../types";
 
-// ─── Airport pedway — opposing-loop people-mover ────────────────────
+// ─── Airport pedway — horizontal people-mover ──────────────────────
 //
 // Four stations along a ~1.8 km concourse: Main Terminal at the head
-// and three concourses spaced 600 m apart. Two opposing one-way lines
-// each serve every stop; three trains per line spaced for roughly
-// equal headway. Real airport people-movers (DFW Skylink, ATL Plane
-// Train, IAD AeroTrain) work this way — the dispatch story isn't
+// and three concourses spaced 600 m apart. Two parallel tracks each
+// serve every stop; three trains per line spaced for roughly equal
+// headway. Real airport people-movers (DFW Skylink, ATL Plane Train,
+// IAD AeroTrain) inspire the layout — the dispatch story isn't
 // "which car responds first" but "is the train spacing consistent
 // enough that riders don't pile up?".
 //
 // Lines opt into Orientation::Horizontal so the renderer lays them
-// out as stacked horizontal lanes instead of vertical shafts. Bypass
-// thresholds are intentionally omitted — every train stops at every
-// station.
+// out as stacked horizontal lanes; the per-lane chevron expresses a
+// *visual* outbound/inbound bias rather than a hard direction lock,
+// since elevator-core's 1D axis doesn't model directional tracks.
 
 const STOPS = [
   { name: "Main Terminal", positionM: 0 },
@@ -27,8 +27,6 @@ function weights(perIndex: (i: number) => number): number[] {
 }
 
 const phases: Phase[] = [
-  // Steady operations — diffuse symmetric flow with the Main Terminal
-  // slightly heavier as the canonical entry point.
   {
     name: "Steady operations",
     durationSec: 90,
@@ -36,9 +34,6 @@ const phases: Phase[] = [
     originWeights: weights((i) => (i === 0 ? 2 : 1)),
     destWeights: weights((i) => (i === 0 ? 1.6 : 1)),
   },
-  // A flight lands at Concourse B — surge of arriving passengers
-  // boarding the inbound line back toward the Main Terminal, plus
-  // spillover heading further along the concourse.
   {
     name: "Arrival at Concourse B",
     durationSec: 60,
@@ -50,7 +45,6 @@ const phases: Phase[] = [
       return 1;
     }),
   },
-  // Crowd thins, light symmetric flow.
   {
     name: "Quiet between flights",
     durationSec: 60,
@@ -58,7 +52,6 @@ const phases: Phase[] = [
     originWeights: weights(() => 1),
     destWeights: weights(() => 1),
   },
-  // Mid-concourse landing at C — pulls riders to both terminals.
   {
     name: "Arrival at Concourse C",
     durationSec: 60,
@@ -70,7 +63,6 @@ const phases: Phase[] = [
       return 1.5;
     }),
   },
-  // Far-end arrival at Concourse D — the longest haul back.
   {
     name: "Arrival at Concourse D",
     durationSec: 60,
@@ -88,7 +80,7 @@ export const airportPedway: ScenarioMeta = {
   id: "airport-pedway",
   label: "Airport pedway",
   description:
-    "Two opposing one-way people-mover tracks linking the main terminal to three concourses 600 m apart. Three trains per loop run on roughly equal headway and stop at every station — the dispatch story is keeping the trains evenly spaced as flight arrivals dump passengers onto specific platforms.",
+    "Two parallel people-mover tracks linking the main terminal to three concourses 600 m apart. Three trains per track run on roughly equal headway and stop at every station — the dispatch story is keeping the trains evenly spaced as flight arrivals dump passengers onto specific platforms.",
   defaultStrategy: "scan",
   defaultReposition: "spread",
   disableCompare: true,
@@ -96,19 +88,17 @@ export const airportPedway: ScenarioMeta = {
   seedSpawns: 0,
   abandonAfterSec: 600,
   featureHint:
-    "Two opposing one-way tracks, three trains each, every train stops at every station. Watch how the headway evolves when a flight dumps riders onto one platform at once.",
+    "Two parallel tracks, three trains each, every train stops at every station. Watch how the headway evolves when a flight dumps riders onto one platform at once.",
   buildingName: "Airport Concourse",
   stops: STOPS.map((s) => ({ name: s.name, positionM: s.positionM })),
-  // Six trains total — three per direction. Locked because the line
-  // structure is fixed in the RON (the drawer's car stepper assumes a
-  // single-line scenario it can regenerate from defaults).
+  // Locked: the multi-line RON can't be regenerated from a single-car
+  // template the way flat scenarios can.
   defaultCars: 6,
   elevatorDefaults: {
     maxSpeed: 15.0,
     acceleration: 1.5,
     deceleration: 1.5,
     weightCapacity: 2400.0,
-    // 600 ticks dwell ≈ 10 s at 60 Hz; 60-tick transitions = 1 s open / 1 s close.
     doorOpenTicks: 600,
     doorTransitionTicks: 60,
   },

--- a/playground/src/domain/scenarios/airport-pedway.ts
+++ b/playground/src/domain/scenarios/airport-pedway.ts
@@ -1,0 +1,202 @@
+import type { Phase, ScenarioMeta } from "../../types";
+
+// ─── Airport pedway — opposing-loop people-mover ────────────────────
+//
+// Four stations along a ~1.8 km concourse: Main Terminal at the head
+// and three concourses spaced 600 m apart. Two opposing one-way lines
+// each serve every stop; three trains per line spaced for roughly
+// equal headway. Real airport people-movers (DFW Skylink, ATL Plane
+// Train, IAD AeroTrain) work this way — the dispatch story isn't
+// "which car responds first" but "is the train spacing consistent
+// enough that riders don't pile up?".
+//
+// Lines opt into Orientation::Horizontal so the renderer lays them
+// out as stacked horizontal lanes instead of vertical shafts. Bypass
+// thresholds are intentionally omitted — every train stops at every
+// station.
+
+const STOPS = [
+  { name: "Main Terminal", positionM: 0 },
+  { name: "Concourse B", positionM: 600 },
+  { name: "Concourse C", positionM: 1200 },
+  { name: "Concourse D", positionM: 1800 },
+] as const;
+
+function weights(perIndex: (i: number) => number): number[] {
+  return Array.from({ length: STOPS.length }, (_, i) => perIndex(i));
+}
+
+const phases: Phase[] = [
+  // Steady operations — diffuse symmetric flow with the Main Terminal
+  // slightly heavier as the canonical entry point.
+  {
+    name: "Steady operations",
+    durationSec: 90,
+    ridersPerMin: 16,
+    originWeights: weights((i) => (i === 0 ? 2 : 1)),
+    destWeights: weights((i) => (i === 0 ? 1.6 : 1)),
+  },
+  // A flight lands at Concourse B — surge of arriving passengers
+  // boarding the inbound line back toward the Main Terminal, plus
+  // spillover heading further along the concourse.
+  {
+    name: "Arrival at Concourse B",
+    durationSec: 60,
+    ridersPerMin: 38,
+    originWeights: weights((i) => (i === 1 ? 8 : 1)),
+    destWeights: weights((i) => {
+      if (i === 0) return 6;
+      if (i === 1) return 0;
+      return 1;
+    }),
+  },
+  // Crowd thins, light symmetric flow.
+  {
+    name: "Quiet between flights",
+    durationSec: 60,
+    ridersPerMin: 10,
+    originWeights: weights(() => 1),
+    destWeights: weights(() => 1),
+  },
+  // Mid-concourse landing at C — pulls riders to both terminals.
+  {
+    name: "Arrival at Concourse C",
+    durationSec: 60,
+    ridersPerMin: 36,
+    originWeights: weights((i) => (i === 2 ? 8 : 1)),
+    destWeights: weights((i) => {
+      if (i === 0) return 5;
+      if (i === 2) return 0;
+      return 1.5;
+    }),
+  },
+  // Far-end arrival at Concourse D — the longest haul back.
+  {
+    name: "Arrival at Concourse D",
+    durationSec: 60,
+    ridersPerMin: 34,
+    originWeights: weights((i) => (i === 3 ? 8 : 1)),
+    destWeights: weights((i) => {
+      if (i === 0) return 6;
+      if (i === 3) return 0;
+      return 1.2;
+    }),
+  },
+];
+
+export const airportPedway: ScenarioMeta = {
+  id: "airport-pedway",
+  label: "Airport pedway",
+  description:
+    "Two opposing one-way people-mover tracks linking the main terminal to three concourses 600 m apart. Three trains per loop run on roughly equal headway and stop at every station — the dispatch story is keeping the trains evenly spaced as flight arrivals dump passengers onto specific platforms.",
+  defaultStrategy: "scan",
+  defaultReposition: "spread",
+  disableCompare: true,
+  phases,
+  seedSpawns: 0,
+  abandonAfterSec: 600,
+  featureHint:
+    "Two opposing one-way tracks, three trains each, every train stops at every station. Watch how the headway evolves when a flight dumps riders onto one platform at once.",
+  buildingName: "Airport Concourse",
+  stops: STOPS.map((s) => ({ name: s.name, positionM: s.positionM })),
+  // Six trains total — three per direction. Locked because the line
+  // structure is fixed in the RON (the drawer's car stepper assumes a
+  // single-line scenario it can regenerate from defaults).
+  defaultCars: 6,
+  elevatorDefaults: {
+    maxSpeed: 15.0,
+    acceleration: 1.5,
+    deceleration: 1.5,
+    weightCapacity: 2400.0,
+    // 600 ticks dwell ≈ 10 s at 60 Hz; 60-tick transitions = 1 s open / 1 s close.
+    doorOpenTicks: 600,
+    doorTransitionTicks: 60,
+  },
+  tweakRanges: {
+    cars: { min: 6, max: 6, step: 1 },
+    maxSpeed: { min: 8, max: 25, step: 1 },
+    weightCapacity: { min: 1500, max: 3500, step: 100 },
+    doorCycleSec: { min: 8, max: 18, step: 1 },
+  },
+  passengerMeanIntervalTicks: 90,
+  passengerWeightRange: [55.0, 95.0],
+  ron: `SimConfig(
+    schema_version: 1,
+    building: BuildingConfig(
+        name: "Airport Concourse",
+        stops: [
+            StopConfig(id: StopId(0), name: "Main Terminal", position: 0.0),
+            StopConfig(id: StopId(1), name: "Concourse B",   position: 600.0),
+            StopConfig(id: StopId(2), name: "Concourse C",   position: 1200.0),
+            StopConfig(id: StopId(3), name: "Concourse D",   position: 1800.0),
+        ],
+        lines: Some([
+            LineConfig(
+                id: 0, name: "Outbound",
+                serves: [StopId(0), StopId(1), StopId(2), StopId(3)],
+                orientation: Horizontal,
+                elevators: [
+                    ElevatorConfig(
+                        id: 0, name: "PT-A1",
+                        max_speed: 15.0, acceleration: 1.5, deceleration: 1.5,
+                        weight_capacity: 2400.0,
+                        starting_stop: StopId(0),
+                        door_open_ticks: 600, door_transition_ticks: 60,
+                    ),
+                    ElevatorConfig(
+                        id: 1, name: "PT-A2",
+                        max_speed: 15.0, acceleration: 1.5, deceleration: 1.5,
+                        weight_capacity: 2400.0,
+                        starting_stop: StopId(1),
+                        door_open_ticks: 600, door_transition_ticks: 60,
+                    ),
+                    ElevatorConfig(
+                        id: 2, name: "PT-A3",
+                        max_speed: 15.0, acceleration: 1.5, deceleration: 1.5,
+                        weight_capacity: 2400.0,
+                        starting_stop: StopId(2),
+                        door_open_ticks: 600, door_transition_ticks: 60,
+                    ),
+                ],
+            ),
+            LineConfig(
+                id: 1, name: "Inbound",
+                serves: [StopId(3), StopId(2), StopId(1), StopId(0)],
+                orientation: Horizontal,
+                elevators: [
+                    ElevatorConfig(
+                        id: 3, name: "PT-B1",
+                        max_speed: 15.0, acceleration: 1.5, deceleration: 1.5,
+                        weight_capacity: 2400.0,
+                        starting_stop: StopId(3),
+                        door_open_ticks: 600, door_transition_ticks: 60,
+                    ),
+                    ElevatorConfig(
+                        id: 4, name: "PT-B2",
+                        max_speed: 15.0, acceleration: 1.5, deceleration: 1.5,
+                        weight_capacity: 2400.0,
+                        starting_stop: StopId(2),
+                        door_open_ticks: 600, door_transition_ticks: 60,
+                    ),
+                    ElevatorConfig(
+                        id: 5, name: "PT-B3",
+                        max_speed: 15.0, acceleration: 1.5, deceleration: 1.5,
+                        weight_capacity: 2400.0,
+                        starting_stop: StopId(1),
+                        door_open_ticks: 600, door_transition_ticks: 60,
+                    ),
+                ],
+            ),
+        ]),
+        groups: Some([
+            GroupConfig(id: 0, name: "Outbound", lines: [0], dispatch: Scan, reposition: Some(SpreadEvenly)),
+            GroupConfig(id: 1, name: "Inbound",  lines: [1], dispatch: Scan, reposition: Some(SpreadEvenly)),
+        ]),
+    ),
+    simulation: SimulationParams(ticks_per_second: 60.0),
+    passenger_spawning: PassengerSpawnConfig(
+        mean_interval_ticks: 90,
+        weight_range: (55.0, 95.0),
+    ),
+)`,
+};

--- a/playground/src/domain/scenarios/index.ts
+++ b/playground/src/domain/scenarios/index.ts
@@ -1,1 +1,1 @@
-export { SCENARIOS, scenarioById } from "./scenarios";
+export { SCENARIOS, effectiveCompare, scenarioById } from "./scenarios";

--- a/playground/src/domain/scenarios/scenarios.ts
+++ b/playground/src/domain/scenarios/scenarios.ts
@@ -1,4 +1,5 @@
 import type { Phase, ScenarioMeta, TweakRanges } from "../../types";
+import { airportPedway } from "./airport-pedway";
 
 // ─── Default tweak bounds ───────────────────────────────────────────
 //
@@ -681,14 +682,17 @@ const spaceElevator: ScenarioMeta = {
 )`,
 };
 
+// Airport pedway lives in its own module — see ./airport-pedway.ts.
+
 // Order is "first-impression first": skyscraper leads because its
 // 40-floor multi-bank topology + sky-lobby transfers showcase the
 // playground's signature features the moment a visitor lands. Space
-// elevator second sets up the "zoom out" jump in scale. Convention
+// elevator second sets up the "zoom out" jump in scale. Airport
+// pedway third introduces the horizontal-line story. Convention
 // center last — it's an acute stress-test scenario rather than a
 // typical day cycle, useful but niche, so it sits at the end of the
 // row instead of greeting cold visitors.
-export const SCENARIOS: ScenarioMeta[] = [skyscraper, spaceElevator, convention];
+export const SCENARIOS: ScenarioMeta[] = [skyscraper, spaceElevator, airportPedway, convention];
 
 export function scenarioById(id: string): ScenarioMeta {
   const match = SCENARIOS.find((s) => s.id === id);

--- a/playground/src/domain/scenarios/scenarios.ts
+++ b/playground/src/domain/scenarios/scenarios.ts
@@ -1,4 +1,5 @@
 import type { Phase, ScenarioMeta, TweakRanges } from "../../types";
+import type { PermalinkState } from "../permalink";
 import { airportPedway } from "./airport-pedway";
 
 // ─── Default tweak bounds ───────────────────────────────────────────
@@ -700,4 +701,10 @@ export function scenarioById(id: string): ScenarioMeta {
   const fallback = SCENARIOS[0];
   if (fallback) return fallback;
   throw new Error(`unknown scenario "${id}" and empty registry`);
+}
+
+// User preference (`permalink.compare`) is preserved across scenario
+// switches; the *effective* value is what the loop / reset paths read.
+export function effectiveCompare(p: PermalinkState): boolean {
+  return p.compare && scenarioById(p.scenario).disableCompare !== true;
 }

--- a/playground/src/features/scenario-picker/switch.ts
+++ b/playground/src/features/scenario-picker/switch.ts
@@ -26,6 +26,10 @@ export interface ScenarioSwitchUi {
   paneB: ScenarioPaneHandles;
   scenarioCards: HTMLElement;
   toast: HTMLElement;
+  /** Compare-mode toggle; gated when the next scenario disables compare. */
+  compareToggle: HTMLInputElement;
+  /** Layout root whose `data-mode` reflects compare vs single. */
+  layout: HTMLElement;
 }
 
 /**
@@ -63,12 +67,20 @@ export async function switchScenario(
   hooks: ScenarioSwitchHooks,
 ): Promise<void> {
   const scenario = scenarioById(scenarioId);
+  // Scenarios that opt out of compare (horizontal pedway, where the
+  // stacked-lane render doesn't tile vertically) coerce compare off
+  // before the rest of the switch resolves so `resetAll` rebuilds the
+  // single pane instead of two.
+  const compareCapable = scenario.disableCompare !== true;
+  const effectiveCompare = state.permalink.compare && compareCapable;
+  ui.compareToggle.checked = effectiveCompare;
+  ui.compareToggle.disabled = !compareCapable;
+  ui.compareToggle.title = compareCapable ? "" : "Compare is unavailable for this scenario";
+  ui.layout.dataset["mode"] = effectiveCompare ? "compare" : "single";
   // Snap pane A (and pane B when in single-pane mode) to the
   // scenario's recommended strategy. In compare mode we leave both
   // panes alone so the user's comparison setup survives.
-  const nextStrategyA = state.permalink.compare
-    ? state.permalink.strategyA
-    : scenario.defaultStrategy;
+  const nextStrategyA = effectiveCompare ? state.permalink.strategyA : scenario.defaultStrategy;
   // Reposition is snapped on scenario switch only when the scenario
   // opts in via `defaultReposition` — carrying a Lobby pick from a
   // skyscraper into the space elevator made every idle climber
@@ -77,7 +89,7 @@ export async function switchScenario(
   // preference, and a long-haul scenario where individual trips
   // take minutes is intentional, not a UX bug.
   const nextReposition: RepositionStrategyName =
-    scenario.defaultReposition !== undefined && !state.permalink.compare
+    scenario.defaultReposition !== undefined && !effectiveCompare
       ? scenario.defaultReposition
       : state.permalink.repositionA;
   state.permalink = {
@@ -85,6 +97,7 @@ export async function switchScenario(
     scenario: scenario.id,
     strategyA: nextStrategyA,
     repositionA: nextReposition,
+    compare: effectiveCompare,
     overrides: {},
   };
   syncPermalinkUrl(state.permalink);

--- a/playground/src/features/scenario-picker/switch.ts
+++ b/playground/src/features/scenario-picker/switch.ts
@@ -68,17 +68,17 @@ export async function switchScenario(
   hooks: ScenarioSwitchHooks,
 ): Promise<void> {
   const scenario = scenarioById(scenarioId);
-  // Scenarios that opt out of compare (horizontal pedway, where the
-  // stacked-lane render doesn't tile vertically) coerce compare off
-  // before the rest of the switch resolves so `resetAll` rebuilds the
-  // single pane instead of two.
+  // The user's compare preference is preserved across scenarios — only
+  // its *effective* value flips off when the new scenario disables
+  // compare. Persisting the preference means switching back to a
+  // compare-capable scenario restores the prior pane setup.
   const scenarioDisablesCompare = scenario.disableCompare === true;
-  const effectiveCompare = state.permalink.compare && !scenarioDisablesCompare;
+  const compare = state.permalink.compare && !scenarioDisablesCompare;
   syncCompareToggle(ui, scenarioDisablesCompare, state.permalink.compare);
   // Snap pane A (and pane B when in single-pane mode) to the
   // scenario's recommended strategy. In compare mode we leave both
   // panes alone so the user's comparison setup survives.
-  const nextStrategyA = effectiveCompare ? state.permalink.strategyA : scenario.defaultStrategy;
+  const nextStrategyA = compare ? state.permalink.strategyA : scenario.defaultStrategy;
   // Reposition is snapped on scenario switch only when the scenario
   // opts in via `defaultReposition` — carrying a Lobby pick from a
   // skyscraper into the space elevator made every idle climber
@@ -87,7 +87,7 @@ export async function switchScenario(
   // preference, and a long-haul scenario where individual trips
   // take minutes is intentional, not a UX bug.
   const nextReposition: RepositionStrategyName =
-    scenario.defaultReposition !== undefined && !effectiveCompare
+    scenario.defaultReposition !== undefined && !compare
       ? scenario.defaultReposition
       : state.permalink.repositionA;
   state.permalink = {
@@ -95,7 +95,6 @@ export async function switchScenario(
     scenario: scenario.id,
     strategyA: nextStrategyA,
     repositionA: nextReposition,
-    compare: effectiveCompare,
     overrides: {},
   };
   syncPermalinkUrl(state.permalink);

--- a/playground/src/features/scenario-picker/switch.ts
+++ b/playground/src/features/scenario-picker/switch.ts
@@ -1,5 +1,6 @@
 import { scenarioById, STRATEGY_LABELS, syncPermalinkUrl, type PermalinkState } from "../../domain";
 import { toast } from "../../platform";
+import { syncCompareToggle } from "../../shell/apply-permalink";
 import type { RepositionStrategyName, StrategyName } from "../../types";
 import { syncScenarioCards } from "./cards";
 
@@ -71,12 +72,9 @@ export async function switchScenario(
   // stacked-lane render doesn't tile vertically) coerce compare off
   // before the rest of the switch resolves so `resetAll` rebuilds the
   // single pane instead of two.
-  const compareCapable = scenario.disableCompare !== true;
-  const effectiveCompare = state.permalink.compare && compareCapable;
-  ui.compareToggle.checked = effectiveCompare;
-  ui.compareToggle.disabled = !compareCapable;
-  ui.compareToggle.title = compareCapable ? "" : "Compare is unavailable for this scenario";
-  ui.layout.dataset["mode"] = effectiveCompare ? "compare" : "single";
+  const scenarioDisablesCompare = scenario.disableCompare === true;
+  const effectiveCompare = state.permalink.compare && !scenarioDisablesCompare;
+  syncCompareToggle(ui, scenarioDisablesCompare, state.permalink.compare);
   // Snap pane A (and pane B when in single-pane mode) to the
   // scenario's recommended strategy. In compare mode we leave both
   // panes alone so the user's comparison setup survives.

--- a/playground/src/render/draw-pedway.ts
+++ b/playground/src/render/draw-pedway.ts
@@ -98,7 +98,7 @@ function computeLanes(
       cy: (top + bottom) / 2,
       top,
       bottom,
-      dir: i === 0 ? 1 : -1,
+      dir: i % 2 === 0 ? 1 : -1,
     });
   }
   return lanes;

--- a/playground/src/render/draw-pedway.ts
+++ b/playground/src/render/draw-pedway.ts
@@ -2,27 +2,24 @@ import type { CarDto, Snapshot, StopDto } from "../types";
 import { withAlpha } from "./color-utils";
 import type { Scale } from "./layout";
 import { CAR_DOT_COLOR, STOP_LABEL, UP_COLOR } from "./palette";
+import { roundedRect } from "./primitives";
 
 /**
- * Pedway (horizontal line) rendering. Triggered when any line in the
- * snapshot reports `orientation: "horizontal"`. The simulation still
- * runs along a 1D axis; the renderer just maps that axis onto the
- * canvas X axis and stacks each line as a horizontal lane.
- *
- * Layout convention: the first horizontal line is drawn as the top
- * lane (outbound, right-pointing chevron); the second is the bottom
- * lane (inbound, left-pointing chevron). Future scenarios with more
- * than two horizontal lines fall through to a generic stack.
+ * Pedway (horizontal line) rendering. The simulation still runs along
+ * a 1D axis; this module maps that axis onto canvas X and stacks each
+ * horizontal line as a lane. The first line lands on top with a
+ * right-pointing chevron, subsequent lines below with left-pointing
+ * chevrons; chevrons express a visual direction bias since the engine
+ * doesn't model directional tracks.
  */
 
 const CEILING_BAND_PX = 18;
 const FLOOR_BAND_PX = 22;
 const LANE_GAP_PX = 14;
 const STATION_LABEL_GAP = 6;
-/** Chevron triangle marker height; doubles as the lane header offset. */
 const CHEVRON_PX = 8;
+const CHEVRON_ALPHAS = [0.55, 0.25] as const;
 
-/** Subtle indoor concourse atmosphere: warm ceiling band, tiled floor. */
 function drawConcourseBackdrop(
   ctx: CanvasRenderingContext2D,
   w: number,
@@ -30,13 +27,11 @@ function drawConcourseBackdrop(
   laneLeft: number,
   laneRight: number,
 ): void {
-  // Ceiling band — faint warm glow suggesting concourse lighting.
   const ceilGrad = ctx.createLinearGradient(0, 0, 0, CEILING_BAND_PX);
   ceilGrad.addColorStop(0, "rgba(245, 158, 11, 0.06)");
   ceilGrad.addColorStop(1, "rgba(245, 158, 11, 0)");
   ctx.fillStyle = ceilGrad;
   ctx.fillRect(0, 0, w, CEILING_BAND_PX);
-  // Hairline at the ceiling's lower edge so the band reads as a defined surface.
   ctx.strokeStyle = withAlpha("#f59e0b", 0.18);
   ctx.lineWidth = 1;
   ctx.beginPath();
@@ -44,14 +39,13 @@ function drawConcourseBackdrop(
   ctx.lineTo(w, CEILING_BAND_PX + 0.5);
   ctx.stroke();
 
-  // Floor band — tiled stripes hint at concourse flooring without
-  // overwhelming the lane visualization.
   const floorTop = h - FLOOR_BAND_PX;
   ctx.fillStyle = "rgba(20, 20, 26, 0.8)";
   ctx.fillRect(0, floorTop, w, FLOOR_BAND_PX);
   ctx.strokeStyle = "rgba(255, 255, 255, 0.04)";
   ctx.lineWidth = 1;
-  // Tile stride scales with lane width — keep ~32px between tiles regardless.
+  // Tile stride scales with lane width so phones and desktops both
+  // get roughly the same visual cadence between marks.
   const stride = Math.max(24, Math.min(48, (laneRight - laneLeft) / 18));
   ctx.beginPath();
   for (let x = laneLeft; x <= laneRight; x += stride) {
@@ -59,7 +53,6 @@ function drawConcourseBackdrop(
     ctx.lineTo(x, h - 4);
   }
   ctx.stroke();
-  // Hairline at floor's top edge.
   ctx.strokeStyle = "rgba(255, 255, 255, 0.06)";
   ctx.beginPath();
   ctx.moveTo(0, floorTop + 0.5);
@@ -68,38 +61,40 @@ function drawConcourseBackdrop(
 }
 
 interface LaneLayout {
-  /** Center y of the lane track. */
+  lineId: number;
+  name: string;
   cy: number;
-  /** Top edge of the lane band. */
   top: number;
-  /** Bottom edge of the lane band. */
   bottom: number;
-  /** Direction chevron points right (+1) or left (-1). */
+  /** +1 = chevron points right, -1 = left. */
   dir: 1 | -1;
 }
 
-/**
- * Compute lane y bands within the available drawable area.
- *
- * Lane height is capped so portrait viewports (where the available
- * vertical room is generous but the long-axis story is along x)
- * don't stretch each track into a tall empty band — readability
- * comes from horizontal spacing, not lane thickness.
- */
-function computeLanes(laneTop: number, laneBottom: number, laneCount: number): LaneLayout[] {
+// Lane height is capped so portrait viewports (where vertical room is
+// generous but the long-axis story is along x) don't stretch each
+// track into a tall empty band.
+function computeLanes(
+  laneTop: number,
+  laneBottom: number,
+  ids: readonly number[],
+  nameOf: (id: number) => string,
+): LaneLayout[] {
   const MAX_LANE_H = 64;
+  const laneCount = ids.length;
   const totalH = laneBottom - laneTop;
   const naturalLaneH = (totalH - LANE_GAP_PX * (laneCount - 1)) / laneCount;
   const laneH = Math.min(MAX_LANE_H, naturalLaneH);
-  // Center the lane stack vertically when capped, so the float reads
-  // as "concourse cross-section" rather than "tracks pinned to the top".
   const stackH = laneH * laneCount + LANE_GAP_PX * (laneCount - 1);
   const stackTop = laneTop + Math.max(0, (totalH - stackH) / 2);
   const lanes: LaneLayout[] = [];
   for (let i = 0; i < laneCount; i++) {
+    const id = ids[i];
+    if (id === undefined) continue;
     const top = stackTop + i * (laneH + LANE_GAP_PX);
     const bottom = top + laneH;
     lanes.push({
+      lineId: id,
+      name: nameOf(id),
       cy: (top + bottom) / 2,
       top,
       bottom,
@@ -109,17 +104,14 @@ function computeLanes(laneTop: number, laneBottom: number, laneCount: number): L
   return lanes;
 }
 
-/** Lane background + direction chevron + track centerline. */
 function drawLane(
   ctx: CanvasRenderingContext2D,
   lane: LaneLayout,
   laneLeft: number,
   laneRight: number,
 ): void {
-  // Lane fill — faint stripe darker than the canvas bg so it reads as a track gutter.
   ctx.fillStyle = "rgba(10, 12, 16, 0.55)";
   ctx.fillRect(laneLeft, lane.top, laneRight - laneLeft, lane.bottom - lane.top);
-  // Lane frame.
   ctx.strokeStyle = "rgba(58, 58, 69, 0.7)";
   ctx.lineWidth = 1;
   ctx.strokeRect(
@@ -128,7 +120,6 @@ function drawLane(
     laneRight - laneLeft - 1,
     lane.bottom - lane.top - 1,
   );
-  // Track centerline — dashed.
   ctx.strokeStyle = "rgba(255, 255, 255, 0.06)";
   ctx.setLineDash([6, 8]);
   ctx.beginPath();
@@ -137,29 +128,22 @@ function drawLane(
   ctx.stroke();
   ctx.setLineDash([]);
 
-  // Direction chevron at the leading end of the lane (where new trains "appear" from).
-  const chevX = lane.dir === 1 ? laneLeft + 6 : laneRight - 6;
-  const tipX = chevX + lane.dir * CHEVRON_PX;
-  ctx.fillStyle = withAlpha("#f59e0b", 0.55);
-  ctx.beginPath();
-  ctx.moveTo(chevX, lane.cy - CHEVRON_PX / 2);
-  ctx.lineTo(tipX, lane.cy);
-  ctx.lineTo(chevX, lane.cy + CHEVRON_PX / 2);
-  ctx.closePath();
-  ctx.fill();
-  // Tiny secondary chevron behind the first for clearer direction read.
-  const chevX2 = chevX - lane.dir * (CHEVRON_PX + 2);
-  const tipX2 = chevX2 + lane.dir * CHEVRON_PX;
-  ctx.fillStyle = withAlpha("#f59e0b", 0.25);
-  ctx.beginPath();
-  ctx.moveTo(chevX2, lane.cy - CHEVRON_PX / 2);
-  ctx.lineTo(tipX2, lane.cy);
-  ctx.lineTo(chevX2, lane.cy + CHEVRON_PX / 2);
-  ctx.closePath();
-  ctx.fill();
+  // Two stacked chevrons: leading at full alpha, trailing as a faded
+  // afterimage to imply motion.
+  const baseX = lane.dir === 1 ? laneLeft + 6 : laneRight - 6;
+  const halfH = CHEVRON_PX / 2;
+  for (let i = 0; i < CHEVRON_ALPHAS.length; i++) {
+    const x = baseX - lane.dir * i * (CHEVRON_PX + 2);
+    ctx.fillStyle = withAlpha("#f59e0b", CHEVRON_ALPHAS[i] ?? 0);
+    ctx.beginPath();
+    ctx.moveTo(x, lane.cy - halfH);
+    ctx.lineTo(x + lane.dir * CHEVRON_PX, lane.cy);
+    ctx.lineTo(x, lane.cy + halfH);
+    ctx.closePath();
+    ctx.fill();
+  }
 }
 
-/** Draw vertical platform markers spanning all lanes at each station. */
 function drawStations(
   ctx: CanvasRenderingContext2D,
   stops: StopDto[],
@@ -174,10 +158,8 @@ function drawStations(
   ctx.textBaseline = "top";
   for (const stop of stops) {
     const x = toScreenX(stop.y);
-    // Platform pad: subtle vertical strip at the station x.
     ctx.fillStyle = "rgba(245, 158, 11, 0.12)";
     ctx.fillRect(x - 3, topLaneY - 4, 6, bottomLaneY - topLaneY + 8);
-    // Hairline edges.
     ctx.strokeStyle = withAlpha("#f59e0b", 0.4);
     ctx.lineWidth = 1;
     ctx.beginPath();
@@ -186,8 +168,8 @@ function drawStations(
     ctx.moveTo(x + 3, topLaneY - 4);
     ctx.lineTo(x + 3, bottomLaneY + 4);
     ctx.stroke();
-    // Label below the floor band, clamped so the leftmost / rightmost
-    // station name doesn't slip off-canvas on narrow portrait widths.
+    // Clamp the label so the leftmost / rightmost station name doesn't
+    // slip off-canvas on narrow portrait widths.
     ctx.fillStyle = STOP_LABEL;
     const labelW = ctx.measureText(stop.name).width;
     let alignX = x;
@@ -204,7 +186,6 @@ function drawStations(
   }
 }
 
-/** Pre-built rider variant cache for waiting-figure silhouettes. */
 function drawWaitingCount(
   ctx: CanvasRenderingContext2D,
   count: number,
@@ -216,27 +197,12 @@ function drawWaitingCount(
   ctx.font = `600 ${s.fontSmall}px system-ui, -apple-system, "Segoe UI", sans-serif`;
   ctx.textAlign = "center";
   ctx.textBaseline = "middle";
-  ctx.fillStyle = withAlpha(UP_COLOR, 0.92);
   const label = count > 99 ? "99+" : String(count);
-  // Pill background for legibility.
   const padX = 4;
   const w = ctx.measureText(label).width + padX * 2;
   const hPx = s.fontSmall + 4;
+  roundedRect(ctx, cx - w / 2, cy - hPx / 2, w, hPx, hPx / 2);
   ctx.fillStyle = "rgba(8, 10, 14, 0.72)";
-  ctx.beginPath();
-  const r = hPx / 2;
-  const left = cx - w / 2;
-  const top = cy - hPx / 2;
-  ctx.moveTo(left + r, top);
-  ctx.lineTo(left + w - r, top);
-  ctx.arcTo(left + w, top, left + w, top + r, r);
-  ctx.lineTo(left + w, top + hPx - r);
-  ctx.arcTo(left + w, top + hPx, left + w - r, top + hPx, r);
-  ctx.lineTo(left + r, top + hPx);
-  ctx.arcTo(left, top + hPx, left, top + hPx - r, r);
-  ctx.lineTo(left, top + r);
-  ctx.arcTo(left, top, left + r, top, r);
-  ctx.closePath();
   ctx.fill();
   ctx.strokeStyle = withAlpha(UP_COLOR, 0.45);
   ctx.lineWidth = 1;
@@ -245,7 +211,17 @@ function drawWaitingCount(
   ctx.fillText(label, cx, cy + 0.5);
 }
 
-/** Long thin train glyph with window strip + chamfered nose. */
+// Phase colors for the train body. Distinct from `PHASE_COLORS` in
+// palette.ts (which is tuned for vertical-shaft cars) — the pedway
+// glyph reads better at low contrast against the indoor backdrop.
+const TRAIN_BODY_COLORS: Partial<Record<CarDto["phase"], string>> = {
+  loading: "rgba(28, 50, 70, 0.95)",
+  "door-opening": "rgba(60, 42, 12, 0.95)",
+  "door-closing": "rgba(60, 42, 12, 0.95)",
+  moving: "rgba(50, 38, 12, 0.95)",
+};
+const TRAIN_BODY_DEFAULT = "rgba(35, 40, 50, 0.95)";
+
 function drawTrain(
   ctx: CanvasRenderingContext2D,
   cx: number,
@@ -258,43 +234,32 @@ function drawTrain(
   const left = cx - trainW / 2;
   const top = cy - trainH / 2;
   const r = Math.min(4, trainH / 2);
-  // Body fill, picked from car phase via PHASE_COLORS so loading/moving still read.
-  let bodyFill = "rgba(35, 40, 50, 0.95)";
-  if (car.phase === "loading") bodyFill = "rgba(28, 50, 70, 0.95)";
-  else if (car.phase === "door-opening" || car.phase === "door-closing")
-    bodyFill = "rgba(60, 42, 12, 0.95)";
-  else if (car.phase === "moving") bodyFill = "rgba(50, 38, 12, 0.95)";
-
-  ctx.fillStyle = bodyFill;
-  // Rounded rect with one chamfered nose end on the leading side.
-  ctx.beginPath();
-  if (dir === 1) {
-    // Nose right; rounded back-left.
-    ctx.moveTo(left + r, top);
-    ctx.lineTo(left + trainW - trainH * 0.4, top);
-    ctx.lineTo(left + trainW, cy);
-    ctx.lineTo(left + trainW - trainH * 0.4, top + trainH);
-    ctx.lineTo(left + r, top + trainH);
-    ctx.arcTo(left, top + trainH, left, top + trainH - r, r);
-    ctx.lineTo(left, top + r);
-    ctx.arcTo(left, top, left + r, top, r);
-  } else {
-    // Nose left; rounded back-right.
-    ctx.moveTo(left + trainH * 0.4, top);
-    ctx.lineTo(left + trainW - r, top);
-    ctx.arcTo(left + trainW, top, left + trainW, top + r, r);
-    ctx.lineTo(left + trainW, top + trainH - r);
-    ctx.arcTo(left + trainW, top + trainH, left + trainW - r, top + trainH, r);
-    ctx.lineTo(left + trainH * 0.4, top + trainH);
-    ctx.lineTo(left, cy);
+  const nose = trainH * 0.4;
+  // Path is authored with the chamfered nose on the right; mirror via
+  // canvas transform when the train points left so the body shape
+  // stays a single beginPath sequence.
+  ctx.save();
+  if (dir === -1) {
+    ctx.translate(2 * cx, 0);
+    ctx.scale(-1, 1);
   }
+  ctx.fillStyle = TRAIN_BODY_COLORS[car.phase] ?? TRAIN_BODY_DEFAULT;
+  ctx.beginPath();
+  ctx.moveTo(left + r, top);
+  ctx.lineTo(left + trainW - nose, top);
+  ctx.lineTo(left + trainW, cy);
+  ctx.lineTo(left + trainW - nose, top + trainH);
+  ctx.lineTo(left + r, top + trainH);
+  ctx.arcTo(left, top + trainH, left, top + trainH - r, r);
+  ctx.lineTo(left, top + r);
+  ctx.arcTo(left, top, left + r, top, r);
   ctx.closePath();
   ctx.fill();
   ctx.strokeStyle = "rgba(180, 188, 205, 0.45)";
   ctx.lineWidth = 1;
   ctx.stroke();
+  ctx.restore();
 
-  // Window strip — slightly inset, lighter band.
   const winInsetX = trainH * 0.45;
   const winTop = top + trainH * 0.32;
   const winH = trainH * 0.36;
@@ -303,7 +268,6 @@ function drawTrain(
   if (winRight > winLeft) {
     ctx.fillStyle = "rgba(170, 220, 255, 0.18)";
     ctx.fillRect(winLeft, winTop, winRight - winLeft, winH);
-    // Mullions: vertical separators every ~10 px.
     ctx.strokeStyle = "rgba(8, 10, 14, 0.6)";
     ctx.lineWidth = 1;
     ctx.beginPath();
@@ -315,7 +279,6 @@ function drawTrain(
     ctx.stroke();
   }
 
-  // Capacity dot — small dot per rider aboard, clamped to the visible window strip.
   if (car.riders > 0 && winRight - winLeft > 6) {
     const dotR = Math.min(1.6, winH / 4);
     const dotStride = 5;
@@ -329,6 +292,21 @@ function drawTrain(
       ctx.fill();
     }
   }
+}
+
+// Single-pass minimum gap between consecutive stop x-positions after
+// sorting; falls back to 100 px when no positive gap exists.
+function minStopGapPx(stops: readonly StopDto[], toScreenX: (y: number) => number): number {
+  const sortedX = stops.map((stp) => toScreenX(stp.y)).sort((a, b) => a - b);
+  let g = Infinity;
+  for (let i = 1; i < sortedX.length; i++) {
+    const cur = sortedX[i];
+    const prev = sortedX[i - 1];
+    if (cur === undefined || prev === undefined) continue;
+    const d = cur - prev;
+    if (d > 0 && d < g) g = d;
+  }
+  return Number.isFinite(g) ? g : 100;
 }
 
 /** Top-level entry — call from the main renderer when a horizontal line exists. */
@@ -364,101 +342,65 @@ export function drawPedwayScene(
   const toScreenX = (pos: number): number =>
     laneLeft + ((pos - minPos) / range) * (laneRight - laneLeft);
 
-  // Vertical band reserved for lanes lives between the ceiling band
-  // and the floor band, with extra room at the top for the lane header
-  // and at the bottom for station labels.
   const headerH = 14;
   const stationLabelH = s.fontMain + STATION_LABEL_GAP + 4;
   const lanesTop = CEILING_BAND_PX + headerH;
   const lanesBottom = h - FLOOR_BAND_PX - stationLabelH;
-  const lanes = computeLanes(lanesTop, lanesBottom, horizontalLineIds.length);
+  const nameOf = (id: number): string =>
+    snap.lines.find((ln) => ln.id === id)?.name ?? `Line ${id}`;
+  const lanes = computeLanes(lanesTop, lanesBottom, horizontalLineIds, nameOf);
 
-  // 1. Backdrop (ceiling + floor).
   drawConcourseBackdrop(ctx, w, h, laneLeft, laneRight);
 
-  // 2. Lanes (background + dashed centerline + chevron).
   for (const lane of lanes) {
     drawLane(ctx, lane, laneLeft, laneRight);
   }
 
-  // 3. Lane header labels — sourced from each line's `name` in the
-  // snapshot so a future scenario with different terminology
-  // ("Terminal A → Terminal B") doesn't read "Outbound / Inbound".
-  // The arrow glyph follows the lane's render direction.
   ctx.font = `500 ${s.fontSmall}px system-ui, -apple-system, "Segoe UI", sans-serif`;
   ctx.textBaseline = "bottom";
   ctx.fillStyle = STOP_LABEL;
-  for (let i = 0; i < lanes.length; i++) {
-    const lane = lanes[i];
-    const lineId = horizontalLineIds[i];
-    if (lane === undefined || lineId === undefined) continue;
-    const name = snap.lines.find((ln) => ln.id === lineId)?.name ?? `Line ${lineId}`;
+  for (const lane of lanes) {
     if (lane.dir === 1) {
       ctx.textAlign = "left";
-      ctx.fillText(`${name} →`, laneLeft + 18, lane.top - 2);
+      ctx.fillText(`${lane.name} →`, laneLeft + 18, lane.top - 2);
     } else {
       ctx.textAlign = "right";
-      ctx.fillText(`← ${name}`, laneRight - 18, lane.top - 2);
+      ctx.fillText(`← ${lane.name}`, laneRight - 18, lane.top - 2);
     }
   }
 
-  // 4. Station markers across all lanes + station labels under the floor.
   const topLaneY = lanes[0]?.top ?? lanesTop;
   const bottomLaneY = lanes[lanes.length - 1]?.bottom ?? lanesBottom;
   drawStations(ctx, snap.stops, toScreenX, topLaneY, bottomLaneY, h - FLOOR_BAND_PX, w, s);
 
-  // 5. Trains — one glyph per car, mapped to its line's lane.
   // Train width scales with the line's stop spacing so it reads as a
   // train (long-thin) rather than an elevator car (~square).
-  const minStopGapPx = (() => {
-    const sortedX = snap.stops.map((stp) => toScreenX(stp.y)).sort((a, b) => a - b);
-    let g = Infinity;
-    for (let i = 1; i < sortedX.length; i++) {
-      const cur = sortedX[i];
-      const prev = sortedX[i - 1];
-      if (cur === undefined || prev === undefined) continue;
-      const d = cur - prev;
-      if (d > 0 && d < g) g = d;
-    }
-    return Number.isFinite(g) ? g : 100;
-  })();
-  const trainW = Math.max(36, Math.min(110, minStopGapPx * 0.55));
+  const trainW = Math.max(36, Math.min(110, minStopGapPx(snap.stops, toScreenX) * 0.55));
   const laneH = lanes[0] ? lanes[0].bottom - lanes[0].top : 24;
   const trainH = Math.max(14, Math.min(28, laneH * 0.7));
 
-  // Map line id → lane index.
-  const laneOf = new Map<number, LaneLayout>();
-  for (let i = 0; i < horizontalLineIds.length; i++) {
-    const id = horizontalLineIds[i];
-    const lane = lanes[i];
-    if (id !== undefined && lane !== undefined) laneOf.set(id, lane);
-  }
+  const laneByLineId = new Map<number, LaneLayout>();
+  for (const lane of lanes) laneByLineId.set(lane.lineId, lane);
 
   for (const car of snap.cars) {
-    const lane = laneOf.get(car.line);
+    const lane = laneByLineId.get(car.line);
     if (lane === undefined) continue;
-    const cx = toScreenX(car.y);
-    drawTrain(ctx, cx, lane.cy, trainW, trainH, lane.dir, car);
+    drawTrain(ctx, toScreenX(car.y), lane.cy, trainW, trainH, lane.dir, car);
   }
 
-  // 6. Per-lane waiting badges — split using `waiting_by_line` so a
-  // platform shared by both directions shows one badge per direction
-  // rather than conflating the two into the outbound count. Badges
-  // straddle each lane (above the top lane, below the bottom lane)
-  // so they don't collide with the lane chrome or station labels.
+  // Per-lane waiting badges via `waiting_by_line` — using the
+  // aggregate `stop.waiting` would conflate riders bound for opposite
+  // directions onto a single count.
   const badgeOffset = 8;
   for (const stop of snap.stops) {
     if (stop.waiting === 0) continue;
     const x = toScreenX(stop.y);
     for (let i = 0; i < lanes.length; i++) {
       const lane = lanes[i];
-      const lineId = horizontalLineIds[i];
-      if (lane === undefined || lineId === undefined) continue;
-      const slice = stop.waiting_by_line.find((w) => w.line === lineId);
+      if (lane === undefined) continue;
+      const slice = stop.waiting_by_line.find((w) => w.line === lane.lineId);
       const count = slice?.count ?? 0;
       if (count === 0) continue;
-      // First lane: badge above; subsequent lanes: badge below so
-      // stacked lanes don't all crowd the top edge.
       const cy = i === 0 ? lane.top - badgeOffset : lane.bottom + badgeOffset;
       drawWaitingCount(ctx, count, x, cy, s);
     }

--- a/playground/src/render/draw-pedway.ts
+++ b/playground/src/render/draw-pedway.ts
@@ -1,0 +1,450 @@
+import type { CarDto, Snapshot, StopDto } from "../types";
+import { withAlpha } from "./color-utils";
+import type { Scale } from "./layout";
+import { CAR_DOT_COLOR, STOP_LABEL, UP_COLOR } from "./palette";
+
+/**
+ * Pedway (horizontal line) rendering. Triggered when any line in the
+ * snapshot reports `orientation: "horizontal"`. The simulation still
+ * runs along a 1D axis; the renderer just maps that axis onto the
+ * canvas X axis and stacks each line as a horizontal lane.
+ *
+ * Layout convention: the first horizontal line is drawn as the top
+ * lane (outbound, right-pointing chevron); the second is the bottom
+ * lane (inbound, left-pointing chevron). Future scenarios with more
+ * than two horizontal lines fall through to a generic stack.
+ */
+
+const CEILING_BAND_PX = 18;
+const FLOOR_BAND_PX = 22;
+const LANE_GAP_PX = 14;
+const STATION_LABEL_GAP = 6;
+/** Chevron triangle marker height; doubles as the lane header offset. */
+const CHEVRON_PX = 8;
+
+/** Subtle indoor concourse atmosphere: warm ceiling band, tiled floor. */
+function drawConcourseBackdrop(
+  ctx: CanvasRenderingContext2D,
+  w: number,
+  h: number,
+  laneLeft: number,
+  laneRight: number,
+): void {
+  // Ceiling band — faint warm glow suggesting concourse lighting.
+  const ceilGrad = ctx.createLinearGradient(0, 0, 0, CEILING_BAND_PX);
+  ceilGrad.addColorStop(0, "rgba(245, 158, 11, 0.06)");
+  ceilGrad.addColorStop(1, "rgba(245, 158, 11, 0)");
+  ctx.fillStyle = ceilGrad;
+  ctx.fillRect(0, 0, w, CEILING_BAND_PX);
+  // Hairline at the ceiling's lower edge so the band reads as a defined surface.
+  ctx.strokeStyle = withAlpha("#f59e0b", 0.18);
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(0, CEILING_BAND_PX + 0.5);
+  ctx.lineTo(w, CEILING_BAND_PX + 0.5);
+  ctx.stroke();
+
+  // Floor band — tiled stripes hint at concourse flooring without
+  // overwhelming the lane visualization.
+  const floorTop = h - FLOOR_BAND_PX;
+  ctx.fillStyle = "rgba(20, 20, 26, 0.8)";
+  ctx.fillRect(0, floorTop, w, FLOOR_BAND_PX);
+  ctx.strokeStyle = "rgba(255, 255, 255, 0.04)";
+  ctx.lineWidth = 1;
+  // Tile stride scales with lane width — keep ~32px between tiles regardless.
+  const stride = Math.max(24, Math.min(48, (laneRight - laneLeft) / 18));
+  ctx.beginPath();
+  for (let x = laneLeft; x <= laneRight; x += stride) {
+    ctx.moveTo(x, floorTop + 4);
+    ctx.lineTo(x, h - 4);
+  }
+  ctx.stroke();
+  // Hairline at floor's top edge.
+  ctx.strokeStyle = "rgba(255, 255, 255, 0.06)";
+  ctx.beginPath();
+  ctx.moveTo(0, floorTop + 0.5);
+  ctx.lineTo(w, floorTop + 0.5);
+  ctx.stroke();
+}
+
+interface LaneLayout {
+  /** Center y of the lane track. */
+  cy: number;
+  /** Top edge of the lane band. */
+  top: number;
+  /** Bottom edge of the lane band. */
+  bottom: number;
+  /** Direction chevron points right (+1) or left (-1). */
+  dir: 1 | -1;
+}
+
+/**
+ * Compute lane y bands within the available drawable area.
+ *
+ * Lane height is capped so portrait viewports (where the available
+ * vertical room is generous but the long-axis story is along x)
+ * don't stretch each track into a tall empty band — readability
+ * comes from horizontal spacing, not lane thickness.
+ */
+function computeLanes(laneTop: number, laneBottom: number, laneCount: number): LaneLayout[] {
+  const MAX_LANE_H = 64;
+  const totalH = laneBottom - laneTop;
+  const naturalLaneH = (totalH - LANE_GAP_PX * (laneCount - 1)) / laneCount;
+  const laneH = Math.min(MAX_LANE_H, naturalLaneH);
+  // Center the lane stack vertically when capped, so the float reads
+  // as "concourse cross-section" rather than "tracks pinned to the top".
+  const stackH = laneH * laneCount + LANE_GAP_PX * (laneCount - 1);
+  const stackTop = laneTop + Math.max(0, (totalH - stackH) / 2);
+  const lanes: LaneLayout[] = [];
+  for (let i = 0; i < laneCount; i++) {
+    const top = stackTop + i * (laneH + LANE_GAP_PX);
+    const bottom = top + laneH;
+    lanes.push({
+      cy: (top + bottom) / 2,
+      top,
+      bottom,
+      dir: i === 0 ? 1 : -1,
+    });
+  }
+  return lanes;
+}
+
+/** Lane background + direction chevron + track centerline. */
+function drawLane(
+  ctx: CanvasRenderingContext2D,
+  lane: LaneLayout,
+  laneLeft: number,
+  laneRight: number,
+  s: Scale,
+): void {
+  // Lane fill — faint stripe darker than the canvas bg so it reads as a track gutter.
+  ctx.fillStyle = "rgba(10, 12, 16, 0.55)";
+  ctx.fillRect(laneLeft, lane.top, laneRight - laneLeft, lane.bottom - lane.top);
+  // Lane frame.
+  ctx.strokeStyle = "rgba(58, 58, 69, 0.7)";
+  ctx.lineWidth = 1;
+  ctx.strokeRect(
+    laneLeft + 0.5,
+    lane.top + 0.5,
+    laneRight - laneLeft - 1,
+    lane.bottom - lane.top - 1,
+  );
+  // Track centerline — dashed.
+  ctx.strokeStyle = "rgba(255, 255, 255, 0.06)";
+  ctx.setLineDash([6, 8]);
+  ctx.beginPath();
+  ctx.moveTo(laneLeft + 4, lane.cy);
+  ctx.lineTo(laneRight - 4, lane.cy);
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  // Direction chevron at the leading end of the lane (where new trains "appear" from).
+  const chevX = lane.dir === 1 ? laneLeft + 6 : laneRight - 6;
+  const tipX = chevX + lane.dir * CHEVRON_PX;
+  ctx.fillStyle = withAlpha("#f59e0b", 0.55);
+  ctx.beginPath();
+  ctx.moveTo(chevX, lane.cy - CHEVRON_PX / 2);
+  ctx.lineTo(tipX, lane.cy);
+  ctx.lineTo(chevX, lane.cy + CHEVRON_PX / 2);
+  ctx.closePath();
+  ctx.fill();
+  // Tiny secondary chevron behind the first for clearer direction read.
+  const chevX2 = chevX - lane.dir * (CHEVRON_PX + 2);
+  const tipX2 = chevX2 + lane.dir * CHEVRON_PX;
+  ctx.fillStyle = withAlpha("#f59e0b", 0.25);
+  ctx.beginPath();
+  ctx.moveTo(chevX2, lane.cy - CHEVRON_PX / 2);
+  ctx.lineTo(tipX2, lane.cy);
+  ctx.lineTo(chevX2, lane.cy + CHEVRON_PX / 2);
+  ctx.closePath();
+  ctx.fill();
+
+  void s;
+}
+
+/** Draw vertical platform markers spanning all lanes at each station. */
+function drawStations(
+  ctx: CanvasRenderingContext2D,
+  stops: StopDto[],
+  toScreenX: (pos: number) => number,
+  topLaneY: number,
+  bottomLaneY: number,
+  floorY: number,
+  canvasW: number,
+  s: Scale,
+): void {
+  ctx.font = `500 ${s.fontMain}px system-ui, -apple-system, "Segoe UI", sans-serif`;
+  ctx.textBaseline = "top";
+  for (const stop of stops) {
+    const x = toScreenX(stop.y);
+    // Platform pad: subtle vertical strip at the station x.
+    ctx.fillStyle = "rgba(245, 158, 11, 0.12)";
+    ctx.fillRect(x - 3, topLaneY - 4, 6, bottomLaneY - topLaneY + 8);
+    // Hairline edges.
+    ctx.strokeStyle = withAlpha("#f59e0b", 0.4);
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(x - 3, topLaneY - 4);
+    ctx.lineTo(x - 3, bottomLaneY + 4);
+    ctx.moveTo(x + 3, topLaneY - 4);
+    ctx.lineTo(x + 3, bottomLaneY + 4);
+    ctx.stroke();
+    // Label below the floor band, clamped so the leftmost / rightmost
+    // station name doesn't slip off-canvas on narrow portrait widths.
+    ctx.fillStyle = STOP_LABEL;
+    const labelW = ctx.measureText(stop.name).width;
+    let alignX = x;
+    let align: CanvasTextAlign = "center";
+    if (x - labelW / 2 < 4) {
+      align = "left";
+      alignX = 4;
+    } else if (x + labelW / 2 > canvasW - 4) {
+      align = "right";
+      alignX = canvasW - 4;
+    }
+    ctx.textAlign = align;
+    ctx.fillText(stop.name, alignX, floorY + STATION_LABEL_GAP);
+  }
+}
+
+/** Pre-built rider variant cache for waiting-figure silhouettes. */
+function drawWaitingCount(
+  ctx: CanvasRenderingContext2D,
+  count: number,
+  cx: number,
+  cy: number,
+  s: Scale,
+): void {
+  if (count <= 0) return;
+  ctx.font = `600 ${s.fontSmall}px system-ui, -apple-system, "Segoe UI", sans-serif`;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillStyle = withAlpha(UP_COLOR, 0.92);
+  const label = count > 99 ? "99+" : String(count);
+  // Pill background for legibility.
+  const padX = 4;
+  const w = ctx.measureText(label).width + padX * 2;
+  const hPx = s.fontSmall + 4;
+  ctx.fillStyle = "rgba(8, 10, 14, 0.72)";
+  ctx.beginPath();
+  const r = hPx / 2;
+  const left = cx - w / 2;
+  const top = cy - hPx / 2;
+  ctx.moveTo(left + r, top);
+  ctx.lineTo(left + w - r, top);
+  ctx.arcTo(left + w, top, left + w, top + r, r);
+  ctx.lineTo(left + w, top + hPx - r);
+  ctx.arcTo(left + w, top + hPx, left + w - r, top + hPx, r);
+  ctx.lineTo(left + r, top + hPx);
+  ctx.arcTo(left, top + hPx, left, top + hPx - r, r);
+  ctx.lineTo(left, top + r);
+  ctx.arcTo(left, top, left + r, top, r);
+  ctx.closePath();
+  ctx.fill();
+  ctx.strokeStyle = withAlpha(UP_COLOR, 0.45);
+  ctx.lineWidth = 1;
+  ctx.stroke();
+  ctx.fillStyle = withAlpha(UP_COLOR, 0.95);
+  ctx.fillText(label, cx, cy + 0.5);
+}
+
+/** Long thin train glyph with window strip + chamfered nose. */
+function drawTrain(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  trainW: number,
+  trainH: number,
+  dir: 1 | -1,
+  car: CarDto,
+): void {
+  const left = cx - trainW / 2;
+  const top = cy - trainH / 2;
+  const r = Math.min(4, trainH / 2);
+  // Body fill, picked from car phase via PHASE_COLORS so loading/moving still read.
+  let bodyFill = "rgba(35, 40, 50, 0.95)";
+  if (car.phase === "loading") bodyFill = "rgba(28, 50, 70, 0.95)";
+  else if (car.phase === "door-opening" || car.phase === "door-closing")
+    bodyFill = "rgba(60, 42, 12, 0.95)";
+  else if (car.phase === "moving") bodyFill = "rgba(50, 38, 12, 0.95)";
+
+  ctx.fillStyle = bodyFill;
+  // Rounded rect with one chamfered nose end on the leading side.
+  ctx.beginPath();
+  if (dir === 1) {
+    // Nose right; rounded back-left.
+    ctx.moveTo(left + r, top);
+    ctx.lineTo(left + trainW - trainH * 0.4, top);
+    ctx.lineTo(left + trainW, cy);
+    ctx.lineTo(left + trainW - trainH * 0.4, top + trainH);
+    ctx.lineTo(left + r, top + trainH);
+    ctx.arcTo(left, top + trainH, left, top + trainH - r, r);
+    ctx.lineTo(left, top + r);
+    ctx.arcTo(left, top, left + r, top, r);
+  } else {
+    // Nose left; rounded back-right.
+    ctx.moveTo(left + trainH * 0.4, top);
+    ctx.lineTo(left + trainW - r, top);
+    ctx.arcTo(left + trainW, top, left + trainW, top + r, r);
+    ctx.lineTo(left + trainW, top + trainH - r);
+    ctx.arcTo(left + trainW, top + trainH, left + trainW - r, top + trainH, r);
+    ctx.lineTo(left + trainH * 0.4, top + trainH);
+    ctx.lineTo(left, cy);
+  }
+  ctx.closePath();
+  ctx.fill();
+  ctx.strokeStyle = "rgba(180, 188, 205, 0.45)";
+  ctx.lineWidth = 1;
+  ctx.stroke();
+
+  // Window strip — slightly inset, lighter band.
+  const winInsetX = trainH * 0.45;
+  const winTop = top + trainH * 0.32;
+  const winH = trainH * 0.36;
+  const winLeft = left + winInsetX;
+  const winRight = left + trainW - winInsetX;
+  if (winRight > winLeft) {
+    ctx.fillStyle = "rgba(170, 220, 255, 0.18)";
+    ctx.fillRect(winLeft, winTop, winRight - winLeft, winH);
+    // Mullions: vertical separators every ~10 px.
+    ctx.strokeStyle = "rgba(8, 10, 14, 0.6)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    const mullionStride = 10;
+    for (let mx = winLeft + mullionStride; mx < winRight; mx += mullionStride) {
+      ctx.moveTo(mx, winTop);
+      ctx.lineTo(mx, winTop + winH);
+    }
+    ctx.stroke();
+  }
+
+  // Capacity dot — small dot per rider aboard, clamped to the visible window strip.
+  if (car.riders > 0 && winRight - winLeft > 6) {
+    const dotR = Math.min(1.6, winH / 4);
+    const dotStride = 5;
+    const maxDots = Math.floor((winRight - winLeft - 6) / dotStride);
+    const drawDots = Math.min(car.riders, Math.max(1, maxDots));
+    ctx.fillStyle = withAlpha(CAR_DOT_COLOR, 0.85);
+    for (let i = 0; i < drawDots; i++) {
+      const dx = winLeft + 4 + i * dotStride;
+      ctx.beginPath();
+      ctx.arc(dx, winTop + winH / 2, dotR, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+}
+
+/** Top-level entry — call from the main renderer when a horizontal line exists. */
+export function drawPedwayScene(
+  ctx: CanvasRenderingContext2D,
+  snap: Snapshot,
+  w: number,
+  h: number,
+  s: Scale,
+): void {
+  // Pick lines we know how to render. Vertical lines mixed in are
+  // ignored for now — the airport scenario has only horizontal lines.
+  const horizontalLineIds: number[] = [];
+  for (const ln of snap.lines) {
+    if (ln.orientation === "horizontal") horizontalLineIds.push(ln.id);
+  }
+  if (horizontalLineIds.length === 0 || snap.stops.length < 2) return;
+  // Stable ascending order so lane assignment is deterministic frame to frame.
+  horizontalLineIds.sort((a, b) => a - b);
+
+  // X-axis range: span min..max stop position, with a small pad so the
+  // outermost stations don't sit flush against the canvas edge.
+  let minPos = snap.stops[0]?.y ?? 0;
+  let maxPos = minPos;
+  for (const stop of snap.stops) {
+    if (stop.y < minPos) minPos = stop.y;
+    if (stop.y > maxPos) maxPos = stop.y;
+  }
+  const range = Math.max(1e-6, maxPos - minPos);
+  const sidePad = Math.max(48, s.padX + 30);
+  const laneLeft = sidePad;
+  const laneRight = w - sidePad;
+  const toScreenX = (pos: number): number =>
+    laneLeft + ((pos - minPos) / range) * (laneRight - laneLeft);
+
+  // Vertical band reserved for lanes lives between the ceiling band
+  // and the floor band, with extra room at the top for the lane header
+  // and at the bottom for station labels.
+  const headerH = 14;
+  const stationLabelH = s.fontMain + STATION_LABEL_GAP + 4;
+  const lanesTop = CEILING_BAND_PX + headerH;
+  const lanesBottom = h - FLOOR_BAND_PX - stationLabelH;
+  const lanes = computeLanes(lanesTop, lanesBottom, horizontalLineIds.length);
+
+  // 1. Backdrop (ceiling + floor).
+  drawConcourseBackdrop(ctx, w, h, laneLeft, laneRight);
+
+  // 2. Lanes (background + dashed centerline + chevron).
+  for (const lane of lanes) {
+    drawLane(ctx, lane, laneLeft, laneRight, s);
+  }
+
+  // 3. Lane header labels (above the top lane).
+  ctx.font = `500 ${s.fontSmall}px system-ui, -apple-system, "Segoe UI", sans-serif`;
+  ctx.textBaseline = "bottom";
+  ctx.fillStyle = STOP_LABEL;
+  if (lanes[0]) {
+    ctx.textAlign = "left";
+    ctx.fillText("Outbound →", laneLeft + 18, lanes[0].top - 2);
+  }
+  if (lanes[1]) {
+    ctx.textAlign = "right";
+    ctx.fillText("← Inbound", laneRight - 18, lanes[1].top - 2);
+  }
+
+  // 4. Station markers across all lanes + station labels under the floor.
+  const topLaneY = lanes[0]?.top ?? lanesTop;
+  const bottomLaneY = lanes[lanes.length - 1]?.bottom ?? lanesBottom;
+  drawStations(ctx, snap.stops, toScreenX, topLaneY, bottomLaneY, h - FLOOR_BAND_PX, w, s);
+
+  // 5. Trains — one glyph per car, mapped to its line's lane.
+  // Train width scales with the line's stop spacing so it reads as a
+  // train (long-thin) rather than an elevator car (~square).
+  const minStopGapPx = (() => {
+    const sortedX = snap.stops.map((stp) => toScreenX(stp.y)).sort((a, b) => a - b);
+    let g = Infinity;
+    for (let i = 1; i < sortedX.length; i++) {
+      const cur = sortedX[i];
+      const prev = sortedX[i - 1];
+      if (cur === undefined || prev === undefined) continue;
+      const d = cur - prev;
+      if (d > 0 && d < g) g = d;
+    }
+    return Number.isFinite(g) ? g : 100;
+  })();
+  const trainW = Math.max(36, Math.min(110, minStopGapPx * 0.55));
+  const laneH = lanes[0] ? lanes[0].bottom - lanes[0].top : 24;
+  const trainH = Math.max(14, Math.min(28, laneH * 0.7));
+
+  // Map line id → lane index.
+  const laneOf = new Map<number, LaneLayout>();
+  for (let i = 0; i < horizontalLineIds.length; i++) {
+    const id = horizontalLineIds[i];
+    const lane = lanes[i];
+    if (id !== undefined && lane !== undefined) laneOf.set(id, lane);
+  }
+
+  for (const car of snap.cars) {
+    const lane = laneOf.get(car.line);
+    if (lane === undefined) continue;
+    const cx = toScreenX(car.y);
+    drawTrain(ctx, cx, lane.cy, trainW, trainH, lane.dir, car);
+  }
+
+  // 6. Per-station waiting count badges on the lane that serves it.
+  // Show the count above each platform on the top lane, below on the
+  // bottom lane, so badges don't collide with the rest of the UI.
+  for (const stop of snap.stops) {
+    if (stop.waiting === 0) continue;
+    const x = toScreenX(stop.y);
+    const top = lanes[0];
+    if (top) {
+      drawWaitingCount(ctx, stop.waiting, x, top.top - 8, s);
+    }
+  }
+}

--- a/playground/src/render/draw-pedway.ts
+++ b/playground/src/render/draw-pedway.ts
@@ -115,7 +115,6 @@ function drawLane(
   lane: LaneLayout,
   laneLeft: number,
   laneRight: number,
-  s: Scale,
 ): void {
   // Lane fill — faint stripe darker than the canvas bg so it reads as a track gutter.
   ctx.fillStyle = "rgba(10, 12, 16, 0.55)";
@@ -158,8 +157,6 @@ function drawLane(
   ctx.lineTo(chevX2, lane.cy + CHEVRON_PX / 2);
   ctx.closePath();
   ctx.fill();
-
-  void s;
 }
 
 /** Draw vertical platform markers spanning all lanes at each station. */
@@ -381,20 +378,28 @@ export function drawPedwayScene(
 
   // 2. Lanes (background + dashed centerline + chevron).
   for (const lane of lanes) {
-    drawLane(ctx, lane, laneLeft, laneRight, s);
+    drawLane(ctx, lane, laneLeft, laneRight);
   }
 
-  // 3. Lane header labels (above the top lane).
+  // 3. Lane header labels — sourced from each line's `name` in the
+  // snapshot so a future scenario with different terminology
+  // ("Terminal A → Terminal B") doesn't read "Outbound / Inbound".
+  // The arrow glyph follows the lane's render direction.
   ctx.font = `500 ${s.fontSmall}px system-ui, -apple-system, "Segoe UI", sans-serif`;
   ctx.textBaseline = "bottom";
   ctx.fillStyle = STOP_LABEL;
-  if (lanes[0]) {
-    ctx.textAlign = "left";
-    ctx.fillText("Outbound →", laneLeft + 18, lanes[0].top - 2);
-  }
-  if (lanes[1]) {
-    ctx.textAlign = "right";
-    ctx.fillText("← Inbound", laneRight - 18, lanes[1].top - 2);
+  for (let i = 0; i < lanes.length; i++) {
+    const lane = lanes[i];
+    const lineId = horizontalLineIds[i];
+    if (lane === undefined || lineId === undefined) continue;
+    const name = snap.lines.find((ln) => ln.id === lineId)?.name ?? `Line ${lineId}`;
+    if (lane.dir === 1) {
+      ctx.textAlign = "left";
+      ctx.fillText(`${name} →`, laneLeft + 18, lane.top - 2);
+    } else {
+      ctx.textAlign = "right";
+      ctx.fillText(`← ${name}`, laneRight - 18, lane.top - 2);
+    }
   }
 
   // 4. Station markers across all lanes + station labels under the floor.
@@ -436,15 +441,26 @@ export function drawPedwayScene(
     drawTrain(ctx, cx, lane.cy, trainW, trainH, lane.dir, car);
   }
 
-  // 6. Per-station waiting count badges on the lane that serves it.
-  // Show the count above each platform on the top lane, below on the
-  // bottom lane, so badges don't collide with the rest of the UI.
+  // 6. Per-lane waiting badges — split using `waiting_by_line` so a
+  // platform shared by both directions shows one badge per direction
+  // rather than conflating the two into the outbound count. Badges
+  // straddle each lane (above the top lane, below the bottom lane)
+  // so they don't collide with the lane chrome or station labels.
+  const badgeOffset = 8;
   for (const stop of snap.stops) {
     if (stop.waiting === 0) continue;
     const x = toScreenX(stop.y);
-    const top = lanes[0];
-    if (top) {
-      drawWaitingCount(ctx, stop.waiting, x, top.top - 8, s);
+    for (let i = 0; i < lanes.length; i++) {
+      const lane = lanes[i];
+      const lineId = horizontalLineIds[i];
+      if (lane === undefined || lineId === undefined) continue;
+      const slice = stop.waiting_by_line.find((w) => w.line === lineId);
+      const count = slice?.count ?? 0;
+      if (count === 0) continue;
+      // First lane: badge above; subsequent lanes: badge below so
+      // stacked lanes don't all crowd the top edge.
+      const cy = i === 0 ? lane.top - badgeOffset : lane.bottom + badgeOffset;
+      drawWaitingCount(ctx, count, x, cy, s);
     }
   }
 }

--- a/playground/src/render/renderer.ts
+++ b/playground/src/render/renderer.ts
@@ -217,10 +217,6 @@ export class CanvasRenderer {
       this.#drawTetherMode(snap, w, h, s, speedMultiplier, bubbles, this.#tether);
       return;
     }
-    // Pedway mode dispatch — any horizontal line swaps the multi-shaft
-    // column layout for stacked horizontal lanes. Driven from
-    // `Line.orientation` so future mixed-orientation scenarios opt in
-    // per-line rather than via a scenario-level flag.
     if (snap.lines.some((ln) => ln.orientation === "horizontal")) {
       drawPedwayScene(ctx, snap, w, h, s);
       return;

--- a/playground/src/render/renderer.ts
+++ b/playground/src/render/renderer.ts
@@ -6,6 +6,7 @@ import {
   drawWaitingFigures,
 } from "./draw-building";
 import { drawBubbles, drawCar, drawCarTrail, drawTargetMarkers } from "./draw-cars";
+import { drawPedwayScene } from "./draw-pedway";
 import { drawTetherScene, type TetherRenderState } from "./draw-tether";
 import type { ClimberHud } from "./draw-tether-hud";
 import type { RiderVariant } from "./figures/rider";
@@ -214,6 +215,14 @@ export class CanvasRenderer {
 
     if (this.#tether !== null) {
       this.#drawTetherMode(snap, w, h, s, speedMultiplier, bubbles, this.#tether);
+      return;
+    }
+    // Pedway mode dispatch — any horizontal line swaps the multi-shaft
+    // column layout for stacked horizontal lanes. Driven from
+    // `Line.orientation` so future mixed-orientation scenarios opt in
+    // per-line rather than via a scenario-level flag.
+    if (snap.lines.some((ln) => ln.orientation === "horizontal")) {
+      drawPedwayScene(ctx, snap, w, h, s);
       return;
     }
 

--- a/playground/src/shell/apply-permalink.ts
+++ b/playground/src/shell/apply-permalink.ts
@@ -9,6 +9,25 @@ export const speedLabel = (v: number): string => `${v}\u00d7`;
 export const intensityLabel = (v: number): string => `${v.toFixed(1)}\u00d7`;
 
 /**
+ * Drive the compare-toggle's checked / disabled / mode-class triplet.
+ * Called from both permalink application and scenario switching so a
+ * scenario that opts out of compare can't drift between them.
+ */
+export function syncCompareToggle(
+  ui: UiHandles,
+  scenarioDisablesCompare: boolean,
+  preferredCompare: boolean,
+): void {
+  const effectiveCompare = scenarioDisablesCompare ? false : preferredCompare;
+  ui.compareToggle.checked = effectiveCompare;
+  ui.compareToggle.disabled = scenarioDisablesCompare;
+  ui.compareToggle.title = scenarioDisablesCompare
+    ? "Compare is unavailable for this scenario"
+    : "";
+  ui.layout.dataset["mode"] = effectiveCompare ? "compare" : "single";
+}
+
+/**
  * Draw a random seed word from the `random-words` dictionary
  * (~1800 short English words). Bounded length so the field stays
  * readable in the compact control strip — typical results look like
@@ -22,8 +41,13 @@ export function randomSeedWord(): string {
 }
 
 export function applyPermalinkToUi(p: PermalinkState, ui: UiHandles): void {
-  ui.compareToggle.checked = p.compare;
-  ui.layout.dataset["mode"] = p.compare ? "compare" : "single";
+  const scenario = scenarioById(p.scenario);
+  // Scenarios that opt out of compare mode (e.g. horizontal pedway,
+  // whose stacked-lane layout doesn't tile vertically into the
+  // compare grid) coerce the toggle off and disable the control while
+  // active. The permalink keeps its prior value so toggling back to a
+  // compare-capable scenario restores the user's preference.
+  syncCompareToggle(ui, scenario.disableCompare === true, p.compare);
   ui.seedInput.value = p.seed;
   ui.speedInput.value = String(p.speed);
   ui.speedLabel.textContent = speedLabel(p.speed);
@@ -34,7 +58,6 @@ export function applyPermalinkToUi(p: PermalinkState, ui: UiHandles): void {
   renderPaneRepositionInfo(ui.paneA, p.repositionA);
   renderPaneRepositionInfo(ui.paneB, p.repositionB);
   syncScenarioCards(ui, p.scenario);
-  const scenario = scenarioById(p.scenario);
   // Auto-open the drawer when the permalink carries any override —
   // the recipient sees what the sender customized without an extra
   // click. A clean URL leaves the drawer closed so first-time

--- a/playground/src/shell/apply-permalink.ts
+++ b/playground/src/shell/apply-permalink.ts
@@ -8,13 +8,19 @@ import type { UiHandles } from "./wire-ui";
 export const speedLabel = (v: number): string => `${v}\u00d7`;
 export const intensityLabel = (v: number): string => `${v.toFixed(1)}\u00d7`;
 
+/** Narrow shape both `applyPermalinkToUi` and `switchScenario` can satisfy. */
+export interface CompareToggleHandles {
+  compareToggle: HTMLInputElement;
+  layout: HTMLElement;
+}
+
 /**
  * Drive the compare-toggle's checked / disabled / mode-class triplet.
  * Called from both permalink application and scenario switching so a
  * scenario that opts out of compare can't drift between them.
  */
 export function syncCompareToggle(
-  ui: UiHandles,
+  ui: CompareToggleHandles,
   scenarioDisablesCompare: boolean,
   preferredCompare: boolean,
 ): void {

--- a/playground/src/shell/listeners.ts
+++ b/playground/src/shell/listeners.ts
@@ -256,7 +256,11 @@ function attachKeyboardShortcuts(
       case "c":
       case "C": {
         ev.preventDefault();
-        ui.compareToggle.click();
+        if (ui.compareToggle.disabled) {
+          toast(ui.toast, "Compare is unavailable for this scenario");
+        } else {
+          ui.compareToggle.click();
+        }
         return;
       }
       case "s":

--- a/playground/src/shell/loop.ts
+++ b/playground/src/shell/loop.ts
@@ -2,6 +2,7 @@ import { updatePhaseIndicator, updatePhaseProgress } from "../features/phase-str
 import { diffMetrics, renderMetricRows } from "../features/scoreboard";
 import type { Pane } from "../features/compare-pane";
 import { forEachPane, renderPane, updateBubbles, updateModeBadge } from "../features/compare-pane";
+import { effectiveCompare } from "../domain";
 import type { Snapshot } from "../types";
 import type { State } from "./state";
 import type { UiHandles } from "./wire-ui";
@@ -77,7 +78,12 @@ export function loop(state: State, ui: UiHandles): void {
     // awaited pane-B construction) would let pane A race ahead.
     const paneA = state.paneA;
     const paneB = state.paneB;
-    const panesReady = paneA !== null && (!state.permalink.compare || paneB !== null);
+    // Reading `permalink.compare` alone would freeze the loop on a
+    // `disableCompare` scenario where the user's preference is still
+    // `compare=true` — paneB never gets built, so panesReady would be
+    // permanently false.
+    const compareActive = effectiveCompare(state.permalink);
+    const panesReady = paneA !== null && (!compareActive || paneB !== null);
     if (state.running && state.ready && panesReady) {
       const ticks = state.permalink.speed;
       // Step both panes; capture paneA's post-step snapshot when its

--- a/playground/src/shell/reset.ts
+++ b/playground/src/shell/reset.ts
@@ -3,7 +3,7 @@ import { updatePhaseIndicator, updatePhaseProgress } from "../features/phase-str
 import { initMetricRows } from "../features/scoreboard";
 import { renderPaneStrategyInfo, renderPaneRepositionInfo } from "../features/strategy-picker";
 import { renderTweakPanel } from "../features/tweak-drawer";
-import { hashSeedWord, scenarioById } from "../domain";
+import { effectiveCompare, hashSeedWord, scenarioById } from "../domain";
 import { toast } from "../platform";
 import { TrafficDriver } from "../sim";
 import type { ScenarioMeta } from "../types";
@@ -74,7 +74,7 @@ export async function resetAll(state: State, ui: UiHandles): Promise<void> {
     renderPaneRepositionInfo(ui.paneA, state.permalink.repositionA);
     initMetricRows(ui.paneA.metrics);
     let paneB: Pane | null = null;
-    if (state.permalink.compare) {
+    if (effectiveCompare(state.permalink)) {
       try {
         paneB = await makePane(
           ui.paneB,

--- a/playground/src/types/scenario.ts
+++ b/playground/src/types/scenario.ts
@@ -166,4 +166,11 @@ export interface ScenarioMeta {
    * to keep idle climbers distributed across the platforms.
    */
   defaultReposition?: RepositionStrategyName;
+  /**
+   * Hide this scenario from compare mode. Some scenarios use a render
+   * layout (e.g. horizontal pedway) that doesn't tile vertically into
+   * the side-by-side compare grid; opting out keeps the compare view
+   * coherent without forcing every renderer mode to support it.
+   */
+  disableCompare?: boolean;
 }


### PR DESCRIPTION
## Summary

Adds the **Airport pedway** scenario as a third orientation in the lineup alongside the vertical Skyscraper and Space Elevator scenarios.

- Two opposing one-way lines (Outbound, Inbound) sharing four stops 600 m apart — Main Terminal + Concourse B/C/D.
- Three trains per line, every train stops at every station — the dispatch story is *headway*, not "which car responds first."
- Phases: steady operations + per-concourse arrival surges (B / C / D).

The renderer branches on `Line.orientation` (now exposed via a new `LineDto` on the snapshot) and lays the lines out as **stacked horizontal lanes** with an indoor concourse atmosphere — ceiling band, tiled floor, direction chevrons, long-thin train glyphs with a window strip — instead of the multi-shaft column layout used for vertical scenarios.

Compare-mode is gated via a new `ScenarioMeta.disableCompare` flag so horizontal scenarios opt out without forcing every renderer mode to support side-by-side compare. The toggle disables / re-enables itself based on the active scenario.

## Notable choices

- **Render dispatch via `Line.orientation`** — driven from the snapshot DTO so future mixed-orientation scenarios (e.g., a building with a pedway connector) can opt in per-line rather than via a scenario-level flag.
- **Two opposing one-way lines, not one bidirectional shuttle** — matches DFW Skylink / ATL Plane Train. Each line is a standard 1D path; the "loop" is implicit in the rider's direction choice.
- **Bypass thresholds intentionally omitted** — every train stops at every station, which emerges naturally from `Scan` + arrival rates that keep every stop with calls.
- **`SpreadEvenly` reposition per line** — keeps three idle trains evenly spaced when traffic dips, which is exactly the headway story this scenario teaches.
- Airport scenario lives in its own module (`scenarios/airport-pedway.ts`) so `scenarios.ts` stays under the line-count threshold.

## Test plan

- [ ] Open the Airport pedway scenario and verify two stacked lanes, six trains, four stations render correctly on desktop.
- [ ] Verify mobile portrait layout — lanes capped, station labels clamp at canvas edges.
- [ ] Verify compare-toggle disables when switching to the airport scenario, re-enables when switching back to skyscraper.
- [ ] Verify per-concourse arrival phases pile riders at the right platform.
- [ ] Verify deep-link permalink including `compare=true` + airport scenario coerces to single-pane on load.