### PR TITLE
feat(playground): airport polish — tighter corridor, on-demand HUD, centered trains

### DIFF
--- a/playground/src/render/airport-geometry.ts
+++ b/playground/src/render/airport-geometry.ts
@@ -36,6 +36,18 @@ export function outwardNormal(p: PerimeterPoint): { nx: number; ny: number } {
   return { nx: Math.sin(p.tangent), ny: -Math.cos(p.tangent) };
 }
 
+/**
+ * Project a perimeter point inward by `gap`. Used to render inner-loop
+ * stations and trains at canvas positions geometrically aligned with
+ * the corresponding outer-loop point, instead of via independent
+ * perimeter-fraction lookup (which misaligns at corners because the
+ * loops have different perimeters).
+ */
+export function projectInward(p: PerimeterPoint, gap: number): PerimeterPoint {
+  const { nx, ny } = outwardNormal(p);
+  return { x: p.x - nx * gap, y: p.y - ny * gap, tangent: p.tangent };
+}
+
 export function tracedRoundedRect(ctx: CanvasRenderingContext2D, rect: RectGeometry): void {
   const { cx, cy, w, h, r } = rect;
   const left = cx - w / 2;

--- a/playground/src/render/draw-airport-hud.ts
+++ b/playground/src/render/draw-airport-hud.ts
@@ -12,11 +12,10 @@ import type { CarDto, StopDto } from "../types";
 export type { AABB, PerimeterPoint } from "./airport-geometry";
 
 /**
- * Persistent per-train HUD for the airport scene — the analogue of
- * the tether scenario's climber chips. One inline tag per train,
- * accent stripe colored by the train's loop. Outer trains push chips
- * outward; inner trains push chips inward into the empty interior of
- * the inner ring (clean drop zone, no labels or rings to overlap).
+ * Per-train HUD for the airport scene. Slim one-line pill carrying
+ * destination, current speed in km/h, and ETA. Pills are gated: only
+ * dwelling trains and the user's hovered/touched train get a pill, so
+ * the moving-scene reads clean and detail surfaces on demand.
  */
 
 export interface AirportPhysics {
@@ -26,70 +25,90 @@ export interface AirportPhysics {
   weightCapacity: number;
 }
 
+// Module-level hover state. Updated externally (renderer's pointer
+// handler) and read each frame in drawTrainHuds.
+let hoveredCarId: number | undefined;
+const lastTrainAnchors = new Map<number, { x: number; y: number }>();
+
+export function setAirportHoveredCar(id: number | undefined): void {
+  hoveredCarId = id;
+}
+
+/** Nearest train within `radius` of (cx, cy) in canvas-CSS coords. */
+export function pickAirportTrainAt(cx: number, cy: number, radius: number): number | undefined {
+  let best: number | undefined;
+  let bestD2 = radius * radius;
+  for (const [id, p] of lastTrainAnchors) {
+    const dx = p.x - cx;
+    const dy = p.y - cy;
+    const d2 = dx * dx + dy * dy;
+    if (d2 < bestD2) {
+      bestD2 = d2;
+      best = id;
+    }
+  }
+  return best;
+}
+
 export interface TrainPlacement {
   car: CarDto;
   anchor: PerimeterPoint;
-  letter: string;
   nextStop: StopDto | undefined;
   remainingM: number;
-  lineColor: string;
   isInner: boolean;
 }
 
 interface HudPlacement {
   placement: TrainPlacement;
-  lines: string[];
+  head: string;
+  tail: string;
   bx: number;
   by: number;
   bubbleW: number;
   bubbleH: number;
 }
 
-// HUD chips use the same surface tokens as the playground's pane
-// headers and metric panels: bg-elevated → bg-secondary gradient
-// territory, border-subtle frame, text-secondary eyebrow + text-primary
-// body. Matches scenarios like the metrics strip and tweak panel
-// rather than carrying a scenario-specific colored accent stripe.
-const HUD_BG = "#252530"; // --bg-elevated
-const HUD_BORDER = "#2a2a35"; // --border-subtle
-const HUD_EYEBROW = "#8b8c92"; // --text-tertiary, uppercase tracking
-const HUD_TEXT = "#fafafa"; // --text-primary
-const HUD_MUTED = "#a1a1aa"; // --text-secondary
-const AVG_RIDER_WEIGHT_KG = 75;
+const HUD_BG = "rgba(20, 22, 30, 0.78)";
+const HUD_BORDER = "rgba(255, 255, 255, 0.08)";
+const HUD_TEXT = "#fafafa";
+const HUD_MUTED = "#a1a1aa";
 const DWELLING_PHASES = new Set(["loading", "door-opening", "door-closing"]);
 
 function isDwelling(car: CarDto): boolean {
   return DWELLING_PHASES.has(car.phase);
 }
 
-function hasChipOverlap(me: HudPlacement, all: HudPlacement[], myIdx: number): boolean {
-  for (let i = 0; i < all.length; i++) {
+function formatKmh(vMs: number): string {
+  const kph = Math.abs(vMs) * 3.6;
+  if (kph < 0.5) return "0 km/h";
+  return `${Math.round(kph)} km/h`;
+}
+
+function overlapsAny(me: HudPlacement, others: HudPlacement[], myIdx: number): boolean {
+  for (let i = 0; i < others.length; i++) {
     if (i === myIdx) continue;
-    const o = all[i];
-    if (!o) continue;
-    if (rectIntersects(me.bx, me.by, me.bubbleW, me.bubbleH, o.bx, o.by, o.bubbleW, o.bubbleH)) {
+    const o = others[i];
+    if (o && rectIntersects(me.bx, me.by, me.bubbleW, me.bubbleH, o.bx, o.by, o.bubbleW, o.bubbleH))
       return true;
-    }
   }
   return false;
 }
 
-function hasObstacleOverlap(me: HudPlacement, obstacles: AABB[]): boolean {
-  for (const obs of obstacles) {
-    if (rectIntersects(me.bx, me.by, me.bubbleW, me.bubbleH, obs.x, obs.y, obs.w, obs.h)) {
-      return true;
-    }
+function overlapsObstacle(me: HudPlacement, obstacles: AABB[]): boolean {
+  for (const o of obstacles) {
+    if (rectIntersects(me.bx, me.by, me.bubbleW, me.bubbleH, o.x, o.y, o.w, o.h)) return true;
   }
   return false;
 }
 
-function buildHudLines(train: TrainPlacement, tripCap: number, physics: AirportPhysics): string[] {
-  const totalRiders = train.car.riders;
-  const loadLine = tripCap > 0 ? `${totalRiders} / ${tripCap}` : `${totalRiders}`;
-  const destName = train.nextStop?.name ?? "—";
+function buildHudText(
+  train: TrainPlacement,
+  physics: AirportPhysics,
+): { head: string; tail: string } {
   const arrow = isDwelling(train.car) ? "@" : "→";
-  const segmentLine = `${arrow} ${destName}`;
-  let etaLine = "ETA —";
+  const dest = train.nextStop?.name ?? "—";
+  const speed = formatKmh(train.car.v);
+  let etaStr = "—";
   if (train.nextStop && Number.isFinite(train.remainingM)) {
     const eta = tetherEta(
       0,
@@ -99,12 +118,9 @@ function buildHudLines(train: TrainPlacement, tripCap: number, physics: AirportP
       physics.acceleration,
       physics.deceleration,
     );
-    etaLine = `ETA ${formatDuration(eta)}`;
+    etaStr = formatDuration(eta);
   }
-  // First line is rendered as an eyebrow (small uppercase tracking),
-  // the rest as primary body text. Order is preserved from before so
-  // the placement / measurement code stays simple.
-  return [`Train ${train.letter}`, segmentLine, loadLine, etaLine];
+  return { head: `${arrow} ${dest}`, tail: `${speed}  ${etaStr}` };
 }
 
 export function drawTrainHuds(
@@ -118,58 +134,46 @@ export function drawTrainHuds(
   carBodyH: number,
   stationObstacles: AABB[],
 ): void {
+  // Refresh hit-test anchors every frame so the pointer handler picks
+  // the train under the cursor against current positions.
+  lastTrainAnchors.clear();
+  for (const t of trains) lastTrainAnchors.set(t.car.id, { x: t.anchor.x, y: t.anchor.y });
+
   if (trains.length === 0) return;
   if (Math.min(canvasW, canvasH) < 340) return;
 
-  const fontPx = showFullLabels ? 11 : 10;
-  const eyebrowPx = Math.round(fontPx - 2);
-  const padX = 8;
-  const padY = 5;
-  const lh = fontPx + 2;
-  const eyebrowLh = eyebrowPx + 4;
+  // Visible set: dwelling trains (info-rich moment) + the hovered
+  // train. Moving, un-hovered trains stay un-annotated.
+  const visible = trains.filter((t) => isDwelling(t.car) || t.car.id === hoveredCarId);
+  if (visible.length === 0) return;
 
-  const tripCap =
-    physics.weightCapacity > 0
-      ? Math.max(1, Math.floor(physics.weightCapacity / AVG_RIDER_WEIGHT_KG))
-      : 0;
+  const fontPx = showFullLabels ? 11 : 10;
+  const padX = 8;
+  const padY = 4;
   const placements: HudPlacement[] = [];
 
-  // Measure widest line across the body font and the eyebrow font so
-  // chip width clears the longest of the two regardless of which line
-  // is dominant.
   ctx.font = `600 ${fontPx}px ${CANVAS_FONT_SANS}`;
-  for (const train of trains) {
-    const lines = buildHudLines(train, tripCap, physics);
-    let textW = 0;
-    ctx.font = `700 ${eyebrowPx}px ${CANVAS_FONT_SANS}`;
-    const eyebrowText = (lines[0] ?? "").toUpperCase();
-    textW = Math.max(textW, ctx.measureText(eyebrowText).width);
-    ctx.font = `600 ${fontPx}px ${CANVAS_FONT_SANS}`;
-    for (let i = 1; i < lines.length; i++) {
-      textW = Math.max(textW, ctx.measureText(lines[i] ?? "").width);
-    }
+  const gapW = ctx.measureText("  ").width;
+  for (const train of visible) {
+    const { head, tail } = buildHudText(train, physics);
+    const textW = ctx.measureText(head).width + (tail ? gapW + ctx.measureText(tail).width : 0);
     const bubbleW = textW + padX * 2;
-    const bubbleH = eyebrowLh + lh * (lines.length - 1) + padY * 2;
+    const bubbleH = fontPx + padY * 2;
 
-    // Outer trains push chips outward; inner trains push inward into
-    // the empty inner-ring interior (clean drop zone, no rings or
-    // station labels to overlap).
     const { nx, ny } = outwardNormal(train.anchor);
     const dir = train.isInner ? -1 : 1;
-    const offset = carBodyH + 18;
+    const offset = carBodyH + 14;
     const ax = train.anchor.x + nx * dir * offset;
     const ay = train.anchor.y + ny * dir * offset;
 
-    let bx = ax - bubbleW / 2;
-    let by = ay - bubbleH / 2;
-    bx = Math.max(4, Math.min(canvasW - bubbleW - 4, bx));
-    by = Math.max(4, Math.min(canvasH - bubbleH - 4, by));
-    placements.push({ placement: train, lines, bx, by, bubbleW, bubbleH });
+    const bx = Math.max(4, Math.min(canvasW - bubbleW - 4, ax - bubbleW / 2));
+    const by = Math.max(4, Math.min(canvasH - bubbleH - 4, ay - bubbleH / 2));
+    placements.push({ placement: train, head, tail, bx, by, bubbleW, bubbleH });
   }
 
   // Collision pass — slide along the local tangent until clear of
-  // other chips and station-label obstacles. Up to 12 attempts with
-  // widening steps; last-resort drop into `innerSafe` if still stuck.
+  // other chips. Station-label overlap is tolerated; pill stays near
+  // its train. Inner-safe fallback only when chips still overlap.
   for (let i = 0; i < placements.length; i++) {
     const me = placements[i];
     if (!me) continue;
@@ -179,7 +183,7 @@ export function drawTrainHuds(
     let attempts = 0;
     while (
       attempts < 12 &&
-      (hasChipOverlap(me, placements, i) || hasObstacleOverlap(me, stationObstacles))
+      (overlapsAny(me, placements, i) || overlapsObstacle(me, stationObstacles))
     ) {
       const sign = attempts % 2 === 0 ? 1 : -1;
       const stepCount = Math.floor(attempts / 2) + 1;
@@ -189,14 +193,10 @@ export function drawTrainHuds(
       attempts++;
     }
     if (
-      (hasChipOverlap(me, placements, i) || hasObstacleOverlap(me, stationObstacles)) &&
+      overlapsAny(me, placements, i) &&
       innerSafe.w > me.bubbleW + 8 &&
       innerSafe.h > me.bubbleH + 8
     ) {
-      // Drop into the inner safe zone, stacked vertically. Clamp the
-      // slot so chips past capacity sit at the bottom of the safe
-      // zone rather than running off the canvas. Same-slot overlap
-      // is the lesser evil — better than half-rendered chips.
       const occupied = placements
         .slice(0, i)
         .filter(
@@ -214,8 +214,10 @@ export function drawTrainHuds(
     }
   }
 
+  ctx.textBaseline = "middle";
+  ctx.textAlign = "left";
+  ctx.font = `600 ${fontPx}px ${CANVAS_FONT_SANS}`;
   for (const p of placements) {
-    ctx.save();
     const bubbleRect = {
       cx: p.bx + p.bubbleW / 2,
       cy: p.by + p.bubbleH / 2,
@@ -230,26 +232,13 @@ export function drawTrainHuds(
     ctx.lineWidth = 1;
     tracedRoundedRect(ctx, bubbleRect);
     ctx.stroke();
-
-    ctx.textBaseline = "middle";
-    ctx.textAlign = "left";
-    let ly = p.by + padY + eyebrowLh / 2;
-    // Eyebrow: small uppercase tracking, text-tertiary. Same look as
-    // the "DISPATCH", "PARKING", "TRAFFIC" eyebrows in the pane header.
-    ctx.font = `700 ${eyebrowPx}px ${CANVAS_FONT_SANS}`;
-    ctx.fillStyle = HUD_EYEBROW;
-    const eyebrow = (p.lines[0] ?? "").toUpperCase();
-    ctx.fillText(eyebrow, p.bx + padX, ly);
-    ly += eyebrowLh / 2 + lh / 2;
-    // Body: primary text. Third line (ETA) muted so the chip doesn't
-    // shout the static physics-derived number.
-    ctx.font = `600 ${fontPx}px ${CANVAS_FONT_SANS}`;
-    for (let i = 1; i < p.lines.length; i++) {
-      const line = p.lines[i] ?? "";
-      ctx.fillStyle = i === p.lines.length - 1 ? HUD_MUTED : HUD_TEXT;
-      ctx.fillText(line, p.bx + padX, ly);
-      ly += lh;
+    const midY = p.by + p.bubbleH / 2;
+    ctx.fillStyle = HUD_TEXT;
+    ctx.fillText(p.head, p.bx + padX, midY);
+    if (p.tail) {
+      const tailX = p.bx + padX + ctx.measureText(p.head).width + gapW;
+      ctx.fillStyle = HUD_MUTED;
+      ctx.fillText(p.tail, tailX, midY);
     }
-    ctx.restore();
   }
 }

--- a/playground/src/render/draw-airport-hud.ts
+++ b/playground/src/render/draw-airport-hud.ts
@@ -25,29 +25,35 @@ export interface AirportPhysics {
   weightCapacity: number;
 }
 
-// Module-level hover state. Updated externally (renderer's pointer
-// handler) and read each frame in drawTrainHuds.
-let hoveredCarId: number | undefined;
-const lastTrainAnchors = new Map<number, { x: number; y: number }>();
+/**
+ * Per-renderer hover state for the airport scene. Owned by
+ * `CanvasRenderer` so each instance has its own pointer focus and
+ * train-anchor cache. The pointer handler writes to it; `drawTrainHuds`
+ * reads it each frame to decide which pills to surface.
+ */
+export class AirportHoverState {
+  hoveredCarId: number | undefined;
+  readonly trainAnchors = new Map<number, { x: number; y: number }>();
 
-export function setAirportHoveredCar(id: number | undefined): void {
-  hoveredCarId = id;
-}
-
-/** Nearest train within `radius` of (cx, cy) in canvas-CSS coords. */
-export function pickAirportTrainAt(cx: number, cy: number, radius: number): number | undefined {
-  let best: number | undefined;
-  let bestD2 = radius * radius;
-  for (const [id, p] of lastTrainAnchors) {
-    const dx = p.x - cx;
-    const dy = p.y - cy;
-    const d2 = dx * dx + dy * dy;
-    if (d2 < bestD2) {
-      bestD2 = d2;
-      best = id;
-    }
+  setHovered(id: number | undefined): void {
+    this.hoveredCarId = id;
   }
-  return best;
+
+  /** Nearest train within `radius` of (cx, cy) in canvas-CSS coords. */
+  pick(cx: number, cy: number, radius: number): number | undefined {
+    let best: number | undefined;
+    let bestD2 = radius * radius;
+    for (const [id, p] of this.trainAnchors) {
+      const dx = p.x - cx;
+      const dy = p.y - cy;
+      const d2 = dx * dx + dy * dy;
+      if (d2 < bestD2) {
+        bestD2 = d2;
+        best = id;
+      }
+    }
+    return best;
+  }
 }
 
 export interface TrainPlacement {
@@ -133,18 +139,19 @@ export function drawTrainHuds(
   showFullLabels: boolean,
   carBodyH: number,
   stationObstacles: AABB[],
+  hoverState: AirportHoverState,
 ): void {
   // Refresh hit-test anchors every frame so the pointer handler picks
   // the train under the cursor against current positions.
-  lastTrainAnchors.clear();
-  for (const t of trains) lastTrainAnchors.set(t.car.id, { x: t.anchor.x, y: t.anchor.y });
+  hoverState.trainAnchors.clear();
+  for (const t of trains) hoverState.trainAnchors.set(t.car.id, { x: t.anchor.x, y: t.anchor.y });
 
   if (trains.length === 0) return;
   if (Math.min(canvasW, canvasH) < 340) return;
 
   // Visible set: dwelling trains (info-rich moment) + the hovered
   // train. Moving, un-hovered trains stay un-annotated.
-  const visible = trains.filter((t) => isDwelling(t.car) || t.car.id === hoveredCarId);
+  const visible = trains.filter((t) => isDwelling(t.car) || t.car.id === hoverState.hoveredCarId);
   if (visible.length === 0) return;
 
   const fontPx = showFullLabels ? 11 : 10;

--- a/playground/src/render/draw-airport.ts
+++ b/playground/src/render/draw-airport.ts
@@ -6,7 +6,12 @@ import {
   type PerimeterPoint,
   type RectGeometry,
 } from "./airport-geometry";
-import { drawTrainHuds, type AirportPhysics, type TrainPlacement } from "./draw-airport-hud";
+import {
+  drawTrainHuds,
+  type AirportHoverState,
+  type AirportPhysics,
+  type TrainPlacement,
+} from "./draw-airport-hud";
 import { CANVAS_FONT_SANS } from "./palette";
 import type { AirportMeta, CarDto, Snapshot, StopDto } from "../types";
 
@@ -64,6 +69,7 @@ export function drawAirportScene(
   _phaseRatio: number,
   _accent: string,
   physics: AirportPhysics,
+  hoverState: AirportHoverState,
 ): void {
   ctx.save();
 
@@ -179,6 +185,7 @@ export function drawAirportScene(
     showFullLabels,
     carBodyH,
     stationObstacles,
+    hoverState,
   );
 
   ctx.restore();

--- a/playground/src/render/draw-airport.ts
+++ b/playground/src/render/draw-airport.ts
@@ -1,5 +1,6 @@
 import {
   outwardNormal,
+  projectInward,
   tracedRoundedRect,
   type AABB,
   type PerimeterPoint,
@@ -14,32 +15,32 @@ import type { AirportMeta, CarDto, Snapshot, StopDto } from "../types";
  *
  * Two concentric rounded-rectangles separated by a small gap form
  * two *distinct* lines: outer in playground blue, inner in coral.
- * Outline-circle stations on the midline serve both lines; one dot
- * per rider whether they're waiting at a platform or riding inside a
- * car. Outer trains sweep clockwise, inner trains sweep
- * counter-clockwise.
+ * Each stop renders as a single neutral tick perpendicular to the
+ * tracks, spanning the gap — minimal footprint, clearly a marker,
+ * never confused for a train segment. Inner-loop trains parameterize
+ * positions on the OUTER perimeter and project inward by `gap` so
+ * same-name stops align across loops (each loop's own perimeter
+ * lookup would misalign at corners since the arcs differ).
  *
- * A persistent per-train HUD tag pinned beside each train (outer
- * chips push outward, inner chips drop into the inner ring's empty
- * interior) carries the train's identity, next stop, load, and ETA.
+ * Outer trains sweep clockwise, inner counter-clockwise; lead car is
+ * brightened with a forward-pointing chevron so direction of motion
+ * reads at a glance.
+ *
+ * Per-train info pills are gated: dwelling trains always show one
+ * (info-rich moment), and the user's hovered/touched train shows one.
+ * Moving, un-hovered trains stay un-annotated to keep the scene calm.
  */
 
-// ── Color tokens ──────────────────────────────────────────────────────
-// Tracks are MUTED so the airport scene reads as native to the
-// playground — the rest of the scenarios use low-alpha shaft fills
-// with neutral frames, not bold saturated strokes. Loop identity
-// still comes through via the trains and waiting clusters, which
-// stay at full saturation against the muted track. Outer-track =
-// blue-tinted, inner-track = coral-tinted, both at low alpha.
-const OUTER_TRACK = "rgba(125, 211, 252, 0.45)"; // pane-a, muted
-const INNER_TRACK = "rgba(253, 164, 175, 0.4)"; // pane-b, muted
-const OUTER_TRAIN = "#7dd3fc"; // pane-a, bright — pops against the track
-const INNER_TRAIN = "#fda4af"; // pane-b, bright
+// Tracks are muted so the line identity comes through via the
+// full-saturation trains and waiting clusters on top, not the rings.
+const OUTER_TRACK = "rgba(125, 211, 252, 0.45)";
+const INNER_TRACK = "rgba(253, 164, 175, 0.4)";
+const OUTER_TRAIN = "#7dd3fc";
+const INNER_TRAIN = "#fda4af";
 const OUTER_RIDER = "rgba(125, 211, 252, 0.9)";
 const INNER_RIDER = "rgba(253, 164, 175, 0.9)";
-const STATION_RING = "#3a3a45"; // --border-default (neutral, matches shaft frames)
-const STATION_FILL = "#0b0d12";
-const STATION_LABEL = "#a1a1aa"; // --text-secondary (matches other scenarios' floor labels)
+const STATION_LABEL = "#a1a1aa";
+const STATION_TICK = "rgba(212, 212, 216, 0.55)"; // muted neutral, perpendicular to track
 
 const NARROW_LABELS_PX = 480;
 const TRAIN_CAR_COUNT = 4;
@@ -60,7 +61,7 @@ export function drawAirportScene(
   w: number,
   h: number,
   airport: AirportMeta,
-  phaseRatio: number,
+  _phaseRatio: number,
   _accent: string,
   physics: AirportPhysics,
 ): void {
@@ -68,13 +69,18 @@ export function drawAirportScene(
 
   const minDim = Math.min(w, h);
   const showFullLabels = minDim >= NARROW_LABELS_PX;
-  const rectW = w * 0.88;
-  const rectH = Math.min(h * 0.6, w * 0.42);
+  // Reserve canvas margins for station labels. Full-name labels need
+  // ~95px clearance horizontally (longest is "Concourse X" plus the
+  // outward label offset). Vertical clearance must cover the same
+  // outward offset (~38px) plus a small breathing margin so top/bottom
+  // labels never clip against the canvas edge. Glyph mode at narrow
+  // viewports drops the horizontal budget since labels become 1 char.
+  const labelPadX = showFullLabels ? 95 : 32;
+  const labelPadY = 44;
+  const rectW = Math.min(w * 0.92, Math.max(160, w - labelPadX * 2));
+  const rectH = Math.min(Math.max(120, h - labelPadY * 2), w * 0.5);
   const cornerR = Math.min(rectW, rectH) * 0.32;
-  const gap = Math.max(28, minDim * 0.06);
-  // Thin tracks, matching the playground's hairline-frame language.
-  // The bright trains on top do the visual heavy lifting; the rings
-  // are just the path.
+  const gap = Math.max(14, minDim * 0.025);
   const ringThickness = Math.max(1.5, minDim * 0.005);
 
   const outer: TrackGeometry = {
@@ -94,13 +100,6 @@ export function drawAirportScene(
     r: Math.max(0, cornerR - gap),
     color: INNER_TRACK,
     thickness: ringThickness,
-  };
-  const midline: RectGeometry = {
-    cx: w / 2,
-    cy: h / 2,
-    w: (outer.w + inner.w) / 2,
-    h: (outer.h + inner.h) / 2,
-    r: (outer.r + inner.r) / 2,
   };
 
   drawTrack(ctx, outer);
@@ -124,9 +123,8 @@ export function drawAirportScene(
     ctx,
     outerStops,
     innerStops,
-    midline,
     outer,
-    inner,
+    gap,
     airport,
     showFullLabels,
   );
@@ -136,32 +134,30 @@ export function drawAirportScene(
   const segLen = trainPx / TRAIN_CAR_COUNT;
   const carBodyH = Math.max(9, ringThickness * 2.8);
 
-  const letterByCarId = assignLetters([...outerCars, ...innerCars]);
-
   const outerPlacements = drawTrainsOnLoop(
     ctx,
     outerCars,
     outerStops,
     outer,
+    0,
     airport,
     carBodyW,
     carBodyH,
     segLen,
     false,
-    letterByCarId,
     OUTER_TRAIN,
   );
   const innerPlacements = drawTrainsOnLoop(
     ctx,
     innerCars,
     innerStops,
-    inner,
+    outer,
+    gap,
     airport,
     carBodyW,
     carBodyH,
     segLen,
     true,
-    letterByCarId,
     INNER_TRAIN,
   );
 
@@ -184,12 +180,6 @@ export function drawAirportScene(
     carBodyH,
     stationObstacles,
   );
-
-  // Day-phase intensity is already shown by the phase strip at the
-  // top of the page chrome (shared with every scenario). Pulsing the
-  // canvas tracks too would be airport-specific noise the rest of
-  // the playground doesn't do.
-  void phaseRatio;
 
   ctx.restore();
 }
@@ -278,16 +268,18 @@ function drawStations(
   ctx: CanvasRenderingContext2D,
   outerStops: StopDto[],
   innerStops: StopDto[],
-  midline: RectGeometry,
   outer: TrackGeometry,
-  inner: TrackGeometry,
+  gap: number,
   airport: AirportMeta,
   showFullLabels: boolean,
 ): AABB[] {
-  const stationR = Math.max(5, midline.h * 0.022);
-  const ringWidth = Math.max(1.5, stationR * 0.32);
+  const stationR = Math.max(5, gap * 0.12);
   const fontPx = 11;
   const obstacles: AABB[] = [];
+
+  ctx.strokeStyle = STATION_TICK;
+  ctx.lineWidth = Math.max(1.4, outer.thickness * 1.1);
+  ctx.lineCap = "round";
 
   const pairCount = Math.min(outerStops.length, innerStops.length);
   for (let i = 0; i < pairCount; i++) {
@@ -295,28 +287,25 @@ function drawStations(
     const innerStop = innerStops[i];
     if (!outerStop || !innerStop) continue;
 
+    // Both loops anchor on the outer perimeter at the stop's sim
+    // fraction; inner is the same point projected inward by `gap`.
+    // Same-name stops align across loops, which they wouldn't if each
+    // loop indexed by its own perimeter (matching straights, mismatched
+    // arc lengths).
     const fraction = outerStop.y / airport.circumferenceM;
-    const midPoint = perimeterPoint(midline, fraction);
     const outerPoint = perimeterPoint(outer, fraction);
-    const innerPoint = perimeterPoint(inner, fraction);
+    const innerPoint = projectInward(outerPoint, gap);
 
-    // Outline-circle station — neutral ring matching the playground's
-    // shaft-frame language. No letter glyph inside; the text label
-    // outside the ring carries identity.
+    // One neutral tick perpendicular to the tracks, spanning the gap.
+    // Reads as a station marker without competing with the trains.
     ctx.beginPath();
-    ctx.arc(midPoint.x, midPoint.y, stationR, 0, Math.PI * 2);
-    ctx.fillStyle = STATION_FILL;
-    ctx.fill();
-    ctx.strokeStyle = STATION_RING;
-    ctx.lineWidth = ringWidth;
+    ctx.moveTo(outerPoint.x, outerPoint.y);
+    ctx.lineTo(innerPoint.x, innerPoint.y);
     ctx.stroke();
 
-    // Edge-aware label placement: outward perpendicular from the
-    // outer ring point, with the offset chosen to clear the capped
-    // outer-waiting-cluster extent (`QUEUE_MAX_VISIBLE_ROWS` rows of
-    // dots above the ring, plus a small gap). Without this the label
-    // would land on top of the queue at busy stations — exactly the
-    // overlap the user reported.
+    // Label outside the outer loop, offset to clear the queue cluster
+    // cap. All labels share the same weight/size; identity comes from
+    // position around the ring.
     const dotR = Math.max(1.8, stationR * 0.22);
     const stride = dotR * 2.4;
     const queueExtent = stationR + dotR * 1.6 + stride * (QUEUE_MAX_VISIBLE_ROWS - 1) + dotR;
@@ -339,13 +328,13 @@ function drawStations(
       h: fontPx + labelPad * 2,
     });
 
-    // Waiting riders — one cluster per loop, colored to match its
-    // line. Outer cluster stacks OUTWARD perpendicular to the outer
-    // track; inner cluster stacks INWARD into the inner ring's empty
-    // interior. Row axis is tangential to the track so the queue
-    // grows parallel to the line, not diagonally into the corner.
     drawWaitingCluster(ctx, outerPoint, outerStop.waiting, "outward", OUTER_RIDER, stationR);
     drawWaitingCluster(ctx, innerPoint, innerStop.waiting, "inward", INNER_RIDER, stationR);
+
+    // Stroke state may have been clobbered by waiting cluster fills.
+    ctx.strokeStyle = STATION_TICK;
+    ctx.lineWidth = Math.max(1.4, outer.thickness * 1.1);
+    ctx.lineCap = "round";
   }
   return obstacles;
 }
@@ -430,49 +419,57 @@ function distributeLoad(totalRiders: number): number[] {
   return out;
 }
 
-function assignLetters(cars: CarDto[]): Map<number, string> {
-  const sorted = [...cars].sort((a, b) => a.id - b.id);
-  const out = new Map<number, string>();
-  for (let i = 0; i < sorted.length; i++) {
-    const car = sorted[i];
-    if (car) out.set(car.id, String.fromCharCode(65 + i));
-  }
-  return out;
-}
-
 function drawTrainsOnLoop(
   ctx: CanvasRenderingContext2D,
   cars: CarDto[],
   stops: StopDto[],
-  track: TrackGeometry,
+  outer: TrackGeometry,
+  inwardGap: number,
   airport: AirportMeta,
   carBodyW: number,
   carBodyH: number,
   segLen: number,
   reverseDirection: boolean,
-  letterByCarId: Map<number, string>,
   lineColor: string,
 ): TrainPlacement[] {
   if (cars.length === 0) return [];
-  const perim = perimeterLength(track);
+  // Both loops parameterize positions on the outer perimeter; inner
+  // cars are then projected inward by `inwardGap`. Keeps train and
+  // station positions on the inner loop visually consistent with the
+  // outer (same straight-edge lengths, mirrored stops align).
+  const perim = perimeterLength(outer);
+  const onLoop = (f: number): PerimeterPoint => {
+    const p = perimeterPoint(outer, f);
+    return inwardGap > 0 ? projectInward(p, inwardGap) : p;
+  };
   const placements: TrainPlacement[] = [];
+
+  // Half a train (in perimeter pixels) — used to shift the train so
+  // that its CENTER sits on car.y instead of the lead car. Without
+  // this, a dwelling train's lead car would land at the platform but
+  // the other 3 cars would trail off behind the stop.
+  const halfTrainPx = (TRAIN_CAR_COUNT * segLen) / 2;
 
   for (const car of cars) {
     const baseFraction = car.y / airport.circumferenceM;
-    const frontFraction = reverseDirection ? 1 - baseFraction : baseFraction;
     const perCarLoad = distributeLoad(car.riders);
+    const dir = reverseDirection ? -1 : 1;
+    const centeredBase = reverseDirection ? 1 - baseFraction : baseFraction;
+    const frontFraction = centeredBase + (dir * halfTrainPx) / perim;
+    const carPoints: PerimeterPoint[] = [];
     for (let i = 0; i < TRAIN_CAR_COUNT; i++) {
-      const dir = reverseDirection ? -1 : 1;
       const segCenterPx = -dir * (i * segLen + segLen / 2);
       const segFraction = (((frontFraction + segCenterPx / perim) % 1) + 1) % 1;
-      const point = perimeterPoint(track, segFraction);
-      const load = perCarLoad[i] ?? 0;
-      drawCarBody(ctx, point, carBodyW, carBodyH, lineColor, load, i === 0);
+      carPoints.push(onLoop(segFraction));
     }
-    const dir = reverseDirection ? -1 : 1;
+    for (let i = 0; i < TRAIN_CAR_COUNT; i++) {
+      const point = carPoints[i];
+      if (!point) continue;
+      const load = perCarLoad[i] ?? 0;
+      drawCarBody(ctx, point, carBodyW, carBodyH, lineColor, load, i === 0, dir);
+    }
     const leadFraction = (((frontFraction + (-dir * segLen) / 2 / perim) % 1) + 1) % 1;
-    const anchor = perimeterPoint(track, leadFraction);
-    const letter = letterByCarId.get(car.id) ?? "?";
+    const anchor = onLoop(leadFraction);
 
     const nextStop = pickNextStop(car, stops, airport.circumferenceM);
     const remainingM = nextStop
@@ -481,10 +478,8 @@ function drawTrainsOnLoop(
     placements.push({
       car,
       anchor,
-      letter,
       nextStop,
       remainingM,
-      lineColor,
       isInner: reverseDirection,
     });
   }
@@ -513,24 +508,36 @@ function drawCarBody(
   fill: string,
   load: number,
   isLead: boolean,
+  forwardX: number,
 ): void {
   ctx.save();
   ctx.translate(point.x, point.y);
   ctx.rotate(point.tangent);
   const halfL = length / 2;
   const halfW = width / 2;
-  const r = Math.min(halfL, halfW) * 0.5;
-  tracedRoundedRect(ctx, { cx: 0, cy: 0, w: length, h: width, r });
+  const r = Math.min(length, width) * 0.25;
+  const body = { cx: 0, cy: 0, w: length, h: width, r };
+  tracedRoundedRect(ctx, body);
   ctx.fillStyle = fill;
   ctx.fill();
-  // Subtle inner highlight on the lead car so the train direction
-  // reads at a glance — Mini Metro doesn't do this, but our trains
-  // are dark capsules on a dark bg and need a directional cue.
   if (isLead) {
-    ctx.fillStyle = "rgba(255, 255, 255, 0.35)";
-    ctx.beginPath();
-    ctx.arc(halfL - r * 1.1, 0, halfW * 0.32, 0, Math.PI * 2);
+    tracedRoundedRect(ctx, body);
+    ctx.fillStyle = "rgba(255, 255, 255, 0.55)";
     ctx.fill();
+    // Chevron tip at the leading edge — forwardX flips for inner-loop
+    // (counter-clockwise) trains so the chevron always points along
+    // direction of travel, not just along the perimeter parameterization.
+    const tipX = forwardX * (halfL - r * 0.4);
+    const backX = forwardX * (halfL - r * 0.4 - halfW * 0.95);
+    ctx.strokeStyle = "rgba(255, 255, 255, 0.95)";
+    ctx.lineWidth = Math.max(1.2, halfW * 0.32);
+    ctx.lineCap = "round";
+    ctx.lineJoin = "round";
+    ctx.beginPath();
+    ctx.moveTo(backX, -halfW * 0.55);
+    ctx.lineTo(tipX, 0);
+    ctx.lineTo(backX, halfW * 0.55);
+    ctx.stroke();
   }
   if (load > 0) drawRidersInCar(ctx, length, width, load);
   ctx.restore();
@@ -551,9 +558,6 @@ function drawRidersInCar(
   const cellW = innerW / cols;
   const cellH = innerH / rows;
   const dotR = Math.max(0.7, Math.min(cellW, cellH) * 0.36);
-  // Near-black dots — high contrast against the lighter line-colored
-  // car bodies, mirroring Mini Metro's dark passenger marks on
-  // bright trains.
   ctx.fillStyle = "rgba(20, 22, 30, 0.85)";
   let placed = 0;
   for (let row = 0; row < rows && placed < load; row++) {

--- a/playground/src/render/renderer.ts
+++ b/playground/src/render/renderer.ts
@@ -1,6 +1,6 @@
 import type { AirportMeta, CarDto, CarBubble, Snapshot, StopDto, TetherMeta } from "../types";
 import { drawAirportScene } from "./draw-airport";
-import { pickAirportTrainAt, setAirportHoveredCar } from "./draw-airport-hud";
+import { AirportHoverState } from "./draw-airport-hud";
 import {
   drawFloors,
   drawShaftChannels,
@@ -156,6 +156,7 @@ export class CanvasRenderer {
     else this.#unwireAirportHover();
   }
 
+  readonly #airportHover = new AirportHoverState();
   #airportHoverHandlers: { move: (e: PointerEvent) => void; leave: () => void } | null = null;
 
   #wireAirportHover(): void {
@@ -167,10 +168,10 @@ export class CanvasRenderer {
       // Picking radius scales with min canvas dimension so it works
       // across viewport sizes.
       const radius = Math.max(40, Math.min(rect.width, rect.height) * 0.07);
-      setAirportHoveredCar(pickAirportTrainAt(cx, cy, radius));
+      this.#airportHover.setHovered(this.#airportHover.pick(cx, cy, radius));
     };
     const leave = (): void => {
-      setAirportHoveredCar(undefined);
+      this.#airportHover.setHovered(undefined);
     };
     this.#canvas.addEventListener("pointermove", move);
     this.#canvas.addEventListener("pointerleave", leave);
@@ -182,7 +183,7 @@ export class CanvasRenderer {
     this.#canvas.removeEventListener("pointermove", this.#airportHoverHandlers.move);
     this.#canvas.removeEventListener("pointerleave", this.#airportHoverHandlers.leave);
     this.#airportHoverHandlers = null;
-    setAirportHoveredCar(undefined);
+    this.#airportHover.setHovered(undefined);
   }
 
   // Clear per-car kinematic state on every scenario swap. Prevents a
@@ -278,12 +279,22 @@ export class CanvasRenderer {
     if (s === null) return;
 
     if (this.#airport !== null) {
-      drawAirportScene(ctx, snap, w, h, this.#airport, phaseRatio, this.#accent, {
-        maxSpeed: this.#activeMaxSpeed,
-        acceleration: this.#activeAcceleration,
-        deceleration: this.#activeDeceleration,
-        weightCapacity: this.#activeWeightCapacity,
-      });
+      drawAirportScene(
+        ctx,
+        snap,
+        w,
+        h,
+        this.#airport,
+        phaseRatio,
+        this.#accent,
+        {
+          maxSpeed: this.#activeMaxSpeed,
+          acceleration: this.#activeAcceleration,
+          deceleration: this.#activeDeceleration,
+          weightCapacity: this.#activeWeightCapacity,
+        },
+        this.#airportHover,
+      );
       return;
     }
 

--- a/playground/src/render/renderer.ts
+++ b/playground/src/render/renderer.ts
@@ -1,5 +1,6 @@
 import type { AirportMeta, CarDto, CarBubble, Snapshot, StopDto, TetherMeta } from "../types";
 import { drawAirportScene } from "./draw-airport";
+import { pickAirportTrainAt, setAirportHoveredCar } from "./draw-airport-hud";
 import {
   drawFloors,
   drawShaftChannels,
@@ -130,6 +131,7 @@ export class CanvasRenderer {
 
   dispose(): void {
     window.removeEventListener("resize", this.#onResize);
+    this.#unwireAirportHover();
   }
 
   get canvas(): HTMLCanvasElement {
@@ -150,6 +152,37 @@ export class CanvasRenderer {
   setAirportConfig(airport: AirportMeta | null): void {
     this.#airport = airport;
     this.#resetModeState();
+    if (airport !== null) this.#wireAirportHover();
+    else this.#unwireAirportHover();
+  }
+
+  #airportHoverHandlers: { move: (e: PointerEvent) => void; leave: () => void } | null = null;
+
+  #wireAirportHover(): void {
+    if (this.#airportHoverHandlers !== null) return;
+    const move = (e: PointerEvent): void => {
+      const rect = this.#canvas.getBoundingClientRect();
+      const cx = e.clientX - rect.left;
+      const cy = e.clientY - rect.top;
+      // Picking radius scales with min canvas dimension so it works
+      // across viewport sizes.
+      const radius = Math.max(40, Math.min(rect.width, rect.height) * 0.07);
+      setAirportHoveredCar(pickAirportTrainAt(cx, cy, radius));
+    };
+    const leave = (): void => {
+      setAirportHoveredCar(undefined);
+    };
+    this.#canvas.addEventListener("pointermove", move);
+    this.#canvas.addEventListener("pointerleave", leave);
+    this.#airportHoverHandlers = { move, leave };
+  }
+
+  #unwireAirportHover(): void {
+    if (this.#airportHoverHandlers === null) return;
+    this.#canvas.removeEventListener("pointermove", this.#airportHoverHandlers.move);
+    this.#canvas.removeEventListener("pointerleave", this.#airportHoverHandlers.leave);
+    this.#airportHoverHandlers = null;
+    setAirportHoveredCar(undefined);
   }
 
   // Clear per-car kinematic state on every scenario swap. Prevents a

--- a/playground/src/shell/airport-labels.ts
+++ b/playground/src/shell/airport-labels.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared airport-scenario labels used by both the per-pane chip
+ * override (`apply-permalink.ts`) and the document-title / SEO copy
+ * (`document-meta.ts`). Centralised so the two stay in sync — the
+ * airport's dispatch is hard-pinned in the RON per-group config, so
+ * the global strategy chip is overridden and the title likewise needs
+ * to read the actual running dispatch.
+ */
+export const AIRPORT_DISPATCH_LABEL = "LoopSchedule";
+export const AIRPORT_DISPATCH_DESC = "Fixed-headway timetable on a one-way loop.";

--- a/playground/src/shell/apply-permalink.ts
+++ b/playground/src/shell/apply-permalink.ts
@@ -24,16 +24,15 @@ export function randomSeedWord(): string {
 
 const AIRPORT_DISPATCH_LABEL = "LoopSchedule";
 const AIRPORT_DISPATCH_DESC = "Fixed-headway timetable on a one-way loop.";
-const AIRPORT_REPOSITION_LABEL = "—";
 
 /**
  * Single-pane gating for scenarios that can't survive compare mode
  * (concentric viz at half-width) and that hard-pin their dispatch via
  * RON per-group config (LoopSchedule). Disables the relevant triggers,
- * forces compare off in the UI, and overwrites the dispatch / parking
- * chip text so the disabled triggers show what's actually running.
- * Must run AFTER `renderPaneStrategyInfo` / `renderPaneRepositionInfo`
- * so the label override isn't immediately clobbered.
+ * forces compare off in the UI, overwrites the dispatch chip text,
+ * and hides the parking chip entirely since the scenario has no
+ * reposition strategy. Must run AFTER `renderPaneStrategyInfo` /
+ * `renderPaneRepositionInfo` so overrides aren't clobbered.
  */
 export function applyScenarioGating(ui: UiHandles, scenario: ScenarioMeta): boolean {
   const singlePane = scenario.airport !== undefined;
@@ -42,14 +41,17 @@ export function applyScenarioGating(ui: UiHandles, scenario: ScenarioMeta): bool
   ui.paneB.trigger.disabled = singlePane;
   ui.paneA.repoTrigger.disabled = singlePane;
   ui.paneB.repoTrigger.disabled = singlePane;
+  for (const pane of [ui.paneA, ui.paneB]) {
+    const parkSection = pane.repoTrigger.closest(".pane-section");
+    if (parkSection instanceof HTMLElement) parkSection.hidden = singlePane;
+    if (singlePane) {
+      pane.name.textContent = AIRPORT_DISPATCH_LABEL;
+      pane.desc.textContent = AIRPORT_DISPATCH_DESC;
+    }
+  }
   if (singlePane) {
     ui.compareToggle.checked = false;
     ui.layout.dataset["mode"] = "single";
-    for (const pane of [ui.paneA, ui.paneB]) {
-      pane.name.textContent = AIRPORT_DISPATCH_LABEL;
-      pane.desc.textContent = AIRPORT_DISPATCH_DESC;
-      pane.repoName.textContent = AIRPORT_REPOSITION_LABEL;
-    }
   }
   return singlePane;
 }

--- a/playground/src/shell/apply-permalink.ts
+++ b/playground/src/shell/apply-permalink.ts
@@ -5,6 +5,7 @@ import { scenarioById, type PermalinkState } from "../domain";
 import { generate as generateRandomWords } from "random-words";
 import type { ScenarioMeta } from "../types";
 import type { UiHandles } from "./wire-ui";
+import { AIRPORT_DISPATCH_LABEL, AIRPORT_DISPATCH_DESC } from "./airport-labels";
 
 export const speedLabel = (v: number): string => `${v}\u00d7`;
 export const intensityLabel = (v: number): string => `${v.toFixed(1)}\u00d7`;
@@ -21,9 +22,6 @@ export function randomSeedWord(): string {
   // on options; normalise to the first element.
   return Array.isArray(word) ? (word[0] ?? "seed") : word;
 }
-
-const AIRPORT_DISPATCH_LABEL = "LoopSchedule";
-const AIRPORT_DISPATCH_DESC = "Fixed-headway timetable on a one-way loop.";
 
 /**
  * Single-pane gating for scenarios that can't survive compare mode

--- a/playground/src/shell/document-meta.ts
+++ b/playground/src/shell/document-meta.ts
@@ -20,6 +20,8 @@ export function updateRuntimeMeta(state: PermalinkState): void {
   setDocumentMeta(buildMeta(state));
 }
 
+const AIRPORT_DISPATCH_LABEL = "LoopSchedule";
+
 function buildMeta(state: PermalinkState): { title: string; description: string } {
   if (state.mode === "quest") {
     return {
@@ -31,6 +33,19 @@ function buildMeta(state: PermalinkState): { title: string; description: string 
 
   const scenario = scenarioById(state.scenario);
   const scenarioLabel = scenario.label;
+
+  // Airport hard-pins LoopSchedule via RON per-group config and has no
+  // parking strategy, so the global strategyA/repositionA fields don't
+  // describe what's actually running. Render the actual dispatch and
+  // drop the parking phrase.
+  if (scenario.airport !== undefined) {
+    const title = `${scenarioLabel}: ${AIRPORT_DISPATCH_LABEL} dispatch — Elevator dispatch playground`;
+    const description =
+      `Watch ${AIRPORT_DISPATCH_LABEL} dispatch handle live rider traffic on the ` +
+      `${scenarioLabel.toLowerCase()} scenario. ${BASE_DESCRIPTION}`;
+    return { title, description };
+  }
+
   const stratA = STRATEGY_LABELS[state.strategyA];
   const stratB = STRATEGY_LABELS[state.strategyB];
   const parkA = REPOSITION_LABELS[state.repositionA];

--- a/playground/src/shell/document-meta.ts
+++ b/playground/src/shell/document-meta.ts
@@ -1,5 +1,6 @@
 import { REPOSITION_LABELS, STRATEGY_LABELS, scenarioById, type PermalinkState } from "../domain";
 import { setDocumentMeta } from "../platform";
+import { AIRPORT_DISPATCH_LABEL } from "./airport-labels";
 
 const APP_SUFFIX = "elevator-core playground";
 const BASE_DESCRIPTION =
@@ -19,8 +20,6 @@ const BASE_DESCRIPTION =
 export function updateRuntimeMeta(state: PermalinkState): void {
   setDocumentMeta(buildMeta(state));
 }
-
-const AIRPORT_DISPATCH_LABEL = "LoopSchedule";
 
 function buildMeta(state: PermalinkState): { title: string; description: string } {
   if (state.mode === "quest") {


### PR DESCRIPTION
## Summary

Reworks the airport scenario's visual density so the metro-map read stays calm and trains/stations don't fight for attention.

- **Tighter corridor** — gap between outer & inner loops halved (`max(28, 6%)` → `max(14, 2.5%)`); the two concentric rounded-rects now read as one corridor while trains stay vertically distinguishable when both loops are at the same stop.
- **Cross-loop alignment** — inner stations and trains parameterize on the OUTER perimeter and project inward by `gap` via a new `projectInward` helper. Same-name stops now line up across loops geometrically; previously they misaligned at corners because the two loops share straight-edge lengths but have different arc lengths.
- **Calmer station markers** — replaced the line-colored outlined platform bars (one per loop, per stop = 14 markers) with a single neutral perpendicular tick spanning the gap (7 markers total).
- **Trains centered on stops** — train cars are now arranged around `car.y` instead of pinning the lead car to it. A dwelling train visually straddles its platform rather than trailing off the back of it.
- **Stronger lead-car cue** — 0.55-alpha white overlay plus a forward-pointing chevron whose orientation flips for the counter-clockwise inner loop. Couplers dropped to keep the train glyph count down.
- **On-demand HUD** — per-train pill slims to a single line `→ Concourse F  45 km/h  23s`, and is gated: dwelling trains always show it (info-rich moment), otherwise only the pointer-targeted train shows it. New module-level hit-test picks the nearest train within a viewport-scaled radius; renderer wires up `pointermove`/`pointerleave` scoped to airport mode.
- **Canvas fill** — loop now uses ~88% of available height (was capped at 60% via `min(h*0.6, w*0.42)`). Calibrated label clearance keeps station names from clipping on either axis.
- **PARKING control hidden** for airport scenarios (no reposition strategy applies).
- **Page title fix** — airport scenario reads `LoopSchedule dispatch` instead of the global `SCAN` default (dispatch is hard-pinned by RON per-group config).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` — 345/345 passing
- [x] `pnpm lint` clean (one pre-existing `max-lines` warning on `renderer.ts`)
- [x] Visual: airport renders with stations, trains, hover pills, direction chevrons — verified via headless Chromium screenshots at 1400×900
- [ ] Verify mobile portrait + landscape (P0 gate)
- [ ] Verify other scenarios still render correctly (no regression from PARKING hide / document-meta changes)