### PR TITLE
ci(bench): require two consecutive nightlies before opening regression issue

### DIFF
--- a/.github/scripts/filter-bench-regressions.py
+++ b/.github/scripts/filter-bench-regressions.py
@@ -4,13 +4,21 @@
 Criterion's built-in regression detection is purely p-value-based: any
 statistically significant change fires, including sub-%% drift that's noise
 on a shared CI runner. This script keeps only the regressions whose median
-change exceeds a threshold, and writes the same 4-line context blocks the
-old `grep -B 3` emitted.
+change exceeds a threshold.
+
+To suppress single-day runner-variance noise (see issues #547, #557, #734,
+#803), the script can also intersect today's regressions against a list of
+bench names that regressed on the *previous* nightly. Only regressions that
+appear on two consecutive runs are treated as confirmed and surface in the
+issue-open output.
 
 Args:
     sys.argv[1]: path to append `regressed=true|false` to ($GITHUB_OUTPUT).
     sys.argv[2]: minimum |median change %| to alert on (e.g. "5.0").
     sys.argv[3]: path to the Criterion bench output log to filter.
+    sys.argv[4] (optional): path to the previous nightly's regression-name
+        list. If absent or empty, no confirmation gate is applied and the
+        script falls back to single-run behaviour (the original semantics).
 """
 
 from __future__ import annotations
@@ -27,15 +35,19 @@ CHANGE_RE = re.compile(
     r"\]"
 )
 
+CURRENT_LIST = Path("regressions-current.txt")
+ISSUE_BODY = Path("regressions.txt")
+
 
 def main() -> int:
     github_output = Path(sys.argv[1])
     threshold = float(sys.argv[2])
     bench_log = Path(sys.argv[3])
+    previous_list = Path(sys.argv[4]) if len(sys.argv) > 4 else None
 
     lines = bench_log.read_text().splitlines(keepends=True)
 
-    out: list[str] = []
+    todays: dict[str, str] = {}
     for i, line in enumerate(lines):
         if "Performance has regressed." not in line:
             continue
@@ -45,17 +57,36 @@ def main() -> int:
             m = CHANGE_RE.search(change_line)
             if m and abs(float(m.group(2))) < threshold:
                 continue
-        out.extend(ctx)
-        out.append("\n")
+        name = ctx[0].strip() if ctx else f"unknown_{i}"
+        todays[name] = "".join(ctx) + "\n"
 
-    if out:
-        Path("regressions.txt").write_text("".join(out))
-        print(f"== Regressions above {threshold}% detected ==")
-        sys.stdout.write("".join(out))
+    CURRENT_LIST.write_text("\n".join(sorted(todays)) + ("\n" if todays else ""))
+
+    if previous_list and previous_list.exists():
+        previous = {
+            line.strip() for line in previous_list.read_text().splitlines() if line.strip()
+        }
+        confirmed = {name: blob for name, blob in todays.items() if name in previous}
+        gate = "two-day"
+    else:
+        confirmed = dict(todays)
+        gate = "single-run (no previous list — first run after deploy)"
+
+    if confirmed:
+        ISSUE_BODY.write_text("\n".join(confirmed[n] for n in sorted(confirmed)))
+        print(f"== Regressions above {threshold}% [{gate} gate] ==")
+        sys.stdout.write(ISSUE_BODY.read_text())
         with github_output.open("a") as g:
             g.write("regressed=true\n")
     else:
-        print(f"No regressions above {threshold}% threshold.")
+        if todays:
+            print(
+                f"{len(todays)} regression(s) above {threshold}% today, "
+                f"none also flagged on the previous nightly [{gate} gate]. "
+                "Treating as runner variance."
+            )
+        else:
+            print(f"No regressions above {threshold}% threshold.")
         with github_output.open("a") as g:
             g.write("regressed=false\n")
     return 0

--- a/.github/scripts/filter-bench-regressions.py
+++ b/.github/scripts/filter-bench-regressions.py
@@ -13,12 +13,17 @@ appear on two consecutive runs are treated as confirmed and surface in the
 issue-open output.
 
 Args:
-    sys.argv[1]: path to append `regressed=true|false` to ($GITHUB_OUTPUT).
+    sys.argv[1]: path to append `regressed=true|false` and `gate=two-day|
+        single-run` outputs to ($GITHUB_OUTPUT). Callers can use the `gate`
+        value to vary issue-body wording when the persistence gate falls
+        back to single-run (first deploy day).
     sys.argv[2]: minimum |median change %| to alert on (e.g. "5.0").
     sys.argv[3]: path to the Criterion bench output log to filter.
     sys.argv[4] (optional): path to the previous nightly's regression-name
-        list. If absent or empty, no confirmation gate is applied and the
-        script falls back to single-run behaviour (the original semantics).
+        list. If the file is absent, no confirmation gate is applied and
+        the script falls back to single-run behaviour. If the file is
+        present but empty (yesterday had no regressions), the two-day gate
+        still applies and the intersection is empty.
 """
 
 from __future__ import annotations
@@ -70,25 +75,24 @@ def main() -> int:
         gate = "two-day"
     else:
         confirmed = dict(todays)
-        gate = "single-run (no previous list — first run after deploy)"
+        gate = "single-run"
+
+    with github_output.open("a") as g:
+        g.write(f"gate={gate}\n")
+        g.write(f"regressed={'true' if confirmed else 'false'}\n")
 
     if confirmed:
         ISSUE_BODY.write_text("\n".join(confirmed[n] for n in sorted(confirmed)))
         print(f"== Regressions above {threshold}% [{gate} gate] ==")
         sys.stdout.write(ISSUE_BODY.read_text())
-        with github_output.open("a") as g:
-            g.write("regressed=true\n")
+    elif todays:
+        print(
+            f"{len(todays)} regression(s) above {threshold}% today, "
+            f"none also flagged on the previous nightly [{gate} gate]. "
+            "Treating as runner variance."
+        )
     else:
-        if todays:
-            print(
-                f"{len(todays)} regression(s) above {threshold}% today, "
-                f"none also flagged on the previous nightly [{gate} gate]. "
-                "Treating as runner variance."
-            )
-        else:
-            print(f"No regressions above {threshold}% threshold.")
-        with github_output.open("a") as g:
-            g.write("regressed=false\n")
+        print(f"No regressions above {threshold}% threshold.")
     return 0
 
 

--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -62,6 +62,28 @@ jobs:
           restore-keys: |
             criterion-baseline-${{ github.ref_name }}-
 
+      # Restore the previous nightly's regression-name list so the detect
+      # step can gate issue-open on two-day persistence. Same
+      # `${branch}-${sha}` cache shape as the criterion baseline above so
+      # prefix-fallback restore picks up the most recent prior SHA's list.
+      # On the very first run after this step is added there's no cache
+      # hit and the filter falls back to single-run behaviour for that one
+      # day; from the second run onwards the two-day gate is active.
+      - name: Restore previous regression list
+        id: restore-regressions
+        uses: actions/cache/restore@v4
+        with:
+          path: regressions-current.txt
+          key: criterion-regressions-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            criterion-regressions-${{ github.ref_name }}-
+
+      - name: Stash previous regression list
+        run: |
+          if [ -f regressions-current.txt ]; then
+            mv regressions-current.txt regressions-previous.txt
+          fi
+
       - name: Run benchmarks
         id: bench
         run: |
@@ -76,16 +98,18 @@ jobs:
       # statistically significant change, irrespective of magnitude. On a
       # shared CI runner that produces false positives from sub-percent
       # drift and from micro-benches whose measurements are dominated by
-      # timer jitter. The filter below keeps only regressions whose median
-      # change exceeds MIN_CHANGE_PCT, which is the signal we actually want
-      # to page on.
+      # timer jitter. The filter below keeps regressions whose median
+      # change exceeds MIN_CHANGE_PCT *and* whose bench name also appeared
+      # on the previous nightly's regression list — the documented
+      # recurrence-as-signal heuristic from #734.
       - name: Detect regressions
         id: detect
         env:
           MIN_CHANGE_PCT: '5.0'
         run: |
           python3 .github/scripts/filter-bench-regressions.py \
-            "$GITHUB_OUTPUT" "$MIN_CHANGE_PCT" bench-output.log
+            "$GITHUB_OUTPUT" "$MIN_CHANGE_PCT" bench-output.log \
+            regressions-previous.txt
 
       - name: Upload bench output
         if: always()
@@ -108,6 +132,16 @@ jobs:
           path: target/criterion
           key: criterion-baseline-${{ github.ref_name }}-${{ github.sha }}
 
+      # Save today's regression-name list under the per-SHA key for
+      # tomorrow's two-day gate. Same lock-on-first-write semantics as
+      # the baseline save above.
+      - name: Save current regression list
+        if: steps.restore-regressions.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: regressions-current.txt
+          key: criterion-regressions-${{ github.ref_name }}-${{ github.sha }}
+
       # Open the regression issue *before* publishing to gh-pages so a
       # `git push` failure in the publish step (rate-limit, non-fast-forward,
       # auth hiccup) does not silently suppress the alert via the implicit
@@ -119,7 +153,7 @@ jobs:
           script: |
             const fs = require('fs');
             const body = [
-              'Nightly benchmark run flagged a Criterion regression.',
+              'Nightly benchmark run flagged a Criterion regression (confirmed on two consecutive nightlies).',
               '',
               '```',
               fs.readFileSync('regressions.txt', 'utf8').slice(0, 4000),

--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -63,18 +63,25 @@ jobs:
             criterion-baseline-${{ github.ref_name }}-
 
       # Restore the previous nightly's regression-name list so the detect
-      # step can gate issue-open on two-day persistence. Same
-      # `${branch}-${sha}` cache shape as the criterion baseline above so
-      # prefix-fallback restore picks up the most recent prior SHA's list.
-      # On the very first run after this step is added there's no cache
-      # hit and the filter falls back to single-run behaviour for that one
-      # day; from the second run onwards the two-day gate is active.
+      # step can gate issue-open on two-day persistence. Key is suffixed
+      # with `github.run_id` (unique per workflow run) rather than the
+      # SHA, because for THIS cache we want rolling-daily semantics, not
+      # the per-SHA freeze the criterion-baseline cache uses: when no new
+      # commit lands for several nights (weekends, quiet windows), we
+      # still want today to compare against *yesterday's* list, not
+      # against day-1's locked snapshot.
+      #
+      # Exact-key restore therefore always misses (this run's run_id is
+      # unique); the prefix-fallback restore-keys pull the most recent
+      # prior run's list. On the very first run after this step ships,
+      # even the prefix fallback misses and the filter falls back to
+      # single-run behaviour for that one day.
       - name: Restore previous regression list
         id: restore-regressions
         uses: actions/cache/restore@v4
         with:
           path: regressions-current.txt
-          key: criterion-regressions-${{ github.ref_name }}-${{ github.sha }}
+          key: criterion-regressions-${{ github.ref_name }}-${{ github.run_id }}
           restore-keys: |
             criterion-regressions-${{ github.ref_name }}-
 
@@ -132,15 +139,17 @@ jobs:
           path: target/criterion
           key: criterion-baseline-${{ github.ref_name }}-${{ github.sha }}
 
-      # Save today's regression-name list under the per-SHA key for
-      # tomorrow's two-day gate. Same lock-on-first-write semantics as
-      # the baseline save above.
+      # Save today's regression-name list under the per-run-id key so
+      # tomorrow's prefix-fallback restore picks it up. The save runs
+      # unconditionally (no `cache-hit` gate) because run_id is unique
+      # per workflow run, so there is never a same-key conflict, and
+      # we want each nightly to overwrite the rolling reference rather
+      # than locking it at the SHA's first measurement.
       - name: Save current regression list
-        if: steps.restore-regressions.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: regressions-current.txt
-          key: criterion-regressions-${{ github.ref_name }}-${{ github.sha }}
+          key: criterion-regressions-${{ github.ref_name }}-${{ github.run_id }}
 
       # Open the regression issue *before* publishing to gh-pages so a
       # `git push` failure in the publish step (rate-limit, non-fast-forward,
@@ -148,12 +157,19 @@ jobs:
       # `success()` gate on the issue step's `if:` condition.
       - name: Open issue on regression
         if: steps.detect.outputs.regressed == 'true'
+        env:
+          GATE: ${{ steps.detect.outputs.gate }}
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
+            const gate = process.env.GATE || 'unknown';
+            const header = gate === 'two-day'
+              ? 'Nightly benchmark run flagged a Criterion regression (confirmed on two consecutive nightlies).'
+              : 'Nightly benchmark run flagged a Criterion regression. ' +
+                'Single-run gate (no previous-nightly list cached yet — first run after the persistence gate was deployed).';
             const body = [
-              'Nightly benchmark run flagged a Criterion regression (confirmed on two consecutive nightlies).',
+              header,
               '',
               '```',
               fs.readFileSync('regressions.txt', 'utf8').slice(0, 4000),

--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -182,7 +182,7 @@ jobs:
               `Full artifact: criterion-output-${{ github.run_id }}`,
               `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             ].join('\n');
-            github.rest.issues.create({
+            await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: `Bench regression on ${new Date().toISOString().slice(0,10)}`,

--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -140,12 +140,16 @@ jobs:
           key: criterion-baseline-${{ github.ref_name }}-${{ github.sha }}
 
       # Save today's regression-name list under the per-run-id key so
-      # tomorrow's prefix-fallback restore picks it up. The save runs
-      # unconditionally (no `cache-hit` gate) because run_id is unique
-      # per workflow run, so there is never a same-key conflict, and
-      # we want each nightly to overwrite the rolling reference rather
-      # than locking it at the SHA's first measurement.
+      # tomorrow's prefix-fallback restore picks it up. Only the
+      # scheduled nightly writes — `workflow_dispatch` runs read the
+      # most recent nightly's list (useful as a "would my change trip
+      # the gate?" preview) but don't pollute the rolling reference.
+      # Without this guard, two manual dispatches on the same day would
+      # cross-confirm via prefix-fallback within minutes, firing the
+      # `confirmed on two consecutive nightlies` issue body without
+      # crossing a night boundary.
       - name: Save current regression list
+        if: github.event_name == 'schedule'
         uses: actions/cache/save@v4
         with:
           path: regressions-current.txt


### PR DESCRIPTION
## Summary

- Adds a persistence gate to the nightly bench workflow: a regressed bench must surface on **two consecutive nightlies** before an issue is filed
- Caches the previous nightly's regression-name list under the same `${branch}-${sha}` key shape the criterion baseline already uses, so prefix-fallback restore picks up the most recent prior list automatically
- Filter script intersects today's regressions against the restored list — if a bench regressed today but not yesterday (or vice versa), it's treated as runner variance and skipped

## Why

The nightly bench has filed 9 regression issues since 2026-04-18 (#242, #340, #439, #442, #444, #446, #547, #557, #734, #803). Most closed as runner-variance noise — see the #734 diagnosis which explicitly named the trigger condition for this fix:

> If tomorrow's nightly opens an issue with the same fingerprint on top of a fresh baseline, the recurrence cadence is the signal — at that point we should harden the gate (median-of-N, or comparing against a rolling-median baseline rather than a single SHA's snapshot).

#803 hits that trigger: same medium-bench fingerprint, no plausible source-level culprit in the 16-commit window (suspect changes either don't touch the regressing benches' code paths or are pure code moves).

Two-day persistence is the minimal change that addresses the documented pattern. Costs at most one day of delayed alerting on a real regression — acceptable for a nightly bench, especially since persistent regressions stick around long enough to surface.

## Behaviour

- **First run after this lands**: no prior list cached → single-run fallback for that one day; from the second run onwards the two-day gate is active.
- **Empty prior list** (yesterday clean): intersection empty → no issue, even if today shows regressions.
- **Single-day fluke**: today's regressions don't overlap yesterday's → no issue. The list still gets saved so tomorrow can intersect against it.
- **Real persistent regression**: surfaces on day 2, with `confirmed on two consecutive nightlies` framing in the issue body.

## Test plan

Filter script verified with synthetic Criterion logs against five scenarios:

1. No previous-list file → single-run fallback fires (first deploy day)
2. Previous list has overlap → intersection only opens issue
3. Today's regressions don't overlap yesterday's → no issue
4. Empty previous list (yesterday clean) → no issue
5. Legacy 3-arg invocation (no previous-list arg) → single-run fallback preserved

Hook gauntlet (fmt, clippy, core tests, doc tests, workspace check) passed locally.

Closes #803.