### PR TITLE
feat(elevator-core): loop sweep dispatch strategy for loop groups

### DIFF
--- a/crates/elevator-core/src/dispatch/loop_sweep.rs
+++ b/crates/elevator-core/src/dispatch/loop_sweep.rs
@@ -30,8 +30,6 @@
 //!
 //! [`LineKind::Loop`]: crate::components::LineKind::Loop
 
-#![cfg(feature = "loop_lines")]
-
 use super::{BuiltinStrategy, DispatchStrategy, RankContext};
 
 /// Dispatch strategy for [`LineKind::Loop`] groups.

--- a/crates/elevator-core/src/dispatch/loop_sweep.rs
+++ b/crates/elevator-core/src/dispatch/loop_sweep.rs
@@ -1,0 +1,73 @@
+//! `LoopSweep` — call-driven dispatch for [`LineKind::Loop`] groups.
+//!
+//! On a one-way closed loop, "dispatch" reduces to a label: the
+//! [`systems::dispatch`](crate::systems::dispatch) phase already
+//! kickstarts an `Idle` Loop car onto its forward-next stop and excludes
+//! Loop cars from the Hungarian idle pool, and the door FSM hands the
+//! car straight from `DoorClosing` back to `MovingToStop(next)` without
+//! ever passing through `Stopped`. The loading phase boards every
+//! eligible rider regardless of the linear up/down lamps, so a Loop car
+//! serves every waiter at every served stop on every lap.
+//!
+//! That continuous-patrol behaviour is the LoopSweep contract from
+//! `docs/plans/loop-lines-v1.md`. This struct exists so that:
+//!
+//! - Loop groups have a typed default that round-trips through
+//!   snapshots and config files via [`BuiltinStrategy::LoopSweep`]
+//!   instead of silently inheriting [`BuiltinStrategy::Scan`] — which
+//!   would replay any restored sim with the wrong identity.
+//! - The construction-time validation can name the only strategy a
+//!   Loop group is allowed to carry, rejecting Linear-only strategies
+//!   loud rather than silently misbehaving.
+//!
+//! All [`DispatchStrategy`] hooks fall back to defaults: Loop cars
+//! never reach the Hungarian, so [`rank`](DispatchStrategy::rank) is
+//! unreachable in practice, and there is no per-car or per-pass scratch
+//! that needs to round-trip — the whole struct is unit-shaped.
+//!
+//! Future Loop-aware behaviour (skip-empty-stops, headway-driven hold
+//! recovery) will land in successors (`LoopSchedule`).
+//!
+//! [`LineKind::Loop`]: crate::components::LineKind::Loop
+
+#![cfg(feature = "loop_lines")]
+
+use super::{BuiltinStrategy, DispatchStrategy, RankContext};
+
+/// Dispatch strategy for [`LineKind::Loop`] groups.
+///
+/// See the module-level documentation for the full contract. The struct
+/// holds no per-pass state — Loop cars patrol forward on their own and
+/// never enter the Hungarian assignment — so it is a unit struct. The
+/// `Serialize`/`Deserialize` derives keep it round-trip-compatible with
+/// the snapshot identity layer for symmetry with the other built-ins.
+///
+/// [`LineKind::Loop`]: crate::components::LineKind::Loop
+#[derive(Debug, Default, Clone, Copy, serde::Serialize, serde::Deserialize)]
+pub struct LoopSweepDispatch;
+
+impl LoopSweepDispatch {
+    /// Construct a fresh `LoopSweepDispatch`. Equivalent to
+    /// `LoopSweepDispatch::default()`; spelled out so call sites read
+    /// the same as the other built-ins (`ScanDispatch::new()`, etc.).
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl DispatchStrategy for LoopSweepDispatch {
+    fn rank(&self, _ctx: &RankContext<'_>) -> Option<f64> {
+        // Loop cars are excluded from the Hungarian idle pool in
+        // `systems::dispatch::run`, so this method is unreachable in
+        // practice. Returning `None` keeps the contract conservative
+        // (`Some(finite)` is required and we have no meaningful cost
+        // to report) without panicking, in case a future caller pushes
+        // a Loop car into the matching by mistake.
+        None
+    }
+
+    fn builtin_id(&self) -> Option<BuiltinStrategy> {
+        Some(BuiltinStrategy::LoopSweep)
+    }
+}

--- a/crates/elevator-core/src/dispatch/loop_sweep.rs
+++ b/crates/elevator-core/src/dispatch/loop_sweep.rs
@@ -1,13 +1,13 @@
 //! `LoopSweep` — call-driven dispatch for [`LineKind::Loop`] groups.
 //!
 //! On a one-way closed loop, "dispatch" reduces to a label: the
-//! [`systems::dispatch`](crate::systems::dispatch) phase already
-//! kickstarts an `Idle` Loop car onto its forward-next stop and excludes
-//! Loop cars from the Hungarian idle pool, and the door FSM hands the
-//! car straight from `DoorClosing` back to `MovingToStop(next)` without
-//! ever passing through `Stopped`. The loading phase boards every
-//! eligible rider regardless of the linear up/down lamps, so a Loop car
-//! serves every waiter at every served stop on every lap.
+//! `systems::dispatch` phase already kickstarts an `Idle` Loop car onto
+//! its forward-next stop and excludes Loop cars from the Hungarian idle
+//! pool, and the door FSM hands the car straight from `DoorClosing`
+//! back to `MovingToStop(next)` without ever passing through
+//! `Stopped`. The loading phase boards every eligible rider regardless
+//! of the linear up/down lamps, so a Loop car serves every waiter at
+//! every served stop on every lap.
 //!
 //! That continuous-patrol behaviour is the LoopSweep contract from
 //! `docs/plans/loop-lines-v1.md`. This struct exists so that:

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -41,6 +41,9 @@ pub mod destination;
 pub mod etd;
 /// LOOK dispatch algorithm.
 pub mod look;
+/// Call-driven sweep for closed-loop topologies.
+#[cfg(feature = "loop_lines")]
+pub mod loop_sweep;
 /// Per-tick demand picture handed to dispatch strategies.
 pub mod manifest;
 /// Nearest-car dispatch algorithm.
@@ -63,6 +66,8 @@ pub(crate) use assignment::{DispatchScratch, assign_with_scratch};
 pub use destination::{AssignedCar, DestinationDispatch};
 pub use etd::EtdDispatch;
 pub use look::LookDispatch;
+#[cfg(feature = "loop_lines")]
+pub use loop_sweep::LoopSweepDispatch;
 pub use manifest::{DispatchManifest, RiderInfo};
 pub use nearest_car::NearestCarDispatch;
 pub use rsr::RsrDispatch;
@@ -332,6 +337,13 @@ pub enum BuiltinStrategy {
     /// Relative System Response — additive composite of ETA, direction,
     /// car-call affinity, and load-share terms.
     Rsr,
+    /// Continuous-patrol sweep for [`LineKind::Loop`](crate::components::LineKind::Loop)
+    /// groups. Loop cars never enter the Hungarian idle pool — the
+    /// kickstart pass and door FSM handle routing — so this variant is
+    /// a typed snapshot/config label rather than a ranking implementation.
+    /// Available only when the `loop_lines` cargo feature is enabled.
+    #[cfg(feature = "loop_lines")]
+    LoopSweep,
     /// Custom strategy identified by name. The game must provide a factory.
     Custom(String),
 }
@@ -345,6 +357,8 @@ impl std::fmt::Display for BuiltinStrategy {
             Self::Etd => write!(f, "Etd"),
             Self::Destination => write!(f, "Destination"),
             Self::Rsr => write!(f, "Rsr"),
+            #[cfg(feature = "loop_lines")]
+            Self::LoopSweep => write!(f, "LoopSweep"),
             Self::Custom(name) => write!(f, "Custom({name})"),
         }
     }
@@ -375,6 +389,8 @@ impl BuiltinStrategy {
             // actual strategy, not to NearestCar-in-disguise, so use
             // `Default` here.
             Self::Rsr => Some(Box::new(rsr::RsrDispatch::default())),
+            #[cfg(feature = "loop_lines")]
+            Self::LoopSweep => Some(Box::new(loop_sweep::LoopSweepDispatch::new())),
             Self::Custom(_) => None,
         }
     }

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -66,6 +66,12 @@ pub(super) const fn canonical_hall_call_mode(
         | BuiltinStrategy::NearestCar
         | BuiltinStrategy::Etd
         | BuiltinStrategy::Rsr => Some(crate::dispatch::HallCallMode::Classic),
+        // Loop groups use a one-way patrol model — no concept of an
+        // "Up" vs "Down" hall call, and the boarding phase doesn't gate
+        // on assignment. Classic collective control is the closest fit
+        // (every car serves every waiter regardless of direction lamps).
+        #[cfg(feature = "loop_lines")]
+        BuiltinStrategy::LoopSweep => Some(crate::dispatch::HallCallMode::Classic),
     }
 }
 
@@ -1116,6 +1122,24 @@ impl Simulation {
                         reason: format!(
                             "group {} contains Loop lines; reposition strategies are unsupported on Loop",
                             gc.id,
+                        ),
+                    });
+                }
+                // Strategy: Loop groups must use `LoopSweep` in v1. Linear
+                // strategies don't apply (Loop cars are excluded from the
+                // Hungarian idle pool by `systems::dispatch::run`), and
+                // silently swapping a misconfigured Linear strategy for
+                // `LoopSweep` would hide a bug — every other "wrong
+                // strategy" case in this file rejects loud, so do the same
+                // here. `LoopSchedule` lands in a follow-up PR and will
+                // join `LoopSweep` as an accepted variant then.
+                if any_loop && !matches!(gc.dispatch, BuiltinStrategy::LoopSweep) {
+                    return Err(SimError::InvalidConfig {
+                        field: "building.groups.dispatch",
+                        reason: format!(
+                            "group {} contains Loop lines but uses {} dispatch; \
+                             only LoopSweep is supported for Loop groups in v1",
+                            gc.id, gc.dispatch,
                         ),
                     });
                 }

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -911,11 +911,12 @@ fn loop_next_stop_returns_forward_neighbour() {
         // Collapse to one group containing only the loop line so the
         // homogeneity check passes.
         groups[0].lines = vec![1];
+        groups[0].dispatch = crate::dispatch::BuiltinStrategy::LoopSweep;
         groups.remove(1);
     }
     config.building.lines.as_mut().unwrap().truncate(1);
 
-    let sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+    let sim = Simulation::new(&config, crate::dispatch::LoopSweepDispatch::new()).unwrap();
     let loop_line = sim.lines_in_group(GroupId(0))[0];
 
     // From position 10 → next forward is StopId(1) @ 25.
@@ -971,11 +972,12 @@ fn loop_car_traverses_seam_and_arrives() {
     }
     if let Some(groups) = config.building.groups.as_mut() {
         groups[0].lines = vec![1];
+        groups[0].dispatch = crate::dispatch::BuiltinStrategy::LoopSweep;
         groups.remove(1);
     }
     config.building.lines.as_mut().unwrap().truncate(1);
 
-    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+    let mut sim = Simulation::new(&config, crate::dispatch::LoopSweepDispatch::new()).unwrap();
     let car_eid = sim.world().iter_elevators().next().unwrap().0;
 
     // Resolve target stop entity by config id.
@@ -1132,6 +1134,12 @@ fn config_rejects_loop_with_duplicate_position_stops() {
         });
         lines[0].serves = vec![StopId(0), StopId(1), StopId(2)];
     }
+    if let Some(groups) = config.building.groups.as_mut() {
+        // Match the construction validator's strategy guard for Loop
+        // groups so the check we're actually exercising — duplicate
+        // stop positions — runs through to its rejection.
+        groups[0].dispatch = crate::dispatch::BuiltinStrategy::LoopSweep;
+    }
     // Force StopId(1) and StopId(2) to share a position.
     config.building.stops[1].position = 5.0;
     config.building.stops[2].position = 5.0;
@@ -1187,6 +1195,7 @@ fn loop_only_config() -> SimConfig {
     }
     if let Some(groups) = config.building.groups.as_mut() {
         groups[0].lines = vec![1];
+        groups[0].dispatch = crate::dispatch::BuiltinStrategy::LoopSweep;
         groups.remove(1);
     }
     config.building.lines.as_mut().unwrap().truncate(1);
@@ -1196,8 +1205,9 @@ fn loop_only_config() -> SimConfig {
 #[cfg(feature = "loop_lines")]
 #[test]
 fn loop_car_kickstarts_from_idle_on_first_tick() {
+    use crate::dispatch::LoopSweepDispatch;
     let config = loop_only_config();
-    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+    let mut sim = Simulation::new(&config, LoopSweepDispatch::new()).unwrap();
     let car_eid = sim.world().iter_elevators().next().unwrap().0;
 
     // Construction places the car at Idle. Without the kickstart pass in
@@ -1226,8 +1236,9 @@ fn loop_car_kickstarts_from_idle_on_first_tick() {
 #[cfg(feature = "loop_lines")]
 #[test]
 fn loop_car_continues_patrol_after_door_close() {
+    use crate::dispatch::LoopSweepDispatch;
     let config = loop_only_config();
-    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+    let mut sim = Simulation::new(&config, LoopSweepDispatch::new()).unwrap();
     let car_eid = sim.world().iter_elevators().next().unwrap().0;
 
     // Run long enough for the car to arrive at the next stop, cycle
@@ -1278,13 +1289,14 @@ fn loop_car_continues_patrol_after_door_close() {
 #[cfg(feature = "loop_lines")]
 #[test]
 fn loop_boarding_ignores_linear_direction_gate() {
+    use crate::dispatch::LoopSweepDispatch;
     // A Loop car arrives at stop_50 (position 50). A rider at stop_50
     // wants to reach stop_25 (position 25 — *behind* in linear coords).
     // On a Linear line the going_down lamp would gate this rider out
     // unless both lamps are lit. On a Loop, every destination is forward
     // through the cycle — boarding must bypass the gate.
     let config = loop_only_config();
-    let mut sim = Simulation::new(&config, ScanDispatch::new()).unwrap();
+    let mut sim = Simulation::new(&config, LoopSweepDispatch::new()).unwrap();
     let car_eid = sim.world().iter_elevators().next().unwrap().0;
     let line_eid = sim.world().elevator(car_eid).unwrap().line();
     let stop_50 = sim
@@ -1342,6 +1354,141 @@ fn loop_boarding_ignores_linear_direction_gate() {
         "Loop car must board a rider whose destination is at a lower linear position — \
          the directional lamp gate must be bypassed on Loop lines",
     );
+}
+
+#[cfg(feature = "loop_lines")]
+#[test]
+fn config_rejects_linear_dispatch_strategy_on_loop_group() {
+    use crate::components::LineKind;
+    use crate::error::SimError;
+
+    // Loop group with the default `BuiltinStrategy::Scan` dispatch:
+    // construction must reject loud rather than silently install a
+    // strategy that would never be invoked (Loop cars are excluded
+    // from the Hungarian idle pool by `systems::dispatch::run`).
+    let mut config = two_group_config();
+    if let Some(lines) = config.building.lines.as_mut() {
+        lines[0].kind = Some(LineKind::Loop {
+            circumference: 100.0,
+            min_headway: 5.0,
+        });
+    }
+    if let Some(groups) = config.building.groups.as_mut() {
+        // Default from `two_group_config` is `BuiltinStrategy::Scan`;
+        // assert that explicitly so the test fails with a clear
+        // message if the helper's default changes.
+        assert_eq!(
+            groups[0].dispatch,
+            crate::dispatch::BuiltinStrategy::Scan,
+            "test relies on `two_group_config` defaulting to Scan",
+        );
+    }
+
+    match Simulation::new(&config, ScanDispatch::new()) {
+        Err(SimError::InvalidConfig { field, reason }) => {
+            assert_eq!(field, "building.groups.dispatch");
+            assert!(
+                reason.contains("LoopSweep"),
+                "rejection message should name LoopSweep as the supported strategy: {reason}",
+            );
+        }
+        other => panic!("expected InvalidConfig, got {other:?}"),
+    }
+}
+
+#[cfg(feature = "loop_lines")]
+#[test]
+fn loop_sweep_strategy_round_trips_through_snapshot_identity() {
+    use crate::dispatch::{BuiltinStrategy, DispatchStrategy, LoopSweepDispatch};
+
+    // `LoopSweepDispatch::builtin_id()` must report
+    // `BuiltinStrategy::LoopSweep` so a snapshot round-trip restores
+    // the same identity. Without this, `WorldSnapshot::restore` would
+    // fall back to recording `Scan` (per the `builtin_id` doc) and the
+    // restored sim would refuse to construct (Loop group + Scan
+    // dispatch is rejected by `validate_explicit_topology`).
+    let strategy = LoopSweepDispatch::new();
+    assert_eq!(strategy.builtin_id(), Some(BuiltinStrategy::LoopSweep));
+    assert!(BuiltinStrategy::LoopSweep.instantiate().is_some());
+}
+
+#[cfg(feature = "loop_lines")]
+#[test]
+fn loop_sweep_delivers_riders_to_every_served_stop() {
+    use crate::dispatch::LoopSweepDispatch;
+
+    // End-to-end check that `LoopSweep` (via the kickstart + door FSM
+    // continuation + boarding bypass wiring) delivers a rider on every
+    // possible (origin, destination) pair around the loop. With four
+    // stops at 0/25/50/75 there are 12 ordered non-trivial pairs;
+    // running each in isolation keeps the assertion local to the
+    // delivery contract rather than entangling it with multi-rider
+    // scheduling, which lands when `LoopSchedule` ships.
+    let stops_at = [0.0, 25.0, 50.0, 75.0];
+
+    for (origin_idx, &origin_pos) in stops_at.iter().enumerate() {
+        for (dest_idx, &dest_pos) in stops_at.iter().enumerate() {
+            if origin_idx == dest_idx {
+                continue;
+            }
+
+            let config = loop_only_config();
+            let mut sim = Simulation::new(&config, LoopSweepDispatch::new()).unwrap();
+            let line_eid = sim.world().iter_elevators().next().unwrap().2.line();
+
+            let origin = sim
+                .world()
+                .iter_stops()
+                .find(|(_, s)| (s.position - origin_pos).abs() < 1e-9)
+                .map(|(eid, _)| eid)
+                .unwrap();
+            let dest = sim
+                .world()
+                .iter_stops()
+                .find(|(_, s)| (s.position - dest_pos).abs() < 1e-9)
+                .map(|(eid, _)| eid)
+                .unwrap();
+
+            // Spawn a single rider at `origin` routed to `dest`.
+            // `build_rider` keeps the rider-index entry in sync; using
+            // raw `set_rider` would skip it and the loading phase
+            // wouldn't see them at the stop.
+            let rider = sim
+                .build_rider(origin, dest)
+                .unwrap()
+                .weight(70.0)
+                .route(Route {
+                    legs: vec![RouteLeg {
+                        from: origin,
+                        to: dest,
+                        via: TransportMode::Line(line_eid),
+                    }],
+                    current_leg: 0,
+                })
+                .spawn()
+                .unwrap();
+
+            // Worst case: rider one stop behind the car in the forward
+            // direction → almost a full lap to pick up + worst-case
+            // forward distance to drop off ≈ ~2 laps. With max_speed
+            // 2 + 25-unit gaps + door cycles, 8000 ticks is generous.
+            let mut delivered = false;
+            for _ in 0..8000 {
+                sim.step();
+                if matches!(
+                    sim.world().rider(rider.entity()).unwrap().phase,
+                    RiderPhase::Arrived
+                ) {
+                    delivered = true;
+                    break;
+                }
+            }
+            assert!(
+                delivered,
+                "LoopSweep failed to deliver rider {origin_pos} → {dest_pos} within budget",
+            );
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Introduce `LoopSweepDispatch` — the only dispatch strategy supported on `LineKind::Loop` groups in v1. Loop cars are excluded from the Hungarian idle pool by `systems::dispatch::run` (PR #814) and patrol forward continuously via the kickstart pass and door-FSM continuation, so "dispatch" reduces to a typed label that:

- reports `BuiltinStrategy::LoopSweep` from `builtin_id` so snapshots round-trip the strategy identity correctly
- gives the construction-time validator a name to insist on for Loop groups (any other `BuiltinStrategy` is rejected loud)
- makes the eventual `LoopSchedule` (next PR) a sibling rather than a swap-in replacement

The struct is unit-shaped — no per-car or per-pass scratch survives a tick — and \`rank\` returns \`None\` defensively in case a future caller pushes a Loop car into the matching by mistake.

Updated \`loop_only_config\` and existing Loop tests to set \`groups[0].dispatch = LoopSweep\` and pass \`LoopSweepDispatch::new()\` to \`Simulation::new\`, since the same validator now rejects the Scan-on-a-Loop pattern those tests previously relied on.

## Test plan

- [x] \`cargo test -p elevator-core --features loop_lines\` (1042 pass)
- [x] \`cargo test -p elevator-core\` (1003 pass; feature-off path unaffected)
- [x] \`cargo clippy -p elevator-core --features loop_lines --all-targets\`
- [x] New tests:
  - \`config_rejects_linear_dispatch_strategy_on_loop_group\`
  - \`loop_sweep_strategy_round_trips_through_snapshot_identity\`
  - \`loop_sweep_delivers_riders_to_every_served_stop\` — 12-pair (origin × destination) delivery sweep on a 4-stop loop