### PR TITLE
feat(elevator-wasm): loop lines feature opt-in and LineView kind exposure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "20.11.0"
+version = "20.12.0"
 dependencies = [
  "criterion",
  "ordered-float",

--- a/crates/elevator-wasm/Cargo.toml
+++ b/crates/elevator-wasm/Cargo.toml
@@ -37,7 +37,7 @@ default = []
 deterministic-fp = ["elevator-core/deterministic-fp"]
 
 [dependencies]
-elevator-core = { path = "../elevator-core", features = ["traffic"] }
+elevator-core = { path = "../elevator-core", features = ["loop_lines", "traffic"] }
 wasm-bindgen = "0.2"
 js-sys = "0.3"
 serde-wasm-bindgen = "0.6"

--- a/crates/elevator-wasm/src/world_view.rs
+++ b/crates/elevator-wasm/src/world_view.rs
@@ -107,10 +107,18 @@ pub struct CarView {
     pub rider_ids: Vec<u64>,
     /// Door FSM state with transition progress.
     pub door: DoorView,
-    /// Direction lamp: car will accept up-pickups.
+    /// Direction lamp: car will accept up-pickups. Always `false` on
+    /// Loop cars (the up/down axis is meaningless on a one-way cycle).
     pub going_up: bool,
-    /// Direction lamp: car will accept down-pickups.
+    /// Direction lamp: car will accept down-pickups. Always `false` on
+    /// Loop cars (see [`Self::going_up`]).
     pub going_down: bool,
+    /// Direction lamp for Loop topologies: car is patrolling forward
+    /// around its line. Always `false` on Linear cars. Renderers that
+    /// show a single direction-arrow glyph should prefer this over the
+    /// `going_up`/`going_down` pair when set; on Linear cars the
+    /// arrow is derived from the up/down pair as before.
+    pub going_forward: bool,
     /// ETA to `target` in seconds, or `None` if not currently dispatched
     /// to a known stop or the destination queue is empty.
     pub eta_seconds: Option<f64>,
@@ -198,6 +206,20 @@ pub struct LineView {
     pub name: String,
     pub min_position: f64,
     pub max_position: f64,
+    /// Topology kind. `"linear"` for open-ended shafts (the default);
+    /// `"loop"` for closed-loop people-movers, gondolas, and monorails.
+    /// Renderers branch on this to pick layout: linear shafts render as
+    /// vertical/horizontal strips; loops render as cycles, deriving the
+    /// rendering radius from `circumference`.
+    #[tsify(type = r#""linear" | "loop""#)]
+    pub kind: &'static str,
+    /// Total path length around the loop, in distance units. Always
+    /// present (`Some`) for `kind == "loop"` and absent (`None`) for
+    /// `kind == "linear"` — for backward compatibility,
+    /// `max_position - min_position` still spans the renderable range
+    /// in both cases, so consumers that don't yet branch on `kind`
+    /// keep rendering correctly.
+    pub circumference: Option<f64>,
     /// Stops served, in entity-id order.
     pub stop_ids: Vec<u64>,
     /// Cars on this line.
@@ -282,19 +304,27 @@ fn build_topology(
                     .or_default()
                     .push(entity_to_u64(line_eid));
             }
+            let circumference = line.circumference();
+            // Use the line's topology kind (`is_loop` keys off the same
+            // enum variant) rather than the circumference presence so
+            // a Loop with a zero-derived `[0, 0]` linear span (which
+            // shouldn't happen, but is defensible) still reports
+            // `"loop"`. Two-state today; widen to a real Tsify enum
+            // when a third topology variant ships.
+            let kind = if line.is_loop() { "loop" } else { "linear" };
             lines.push(LineView {
                 id: entity_to_u64(line_eid),
                 group: group_id,
                 name: line.name().to_string(),
-                // Loop lines (gated behind the `loop_lines` feature) report
-                // `[0, circumference]` here so existing playground rendering
-                // doesn't blow up; tsified `LineView` will gain a kind field
-                // when loop support reaches the host wiring PR.
+                // Loop lines report `[0, circumference]` so consumers that
+                // pre-date the `kind`/`circumference` fields keep
+                // rendering a meaningful range. Loop-aware consumers
+                // branch on `kind` and derive layout from
+                // `circumference` directly.
                 min_position: line.linear_min().unwrap_or(0.0),
-                max_position: line
-                    .linear_max()
-                    .or_else(|| line.circumference())
-                    .unwrap_or(0.0),
+                max_position: line.linear_max().or(circumference).unwrap_or(0.0),
+                kind,
+                circumference,
                 stop_ids: line_info
                     .serves()
                     .iter()
@@ -344,6 +374,7 @@ fn build_cars(sim: &Simulation) -> Vec<CarView> {
                 door,
                 going_up: car.going_up(),
                 going_down: car.going_down(),
+                going_forward: car.going_forward(),
                 eta_seconds,
             }
         })

--- a/docs/plans/loop-lines-v1.md
+++ b/docs/plans/loop-lines-v1.md
@@ -16,8 +16,9 @@ All work ships behind the `loop_lines` cargo feature (default off).
 | 7 | `LoopSweep` dispatch | shipped (#816) |
 | 8 | `LoopSchedule` fixed-dwell | shipped (#818) |
 | 9 | `LoopSchedule` hold-recovery | shipped (#820) |
-| 10 | Demo scenario + Bevy opt-in + mdBook chapter | this PR |
-| 11 | TUI / WASM host wiring (deferred) | not started |
+| 10 | Demo scenario + Bevy opt-in + mdBook chapter | shipped (#822) |
+| 11 | WASM host opt-in + `LineView.kind` exposure | this PR |
+| 12 | TUI loop-strip rendering | not started |
 
 ## Locked decisions
 


### PR DESCRIPTION
## Summary

Enable the \`loop_lines\` feature on the WASM crate so the browser playground can load Loop scenarios. Extend \`LineView\` with a \`kind\` discriminator (\`\"linear\"\` | \`\"loop\"\`) and an \`Option<f64>\` \`circumference\` field so TypeScript consumers can branch on topology without hand-mirroring the core enum.

\`CarView\` gains a \`going_forward\` flag mirroring the field PR #814 added to the \`Elevator\` component, so renderers can pick a single direction-arrow glyph for Loop cars rather than reading the (always-\`false\` on Loop) \`going_up\` / \`going_down\` pair.

## Backward compatibility

Loop lines continue to report \`[min_position, max_position] = [0, circumference]\`, so the existing playground rendering keeps drawing a meaningful range when it doesn't yet branch on \`kind\`. tsify auto-generates the new fields into \`elevator_wasm.d.ts\` — no hand-mirroring in the playground TypeScript layer.

## Scope split

TUI loop-strip rendering deferred to a follow-up PR — it's a new render mode, not metadata exposure, and reviews better on its own.

## Test plan

- [x] \`cargo check -p elevator-wasm\`
- [x] \`cargo clippy -p elevator-wasm --all-targets\`
- [x] \`scripts/build-wasm.sh\` (regenerates \`elevator_wasm.d.ts\` cleanly)
- [x] \`pnpm --filter elevator-playground typecheck\` (no errors)
- [x] \`pnpm --filter elevator-playground test\` (344/344 vitest pass)
- [x] \`scripts/check-abi-pins.sh\` (in sync at version 5)
- [x] \`cargo test -p elevator-core --features loop_lines\` (1050 pass)