### PR TITLE
feat(elevator-core): hold-recovery for loop schedule dispatch

### DIFF
--- a/crates/elevator-core/src/dispatch/loop_schedule.rs
+++ b/crates/elevator-core/src/dispatch/loop_schedule.rs
@@ -45,7 +45,7 @@
 //! [`DoorCommand::HoldOpen`]: crate::door::DoorCommand::HoldOpen
 //! [`LineKind::Loop`]: crate::components::LineKind::Loop
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use crate::components::ElevatorPhase;
 use crate::door::DoorCommand;
@@ -93,14 +93,27 @@ pub struct LoopScheduleDispatch {
     /// restored sims rebuild the map on the first arrival at each stop
     /// after restore. The first-arrival miss is a one-time cost
     /// equivalent to one un-held tick per stop after restore.
+    ///
+    /// Keyed on the served stop's [`EntityId`]. Entries for stops
+    /// removed via [`Simulation::remove_stop`](crate::sim::Simulation::remove_stop)
+    /// remain in the map; this is safe because the entity allocator
+    /// uses generation counters under `slotmap`, so a removed
+    /// [`EntityId`] never re-points at a newly-spawned stop.
+    /// Long-running sims that churn stops will leak a few bytes per
+    /// retired stop — bounded and acceptable for v1.
     #[serde(skip)]
     last_arrival_tick: HashMap<EntityId, u64>,
-    /// Cars currently in Loading whose arrival we've already
-    /// accounted for. Tracks which cars to *skip* on a given tick —
-    /// without it, we'd re-issue `HoldOpen` on every tick the car is
-    /// in Loading rather than just the entry tick.
+    /// Per-car `(last loading-pre-dispatch tick, last seen stop)`.
+    /// The fresh-arrival predicate fires whenever the recorded tick
+    /// is not the immediately preceding `pre_dispatch` tick *or* the
+    /// recorded stop changed. The tick-anchored half catches
+    /// same-stop re-arrivals on a tiny loop (car leaves S, runs once
+    /// around, returns to S); the stop-anchored half catches normal
+    /// arrival-at-the-next-stop transitions while the car was still
+    /// in Loading state on the previous pass (rare but legal under
+    /// long dwells).
     #[serde(skip)]
-    seen_loading: HashSet<EntityId>,
+    seen: HashMap<EntityId, (u64, EntityId)>,
 }
 
 impl LoopScheduleDispatch {
@@ -118,7 +131,7 @@ impl LoopScheduleDispatch {
             target_headway_ticks: target_headway_ticks.max(1),
             hold_cap_ticks: hold_cap_ticks.max(1),
             last_arrival_tick: HashMap::new(),
-            seen_loading: HashSet::new(),
+            seen: HashMap::new(),
         }
     }
 
@@ -164,16 +177,12 @@ impl DispatchStrategy for LoopScheduleDispatch {
         // tick parameter (the trait predates loop-aware strategies),
         // so we read the `CurrentTick` resource the runtime keeps in
         // sync. Missing the resource means we're being driven by tests
-        // that didn't seed it; fall back to `0` and skip the recovery
-        // path (no fake "5 ticks ago" gaps).
+        // that didn't seed it; hold `None` and skip the recovery path
+        // entirely. A `0` fallback would fabricate gaps against any
+        // prior arrival recorded at a non-zero tick.
         let now = world
             .resource::<crate::arrival_log::CurrentTick>()
             .map(|ct| ct.0);
-
-        // Build a fresh "in loading this tick" set. Cars that left the
-        // set since the last tick are off the stop; cars that entered
-        // it are *fresh arrivals* whose dwell we may need to extend.
-        let mut still_loading: HashSet<EntityId> = HashSet::new();
 
         for line in group.lines() {
             let line_eid = line.entity();
@@ -211,19 +220,27 @@ impl DispatchStrategy for LoopScheduleDispatch {
                 if !matches!(phase, ElevatorPhase::Loading) {
                     continue;
                 }
-                still_loading.insert(eid);
+                let Some(now) = now else { continue };
+                let Some(stop) = at_stop else { continue };
 
-                // Only act on the *fresh arrival* tick — the tick where
-                // the car first appears in Loading after a movement
-                // leg. Subsequent ticks the car is still in Loading
-                // shouldn't keep re-extending its dwell, or it'd never
-                // depart.
-                if self.seen_loading.contains(&eid) {
+                // Fresh-arrival predicate: the car was either not
+                // observed in Loading on the immediately preceding
+                // pre_dispatch tick, OR it's now at a different stop
+                // than it was on the previous Loading observation. The
+                // tick-anchored half catches same-stop re-arrivals
+                // (car runs a full lap on a tiny loop and returns to
+                // the same stop), the stop-anchored half catches the
+                // normal arrival-at-next-stop transition. Subsequent
+                // ticks where the car remains in Loading at the same
+                // stop update `seen` but don't re-issue HoldOpen.
+                let prev_seen = self.seen.insert(eid, (now, stop));
+                let is_fresh_arrival = match prev_seen {
+                    None => true,
+                    Some((prev_tick, prev_stop)) => prev_tick + 1 != now || prev_stop != stop,
+                };
+                if !is_fresh_arrival {
                     continue;
                 }
-
-                let Some(stop) = at_stop else { continue };
-                let Some(now) = now else { continue };
 
                 // Gap = how long since the previous arrival at this
                 // stop. The first arrival at a stop has no previous;
@@ -268,8 +285,6 @@ impl DispatchStrategy for LoopScheduleDispatch {
                 }
             }
         }
-
-        self.seen_loading = still_loading;
     }
 
     fn rank(&self, _ctx: &RankContext<'_>) -> Option<f64> {
@@ -306,9 +321,9 @@ impl DispatchStrategy for LoopScheduleDispatch {
     }
 
     fn notify_removed(&mut self, elevator: EntityId) {
-        // Drop bookkeeping for removed elevators so the set doesn't
+        // Drop bookkeeping for removed elevators so the map doesn't
         // grow without bound across long-running sims that swap cars
         // in and out (e.g. test harnesses).
-        self.seen_loading.remove(&elevator);
+        self.seen.remove(&elevator);
     }
 }

--- a/crates/elevator-core/src/dispatch/loop_schedule.rs
+++ b/crates/elevator-core/src/dispatch/loop_schedule.rs
@@ -9,45 +9,63 @@
 //! lap — which is what people-mover lines, gondolas, and timetabled
 //! shuttle services want.
 //!
-//! ## What this PR ships
+//! ## What this strategy does
 //!
-//! - Fixed-dwell override applied via `pre_dispatch`: every Loop car
-//!   in the group has its `door_open_ticks` rewritten to the schedule's
-//!   `dwell_ticks` once per pass. Idempotent — the same value is
+//! - **Fixed dwell**: every Loop car in the group has its
+//!   `door_open_ticks` rewritten to the schedule's `dwell_ticks` once
+//!   per pass via `pre_dispatch`. Idempotent — the same value is
 //!   written unconditionally each tick, so re-applying the strategy
 //!   leaves car state unchanged.
-//! - Round-trips through snapshots and config: `builtin_id` returns
+//! - **Hold-recovery**: when a car arrives at a stop sooner than
+//!   `target_headway_ticks` after the preceding car arrived at the
+//!   same stop, the strategy issues a [`DoorCommand::HoldOpen`]
+//!   extending the dwell by `min(target_headway_ticks - gap,
+//!   hold_cap_ticks)`. This pushes the bunched follower back to its
+//!   schedule slot rather than letting it tailgate the leader.
+//!   - The cap prevents indefinite hold if the leader is stuck (e.g.
+//!     stopped indefinitely for heavy boarding) — the follower waits
+//!     at most `hold_cap_ticks` extra per stop, then resumes patrol.
+//!   - Crucially, hold-recovery **never speeds a car up**: an
+//!     early-arriving follower can only delay itself, never overtake.
+//!   - A leader that runs late is not held — only followers running
+//!     ahead of their schedule are held.
+//! - **Snapshot round-trip**: `builtin_id` returns
 //!   [`BuiltinStrategy::LoopSchedule`] and `snapshot_config` /
-//!   `restore_config` carry the two tunable fields.
-//! - The construction-time validator (relaxed from the
-//!   `LoopSweep`-only check in PR #816) accepts both `LoopSweep` and
-//!   `LoopSchedule` on Loop groups.
+//!   `restore_config` carry all three tunable fields. Per-pass
+//!   bookkeeping (last-arrival ticks, in-loading set) is `#[serde(skip)]`
+//!   — restored sims rebuild it on the first tick where each car next
+//!   enters Loading.
 //!
-//! ## Deferred to a follow-up
+//! Bunching under heavy load is **largely** mitigated by hold-recovery
+//! but not eliminated: a leader that takes an unusually long time to
+//! board may exceed `hold_cap_ticks` of follower hold, and the
+//! follower then catches up before recovering. Tune `hold_cap_ticks`
+//! to the worst-case boarding burst your line expects.
 //!
-//! The `target_headway_ticks` field is parsed and serialized but the
-//! hold-recovery mechanism that would consume it (extending dwell when
-//! a car arrives early relative to the preceding car so the schedule
-//! resynchronises) lands in the next PR in this series. Keeping it on
-//! the struct now is forward-compatible: snapshots taken today survive
-//! the wiring change unchanged.
-//!
-//! Bunching under heavy load is therefore a known v1 limitation. With
-//! fixed dwell alone, a leading car that picks up an unusually large
-//! group can fall behind schedule, and the following car catches up.
-//! Hold-recovery prevents that follower-on-leader bunching.
-//!
+//! [`DoorCommand::HoldOpen`]: crate::door::DoorCommand::HoldOpen
 //! [`LineKind::Loop`]: crate::components::LineKind::Loop
 
+use std::collections::{HashMap, HashSet};
+
+use crate::components::ElevatorPhase;
+use crate::door::DoorCommand;
 use crate::entity::EntityId;
 use crate::world::World;
 
 use super::{BuiltinStrategy, DispatchManifest, DispatchStrategy, ElevatorGroup, RankContext};
 
-/// Dispatch strategy that holds Loop cars to a uniform dwell at every
-/// stop.
+/// Default hold-recovery cap.
 ///
-/// See the module-level documentation for the full contract. The two
+/// Picked to be comfortably below most real-world worst-case dwells
+/// while still letting the schedule recover from typical boarding
+/// excursions on a 60Hz sim. Hosts should tune via
+/// [`LoopScheduleDispatch::new`] for production scenarios.
+pub const DEFAULT_HOLD_CAP_TICKS: u32 = 120;
+
+/// Dispatch strategy that holds Loop cars to a uniform dwell at every
+/// stop, with hold-recovery to keep the timetable stable under load.
+///
+/// See the module-level documentation for the full contract. The
 /// tunable fields are exposed through accessors so hosts can inspect
 /// the schedule in-flight (HUDs, debuggers). The struct itself is
 /// immutable after construction — replace the active strategy via
@@ -55,37 +73,52 @@ use super::{BuiltinStrategy, DispatchManifest, DispatchStrategy, ElevatorGroup, 
 /// with a freshly-built instance to retune live, or rely on
 /// [`restore_config`](DispatchStrategy::restore_config) on the snapshot
 /// path.
-#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct LoopScheduleDispatch {
     /// Target dwell at each stop, in ticks. Overrides every Loop car's
     /// per-car `door_open_ticks` whenever this strategy is active on
     /// the group.
     dwell_ticks: u32,
     /// Desired tick gap between consecutive cars arriving at the same
-    /// stop. Held on the struct now for snapshot-stability; the
-    /// hold-recovery path that consumes it ships in a follow-up PR.
+    /// stop. A follower arriving below this gap holds its dwell to
+    /// recover. Set above expected loop transit time for the gap to be
+    /// reachable.
     target_headway_ticks: u32,
+    /// Upper bound on the extra dwell hold-recovery applies per stop.
+    /// Without this cap, a stalled leader (e.g. heavy boarding well
+    /// beyond `dwell_ticks`) would freeze the follower indefinitely.
+    hold_cap_ticks: u32,
+    /// Per-stop tick of the most recent arrival, used to compute the
+    /// gap on the next arrival. Skipped in snapshot serialization —
+    /// restored sims rebuild the map on the first arrival at each stop
+    /// after restore. The first-arrival miss is a one-time cost
+    /// equivalent to one un-held tick per stop after restore.
+    #[serde(skip)]
+    last_arrival_tick: HashMap<EntityId, u64>,
+    /// Cars currently in Loading whose arrival we've already
+    /// accounted for. Tracks which cars to *skip* on a given tick —
+    /// without it, we'd re-issue `HoldOpen` on every tick the car is
+    /// in Loading rather than just the entry tick.
+    #[serde(skip)]
+    seen_loading: HashSet<EntityId>,
 }
 
 impl LoopScheduleDispatch {
-    /// Construct a `LoopScheduleDispatch`.
+    /// Construct a `LoopScheduleDispatch` with explicit tunables.
     ///
-    /// Both `dwell_ticks` and `target_headway_ticks` are clamped to a
-    /// minimum of `1` — a zero dwell would collapse the door cycle into
-    /// a no-op (the car arrives, immediately departs, never boards),
-    /// and a zero headway is meaningless. Construction-time validation
-    /// in `validate_explicit_topology` rejects pathological values up
-    /// front; this clamp is a defence in depth for hosts wiring the
-    /// strategy at runtime through `set_dispatch`.
+    /// All three integer parameters are clamped to a minimum of `1`:
+    /// a zero dwell would collapse the door cycle into a no-op, a zero
+    /// headway would never trigger recovery, and a zero hold cap would
+    /// disable recovery entirely (use a small but positive value to
+    /// keep recovery active without unbounded waits).
     #[must_use]
-    pub const fn new(dwell_ticks: u32, target_headway_ticks: u32) -> Self {
+    pub fn new(dwell_ticks: u32, target_headway_ticks: u32, hold_cap_ticks: u32) -> Self {
         Self {
-            dwell_ticks: if dwell_ticks == 0 { 1 } else { dwell_ticks },
-            target_headway_ticks: if target_headway_ticks == 0 {
-                1
-            } else {
-                target_headway_ticks
-            },
+            dwell_ticks: dwell_ticks.max(1),
+            target_headway_ticks: target_headway_ticks.max(1),
+            hold_cap_ticks: hold_cap_ticks.max(1),
+            last_arrival_tick: HashMap::new(),
+            seen_loading: HashSet::new(),
         }
     }
 
@@ -96,20 +129,27 @@ impl LoopScheduleDispatch {
         self.dwell_ticks
     }
 
-    /// Desired tick gap between consecutive arrivals.
+    /// Desired tick gap between consecutive arrivals at the same stop.
     #[must_use]
     pub const fn target_headway_ticks(&self) -> u32 {
         self.target_headway_ticks
+    }
+
+    /// Maximum extra dwell hold-recovery will apply per stop.
+    #[must_use]
+    pub const fn hold_cap_ticks(&self) -> u32 {
+        self.hold_cap_ticks
     }
 }
 
 impl Default for LoopScheduleDispatch {
     /// Sensible defaults for a 60-tick-per-second sim: a 30-tick
-    /// (half-second) dwell and a 300-tick (5-second) headway target.
-    /// Hosts should call [`Self::new`] with values matched to their
-    /// line geometry rather than relying on these.
+    /// (half-second) dwell, a 300-tick (5-second) headway target, and
+    /// a 120-tick (2-second) hold cap. Hosts should call [`Self::new`]
+    /// with values matched to their line geometry rather than relying
+    /// on these.
     fn default() -> Self {
-        Self::new(30, 300)
+        Self::new(30, 300, DEFAULT_HOLD_CAP_TICKS)
     }
 }
 
@@ -120,32 +160,116 @@ impl DispatchStrategy for LoopScheduleDispatch {
         _manifest: &DispatchManifest,
         world: &mut World,
     ) {
-        // Stamp the schedule's dwell onto every Loop car in the group.
-        // We rewrite unconditionally rather than compare-then-write
-        // because the comparison + branch saves nothing in practice
-        // (the field is a `u32` on a struct already in cache) and the
-        // unconditional write keeps the operation defensively
-        // idempotent against any host that re-set `door_open_ticks`
-        // out-of-band between ticks.
-        //
-        // Lines that the group claims but the world doesn't know about,
-        // and elevators whose entity has been removed since the group
-        // was last rebuilt, are simply skipped — there's no useful work
-        // to do, and silently degrading matches how every other
-        // dispatch strategy handles dangling references.
+        // Tick fetched once up-front. `pre_dispatch` doesn't carry a
+        // tick parameter (the trait predates loop-aware strategies),
+        // so we read the `CurrentTick` resource the runtime keeps in
+        // sync. Missing the resource means we're being driven by tests
+        // that didn't seed it; fall back to `0` and skip the recovery
+        // path (no fake "5 ticks ago" gaps).
+        let now = world
+            .resource::<crate::arrival_log::CurrentTick>()
+            .map(|ct| ct.0);
+
+        // Build a fresh "in loading this tick" set. Cars that left the
+        // set since the last tick are off the stop; cars that entered
+        // it are *fresh arrivals* whose dwell we may need to extend.
+        let mut still_loading: HashSet<EntityId> = HashSet::new();
+
         for line in group.lines() {
+            let line_eid = line.entity();
             if !world
-                .line(line.entity())
+                .line(line_eid)
                 .is_some_and(crate::components::Line::is_loop)
             {
                 continue;
             }
-            for &eid in line.elevators() {
-                if let Some(car) = world.elevator_mut(eid) {
-                    car.door_open_ticks = self.dwell_ticks;
+            // Snapshot elevator entities up front so we can take a
+            // separate mutable borrow per car inside the loop without
+            // holding the immutable `&[EntityId]` from `line.elevators()`
+            // across mutable accesses to `world`.
+            let elevators: Vec<EntityId> = line.elevators().to_vec();
+
+            for eid in elevators {
+                let Some(car) = world.elevator(eid) else {
+                    continue;
+                };
+                // Fixed-dwell override applied to every Loop car, every
+                // tick. Idempotent — the same value is written
+                // regardless of the car's current phase, so a car
+                // mid-cycle picks up the override on its next request.
+                let phase = car.phase;
+                let at_stop = car.target_stop;
+                {
+                    // Re-acquire as `_mut` for the write, then drop
+                    // immediately so the gap-recovery branch below can
+                    // hold its own borrow.
+                    if let Some(c) = world.elevator_mut(eid) {
+                        c.door_open_ticks = self.dwell_ticks;
+                    }
+                }
+
+                if !matches!(phase, ElevatorPhase::Loading) {
+                    continue;
+                }
+                still_loading.insert(eid);
+
+                // Only act on the *fresh arrival* tick — the tick where
+                // the car first appears in Loading after a movement
+                // leg. Subsequent ticks the car is still in Loading
+                // shouldn't keep re-extending its dwell, or it'd never
+                // depart.
+                if self.seen_loading.contains(&eid) {
+                    continue;
+                }
+
+                let Some(stop) = at_stop else { continue };
+                let Some(now) = now else { continue };
+
+                // Gap = how long since the previous arrival at this
+                // stop. The first arrival at a stop has no previous;
+                // there's nothing to recover *against*, so the dwell
+                // override is the only thing applied.
+                let Some(&prev) = self.last_arrival_tick.get(&stop) else {
+                    self.last_arrival_tick.insert(stop, now);
+                    continue;
+                };
+                self.last_arrival_tick.insert(stop, now);
+
+                let gap = now.saturating_sub(prev);
+                let target = u64::from(self.target_headway_ticks);
+                if gap >= target {
+                    continue;
+                }
+                // Cars arriving below target headway extend their
+                // dwell by the gap deficit, capped to keep a stuck
+                // leader from freezing the follower indefinitely.
+                #[allow(
+                    clippy::cast_possible_truncation,
+                    reason = "deficit is bounded by target_headway_ticks (u32); truncation to u32 is exact"
+                )]
+                let deficit = (target - gap) as u32;
+                let extra = deficit.min(self.hold_cap_ticks);
+                if extra == 0 {
+                    continue;
+                }
+                if let Some(c) = world.elevator_mut(eid) {
+                    // Push directly to the per-car queue rather than
+                    // routing through `Simulation::enqueue_door_command`
+                    // — the strategy only has `&mut World`, not a sim
+                    // handle, and `HoldOpen` is explicitly cumulative
+                    // (collapsing adjacent dupes would silently drop a
+                    // real recovery deficit). Honour the cap so the
+                    // queue can't grow unbounded across a sustained
+                    // bunching episode.
+                    if c.door_command_queue.len() < crate::components::DOOR_COMMAND_QUEUE_CAP {
+                        c.door_command_queue
+                            .push(DoorCommand::HoldOpen { ticks: extra });
+                    }
                 }
             }
         }
+
+        self.seen_loading = still_loading;
     }
 
     fn rank(&self, _ctx: &RankContext<'_>) -> Option<f64> {
@@ -181,7 +305,10 @@ impl DispatchStrategy for LoopScheduleDispatch {
         Ok(())
     }
 
-    fn notify_removed(&mut self, _elevator: EntityId) {
-        // No per-car state to evict.
+    fn notify_removed(&mut self, elevator: EntityId) {
+        // Drop bookkeeping for removed elevators so the set doesn't
+        // grow without bound across long-running sims that swap cars
+        // in and out (e.g. test harnesses).
+        self.seen_loading.remove(&elevator);
     }
 }

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -1496,12 +1496,12 @@ fn loop_sweep_delivers_riders_to_every_served_stop() {
 fn loop_schedule_strategy_round_trips_through_snapshot_identity() {
     use crate::dispatch::{BuiltinStrategy, DispatchStrategy, LoopScheduleDispatch};
 
-    let strategy = LoopScheduleDispatch::new(45, 360);
+    let strategy = LoopScheduleDispatch::new(45, 360, 90);
     assert_eq!(strategy.builtin_id(), Some(BuiltinStrategy::LoopSchedule));
     assert!(BuiltinStrategy::LoopSchedule.instantiate().is_some());
 
-    // Snapshot config must carry both tunables so the next sim resumes
-    // with the original schedule rather than the `default()` 30/300
+    // Snapshot config must carry all three tunables so the next sim
+    // resumes with the original schedule rather than the `default()`
     // tuning that `BuiltinStrategy::instantiate` would otherwise emit.
     let serialized = strategy.snapshot_config().expect("snapshot_config");
     let mut restored = LoopScheduleDispatch::default();
@@ -1510,6 +1510,7 @@ fn loop_schedule_strategy_round_trips_through_snapshot_identity() {
         .expect("restore_config");
     assert_eq!(restored.dwell_ticks(), 45);
     assert_eq!(restored.target_headway_ticks(), 360);
+    assert_eq!(restored.hold_cap_ticks(), 90);
 }
 
 #[cfg(feature = "loop_lines")]
@@ -1525,7 +1526,7 @@ fn loop_schedule_overrides_per_car_door_open_ticks() {
     if let Some(groups) = config.building.groups.as_mut() {
         groups[0].dispatch = crate::dispatch::BuiltinStrategy::LoopSchedule;
     }
-    let mut sim = Simulation::new(&config, LoopScheduleDispatch::new(42, 600)).unwrap();
+    let mut sim = Simulation::new(&config, LoopScheduleDispatch::new(42, 600, 120)).unwrap();
     let car_eid = sim.world().iter_elevators().next().unwrap().0;
 
     assert_eq!(
@@ -1573,7 +1574,7 @@ fn loop_schedule_delivers_riders_around_loop() {
         // Pick a dwell that's small enough not to dominate the
         // delivery budget. Real schedules pick this from the
         // expected boarding time at each stop.
-        let mut sim = Simulation::new(&config, LoopScheduleDispatch::new(20, 600)).unwrap();
+        let mut sim = Simulation::new(&config, LoopScheduleDispatch::new(20, 600, 120)).unwrap();
         let line_eid = sim.world().iter_elevators().next().unwrap().2.line();
 
         let origin = sim
@@ -1636,6 +1637,316 @@ fn config_accepts_loop_schedule_strategy_on_loop_group() {
     }
     Simulation::new(&config, crate::dispatch::LoopScheduleDispatch::default())
         .expect("LoopSchedule must be accepted on a Loop group");
+}
+
+#[cfg(feature = "loop_lines")]
+#[test]
+fn loop_schedule_hold_recovery_extends_dwell_for_early_arrival() {
+    // Drive the hold-recovery path with a hand-built world. Two
+    // elevators on a Loop line; we record an earlier arrival at a
+    // stop, then put the second car in Loading at that stop with
+    // `CurrentTick` close to the recorded arrival (i.e. *below*
+    // target headway). The strategy must enqueue a HoldOpen on the
+    // second car whose extension matches the gap deficit.
+    use crate::arrival_log::CurrentTick;
+    use crate::components::{ElevatorPhase, Line, LineKind, Orientation, Stop};
+    use crate::dispatch::{DispatchManifest, DispatchStrategy, ElevatorGroup, LineInfo};
+    use crate::door::DoorCommand;
+    use crate::ids::GroupId;
+    use crate::world::World;
+
+    let mut world = World::new();
+
+    // Build the Loop line.
+    let line_eid = world.spawn();
+    world.set_line(
+        line_eid,
+        Line {
+            name: "Track".into(),
+            group: GroupId(0),
+            orientation: Orientation::Vertical,
+            position: None,
+            kind: LineKind::Loop {
+                circumference: 100.0,
+                min_headway: 5.0,
+            },
+            max_cars: None,
+        },
+    );
+
+    // One served stop is enough for this test — hold-recovery keys on
+    // per-stop arrival ticks, not per-line.
+    let stop_eid = world.spawn();
+    world.set_stop(
+        stop_eid,
+        Stop {
+            name: "S0".into(),
+            position: 0.0,
+        },
+    );
+
+    // Spawn two elevators on the loop. The leader is parked off-stop
+    // and idle — pre_dispatch shouldn't touch its phase, only its
+    // dwell. The follower is parked at `stop_eid` in Loading.
+    let leader = super::dispatch_tests::spawn_elevator(&mut world, 50.0);
+    let follower = super::dispatch_tests::spawn_elevator(&mut world, 0.0);
+    {
+        let car = world.elevator_mut(follower).unwrap();
+        car.line = line_eid;
+        car.phase = ElevatorPhase::Loading;
+        car.target_stop = Some(stop_eid);
+    }
+    {
+        let car = world.elevator_mut(leader).unwrap();
+        car.line = line_eid;
+    }
+
+    let group = ElevatorGroup::new(
+        GroupId(0),
+        "Track".into(),
+        vec![LineInfo::new(
+            line_eid,
+            vec![leader, follower],
+            vec![stop_eid],
+        )],
+    );
+
+    // Target headway 600 ticks; the recorded prior arrival was 100
+    // ticks ago. Deficit = 500. Cap = 1000 (high enough not to bind).
+    world.insert_resource(CurrentTick(1_000));
+    let mut sched = crate::dispatch::LoopScheduleDispatch::new(20, 600, 1_000);
+
+    // Two arrivals at the same stop drive recovery: run pre_dispatch
+    // once with the leader in Loading at the stop (records its
+    // arrival tick), then move the leader away, advance the clock by
+    // 100, put the follower in Loading at the same stop, and run
+    // pre_dispatch again.
+    {
+        let car = world.elevator_mut(leader).unwrap();
+        car.phase = ElevatorPhase::Loading;
+        car.target_stop = Some(stop_eid);
+        car.door_command_queue.clear();
+    }
+    {
+        let car = world.elevator_mut(follower).unwrap();
+        car.phase = ElevatorPhase::Idle;
+    }
+    let manifest = DispatchManifest::default();
+    sched.pre_dispatch(&group, &manifest, &mut world);
+
+    // Advance the clock 100 ticks, swap roles: leader leaves, follower
+    // arrives. The recorded gap is therefore 100, well below the 600
+    // target headway → deficit 500, capped only by hold_cap_ticks.
+    world.insert_resource(CurrentTick(1_100));
+    {
+        let car = world.elevator_mut(leader).unwrap();
+        car.phase = ElevatorPhase::MovingToStop(stop_eid);
+    }
+    {
+        let car = world.elevator_mut(follower).unwrap();
+        car.phase = ElevatorPhase::Loading;
+        car.target_stop = Some(stop_eid);
+        car.door_command_queue.clear();
+    }
+    sched.pre_dispatch(&group, &manifest, &mut world);
+
+    let follower_q = &world.elevator(follower).unwrap().door_command_queue;
+    let hold = follower_q
+        .iter()
+        .find_map(|c| match c {
+            DoorCommand::HoldOpen { ticks } => Some(*ticks),
+            _ => None,
+        })
+        .expect("follower must receive a HoldOpen on early arrival");
+    assert_eq!(
+        hold, 500,
+        "hold extension should equal target_headway - gap = 600 - 100 = 500",
+    );
+}
+
+#[cfg(feature = "loop_lines")]
+#[test]
+fn loop_schedule_hold_recovery_respects_cap() {
+    // Same shape as the previous test, but with a tight `hold_cap_ticks`
+    // that bounds the extension. Deficit would be 5000 ticks; the cap
+    // is 30. The issued HoldOpen must equal the cap, never the raw
+    // deficit — otherwise a stuck leader would freeze the follower.
+    use crate::arrival_log::CurrentTick;
+    use crate::components::{ElevatorPhase, Line, LineKind, Orientation, Stop};
+    use crate::dispatch::{DispatchManifest, DispatchStrategy, ElevatorGroup, LineInfo};
+    use crate::door::DoorCommand;
+    use crate::ids::GroupId;
+    use crate::world::World;
+
+    let mut world = World::new();
+    let line_eid = world.spawn();
+    world.set_line(
+        line_eid,
+        Line {
+            name: "Track".into(),
+            group: GroupId(0),
+            orientation: Orientation::Vertical,
+            position: None,
+            kind: LineKind::Loop {
+                circumference: 100.0,
+                min_headway: 5.0,
+            },
+            max_cars: None,
+        },
+    );
+    let stop_eid = world.spawn();
+    world.set_stop(
+        stop_eid,
+        Stop {
+            name: "S0".into(),
+            position: 0.0,
+        },
+    );
+    let leader = super::dispatch_tests::spawn_elevator(&mut world, 50.0);
+    let follower = super::dispatch_tests::spawn_elevator(&mut world, 0.0);
+    {
+        let car = world.elevator_mut(leader).unwrap();
+        car.line = line_eid;
+        car.phase = ElevatorPhase::Loading;
+        car.target_stop = Some(stop_eid);
+    }
+    {
+        let car = world.elevator_mut(follower).unwrap();
+        car.line = line_eid;
+    }
+    let group = ElevatorGroup::new(
+        GroupId(0),
+        "Track".into(),
+        vec![LineInfo::new(
+            line_eid,
+            vec![leader, follower],
+            vec![stop_eid],
+        )],
+    );
+
+    world.insert_resource(CurrentTick(0));
+    let mut sched = crate::dispatch::LoopScheduleDispatch::new(20, 5_000, 30);
+    let manifest = DispatchManifest::default();
+    sched.pre_dispatch(&group, &manifest, &mut world); // records leader arrival
+
+    // Follower arrives almost immediately — gap=1 tick, deficit=4999.
+    world.insert_resource(CurrentTick(1));
+    {
+        let car = world.elevator_mut(leader).unwrap();
+        car.phase = ElevatorPhase::MovingToStop(stop_eid);
+    }
+    {
+        let car = world.elevator_mut(follower).unwrap();
+        car.phase = ElevatorPhase::Loading;
+        car.target_stop = Some(stop_eid);
+        car.door_command_queue.clear();
+    }
+    sched.pre_dispatch(&group, &manifest, &mut world);
+
+    let hold = world
+        .elevator(follower)
+        .unwrap()
+        .door_command_queue
+        .iter()
+        .find_map(|c| match c {
+            DoorCommand::HoldOpen { ticks } => Some(*ticks),
+            _ => None,
+        })
+        .expect("follower must still receive a HoldOpen");
+    assert_eq!(
+        hold, 30,
+        "hold extension must be capped to hold_cap_ticks (30), not the raw deficit (4999)",
+    );
+}
+
+#[cfg(feature = "loop_lines")]
+#[test]
+fn loop_schedule_skips_recovery_when_gap_meets_target() {
+    // Follower arrives *at or beyond* the target headway: no
+    // recovery, no HoldOpen. Confirms the strategy doesn't issue
+    // spurious holds when the schedule is on time.
+    use crate::arrival_log::CurrentTick;
+    use crate::components::{ElevatorPhase, Line, LineKind, Orientation, Stop};
+    use crate::dispatch::{DispatchManifest, DispatchStrategy, ElevatorGroup, LineInfo};
+    use crate::door::DoorCommand;
+    use crate::ids::GroupId;
+    use crate::world::World;
+
+    let mut world = World::new();
+    let line_eid = world.spawn();
+    world.set_line(
+        line_eid,
+        Line {
+            name: "Track".into(),
+            group: GroupId(0),
+            orientation: Orientation::Vertical,
+            position: None,
+            kind: LineKind::Loop {
+                circumference: 100.0,
+                min_headway: 5.0,
+            },
+            max_cars: None,
+        },
+    );
+    let stop_eid = world.spawn();
+    world.set_stop(
+        stop_eid,
+        Stop {
+            name: "S0".into(),
+            position: 0.0,
+        },
+    );
+    let leader = super::dispatch_tests::spawn_elevator(&mut world, 50.0);
+    let follower = super::dispatch_tests::spawn_elevator(&mut world, 0.0);
+    {
+        let car = world.elevator_mut(leader).unwrap();
+        car.line = line_eid;
+        car.phase = ElevatorPhase::Loading;
+        car.target_stop = Some(stop_eid);
+    }
+    {
+        let car = world.elevator_mut(follower).unwrap();
+        car.line = line_eid;
+    }
+    let group = ElevatorGroup::new(
+        GroupId(0),
+        "Track".into(),
+        vec![LineInfo::new(
+            line_eid,
+            vec![leader, follower],
+            vec![stop_eid],
+        )],
+    );
+
+    world.insert_resource(CurrentTick(0));
+    let mut sched = crate::dispatch::LoopScheduleDispatch::new(20, 100, 200);
+    let manifest = DispatchManifest::default();
+    sched.pre_dispatch(&group, &manifest, &mut world); // records leader
+
+    // Follower arrives exactly at target_headway: no recovery needed.
+    world.insert_resource(CurrentTick(100));
+    {
+        let car = world.elevator_mut(leader).unwrap();
+        car.phase = ElevatorPhase::MovingToStop(stop_eid);
+    }
+    {
+        let car = world.elevator_mut(follower).unwrap();
+        car.phase = ElevatorPhase::Loading;
+        car.target_stop = Some(stop_eid);
+        car.door_command_queue.clear();
+    }
+    sched.pre_dispatch(&group, &manifest, &mut world);
+
+    let has_hold = world
+        .elevator(follower)
+        .unwrap()
+        .door_command_queue
+        .iter()
+        .any(|c| matches!(c, DoorCommand::HoldOpen { .. }));
+    assert!(
+        !has_hold,
+        "on-time arrival (gap == target_headway) must not trigger hold-recovery",
+    );
 }
 
 #[test]

--- a/docs/plans/loop-lines-v1.md
+++ b/docs/plans/loop-lines-v1.md
@@ -14,8 +14,8 @@ All work ships behind the `loop_lines` cargo feature (default off).
 | 5 | Cyclic motion wired into the movement systems phase | shipped (#812) |
 | 6 | Loop FSM completion: door continuation + kickstart + boarding bypass | shipped (#814) |
 | 7 | `LoopSweep` dispatch | shipped (#816) |
-| 8 | `LoopSchedule` fixed-dwell | this PR |
-| 9 | `LoopSchedule` hold-recovery | not started |
+| 8 | `LoopSchedule` fixed-dwell | shipped (#818) |
+| 9 | `LoopSchedule` hold-recovery | this PR |
 | 10 | Demo scenario + host wiring | not started |
 
 ## Locked decisions


### PR DESCRIPTION
## Summary

Wire the hold-recovery mechanism deferred from PR #818. \`LoopSchedule\` now extends a follower's dwell whenever it arrives at a stop within \`target_headway_ticks\` of the preceding car's arrival at the same stop. The extra ticks come from a new \`hold_cap_ticks\` tunable (default 120 ticks / 2 seconds at 60 Hz) so a stuck leader can't freeze the follower indefinitely.

### Mechanism

- **Per-stop arrival ticks** tracked in \`LoopScheduleDispatch::last_arrival_tick\`, keyed off the \`CurrentTick\` resource the runtime keeps in sync.
- **Fresh-arrival detection** via a \`seen_loading: HashSet<EntityId>\` — the strategy issues at most one \`HoldOpen\` per arrival, on the tick the car first appears in \`ElevatorPhase::Loading\`.
- **Recovery extension** = \`min(target_headway_ticks - gap, hold_cap_ticks)\`, pushed onto the car's \`door_command_queue\` directly. \`HoldOpen\` is the cumulative door command the door FSM already honours.
- **No-overtake preserved**: an early leader is never sped up — recovery only delays followers.
- **Snapshot stability**: the bookkeeping maps are \`#[serde(skip)]\`. Snapshot restore rebuilds them on the next arrival at each stop; a one-time un-recovered tick per stop is acceptable.

### Limitations

A leader exceeding \`hold_cap_ticks\` of boarding still lets the follower catch up. Tune \`hold_cap_ticks\` to the worst-case boarding burst the line expects.

## Test plan

- [x] \`cargo test -p elevator-core --features loop_lines\` (1049 pass)
- [x] \`cargo clippy -p elevator-core --features loop_lines --all-targets\`
- [x] New tests:
  - \`loop_schedule_hold_recovery_extends_dwell_for_early_arrival\` — gap 100 vs headway 600 yields \`HoldOpen { ticks: 500 }\`
  - \`loop_schedule_hold_recovery_respects_cap\` — deficit 4999 with cap 30 yields \`HoldOpen { ticks: 30 }\`
  - \`loop_schedule_skips_recovery_when_gap_meets_target\` — arrival at exact headway emits no \`HoldOpen\`