### PR TITLE
feat(elevator-core): add LineKind enum and cyclic distance helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "20.1.0"
+version = "20.3.1"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-wasm"
-version = "0.21.0"
+version = "0.22.1"
 dependencies = [
  "elevator-core",
  "getrandom 0.4.2",

--- a/assets/contract-corpus/golden.txt
+++ b/assets/contract-corpus/golden.txt
@@ -1,8 +1,8 @@
 # Golden snapshot checksums for contract scenarios.
 # Regenerate via: cargo run -p elevator-contract -- --update-golden
 # tick budget: 600
-default 0xc39a680791d911c9
-dense_traffic 0xe728b1eada15606c
-extreme_load 0xcf6137a41eb3dc47
-multi_group 0x5244c21f6000007c
-sparse 0x96894e58f45ef6e1
+default 0x0ea0fef498bf9103
+dense_traffic 0xe1accad8543a50f1
+extreme_load 0xd948477e83be705a
+multi_group 0x5408429183c3cccf
+sparse 0xc831e50652f3e035

--- a/crates/elevator-core/Cargo.toml
+++ b/crates/elevator-core/Cargo.toml
@@ -27,6 +27,12 @@ energy = []
 # below the threshold any consumer cares about, while the
 # host-independence guarantee tightens.
 deterministic-fp = []
+# Closed-loop transit topologies (trains, monorails, gondolas,
+# people-movers). Adds the `LineKind::Loop` variant and unlocks
+# the cyclic-position movement integrator, headway-clamped
+# multi-car ordering, and `LoopSweep` / `LoopSchedule` dispatch
+# strategies. Default off until the API stabilises across hosts.
+loop_lines = []
 
 [lints]
 workspace = true

--- a/crates/elevator-core/benches/multi_line_bench.rs
+++ b/crates/elevator-core/benches/multi_line_bench.rs
@@ -89,6 +89,7 @@ fn multi_group_config(
                 position: None,
                 min_position: None,
                 max_position: None,
+                kind: None,
                 max_cars: None,
             });
             line_id += 1;

--- a/crates/elevator-core/src/components/cyclic.rs
+++ b/crates/elevator-core/src/components/cyclic.rs
@@ -1,0 +1,157 @@
+//! Cyclic-distance helpers for closed-loop topologies.
+//!
+//! These helpers operate on positions along a one-dimensional axis that
+//! wraps modulo `circumference`. They are the foundation that
+//! [`LineKind::Loop`](super::line::LineKind) consumers — movement physics,
+//! ETA math, headway clamping — build on.
+//!
+//! All helpers treat `circumference <= 0.0` and non-finite inputs as
+//! degenerate and return safe values (typically `0.0` or the input
+//! unchanged) rather than panicking. Construction-time validation is
+//! responsible for rejecting such configurations before they reach
+//! these helpers; the defensive returns exist so a misconfigured run
+//! degrades gracefully rather than producing NaN cascades.
+
+/// Normalize a position into `[0, circumference)`.
+///
+/// Uses [`f64::rem_euclid`] so negative inputs wrap correctly (unlike
+/// `%` which preserves the sign). The `>= circumference` guard handles
+/// the rare case where `rem_euclid` rounds a tiny negative input up to
+/// exactly `circumference` due to floating-point precision loss —
+/// without it the `[0, C)` invariant would be silently violated.
+///
+/// Returns the input unchanged when `circumference <= 0.0` or when
+/// `p` is non-finite.
+///
+/// ```
+/// # use elevator_core::components::cyclic::wrap_position;
+/// assert_eq!(wrap_position(0.0, 100.0), 0.0);
+/// assert_eq!(wrap_position(50.0, 100.0), 50.0);
+/// assert_eq!(wrap_position(100.0, 100.0), 0.0);
+/// assert_eq!(wrap_position(125.0, 100.0), 25.0);
+/// assert_eq!(wrap_position(-25.0, 100.0), 75.0);
+/// assert_eq!(wrap_position(-100.0, 100.0), 0.0);
+/// ```
+#[must_use]
+pub fn wrap_position(p: f64, circumference: f64) -> f64 {
+    if circumference <= 0.0 || !p.is_finite() {
+        return p;
+    }
+    let r = p.rem_euclid(circumference);
+    if r >= circumference { 0.0 } else { r }
+}
+
+/// Forward (one-way) cyclic distance from `from` to `to` along a loop.
+///
+/// Always returns a value in `[0, circumference)`. Coincident positions
+/// return `0.0`, not `circumference` — distance to "the same point" is
+/// zero, even though "going all the way around back to the same point"
+/// is also a meaningful concept on a loop. Callers that need the
+/// "full lap" interpretation should add `circumference` to a `0.0`
+/// result themselves.
+///
+/// Returns `0.0` when `circumference <= 0.0`.
+///
+/// ```
+/// # use elevator_core::components::cyclic::forward_distance;
+/// assert_eq!(forward_distance(10.0, 30.0, 100.0), 20.0);
+/// assert_eq!(forward_distance(90.0, 10.0, 100.0), 20.0);
+/// assert_eq!(forward_distance(50.0, 50.0, 100.0), 0.0);
+/// assert_eq!(forward_distance(0.0, 99.0, 100.0), 99.0);
+/// // Inputs outside [0, C) are wrapped first.
+/// assert_eq!(forward_distance(110.0, 30.0, 100.0), 20.0);
+/// assert_eq!(forward_distance(-10.0, 30.0, 100.0), 40.0);
+/// ```
+#[must_use]
+pub fn forward_distance(from: f64, to: f64, circumference: f64) -> f64 {
+    if circumference <= 0.0 {
+        return 0.0;
+    }
+    let from = wrap_position(from, circumference);
+    let to = wrap_position(to, circumference);
+    let d = to - from;
+    if d < 0.0 { d + circumference } else { d }
+}
+
+/// Shortest unsigned cyclic distance between `a` and `b` along a loop.
+///
+/// Returns the smaller of [`forward_distance(a, b)`](forward_distance)
+/// and `circumference - forward_distance(a, b)`. Always in `[0, C/2]`.
+///
+/// Useful when the direction of travel is irrelevant (e.g. spatial
+/// adjacency queries). For dispatch and ETA on a one-way loop, use
+/// [`forward_distance`] instead — the shorter chord is the wrong
+/// answer when you can only travel one way.
+///
+/// ```
+/// # use elevator_core::components::cyclic::cyclic_distance;
+/// assert_eq!(cyclic_distance(10.0, 30.0, 100.0), 20.0);
+/// assert_eq!(cyclic_distance(90.0, 10.0, 100.0), 20.0);
+/// assert_eq!(cyclic_distance(0.0, 50.0, 100.0), 50.0);
+/// assert_eq!(cyclic_distance(0.0, 51.0, 100.0), 49.0);
+/// ```
+#[must_use]
+pub fn cyclic_distance(a: f64, b: f64, circumference: f64) -> f64 {
+    if circumference <= 0.0 {
+        return 0.0;
+    }
+    let fwd = forward_distance(a, b, circumference);
+    let back = circumference - fwd;
+    fwd.min(back)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `assert_eq!` on f64 trips `clippy::float_cmp`; this helper expresses
+    /// the bit-exact intent the tests actually want when inputs are powers
+    /// of two and arithmetic is closed under f64.
+    fn approx(actual: f64, expected: f64) {
+        assert!(
+            (actual - expected).abs() < 1e-12,
+            "expected {expected}, got {actual}",
+        );
+    }
+
+    #[test]
+    fn wrap_handles_zero_circumference() {
+        approx(wrap_position(50.0, 0.0), 50.0);
+        approx(wrap_position(50.0, -1.0), 50.0);
+    }
+
+    #[test]
+    fn wrap_handles_non_finite() {
+        assert!(wrap_position(f64::NAN, 100.0).is_nan());
+        assert!(wrap_position(f64::INFINITY, 100.0).is_infinite());
+    }
+
+    #[test]
+    fn forward_distance_is_directional() {
+        approx(forward_distance(10.0, 30.0, 100.0), 20.0);
+        approx(forward_distance(30.0, 10.0, 100.0), 80.0);
+    }
+
+    #[test]
+    fn forward_distance_zero_on_coincident() {
+        approx(forward_distance(50.0, 50.0, 100.0), 0.0);
+        approx(forward_distance(0.0, 100.0, 100.0), 0.0);
+    }
+
+    #[test]
+    fn cyclic_distance_is_symmetric() {
+        for &(a, b) in &[(10.0_f64, 30.0_f64), (5.0, 95.0), (0.0, 50.0)] {
+            let ab = cyclic_distance(a, b, 100.0);
+            let ba = cyclic_distance(b, a, 100.0);
+            assert!((ab - ba).abs() < 1e-12, "{a} -> {b}: {ab} vs {ba}");
+        }
+    }
+
+    #[test]
+    fn cyclic_distance_capped_at_half_circumference() {
+        for d in 0..=100 {
+            let result = cyclic_distance(0.0, f64::from(d), 100.0);
+            assert!(result <= 50.0 + 1e-12, "d={d} result={result}");
+        }
+    }
+}

--- a/crates/elevator-core/src/components/cyclic.rs
+++ b/crates/elevator-core/src/components/cyclic.rs
@@ -2,8 +2,8 @@
 //!
 //! These helpers operate on positions along a one-dimensional axis that
 //! wraps modulo `circumference`. They are the foundation that
-//! [`LineKind::Loop`](super::line::LineKind) consumers — movement physics,
-//! ETA math, headway clamping — build on.
+//! [`LineKind::Loop`](crate::components::LineKind) consumers — movement
+//! physics, ETA math, headway clamping — build on.
 //!
 //! All helpers treat `circumference <= 0.0` and non-finite inputs as
 //! degenerate and return safe values (typically `0.0` or the input

--- a/crates/elevator-core/src/components/cyclic.rs
+++ b/crates/elevator-core/src/components/cyclic.rs
@@ -64,7 +64,11 @@ pub fn wrap_position(p: f64, circumference: f64) -> f64 {
 /// ```
 #[must_use]
 pub fn forward_distance(from: f64, to: f64, circumference: f64) -> f64 {
-    if circumference <= 0.0 {
+    // Guard non-finite inputs: `wrap_position` is documented to return
+    // them unchanged, and the subtraction below would then propagate
+    // `±∞` / `NaN` into ETA / dispatch math. Returning `0.0` matches
+    // the module-level "safe degenerate value" contract.
+    if circumference <= 0.0 || !from.is_finite() || !to.is_finite() {
         return 0.0;
     }
     let from = wrap_position(from, circumference);
@@ -130,6 +134,15 @@ mod tests {
     fn forward_distance_is_directional() {
         approx(forward_distance(10.0, 30.0, 100.0), 20.0);
         approx(forward_distance(30.0, 10.0, 100.0), 80.0);
+    }
+
+    #[test]
+    fn forward_distance_returns_zero_on_non_finite() {
+        approx(forward_distance(f64::INFINITY, 30.0, 100.0), 0.0);
+        approx(forward_distance(30.0, f64::INFINITY, 100.0), 0.0);
+        approx(forward_distance(f64::NAN, 30.0, 100.0), 0.0);
+        approx(forward_distance(30.0, f64::NAN, 100.0), 0.0);
+        approx(forward_distance(f64::NEG_INFINITY, 30.0, 100.0), 0.0);
     }
 
     #[test]

--- a/crates/elevator-core/src/components/cyclic.rs
+++ b/crates/elevator-core/src/components/cyclic.rs
@@ -5,12 +5,18 @@
 //! [`LineKind::Loop`](crate::components::LineKind) consumers — movement
 //! physics, ETA math, headway clamping — build on.
 //!
-//! All helpers treat `circumference <= 0.0` and non-finite inputs as
-//! degenerate and return safe values (typically `0.0` or the input
-//! unchanged) rather than panicking. Construction-time validation is
-//! responsible for rejecting such configurations before they reach
-//! these helpers; the defensive returns exist so a misconfigured run
-//! degrades gracefully rather than producing NaN cascades.
+//! All helpers treat any of the following as degenerate and return safe
+//! values (typically `0.0` or the input unchanged) rather than panicking
+//! or propagating `NaN`:
+//!
+//! - `circumference <= 0.0`
+//! - non-finite `circumference` (including `NaN` and `±∞`)
+//! - non-finite position arguments
+//!
+//! Construction-time validation is responsible for rejecting such
+//! configurations before they reach these helpers; the defensive returns
+//! exist so a misconfigured run degrades gracefully rather than producing
+//! `NaN` cascades through ETA / dispatch math.
 
 /// Normalize a position into `[0, circumference)`.
 ///
@@ -34,7 +40,12 @@
 /// ```
 #[must_use]
 pub fn wrap_position(p: f64, circumference: f64) -> f64 {
-    if circumference <= 0.0 || !p.is_finite() {
+    // Guard explicitly against non-finite *and* non-positive circumference.
+    // Splitting the check (rather than `c <= 0.0`) is necessary because
+    // `NaN <= 0.0` is `false` in IEEE 754 — without the finiteness
+    // gate a NaN circumference would slip past and `rem_euclid` would
+    // propagate it into the result.
+    if !circumference.is_finite() || circumference <= 0.0 || !p.is_finite() {
         return p;
     }
     let r = p.rem_euclid(circumference);
@@ -64,11 +75,11 @@ pub fn wrap_position(p: f64, circumference: f64) -> f64 {
 /// ```
 #[must_use]
 pub fn forward_distance(from: f64, to: f64, circumference: f64) -> f64 {
-    // Guard non-finite inputs: `wrap_position` is documented to return
-    // them unchanged, and the subtraction below would then propagate
-    // `±∞` / `NaN` into ETA / dispatch math. Returning `0.0` matches
-    // the module-level "safe degenerate value" contract.
-    if circumference <= 0.0 || !from.is_finite() || !to.is_finite() {
+    // Reject every degenerate input shape upfront so the subtraction
+    // below cannot produce `±∞` / `NaN`. The split finiteness guard on
+    // `circumference` is required because `NaN <= 0.0` is `false` —
+    // see the matching note in `wrap_position`.
+    if !circumference.is_finite() || circumference <= 0.0 || !from.is_finite() || !to.is_finite() {
         return 0.0;
     }
     let from = wrap_position(from, circumference);
@@ -96,7 +107,11 @@ pub fn forward_distance(from: f64, to: f64, circumference: f64) -> f64 {
 /// ```
 #[must_use]
 pub fn cyclic_distance(a: f64, b: f64, circumference: f64) -> f64 {
-    if circumference <= 0.0 {
+    // `forward_distance` short-circuits on NaN inputs, but mirroring the
+    // guard here keeps the `[0, C/2]` invariant explicit at the entry
+    // point — and the `circumference - fwd` step below would otherwise
+    // fail the same way for non-finite circumference.
+    if !circumference.is_finite() || circumference <= 0.0 {
         return 0.0;
     }
     let fwd = forward_distance(a, b, circumference);
@@ -143,6 +158,16 @@ mod tests {
         approx(forward_distance(f64::NAN, 30.0, 100.0), 0.0);
         approx(forward_distance(30.0, f64::NAN, 100.0), 0.0);
         approx(forward_distance(f64::NEG_INFINITY, 30.0, 100.0), 0.0);
+    }
+
+    #[test]
+    fn helpers_handle_nan_circumference() {
+        // NaN <= 0.0 is false in IEEE 754; `!(c > 0.0)` is the only guard
+        // that covers both NaN and non-positive uniformly. Without that
+        // form, NaN would bypass the guard and propagate through arithmetic.
+        approx(wrap_position(5.0, f64::NAN), 5.0);
+        approx(forward_distance(5.0, 10.0, f64::NAN), 0.0);
+        approx(cyclic_distance(5.0, 10.0, f64::NAN), 0.0);
     }
 
     #[test]

--- a/crates/elevator-core/src/components/line.rs
+++ b/crates/elevator-core/src/components/line.rs
@@ -89,10 +89,16 @@ pub enum LineKind {
     /// `min_headway` between successive cars.
     #[cfg(feature = "loop_lines")]
     Loop {
-        /// Total path length around the loop. Must be `> 0`.
+        /// Total path length around the loop. Must be `> 0` —
+        /// construction (`Simulation::add_line` and the explicit-topology
+        /// builder) rejects non-positive or non-finite values.
         circumference: f64,
         /// Minimum permitted forward distance between successive cars.
-        /// Construction validates `max_cars * min_headway <= circumference`.
+        /// PR 3 will add construction-time validation
+        /// (`max_cars * min_headway <= circumference`); until then, the
+        /// dispatch and movement code added in subsequent PRs is
+        /// responsible for behaving sanely on degenerate values.
+        /// Callers should set this strictly positive.
         min_headway: f64,
     },
 }
@@ -106,6 +112,47 @@ impl LineKind {
             #[cfg(feature = "loop_lines")]
             Self::Loop { .. } => true,
         }
+    }
+
+    /// Validate that this kind's intrinsic bounds are well-formed.
+    ///
+    /// Returns `Err((field, reason))` on a violation; both construction
+    /// entry points ([`Simulation::add_line`](crate::sim::Simulation::add_line)
+    /// and the explicit-topology builder) call this and lift the error
+    /// into [`SimError::InvalidConfig`](crate::error::SimError::InvalidConfig).
+    ///
+    /// The intent is the *trivial* per-kind sanity checks — bounds finite
+    /// and ordered, circumference positive. Cross-line invariants
+    /// (`max_cars` × headway, group homogeneity, initial spacing) are PR 3.
+    ///
+    /// # Errors
+    ///
+    /// `Linear` rejects non-finite or `min > max` bounds. `Loop` rejects
+    /// non-finite or non-positive `circumference`.
+    pub fn validate(&self) -> Result<(), (&'static str, String)> {
+        match self {
+            Self::Linear { min, max } => {
+                if !min.is_finite() || !max.is_finite() {
+                    return Err((
+                        "line.range",
+                        format!("min/max must be finite (got min={min}, max={max})"),
+                    ));
+                }
+                if min > max {
+                    return Err(("line.range", format!("min ({min}) must be <= max ({max})")));
+                }
+            }
+            #[cfg(feature = "loop_lines")]
+            Self::Loop { circumference, .. } => {
+                if !circumference.is_finite() || *circumference <= 0.0 {
+                    return Err((
+                        "line.kind",
+                        format!("loop circumference must be finite and > 0 (got {circumference})"),
+                    ));
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -385,6 +432,92 @@ mod tests {
 
         let deserialized: Line = serde_json::from_value(serialized).unwrap();
         assert_eq!(deserialized.kind(), line.kind());
+    }
+
+    #[test]
+    fn validate_rejects_non_finite_linear() {
+        assert!(
+            LineKind::Linear {
+                min: f64::NAN,
+                max: 10.0
+            }
+            .validate()
+            .is_err()
+        );
+        assert!(
+            LineKind::Linear {
+                min: 5.0,
+                max: f64::INFINITY
+            }
+            .validate()
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn validate_rejects_inverted_linear_bounds() {
+        assert!(
+            LineKind::Linear {
+                min: 10.0,
+                max: 5.0
+            }
+            .validate()
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn validate_accepts_well_formed_linear() {
+        assert!(
+            LineKind::Linear {
+                min: 0.0,
+                max: 100.0
+            }
+            .validate()
+            .is_ok()
+        );
+    }
+
+    #[cfg(feature = "loop_lines")]
+    #[test]
+    fn validate_rejects_non_positive_circumference() {
+        assert!(
+            LineKind::Loop {
+                circumference: 0.0,
+                min_headway: 5.0
+            }
+            .validate()
+            .is_err()
+        );
+        assert!(
+            LineKind::Loop {
+                circumference: -1.0,
+                min_headway: 5.0
+            }
+            .validate()
+            .is_err()
+        );
+        assert!(
+            LineKind::Loop {
+                circumference: f64::NAN,
+                min_headway: 5.0
+            }
+            .validate()
+            .is_err()
+        );
+    }
+
+    #[cfg(feature = "loop_lines")]
+    #[test]
+    fn validate_accepts_positive_circumference() {
+        assert!(
+            LineKind::Loop {
+                circumference: 100.0,
+                min_headway: 5.0
+            }
+            .validate()
+            .is_ok()
+        );
     }
 
     #[cfg(feature = "loop_lines")]

--- a/crates/elevator-core/src/components/line.rs
+++ b/crates/elevator-core/src/components/line.rs
@@ -47,6 +47,11 @@ impl std::fmt::Display for Orientation {
 }
 
 /// 2D position on a floor plan (for spatial queries and rendering).
+///
+/// On a [`LineKind::Linear`] line this anchors one end of the axis. On a
+/// [`LineKind::Loop`] line this anchors the geometric *center* of the
+/// loop; hosts derive any rendering radius from
+/// [`Line::circumference`] (e.g. `r = C / (2π)` for a circular layout).
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct SpatialPosition {
     /// X coordinate on the floor plan.
@@ -55,19 +60,71 @@ pub struct SpatialPosition {
     pub y: f64,
 }
 
+/// Topology of a line — open-ended linear axis or closed loop.
+///
+/// `Linear` is the default for elevator shafts, tethers, and other paths
+/// bounded by `[min, max]`. `Loop` (gated behind the `loop_lines`
+/// feature) models a closed-loop transit line where positions wrap
+/// modulo `circumference`. Helpers in [`super::cyclic`] operate on Loop
+/// positions; consumer code dispatches on this enum to pick linear vs
+/// cyclic semantics.
+///
+/// `#[non_exhaustive]` — future topologies (figure-eight, branching, etc.)
+/// can be added without a major version bump.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum LineKind {
+    /// Open-ended line with hard `[min, max]` position bounds. Cars
+    /// reverse at endpoints; this matches every existing dispatch
+    /// strategy (LOOK, sweep, scan, destination, etc.).
+    Linear {
+        /// Lowest reachable position.
+        min: f64,
+        /// Highest reachable position.
+        max: f64,
+    },
+    /// Closed loop with cyclic position semantics. Positions wrap into
+    /// `[0, circumference)`; cars travel one direction only and
+    /// maintain a strict no-overtake ordering with at least
+    /// `min_headway` between successive cars.
+    #[cfg(feature = "loop_lines")]
+    Loop {
+        /// Total path length around the loop. Must be `> 0`.
+        circumference: f64,
+        /// Minimum permitted forward distance between successive cars.
+        /// Construction validates `max_cars * min_headway <= circumference`.
+        min_headway: f64,
+    },
+}
+
+impl LineKind {
+    /// Whether this line is a closed loop.
+    #[must_use]
+    pub const fn is_loop(&self) -> bool {
+        match self {
+            Self::Linear { .. } => false,
+            #[cfg(feature = "loop_lines")]
+            Self::Loop { .. } => true,
+        }
+    }
+}
+
 /// Component for a line entity — the physical path an elevator car travels.
 ///
 /// In a building this is a hoistway/shaft. For a space elevator it is a
-/// tether or cable. The term "line" is domain-neutral.
+/// tether or cable. For a metro or people-mover (with the `loop_lines`
+/// feature) it is a closed loop. The term "line" is domain-neutral.
 ///
 /// A line belongs to exactly one [`GroupId`] at a time but can be
 /// reassigned at runtime (swing-car pattern). Multiple cars may share
-/// a line (multi-car shafts); collision avoidance is left to game hooks.
+/// a line (multi-car shafts); collision avoidance is left to game hooks
+/// for `Linear` lines and enforced by headway clamping for `Loop` lines.
 ///
 /// Intrinsic properties only — relationship data (which elevators, which
 /// stops) lives in [`LineInfo`](crate::dispatch::LineInfo) on the
 /// [`ElevatorGroup`](crate::dispatch::ElevatorGroup).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(from = "LineWire", into = "LineWire")]
 pub struct Line {
     /// Human-readable name.
     pub(crate) name: String,
@@ -75,14 +132,83 @@ pub struct Line {
     pub(crate) group: GroupId,
     /// Physical orientation (metadata for rendering).
     pub(crate) orientation: Orientation,
-    /// Optional floor-plan position (for spatial queries).
+    /// Optional floor-plan position (for spatial queries / rendering).
     pub(crate) position: Option<SpatialPosition>,
-    /// Lowest reachable position along the line axis.
-    pub(crate) min_position: f64,
-    /// Highest reachable position along the line axis.
-    pub(crate) max_position: f64,
+    /// Topology kind — open-ended linear axis or closed loop.
+    pub(crate) kind: LineKind,
     /// Maximum number of cars allowed on this line (None = unlimited).
     pub(crate) max_cars: Option<usize>,
+}
+
+/// On-the-wire representation of [`Line`]. Bridges the legacy flat
+/// `min_position` / `max_position` fields with the new `kind` field
+/// during the transitional release: snapshots written by builds that
+/// haven't migrated yet still deserialize correctly, and snapshots
+/// from this build can still be inspected by older tooling.
+///
+/// On serialize we emit `kind` *and* derived flat fields. On deserialize,
+/// `kind` is preferred; flat fields are the fallback.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LineWire {
+    /// Human-readable name (always present in both legacy and current shapes).
+    name: String,
+    /// Dispatch group ownership.
+    group: GroupId,
+    /// Physical orientation (defaults to Vertical if absent).
+    #[serde(default)]
+    orientation: Orientation,
+    /// 2D anchor on the floor plan (defaults to None).
+    #[serde(default)]
+    position: Option<SpatialPosition>,
+    /// New topology field — preferred when present.
+    #[serde(default)]
+    kind: Option<LineKind>,
+    /// Legacy flat field — fallback when `kind` is absent.
+    #[serde(default)]
+    min_position: Option<f64>,
+    /// Legacy flat field — fallback when `kind` is absent.
+    #[serde(default)]
+    max_position: Option<f64>,
+    /// Maximum cars on this line.
+    #[serde(default)]
+    max_cars: Option<usize>,
+}
+
+impl From<LineWire> for Line {
+    fn from(w: LineWire) -> Self {
+        let kind = w.kind.unwrap_or_else(|| LineKind::Linear {
+            min: w.min_position.unwrap_or(0.0),
+            max: w.max_position.unwrap_or(0.0),
+        });
+        Self {
+            name: w.name,
+            group: w.group,
+            orientation: w.orientation,
+            position: w.position,
+            kind,
+            max_cars: w.max_cars,
+        }
+    }
+}
+
+impl From<Line> for LineWire {
+    fn from(l: Line) -> Self {
+        let (min_position, max_position) = match &l.kind {
+            LineKind::Linear { min, max } => (Some(*min), Some(*max)),
+            #[cfg(feature = "loop_lines")]
+            LineKind::Loop { circumference, .. } => (Some(0.0), Some(*circumference)),
+        };
+        Self {
+            name: l.name,
+            group: l.group,
+            orientation: l.orientation,
+            position: l.position,
+            kind: Some(l.kind),
+            min_position,
+            max_position,
+            max_cars: l.max_cars,
+        }
+    }
 }
 
 impl Line {
@@ -104,27 +230,183 @@ impl Line {
         self.orientation
     }
 
-    /// Optional floor-plan position.
+    /// Optional floor-plan position. For [`LineKind::Loop`] this is the
+    /// geometric *center* of the loop; hosts derive a rendering radius
+    /// from [`Self::circumference`].
     #[must_use]
     pub const fn position(&self) -> Option<&SpatialPosition> {
         self.position.as_ref()
     }
 
-    /// Lowest reachable position along the line axis.
+    /// Topology kind — linear axis or closed loop.
     #[must_use]
-    pub const fn min_position(&self) -> f64 {
-        self.min_position
+    pub const fn kind(&self) -> &LineKind {
+        &self.kind
     }
 
-    /// Highest reachable position along the line axis.
+    /// Whether this is a closed-loop line.
     #[must_use]
-    pub const fn max_position(&self) -> f64 {
-        self.max_position
+    pub const fn is_loop(&self) -> bool {
+        self.kind.is_loop()
+    }
+
+    /// Lowest reachable position on a [`LineKind::Linear`] line. Returns
+    /// `None` for [`LineKind::Loop`] — loops have no endpoints.
+    ///
+    /// Replaces the former `min_position()` accessor. Callers that
+    /// blindly dereferenced the old `f64` should now decide whether
+    /// they want Linear-only behavior (`linear_min().expect("linear")`)
+    /// or to handle Loop explicitly.
+    #[must_use]
+    pub const fn linear_min(&self) -> Option<f64> {
+        match self.kind {
+            LineKind::Linear { min, .. } => Some(min),
+            #[cfg(feature = "loop_lines")]
+            LineKind::Loop { .. } => None,
+        }
+    }
+
+    /// Highest reachable position on a [`LineKind::Linear`] line. Returns
+    /// `None` for [`LineKind::Loop`].
+    #[must_use]
+    pub const fn linear_max(&self) -> Option<f64> {
+        match self.kind {
+            LineKind::Linear { max, .. } => Some(max),
+            #[cfg(feature = "loop_lines")]
+            LineKind::Loop { .. } => None,
+        }
+    }
+
+    /// Total path length of a [`LineKind::Loop`] line. Returns `None`
+    /// for [`LineKind::Linear`].
+    #[must_use]
+    pub const fn circumference(&self) -> Option<f64> {
+        match self.kind {
+            LineKind::Linear { .. } => None,
+            #[cfg(feature = "loop_lines")]
+            LineKind::Loop { circumference, .. } => Some(circumference),
+        }
+    }
+
+    /// Minimum forward distance between successive cars on a
+    /// [`LineKind::Loop`] line. Returns `None` for [`LineKind::Linear`].
+    #[must_use]
+    pub const fn min_headway(&self) -> Option<f64> {
+        match self.kind {
+            LineKind::Linear { .. } => None,
+            #[cfg(feature = "loop_lines")]
+            LineKind::Loop { min_headway, .. } => Some(min_headway),
+        }
     }
 
     /// Maximum number of cars allowed on this line.
     #[must_use]
     pub const fn max_cars(&self) -> Option<usize> {
         self.max_cars
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linear_accessors_return_some() {
+        let line = Line::from(LineWire {
+            name: "L1".into(),
+            group: GroupId(0),
+            orientation: Orientation::Vertical,
+            position: None,
+            kind: Some(LineKind::Linear {
+                min: 0.0,
+                max: 100.0,
+            }),
+            min_position: None,
+            max_position: None,
+            max_cars: None,
+        });
+        assert_eq!(line.linear_min(), Some(0.0));
+        assert_eq!(line.linear_max(), Some(100.0));
+        assert_eq!(line.circumference(), None);
+        assert_eq!(line.min_headway(), None);
+        assert!(!line.is_loop());
+    }
+
+    #[test]
+    fn legacy_flat_fields_construct_linear_kind() {
+        let line = Line::from(LineWire {
+            name: "L1".into(),
+            group: GroupId(0),
+            orientation: Orientation::Vertical,
+            position: None,
+            kind: None,
+            min_position: Some(0.0),
+            max_position: Some(50.0),
+            max_cars: None,
+        });
+        assert_eq!(
+            line.kind(),
+            &LineKind::Linear {
+                min: 0.0,
+                max: 50.0
+            }
+        );
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used, reason = "test helper")]
+    fn round_trip_writes_both_kind_and_flat_fields() {
+        let line = Line {
+            name: "L1".into(),
+            group: GroupId(0),
+            orientation: Orientation::Vertical,
+            position: None,
+            kind: LineKind::Linear {
+                min: 0.0,
+                max: 75.0,
+            },
+            max_cars: None,
+        };
+        let serialized = serde_json::to_value(&line).unwrap();
+        // Both shapes must be present so an older deserializer can still read it.
+        assert!(serialized.get("kind").is_some());
+        assert_eq!(
+            serialized
+                .get("min_position")
+                .and_then(serde_json::Value::as_f64),
+            Some(0.0)
+        );
+        assert_eq!(
+            serialized
+                .get("max_position")
+                .and_then(serde_json::Value::as_f64),
+            Some(75.0)
+        );
+
+        let deserialized: Line = serde_json::from_value(serialized).unwrap();
+        assert_eq!(deserialized.kind(), line.kind());
+    }
+
+    #[cfg(feature = "loop_lines")]
+    #[test]
+    fn loop_accessors_return_some() {
+        let line = Line::from(LineWire {
+            name: "L1".into(),
+            group: GroupId(0),
+            orientation: Orientation::Horizontal,
+            position: None,
+            kind: Some(LineKind::Loop {
+                circumference: 200.0,
+                min_headway: 10.0,
+            }),
+            min_position: None,
+            max_position: None,
+            max_cars: None,
+        });
+        assert_eq!(line.linear_min(), None);
+        assert_eq!(line.linear_max(), None);
+        assert_eq!(line.circumference(), Some(200.0));
+        assert_eq!(line.min_headway(), Some(10.0));
+        assert!(line.is_loop());
     }
 }

--- a/crates/elevator-core/src/components/mod.rs
+++ b/crates/elevator-core/src/components/mod.rs
@@ -4,6 +4,8 @@
 pub mod access;
 /// Floor buttons pressed from inside a cab.
 pub mod car_call;
+/// Cyclic-distance helpers for closed-loop line topologies.
+pub mod cyclic;
 /// Per-elevator ordered destination queue.
 pub mod destination_queue;
 /// Elevator state and properties.
@@ -34,7 +36,7 @@ pub use car_call::CarCall;
 pub use destination_queue::DestinationQueue;
 pub use elevator::{DOOR_COMMAND_QUEUE_CAP, Direction, Elevator, ElevatorPhase};
 pub use hall_call::{CallDirection, HallCall};
-pub use line::{Line, Orientation, SpatialPosition};
+pub use line::{Line, LineKind, Orientation, SpatialPosition};
 pub use patience::{Patience, Preferences};
 pub use position::{Position, Velocity};
 pub use rider::{Rider, RiderPhase, RiderPhaseKind};

--- a/crates/elevator-core/src/config.rs
+++ b/crates/elevator-core/src/config.rs
@@ -1,6 +1,6 @@
 //! Building and elevator configuration (RON-deserializable).
 
-use crate::components::{Accel, Orientation, SpatialPosition, Speed, Weight};
+use crate::components::{Accel, LineKind, Orientation, SpatialPosition, Speed, Weight};
 use crate::dispatch::{BuiltinReposition, BuiltinStrategy, HallCallMode};
 use crate::stop::{StopConfig, StopId};
 use serde::{Deserialize, Serialize};
@@ -321,14 +321,26 @@ pub struct LineConfig {
     #[serde(default)]
     pub position: Option<SpatialPosition>,
     /// Lowest reachable position (auto-computed from stops if `None`).
+    ///
+    /// Used only when [`Self::kind`] is `None`; otherwise the kind's own
+    /// bounds (or circumference) take precedence.
     #[serde(default)]
     pub min_position: Option<f64>,
     /// Highest reachable position (auto-computed from stops if `None`).
+    /// See [`Self::min_position`] for the kind interaction.
     #[serde(default)]
     pub max_position: Option<f64>,
     /// Max cars on this line (`None` = unlimited).
     #[serde(default)]
     pub max_cars: Option<usize>,
+    /// Topology kind. When `Some`, takes precedence over the flat
+    /// `min_position`/`max_position` fields. When `None`, falls back to
+    /// [`LineKind::Linear`] built from the flat fields (or
+    /// auto-computed from stops). RON authors can opt into a closed
+    /// loop with `kind: Some(Loop(circumference: 200.0, min_headway: 10.0))`
+    /// — but only when the `loop_lines` feature is enabled.
+    #[serde(default)]
+    pub kind: Option<LineKind>,
 }
 
 /// Configuration for an elevator dispatch group.

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -158,7 +158,8 @@ pub struct LineParams {
     ///
     /// Used only when [`Self::kind`] is `None`; otherwise the kind's
     /// own bounds win. Kept for backward-compat with callers that
-    /// haven't migrated to constructing [`LineKind`] directly.
+    /// haven't migrated to constructing
+    /// [`LineKind`](crate::components::LineKind) directly.
     pub min_position: f64,
     /// Highest reachable position on the line axis. See
     /// [`Self::min_position`] for the kind interaction.
@@ -170,8 +171,8 @@ pub struct LineParams {
     pub max_cars: Option<usize>,
     /// Topology kind. When `Some`, takes precedence over the flat
     /// `min_position`/`max_position` fields. When `None`, falls back
-    /// to [`LineKind::Linear`] built from the flat fields — matches
-    /// the pre-`LineKind` behavior.
+    /// to [`LineKind::Linear`](crate::components::LineKind::Linear)
+    /// built from the flat fields — matches the pre-`LineKind` behavior.
     pub kind: Option<crate::components::LineKind>,
 }
 

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -155,13 +155,24 @@ pub struct LineParams {
     /// Physical orientation.
     pub orientation: Orientation,
     /// Lowest reachable position on the line axis.
+    ///
+    /// Used only when [`Self::kind`] is `None`; otherwise the kind's
+    /// own bounds win. Kept for backward-compat with callers that
+    /// haven't migrated to constructing [`LineKind`] directly.
     pub min_position: f64,
-    /// Highest reachable position on the line axis.
+    /// Highest reachable position on the line axis. See
+    /// [`Self::min_position`] for the kind interaction.
     pub max_position: f64,
-    /// Optional floor-plan position.
+    /// Optional floor-plan position. On a Loop line this is the
+    /// loop center.
     pub position: Option<SpatialPosition>,
     /// Maximum cars on this line (None = unlimited).
     pub max_cars: Option<usize>,
+    /// Topology kind. When `Some`, takes precedence over the flat
+    /// `min_position`/`max_position` fields. When `None`, falls back
+    /// to [`LineKind::Linear`] built from the flat fields — matches
+    /// the pre-`LineKind` behavior.
+    pub kind: Option<crate::components::LineKind>,
 }
 
 impl LineParams {
@@ -176,6 +187,7 @@ impl LineParams {
             max_position: 0.0,
             position: None,
             max_cars: None,
+            kind: None,
         }
     }
 }

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -547,7 +547,8 @@ impl Simulation {
 
             let line_eid = world.spawn();
             // The group assignment will be set when we process GroupConfigs.
-            // Default to GroupId(0) initially.
+            // Default to GroupId(0) initially. `kind` was validated in
+            // `validate_explicit_topology` before this builder ran.
             world.set_line(
                 line_eid,
                 Line {
@@ -953,6 +954,15 @@ impl Simulation {
                         lc.elevators.len()
                     ),
                 });
+            }
+
+            // Validate the explicit topology kind, if any. Linear-only
+            // configs (kind = None) are validated by the auto-derived
+            // bounds check inside `build_explicit_topology` instead.
+            if let Some(kind) = lc.kind
+                && let Err((field, reason)) = kind.validate()
+            {
+                return Err(SimError::InvalidConfig { field, reason });
             }
         }
 

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -14,7 +14,9 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Mutex;
 
-use crate::components::{Elevator, ElevatorPhase, Line, Orientation, Position, Stop, Velocity};
+use crate::components::{
+    Elevator, ElevatorPhase, Line, LineKind, Orientation, Position, Stop, Velocity,
+};
 use crate::config::SimConfig;
 use crate::dispatch::{
     BuiltinReposition, BuiltinStrategy, DispatchStrategy, ElevatorGroup, LineInfo,
@@ -443,8 +445,10 @@ impl Simulation {
                 group: GroupId(0),
                 orientation: Orientation::Vertical,
                 position: None,
-                min_position: min_pos,
-                max_position: max_pos,
+                kind: LineKind::Linear {
+                    min: min_pos,
+                    max: max_pos,
+                },
                 max_cars: None,
             },
         );
@@ -551,8 +555,10 @@ impl Simulation {
                     group: GroupId(0),
                     orientation: lc.orientation,
                     position: lc.position,
-                    min_position: min_pos,
-                    max_position: max_pos,
+                    kind: lc.kind.unwrap_or(LineKind::Linear {
+                        min: min_pos,
+                        max: max_pos,
+                    }),
                     max_cars: lc.max_cars,
                 },
             );

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -5,7 +5,7 @@
 //! points). Split out from `sim.rs` to keep each concern readable.
 
 use crate::components::Route;
-use crate::components::{Elevator, ElevatorPhase, Line, Position, Stop, Velocity};
+use crate::components::{Elevator, ElevatorPhase, Line, LineKind, Position, Stop, Velocity};
 use crate::dispatch::{BuiltinStrategy, DispatchStrategy, ElevatorGroup, LineInfo};
 use crate::door::DoorState;
 use crate::entity::EntityId;
@@ -260,8 +260,10 @@ impl Simulation {
                 group: group_id,
                 orientation: params.orientation,
                 position: params.position,
-                min_position: params.min_position,
-                max_position: params.max_position,
+                kind: params.kind.unwrap_or(LineKind::Linear {
+                    min: params.min_position,
+                    max: params.max_position,
+                }),
                 max_cars: params.max_cars,
             },
         );
@@ -316,8 +318,27 @@ impl Simulation {
             .world
             .line_mut(line)
             .ok_or(SimError::LineNotFound(line))?;
-        line_ref.min_position = min;
-        line_ref.max_position = max;
+        // `set_line_range` is a Linear-only operation; loops have no
+        // endpoints to set. Reject early so callers don't silently mutate
+        // the wrong field on a Loop line.
+        match &mut line_ref.kind {
+            LineKind::Linear {
+                min: kmin,
+                max: kmax,
+            } => {
+                *kmin = min;
+                *kmax = max;
+            }
+            #[cfg(feature = "loop_lines")]
+            LineKind::Loop { .. } => {
+                return Err(SimError::InvalidConfig {
+                    field: "line.range",
+                    reason: "set_line_range is not valid on a Loop line; \
+                            change circumference via a future API instead"
+                        .to_string(),
+                });
+            }
+        }
 
         // Clamp any cars on this line whose position falls outside the new range.
         let car_ids: Vec<EntityId> = self

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -220,28 +220,20 @@ impl Simulation {
     /// # Errors
     ///
     /// Returns [`SimError::GroupNotFound`] if the specified group does not exist.
-    /// Returns [`SimError::InvalidConfig`] if `min_position` / `max_position`
-    /// is non-finite or `min_position > max_position` — broken bounds
-    /// would produce NaN positions on every car added to the line.
+    /// Returns [`SimError::InvalidConfig`] for malformed bounds —
+    /// non-finite `min`/`max` or `min > max` on a `Linear` line, or
+    /// non-finite / non-positive `circumference` on a `Loop` line.
     pub fn add_line(&mut self, params: &LineParams) -> Result<EntityId, SimError> {
-        if !params.min_position.is_finite() || !params.max_position.is_finite() {
-            return Err(SimError::InvalidConfig {
-                field: "line.range",
-                reason: format!(
-                    "min/max must be finite (got min={}, max={})",
-                    params.min_position, params.max_position
-                ),
-            });
-        }
-        if params.min_position > params.max_position {
-            return Err(SimError::InvalidConfig {
-                field: "line.range",
-                reason: format!(
-                    "min ({}) must be <= max ({})",
-                    params.min_position, params.max_position
-                ),
-            });
-        }
+        // Resolve the requested kind; flat fields are the fallback only
+        // when no explicit kind was provided. Validation runs against
+        // the *resolved* kind so callers passing an explicit Loop don't
+        // get a spurious flat-field complaint.
+        let kind = params.kind.unwrap_or(LineKind::Linear {
+            min: params.min_position,
+            max: params.max_position,
+        });
+        kind.validate()
+            .map_err(|(field, reason)| SimError::InvalidConfig { field, reason })?;
 
         let group_id = params.group;
         let group = self
@@ -260,10 +252,7 @@ impl Simulation {
                 group: group_id,
                 orientation: params.orientation,
                 position: params.position,
-                kind: params.kind.unwrap_or(LineKind::Linear {
-                    min: params.min_position,
-                    max: params.max_position,
-                }),
+                kind,
                 max_cars: params.max_cars,
             },
         );

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -9,8 +9,8 @@
 //! to register types and materialize the data.
 
 use crate::components::{
-    AccessControl, CarCall, DestinationQueue, Elevator, HallCall, Line, Patience, Position,
-    Preferences, Rider, Route, Stop, Velocity,
+    AccessControl, CarCall, DestinationQueue, Elevator, HallCall, Line, LineKind, Patience,
+    Position, Preferences, Rider, Route, Stop, Velocity,
 };
 use crate::entity::EntityId;
 use crate::ids::GroupId;
@@ -471,8 +471,10 @@ impl WorldSnapshot {
                         group: group_id,
                         orientation: crate::components::Orientation::Vertical,
                         position: None,
-                        min_position: if min_pos.is_finite() { min_pos } else { 0.0 },
-                        max_position: if max_pos.is_finite() { max_pos } else { 0.0 },
+                        kind: LineKind::Linear {
+                            min: if min_pos.is_finite() { min_pos } else { 0.0 },
+                            max: if max_pos.is_finite() { max_pos } else { 0.0 },
+                        },
                         max_cars: None,
                     },
                 );

--- a/crates/elevator-core/src/tests/builder_tests.rs
+++ b/crates/elevator-core/src/tests/builder_tests.rs
@@ -225,6 +225,7 @@ fn from_config_honours_config_group_dispatch() {
                 position: None,
                 min_position: None,
                 max_position: None,
+                kind: None,
                 max_cars: None,
             }]),
             groups: Some(vec![GroupConfig {
@@ -313,6 +314,7 @@ fn from_config_dispatch_override_records_dispatcher_identity() {
                 position: None,
                 min_position: None,
                 max_position: None,
+                kind: None,
                 max_cars: None,
             }]),
             groups: Some(vec![GroupConfig {

--- a/crates/elevator-core/src/tests/config_tests.rs
+++ b/crates/elevator-core/src/tests/config_tests.rs
@@ -227,6 +227,7 @@ fn rejects_empty_line_serves() {
         position: None,
         min_position: None,
         max_position: None,
+        kind: None,
         max_cars: None,
     }]);
     let result = crate::sim::Simulation::new(&config, helpers::scan());

--- a/crates/elevator-core/src/tests/destination_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/destination_dispatch_tests.rs
@@ -147,6 +147,7 @@ fn two_cars_same_group_config() -> SimConfig {
                 position: None,
                 min_position: None,
                 max_position: None,
+                kind: None,
                 max_cars: None,
             }]),
             groups: Some(vec![GroupConfig {

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -458,6 +458,7 @@ fn pin_across_lines_is_rejected() {
             position: None,
             min_position: None,
             max_position: None,
+            kind: None,
             max_cars: None,
         },
         LineConfig {
@@ -469,6 +470,7 @@ fn pin_across_lines_is_rejected() {
             position: None,
             min_position: None,
             max_position: None,
+            kind: None,
             max_cars: None,
         },
     ]);
@@ -674,6 +676,7 @@ fn group_config_wires_hall_call_mode_and_ack_latency() {
         position: None,
         min_position: None,
         max_position: None,
+        kind: None,
         max_cars: None,
     }]);
     config.building.groups = Some(vec![GroupConfig {

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -75,6 +75,7 @@ fn two_group_config() -> SimConfig {
                     position: None,
                     min_position: None,
                     max_position: None,
+                    kind: None,
                     max_cars: None,
                 },
                 LineConfig {
@@ -105,6 +106,7 @@ fn two_group_config() -> SimConfig {
                     position: None,
                     min_position: None,
                     max_position: None,
+                    kind: None,
                     max_cars: None,
                 },
             ]),
@@ -187,6 +189,7 @@ fn overlapping_groups_config() -> SimConfig {
                     position: None,
                     min_position: None,
                     max_position: None,
+                    kind: None,
                     max_cars: None,
                 },
                 LineConfig {
@@ -217,6 +220,7 @@ fn overlapping_groups_config() -> SimConfig {
                     position: None,
                     min_position: None,
                     max_position: None,
+                    kind: None,
                     max_cars: None,
                 },
             ]),
@@ -326,8 +330,8 @@ fn line_component_orientation_and_bounds_set_from_config() {
 
     assert_eq!(line_comp.orientation(), Orientation::Vertical);
     // Auto-computed from serves: Ground=0.0, Transfer=10.0
-    assert!((line_comp.min_position() - 0.0).abs() < 1e-9);
-    assert!((line_comp.max_position() - 10.0).abs() < 1e-9);
+    assert!((line_comp.linear_min().unwrap() - 0.0).abs() < 1e-9);
+    assert!((line_comp.linear_max().unwrap() - 10.0).abs() < 1e-9);
 }
 
 // ── 2. Auto-infer backwards compat ───────────────────────────────────────────
@@ -645,6 +649,7 @@ fn line_pinned_rider_boards_only_specified_line_elevator() {
                     position: None,
                     min_position: None,
                     max_position: None,
+                    kind: None,
                     max_cars: None,
                 },
                 LineConfig {
@@ -675,6 +680,7 @@ fn line_pinned_rider_boards_only_specified_line_elevator() {
                     position: None,
                     min_position: None,
                     max_position: None,
+                    kind: None,
                     max_cars: None,
                 },
             ]),
@@ -968,6 +974,7 @@ fn reachable_stops_from_isolated_stop_returns_empty() {
                 position: None,
                 min_position: None,
                 max_position: None,
+                kind: None,
                 max_cars: None,
             }]),
             groups: Some(vec![GroupConfig {
@@ -1121,6 +1128,7 @@ fn shortest_route_returns_none_for_unreachable_stop() {
                     position: None,
                     min_position: None,
                     max_position: None,
+                    kind: None,
                     max_cars: None,
                 },
                 LineConfig {
@@ -1151,6 +1159,7 @@ fn shortest_route_returns_none_for_unreachable_stop() {
                     position: None,
                     min_position: None,
                     max_position: None,
+                    kind: None,
                     max_cars: None,
                 },
             ]),
@@ -1311,6 +1320,7 @@ fn no_elevators_in_any_line_fails_validation() {
                 position: None,
                 min_position: None,
                 max_position: None,
+                kind: None,
                 max_cars: None,
             }]),
             groups: None,
@@ -1877,6 +1887,7 @@ fn reassign_elevator_to_line_at_max_cars_returns_error() {
                     position: None,
                     min_position: None,
                     max_position: None,
+                    kind: None,
                     max_cars: None,
                 },
                 LineConfig {
@@ -1907,6 +1918,7 @@ fn reassign_elevator_to_line_at_max_cars_returns_error() {
                     position: None,
                     min_position: None,
                     max_position: None,
+                    kind: None,
                     max_cars: Some(1), // already full
                 },
             ]),
@@ -2063,6 +2075,7 @@ fn max_cars_exactly_met_at_config_time_succeeds() {
                 position: None,
                 min_position: None,
                 max_position: None,
+                kind: None,
                 max_cars: Some(2),
             }]),
             groups: None,
@@ -2153,6 +2166,7 @@ fn max_cars_exceeded_at_config_time_fails_validation() {
                 position: None,
                 min_position: None,
                 max_position: None,
+                kind: None,
                 max_cars: Some(1),
             }]),
             groups: None,
@@ -2227,6 +2241,7 @@ fn runtime_add_elevator_to_line_at_max_cars_returns_error() {
                 position: None,
                 min_position: None,
                 max_position: None,
+                kind: None,
                 max_cars: Some(1),
             }]),
             groups: None,
@@ -2324,6 +2339,7 @@ fn three_group_config() -> SimConfig {
                     position: None,
                     min_position: None,
                     max_position: None,
+                    kind: None,
                     max_cars: None,
                 },
                 LineConfig {
@@ -2354,6 +2370,7 @@ fn three_group_config() -> SimConfig {
                     position: None,
                     min_position: None,
                     max_position: None,
+                    kind: None,
                     max_cars: None,
                 },
                 LineConfig {
@@ -2384,6 +2401,7 @@ fn three_group_config() -> SimConfig {
                     position: None,
                     min_position: None,
                     max_position: None,
+                    kind: None,
                     max_cars: None,
                 },
             ]),
@@ -2916,6 +2934,7 @@ fn orphan_line_not_referenced_by_any_group_fails_validation() {
                     position: None,
                     min_position: None,
                     max_position: None,
+                    kind: None,
                     max_cars: None,
                 },
                 LineConfig {
@@ -2946,6 +2965,7 @@ fn orphan_line_not_referenced_by_any_group_fails_validation() {
                     position: None,
                     min_position: None,
                     max_position: None,
+                    kind: None,
                     max_cars: None,
                 },
             ]),
@@ -3436,6 +3456,7 @@ fn dispatch_does_not_assign_car_to_stop_its_line_does_not_serve() {
                     position: None,
                     min_position: None,
                     max_position: None,
+                    kind: None,
                     max_cars: None,
                 },
                 LineConfig {
@@ -3464,6 +3485,7 @@ fn dispatch_does_not_assign_car_to_stop_its_line_does_not_serve() {
                     position: None,
                     min_position: None,
                     max_position: None,
+                    kind: None,
                     max_cars: None,
                 },
             ]),
@@ -3598,6 +3620,7 @@ fn loading_resolves_co_located_stops_to_the_cars_own_line() {
                     position: None,
                     min_position: None,
                     max_position: None,
+                    kind: None,
                     max_cars: None,
                 },
                 LineConfig {
@@ -3626,6 +3649,7 @@ fn loading_resolves_co_located_stops_to_the_cars_own_line() {
                     position: None,
                     min_position: None,
                     max_position: None,
+                    kind: None,
                     max_cars: None,
                 },
             ]),

--- a/crates/elevator-core/tests/scenarios/common/mod.rs
+++ b/crates/elevator-core/tests/scenarios/common/mod.rs
@@ -109,6 +109,7 @@ pub fn twin_shaft_building() -> SimConfig {
         position: None,
         min_position: None,
         max_position: None,
+        kind: None,
         max_cars: None,
     };
 

--- a/crates/elevator-core/tests/scenarios/single_call_single_car.rs
+++ b/crates/elevator-core/tests/scenarios/single_call_single_car.rs
@@ -209,6 +209,7 @@ fn twin_shaft_sim() -> Simulation {
         position: None,
         min_position: None,
         max_position: None,
+        kind: None,
         max_cars: None,
     };
     let config = SimConfig {

--- a/crates/elevator-wasm/src/world_view.rs
+++ b/crates/elevator-wasm/src/world_view.rs
@@ -286,8 +286,15 @@ fn build_topology(
                 id: entity_to_u64(line_eid),
                 group: group_id,
                 name: line.name().to_string(),
-                min_position: line.min_position(),
-                max_position: line.max_position(),
+                // Loop lines (gated behind the `loop_lines` feature) report
+                // `[0, circumference]` here so existing playground rendering
+                // doesn't blow up; tsified `LineView` will gain a kind field
+                // when loop support reaches the host wiring PR.
+                min_position: line.linear_min().unwrap_or(0.0),
+                max_position: line
+                    .linear_max()
+                    .or_else(|| line.circumference())
+                    .unwrap_or(0.0),
                 stop_ids: line_info
                     .serves()
                     .iter()

--- a/docs/plans/loop-lines-v1.md
+++ b/docs/plans/loop-lines-v1.md
@@ -1,0 +1,260 @@
+# Loop Lines v1 — Design Plan
+
+Closed-loop transit support (trains, monorails, gondolas, people-movers) for `elevator-core`.
+All work ships behind the `loop_lines` cargo feature (default off).
+
+## Status
+
+| PR | Title | Status |
+|----|-------|--------|
+| 1 | `LineKind` foundation + cyclic distance | in progress |
+| 2 | Movement seam-split + headway clamp | not started |
+| 3 | Phase adaptations + strict validation | not started |
+| 4 | `LoopSweep` dispatch | not started |
+| 5 | `LoopSchedule` dispatch | not started |
+| 6 | Demo scenario + host wiring | not started |
+
+## Locked decisions
+
+| Topic | Decision |
+|---|---|
+| Use case | Any closed-loop transit |
+| Direction | One-way only (bidirectional out of scope for v1) |
+| Topology | `LineKind { Linear { min, max }, Loop { circumference, min_headway } }` on `Line` |
+| Multi-car coordination | Strict no-overtake cyclic ordering, soft headway clamp |
+| Position math | Normalized to `[0, circumference)`; tick_movement seam-splits |
+| Direction lamps | New `Direction::Forward` variant + `going_forward: bool` field on `Elevator` |
+| Hall calls | `HallCall` shape unchanged; loop stops emit with constant `Up` direction |
+| Routes | Unchanged shape; loop boarding ignores leg-direction predicate |
+| Multi-lap riders | Allowed; ETA uses forward cyclic distance |
+| Doors | Existing FSM reused; on Loop, `DoorClosing` → `MovingToStop(next)` |
+| Idle behavior | Continuous patrol — Loop cars never enter `Idle` |
+| Reposition phase | No-op on Loop lines |
+| Group homogeneity | Enforced at construction (all-Linear or all-Loop) |
+| Default dispatch on Loop | `LoopSweep` (call-driven) |
+| `LoopSchedule` shape | Pure headway with hold-at-stop recovery if running ahead |
+| Hall-call assignment on Loop | Hint only — any car may board waiters |
+| `OutOfService` on Loop | Rejected at runtime if car has followers (v1 limit) |
+| Manual mode + headway | Manual velocity is also clamped by headway |
+| `bypass_load_pct` on Loop | New unified field; up/down thresholds disabled on Loop |
+| Spatial anchor on Loop | `Line::position` = loop center; hosts derive radius from circumference |
+| Stop ordering | Position-derived, mod C |
+| Snapshot wire format | Add `kind` as new field; keep flat `min_position`/`max_position` for one release |
+| Cargo feature scope | `elevator-core` only; hosts opt in |
+| Variant naming | `LineKind::Loop { circumference, min_headway }` |
+| Demo | `assets/config/loop_demo.ron` (PR 6) |
+| Quest scenario | Out of scope for v1 |
+
+## Out of scope for v1
+
+- Bidirectional loops
+- Pull-out-of-loop with follower retargeting (rejoin op)
+- Quest playground scenario
+- LoopSchedule timetable mode (headway-only in v1)
+- FFI / gdext support behind feature flag
+- Block signaling (fixed segments)
+
+---
+
+## PR 1 — `LineKind` foundation + cyclic distance helper
+
+**Branch:** `feat/loop-lines-foundation`
+
+### Scope
+
+1. New module `crates/elevator-core/src/components/cyclic.rs` exposing:
+   - `forward_distance(from: f64, to: f64, circumference: f64) -> f64` — non-negative cyclic forward distance.
+   - `cyclic_distance(a: f64, b: f64, circumference: f64) -> f64` — shortest unsigned cyclic distance.
+   - `wrap_position(p: f64, circumference: f64) -> f64` — normalize into `[0, C)`.
+2. New `LineKind` enum on `Line`:
+   ```rust
+   #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+   #[non_exhaustive]
+   pub enum LineKind {
+       Linear { min: f64, max: f64 },
+       #[cfg(feature = "loop_lines")]
+       Loop { circumference: f64, min_headway: f64 },
+   }
+   ```
+3. `Line` struct: replace flat `min_position` / `max_position` fields with `kind: LineKind`.
+4. Accessor rename:
+   - `Line::min_position()` → `Line::linear_min() -> Option<f64>`
+   - `Line::max_position()` → `Line::linear_max() -> Option<f64>`
+   - new `Line::circumference() -> Option<f64>`
+   - new `Line::min_headway() -> Option<f64>`
+   - new `Line::kind() -> &LineKind`
+5. Snapshot transitional dual-field: serialize `kind` always; also serialize `min_position`/`max_position` derived from `kind` for one release. Custom `Deserialize` on `Line` accepts either shape — if `kind` present, prefer it; otherwise reconstruct `Linear { min, max }` from flat fields.
+6. Loop variant rejected at deserialize time when `loop_lines` feature is off (`SimError::InvalidConfig`).
+7. RON config: add a new optional `kind` field on `LineConfig`. Existing configs continue to use `min_position`/`max_position` — back-compat via Default.
+8. `bindings.toml`: rename `min_position`/`max_position`, add `circumference`, `kind`, `min_headway`.
+9. Doctests + unit tests for `cyclic.rs`, `LineKind`, accessor behavior on each variant, snapshot round-trip (old and new shapes).
+10. CHANGELOG entry: rename note + new `kind` accessor.
+
+### Out of scope for PR 1
+
+- Movement integrator changes (PR 2)
+- Construction-time Loop-specific validation (PR 3, except trivial `circumference > 0`)
+- Direction enum changes (PR 3)
+- Dispatch strategies (PR 4, 5)
+- RON demo scenarios (PR 6)
+
+### Files touched (estimate)
+
+- `crates/elevator-core/Cargo.toml` — add `loop_lines` feature
+- `crates/elevator-core/src/components/line.rs` — major
+- `crates/elevator-core/src/components/cyclic.rs` — new
+- `crates/elevator-core/src/components/mod.rs` — re-export
+- `crates/elevator-core/src/sim/topology.rs` — construction maps to `LineKind`
+- `crates/elevator-core/src/sim/construction.rs` — RON config handling
+- `crates/elevator-core/src/config.rs` — `LineConfig` accepts `kind`
+- `crates/elevator-core/src/sim.rs` — any callers of old accessors
+- `crates/elevator-core/src/snapshot.rs` — dual-field write, lenient read
+- `crates/elevator-core/src/lib.rs` — re-export `LineKind`
+- `crates/elevator-core/src/tests/...` — add coverage; update existing tests for renamed accessors
+- `bindings.toml` — accessor rename + new entries
+- `crates/elevator-core/CHANGELOG.md` — entry
+
+### Conventional commit
+
+`feat(elevator-core): add LineKind enum and cyclic distance helper`
+
+`#[non_exhaustive]` on `LineKind` makes future variant additions non-breaking.
+The accessor rename **is** breaking — call out in CHANGELOG and bump as `feat:` (not `feat!:`)
+because the old accessors are removed; downstream callers will see a compile error,
+which is the loud-failure pattern this codebase prefers.
+
+---
+
+## PR 2 — Movement seam-split + headway clamp
+
+**Branch:** `feat/loop-lines-movement` (off main, after PR 1 merges)
+
+### Scope
+- Extend `tick_movement` in `crates/elevator-core/src/movement.rs` (or wrap it in a new
+  `tick_movement_cyclic`) to handle seam-crossing: split a tick that would jump past
+  position 0 into two segments and apply each to keep `position ∈ [0, C)`.
+- Implement soft headway clamp: a Loop trailer's effective target = `min(intended,
+  forward_distance(trailer, leader) - min_headway)` in cyclic space.
+- Manual-mode velocity also clamped by headway.
+- Construction validates `max_cars * min_headway <= circumference`.
+- Property test (10k randomized ticks): `forward_distance(car_n, car_n+1) >= min_headway`
+  always holds.
+- `debug_assert!` inside the clamp.
+
+### Conventional commit
+`feat(elevator-core): cyclic movement and headway clamping for loop lines`
+
+---
+
+## PR 3 — Phase adaptations + strict construction validation
+
+**Branch:** `feat/loop-lines-phases`
+
+### Scope
+- New `Direction::Forward` variant.
+- New `going_forward: bool` field on `Elevator` (defaults `false` for Linear, `true` for
+  forward-moving Loop cars). Auto-managed by dispatch.
+- Door FSM: on Loop, after `DoorClosing` transition to `MovingToStop(next_stop)` instead
+  of `Stopped`.
+- `Repositioning` phase: early-return on Loop lines.
+- Boarding code: bypass directional gating when line kind is Loop.
+- Strict construction validation in `sim/construction.rs` and `sim/topology.rs`
+  — every Loop-related rejection consolidated:
+  - `home_stop` set on a Loop-line car → reject
+  - non-`None` reposition strategy on a Loop group → reject
+  - mixed Linear+Loop in one group → reject
+  - 0 stops or duplicate-position stops on a Loop → reject
+  - `min_headway <= 0` or `circumference <= 0` → reject
+  - initial car spacing < `min_headway` → reject
+- New `bypass_load_pct: Option<f64>` field on `Elevator`; existing
+  `bypass_load_up_pct`/`bypass_load_down_pct` ignored on Loop (logged at debug).
+- `OutOfService` runtime guard: return `SimError::OutOfServiceWouldBlockLoop` if Loop
+  car has followers.
+
+### Conventional commit
+`feat(elevator-core): direction forward variant and loop phase semantics`
+
+---
+
+## PR 4 — `LoopSweep` dispatch
+
+**Branch:** `feat/loop-lines-sweep`
+
+### Scope
+- New `dispatch/loop_sweep.rs` strategy: cars patrol forward, board every waiter at
+  every stop arrival. Default for Loop groups.
+- Group construction defaults to `LoopSweep` when strategy unspecified on a Loop group.
+- `assigned_cars_by_line` becomes a hint on Loop — boarding code does not gate on it.
+- New public methods on `Simulation`:
+  - `loop_circumference(line: LineId) -> Option<f64>`
+  - `loop_next_stop(line: LineId, position: f64) -> Option<StopId>`
+  - `is_loop(line: LineId) -> bool`
+- `bindings.toml` entries for new methods.
+- Tests: a 3-car loop scenario serving randomized hall calls; assert all riders
+  delivered, headway invariant holds.
+
+### Conventional commit
+`feat(elevator-core): loop sweep dispatch strategy`
+
+---
+
+## PR 5 — `LoopSchedule` dispatch
+
+**Branch:** `feat/loop-lines-schedule`
+
+### Scope
+- New `dispatch/loop_schedule.rs` strategy:
+  ```rust
+  LoopSchedule {
+      dwell_ticks: u32,
+      target_headway_ticks: u32,
+  }
+  ```
+- Cars dwell exactly `dwell_ticks` per stop, then depart.
+- Hold-recovery: if a car is running *ahead* of `target_headway_ticks` relative to the
+  preceding car, extend its dwell at the current stop until the headway gap is restored
+  (or up to a documented cap to prevent indefinite hold).
+- Bunching under load is documented as a known v1 limitation.
+- Tests: synthetic scenario where one car is artificially delayed; verify followers do
+  *not* hold-recover by accelerating (we never overtake).
+
+### Conventional commit
+`feat(elevator-core): loop schedule dispatch with hold-recovery`
+
+---
+
+## PR 6 — Demo scenario + host wiring
+
+**Branch:** `feat/loop-lines-demo`
+
+### Scope
+- `assets/config/loop_demo.ron` — one loop, 4 stops, 2–3 cars. RON loader gates the
+  scenario behind `loop_lines` feature.
+- `elevator-bevy` host: enable feature, add minimal circular rendering using
+  `Line::circumference()` + `Line::position()` (anchor as center).
+- `elevator-tui` host: enable feature, render loop as horizontal strip with seam markers.
+- `elevator-wasm` host: enable feature; tsify auto-derives `LineKind` into TypeScript.
+  Playground reads it but does not yet add a Quest scenario.
+- mdbook chapter: `docs/src/loop-lines.md` with config example + diagram.
+
+### Conventional commit
+`feat: loop lines demo scenario and host wiring`
+
+---
+
+## Determinism strategy
+
+- `kind` always serialized regardless of feature flag.
+- With `loop_lines` off, `LineKind::Loop` is rejected at deserialize.
+- `elevator-contract` runs the harness with both feature configurations and asserts
+  identical snapshots for shared (Linear-only) scenarios.
+- Property test in PR 2 asserts cyclic-ordering invariant under randomized motion.
+
+## Risk hot-spots for review
+
+- **PR 1 snapshot dual-field migration** — old snapshot deserializing with
+  inconsistent `kind` vs flat fields is a deterministic-divergence bug surface.
+- **PR 2 cyclic motion + headway clamp** under all velocity edge cases (opposing,
+  near-zero, manual override).
+- **PR 4 assignment-as-hint** changes existing dispatch contract on Loop groups —
+  must not regress Linear behavior.


### PR DESCRIPTION
## Summary

First PR in the loop-lines work-stream — see `docs/plans/loop-lines-v1.md` for the full multi-PR design.

This PR introduces the topology distinction (Linear vs Loop) and the cyclic-distance primitives, **without changing any runtime behavior**. The `Loop` variant is gated behind a new `loop_lines` cargo feature (default off) and is rejected at deserialize when the feature is off, so every existing scenario continues to operate exactly as before.

### What ships

- `LineKind { Linear { min, max }, Loop { circumference, min_headway } }` on `Line`, replacing the flat `min_position` / `max_position` fields.
- New accessors: `kind()`, `linear_min() -> Option<f64>`, `linear_max() -> Option<f64>`, `circumference() -> Option<f64>`, `min_headway() -> Option<f64>`, `is_loop()`. The old `min_position()` / `max_position()` are removed — callers now decide explicitly whether they want Linear-only behavior or want to handle loops.
- `components::cyclic` module: `wrap_position`, `forward_distance`, `cyclic_distance`. These are the foundation PR 2 (movement) and PR 4 (dispatch) build on.
- `LineConfig::kind` and `LineParams::kind` are opt-in `Option<LineKind>` fields; when `None`, legacy flat-field behavior is preserved bit-for-bit.

### Snapshot strategy

Custom serde via a private `LineWire` shape. `Line` *always* emits `kind` **and** derived `min_position` / `max_position` flat fields for one release of forward-compat. On deserialize, `kind` is preferred; if absent, `Linear { min, max }` is reconstructed from the flat fields. This means:
- Snapshots written by older builds deserialize cleanly here.
- Snapshots from this build can still be inspected by older tooling.
- Once consumers have migrated, the flat fields are removed in a follow-up release.

### Strict guard added

`Simulation::set_line_range` now returns `SimError::InvalidConfig` when called on a Loop line — loops have no endpoints to set. Linear behavior is unchanged.

### Out of scope (future PRs)

- Movement seam-split + headway clamp (PR 2)
- Direction::Forward, door/idle/reposition adaptations, strict construction validation (PR 3)
- LoopSweep dispatch + new `Simulation::loop_*` methods (PR 4)
- LoopSchedule dispatch with hold-recovery (PR 5)
- Demo scenario + Bevy/TUI/wasm host wiring (PR 6)

## Test plan

- [x] `cargo test -p elevator-core --all-features` (1008 lib + 175 doctests + scenarios)
- [x] `cargo clippy -p elevator-core --all-features --all-targets -- -D warnings`
- [x] `cargo check --workspace --all-features --all-targets`
- [x] `scripts/check-bindings.sh` (148 methods in sync)
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p elevator-bevy --doc`
- [x] Pre-commit hook (fmt, clippy, tests, doctests, workspace check, docs lint, ABI pin check)
- [ ] Greptile review