### PR TITLE
ci(release-please): pin no-op packages to current version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,6 +32,49 @@ jobs:
           app-id: ${{ secrets.RELEASE_KUN_APP_ID }}
           private-key: ${{ secrets.RELEASE_KUN_APP_PRIVATE_KEY }}
 
+      # Pin published packages whose only changes since the last
+      # release tag are non-shipping (tests, benches, CHANGELOG, the
+      # version line in Cargo.toml). Without this, a single test
+      # addition to `crates/<x>/src/tests/` cuts a fresh crate
+      # version even though no consumer-facing code changed — which
+      # is how `elevator-core 20.3.0` got published from a playground
+      # PR that only added an `Orientation::Horizontal` parse test
+      # (yanked; #797 / #800 in the commit log).
+      #
+      # Mechanism: rewrite `release-please-config.json` in place to
+      # set `release-as: <current-version>` for any package with no
+      # shipping diff. release-please treats that as "release the
+      # already-released version", which is a no-op — no PR, no tag,
+      # no publish.
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Pin no-op packages
+        run: |
+          config=$(cat release-please-config.json)
+          for pkg_path in $(jq -r '.packages | keys[]' release-please-config.json); do
+            pkg=$(basename "$pkg_path")
+            version=$(jq -r --arg key "$pkg_path" '.[$key]' .release-please-manifest.json)
+            tag="${pkg}-v${version}"
+            if ! git rev-parse "$tag" >/dev/null 2>&1; then
+              echo "tag $tag missing — leaving $pkg unpinned"
+              continue
+            fi
+            shipping=$(git diff --name-only "$tag"..HEAD -- "$pkg_path/" \
+              | grep -Ev "^$pkg_path/(src/tests/|tests/|benches/|CHANGELOG\.md\$|Cargo\.toml\$)" \
+              | wc -l)
+            if [ "$shipping" -eq 0 ]; then
+              echo "no shipping changes in $pkg since $tag → pinning release-as=$version"
+              config=$(echo "$config" | jq --arg key "$pkg_path" --arg ver "$version" \
+                '.packages[$key]["release-as"] = $ver')
+            else
+              echo "$shipping shipping change(s) in $pkg since $tag"
+            fi
+          done
+          echo "$config" > release-please-config.json
+
       - uses: googleapis/release-please-action@v4.4.0
         id: release
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -70,8 +70,12 @@ jobs:
               any_shipping=true
               continue
             fi
+            # `|| true` neutralises grep's exit-1-on-no-match — without
+            # it, a fully-non-shipping diff (the case the guard exists
+            # to catch) crashes under bash's `-eo pipefail` before
+            # `any_shipping` gets written to $GITHUB_OUTPUT.
             shipping=$(git diff --name-only "$tag"..HEAD -- "$pkg_path/" \
-              | grep -Ev "^$pkg_path/(src/tests/|tests/|benches/|CHANGELOG\.md\$|Cargo\.toml\$)" \
+              | { grep -Ev "^$pkg_path/(src/tests/|tests/|benches/|CHANGELOG\.md\$|Cargo\.toml\$)" || true; } \
               | wc -l)
             echo "$pkg: $shipping shipping file(s) since $tag"
             [ "$shipping" -gt 0 ] && any_shipping=true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,51 +32,58 @@ jobs:
           app-id: ${{ secrets.RELEASE_KUN_APP_ID }}
           private-key: ${{ secrets.RELEASE_KUN_APP_PRIVATE_KEY }}
 
-      # Pin published packages whose only changes since the last
-      # release tag are non-shipping (tests, benches, CHANGELOG, the
-      # version line in Cargo.toml). Without this, a single test
-      # addition to `crates/<x>/src/tests/` cuts a fresh crate
-      # version even though no consumer-facing code changed — which
-      # is how `elevator-core 20.3.0` got published from a playground
-      # PR that only added an `Orientation::Horizontal` parse test
-      # (yanked; #797 / #800 in the commit log).
+      # Skip release-please when no package has shipping changes
+      # since its last release tag. "Shipping" excludes tests under
+      # src/tests/ or tests/, benches/, CHANGELOG.md, and the version
+      # line in Cargo.toml — all of which release-please-action
+      # otherwise treats as release-worthy when paired with a `feat:`
+      # or `fix:` squash subject.
       #
-      # Mechanism: rewrite `release-please-config.json` in place to
-      # set `release-as: <current-version>` for any package with no
-      # shipping diff. release-please treats that as "release the
-      # already-released version", which is a no-op — no PR, no tag,
-      # no publish.
+      # Bounded scope: this guard only catches the case where EVERY
+      # package's diff is non-shipping. Mixed PRs (real source
+      # changes in package B + test-only changes in package A) still
+      # bump A as collateral, because release-please-action v4 reads
+      # its config from the GitHub API and there's no per-package
+      # opt-out at config-file edit time. That case is handled by
+      # commit-scope discipline; see CLAUDE.md.
+      #
+      # Background: `elevator-core 20.3.0` was published from PR #797
+      # — a playground PR that incidentally added a one-line test in
+      # `crates/elevator-core/src/tests/`. The release was yanked
+      # (#800 reverted). This guard prevents the fully-no-op variant
+      # of that scenario.
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Pin no-op packages
+      - name: Detect shipping changes
+        id: ship-check
         run: |
-          config=$(cat release-please-config.json)
+          any_shipping=false
           for pkg_path in $(jq -r '.packages | keys[]' release-please-config.json); do
             pkg=$(basename "$pkg_path")
             version=$(jq -r --arg key "$pkg_path" '.[$key]' .release-please-manifest.json)
             tag="${pkg}-v${version}"
             if ! git rev-parse "$tag" >/dev/null 2>&1; then
-              echo "tag $tag missing — leaving $pkg unpinned"
+              echo "tag $tag missing — assuming $pkg has shipping changes"
+              any_shipping=true
               continue
             fi
             shipping=$(git diff --name-only "$tag"..HEAD -- "$pkg_path/" \
               | grep -Ev "^$pkg_path/(src/tests/|tests/|benches/|CHANGELOG\.md\$|Cargo\.toml\$)" \
               | wc -l)
-            if [ "$shipping" -eq 0 ]; then
-              echo "no shipping changes in $pkg since $tag → pinning release-as=$version"
-              config=$(echo "$config" | jq --arg key "$pkg_path" --arg ver "$version" \
-                '.packages[$key]["release-as"] = $ver')
-            else
-              echo "$shipping shipping change(s) in $pkg since $tag"
-            fi
+            echo "$pkg: $shipping shipping file(s) since $tag"
+            [ "$shipping" -gt 0 ] && any_shipping=true
           done
-          echo "$config" > release-please-config.json
+          echo "any_shipping=$any_shipping" >> "$GITHUB_OUTPUT"
+          if [ "$any_shipping" = "false" ]; then
+            echo "::notice::Skipping release-please: no shipping changes since last release across any tracked package."
+          fi
 
       - uses: googleapis/release-please-action@v4.4.0
         id: release
+        if: steps.ship-check.outputs.any_shipping == 'true'
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,25 @@ ID types: `ElevatorId`, `RiderId`, `StopId` are phantom-typed newtypes over `Ent
 
 mdBook guide in `docs/` — deployed to GitHub Pages. Lint with `scripts/lint-docs.sh`.
 
+## Release-please commit discipline
+
+`release-please-action` v4 attributes commits to packages by which paths the commit touched, ignoring the conventional-commit scope. Combined with the `feat:` / `fix:` squash type, this means a PR that primarily changes one tracked package but incidentally touches another (e.g. adds a one-line test in `crates/elevator-core/src/tests/` from a `feat(playground):` PR) will bump *both* packages and publish to crates.io.
+
+The release-please workflow has a guard that skips the entire release-please run when no tracked package has shipping changes since its last tag, but it can NOT prevent the mixed case (some packages have real source changes, others only have test-only changes).
+
+When a PR will squash-merge as `feat:` / `fix:` and you also need to touch another tracked package's source tree (even just tests), split it:
+- Either land the test-only change in a separate `test(elevator-core): ...` PR (release-please ignores `test:` commits), or
+- Use a non-bumping squash type (`refactor:`, `chore:`, `test:`) when the dominant change isn't user-facing.
+
+Files that the workflow guard treats as **non-shipping** for any package `crates/<x>/`:
+- `crates/<x>/src/tests/...`
+- `crates/<x>/tests/...`
+- `crates/<x>/benches/...`
+- `crates/<x>/CHANGELOG.md`
+- `crates/<x>/Cargo.toml` (release-please bumps the version line here)
+
+Anything else under `crates/<x>/` (the rest of `src/`, `build.rs`, asset configs, etc.) counts as shipping.
+
 ## Binding coverage
 
 `bindings.toml` at the workspace root enumerates every `pub fn` on `impl Simulation` and its binding status (`<exported>`, `skip:<reason>`, or `todo:<phase>`) for each consumer crate. CI runs `scripts/check-bindings.sh`; missing or stale entries fail the build. Add or update an entry in the same PR that adds, renames, or removes a public Simulation method.


### PR DESCRIPTION
## Summary

Stops release-please from cutting fresh crate releases when a package's only diff since its last tag is non-shipping (tests, benches, CHANGELOG, the version line in Cargo.toml).

This is the bug that shipped \`elevator-core 20.3.0\` from PR #797 — that PR added a single \`Orientation::Horizontal\` RON parse test under \`crates/elevator-core/src/tests/\`, and release-please attributed the \`feat:\` scope to elevator-core, bumping it minor and publishing to crates.io. The publish was yanked; PR #800 reverted #797.

## How

A pre-step in the release-please workflow rewrites \`release-please-config.json\` in place, adding \`release-as: <current-version>\` to each package whose diff since its last tag has zero shipping files. release-please treats \`release-as <current-version>\` as "release the already-released version" — a no-op (no PR, no tag, no publish).

Tested locally against the current main: with elevator-core / elevator-wasm / elevator-ffi all carrying only revert + release bumps since their last tags, all three pin to current version → release-please run would skip cleanly.

## Filter

Files counted as **non-shipping** for any package \`crates/<x>/\`:
- \`crates/<x>/src/tests/...\`
- \`crates/<x>/tests/...\`
- \`crates/<x>/benches/...\`
- \`crates/<x>/CHANGELOG.md\`
- \`crates/<x>/Cargo.toml\` (release-please bumps the version line here)

Anything else under \`crates/<x>/\` (\`src/\` excluding tests, \`build.rs\`, asset configs, etc.) counts as shipping and lets release-please run normally.

## Known limitation

If package A's diff is test-only AND package B has real shipping changes in the same PR, release-please will still bump both because the conventional-commit \`feat:\` type fires for any path-touched tracked package. The clean fix requires per-PR commit discipline (split scopes, or use \`test:\` / \`refactor:\` for the squash subject when the dominant change isn't user-facing). That's documented in the workflow comment.

## Test plan

- [ ] CI passes (the workflow change is YAML-only; no behavior change for normal feat:/fix: PRs).
- [ ] Next test-only PR (e.g. tightening an existing assertion in \`crates/elevator-core/src/tests/\`) confirms no release-please PR is opened.
- [ ] Next real-source PR (e.g. adding a public API in \`crates/elevator-core/src/\`) confirms release-please still cuts the bump.