### PR TITLE
fix(playground): clear bottom controls bar on mobile scenario config

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -690,7 +690,7 @@
 
     <section
       id="scenario-config"
-      class="scenario-config mx-5 mb-3 max-md:mx-3.5 max-md:mb-2.5"
+      class="scenario-config mx-5 mb-3 max-md:mx-3.5 max-md:mb-[calc(var(--controls-bar-h,52px)+12px+env(safe-area-inset-bottom))]"
       aria-label="Active scenario configuration"
     >
       <details id="scenario-config-details" class="scenario-config-details">


### PR DESCRIPTION
## Summary

The active scenario-config panel (added in #838) was getting clipped by the fixed bottom controls bar on mobile web. Bumps the panel's mobile bottom margin from `mb-2.5` (10px) to the same calc-based clearance used by `<main id="layout">`.

- `<section id="scenario-config">` sits after `<main>` in document flow.
- On mobile the desktop `<footer>` is hidden (`max-md:hidden`), so the panel is the last visible element.
- The fixed `controls-bar` at `bottom: 0` therefore overlaid the bottom ~52px of the panel once the user expanded it.

Fix: mirror the clearance pattern already used by `<main>`:
`max-md:mb-[calc(var(--controls-bar-h,52px)+12px+env(safe-area-inset-bottom))]`. `--controls-bar-h` is kept in sync with the bar's measured border-box height by the ResizeObserver in `shell/wire-ui.ts`, so the gap follows real bar height across breakpoints and iOS safe-area insets.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors (2 pre-existing warnings)
- [x] `pnpm test --run` — 353/353 passing
- [x] Pre-commit hook — passed (lint-staged + typecheck + vitest)
- [ ] Visual: mobile portrait, mobile landscape, with the panel collapsed and expanded — scenario-config bottom edge should clear the controls bar with a small gap
- [ ] Visual: desktop — no regression (only mobile clearance changed)