### PR TITLE
feat(elevator-core): wire cyclic motion into the movement systems phase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "20.5.0"
+version = "20.6.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/systems/movement.rs
+++ b/crates/elevator-core/src/systems/movement.rs
@@ -202,9 +202,17 @@ pub fn run(
             v.value = result.velocity;
         }
 
-        // Track repositioning distance.
+        // Track repositioning distance. On a Loop line a tick that wraps
+        // through the seam has `new_pos < old_pos` even though the car
+        // travelled forward; the chord `(new - old).abs()` would record
+        // `circumference - arc` instead of the actual arc travelled.
+        // Compute via forward cyclic distance when a circumference is
+        // present so the metric tracks the *real* path.
         if is_repositioning {
-            let dist = (new_pos - old_pos).abs();
+            let dist = circumference.map_or_else(
+                || (new_pos - old_pos).abs(),
+                |c| crate::components::cyclic::forward_distance(old_pos, new_pos, c),
+            );
             if dist > 0.0 {
                 metrics.record_reposition_distance(dist);
             }
@@ -226,14 +234,27 @@ pub fn run(
             // sign-of-displacement rule still holds.
             let moving_up = circumference.is_some() || new_pos > old_pos;
 
-            let emit_range = |lo: f64, hi: f64, world_ref: &World, events_ref: &mut EventBus| {
+            // `inclusive_lo = true` includes a stop at exactly `lo` in the
+            // emitted range. The seam-crossing case uses this for the
+            // wrap-around segment `[0, new_pos)`: the car physically
+            // sweeps through position 0, so a stop sitting there should
+            // fire `PassingFloor`. The default exclusive form is used for
+            // the linear case and the seam's pre-wrap segment, where `lo`
+            // is the position the car *left* this tick and would
+            // double-count if included.
+            let emit_range = |lo: f64,
+                              hi: f64,
+                              inclusive_lo: bool,
+                              world_ref: &World,
+                              events_ref: &mut EventBus| {
                 if hi <= lo + 1e-9 {
                     return 0u64;
                 }
                 let Some(sorted) = world_ref.resource::<SortedStops>() else {
                     return 0;
                 };
-                let start = sorted.0.partition_point(|&(p, _)| p <= lo + 1e-9);
+                let lo_threshold = if inclusive_lo { lo - 1e-9 } else { lo + 1e-9 };
+                let start = sorted.0.partition_point(|&(p, _)| p <= lo_threshold);
                 let end = sorted.0.partition_point(|&(p, _)| p < hi - 1e-9);
                 let mut count = 0;
                 for &(_, stop_eid) in &sorted.0[start..end] {
@@ -253,15 +274,18 @@ pub fn run(
 
             if crossed_seam {
                 let c = circumference.unwrap_or(0.0);
-                passing_moves += emit_range(old_pos, c, world, events);
-                passing_moves += emit_range(0.0, new_pos, world, events);
+                // Pre-wrap: car was at `old_pos`, exclude it.
+                passing_moves += emit_range(old_pos, c, false, world, events);
+                // Post-wrap: car physically crossed position 0 forward,
+                // so include a stop sitting there.
+                passing_moves += emit_range(0.0, new_pos, true, world, events);
             } else {
                 let (lo, hi) = if moving_up {
                     (old_pos, new_pos)
                 } else {
                     (new_pos, old_pos)
                 };
-                passing_moves += emit_range(lo, hi, world, events);
+                passing_moves += emit_range(lo, hi, false, world, events);
             }
         }
         if passing_moves > 0 {

--- a/crates/elevator-core/src/systems/movement.rs
+++ b/crates/elevator-core/src/systems/movement.rs
@@ -6,6 +6,8 @@ use crate::entity::EntityId;
 use crate::events::{Event, EventBus};
 use crate::metrics::Metrics;
 use crate::movement::tick_movement;
+#[cfg(feature = "loop_lines")]
+use crate::movement::tick_movement_cyclic;
 use crate::world::{SortedStops, World};
 
 use super::PhaseContext;
@@ -133,6 +135,53 @@ pub fn run(
             "ElevatorPhase::Repositioning and car.repositioning flag diverged at eid={eid:?}"
         );
 
+        // Loop cars use cyclic motion: position wraps modulo the line's
+        // circumference, the integrator picks the forward path to the
+        // target, and seam-crossings (old_pos > new_pos within a single
+        // tick) are emitted in two passing-floor ranges below. Linear
+        // cars take the existing trapezoidal-on-axis path.
+        #[cfg(feature = "loop_lines")]
+        let circumference = world
+            .line(
+                world
+                    .elevator(eid)
+                    .map_or_else(EntityId::default, |c| c.line),
+            )
+            .and_then(crate::components::Line::circumference);
+        // Mirrored unconditional binding so the seam-aware passing-floor
+        // logic below (which is itself unconditional, just behaviourally
+        // a no-op without a `circumference`) compiles on either feature
+        // configuration.
+        #[cfg(not(feature = "loop_lines"))]
+        let circumference: Option<f64> = None;
+
+        #[cfg(feature = "loop_lines")]
+        #[allow(
+            clippy::option_if_let_else,
+            reason = "the two arms call different functions with different arities; map_or_else closures would just duplicate the eight-argument call"
+        )]
+        let result = match circumference {
+            Some(c) => tick_movement_cyclic(
+                pos,
+                vel,
+                target_pos,
+                max_speed,
+                acceleration,
+                deceleration,
+                ctx.dt,
+                c,
+            ),
+            None => tick_movement(
+                pos,
+                vel,
+                target_pos,
+                max_speed,
+                acceleration,
+                deceleration,
+                ctx.dt,
+            ),
+        };
+        #[cfg(not(feature = "loop_lines"))]
         let result = tick_movement(
             pos,
             vel,
@@ -163,29 +212,56 @@ pub fn run(
 
         // Emit PassingFloor for any stops crossed between old and new position
         // (excluding the target stop — that gets an ElevatorArrived instead).
+        //
+        // On a Loop line a single tick can cross the seam: `old_pos > new_pos`
+        // even though we travelled forward. In that case the swept range is
+        // `[old_pos, circumference) ∪ [0, new_pos)` rather than a single
+        // `[lo, hi)` interval, so we walk the sorted-stops index in two
+        // passes. Linear and Loop-without-seam ticks fall through to the
+        // single-pass path.
         let mut passing_moves: u64 = 0;
         if !result.arrived {
-            let moving_up = new_pos > old_pos;
-            let (lo, hi) = if moving_up {
-                (old_pos, new_pos)
-            } else {
-                (new_pos, old_pos)
-            };
-            if let Some(sorted) = world.resource::<SortedStops>() {
+            let crossed_seam = circumference.is_some() && new_pos < old_pos;
+            // Loop cars always patrol forward; otherwise the existing
+            // sign-of-displacement rule still holds.
+            let moving_up = circumference.is_some() || new_pos > old_pos;
+
+            let emit_range = |lo: f64, hi: f64, world_ref: &World, events_ref: &mut EventBus| {
+                if hi <= lo + 1e-9 {
+                    return 0u64;
+                }
+                let Some(sorted) = world_ref.resource::<SortedStops>() else {
+                    return 0;
+                };
                 let start = sorted.0.partition_point(|&(p, _)| p <= lo + 1e-9);
                 let end = sorted.0.partition_point(|&(p, _)| p < hi - 1e-9);
+                let mut count = 0;
                 for &(_, stop_eid) in &sorted.0[start..end] {
                     if stop_eid == target_stop_eid {
                         continue;
                     }
-                    events.emit(Event::PassingFloor {
+                    events_ref.emit(Event::PassingFloor {
                         elevator: eid,
                         stop: stop_eid,
                         moving_up,
                         tick: ctx.tick,
                     });
-                    passing_moves += 1;
+                    count += 1;
                 }
+                count
+            };
+
+            if crossed_seam {
+                let c = circumference.unwrap_or(0.0);
+                passing_moves += emit_range(old_pos, c, world, events);
+                passing_moves += emit_range(0.0, new_pos, world, events);
+            } else {
+                let (lo, hi) = if moving_up {
+                    (old_pos, new_pos)
+                } else {
+                    (new_pos, old_pos)
+                };
+                passing_moves += emit_range(lo, hi, world, events);
             }
         }
         if passing_moves > 0 {

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -945,11 +945,13 @@ fn loop_next_stop_returns_forward_neighbour() {
 fn loop_car_traverses_seam_and_arrives() {
     use crate::components::{ElevatorPhase, LineKind};
 
-    // 4-stop loop at positions 0/25/50/75; circumference = 100.
+    // 3-stop loop at positions 0 / 25 / 50; circumference = 100.
     // Build a config with exactly one elevator on the loop, starting at
-    // stop @ 75. Manually set the car's phase to `MovingToStop(stop @
-    // 25)` so the only forward path crosses the seam — verifies the
-    // cyclic movement integration in `systems/movement.rs`.
+    // stop @ 50, and target stop @ 25. The forward cyclic path is
+    // 50 → 100 → 0 → 25 (75 units, crossing the seam) — verifies the
+    // cyclic movement integration in `systems/movement.rs` as well as
+    // the seam-aware PassingFloor split (the stop at position 0 must
+    // fire its event during the wrap segment).
     let mut config = two_group_config();
     {
         let stops = &mut config.building.stops;
@@ -993,7 +995,16 @@ fn loop_car_traverses_seam_and_arrives() {
     // Step until arrival or a generous bound. With max_speed 2 and
     // accel/decel 1.5/2 and dt=1/60, 75 units ≈ 38 seconds = 2280
     // ticks — pad to 5000.
+    // Resolve the stop @ 0 entity — we'll watch for its PassingFloor.
+    let stop_zero = sim
+        .world()
+        .iter_stops()
+        .find(|(_, s)| s.position.abs() < 1e-9)
+        .map(|(eid, _)| eid)
+        .unwrap();
+
     let mut crossed_seam = false;
+    let mut saw_stop_zero_pass = false;
     let mut prev_pos = sim.world().position(car_eid).unwrap().value;
     let mut arrived = false;
     for _ in 0..5000 {
@@ -1005,6 +1016,13 @@ fn loop_car_traverses_seam_and_arrives() {
             crossed_seam = true;
         }
         prev_pos = current_pos;
+        for ev in sim.drain_events() {
+            if let crate::events::Event::PassingFloor { stop, .. } = ev
+                && stop == stop_zero
+            {
+                saw_stop_zero_pass = true;
+            }
+        }
         if matches!(
             sim.world().elevator(car_eid).unwrap().phase,
             ElevatorPhase::DoorOpening
@@ -1020,6 +1038,10 @@ fn loop_car_traverses_seam_and_arrives() {
     assert!(
         crossed_seam,
         "expected the cyclic movement integrator to wrap past the seam",
+    );
+    assert!(
+        saw_stop_zero_pass,
+        "expected PassingFloor for the stop at position 0 during seam crossing",
     );
     assert!(
         arrived,

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -942,6 +942,98 @@ fn loop_next_stop_returns_forward_neighbour() {
 
 #[cfg(feature = "loop_lines")]
 #[test]
+fn loop_car_traverses_seam_and_arrives() {
+    use crate::components::{ElevatorPhase, LineKind};
+
+    // 4-stop loop at positions 0/25/50/75; circumference = 100.
+    // Build a config with exactly one elevator on the loop, starting at
+    // stop @ 75. Manually set the car's phase to `MovingToStop(stop @
+    // 25)` so the only forward path crosses the seam — verifies the
+    // cyclic movement integration in `systems/movement.rs`.
+    let mut config = two_group_config();
+    {
+        let stops = &mut config.building.stops;
+        stops[0].position = 0.0;
+        stops[1].position = 25.0;
+        stops[2].position = 50.0;
+    }
+    if let Some(lines) = config.building.lines.as_mut() {
+        lines[0].kind = Some(LineKind::Loop {
+            circumference: 100.0,
+            min_headway: 5.0,
+        });
+        lines[0].serves = vec![StopId(0), StopId(1), StopId(2)];
+        // Move the elevator's starting stop to one *behind* the target
+        // in linear coords so cyclic semantics are exercised.
+        lines[0].elevators[0].starting_stop = StopId(2); // position 50
+    }
+    if let Some(groups) = config.building.groups.as_mut() {
+        groups[0].lines = vec![1];
+        groups.remove(1);
+    }
+    config.building.lines.as_mut().unwrap().truncate(1);
+
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+    let car_eid = sim.world().iter_elevators().next().unwrap().0;
+
+    // Resolve target stop entity by config id.
+    let stop_25 = sim
+        .world()
+        .iter_stops()
+        .find(|(_, s)| (s.position - 25.0).abs() < 1e-9)
+        .map(|(eid, _)| eid)
+        .unwrap();
+
+    // Push a destination so the per-tick `advance_queue` phase doesn't
+    // reset the manually-set MovingToStop back to Idle. The car still
+    // moves under the cyclic integrator because its line is a Loop.
+    sim.push_destination(ElevatorId::from(car_eid), stop_25)
+        .expect("push destination on loop car");
+
+    // Step until arrival or a generous bound. With max_speed 2 and
+    // accel/decel 1.5/2 and dt=1/60, 75 units ≈ 38 seconds = 2280
+    // ticks — pad to 5000.
+    let mut crossed_seam = false;
+    let mut prev_pos = sim.world().position(car_eid).unwrap().value;
+    let mut arrived = false;
+    for _ in 0..5000 {
+        sim.step();
+        let current_pos = sim.world().position(car_eid).unwrap().value;
+        // Seam crossing on a forward-moving Loop car: new_pos < old_pos
+        // mid-trip.
+        if current_pos < prev_pos - 1e-9 {
+            crossed_seam = true;
+        }
+        prev_pos = current_pos;
+        if matches!(
+            sim.world().elevator(car_eid).unwrap().phase,
+            ElevatorPhase::DoorOpening
+                | ElevatorPhase::Loading
+                | ElevatorPhase::DoorClosing
+                | ElevatorPhase::Stopped
+        ) {
+            arrived = true;
+            break;
+        }
+    }
+
+    assert!(
+        crossed_seam,
+        "expected the cyclic movement integrator to wrap past the seam",
+    );
+    assert!(
+        arrived,
+        "loop car never reached the target stop within the tick budget",
+    );
+    let final_pos = sim.world().position(car_eid).unwrap().value;
+    assert!(
+        (final_pos - 25.0).abs() < 1e-6,
+        "loop car arrived at {final_pos}, expected 25.0",
+    );
+}
+
+#[cfg(feature = "loop_lines")]
+#[test]
 fn config_rejects_mixed_loop_and_linear_in_same_group() {
     use crate::components::LineKind;
     use crate::error::SimError;


### PR DESCRIPTION
## Summary

PR 5 of the loop-lines work-stream (see `docs/plans/loop-lines-v1.md`). Wires `tick_movement_cyclic` (PR 2) into `systems/movement.rs` so a Loop-line car observably patrols when stepped under `Simulation::step` — the first PR where the loop primitives produce visible runtime behaviour. Linear shafts continue to use the original `tick_movement` integrator unchanged; the dispatch is gated on the line entity's `circumference()` accessor, which is `None` for any non-Loop line.

### Loop-only behaviour

- **Per-tick movement** uses the cyclic integrator, wrapping through the seam without manual handling. Trapezoidal physics (opposing-direction, brake-distance, overshoot) stays shared between Linear and Loop because `tick_movement_cyclic` delegates to the linear integrator on a virtual axis.
- **PassingFloor emission** when a tick crosses the seam: the swept range is split into `[old_pos, circumference) ∪ [0, new_pos)` and stops in either segment fire `PassingFloor`. Linear and non-seam Loop ticks fall through to the existing single-pass partition.

### Test

`loop_car_traverses_seam_and_arrives` configures a 4-stop loop (circumference 100), starts a car at position 50 with target stop at position 25 (forward path goes 50 → 75 → 0 → 25, crossing the seam), and asserts:
- some tick yields `new_pos < old_pos` (seam crossing observable)
- the car arrives at exactly position 25 within a generous tick budget

The same setup under linear `tick_movement` would reject as a backwards step.

### Out of scope (subsequent PRs)

- Door-FSM continuation on Loop (`DoorClosing` → `MovingToStop(next)`)
- `Repositioning` no-op on Loop
- Boarding-phase directional-gate bypass on Loop
- `going_forward = true` runtime management
- Manual-mode headway clamp
- `LoopSweep` / `LoopSchedule` dispatch strategies

## Test plan

- [x] `cargo test -p elevator-core --all-features` (1036 lib + 175 doctests + scenarios)
- [x] `cargo clippy -p elevator-core --all-features --all-targets -- -D warnings`
- [x] `cargo run -p elevator-contract` (no golden churn — purely additive)
- [x] `cargo check --workspace --all-features --all-targets`
- [x] `cargo fmt --all --check`
- [ ] Greptile review