### PR TITLE
feat(playground): disable compare mode for the space elevator scenario

### DIFF
--- a/playground/src/__tests__/scenarios.test.ts
+++ b/playground/src/__tests__/scenarios.test.ts
@@ -88,4 +88,15 @@ describe("scenarios metadata", () => {
     const elevatorCount = (airport.ron.match(/ElevatorConfig\s*\(/g) ?? []).length;
     expect(elevatorCount).toBe(6);
   });
+
+  it("tether-mode scenarios opt out of compare mode", () => {
+    // Tether visualization is too tall to tile vertically into the
+    // compare grid; any scenario opting into the tether renderer
+    // must also disable compare.
+    for (const s of SCENARIOS) {
+      if (s.tether !== undefined) {
+        expect(s.disableCompare, s.id).toBe(true);
+      }
+    }
+  });
 });

--- a/playground/src/domain/scenarios/scenarios.ts
+++ b/playground/src/domain/scenarios/scenarios.ts
@@ -550,6 +550,10 @@ const spaceElevator: ScenarioMeta = {
   // per platform — exactly what you want for sparse long-haul
   // traffic.
   defaultReposition: "spread",
+  // Tether mode is too tall to tile vertically into a side-by-side
+  // compare grid — pane height ends up squashing the GEO-to-Ground
+  // axis below the threshold where the trapezoidal profile reads.
+  disableCompare: true,
   // Phase durations are tuned to the tether's natural timescale, not
   // a building's "morning rush / evening commute" model. A short hop
   // up to Karman is ~250 sim seconds round-trip, so each phase lasts


### PR DESCRIPTION
## Summary

The tether renderer paints a single 35,786 km cable spanning the full canvas height; halving that height for compare mode squashes the log-scale altitude axis below the threshold where the trapezoidal motion profile reads. Same reasoning as the airport pedway — the horizontal-lane and tether modes both want the full viewport on their long axis.

Adds \`disableCompare: true\` to the space-elevator scenario meta. The infrastructure (\`syncCompareToggle\`, \`effectiveCompare\`, keyboard-shortcut toast) all came in with #797, so this is a one-flag opt-in.

## Test plan

- [ ] Open the Space elevator scenario; compare toggle should be disabled with the "Compare is unavailable for this scenario" tooltip.
- [ ] Switch from skyscraper (with compare on) to space elevator: pane B torn down, toggle disabled but preference preserved.
- [ ] Switch back to skyscraper: pane B re-built; compare visually restored.
- [ ] Press \`c\` while space elevator is active: toast surfaces, no state change.
- [ ] Existing 26 test files / 346 tests still pass; new \`tether-mode scenarios opt out of compare mode\` test covers the regression case.