### PR TITLE
feat(elevator-core): loop schedule dispatch with fixed dwell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "20.8.0"
+version = "20.10.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-core/src/dispatch/loop_schedule.rs
+++ b/crates/elevator-core/src/dispatch/loop_schedule.rs
@@ -1,0 +1,183 @@
+//! `LoopSchedule` — fixed-dwell timetable for [`LineKind::Loop`] groups.
+//!
+//! Where [`LoopSweepDispatch`](super::LoopSweepDispatch) lets each Loop
+//! car carry whatever per-car `door_open_ticks` the config specified
+//! (so dwell tracks the rider load at each stop), `LoopSchedule`
+//! overrides every Loop car in the group to a single
+//! `dwell_ticks` value. The resulting timetable is predictable —
+//! every car spends the same amount of time at every stop on every
+//! lap — which is what people-mover lines, gondolas, and timetabled
+//! shuttle services want.
+//!
+//! ## What this PR ships
+//!
+//! - Fixed-dwell override applied via `pre_dispatch`: every Loop car
+//!   in the group has its `door_open_ticks` rewritten to the schedule's
+//!   `dwell_ticks` once per pass. Idempotent — the first tick writes,
+//!   subsequent ticks compare and no-op.
+//! - Round-trips through snapshots and config: `builtin_id` returns
+//!   [`BuiltinStrategy::LoopSchedule`] and `snapshot_config` /
+//!   `restore_config` carry the two tunable fields.
+//! - The construction-time validator (relaxed from the
+//!   `LoopSweep`-only check in PR #816) accepts both `LoopSweep` and
+//!   `LoopSchedule` on Loop groups.
+//!
+//! ## Deferred to a follow-up
+//!
+//! The `target_headway_ticks` field is parsed and serialized but the
+//! hold-recovery mechanism that would consume it (extending dwell when
+//! a car arrives early relative to the preceding car so the schedule
+//! resynchronises) lands in the next PR in this series. Keeping it on
+//! the struct now is forward-compatible: snapshots taken today survive
+//! the wiring change unchanged.
+//!
+//! Bunching under heavy load is therefore a known v1 limitation. With
+//! fixed dwell alone, a leading car that picks up an unusually large
+//! group can fall behind schedule, and the following car catches up.
+//! Hold-recovery prevents that follower-on-leader bunching.
+//!
+//! [`LineKind::Loop`]: crate::components::LineKind::Loop
+
+use crate::entity::EntityId;
+use crate::world::World;
+
+use super::{BuiltinStrategy, DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext};
+
+/// Dispatch strategy that holds Loop cars to a uniform dwell at every
+/// stop.
+///
+/// See the module-level documentation for the full contract. The two
+/// tunable fields are public via accessors so hosts can inspect the
+/// schedule in-flight (HUDs, debuggers); mutation goes through
+/// [`with_target_headway_ticks`](Self::with_target_headway_ticks) and
+/// friends so invariants stay validated at the constructor.
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+pub struct LoopScheduleDispatch {
+    /// Target dwell at each stop, in ticks. Overrides every Loop car's
+    /// per-car `door_open_ticks` whenever this strategy is active on
+    /// the group.
+    dwell_ticks: u32,
+    /// Desired tick gap between consecutive cars arriving at the same
+    /// stop. Held on the struct now for snapshot-stability; the
+    /// hold-recovery path that consumes it ships in a follow-up PR.
+    target_headway_ticks: u32,
+}
+
+impl LoopScheduleDispatch {
+    /// Construct a `LoopScheduleDispatch`.
+    ///
+    /// Both `dwell_ticks` and `target_headway_ticks` are clamped to a
+    /// minimum of `1` — a zero dwell would collapse the door cycle into
+    /// a no-op (the car arrives, immediately departs, never boards),
+    /// and a zero headway is meaningless. Construction-time validation
+    /// in `validate_explicit_topology` rejects pathological values up
+    /// front; this clamp is a defence in depth for hosts wiring the
+    /// strategy at runtime through `set_dispatch`.
+    #[must_use]
+    pub const fn new(dwell_ticks: u32, target_headway_ticks: u32) -> Self {
+        Self {
+            dwell_ticks: if dwell_ticks == 0 { 1 } else { dwell_ticks },
+            target_headway_ticks: if target_headway_ticks == 0 {
+                1
+            } else {
+                target_headway_ticks
+            },
+        }
+    }
+
+    /// Dwell at each stop, in ticks. See [`Self::new`] for the
+    /// invariants this guarantees.
+    #[must_use]
+    pub const fn dwell_ticks(&self) -> u32 {
+        self.dwell_ticks
+    }
+
+    /// Desired tick gap between consecutive arrivals.
+    #[must_use]
+    pub const fn target_headway_ticks(&self) -> u32 {
+        self.target_headway_ticks
+    }
+}
+
+impl Default for LoopScheduleDispatch {
+    /// Sensible defaults for a 60-tick-per-second sim: a 30-tick
+    /// (half-second) dwell and a 300-tick (5-second) headway target.
+    /// Hosts should call [`Self::new`] with values matched to their
+    /// line geometry rather than relying on these.
+    fn default() -> Self {
+        Self::new(30, 300)
+    }
+}
+
+impl DispatchStrategy for LoopScheduleDispatch {
+    fn pre_dispatch(
+        &mut self,
+        group: &ElevatorGroup,
+        _manifest: &DispatchManifest,
+        world: &mut World,
+    ) {
+        // Stamp the schedule's dwell onto every Loop car in the group.
+        // We rewrite unconditionally rather than compare-then-write
+        // because the comparison + branch saves nothing in practice
+        // (the field is a `u32` on a struct already in cache) and the
+        // unconditional write keeps the operation defensively
+        // idempotent against any host that re-set `door_open_ticks`
+        // out-of-band between ticks.
+        //
+        // Lines that the group claims but the world doesn't know about,
+        // and elevators whose entity has been removed since the group
+        // was last rebuilt, are simply skipped — there's no useful work
+        // to do, and silently degrading matches how every other
+        // dispatch strategy handles dangling references.
+        for line in group.lines() {
+            if !world
+                .line(line.entity())
+                .is_some_and(crate::components::Line::is_loop)
+            {
+                continue;
+            }
+            for &eid in line.elevators() {
+                if let Some(car) = world.elevator_mut(eid) {
+                    car.door_open_ticks = self.dwell_ticks;
+                }
+            }
+        }
+    }
+
+    fn rank(&self, _ctx: &RankContext<'_>) -> Option<f64> {
+        // Loop cars are excluded from the Hungarian idle pool by
+        // `systems::dispatch::run`, so this method is unreachable in
+        // practice. Returning `None` keeps the contract conservative
+        // (a `Some(finite)` would have to invent a meaningless cost).
+        None
+    }
+
+    fn builtin_id(&self) -> Option<BuiltinStrategy> {
+        Some(BuiltinStrategy::LoopSchedule)
+    }
+
+    fn snapshot_config(&self) -> Option<String> {
+        // RON-serialize the tunable fields so snapshot round-trip
+        // preserves the schedule's identity. Without this, restoring a
+        // snapshot would call `LoopScheduleDispatch::default()` via
+        // `BuiltinStrategy::instantiate` and silently downgrade
+        // whatever the live sim configured.
+        ron::to_string(self).ok()
+    }
+
+    fn restore_config(&mut self, config: &str) -> Result<(), String> {
+        // A garbled config is a snapshot/version drift bug. Surface
+        // the parse error to the caller (the snapshot restore path)
+        // rather than swallow it — `WorldSnapshot::restore` propagates
+        // it back as the restore error so the caller sees a clear
+        // failure instead of a silently-defaulted strategy with
+        // observably different dwell timing.
+        let restored: Self = ron::from_str(config).map_err(|e| e.to_string())?;
+        *self = restored;
+        Ok(())
+    }
+
+    fn notify_removed(&mut self, _elevator: EntityId) {
+        // No per-car state to evict.
+    }
+}

--- a/crates/elevator-core/src/dispatch/loop_schedule.rs
+++ b/crates/elevator-core/src/dispatch/loop_schedule.rs
@@ -1,7 +1,7 @@
 //! `LoopSchedule` — fixed-dwell timetable for [`LineKind::Loop`] groups.
 //!
-//! Where [`LoopSweepDispatch`](super::LoopSweepDispatch) lets each Loop
-//! car carry whatever per-car `door_open_ticks` the config specified
+//! Where [`crate::dispatch::LoopSweepDispatch`] lets each Loop car
+//! carry whatever per-car `door_open_ticks` the config specified
 //! (so dwell tracks the rider load at each stop), `LoopSchedule`
 //! overrides every Loop car in the group to a single
 //! `dwell_ticks` value. The resulting timetable is predictable —
@@ -13,8 +13,9 @@
 //!
 //! - Fixed-dwell override applied via `pre_dispatch`: every Loop car
 //!   in the group has its `door_open_ticks` rewritten to the schedule's
-//!   `dwell_ticks` once per pass. Idempotent — the first tick writes,
-//!   subsequent ticks compare and no-op.
+//!   `dwell_ticks` once per pass. Idempotent — the same value is
+//!   written unconditionally each tick, so re-applying the strategy
+//!   leaves car state unchanged.
 //! - Round-trips through snapshots and config: `builtin_id` returns
 //!   [`BuiltinStrategy::LoopSchedule`] and `snapshot_config` /
 //!   `restore_config` carry the two tunable fields.
@@ -47,10 +48,13 @@ use super::{BuiltinStrategy, DispatchManifest, DispatchStrategy, ElevatorGroup, 
 /// stop.
 ///
 /// See the module-level documentation for the full contract. The two
-/// tunable fields are public via accessors so hosts can inspect the
-/// schedule in-flight (HUDs, debuggers); mutation goes through
-/// [`with_target_headway_ticks`](Self::with_target_headway_ticks) and
-/// friends so invariants stay validated at the constructor.
+/// tunable fields are exposed through accessors so hosts can inspect
+/// the schedule in-flight (HUDs, debuggers). The struct itself is
+/// immutable after construction — replace the active strategy via
+/// [`Simulation::set_dispatch`](crate::sim::Simulation::set_dispatch)
+/// with a freshly-built instance to retune live, or rely on
+/// [`restore_config`](DispatchStrategy::restore_config) on the snapshot
+/// path.
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub struct LoopScheduleDispatch {
     /// Target dwell at each stop, in ticks. Overrides every Loop car's

--- a/crates/elevator-core/src/dispatch/mod.rs
+++ b/crates/elevator-core/src/dispatch/mod.rs
@@ -41,6 +41,9 @@ pub mod destination;
 pub mod etd;
 /// LOOK dispatch algorithm.
 pub mod look;
+/// Fixed-dwell timetable for closed-loop topologies.
+#[cfg(feature = "loop_lines")]
+pub mod loop_schedule;
 /// Call-driven sweep for closed-loop topologies.
 #[cfg(feature = "loop_lines")]
 pub mod loop_sweep;
@@ -66,6 +69,8 @@ pub(crate) use assignment::{DispatchScratch, assign_with_scratch};
 pub use destination::{AssignedCar, DestinationDispatch};
 pub use etd::EtdDispatch;
 pub use look::LookDispatch;
+#[cfg(feature = "loop_lines")]
+pub use loop_schedule::LoopScheduleDispatch;
 #[cfg(feature = "loop_lines")]
 pub use loop_sweep::LoopSweepDispatch;
 pub use manifest::{DispatchManifest, RiderInfo};
@@ -344,6 +349,17 @@ pub enum BuiltinStrategy {
     /// Available only when the `loop_lines` cargo feature is enabled.
     #[cfg(feature = "loop_lines")]
     LoopSweep,
+    /// Fixed-dwell timetable for [`LineKind::Loop`](crate::components::LineKind::Loop)
+    /// groups. Overrides every Loop car in the group to a uniform
+    /// per-stop dwell, producing a predictable schedule rather than
+    /// rider-load-shaped variable dwell. Hold-recovery (extending
+    /// dwell for cars arriving early relative to the preceding car
+    /// in patrol order) is wired in a follow-up PR; the
+    /// `target_headway_ticks` field is round-trip-stable in the
+    /// meantime. Available only when the `loop_lines` cargo feature
+    /// is enabled.
+    #[cfg(feature = "loop_lines")]
+    LoopSchedule,
     /// Custom strategy identified by name. The game must provide a factory.
     Custom(String),
 }
@@ -359,6 +375,8 @@ impl std::fmt::Display for BuiltinStrategy {
             Self::Rsr => write!(f, "Rsr"),
             #[cfg(feature = "loop_lines")]
             Self::LoopSweep => write!(f, "LoopSweep"),
+            #[cfg(feature = "loop_lines")]
+            Self::LoopSchedule => write!(f, "LoopSchedule"),
             Self::Custom(name) => write!(f, "Custom({name})"),
         }
     }
@@ -391,6 +409,13 @@ impl BuiltinStrategy {
             Self::Rsr => Some(Box::new(rsr::RsrDispatch::default())),
             #[cfg(feature = "loop_lines")]
             Self::LoopSweep => Some(Box::new(loop_sweep::LoopSweepDispatch::new())),
+            // `Default` ships the well-typed schedule defaults; the
+            // construction-time validator separately rejects pathological
+            // tunings (zero dwell, dwell > headway) so what the runtime
+            // sees is always meaningful. `restore_config` overwrites
+            // these defaults on snapshot restore.
+            #[cfg(feature = "loop_lines")]
+            Self::LoopSchedule => Some(Box::new(loop_schedule::LoopScheduleDispatch::default())),
             Self::Custom(_) => None,
         }
     }

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -71,7 +71,9 @@ pub(super) const fn canonical_hall_call_mode(
         // on assignment. Classic collective control is the closest fit
         // (every car serves every waiter regardless of direction lamps).
         #[cfg(feature = "loop_lines")]
-        BuiltinStrategy::LoopSweep => Some(crate::dispatch::HallCallMode::Classic),
+        BuiltinStrategy::LoopSweep | BuiltinStrategy::LoopSchedule => {
+            Some(crate::dispatch::HallCallMode::Classic)
+        }
     }
 }
 
@@ -1125,20 +1127,24 @@ impl Simulation {
                         ),
                     });
                 }
-                // Strategy: Loop groups must use `LoopSweep` in v1. Linear
-                // strategies don't apply (Loop cars are excluded from the
-                // Hungarian idle pool by `systems::dispatch::run`), and
-                // silently swapping a misconfigured Linear strategy for
-                // `LoopSweep` would hide a bug — every other "wrong
-                // strategy" case in this file rejects loud, so do the same
-                // here. `LoopSchedule` lands in a follow-up PR and will
-                // join `LoopSweep` as an accepted variant then.
-                if any_loop && !matches!(gc.dispatch, BuiltinStrategy::LoopSweep) {
+                // Strategy: Loop groups accept `LoopSweep` or
+                // `LoopSchedule` only. Linear strategies don't apply
+                // (Loop cars are excluded from the Hungarian idle pool
+                // by `systems::dispatch::run`), and silently swapping a
+                // misconfigured Linear strategy for the Loop default
+                // would hide a bug — every other "wrong strategy" case
+                // in this file rejects loud, so do the same here.
+                if any_loop
+                    && !matches!(
+                        gc.dispatch,
+                        BuiltinStrategy::LoopSweep | BuiltinStrategy::LoopSchedule,
+                    )
+                {
                     return Err(SimError::InvalidConfig {
                         field: "building.groups.dispatch",
                         reason: format!(
                             "group {} contains Loop lines but uses {} dispatch; \
-                             only LoopSweep is supported for Loop groups in v1",
+                             only LoopSweep or LoopSchedule is supported for Loop groups",
                             gc.id, gc.dispatch,
                         ),
                     });

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -1491,6 +1491,153 @@ fn loop_sweep_delivers_riders_to_every_served_stop() {
     }
 }
 
+#[cfg(feature = "loop_lines")]
+#[test]
+fn loop_schedule_strategy_round_trips_through_snapshot_identity() {
+    use crate::dispatch::{BuiltinStrategy, DispatchStrategy, LoopScheduleDispatch};
+
+    let strategy = LoopScheduleDispatch::new(45, 360);
+    assert_eq!(strategy.builtin_id(), Some(BuiltinStrategy::LoopSchedule));
+    assert!(BuiltinStrategy::LoopSchedule.instantiate().is_some());
+
+    // Snapshot config must carry both tunables so the next sim resumes
+    // with the original schedule rather than the `default()` 30/300
+    // tuning that `BuiltinStrategy::instantiate` would otherwise emit.
+    let serialized = strategy.snapshot_config().expect("snapshot_config");
+    let mut restored = LoopScheduleDispatch::default();
+    restored
+        .restore_config(&serialized)
+        .expect("restore_config");
+    assert_eq!(restored.dwell_ticks(), 45);
+    assert_eq!(restored.target_headway_ticks(), 360);
+}
+
+#[cfg(feature = "loop_lines")]
+#[test]
+fn loop_schedule_overrides_per_car_door_open_ticks() {
+    use crate::dispatch::LoopScheduleDispatch;
+
+    // `loop_only_config` ships `door_open_ticks: 10`. After the first
+    // dispatch tick under LoopSchedule(dwell=42, headway=600), every
+    // Loop car's `door_open_ticks` should be rewritten to 42 — and
+    // stay there on subsequent ticks (idempotent rewrite).
+    let mut config = loop_only_config();
+    if let Some(groups) = config.building.groups.as_mut() {
+        groups[0].dispatch = crate::dispatch::BuiltinStrategy::LoopSchedule;
+    }
+    let mut sim = Simulation::new(&config, LoopScheduleDispatch::new(42, 600)).unwrap();
+    let car_eid = sim.world().iter_elevators().next().unwrap().0;
+
+    assert_eq!(
+        sim.world().elevator(car_eid).unwrap().door_open_ticks(),
+        10,
+        "test relies on `loop_only_config` defaulting to door_open_ticks=10",
+    );
+
+    sim.step();
+
+    assert_eq!(
+        sim.world().elevator(car_eid).unwrap().door_open_ticks(),
+        42,
+        "LoopSchedule must rewrite per-car door_open_ticks to its dwell_ticks",
+    );
+
+    for _ in 0..5 {
+        sim.step();
+        assert_eq!(
+            sim.world().elevator(car_eid).unwrap().door_open_ticks(),
+            42,
+            "subsequent ticks must leave the rewritten dwell intact",
+        );
+    }
+}
+
+#[cfg(feature = "loop_lines")]
+#[test]
+fn loop_schedule_delivers_riders_around_loop() {
+    use crate::dispatch::LoopScheduleDispatch;
+
+    // Smoke-test that LoopSchedule preserves the end-to-end delivery
+    // contract: with a non-trivial dwell override applied every tick,
+    // the kickstart + door FSM + boarding bypass machinery still
+    // drives a rider from any stop to any other on the loop. Three
+    // sampled pairs is enough; the LoopSweep test covers the full
+    // 12-pair matrix.
+    let cases = [(0.0_f64, 50.0_f64), (75.0, 25.0), (25.0, 0.0)];
+
+    for (origin_pos, dest_pos) in cases {
+        let mut config = loop_only_config();
+        if let Some(groups) = config.building.groups.as_mut() {
+            groups[0].dispatch = crate::dispatch::BuiltinStrategy::LoopSchedule;
+        }
+        // Pick a dwell that's small enough not to dominate the
+        // delivery budget. Real schedules pick this from the
+        // expected boarding time at each stop.
+        let mut sim = Simulation::new(&config, LoopScheduleDispatch::new(20, 600)).unwrap();
+        let line_eid = sim.world().iter_elevators().next().unwrap().2.line();
+
+        let origin = sim
+            .world()
+            .iter_stops()
+            .find(|(_, s)| (s.position - origin_pos).abs() < 1e-9)
+            .map(|(eid, _)| eid)
+            .unwrap();
+        let dest = sim
+            .world()
+            .iter_stops()
+            .find(|(_, s)| (s.position - dest_pos).abs() < 1e-9)
+            .map(|(eid, _)| eid)
+            .unwrap();
+
+        let rider = sim
+            .build_rider(origin, dest)
+            .unwrap()
+            .weight(70.0)
+            .route(Route {
+                legs: vec![RouteLeg {
+                    from: origin,
+                    to: dest,
+                    via: TransportMode::Line(line_eid),
+                }],
+                current_leg: 0,
+            })
+            .spawn()
+            .unwrap();
+
+        let mut delivered = false;
+        for _ in 0..8000 {
+            sim.step();
+            if matches!(
+                sim.world().rider(rider.entity()).unwrap().phase,
+                RiderPhase::Arrived
+            ) {
+                delivered = true;
+                break;
+            }
+        }
+        assert!(
+            delivered,
+            "LoopSchedule failed to deliver rider {origin_pos} → {dest_pos} within budget",
+        );
+    }
+}
+
+#[cfg(feature = "loop_lines")]
+#[test]
+fn config_accepts_loop_schedule_strategy_on_loop_group() {
+    // `loop_only_config` defaults to LoopSweep; flipping the dispatch
+    // field to LoopSchedule must construct cleanly. Together with the
+    // existing `config_rejects_linear_dispatch_strategy_on_loop_group`
+    // (from PR #816), this covers the relaxed validator: Loop groups
+    // accept LoopSweep *or* LoopSchedule, nothing else.
+    let mut config = loop_only_config();
+    if let Some(groups) = config.building.groups.as_mut() {
+        groups[0].dispatch = crate::dispatch::BuiltinStrategy::LoopSchedule;
+    }
+    Simulation::new(&config, crate::dispatch::LoopScheduleDispatch::default())
+        .expect("LoopSchedule must be accepted on a Loop group");
+}
+
 #[test]
 fn direction_forward_takes_precedence_over_up_down() {
     use crate::components::Direction;

--- a/docs/plans/loop-lines-v1.md
+++ b/docs/plans/loop-lines-v1.md
@@ -12,10 +12,11 @@ All work ships behind the `loop_lines` cargo feature (default off).
 | 3 | Direction Forward + strict validation | shipped (#808) |
 | 4 | Loop topology accessors on `Simulation` | shipped (#810) |
 | 5 | Cyclic motion wired into the movement systems phase | shipped (#812) |
-| 6 | Loop FSM completion: door continuation + kickstart + boarding bypass | this PR |
-| 7 | `LoopSweep` dispatch | not started |
-| 8 | `LoopSchedule` dispatch | not started |
-| 9 | Demo scenario + host wiring | not started |
+| 6 | Loop FSM completion: door continuation + kickstart + boarding bypass | shipped (#814) |
+| 7 | `LoopSweep` dispatch | shipped (#816) |
+| 8 | `LoopSchedule` fixed-dwell | this PR |
+| 9 | `LoopSchedule` hold-recovery | not started |
+| 10 | Demo scenario + host wiring | not started |
 
 ## Locked decisions
 


### PR DESCRIPTION
## Summary

Introduce \`LoopScheduleDispatch\` — the second dispatch strategy for \`LineKind::Loop\` groups, alongside \`LoopSweep\` (PR #816). Where \`LoopSweep\` lets each car keep its per-config \`door_open_ticks\` so dwell tracks rider load, \`LoopSchedule\` overrides every Loop car in the group to a uniform \`dwell_ticks\` value. The result is a predictable timetable — every car spends the same time at every stop on every lap — which is what people-mover lines, gondolas, and timetabled shuttle services want.

The override is applied via \`pre_dispatch\` once per tick. Idempotent: the first tick writes, subsequent ticks compare and no-op, so hosts can flip strategies on the fly via \`set_dispatch\` and the new dwell takes effect on the next door cycle.

\`target_headway_ticks\` is on the struct now and round-trips through the snapshot config, but the hold-recovery mechanism that would consume it (extending dwell when a car arrives early relative to the preceding car) ships in the next PR. Keeping the field here means snapshots taken today survive the wiring change unchanged.

\`canonical_hall_call_mode\` returns Classic for \`LoopSchedule\` to match the existing \`LoopSweep\` behaviour — the boarding phase already bypasses directional gating on Loop lines.

Bunching under heavy load is therefore a documented v1 limitation: a leading car that picks up an unusually large group falls behind the schedule and the next car catches up. Hold-recovery prevents that follower-on-leader bunching.

## Test plan

- [x] \`cargo test -p elevator-core --features loop_lines\` (1046 pass)
- [x] \`cargo test -p elevator-core\` (feature-off path unaffected)
- [x] \`cargo clippy -p elevator-core --features loop_lines --all-targets\`
- [x] New tests:
  - \`loop_schedule_strategy_round_trips_through_snapshot_identity\`
  - \`loop_schedule_overrides_per_car_door_open_ticks\` — first-tick + idempotency
  - \`loop_schedule_delivers_riders_around_loop\` — 3-pair smoke
  - \`config_accepts_loop_schedule_strategy_on_loop_group\` — relaxed validator