### PR TITLE
fix(playground): show docs and guide nav links on mobile

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -462,12 +462,12 @@
             ><span aria-hidden="true">&#9733;</span><span class="max-md:hidden">star</span></a
           >
           <a
-            class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content max-md:hidden"
+            class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content"
             href="https://docs.rs/elevator-core"
             >docs</a
           >
           <a
-            class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content max-md:hidden"
+            class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content"
             href="../"
             >guide</a
           >


### PR DESCRIPTION
## Summary
- The header `docs` and `guide` anchors in `playground/index.html` were `max-md:hidden`, so on phones only a lone ★ icon and the `?` button remained — there was no labelled way to reach the API reference or the mdBook guide.
- Drop the `max-md:hidden` class on both anchors. They're short ("docs", "guide") and fit easily inside the mobile header (the cabin legend already collapses at `max-lg:hidden`, leaving real estate).
- No CSS changes; the existing `text-content-tertiary` styling and the nav's `max-md:gap-3` keep the look consistent across breakpoints.

## Test plan
- [ ] Open the playground on a narrow viewport (≤ 480px wide) and confirm `★`, `docs`, `guide`, and `?` are all visible and tappable.
- [ ] At ≥ 768px confirm the header still shows `★ star`, `docs`, `guide`, `?` and the cabin legend in the middle slot.
- [ ] Confirm `docs` links to `https://docs.rs/elevator-core` and `guide` links to `../` (the mdBook root).