### PR TITLE
ci: isolate the loop_lines feature in the wasm32 gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,14 @@ jobs:
       - name: Check core (energy feature, wasm32)
         run: cargo check -p elevator-core --target wasm32-unknown-unknown --no-default-features --features energy
 
+      - name: Check core (loop_lines feature, wasm32)
+        # Mirror of the `energy` isolation check above. `elevator-wasm`
+        # enables `loop_lines` alongside `traffic` (the full-stack line
+        # below exercises that combo), so without this isolated step a
+        # `loop_lines`-only regression on wasm32 would only surface in
+        # a host opting into a narrower feature surface.
+        run: cargo check -p elevator-core --target wasm32-unknown-unknown --no-default-features --features loop_lines
+
       - name: Check elevator-wasm bindgen crate (full stack)
         # Exercises elevator-core with default features (incl. `traffic`)
         # alongside the `wasm_js` getrandom shim — the only target+feature


### PR DESCRIPTION
## Summary

\`elevator-wasm\` (PR #823) enables \`loop_lines\` alongside the existing \`traffic\` feature, so the full-stack \`cargo check -p elevator-wasm --target wasm32-unknown-unknown\` step does exercise the loop code on wasm32. But it only exercises the combo: a \`loop_lines\`-only regression that depends on a feature \`traffic\` happens to bring in would slip past until a host opted into a narrower feature surface.

Mirror the existing \`energy\` isolation pattern: one extra \`cargo check\` line with \`--no-default-features --features loop_lines\` so core remains wasm-compatible on its own.

## Test plan

- [x] Local: \`cargo check -p elevator-core --target wasm32-unknown-unknown --no-default-features --features loop_lines\` finishes clean
- [x] Pre-commit hook passes (full workspace tests + lints)