### PR TITLE
fix(playground): stale scenario references + title suffix consistency

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -176,7 +176,7 @@
           "Compare dispatch strategies side-by-side",
           "Six built-in dispatch algorithms (LOOK, SCAN, NEAREST, ETD, DCS, RSR)",
           "Five idle-parking strategies (Adaptive, Predictive, Lobby, Spread, Stay)",
-          "Three scenarios (Convention center, Skyscraper, Space elevator)",
+          "Four scenarios (Skyscraper, Space elevator, Airport loop, Convention center)",
           "Deterministic seeded traffic generation",
           "Live metrics: wait time, ride time, abandonments, throughput",
           "Permalink sharing of full simulator state",
@@ -343,10 +343,6 @@
         <h2>Scenarios</h2>
         <ul>
           <li>
-            <strong>Convention center</strong> — five named stops (Lobby, Exhibit Hall, Mezzanine,
-            Ballroom, Keynote Hall). Tests burst traffic when a keynote lets out.
-          </li>
-          <li>
             <strong>Skyscraper</strong> — 40 named floors plus three sub-basements and a sky lobby.
             Models morning rush, midday meetings, lunch crowd, evening commute, and late-night
             traffic across low/high banks, an executive line, and a service line.
@@ -354,6 +350,15 @@
           <li>
             <strong>Space elevator</strong> — kilometres-long tether climbers between Earth station
             and orbital platforms. Stress-tests dispatch and parking when stops are far apart.
+          </li>
+          <li>
+            <strong>Airport loop</strong> — two counter-rotating loops connect a terminal to six
+            concourses. Fixed-headway dispatch on a one-way loop, with demand shifting from outbound
+            (morning) to inbound (evening).
+          </li>
+          <li>
+            <strong>Convention center</strong> — five named stops (Lobby, Exhibit Hall, Mezzanine,
+            Ballroom, Keynote Hall). Tests burst traffic when a keynote lets out.
           </li>
         </ul>
 

--- a/playground/src/domain/scenarios/scenarios.ts
+++ b/playground/src/domain/scenarios/scenarios.ts
@@ -754,7 +754,7 @@ const airportPhases: Phase[] = [
 const airport: ScenarioMeta = {
   id: "airport-apm",
   label: "Airport loop",
-  configFilename: "airport_loop.ron",
+  configFilename: "airport_apm.ron",
   description:
     "Two counter-rotating loops connect the terminal to six concourses. Fixed-headway dispatch keeps trains on a predictable cadence; rider demand shifts from outbound (morning) to inbound (evening).",
   // Placeholder — actual dispatch is per-group LoopSchedule in the RON;

--- a/playground/src/features/scenario-config/render.ts
+++ b/playground/src/features/scenario-config/render.ts
@@ -19,12 +19,7 @@ export function wireScenarioConfig(toastEl: HTMLElement): SetScenario {
   const copy = q("scenario-config-copy") as HTMLButtonElement;
 
   // Open on desktop, closed on mobile; phone rotation doesn't override the user.
-  const mql = window.matchMedia(DESKTOP_QUERY);
-  const applyOpen = (): void => {
-    details.open = mql.matches;
-  };
-  applyOpen();
-  mql.addEventListener("change", applyOpen);
+  details.open = window.matchMedia(DESKTOP_QUERY).matches;
 
   let currentId = "";
   let currentSource = "";

--- a/playground/src/shell/document-meta.ts
+++ b/playground/src/shell/document-meta.ts
@@ -38,7 +38,7 @@ function buildMeta(state: PermalinkState): { title: string; description: string 
   // describe what's actually running. Render the actual dispatch and
   // drop the parking phrase.
   if (scenario.airport !== undefined) {
-    const title = `${scenarioLabel}: ${AIRPORT_DISPATCH_LABEL} dispatch — Elevator dispatch playground`;
+    const title = `${scenarioLabel}: ${AIRPORT_DISPATCH_LABEL} dispatch — ${APP_SUFFIX}`;
     const description =
       `Watch ${AIRPORT_DISPATCH_LABEL} dispatch handle live rider traffic on the ` +
       `${scenarioLabel.toLowerCase()} scenario. ${BASE_DESCRIPTION}`;
@@ -51,14 +51,14 @@ function buildMeta(state: PermalinkState): { title: string; description: string 
   const parkB = REPOSITION_LABELS[state.repositionB];
 
   if (state.compare) {
-    const title = `${scenarioLabel}: ${stratA} vs ${stratB} — Elevator dispatch playground`;
+    const title = `${scenarioLabel}: ${stratA} vs ${stratB} — ${APP_SUFFIX}`;
     const description =
       `Compare ${stratA} (parking: ${parkA}) against ${stratB} (parking: ${parkB}) ` +
       `dispatch on the ${scenarioLabel.toLowerCase()} scenario. ${BASE_DESCRIPTION}`;
     return { title, description };
   }
 
-  const title = `${scenarioLabel}: ${stratA} dispatch — Elevator dispatch playground`;
+  const title = `${scenarioLabel}: ${stratA} dispatch — ${APP_SUFFIX}`;
   const description =
     `Watch ${stratA} dispatch (parking: ${parkA}) handle live rider traffic on the ` +
     `${scenarioLabel.toLowerCase()} scenario. ${BASE_DESCRIPTION}`;


### PR DESCRIPTION
## Summary

Four small playground fixes uncovered during a bug hunt, all caused by partial migrations or rename slip-ups:

- **Airport `configFilename` points at a nonexistent file.** PR #837 renamed the scenario label to "Airport loop" but explicitly kept the on-disk file as `airport_apm.ron`. The scenario-config panel header was reading `airport_loop.ron` — a path users could not actually copy or open.
- **Document title suffix was inconsistent.** `APP_SUFFIX = "elevator-core playground"` was defined but only used by the Quest title; all non-quest branches hardcoded `"Elevator dispatch playground"`. Route every branch through `APP_SUFFIX`.
- **Scenario-config details panel force-toggled on viewport breakpoint crossings**, contradicting its own comment that "phone rotation doesn't override the user". Removed the `mql` change-listener so the initial open state is set once and the user's toggle sticks across rotation.
- **`index.html` SEO surface still claimed three scenarios.** The structured-data `featureList` and the no-JS fallback `<h2>Scenarios</h2>` list both omitted Airport loop (added in #830). `scenarios.test.ts` already asserts `SCENARIOS.toHaveLength(4)`, so the live app and the SEO surface had drifted.

No new tests — the existing `scenarios.test.ts` length assertion already covers the runtime list. The static HTML drift is hand-maintained.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` — 353/353 passing
- [x] Pre-commit hook clean (workspace check + playground tests)
- [ ] Visual: scenario-config panel reads `airport_apm.ron` for the airport scenario
- [ ] Visual: document title reads `… — elevator-core playground` across compare / single / airport
- [ ] Visual: rotate device with scenario-config panel open — panel stays in user-selected state