### PR TITLE
feat(playground): show active scenario config below the canvas

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -688,6 +688,33 @@
       </section>
     </main>
 
+    <section
+      id="scenario-config"
+      class="scenario-config mx-5 mb-3 max-md:mx-3.5 max-md:mb-2.5"
+      aria-label="Active scenario configuration"
+    >
+      <details id="scenario-config-details" class="scenario-config-details">
+        <summary class="scenario-config-summary">
+          <span class="scenario-config-caret" aria-hidden="true">&#9656;</span>
+          <span id="scenario-config-filename" class="scenario-config-filename">scenario.ron</span>
+          <span class="scenario-config-eyebrow">Active scenario config</span>
+          <button
+            id="scenario-config-copy"
+            type="button"
+            class="scenario-config-copy"
+            aria-label="Copy scenario config to clipboard"
+          >
+            Copy
+          </button>
+        </summary>
+        <div class="scenario-config-body">
+          <pre
+            class="scenario-config-pre"
+          ><code id="scenario-config-code" class="scenario-config-code"></code></pre>
+        </div>
+      </details>
+    </section>
+
     <footer
       class="text-content-disabled text-[10.5px] tracking-[0.04em] font-mono px-5 pb-2 pt-1 select-none max-md:hidden"
       aria-label="Authorship"

--- a/playground/src/__tests__/scenario-config.test.ts
+++ b/playground/src/__tests__/scenario-config.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { SCENARIOS } from "../domain";
+import { tokenizeRonLine, RON_TOKEN_CLASSES, type RonToken } from "../features/scenario-config";
+
+describe("scenario-config: filename", () => {
+  it("every scenario carries a configFilename", () => {
+    for (const s of SCENARIOS) {
+      expect(s.configFilename, `${s.id}.configFilename`).toMatch(/\.ron$/);
+      expect(s.configFilename.length).toBeGreaterThan(4);
+    }
+  });
+
+  it("configFilenames are unique across scenarios", () => {
+    const names = SCENARIOS.map((s) => s.configFilename);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});
+
+describe("scenario-config: scenarios still parse as RON", () => {
+  // Smoke: every scenario's RON should look structurally sound after
+  // the user-friendly comment rewrite. Catches edits that leave the
+  // template literal unterminated or drop required keys.
+  it("each scenario starts with SimConfig and balances parens", () => {
+    for (const s of SCENARIOS) {
+      expect(s.ron, `${s.id}.ron`).toMatch(/SimConfig\(/);
+      const opens = (s.ron.match(/\(/g) ?? []).length;
+      const closes = (s.ron.match(/\)/g) ?? []).length;
+      expect(opens, `${s.id} parens`).toBe(closes);
+      const obrack = (s.ron.match(/\[/g) ?? []).length;
+      const cbrack = (s.ron.match(/]/g) ?? []).length;
+      expect(obrack, `${s.id} brackets`).toBe(cbrack);
+    }
+  });
+});
+
+describe("scenario-config: highlighter", () => {
+  const ofClass = (tokens: RonToken[], cls: string): string[] =>
+    tokens.filter((t) => t.cls === cls).map((t) => t.text);
+
+  it("tokenizes comments, strings, numbers, types, and keys", () => {
+    const tokens = tokenizeRonLine('SimConfig(name: "Building", speed: 3.5) // tail comment');
+    expect(ofClass(tokens, RON_TOKEN_CLASSES.comment)).toEqual(["// tail comment"]);
+    expect(ofClass(tokens, RON_TOKEN_CLASSES.string)).toEqual(['"Building"']);
+    expect(ofClass(tokens, RON_TOKEN_CLASSES.number)).toEqual(["3.5"]);
+    expect(ofClass(tokens, RON_TOKEN_CLASSES.type)).toEqual(["SimConfig"]);
+    expect(ofClass(tokens, RON_TOKEN_CLASSES.key)).toEqual(["name", "speed"]);
+  });
+
+  it("treats a leading // line as a comment in full", () => {
+    const tokens = tokenizeRonLine("// hello world");
+    expect(tokens).toEqual([{ cls: RON_TOKEN_CLASSES.comment, text: "// hello world" }]);
+  });
+
+  it("handles negative and decimal numbers", () => {
+    const tokens = tokenizeRonLine("x: -4.0, y: -12, z: 0");
+    expect(ofClass(tokens, RON_TOKEN_CLASSES.number)).toEqual(["-4.0", "-12", "0"]);
+  });
+
+  it("identifier without trailing colon is not a key", () => {
+    // Disambiguates `StopId(0)` (type) from `stops: [...]` (key) so
+    // PascalCase constructors aren't miscolored as values.
+    const tokens = tokenizeRonLine('StopId(0), name: "Lobby"');
+    expect(ofClass(tokens, RON_TOKEN_CLASSES.type)).toContain("StopId");
+    expect(ofClass(tokens, RON_TOKEN_CLASSES.key)).toEqual(["name"]);
+  });
+
+  it("preserves total text length across tokenization", () => {
+    const line = '    StopConfig(id: StopId(0), name: "Lobby", position: 0.0),';
+    const tokens = tokenizeRonLine(line);
+    const joined = tokens.map((t) => t.text).join("");
+    expect(joined).toBe(line);
+  });
+});

--- a/playground/src/domain/scenarios/scenarios.ts
+++ b/playground/src/domain/scenarios/scenarios.ts
@@ -80,6 +80,7 @@ const conventionPhases: Phase[] = [
 const convention: ScenarioMeta = {
   id: "convention-burst",
   label: "Convention center",
+  configFilename: "convention_burst.ron",
   description:
     "Five-floor convention center. A keynote ends and 200+ riders spill into the elevators at once — an acute stress test rather than a day cycle.",
   defaultStrategy: "etd",
@@ -111,7 +112,9 @@ const convention: ScenarioMeta = {
   tweakRanges: { ...COMMERCIAL_TWEAK_RANGES, cars: { min: 1, max: 6, step: 1 } },
   passengerMeanIntervalTicks: 30,
   passengerWeightRange: [55.0, 100.0],
-  ron: `SimConfig(
+  ron: `// Five-floor convention center. The keynote ends and 200+ riders
+// flood the lobby at once — a stress test, not a day cycle.
+SimConfig(
     schema_version: 1,
     building: BuildingConfig(
         name: "Convention Center",
@@ -123,12 +126,9 @@ const convention: ScenarioMeta = {
             StopConfig(id: StopId(4), name: "Keynote Hall", position: 16.0),
         ],
     ),
-    // Convention door timing: 5 s dwell for group boarding. Big crowds
-    // after keynote are slow to actually step through the threshold;
-    // rushing the doors closed ejects riders mid-walk and re-opens, a
-    // realistic failure mode. Four cars pre-positioned at Lobby,
-    // Mezzanine, Ballroom, and Keynote Hall so dispatch has both
-    // nearby and far cars available when the pile-up hits.
+    // Doors dwell 5 seconds — crowds boarding in a hurry need a beat
+    // to step through. Four cars start spread across the building so
+    // dispatch has nearby and far options when the rush hits.
     elevators: [
         ElevatorConfig(
             id: 0, name: "Car A",
@@ -389,13 +389,18 @@ function buildSkyscraperRon(): string {
                     bypass_load_up_pct: Some(0.85), bypass_load_down_pct: Some(0.55),
                 ),`;
 
-  return `SimConfig(
+  return `// 40-floor tower with four elevator banks. Cross-zone riders
+// transfer at the Sky Lobby; the Executive car is the only path to
+// the penthouse; the Service car is the only path to the basements.
+SimConfig(
     schema_version: 1,
     building: BuildingConfig(
         name: "Skyscraper",
         stops: [
 ${stops.join("\n")}
         ],
+        // Four banks, each its own line. The core's topology graph
+        // plans multi-leg journeys that transfer at the Sky Lobby.
         lines: Some([
             LineConfig(
                 id: 0, name: "Low bank",
@@ -432,11 +437,8 @@ ${elevator(4, "Service", 1, 350)}
             GroupConfig(id: 0, name: "Low", lines: [0], dispatch: Scan),
             GroupConfig(id: 1, name: "High", lines: [1], dispatch: Scan),
             GroupConfig(id: 2, name: "Executive", lines: [2], dispatch: Scan),
-            // Service parks on NearestIdle so the car stays where it
-            // last finished a trip instead of cycling between B1 and
-            // the Lobby via AdaptiveParking's ReturnToLobby branch.
-            // Service traffic is sparse; there's no benefit to pre-
-            // positioning and the oscillation is visually distracting.
+            // Service traffic is sparse, so the car parks where it
+            // last stopped instead of cycling back to the lobby.
             GroupConfig(id: 3, name: "Service", lines: [3], dispatch: Scan, reposition: Some(NearestIdle)),
         ]),
     ),
@@ -473,6 +475,7 @@ const skyscraperStops: Array<{ name: string; positionM: number }> = [
 const skyscraper: ScenarioMeta = {
   id: "skyscraper-sky-lobby",
   label: "Skyscraper",
+  configFilename: "skyscraper.ron",
   description:
     "40-floor tower with four elevator banks. Most cross-zone riders transfer at the sky lobby; the exec car is the only way up to the penthouse suites; a service elevator links the lobby to three basement levels (B1 loading dock, B2 parking, B3 utility plant).",
   defaultStrategy: "etd",
@@ -538,6 +541,7 @@ function tetherWeights(perIndex: (i: number) => number): number[] {
 const spaceElevator: ScenarioMeta = {
   id: "space-elevator",
   label: "Space elevator",
+  configFilename: "space_elevator.ron",
   description:
     "A 35,786 km tether to geostationary orbit with platforms at the Karman line, LEO, and the GEO terminus. Three climbers move payload along a single cable; the counterweight beyond GEO holds the line taut.",
   defaultStrategy: "scan",
@@ -639,7 +643,10 @@ const spaceElevator: ScenarioMeta = {
     counterweightAltitudeM: COUNTERWEIGHT_M,
     showDayNight: false,
   },
-  ron: `SimConfig(
+  ron: `// Orbital tether climbing from the ground to geostationary
+// altitude (35,786 km). Three climbers share the cable; cruise speed
+// is 1,000 m/s — the same simulation engine, just scaled way up.
+SimConfig(
     schema_version: 1,
     building: BuildingConfig(
         name: "Orbital Tether",
@@ -756,6 +763,7 @@ const airportPhases: Phase[] = [
 const airport: ScenarioMeta = {
   id: "airport-apm",
   label: "Airport loop",
+  configFilename: "airport_loop.ron",
   description:
     "Two counter-rotating loops connect the terminal to six concourses. Fixed-headway dispatch keeps trains on a predictable cadence; rider demand shifts from outbound (morning) to inbound (evening).",
   // Placeholder — actual dispatch is per-group LoopSchedule in the RON;
@@ -791,10 +799,16 @@ const airport: ScenarioMeta = {
     outerStopCount: AIRPORT_OUTER_COUNT,
     circumferenceM: AIRPORT_CIRCUMFERENCE_M,
   },
-  ron: `SimConfig(
+  ron: `// Two counter-rotating loops between the terminal and six
+// concourses. Loop lines run one-way, so trains can't overtake —
+// fixed-headway dispatch keeps them on a predictable cadence.
+SimConfig(
     schema_version: 1,
     building: BuildingConfig(
         name: "Airport Loop",
+        // Each loop has its own Terminal + Concourse stops. Inner
+        // positions are mirrored so the two loops rotate opposite
+        // directions on the same physical track layout.
         stops: [
             StopConfig(id: StopId(0),  name: "Terminal",     position: 0.0),
             StopConfig(id: StopId(1),  name: "Concourse A",  position: 300.0),
@@ -812,6 +826,8 @@ const airport: ScenarioMeta = {
             StopConfig(id: StopId(13), name: "Concourse A",  position: 1200.0),
         ],
         lines: Some([
+            // Outer loop: terminal → A → B → C → D → E → F → terminal.
+            // min_headway keeps trains from bunching on the same loop.
             LineConfig(
                 id: 1, name: "Outer Loop",
                 kind: Some(Loop(circumference: 1500.0, min_headway: 200.0)),
@@ -834,6 +850,9 @@ const airport: ScenarioMeta = {
                     ),
                 ],
             ),
+            // Inner loop runs the same stops in the opposite order so
+            // the two loops cover the terminal-to-concourse round trip
+            // from both directions.
             LineConfig(
                 id: 2, name: "Inner Loop",
                 kind: Some(Loop(circumference: 1500.0, min_headway: 200.0)),

--- a/playground/src/domain/scenarios/scenarios.ts
+++ b/playground/src/domain/scenarios/scenarios.ts
@@ -112,8 +112,7 @@ const convention: ScenarioMeta = {
   tweakRanges: { ...COMMERCIAL_TWEAK_RANGES, cars: { min: 1, max: 6, step: 1 } },
   passengerMeanIntervalTicks: 30,
   passengerWeightRange: [55.0, 100.0],
-  ron: `// Five-floor convention center. The keynote ends and 200+ riders
-// flood the lobby at once — a stress test, not a day cycle.
+  ron: `// Convention center: keynote ends, 200+ riders flood the lobby at once.
 SimConfig(
     schema_version: 1,
     building: BuildingConfig(
@@ -126,9 +125,7 @@ SimConfig(
             StopConfig(id: StopId(4), name: "Keynote Hall", position: 16.0),
         ],
     ),
-    // Doors dwell 5 seconds — crowds boarding in a hurry need a beat
-    // to step through. Four cars start spread across the building so
-    // dispatch has nearby and far options when the rush hits.
+    // 5s door dwell + cars pre-spread across floors for the rush.
     elevators: [
         ElevatorConfig(
             id: 0, name: "Car A",
@@ -389,9 +386,7 @@ function buildSkyscraperRon(): string {
                     bypass_load_up_pct: Some(0.85), bypass_load_down_pct: Some(0.55),
                 ),`;
 
-  return `// 40-floor tower with four elevator banks. Cross-zone riders
-// transfer at the Sky Lobby; the Executive car is the only path to
-// the penthouse; the Service car is the only path to the basements.
+  return `// 40-floor tower: transfer at the Sky Lobby; the Exec car alone reaches the penthouse.
 SimConfig(
     schema_version: 1,
     building: BuildingConfig(
@@ -399,8 +394,7 @@ SimConfig(
         stops: [
 ${stops.join("\n")}
         ],
-        // Four banks, each its own line. The core's topology graph
-        // plans multi-leg journeys that transfer at the Sky Lobby.
+        // Four banks; topology graph plans transfers at the Sky Lobby.
         lines: Some([
             LineConfig(
                 id: 0, name: "Low bank",
@@ -437,8 +431,7 @@ ${elevator(4, "Service", 1, 350)}
             GroupConfig(id: 0, name: "Low", lines: [0], dispatch: Scan),
             GroupConfig(id: 1, name: "High", lines: [1], dispatch: Scan),
             GroupConfig(id: 2, name: "Executive", lines: [2], dispatch: Scan),
-            // Service traffic is sparse, so the car parks where it
-            // last stopped instead of cycling back to the lobby.
+            // Sparse service traffic — park where the trip ends, don't cycle back.
             GroupConfig(id: 3, name: "Service", lines: [3], dispatch: Scan, reposition: Some(NearestIdle)),
         ]),
     ),
@@ -643,9 +636,7 @@ const spaceElevator: ScenarioMeta = {
     counterweightAltitudeM: COUNTERWEIGHT_M,
     showDayNight: false,
   },
-  ron: `// Orbital tether climbing from the ground to geostationary
-// altitude (35,786 km). Three climbers share the cable; cruise speed
-// is 1,000 m/s — the same simulation engine, just scaled way up.
+  ron: `// Tether to GEO (35,786 km). Three climbers at 1,000 m/s; same engine, scaled up.
 SimConfig(
     schema_version: 1,
     building: BuildingConfig(
@@ -799,16 +790,12 @@ const airport: ScenarioMeta = {
     outerStopCount: AIRPORT_OUTER_COUNT,
     circumferenceM: AIRPORT_CIRCUMFERENCE_M,
   },
-  ron: `// Two counter-rotating loops between the terminal and six
-// concourses. Loop lines run one-way, so trains can't overtake —
-// fixed-headway dispatch keeps them on a predictable cadence.
+  ron: `// Counter-rotating loops to six concourses. No overtaking; fixed headway sets the cadence.
 SimConfig(
     schema_version: 1,
     building: BuildingConfig(
         name: "Airport Loop",
-        // Each loop has its own Terminal + Concourse stops. Inner
-        // positions are mirrored so the two loops rotate opposite
-        // directions on the same physical track layout.
+        // Each loop has its own Terminal + Concourse stops; inner positions mirror outer.
         stops: [
             StopConfig(id: StopId(0),  name: "Terminal",     position: 0.0),
             StopConfig(id: StopId(1),  name: "Concourse A",  position: 300.0),
@@ -826,8 +813,7 @@ SimConfig(
             StopConfig(id: StopId(13), name: "Concourse A",  position: 1200.0),
         ],
         lines: Some([
-            // Outer loop: terminal → A → B → C → D → E → F → terminal.
-            // min_headway keeps trains from bunching on the same loop.
+            // Outer loop: Terminal → A→B→C→D→E→F → Terminal. min_headway stops trains bunching.
             LineConfig(
                 id: 1, name: "Outer Loop",
                 kind: Some(Loop(circumference: 1500.0, min_headway: 200.0)),
@@ -850,9 +836,7 @@ SimConfig(
                     ),
                 ],
             ),
-            // Inner loop runs the same stops in the opposite order so
-            // the two loops cover the terminal-to-concourse round trip
-            // from both directions.
+            // Inner loop runs the same stops reversed so both directions are covered.
             LineConfig(
                 id: 2, name: "Inner Loop",
                 kind: Some(Loop(circumference: 1500.0, min_headway: 200.0)),

--- a/playground/src/features/mode-toggle.ts
+++ b/playground/src/features/mode-toggle.ts
@@ -21,7 +21,13 @@
 import type { PlaygroundMode } from "../domain";
 
 /** Elements that exist for compare mode and have no Quest meaning. */
-const COMPARE_CHROME_IDS = ["layout", "scenario-picker", "controls-bar", "cabin-legend"] as const;
+const COMPARE_CHROME_IDS = [
+  "layout",
+  "scenario-picker",
+  "scenario-config",
+  "controls-bar",
+  "cabin-legend",
+] as const;
 
 /** Elements that exist for Quest mode only. */
 const QUEST_CHROME_IDS = ["quest-pane"] as const;

--- a/playground/src/features/scenario-config/highlight.ts
+++ b/playground/src/features/scenario-config/highlight.ts
@@ -1,0 +1,100 @@
+/**
+ * Minimal RON syntax highlighter for the scenario-config panel.
+ *
+ * Hand-rolled rather than pulling Prism/highlight.js: the RON grammar
+ * is small enough that a single regex covers it, and the playground
+ * bundle stays library-free. Returns a DocumentFragment of styled
+ * line rows so callers can mount with `replaceChildren` — no innerHTML.
+ */
+
+const TOKEN_RE =
+  /(\/\/[^\n]*)|("(?:[^"\\]|\\.)*")|(-?\d+(?:\.\d+)?)|([A-Z][A-Za-z0-9_]*)|([a-z_][A-Za-z0-9_]*)(?=\s*:)|([A-Za-z_][A-Za-z0-9_]*)/g;
+
+export type RonToken = { cls: "" | "ron-c" | "ron-s" | "ron-n" | "ron-t" | "ron-k"; text: string };
+
+/**
+ * Tokenize a single source line. Exported so unit tests can pin the
+ * grammar without a DOM environment; runtime callers should use
+ * `highlightRon`, which mounts these tokens into safe text nodes.
+ */
+export function tokenizeRonLine(line: string): RonToken[] {
+  const out: RonToken[] = [];
+  let last = 0;
+  TOKEN_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = TOKEN_RE.exec(line)) !== null) {
+    if (m.index > last) out.push({ cls: "", text: line.slice(last, m.index) });
+    if (m[1] !== undefined) out.push({ cls: "ron-c", text: m[1] });
+    else if (m[2] !== undefined) out.push({ cls: "ron-s", text: m[2] });
+    else if (m[3] !== undefined) out.push({ cls: "ron-n", text: m[3] });
+    else if (m[4] !== undefined) out.push({ cls: "ron-t", text: m[4] });
+    else if (m[5] !== undefined) out.push({ cls: "ron-k", text: m[5] });
+    else if (m[6] !== undefined) out.push({ cls: "", text: m[6] });
+    last = m.index + m[0].length;
+  }
+  if (last < line.length) out.push({ cls: "", text: line.slice(last) });
+  return out;
+}
+
+/**
+ * Build a row element for one source line: line-number cell on the
+ * left, tokenized code on the right. Each token is a `<span>` whose
+ * `textContent` is set safely; no innerHTML anywhere on the path.
+ */
+function buildRow(line: string, lineNumber: number): HTMLDivElement {
+  const row = document.createElement("div");
+  row.className = "ron-row";
+
+  const ln = document.createElement("span");
+  ln.className = "ron-ln";
+  ln.textContent = String(lineNumber);
+  row.appendChild(ln);
+
+  const code = document.createElement("span");
+  code.className = "ron-code";
+  const tokens = tokenizeRonLine(line);
+  if (tokens.length === 0) {
+    // Preserve row height for blank source lines without injecting
+    // an &nbsp; entity (textContent escapes it, so we'd render literal "&nbsp;").
+    code.textContent = " ";
+  } else {
+    for (const t of tokens) {
+      if (t.cls) {
+        const span = document.createElement("span");
+        span.className = t.cls;
+        span.textContent = t.text;
+        code.appendChild(span);
+      } else {
+        code.appendChild(document.createTextNode(t.text));
+      }
+    }
+  }
+  row.appendChild(code);
+  return row;
+}
+
+/**
+ * Render the source as a fragment of line rows. Mount with
+ * `parent.replaceChildren(fragment)`.
+ */
+export function highlightRon(source: string): DocumentFragment {
+  const frag = document.createDocumentFragment();
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    frag.appendChild(buildRow(lines[i] ?? "", i + 1));
+  }
+  return frag;
+}
+
+/**
+ * Token-class enumeration used by both runtime CSS hooks and the
+ * unit test that pins highlighter behavior. Exported so the test
+ * can spot-check tokenization without re-deriving the class names.
+ */
+export const RON_TOKEN_CLASSES = {
+  comment: "ron-c",
+  string: "ron-s",
+  number: "ron-n",
+  type: "ron-t",
+  key: "ron-k",
+} as const;

--- a/playground/src/features/scenario-config/index.ts
+++ b/playground/src/features/scenario-config/index.ts
@@ -1,0 +1,2 @@
+export { wireScenarioConfig, setScenarioConfig, type ScenarioConfigHandles } from "./render";
+export { tokenizeRonLine, RON_TOKEN_CLASSES, type RonToken } from "./highlight";

--- a/playground/src/features/scenario-config/index.ts
+++ b/playground/src/features/scenario-config/index.ts
@@ -1,2 +1,2 @@
-export { wireScenarioConfig, setScenarioConfig, type ScenarioConfigHandles } from "./render";
+export { wireScenarioConfig, type SetScenario } from "./render";
 export { tokenizeRonLine, RON_TOKEN_CLASSES, type RonToken } from "./highlight";

--- a/playground/src/features/scenario-config/render.ts
+++ b/playground/src/features/scenario-config/render.ts
@@ -1,0 +1,69 @@
+import { scenarioById } from "../../domain";
+import { toast } from "../../platform";
+import { highlightRon } from "./highlight";
+
+export interface ScenarioConfigHandles {
+  readonly root: HTMLElement;
+  readonly details: HTMLDetailsElement;
+  readonly filename: HTMLElement;
+  readonly code: HTMLElement;
+  readonly copy: HTMLButtonElement;
+}
+
+function q(id: string): HTMLElement {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`missing element #${id} (scenario-config)`);
+  return el;
+}
+
+const DESKTOP_QUERY = "(min-width: 768px)";
+
+let currentSource = "";
+let currentScenarioId = "";
+
+export function wireScenarioConfig(toastEl: HTMLElement): ScenarioConfigHandles {
+  const handles: ScenarioConfigHandles = {
+    root: q("scenario-config"),
+    details: q("scenario-config-details") as HTMLDetailsElement,
+    filename: q("scenario-config-filename"),
+    code: q("scenario-config-code"),
+    copy: q("scenario-config-copy") as HTMLButtonElement,
+  };
+
+  // Mobile: collapsed by default; desktop: expanded. Re-evaluate on
+  // viewport change so a portrait→landscape rotation snaps back to
+  // the expected state for that width.
+  const mql = window.matchMedia(DESKTOP_QUERY);
+  const applyOpen = (): void => {
+    handles.details.open = mql.matches;
+  };
+  applyOpen();
+  mql.addEventListener("change", applyOpen);
+
+  // The copy button sits inside <summary>, so its click would
+  // otherwise toggle the details. Stop propagation and handle copy.
+  handles.copy.addEventListener("click", (ev) => {
+    ev.preventDefault();
+    ev.stopPropagation();
+    if (!currentSource) return;
+    void navigator.clipboard
+      .writeText(currentSource)
+      .then(() => {
+        toast(toastEl, "Config copied");
+      })
+      .catch(() => {
+        toast(toastEl, "Copy failed");
+      });
+  });
+
+  return handles;
+}
+
+export function setScenarioConfig(handles: ScenarioConfigHandles, scenarioId: string): void {
+  if (scenarioId === currentScenarioId) return;
+  const scenario = scenarioById(scenarioId);
+  currentScenarioId = scenarioId;
+  currentSource = scenario.ron;
+  handles.filename.textContent = scenario.configFilename;
+  handles.code.replaceChildren(highlightRon(scenario.ron));
+}

--- a/playground/src/features/scenario-config/render.ts
+++ b/playground/src/features/scenario-config/render.ts
@@ -2,13 +2,7 @@ import { scenarioById } from "../../domain";
 import { toast } from "../../platform";
 import { highlightRon } from "./highlight";
 
-export interface ScenarioConfigHandles {
-  readonly root: HTMLElement;
-  readonly details: HTMLDetailsElement;
-  readonly filename: HTMLElement;
-  readonly code: HTMLElement;
-  readonly copy: HTMLButtonElement;
-}
+export type SetScenario = (scenarioId: string) => void;
 
 function q(id: string): HTMLElement {
   const el = document.getElementById(id);
@@ -18,35 +12,36 @@ function q(id: string): HTMLElement {
 
 const DESKTOP_QUERY = "(min-width: 768px)";
 
-let currentSource = "";
-let currentScenarioId = "";
+export function wireScenarioConfig(toastEl: HTMLElement): SetScenario {
+  const details = q("scenario-config-details") as HTMLDetailsElement;
+  const filename = q("scenario-config-filename");
+  const code = q("scenario-config-code");
+  const copy = q("scenario-config-copy") as HTMLButtonElement;
 
-export function wireScenarioConfig(toastEl: HTMLElement): ScenarioConfigHandles {
-  const handles: ScenarioConfigHandles = {
-    root: q("scenario-config"),
-    details: q("scenario-config-details") as HTMLDetailsElement,
-    filename: q("scenario-config-filename"),
-    code: q("scenario-config-code"),
-    copy: q("scenario-config-copy") as HTMLButtonElement,
-  };
-
-  // Mobile: collapsed by default; desktop: expanded. Re-evaluate on
-  // viewport change so a portrait→landscape rotation snaps back to
-  // the expected state for that width.
+  // Open on desktop, closed on mobile; phone rotation doesn't override the user.
   const mql = window.matchMedia(DESKTOP_QUERY);
   const applyOpen = (): void => {
-    handles.details.open = mql.matches;
+    details.open = mql.matches;
   };
   applyOpen();
   mql.addEventListener("change", applyOpen);
 
-  // The copy button sits inside <summary>, so its click would
-  // otherwise toggle the details. Stop propagation and handle copy.
-  handles.copy.addEventListener("click", (ev) => {
+  let currentId = "";
+  let currentSource = "";
+
+  copy.addEventListener("click", (ev) => {
+    // Copy button is inside <summary>; stopPropagation prevents the toggle.
     ev.preventDefault();
     ev.stopPropagation();
     if (!currentSource) return;
-    void navigator.clipboard
+    // Undefined in non-secure contexts (HTTP, sandboxed iframes);
+    // lib.dom types it as non-nullable, so cast to expose the runtime gap.
+    const clipboard = navigator.clipboard as Clipboard | undefined;
+    if (!clipboard) {
+      toast(toastEl, "Copy failed");
+      return;
+    }
+    void clipboard
       .writeText(currentSource)
       .then(() => {
         toast(toastEl, "Config copied");
@@ -56,14 +51,12 @@ export function wireScenarioConfig(toastEl: HTMLElement): ScenarioConfigHandles 
       });
   });
 
-  return handles;
-}
-
-export function setScenarioConfig(handles: ScenarioConfigHandles, scenarioId: string): void {
-  if (scenarioId === currentScenarioId) return;
-  const scenario = scenarioById(scenarioId);
-  currentScenarioId = scenarioId;
-  currentSource = scenario.ron;
-  handles.filename.textContent = scenario.configFilename;
-  handles.code.replaceChildren(highlightRon(scenario.ron));
+  return (scenarioId: string): void => {
+    if (scenarioId === currentId) return;
+    const scenario = scenarioById(scenarioId);
+    currentId = scenarioId;
+    currentSource = scenario.ron;
+    filename.textContent = scenario.configFilename;
+    code.replaceChildren(highlightRon(scenario.ron));
+  };
 }

--- a/playground/src/shell/boot.ts
+++ b/playground/src/shell/boot.ts
@@ -1,6 +1,7 @@
 import { reconcileStrategyWithScenario } from "../features/scenario-picker";
 import { applyPlaygroundMode, wireModeToggle } from "../features/mode-toggle";
 import { bootQuestPane } from "../features/quest";
+import { setScenarioConfig, wireScenarioConfig } from "../features/scenario-config";
 import {
   DEFAULT_STATE,
   compactOverrides,
@@ -83,6 +84,11 @@ export async function boot(): Promise<void> {
   applyPlaygroundMode(permalink.mode);
   wireModeToggle(permalink.mode);
   applyPermalinkToUi(permalink, ui);
+  const scenarioConfig = wireScenarioConfig(ui.toast);
+  setScenarioConfig(scenarioConfig, permalink.scenario);
+  onPermalinkSync((p) => {
+    setScenarioConfig(scenarioConfig, p.scenario);
+  });
   const state: State = {
     running: true,
     ready: false,

--- a/playground/src/shell/boot.ts
+++ b/playground/src/shell/boot.ts
@@ -1,7 +1,7 @@
 import { reconcileStrategyWithScenario } from "../features/scenario-picker";
 import { applyPlaygroundMode, wireModeToggle } from "../features/mode-toggle";
 import { bootQuestPane } from "../features/quest";
-import { setScenarioConfig, wireScenarioConfig } from "../features/scenario-config";
+import { wireScenarioConfig } from "../features/scenario-config";
 import {
   DEFAULT_STATE,
   compactOverrides,
@@ -84,10 +84,10 @@ export async function boot(): Promise<void> {
   applyPlaygroundMode(permalink.mode);
   wireModeToggle(permalink.mode);
   applyPermalinkToUi(permalink, ui);
-  const scenarioConfig = wireScenarioConfig(ui.toast);
-  setScenarioConfig(scenarioConfig, permalink.scenario);
+  const setScenarioConfig = wireScenarioConfig(ui.toast);
+  setScenarioConfig(permalink.scenario);
   onPermalinkSync((p) => {
-    setScenarioConfig(scenarioConfig, p.scenario);
+    setScenarioConfig(p.scenario);
   });
   const state: State = {
     running: true,

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -155,6 +155,10 @@
   --bad: #ef4444;
   --bad-soft: color-mix(in srgb, var(--bad) 10%, transparent);
 
+  /* Syntax-highlight tokens for the scenario-config RON panel. */
+  --syntax-string: #86efac;
+  --syntax-type: #e9b97a;
+
   /* Focus ring */
   --focus-ring: var(--accent);
 
@@ -1398,13 +1402,13 @@
     font-style: italic;
   }
   .ron-s {
-    color: #86efac;
+    color: var(--syntax-string);
   }
   .ron-n {
     color: var(--pane-b);
   }
   .ron-t {
-    color: #e9b97a;
+    color: var(--syntax-type);
   }
   .ron-k {
     color: var(--pane-a);

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -1289,6 +1289,138 @@
     }
   }
 
+  /* ── Scenario-config panel ──────────────────────────────────────────── */
+
+  .scenario-config-details {
+    background: linear-gradient(180deg, var(--bg-elevated), var(--bg-secondary));
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
+    padding-bottom: 6px;
+  }
+  .scenario-config-summary {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    cursor: pointer;
+    user-select: none;
+    list-style: none;
+    font: 12px/1 var(--font-stack-sans);
+    color: var(--text-secondary);
+  }
+  .scenario-config-summary::-webkit-details-marker {
+    display: none;
+  }
+  .scenario-config-summary:hover {
+    color: var(--text-primary);
+  }
+  .scenario-config-caret {
+    color: var(--text-tertiary);
+    font-size: 10px;
+    transition: transform var(--transition-fast);
+  }
+  .scenario-config-details[open] .scenario-config-caret {
+    transform: rotate(90deg);
+  }
+  .scenario-config-filename {
+    font: 12px/1 var(--font-stack-mono);
+    color: var(--text-primary);
+    letter-spacing: 0;
+  }
+  .scenario-config-eyebrow {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-disabled);
+    margin-left: auto;
+  }
+  .scenario-config-copy {
+    display: inline-flex;
+    align-items: center;
+    height: 22px;
+    padding: 0 8px;
+    background: var(--bg-active);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    font: 11px/1 var(--font-stack-sans);
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+      background var(--transition-fast),
+      color var(--transition-fast),
+      border-color var(--transition-fast);
+  }
+  .scenario-config-copy:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+    border-color: var(--border-strong);
+  }
+  .scenario-config-body {
+    max-height: 360px;
+    overflow: auto;
+    border-top: 1px solid var(--border-subtle);
+    padding: 6px 0 4px;
+  }
+  .scenario-config-pre {
+    margin: 0;
+    padding: 0;
+    background: transparent;
+    font: 12.5px/1.55 var(--font-stack-mono);
+  }
+  .scenario-config-code {
+    display: block;
+  }
+  .ron-row {
+    display: flex;
+    gap: 12px;
+    padding: 0 12px;
+    white-space: pre;
+  }
+  .ron-row:hover {
+    background: color-mix(in srgb, var(--bg-hover) 50%, transparent);
+  }
+  .ron-ln {
+    flex: 0 0 auto;
+    min-width: 2.5ch;
+    text-align: right;
+    color: var(--text-disabled);
+    user-select: none;
+    font-variant-numeric: tabular-nums;
+  }
+  .ron-code {
+    flex: 1 1 auto;
+    color: var(--text-primary);
+  }
+  .ron-c {
+    color: var(--text-tertiary);
+    font-style: italic;
+  }
+  .ron-s {
+    color: #86efac;
+  }
+  .ron-n {
+    color: var(--pane-b);
+  }
+  .ron-t {
+    color: #e9b97a;
+  }
+  .ron-k {
+    color: var(--pane-a);
+  }
+  @media (max-width: 767px) {
+    .scenario-config-body {
+      max-height: 280px;
+    }
+    .scenario-config-pre {
+      font-size: 11.5px;
+    }
+    .scenario-config-eyebrow {
+      display: none;
+    }
+  }
+
   /* ── Mobile ─────────────────────────────────────────────────────────── */
 
   /* Mobile-specific styling uses Tailwind `max-md:` variants on the HTML

--- a/playground/src/types/scenario.ts
+++ b/playground/src/types/scenario.ts
@@ -116,6 +116,12 @@ export interface ScenarioMeta {
   label: string;
   description: string;
   ron: string;
+  /**
+   * Filename shown above the scenario's RON in the config panel —
+   * e.g. `convention_burst.ron`. Treat it as a label, not a file
+   * path; nothing on disk is loaded by this name.
+   */
+  configFilename: string;
   /** Baseline dispatch strategy for this scenario. User can still swap. */
   defaultStrategy: StrategyName;
   /** Day-cycle phases, ordered. Empty array = static (used by convention-burst). */


### PR DESCRIPTION
## Summary

Adds a syntax-highlighted RON config panel that lives below the simulation canvas and swaps to whatever scenario is currently active. Each scenario gets a learner-friendly filename label (`skyscraper.ron`, `airport_loop.ron`, etc.) and a copy-to-clipboard affordance.

- New `features/scenario-config/` module with a tiny hand-rolled RON tokenizer (no Prism / highlight.js dependency)
- Mobile: collapsed by default via `<details>` driven by `matchMedia("(min-width: 768px)")`; desktop expands automatically; the listener only fires on actual breakpoint crossings so a portrait↔landscape rotation on a phone doesn't snap-back what the user opened
- Inline RON comments rewritten in plain English: the displayed config now reads as teaching material, not author notes
- `ScenarioMeta.configFilename` added so the filename label is data, not a switch-on-id
- Hidden in quest mode via the existing `applyPlaygroundMode` chrome list

The RON itself still parses identically (smoke tested in vitest); only the comments inside changed, which the parser strips anyway.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` — 353/353 passing
- [x] `pnpm lint` — 0 errors, 2 pre-existing warnings
- [x] `pnpm build` — succeeds
- [x] Static HTML inspection: section + IDs present at dev server `/`
- [ ] Visual: desktop + mobile portrait/landscape for each of the 4 scenarios (filename header, syntax colors, line numbers, copy button; scenario swap updates the block)