### PR TITLE
feat(elevator-tui): horizontal loop-strip rendering for loop topologies

### DIFF
--- a/crates/elevator-tui/Cargo.toml
+++ b/crates/elevator-tui/Cargo.toml
@@ -16,7 +16,7 @@ name = "elevator-tui"
 path = "src/main.rs"
 
 [dependencies]
-elevator-core = { path = "../elevator-core", features = ["traffic"] }
+elevator-core = { path = "../elevator-core", features = ["loop_lines", "traffic"] }
 ratatui = { version = "0.30", default-features = false, features = ["crossterm_0_29"] }
 tui-big-text = "0.8"
 crossterm = "0.29"

--- a/crates/elevator-tui/src/ui/shaft.rs
+++ b/crates/elevator-tui/src/ui/shaft.rs
@@ -194,11 +194,43 @@ pub fn draw(frame: &mut Frame<'_>, area: Rect, state: &AppState, sim: &Simulatio
         sim,
         flashing: &is_flashing,
     };
-    let lines: Vec<Line<'_>> = match state.shaft_mode {
-        ShaftMode::Index => render_index_mode(&stops, &ctx, inner.height),
-        ShaftMode::Distance => render_distance_mode(&stops, &ctx, inner.height),
+    // Loop topology renders as a horizontal strip per line: stops
+    // placed along the [0, circumference) axis, cars overlaid at
+    // their current cyclic position, with a `|` seam marker at the
+    // wrap-around. The vertical Index/Distance modes are meaningless
+    // for a loop (there's no top-to-bottom axis), so a sim whose
+    // every line is a Loop bypasses them entirely. Mixed-topology
+    // sims (Linear + Loop in different groups) keep the vertical
+    // view for v1; an integrated split-pane layout is a follow-up.
+    let lines: Vec<Line<'_>> = if all_loop(sim) {
+        render_loop_strips(&ctx, inner.width)
+    } else {
+        match state.shaft_mode {
+            ShaftMode::Index => render_index_mode(&stops, &ctx, inner.height),
+            ShaftMode::Distance => render_distance_mode(&stops, &ctx, inner.height),
+        }
     };
     frame.render_widget(Paragraph::new(lines), inner);
+}
+
+/// True if every line in the sim has `LineKind::Loop` topology.
+///
+/// A sim with no lines (legacy single-group topology) trivially fails
+/// the check — we render the vertical view there. The function is
+/// `pub(super)` so the recommended-width path can also branch on it
+/// in the future (loop strips have a different width contract than
+/// the per-car column-based vertical mode).
+fn all_loop(sim: &Simulation) -> bool {
+    let mut saw_line = false;
+    for group in sim.groups() {
+        for line in group.lines() {
+            saw_line = true;
+            if !sim.is_loop(line.entity()) {
+                return false;
+            }
+        }
+    }
+    saw_line
 }
 
 /// Bundle of per-frame resolution data shared across stop rows.
@@ -272,6 +304,205 @@ fn render_distance_mode<'a>(
             None => spacer_row(row, rows, max_pos, min_pos, ctx),
         })
         .collect()
+}
+
+/// Render every Loop line in the sim as one horizontal strip showing
+/// stops along the `[0, circumference)` axis and cars overlaid at
+/// their current cyclic positions.
+///
+/// Each loop produces three rows:
+///
+/// ```text
+///   Loop                  N · 100.0           ←
+///   ┃───[N]────────────[E]────────────[S]────────────[W]───┃
+///       ↑                                              c1
+/// ```
+///
+/// The top row is the line label + waiting-counts header (one
+/// `name(n)` per stop with non-zero waiters). The middle row is the
+/// track itself: stops sit at `position / circumference` of the
+/// available width; the `┃` glyphs at the ends mark the seam (loop
+/// wrap). The bottom row is the car overlay: each car maps its
+/// continuous cyclic position to the same x-axis and draws a single
+/// glyph, with the focused car bolded and flashing cars accent-tinted.
+///
+/// Width budget: a 4-column inner area is the smallest layout that
+/// can carry a stop and a seam at each edge; anything narrower
+/// silently collapses to a no-op line per loop.
+fn render_loop_strips<'a>(ctx: &RenderCtx<'a>, width: u16) -> Vec<Line<'a>> {
+    let mut lines: Vec<Line<'a>> = Vec::new();
+    // The strip itself spans `(width - 2)` cells: one cell on each
+    // end is reserved for the seam glyph. The math below works out
+    // to roughly the same range for narrow widths so a 6-cell pane
+    // still produces *something* legible.
+    let strip_cols: usize = usize::from(width.saturating_sub(2)).max(1);
+
+    for group in ctx.sim.groups() {
+        for line_info in group.lines() {
+            let line_eid = line_info.entity();
+            let Some(line) = ctx.sim.world().line(line_eid) else {
+                continue;
+            };
+            let Some(circumference) = line.circumference() else {
+                // Defensive: `all_loop` already filtered to Loop lines,
+                // but skip silently if a future variant slips through.
+                continue;
+            };
+
+            // Header: line name + circumference summary, padded to
+            // fit before the first stop column.
+            let header_summary = format!(
+                "{} · C={:.1} · {} stop(s)",
+                line.name(),
+                circumference,
+                line_info.serves().len(),
+            );
+            lines.push(Line::from(Span::styled(
+                header_summary,
+                Style::default()
+                    .fg(palette::TITLE)
+                    .add_modifier(Modifier::BOLD),
+            )));
+
+            lines.push(loop_track_row(
+                line_info.serves(),
+                circumference,
+                strip_cols,
+                ctx,
+            ));
+            lines.push(loop_cars_row(line_eid, circumference, strip_cols, ctx));
+            // Spacer between consecutive loops so two strips don't
+            // visually merge into a single-line ladder.
+            lines.push(Line::from(""));
+        }
+    }
+    lines
+}
+
+/// Build the per-loop track row: seam markers at both ends, `─` rule
+/// across, and `[X]` labels at each stop's fractional position.
+///
+/// Stops at exactly position 0 land *on* the seam — they take the
+/// seam cell with their own label and the wrap visual is implied by
+/// the adjacent end of the strip. Stops at coincident positions
+/// would overwrite each other; construction validation rejects that
+/// case, so it's defensible to take the first-wins behaviour here.
+fn loop_track_row<'a>(
+    served: &'a [EntityId],
+    circumference: f64,
+    strip_cols: usize,
+    ctx: &RenderCtx<'a>,
+) -> Line<'a> {
+    let mut cells: Vec<char> = vec!['─'; strip_cols];
+
+    // Per-stop letter overlay: place the first character of each stop
+    // name at its cyclic-fraction column. Adjacent stops on a tight
+    // loop will collide; let the later one win (deterministic given
+    // `served`'s sort order).
+    for &stop_eid in served {
+        let Some(stop) = ctx.sim.world().stop(stop_eid) else {
+            continue;
+        };
+        let col = cyclic_column(stop.position(), circumference, strip_cols);
+        if let Some(label) = stop.name().chars().next() {
+            cells[col] = label;
+        }
+    }
+
+    let mut spans = Vec::with_capacity(strip_cols + 2);
+    spans.push(Span::styled("┃", Style::default().fg(palette::ACCENT)));
+    let mut current_run: String = String::new();
+    let mut current_style = Style::default().fg(palette::DIM_STRONG);
+    for ch in cells {
+        let style = if ch == '─' {
+            Style::default().fg(palette::DIM_STRONG)
+        } else {
+            Style::default()
+                .fg(palette::TITLE)
+                .add_modifier(Modifier::BOLD)
+        };
+        if style != current_style && !current_run.is_empty() {
+            spans.push(Span::styled(current_run.clone(), current_style));
+            current_run.clear();
+        }
+        current_style = style;
+        current_run.push(ch);
+    }
+    if !current_run.is_empty() {
+        spans.push(Span::styled(current_run, current_style));
+    }
+    spans.push(Span::styled("┃", Style::default().fg(palette::ACCENT)));
+    Line::from(spans)
+}
+
+/// Per-loop car-overlay row. Walks every car on the line, computes its
+/// cyclic-fraction column, and writes a glyph (`▼` by default; `★` for
+/// the focused car; flash-accent tint when the car was recently
+/// touched).
+fn loop_cars_row<'a>(
+    line_eid: EntityId,
+    circumference: f64,
+    strip_cols: usize,
+    ctx: &RenderCtx<'a>,
+) -> Line<'a> {
+    let mut cells: Vec<Span<'a>> = Vec::with_capacity(strip_cols + 2);
+    let mut buf: Vec<Option<(char, Style)>> = vec![None; strip_cols];
+    for car in ctx.cars {
+        if car.elevator.line() != line_eid {
+            continue;
+        }
+        let col = cyclic_column(car.position, circumference, strip_cols);
+        let is_focused = ctx.focused == Some(car.id);
+        let is_flashing = (ctx.flashing)(car.id);
+        let glyph = if is_focused { '★' } else { '▼' };
+        let style = if is_flashing {
+            palette::flash_style()
+        } else if is_focused {
+            Style::default()
+                .fg(palette::ACCENT)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(palette::TITLE)
+        };
+        // Multiple cars sharing a column → the later writer wins;
+        // the headway clamp keeps real loops away from this case,
+        // and a deterministic-but-imperfect collapse is more useful
+        // than a heuristic merge glyph.
+        buf[col] = Some((glyph, style));
+    }
+    // Leading-space column to balance the seam glyph on the track row,
+    // so the car cells align with the track cells underneath them.
+    cells.push(Span::raw(" "));
+    for slot in buf {
+        match slot {
+            Some((ch, style)) => cells.push(Span::styled(ch.to_string(), style)),
+            None => cells.push(Span::raw(" ")),
+        }
+    }
+    cells.push(Span::raw(" "));
+    Line::from(cells)
+}
+
+/// Map a cyclic position (`[0, circumference)`) to a column in the
+/// strip, clamped to `[0, strip_cols - 1]`.
+///
+/// Positions are wrapped via `rem_euclid` so an off-range input (a
+/// numerical near-circumference value or a negative drift) lands on
+/// the correct cell rather than blowing the index. `strip_cols == 0`
+/// would zero-divide; the caller already enforces `strip_cols >= 1`.
+pub(super) fn cyclic_column(position: f64, circumference: f64, strip_cols: usize) -> usize {
+    if !position.is_finite() || !circumference.is_finite() || circumference <= 0.0 {
+        return 0;
+    }
+    let wrapped = position.rem_euclid(circumference);
+    let fraction = wrapped / circumference;
+    #[allow(
+        clippy::cast_sign_loss,
+        clippy::cast_possible_truncation,
+        reason = "fraction is in [0,1); strip_cols is usize; product fits a usize"
+    )]
+    let raw = (fraction * strip_cols as f64) as usize;
+    raw.min(strip_cols.saturating_sub(1))
 }
 
 /// Render one stop row: `↑Lobby   0.0 (3) │ ▲  ·  ▼` with the hall-call
@@ -523,5 +754,54 @@ mod tests {
         // is at 10 + 1 + 26 = 37.
         assert_eq!(column_to_car_idx(10, 37, 1), Some(0));
         assert_eq!(column_to_car_idx(10, 36, 1), None);
+    }
+
+    #[test]
+    fn cyclic_column_maps_zero_to_first_cell() {
+        // Position 0 maps to column 0 regardless of circumference,
+        // matching the visual "seam-anchored" mental model.
+        assert_eq!(cyclic_column(0.0, 100.0, 20), 0);
+        assert_eq!(cyclic_column(0.0, 7.5, 4), 0);
+    }
+
+    #[test]
+    fn cyclic_column_maps_half_circumference_to_middle() {
+        // Half-circumference lands on the midpoint cell.
+        assert_eq!(cyclic_column(50.0, 100.0, 20), 10);
+        assert_eq!(cyclic_column(25.0, 100.0, 20), 5);
+        assert_eq!(cyclic_column(75.0, 100.0, 20), 15);
+    }
+
+    #[test]
+    fn cyclic_column_wraps_past_circumference() {
+        // Cars near-but-past the seam end up back at column 0 rather
+        // than off the right edge. Defends against accumulated
+        // floating-point drift in the cyclic integrator.
+        assert_eq!(cyclic_column(100.0, 100.0, 20), 0);
+        assert_eq!(cyclic_column(101.5, 100.0, 20), 0);
+        assert_eq!(cyclic_column(-10.0, 100.0, 20), 18);
+    }
+
+    #[test]
+    fn cyclic_column_clamps_to_last_cell() {
+        // The largest valid output is `strip_cols - 1`. Fractions
+        // approaching 1.0 must not produce `strip_cols` and overflow
+        // the buffer the caller indexes with this value.
+        let last = cyclic_column(99.9999, 100.0, 20);
+        assert!(
+            last < 20,
+            "cyclic_column must stay within [0, strip_cols); got {last}"
+        );
+    }
+
+    #[test]
+    fn cyclic_column_handles_degenerate_inputs() {
+        // Non-finite and non-positive inputs collapse to column 0
+        // rather than panic or zero-divide. Matches the cyclic helper
+        // module's defensive-degradation contract.
+        assert_eq!(cyclic_column(f64::NAN, 100.0, 20), 0);
+        assert_eq!(cyclic_column(50.0, f64::INFINITY, 20), 0);
+        assert_eq!(cyclic_column(50.0, 0.0, 20), 0);
+        assert_eq!(cyclic_column(50.0, -100.0, 20), 0);
     }
 }

--- a/crates/elevator-tui/src/ui/shaft.rs
+++ b/crates/elevator-tui/src/ui/shaft.rs
@@ -318,9 +318,9 @@ fn render_distance_mode<'a>(
 ///       ↑                                              c1
 /// ```
 ///
-/// The top row is the line label + waiting-counts header (one
-/// `name(n)` per stop with non-zero waiters). The middle row is the
-/// track itself: stops sit at `position / circumference` of the
+/// The top row is the line label + a summary showing circumference
+/// and stop count (`name · C=<c> · <n> stop(s)`). The middle row is
+/// the track itself: stops sit at `position / circumference` of the
 /// available width; the `┃` glyphs at the ends mark the seam (loop
 /// wrap). The bottom row is the car overlay: each car maps its
 /// continuous cyclic position to the same x-axis and draws a single
@@ -386,7 +386,9 @@ fn render_loop_strips<'a>(ctx: &RenderCtx<'a>, width: u16) -> Vec<Line<'a>> {
 /// seam cell with their own label and the wrap visual is implied by
 /// the adjacent end of the strip. Stops at coincident positions
 /// would overwrite each other; construction validation rejects that
-/// case, so it's defensible to take the first-wins behaviour here.
+/// case, so this loop is defensibly last-wins (the final entry in
+/// `served` to land on the cell keeps it; deterministic given
+/// `served`'s sort order).
 fn loop_track_row<'a>(
     served: &'a [EntityId],
     circumference: f64,

--- a/crates/elevator-tui/tests/render_snapshot.rs
+++ b/crates/elevator-tui/tests/render_snapshot.rs
@@ -106,6 +106,44 @@ fn frame_with_events_pane_focused() {
 }
 
 #[test]
+fn frame_renders_loop_topology_as_horizontal_strip() {
+    // The shipped loop demo exercises the LoopSweep + cyclic motion +
+    // door FSM continuation path end-to-end. Render after a few
+    // hundred ticks — long enough for both cars to be patrolling,
+    // doors cycling, and waiters accumulating. The buffer must
+    // contain the seam markers (`┃`) at each strip end and a car
+    // glyph (`▼`) somewhere on the cars-overlay row. Existence of
+    // those glyphs is what differentiates the loop strip from the
+    // vertical shaft view, so this is the load-bearing assertion.
+    use elevator_core::config::SimConfig;
+    use elevator_core::dispatch::LoopSweepDispatch;
+
+    let ron_str = include_str!("../../../assets/config/loop_demo.ron");
+    let config: SimConfig = ron::from_str(ron_str).expect("loop_demo deserializes");
+    let mut sim = Simulation::new(&config, LoopSweepDispatch::new()).expect("loop_demo constructs");
+    for _ in 0..600 {
+        sim.step();
+    }
+
+    let state = AppState::new(1.0).without_welcome();
+    let frame = render(&sim, &state, 100, 30);
+
+    assert!(
+        frame.contains('┃'),
+        "loop topology must render seam markers in the strip; got:\n{frame}"
+    );
+    assert!(
+        frame.contains('▼') || frame.contains('★'),
+        "loop topology must render at least one car glyph on the overlay row; got:\n{frame}"
+    );
+    // Don't snapshot this one — the precise glyph layout depends on
+    // the RNG seed for rider spawning and the exact tick at which
+    // each car arrives. Behavioural-glyph assertions stay stable
+    // across RON-schema drift; the existing snapshot tests cover
+    // the Linear path's full-pixel buffer.
+}
+
+#[test]
 fn frame_with_help_overlay() {
     // The help modal grew with the events-pane scroll/filter section
     // landing in PR2. Render at a taller viewport so every binding is

--- a/docs/plans/loop-lines-v1.md
+++ b/docs/plans/loop-lines-v1.md
@@ -17,8 +17,8 @@ All work ships behind the `loop_lines` cargo feature (default off).
 | 8 | `LoopSchedule` fixed-dwell | shipped (#818) |
 | 9 | `LoopSchedule` hold-recovery | shipped (#820) |
 | 10 | Demo scenario + Bevy opt-in + mdBook chapter | shipped (#822) |
-| 11 | WASM host opt-in + `LineView.kind` exposure | this PR |
-| 12 | TUI loop-strip rendering | not started |
+| 11 | WASM host opt-in + `LineView.kind` exposure | shipped (#823) |
+| 12 | TUI loop-strip rendering | this PR |
 
 ## Locked decisions
 


### PR DESCRIPTION
## Summary

Enable the \`loop_lines\` feature on the TUI host and add a dedicated horizontal-strip renderer for Loop lines. A loop-only sim (e.g. the shipped \`assets/config/loop_demo.ron\`) now renders as one strip per loop:

\`\`\`text
Loop · C=100.0 · 4 stop(s)
┃─N───────E───────S───────W────┃
 ▼                           ★
\`\`\`

The vertical Index / Distance shaft modes are meaningless for loops (there's no top-to-bottom axis), so a sim whose every line is a Loop bypasses them. Mixed-topology sims (Linear + Loop in different groups) keep the vertical view for v1; an integrated split-pane layout is a follow-up.

## Components

- **\`all_loop\`** — sim-wide predicate that opts the renderer into the strip mode. A line-less legacy sim keeps the vertical view.
- **\`render_loop_strips\`** — per-loop three-row layout: header (name · circumference · stop count), track row with seam \`┃\` at each end + \`─\` rule + stop-initial labels, car overlay row with \`▼\` glyphs (\`★\` for the focused car).
- **\`cyclic_column\`** — pure mapping from \`(position, circumference)\` to a strip column index with wrap-around and defensive-degradation handling for non-finite or non-positive inputs.

## Test plan

- [x] \`cargo test -p elevator-tui\` (existing snapshot suite + new tests pass)
- [x] \`cargo clippy -p elevator-tui --all-targets\` (clean)
- [x] \`cargo check --workspace --all-features --all-targets\`
- [x] New tests:
  - \`cyclic_column_*\` (5 tests covering zero, half-circumference, seam wrap, clamp, NaN/inf/zero/negative)
  - \`frame_renders_loop_topology_as_horizontal_strip\` — loads \`loop_demo.ron\`, runs 600 ticks, asserts buffer contains seam markers \`┃\` and at least one car glyph