### PR TITLE
feat: loop lines demo scenario and bevy host opt-in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "20.10.0"
+version = "20.11.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/assets/config/loop_demo.ron
+++ b/assets/config/loop_demo.ron
@@ -1,0 +1,111 @@
+// Loop-line demo scenario.
+//
+// Closed-loop transit topology: a 100-unit one-way loop with four
+// stops spaced 25 units apart and two cars that patrol forward
+// indefinitely. Exercises every piece of the loop_lines feature:
+//
+//   - LineKind::Loop topology + cyclic position math
+//   - Kickstart pass turning Idle Loop cars into MovingToStop on tick 1
+//   - Door FSM continuation (DoorClosing → MovingToStop(next_stop)
+//     without ever passing through Stopped/Idle)
+//   - LoopSweep dispatch (call-driven; each car boards every waiter at
+//     every stop on every lap)
+//   - Boarding bypass on Loop (the linear up/down direction gate is
+//     meaningless on a one-way cycle)
+//
+// Requires the `loop_lines` cargo feature. The default Bevy host opts
+// in via its Cargo.toml; running this config without the feature
+// returns SimError::InvalidConfig with a clear reason.
+SimConfig(
+    schema_version: 1,
+    building: BuildingConfig(
+        name: "Loop Demo",
+        // Four stops evenly spaced around the loop. Cyclic order
+        // follows position mod 100: 0 → 25 → 50 → 75 → wrap to 0.
+        // Stop names mirror gondola/monorail-station naming, not
+        // building floors, so consumers don't accidentally read a
+        // peak-traffic axis into the topology.
+        stops: [
+            StopConfig(id: StopId(0), name: "North",  position: 0.0),
+            StopConfig(id: StopId(1), name: "East",   position: 25.0),
+            StopConfig(id: StopId(2), name: "South",  position: 50.0),
+            StopConfig(id: StopId(3), name: "West",   position: 75.0),
+        ],
+        // Explicit topology: one Loop line, one group, two cars on
+        // the line. The `min_headway: 8.0` reserves enough cyclic
+        // arc for the two cars never to overtake — construction
+        // validates max_cars × min_headway ≤ circumference up front.
+        lines: Some([
+            LineConfig(
+                id: 1,
+                name: "Loop",
+                kind: Some(Loop(
+                    circumference: 100.0,
+                    min_headway: 8.0,
+                )),
+                serves: [StopId(0), StopId(1), StopId(2), StopId(3)],
+                // `position: None` defers to the layout — hosts that
+                // render the loop derive a center anchor and radius
+                // (= circumference / 2π) from the line itself.
+                position: None,
+                orientation: Horizontal,
+                elevators: [
+                    ElevatorConfig(
+                        id: 1,
+                        name: "Car 1",
+                        max_speed: 2.0,
+                        acceleration: 1.5,
+                        deceleration: 2.0,
+                        weight_capacity: 800.0,
+                        // Cars start at diametrically-opposite stops
+                        // so the initial spacing already meets the
+                        // headway constraint and the LoopSweep + door
+                        // FSM continuation maintains it from tick 1.
+                        starting_stop: StopId(0),
+                        door_open_ticks: 60,
+                        door_transition_ticks: 15,
+                    ),
+                    ElevatorConfig(
+                        id: 2,
+                        name: "Car 2",
+                        max_speed: 2.0,
+                        acceleration: 1.5,
+                        deceleration: 2.0,
+                        weight_capacity: 800.0,
+                        starting_stop: StopId(2),
+                        door_open_ticks: 60,
+                        door_transition_ticks: 15,
+                    ),
+                ],
+            ),
+        ]),
+        groups: Some([
+            GroupConfig(
+                id: 0,
+                name: "Loop Service",
+                lines: [1],
+                // `LoopSweep` is the only-or-`LoopSchedule` choice for
+                // Loop groups. Picked here because the demo emphasises
+                // call-driven patrol over fixed-headway timetabling;
+                // swap to `LoopSchedule` for a predictable-cadence
+                // people-mover feel (PRs #818 + #820).
+                dispatch: LoopSweep,
+            ),
+        ]),
+    ),
+    // No legacy flat elevator list — explicit topology declares cars
+    // inside their lines. An empty list keeps the legacy field present
+    // for the schema version's deserializer.
+    elevators: [],
+    simulation: SimulationParams(
+        ticks_per_second: 60.0,
+    ),
+    passenger_spawning: PassengerSpawnConfig(
+        // Faster spawn cadence than the default so the demo always
+        // shows the boarding-and-routing path under exercise; cars
+        // would otherwise patrol an empty line and the visible
+        // behaviour would degrade to "two dots circling."
+        mean_interval_ticks: 60,
+        weight_range: (50.0, 100.0),
+    ),
+)

--- a/crates/elevator-bevy/Cargo.toml
+++ b/crates/elevator-bevy/Cargo.toml
@@ -9,7 +9,13 @@ publish = false
 workspace = true
 
 [dependencies]
-elevator-core = { path = "../elevator-core" }
+# `loop_lines` is enabled here so the bevy binary can load
+# `assets/config/loop_demo.ron` (and any other host-side Loop config
+# the user points it at) out of the box without a separate feature
+# opt-in. The runtime cost of the feature for Linear-only scenarios
+# is a conditional cyclic-motion branch in `systems/movement.rs` —
+# a single predicate per car per tick.
+elevator-core = { path = "../elevator-core", features = ["loop_lines"] }
 bevy = { version = "0.18", default-features = false, features = ["2d"] }
 ron.workspace = true
 rand.workspace = true

--- a/crates/elevator-core/src/tests/config_tests.rs
+++ b/crates/elevator-core/src/tests/config_tests.rs
@@ -329,16 +329,53 @@ fn shipped_assets_pin_to_current_schema_version() {
     // Every config under assets/config/ must declare the current
     // version explicitly; otherwise the asset itself becomes a legacy
     // file the next time someone bumps CURRENT_CONFIG_SCHEMA_VERSION.
-    for asset in [
+    let mut assets = vec![
         include_str!("../../../../assets/config/default.ron"),
         include_str!("../../../../assets/config/space_elevator.ron"),
         include_str!("../../../../assets/config/annotated.ron"),
-    ] {
+    ];
+    // `loop_demo.ron` carries a Loop-kind line and can only be parsed
+    // when the feature is enabled. The deserializer rejects Loop
+    // variants outright with the feature off, so listing it
+    // unconditionally would fail the schema pin on the default
+    // feature configuration. Gating the read mirrors how the binary
+    // would handle the same config at runtime.
+    #[cfg(feature = "loop_lines")]
+    assets.push(include_str!("../../../../assets/config/loop_demo.ron"));
+
+    for asset in assets {
         let config: SimConfig = ron::from_str(asset).expect("shipped asset deserializes");
         assert_eq!(
             config.schema_version,
             crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
             "shipped asset must pin to CURRENT_CONFIG_SCHEMA_VERSION"
         );
+    }
+}
+
+#[cfg(feature = "loop_lines")]
+#[test]
+fn loop_demo_config_loads_and_runs() {
+    // End-to-end smoke check: the shipped loop demo deserializes,
+    // constructs through `Simulation::new`, and survives a handful of
+    // ticks without panicking. Catches RON-schema drift (field names,
+    // variant shape) and runtime-invariant regressions that
+    // construction validation would surface.
+    use crate::dispatch::LoopSweepDispatch;
+    use crate::sim::Simulation;
+
+    let ron_str = include_str!("../../../../assets/config/loop_demo.ron");
+    let config: SimConfig = ron::from_str(ron_str).expect("loop_demo.ron must deserialize cleanly");
+
+    let mut sim = Simulation::new(&config, LoopSweepDispatch::new())
+        .expect("loop_demo.ron must construct a valid Simulation");
+
+    // Run a few hundred ticks — enough for the kickstart pass, the
+    // first door cycle on each car, and the door FSM continuation
+    // handing off to the next forward stop. Smoke test, not a
+    // behavioural assertion, so a successful run = no panics + no
+    // out-of-bounds entity references in the pipeline.
+    for _ in 0..600 {
+        sim.step();
     }
 }

--- a/docs/plans/loop-lines-v1.md
+++ b/docs/plans/loop-lines-v1.md
@@ -15,8 +15,9 @@ All work ships behind the `loop_lines` cargo feature (default off).
 | 6 | Loop FSM completion: door continuation + kickstart + boarding bypass | shipped (#814) |
 | 7 | `LoopSweep` dispatch | shipped (#816) |
 | 8 | `LoopSchedule` fixed-dwell | shipped (#818) |
-| 9 | `LoopSchedule` hold-recovery | this PR |
-| 10 | Demo scenario + host wiring | not started |
+| 9 | `LoopSchedule` hold-recovery | shipped (#820) |
+| 10 | Demo scenario + Bevy opt-in + mdBook chapter | this PR |
+| 11 | TUI / WASM host wiring (deferred) | not started |
 
 ## Locked decisions
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -35,6 +35,7 @@
 # Advanced Topics
 
 - [Writing a Custom Dispatch](custom-dispatch.md)
+- [Loop Lines](loop-lines.md)
 - [Extensions](extensions.md)
 - [Lifecycle Hooks](lifecycle-hooks.md)
 - [Manual and Inspection Modes](manual-inspection-modes.md)

--- a/docs/src/loop-lines.md
+++ b/docs/src/loop-lines.md
@@ -1,0 +1,146 @@
+# Loop Lines
+
+Closed-loop transit topologies -- people-movers, gondolas, monorails, airport pedways -- aren't elevator shafts. They're one-way cycles where every served stop is reachable forward through the line, and "up vs. down" doesn't apply. The `loop_lines` cargo feature adds a `LineKind::Loop` variant that captures this topology end-to-end: cyclic position math, headway-clamped multi-car ordering, two dispatch strategies (`LoopSweep` and `LoopSchedule`), and the FSM adaptations that keep Loop cars patrolling continuously without ever entering `Idle`.
+
+The feature is off by default. Hosts that want to load Loop scenarios opt in via their `Cargo.toml`:
+
+```toml
+elevator-core = { path = "../elevator-core", features = ["loop_lines"] }
+```
+
+The shipped `elevator-bevy` host enables the feature out of the box; `elevator-tui`, `elevator-ffi`, and `elevator-wasm` currently don't.
+
+## When to use a loop
+
+Pick `LineKind::Loop` whenever the physical layout is a closed cycle and the line is one-way. Examples:
+
+- Airport people-movers and parking shuttles
+- Theme-park monorails and gondolas
+- Mining haul-truck circuits
+- Conveyor-style horizontal transport between two towers
+
+If "up" and "down" are meaningful on the line, it's a `Linear` shaft; use the default topology. Mixing Loop and Linear lines in the same group is rejected at construction -- see [Group homogeneity](#group-homogeneity).
+
+## Topology
+
+```mermaid
+graph LR
+    N["North (0.0)"] --> E["East (25.0)"]
+    E --> S["South (50.0)"]
+    S --> W["West (75.0)"]
+    W --> N
+```
+
+A `LineKind::Loop` is configured with two fields:
+
+```ron
+kind: Some(Loop(
+    circumference: 100.0,
+    min_headway: 8.0,
+)),
+```
+
+- **`circumference`** -- total path length of the loop, in the same distance units as stops. Positions on the line are normalised modulo `circumference`, so a car at position `125.0` on a 100-unit loop is treated as position `25.0`.
+- **`min_headway`** -- minimum cyclic arc between consecutive cars. Construction validates `max_cars * min_headway <= circumference`, so a misconfigured loop that couldn't fit every car at full headway is rejected up front.
+
+Stops on a Loop are listed by ID under `serves`. Position determines cyclic order; the lowest-position stop isn't special. Stops sharing a position on the same Loop are rejected (cyclic order would be ambiguous).
+
+## Group homogeneity
+
+A group is either all-Linear or all-Loop. Mixing the topologies in one group is rejected at construction:
+
+```text
+error: group 0 mixes Loop and Linear lines; groups must be homogeneous
+```
+
+The dispatch and reposition strategies that drive a group don't compose across topologies. Loop strategies (`LoopSweep`, `LoopSchedule`) reject Linear ranking; Linear strategies (`Scan`, `Look`, etc.) reject Loop semantics. Splitting the lines into separate groups keeps each group's strategy honest.
+
+Loop groups additionally:
+
+- Reject reposition strategies (Loop cars never enter `Idle`, so there's nothing to reposition).
+- Reject every dispatch strategy except `LoopSweep` and `LoopSchedule`.
+
+## Dispatch strategies
+
+Two dispatch strategies are available for Loop groups:
+
+### `LoopSweep` -- call-driven patrol
+
+Every Loop car patrols forward continuously, boarding every eligible rider at every served stop. Dwell at each stop tracks rider load via the per-car `door_open_ticks` -- a stop with many waiters takes longer than an empty one. This is the default choice for "every car serves everyone, every lap" scenarios.
+
+```ron
+GroupConfig(
+    id: 0,
+    name: "Loop Service",
+    lines: [1],
+    dispatch: LoopSweep,
+),
+```
+
+### `LoopSchedule` -- fixed-dwell timetable
+
+Every Loop car spends a uniform `dwell_ticks` at every stop, producing a predictable timetable. Useful for people-mover lines, gondolas, and timetabled shuttle services where consistent cadence matters more than load-shaped dwell.
+
+`LoopSchedule` also runs **hold-recovery**: when a car arrives at a stop within `target_headway_ticks` of the preceding arrival, it extends its dwell by `min(target_headway_ticks - gap, hold_cap_ticks)` to recover the schedule. The cap prevents a stuck leader from freezing the follower indefinitely.
+
+```rust,no_run
+use elevator_core::dispatch::LoopScheduleDispatch;
+
+// 30-tick dwell, 600-tick target headway, 120-tick cap.
+let schedule = LoopScheduleDispatch::new(30, 600, 120);
+```
+
+Hold-recovery never speeds a car up -- it can only delay followers running ahead of their schedule slot. The no-overtake invariant on Loop lines is preserved.
+
+## Loop-aware FSM adaptations
+
+Several pieces of the engine behave differently on Loop lines:
+
+- **No `Idle` phase**: a Loop car constructed in `Idle` is kickstarted to `MovingToStop(forward_next_stop)` at the start of the next dispatch tick, and the door FSM hands the car straight from `DoorClosing` to `MovingToStop(next)` rather than `Stopped`. Loop cars patrol continuously.
+- **Direction indicator**: Loop cars report `Direction::Forward` instead of `Up` / `Down` / `Either`. The `going_up` / `going_down` lamps are explicitly cleared and `going_forward` is set true.
+- **Boarding gate bypassed**: the linear `(dest_pos > stop_pos) -> requires going_up` filter is meaningless on a cycle. Loop cars board every rider eligible by capacity and route.
+- **Reposition no-op**: even with a (now-rejected) reposition strategy installed, the reposition phase explicitly skips Loop cars.
+- **`OutOfService` rejected with followers**: putting a Loop car into `OutOfService` would freeze every car behind it on the loop. Construction rejects the transition unless the car has zero followers (single-car loops are allowed).
+
+## Example: the shipped demo
+
+`assets/config/loop_demo.ron` ships a 4-stop, 2-car loop:
+
+```text
+Stops:        North (0)  East (25)  South (50)  West (75)
+Loop:         circumference 100, min_headway 8
+Cars:         Car 1 starts at North, Car 2 starts at South
+Dispatch:     LoopSweep (call-driven)
+Spawning:     ~1 rider/sec on the demo's 60 Hz tick rate
+```
+
+Run it from the Bevy host:
+
+```bash
+cargo run -- assets/config/loop_demo.ron
+```
+
+Both cars patrol forward indefinitely, board waiting riders at every stop, and deliver them around the cycle to their destinations. The headway clamp keeps Car 2 from overtaking Car 1 even when Car 1 stops for a heavy boarding burst.
+
+## Snapshots
+
+`LineKind` round-trips through snapshots. Snapshots taken with a Loop scenario can be restored into another sim with the feature enabled. A snapshot containing `LineKind::Loop` cannot be restored by a sim built without the `loop_lines` feature -- deserialization rejects the variant outright.
+
+The wire format will keep the legacy flat `min_position` / `max_position` fields alongside `kind` for one release after this feature lands, to give snapshots produced by pre-feature sims a deterministic deserialization path. Once that release cycle passes, the flat fields will be removed.
+
+## Out of scope for v1
+
+The `loop_lines` v1 ships **one-way** loops only. The following are explicitly out of scope and rejected at construction or runtime:
+
+- Bidirectional loops
+- Pull-a-car-out-of-the-loop with follower retargeting (a Loop car can be put `OutOfService` only when it has no followers)
+- Block signalling for multi-segment lines
+
+Future iterations may revisit these once the v1 surface has soaked.
+
+## Next steps
+
+- [Dispatch Strategies](dispatch-strategies.md) -- the broader strategy interface that `LoopSweep` and `LoopSchedule` plug into
+- [Stops, Lines, and Groups](stops-lines-groups.md) -- the topology primitives `LineKind` extends
+- [Movement and Physics](movement-physics.md) -- the trapezoidal integrator that the cyclic seam-split builds on
+- [Configuration](configuration.md) -- the RON schema `loop_demo.ron` uses


### PR DESCRIPTION
## Summary

Wrap up the \`loop_lines\` v1 feature with a runnable demo, the Bevy host's feature opt-in, and the user-facing mdBook chapter. This is the last v1-scope PR in the loop-lines series — closing the gap between "the engine supports loops" and "the engine ships a loop you can run."

- **\`assets/config/loop_demo.ron\`** — 4-stop 100-unit one-way loop, two cars on LoopSweep, 60-tick rider spawn cadence. Exercises kickstart, door-FSM continuation, headway clamp, and call-driven boarding end-to-end.
- **\`crates/elevator-bevy/Cargo.toml\`** — enable \`loop_lines\` so \`cargo run -- assets/config/loop_demo.ron\` works out of the box. Runtime cost on Linear-only scenarios is one conditional branch in the movement system.
- **\`docs/src/loop-lines.md\`** — mdBook chapter covering topology, dispatch trade-off (LoopSweep vs. LoopSchedule), group homogeneity, FSM adaptations, the shipped demo, and v1 scope boundaries.
- **Schema-pin test** now includes the loop demo (feature-gated). New \`loop_demo_config_loads_and_runs\` smoke test deserializes, constructs, and runs 600 ticks without panicking.

## Scope splits

TUI and WASM host wiring is split into a follow-up — neither host needs the feature for the v1 demo, and bundling them inflates the review surface without buying coverage the smoke test doesn't already give.

## Test plan

- [x] \`cargo test -p elevator-core --features loop_lines\` (1050 pass)
- [x] \`cargo clippy -p elevator-core --features loop_lines --all-targets\`
- [x] \`scripts/lint-docs.sh\` (all checks pass)
- [x] \`cargo check -p elevator-bevy\` (Bevy host compiles with feature opt-in)
- [x] New test: \`loop_demo_config_loads_and_runs\`