### PR TITLE
feat(elevator-core): loop FSM completion — door continuation, kickstart, boarding bypass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "20.6.0"
+version = "20.8.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/components/elevator.rs
+++ b/crates/elevator-core/src/components/elevator.rs
@@ -186,18 +186,11 @@ pub struct Elevator {
     /// On a [`LineKind::Loop`](crate::components::LineKind::Loop) line, the
     /// `Up`/`Down` lamp pair is meaningless; this lamp signals "actively
     /// patrolling forward around the loop". Linear cars always have
-    /// `going_forward = false`. Loop cars *will* have it set to `true`
-    /// while moving and `false` only when out of service or pulled from
-    /// the loop. Defaults to `false` so existing snapshots and Linear
-    /// cars are unaffected.
-    ///
-    /// **PR 3 status:** the field, the [`Direction::Forward`] variant, and
-    /// the precedence in [`Elevator::direction`] are all in place, but
-    /// no code path writes `going_forward = true` yet. The wiring lives
-    /// in PR 4 alongside `tick_movement_cyclic` integration in
-    /// `systems/movement.rs`. Until that lands, a Loop car constructed
-    /// via [`Simulation::new`](crate::sim::Simulation::new) will report
-    /// [`Direction::Either`] from `direction()`.
+    /// `going_forward = false`. Loop cars are kickstarted in the dispatch
+    /// phase and have it flipped to `true` once they begin patrol; the
+    /// door-FSM continuation keeps it set across each subsequent stop.
+    /// Defaults to `false` so existing snapshots and Linear cars are
+    /// unaffected.
     #[serde(default)]
     pub(crate) going_forward: bool,
     /// Count of rounded-floor transitions (passing-floors + arrivals).

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -769,6 +769,80 @@ pub fn elevator_line_serves_indexed<'a>(
     index.get(&line_eid).copied()
 }
 
+/// On a loop, the served stop that comes immediately *after* `position`
+/// in forward cyclic order.
+///
+/// Walks `served_stops`, computes the forward cyclic distance from
+/// `position` to each, and returns the entity with the smallest non-zero
+/// distance. A stop coincident with `position` is treated as a "full lap
+/// ahead" (returns `circumference` for that stop) so callers already at
+/// a stop never get the same stop back as "next" — they get the *next*
+/// distinct stop forward.
+///
+/// Returns `None` if `served_stops` is empty, every stop is missing a
+/// position component, or `position` / `circumference` is non-finite or
+/// non-positive. This is a building block shared by
+/// [`Simulation::loop_next_stop`](crate::sim::Simulation::loop_next_stop)
+/// and the door FSM's loop-continuation path so both pick the same stop
+/// when given the same inputs. Always available regardless of the
+/// `loop_lines` feature flag — `LineKind::Loop` deserialization rejects
+/// when the feature is off, so a Linear-only sim simply never reaches a
+/// caller with a positive `circumference`.
+#[must_use]
+pub fn loop_next_stop_forward(
+    world: &World,
+    circumference: f64,
+    served_stops: &[EntityId],
+    position: f64,
+) -> Option<EntityId> {
+    if !position.is_finite() || !circumference.is_finite() || circumference <= 0.0 {
+        return None;
+    }
+    if served_stops.is_empty() {
+        return None;
+    }
+
+    let mut best: Option<(f64, EntityId)> = None;
+    for &stop_eid in served_stops {
+        let Some(stop_pos) = world.stop_position(stop_eid) else {
+            continue;
+        };
+        let mut d = crate::components::cyclic::forward_distance(position, stop_pos, circumference);
+        if d <= 1e-9 {
+            d = circumference;
+        }
+        match best {
+            Some((d_best, _)) if d_best <= d => {}
+            _ => best = Some((d, stop_eid)),
+        }
+    }
+    best.map(|(_, eid)| eid)
+}
+
+/// Resolve the forward-next stop for a Loop car.
+///
+/// Returns `None` for Linear cars, missing line components, missing
+/// position components, and any `LineKind::Loop` whose served-stop list
+/// is empty (which construction validation rejects, so this is purely
+/// defensive). Shared between the dispatch kickstart and the door-FSM
+/// continuation path so both pick the same stop given identical world
+/// state.
+#[must_use]
+pub fn loop_next_stop_for_car(
+    world: &World,
+    groups: &[ElevatorGroup],
+    elevator: EntityId,
+) -> Option<EntityId> {
+    let car = world.elevator(elevator)?;
+    let line_eid = car.line();
+    let circumference = world
+        .line(line_eid)
+        .and_then(crate::components::Line::circumference)?;
+    let serves = elevator_line_serves(world, groups, elevator)?;
+    let position = world.position(elevator)?.value;
+    loop_next_stop_forward(world, circumference, serves, position)
+}
+
 /// Context passed to [`DispatchStrategy::rank`].
 ///
 /// Bundles the per-call arguments into a single struct so future context

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -789,7 +789,7 @@ pub fn elevator_line_serves_indexed<'a>(
 /// when the feature is off, so a Linear-only sim simply never reaches a
 /// caller with a positive `circumference`.
 #[must_use]
-pub fn loop_next_stop_forward(
+pub(crate) fn loop_next_stop_forward(
     world: &World,
     circumference: f64,
     served_stops: &[EntityId],
@@ -828,7 +828,7 @@ pub fn loop_next_stop_forward(
 /// continuation path so both pick the same stop given identical world
 /// state.
 #[must_use]
-pub fn loop_next_stop_for_car(
+pub(crate) fn loop_next_stop_for_car(
     world: &World,
     groups: &[ElevatorGroup],
     elevator: EntityId,

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -898,33 +898,9 @@ impl Simulation {
     /// `EntityId` despite the input being meaningless.
     #[must_use]
     pub fn loop_next_stop(&self, line: EntityId, position: f64) -> Option<EntityId> {
-        if !position.is_finite() {
-            return None;
-        }
         let circumference = self.loop_circumference(line)?;
         let stops = self.stops_served_by_line(line);
-        if stops.is_empty() {
-            return None;
-        }
-
-        let mut best: Option<(f64, EntityId)> = None;
-        for stop_eid in stops {
-            let Some(stop_pos) = self.world.stop_position(stop_eid) else {
-                continue;
-            };
-            let mut d =
-                crate::components::cyclic::forward_distance(position, stop_pos, circumference);
-            // Coincident → treat as a full lap ahead so we don't return
-            // the caller's current stop as "next".
-            if d <= 1e-9 {
-                d = circumference;
-            }
-            match best {
-                Some((d_best, _)) if d_best <= d => {}
-                _ => best = Some((d, stop_eid)),
-            }
-        }
-        best.map(|(_, eid)| eid)
+        crate::dispatch::loop_next_stop_forward(&self.world, circumference, &stops, position)
     }
 
     /// Find the stop at `position` that's served by `line`.

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -26,6 +26,15 @@ pub fn run(
     rider_index: &RiderIndex,
     scratch: &mut DispatchScratch,
 ) {
+    // Loop cars never enter the Idle/Stopped pool — they patrol forward
+    // continuously. Kickstart any Loop car that is currently Idle by
+    // pinning it to its forward-next stop *before* the per-group idle
+    // pool is built. Covers two cases: (1) freshly-constructed cars
+    // (spawn places everything in `Idle`), and (2) a single-car Loop
+    // returning from `OutOfService` (the OOS guard still allows OOS on
+    // a loop with zero followers).
+    kickstart_loop_cars(world, events, ctx, groups);
+
     for group in groups {
         // Fresh scratch for this group's dispatch pass. Buffers from
         // the previous group (or previous tick) retain their capacity
@@ -132,6 +141,20 @@ pub fn run(
                     && car.riders.is_empty()
                     && !car.repositioning);
             if !eligible {
+                continue;
+            }
+            // Loop cars are kickstarted upstream and patrol forward
+            // continuously. They must never enter the Hungarian idle
+            // pool: a `DispatchDecision::Idle` from the strategy would
+            // clobber `going_forward = true` and demote the car to
+            // `Idle`, breaking the patrol invariant. PRs 7+ introduce
+            // Loop-aware dispatch strategies; until then Loop cars
+            // simply commit to the next forward stop and the loading
+            // phase boards every eligible rider on the way.
+            if world
+                .line(car.line())
+                .is_some_and(crate::components::Line::is_loop)
+            {
                 continue;
             }
             let Some(pos) = world.position(*eid) else {
@@ -567,4 +590,88 @@ pub fn build_manifest(
     }
 
     manifest
+}
+
+/// Promote any `Idle` car on a `LineKind::Loop` line to `MovingToStop`
+/// pointed at its forward-next stop, set `going_forward = true`, clear
+/// the `going_up` / `going_down` lamps (their semantics don't apply on a
+/// Loop), and emit `ElevatorDeparted` from the current stop if the car
+/// is parked at one.
+///
+/// This is the kickstart that begins continuous patrol. Without it, a
+/// freshly-constructed Loop car (spawn defaults `phase = Idle`) would
+/// sit forever — Loop strategies don't write `target_stop` the way the
+/// Linear Hungarian path does, and Loop cars bypass the destination
+/// queue. Cars in any other phase, on Linear lines, in a dispatch-
+/// excluded service mode, or whose loop topology is malformed (no
+/// served stops) are left untouched.
+fn kickstart_loop_cars(
+    world: &mut World,
+    events: &mut EventBus,
+    ctx: &PhaseContext,
+    groups: &[ElevatorGroup],
+) {
+    let mut transitions: Vec<(EntityId, EntityId, Option<EntityId>)> = Vec::new();
+
+    for group in groups {
+        for &eid in group.elevator_entities() {
+            if world.is_disabled(eid) {
+                continue;
+            }
+            if world
+                .service_mode(eid)
+                .is_some_and(|m| m.is_dispatch_excluded())
+            {
+                continue;
+            }
+            let Some(car) = world.elevator(eid) else {
+                continue;
+            };
+            if car.phase != ElevatorPhase::Idle {
+                continue;
+            }
+            let line_eid = car.line();
+            if !world
+                .line(line_eid)
+                .is_some_and(crate::components::Line::is_loop)
+            {
+                continue;
+            }
+            let Some(next_stop) = crate::dispatch::loop_next_stop_for_car(world, groups, eid)
+            else {
+                continue;
+            };
+            // Capture the stop we're departing from so the emitted
+            // `ElevatorDeparted` event matches the existing Linear shape.
+            // A car that started off a stop boundary won't have one and
+            // the event is simply skipped.
+            let pos = world.position(eid).map_or(0.0, |p| p.value);
+            let serves = crate::dispatch::elevator_line_serves(world, groups, eid);
+            let from_stop = serves.and_then(|s| world.find_stop_at_position_in(pos, s));
+            transitions.push((eid, next_stop, from_stop));
+        }
+    }
+
+    for (eid, next_stop, from_stop) in transitions {
+        if let Some(car) = world.elevator_mut(eid) {
+            car.phase = ElevatorPhase::MovingToStop(next_stop);
+            car.target_stop = Some(next_stop);
+            car.going_forward = true;
+            car.going_up = false;
+            car.going_down = false;
+        }
+        events.emit(Event::DirectionIndicatorChanged {
+            elevator: eid,
+            going_up: false,
+            going_down: false,
+            tick: ctx.tick,
+        });
+        if let Some(stop) = from_stop {
+            events.emit(Event::ElevatorDeparted {
+                elevator: eid,
+                from_stop: stop,
+                tick: ctx.tick,
+            });
+        }
+    }
 }

--- a/crates/elevator-core/src/systems/dispatch.rs
+++ b/crates/elevator-core/src/systems/dispatch.rs
@@ -644,8 +644,15 @@ fn kickstart_loop_cars(
             // Capture the stop we're departing from so the emitted
             // `ElevatorDeparted` event matches the existing Linear shape.
             // A car that started off a stop boundary won't have one and
-            // the event is simply skipped.
-            let pos = world.position(eid).map_or(0.0, |p| p.value);
+            // the event is simply skipped. Position is guaranteed to be
+            // present here: `loop_next_stop_for_car` already returned
+            // None — and the `let Some(next_stop) = …` arm above would
+            // have continued — if it were absent, so an explicit guard
+            // signals intent more clearly than a `0.0` fallback.
+            let Some(pos_component) = world.position(eid) else {
+                continue;
+            };
+            let pos = pos_component.value;
             let serves = crate::dispatch::elevator_line_serves(world, groups, eid);
             let from_stop = serves.and_then(|s| world.find_stop_at_position_in(pos, s));
             transitions.push((eid, next_stop, from_stop));

--- a/crates/elevator-core/src/systems/doors.rs
+++ b/crates/elevator-core/src/systems/doors.rs
@@ -82,6 +82,7 @@ pub fn run(
                     // clear them so `Elevator::direction()` reports a
                     // clean `Forward` and hosts that read the lamps
                     // directly aren't shown stale Linear state.
+                    let lamps_dirty = car.going_up || car.going_down;
                     car.phase = ElevatorPhase::MovingToStop(next_stop);
                     car.target_stop = Some(next_stop);
                     car.going_forward = true;
@@ -91,12 +92,19 @@ pub fn run(
                         elevator: eid,
                         tick: ctx.tick,
                     });
-                    events.emit(Event::DirectionIndicatorChanged {
-                        elevator: eid,
-                        going_up: false,
-                        going_down: false,
-                        tick: ctx.tick,
-                    });
+                    // Mirror the Linear branch's `indicators_dirty` guard:
+                    // skip the event during steady-state patrol where the
+                    // lamps were already cleared on a prior cycle, so
+                    // hosts subscribed to `DirectionIndicatorChanged`
+                    // don't receive a redundant emission per door close.
+                    if lamps_dirty {
+                        events.emit(Event::DirectionIndicatorChanged {
+                            elevator: eid,
+                            going_up: false,
+                            going_down: false,
+                            tick: ctx.tick,
+                        });
+                    }
                     if let Some(stop) = from_stop {
                         events.emit(Event::ElevatorDeparted {
                             elevator: eid,

--- a/crates/elevator-core/src/systems/doors.rs
+++ b/crates/elevator-core/src/systems/doors.rs
@@ -31,6 +31,15 @@ pub fn run(
 
         process_door_commands(world, events, ctx, groups, eid);
 
+        // Pre-compute the loop-continuation target before acquiring the
+        // exclusive `&mut Elevator` borrow below. Linear cars and
+        // misconfigured lines yield `None` and fall through to the
+        // existing Stopped-on-FinishedClosing path; Loop cars get the
+        // forward-next stop so the FSM can hand off to `MovingToStop`
+        // without ever passing through `Stopped`/`Idle`.
+        let loop_next: Option<EntityId> =
+            crate::dispatch::loop_next_stop_for_car(world, groups, eid);
+
         let Some(car) = world.elevator_mut(eid) else {
             continue;
         };
@@ -63,31 +72,66 @@ pub fn run(
                 car.phase = ElevatorPhase::DoorClosing;
             }
             DoorTransition::FinishedClosing => {
-                // Transition to Stopped with no committed target — the
-                // car is at a stop and free for reassignment. Also
-                // reset direction lamps so any stale state from the
-                // just-finished leg (e.g., `going_up=false` after a
-                // down-trip) doesn't make `pair_is_useful` reject
-                // opposite-direction pickup in the next dispatch tick.
-                // Without this, a car that dropped a down-bound rider
-                // at the lobby sits idle while an up-bound rider
-                // waits there — another car gets sent to serve them.
-                let indicators_dirty = !(car.going_up && car.going_down);
-                car.phase = ElevatorPhase::Stopped;
-                car.target_stop = None;
-                car.going_up = true;
-                car.going_down = true;
-                events.emit(Event::DoorClosed {
-                    elevator: eid,
-                    tick: ctx.tick,
-                });
-                if indicators_dirty {
-                    events.emit(Event::DirectionIndicatorChanged {
+                let from_stop = car.target_stop;
+
+                if let Some(next_stop) = loop_next {
+                    // Loop continuation: hand straight off to MovingToStop
+                    // without ever passing through Stopped/Idle. The
+                    // up/down indicator lamps are meaningless on a Loop
+                    // (`going_forward` carries the signal); explicitly
+                    // clear them so `Elevator::direction()` reports a
+                    // clean `Forward` and hosts that read the lamps
+                    // directly aren't shown stale Linear state.
+                    car.phase = ElevatorPhase::MovingToStop(next_stop);
+                    car.target_stop = Some(next_stop);
+                    car.going_forward = true;
+                    car.going_up = false;
+                    car.going_down = false;
+                    events.emit(Event::DoorClosed {
                         elevator: eid,
-                        going_up: true,
-                        going_down: true,
                         tick: ctx.tick,
                     });
+                    events.emit(Event::DirectionIndicatorChanged {
+                        elevator: eid,
+                        going_up: false,
+                        going_down: false,
+                        tick: ctx.tick,
+                    });
+                    if let Some(stop) = from_stop {
+                        events.emit(Event::ElevatorDeparted {
+                            elevator: eid,
+                            from_stop: stop,
+                            tick: ctx.tick,
+                        });
+                    }
+                } else {
+                    // Linear: transition to Stopped with no committed
+                    // target — the car is at a stop and free for
+                    // reassignment. Also reset direction lamps so any
+                    // stale state from the just-finished leg (e.g.,
+                    // `going_up=false` after a down-trip) doesn't make
+                    // `pair_is_useful` reject opposite-direction pickup
+                    // in the next dispatch tick. Without this, a car
+                    // that dropped a down-bound rider at the lobby
+                    // sits idle while an up-bound rider waits there —
+                    // another car gets sent to serve them.
+                    let indicators_dirty = !(car.going_up && car.going_down);
+                    car.phase = ElevatorPhase::Stopped;
+                    car.target_stop = None;
+                    car.going_up = true;
+                    car.going_down = true;
+                    events.emit(Event::DoorClosed {
+                        elevator: eid,
+                        tick: ctx.tick,
+                    });
+                    if indicators_dirty {
+                        events.emit(Event::DirectionIndicatorChanged {
+                            elevator: eid,
+                            going_up: true,
+                            going_down: true,
+                            tick: ctx.tick,
+                        });
+                    }
                 }
             }
             DoorTransition::None => {}

--- a/crates/elevator-core/src/systems/loading.rs
+++ b/crates/elevator-core/src/systems/loading.rs
@@ -131,6 +131,14 @@ fn collect_actions(
         // Derive this elevator's group from its line component.
         let elev_line = car.line();
         let elev_group: Option<GroupId> = world.line(elev_line).map(Line::group);
+        // Direction-lamp gating below filters riders by the linear
+        // up/down comparison of `(rider_dest_pos vs current_stop_pos)`.
+        // On a `LineKind::Loop` line the comparison is meaningless —
+        // every served destination is reachable forward through the
+        // loop, and a destination at a *lower* position is just farther
+        // around the cycle, not a "wrong direction" trip. Bypass the
+        // gate entirely so Loop cars board every eligible rider.
+        let line_is_loop = world.line(elev_line).is_some_and(Line::is_loop);
 
         // Single pass: find a boardable rider (fits by weight) or a rejectable one (doesn't fit).
         let remaining_capacity = car.weight_capacity.value() - car.current_load.value();
@@ -217,21 +225,23 @@ fn collect_actions(
                     // Direction indicator filter: rider must be going in a direction
                     // this car will serve. A filtered rider silently stays waiting —
                     // no rejection event — so a later car in the right direction can
-                    // pick them up.
-                    let cur_pos = world.position(current_stop).map(|p| p.value);
-                    let dest_pos = world.position(dest).map(|p| p.value);
-                    if let (Some(cp), Some(dp)) = (cur_pos, dest_pos) {
-                        if dp > cp && !car.going_up {
-                            if direction_filtered.is_none() {
-                                direction_filtered = Some(rid);
+                    // pick them up. Loop cars skip this gate (see `line_is_loop`).
+                    if !line_is_loop {
+                        let cur_pos = world.position(current_stop).map(|p| p.value);
+                        let dest_pos = world.position(dest).map(|p| p.value);
+                        if let (Some(cp), Some(dp)) = (cur_pos, dest_pos) {
+                            if dp > cp && !car.going_up {
+                                if direction_filtered.is_none() {
+                                    direction_filtered = Some(rid);
+                                }
+                                return None;
                             }
-                            return None;
-                        }
-                        if dp < cp && !car.going_down {
-                            if direction_filtered.is_none() {
-                                direction_filtered = Some(rid);
+                            if dp < cp && !car.going_down {
+                                if direction_filtered.is_none() {
+                                    direction_filtered = Some(rid);
+                                }
+                                return None;
                             }
-                            return None;
                         }
                     }
                 }

--- a/crates/elevator-core/src/systems/reposition.rs
+++ b/crates/elevator-core/src/systems/reposition.rs
@@ -59,6 +59,21 @@ pub fn run(
                     return None;
                 }
                 let car = world.elevator(eid)?;
+                // Loop cars are excluded from reposition entirely. A
+                // running Loop car is by construction never `Idle`
+                // (the door FSM continuation hands off straight to
+                // `MovingToStop`), but the kickstart pass and
+                // service-mode resume both produce a brief `Idle`
+                // window before the next dispatch tick can promote
+                // the car. Skipping Loop cars here keeps reposition
+                // from racing in and assigning a one-shot trip that
+                // would conflict with cyclic patrol semantics.
+                if world
+                    .line(car.line())
+                    .is_some_and(crate::components::Line::is_loop)
+                {
+                    return None;
+                }
                 if car.phase == ElevatorPhase::Idle {
                     let pos = world.position(eid)?.value;
                     Some((eid, pos))

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -1148,6 +1148,202 @@ fn config_rejects_loop_with_duplicate_position_stops() {
     }
 }
 
+/// Construct a single-line, single-group Loop config from `two_group_config`.
+/// The base helper ships a Linear two-group setup; this collapses to one
+/// group with a 100-unit loop serving 4 stops at 0 / 25 / 50 / 75.
+#[cfg(feature = "loop_lines")]
+fn loop_only_config() -> SimConfig {
+    use crate::components::LineKind;
+    let mut config = two_group_config();
+    config.building.stops = vec![
+        StopConfig {
+            id: StopId(0),
+            name: "S0".into(),
+            position: 0.0,
+        },
+        StopConfig {
+            id: StopId(1),
+            name: "S1".into(),
+            position: 25.0,
+        },
+        StopConfig {
+            id: StopId(2),
+            name: "S2".into(),
+            position: 50.0,
+        },
+        StopConfig {
+            id: StopId(3),
+            name: "S3".into(),
+            position: 75.0,
+        },
+    ];
+    if let Some(lines) = config.building.lines.as_mut() {
+        lines[0].kind = Some(LineKind::Loop {
+            circumference: 100.0,
+            min_headway: 5.0,
+        });
+        lines[0].serves = vec![StopId(0), StopId(1), StopId(2), StopId(3)];
+        lines[0].elevators[0].starting_stop = StopId(0);
+    }
+    if let Some(groups) = config.building.groups.as_mut() {
+        groups[0].lines = vec![1];
+        groups.remove(1);
+    }
+    config.building.lines.as_mut().unwrap().truncate(1);
+    config
+}
+
+#[cfg(feature = "loop_lines")]
+#[test]
+fn loop_car_kickstarts_from_idle_on_first_tick() {
+    let config = loop_only_config();
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+    let car_eid = sim.world().iter_elevators().next().unwrap().0;
+
+    // Construction places the car at Idle. Without the kickstart pass in
+    // dispatch.run, a Loop car would sit forever — Loop strategies don't
+    // commit destinations through the dispatch matching.
+    assert_eq!(
+        sim.world().elevator(car_eid).unwrap().phase,
+        ElevatorPhase::Idle,
+    );
+    assert!(!sim.world().elevator(car_eid).unwrap().going_forward());
+
+    sim.step();
+
+    let car = sim.world().elevator(car_eid).unwrap();
+    assert!(
+        matches!(car.phase, ElevatorPhase::MovingToStop(_)),
+        "expected kickstart to promote Idle Loop car to MovingToStop, got {:?}",
+        car.phase,
+    );
+    assert!(
+        car.going_forward(),
+        "kickstart must set going_forward = true so direction() reports Forward",
+    );
+}
+
+#[cfg(feature = "loop_lines")]
+#[test]
+fn loop_car_continues_patrol_after_door_close() {
+    let config = loop_only_config();
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+    let car_eid = sim.world().iter_elevators().next().unwrap().0;
+
+    // Run long enough for the car to arrive at the next stop, cycle
+    // doors, and depart for the *following* stop. With a 100-unit loop
+    // and 4 evenly-spaced stops, the car traverses 25 units between
+    // stops — at max_speed 2 + accel/decel 1.5/2 + dt=1/60 that's
+    // roughly 13 seconds = 800 ticks per leg, so 4000 ticks covers
+    // arrive + door cycle + depart for the next stop with margin.
+    let mut visited: std::collections::HashSet<crate::entity::EntityId> =
+        std::collections::HashSet::new();
+    let mut saw_post_close_moving = false;
+    for _ in 0..4000 {
+        sim.step();
+        let car = sim.world().elevator(car_eid).unwrap();
+        // Post-FinishedClosing: the FSM should have handed straight to
+        // MovingToStop, not Stopped/Idle. We watch every tick where the
+        // car is moving and was *not* moving on the previous loading-cycle —
+        // any sighting of a fresh MovingToStop after door cycle confirms
+        // the loop continuation.
+        if let ElevatorPhase::MovingToStop(target) = car.phase {
+            visited.insert(target);
+        }
+        // The bug we're guarding against: car phase ever becoming
+        // Stopped on a Loop line. (Idle is allowed for the very first
+        // tick before kickstart fires.)
+        assert_ne!(
+            car.phase,
+            ElevatorPhase::Stopped,
+            "Loop car must never transition to Stopped — door FSM should hand off to MovingToStop",
+        );
+        if visited.len() >= 2 {
+            saw_post_close_moving = true;
+            break;
+        }
+    }
+    assert!(
+        saw_post_close_moving,
+        "expected the Loop car to commit to a second forward target after the first door close — \
+         visited {} distinct targets",
+        visited.len(),
+    );
+    assert!(
+        sim.world().elevator(car_eid).unwrap().going_forward(),
+        "going_forward must remain true throughout patrol",
+    );
+}
+
+#[cfg(feature = "loop_lines")]
+#[test]
+fn loop_boarding_ignores_linear_direction_gate() {
+    // A Loop car arrives at stop_50 (position 50). A rider at stop_50
+    // wants to reach stop_25 (position 25 — *behind* in linear coords).
+    // On a Linear line the going_down lamp would gate this rider out
+    // unless both lamps are lit. On a Loop, every destination is forward
+    // through the cycle — boarding must bypass the gate.
+    let config = loop_only_config();
+    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+    let car_eid = sim.world().iter_elevators().next().unwrap().0;
+    let line_eid = sim.world().elevator(car_eid).unwrap().line();
+    let stop_50 = sim
+        .world()
+        .iter_stops()
+        .find(|(_, s)| (s.position - 50.0).abs() < 1e-9)
+        .map(|(eid, _)| eid)
+        .unwrap();
+    let stop_25 = sim
+        .world()
+        .iter_stops()
+        .find(|(_, s)| (s.position - 25.0).abs() < 1e-9)
+        .map(|(eid, _)| eid)
+        .unwrap();
+
+    // Spawn a rider at stop_50 routed to stop_25 (the lower-positioned
+    // stop). On a Linear line, this leg's `from > to` would set the
+    // `dp < cp && !going_down` branch and silently filter the rider.
+    let route = Route {
+        legs: vec![RouteLeg {
+            from: stop_50,
+            to: stop_25,
+            via: TransportMode::Line(line_eid),
+        }],
+        current_leg: 0,
+    };
+    let rider = sim
+        .build_rider(stop_50, stop_25)
+        .unwrap()
+        .weight(70.0)
+        .route(route)
+        .spawn()
+        .unwrap();
+
+    // Step until the rider reaches Boarding/Riding/Exiting/Arrived.
+    // 4000 ticks ≈ 66 seconds — enough for the car to traverse half a
+    // loop plus door cycles.
+    let mut boarded = false;
+    for _ in 0..4000 {
+        sim.step();
+        let phase = sim.world().rider(rider.entity()).unwrap().phase;
+        if matches!(
+            phase,
+            RiderPhase::Boarding(_)
+                | RiderPhase::Riding(_)
+                | RiderPhase::Exiting(_)
+                | RiderPhase::Arrived
+        ) {
+            boarded = true;
+            break;
+        }
+    }
+    assert!(
+        boarded,
+        "Loop car must board a rider whose destination is at a lower linear position — \
+         the directional lamp gate must be bypassed on Loop lines",
+    );
+}
+
 #[test]
 fn direction_forward_takes_precedence_over_up_down() {
     use crate::components::Direction;

--- a/docs/plans/loop-lines-v1.md
+++ b/docs/plans/loop-lines-v1.md
@@ -7,12 +7,15 @@ All work ships behind the `loop_lines` cargo feature (default off).
 
 | PR | Title | Status |
 |----|-------|--------|
-| 1 | `LineKind` foundation + cyclic distance | in progress |
-| 2 | Movement seam-split + headway clamp | not started |
-| 3 | Phase adaptations + strict validation | not started |
-| 4 | `LoopSweep` dispatch | not started |
-| 5 | `LoopSchedule` dispatch | not started |
-| 6 | Demo scenario + host wiring | not started |
+| 1 | `LineKind` foundation + cyclic distance | shipped (#804) |
+| 2 | Movement seam-split + headway clamp | shipped (#806) |
+| 3 | Direction Forward + strict validation | shipped (#808) |
+| 4 | Loop topology accessors on `Simulation` | shipped (#810) |
+| 5 | Cyclic motion wired into the movement systems phase | shipped (#812) |
+| 6 | Loop FSM completion: door continuation + kickstart + boarding bypass | this PR |
+| 7 | `LoopSweep` dispatch | not started |
+| 8 | `LoopSchedule` dispatch | not started |
+| 9 | Demo scenario + host wiring | not started |
 
 ## Locked decisions
 


### PR DESCRIPTION
## Summary

Closes the runtime loop by completing the four FSM-level adaptations PR 3 deferred. With this PR, a Loop car constructed via \`Simulation::new\` patrols its line indefinitely without external prompting, and rider routing follows the cyclic semantics established in PRs 1–5.

- **Door FSM continuation:** at \`FinishedClosing\`, a Loop car transitions straight to \`MovingToStop(forward_next_stop)\` instead of the Linear \`Stopped\` terminal.
- **Kickstart:** a pre-pass at the head of \`dispatch::run\` promotes Idle Loop cars to \`MovingToStop(forward_next_stop)\` and flips \`going_forward = true\`.
- **Boarding directional bypass:** the \`(rider_dest_pos vs current_stop_pos)\` gate in \`loading.rs\` is skipped on Loop lines so cars board every eligible rider.
- **Reposition no-op:** defensive Loop guard in the idle-elevator filter.
- **Idle-pool exclusion:** Loop cars never enter the Hungarian idle pool — \`DispatchDecision::Idle\` from a Linear strategy can no longer demote a patrolling Loop car back to Idle.

Three free helpers in \`dispatch/mod.rs\` are shared by the door FSM, the kickstart, and the existing \`Simulation::loop_next_stop\` accessor.

## Test plan

- [x] \`cargo test -p elevator-core --features loop_lines\` (1029 pass)
- [x] \`cargo test -p elevator-core\` (1003 pass; feature-off path unaffected)
- [x] \`cargo clippy -p elevator-core --features loop_lines --all-targets\` (clean)
- [x] \`cargo check --workspace --all-features --all-targets\` (clean)
- [x] New tests:
  - \`loop_car_kickstarts_from_idle_on_first_tick\`
  - \`loop_car_continues_patrol_after_door_close\`
  - \`loop_boarding_ignores_linear_direction_gate\`