### PR TITLE
fix(playground): UX audit — mobile responsiveness, IA, visual & motion polish

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -505,7 +505,7 @@
     <section
       id="scenario-picker"
       aria-label="Scenario picker"
-      class="scenario-cards flex flex-row items-center gap-3 px-5 py-1.5 border-b border-stroke-subtle max-md:gap-2 max-md:px-3.5 max-md:py-1.5"
+      class="scenario-cards relative flex flex-row items-center gap-3 px-5 py-1.5 border-b border-stroke-subtle max-md:gap-2 max-md:px-3.5 max-md:py-1.5"
     >
       <span
         class="text-[10.5px] uppercase tracking-[0.08em] text-content-disabled font-medium select-none flex-none max-md:hidden"
@@ -513,7 +513,7 @@
       >
       <div
         id="scenario-cards"
-        class="flex flex-row flex-wrap items-center gap-1.5 flex-1 min-w-0 max-md:gap-1.5 max-md:flex-nowrap max-md:overflow-x-auto max-md:snap-x max-md:snap-mandatory max-md:[-webkit-overflow-scrolling:touch] max-md:[scrollbar-width:none] max-md:[&::-webkit-scrollbar]:hidden"
+        class="scenario-cards-track flex flex-row flex-wrap items-center gap-1.5 flex-1 min-w-0 max-md:gap-1.5 max-md:flex-nowrap max-md:overflow-x-auto max-md:snap-x max-md:snap-mandatory max-md:[-webkit-overflow-scrolling:touch] max-md:[scrollbar-width:none] max-md:[&::-webkit-scrollbar]:hidden"
       ></div>
     </section>
 

--- a/playground/index.html
+++ b/playground/index.html
@@ -462,16 +462,21 @@
             ><span aria-hidden="true">&#9733;</span><span class="max-md:hidden">star</span></a
           >
           <a
-            class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content max-md:hidden"
+            class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content"
             href="https://docs.rs/elevator-core"
             >docs</a
           >
           <a
-            class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content max-md:hidden"
+            class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content"
             href="../"
             >guide</a
           >
-          <button type="button" id="shortcuts" class="nav-btn" title="Keyboard shortcuts (press ?)">
+          <button
+            type="button"
+            id="shortcuts"
+            class="nav-btn max-md:hidden"
+            title="Keyboard shortcuts (press ?)"
+          >
             ?
           </button>
         </nav>

--- a/playground/scripts/audit-screenshots.mjs
+++ b/playground/scripts/audit-screenshots.mjs
@@ -1,0 +1,150 @@
+// Audit-pass screenshot harness. Snaps the playground at two viewports
+// (375 wide with the iPhone 14 device descriptor, 1440 wide desktop)
+// across the states the UX audit cares about: cold-start, each
+// scenario's happy-path single-pane, default compare-pane, tweak-drawer
+// open (empty + with overrides), and scenario-config-details expanded.
+//
+// NOTE: WebKit binaries shipped with Playwright link against Ubuntu's
+// libicu .so.74 which Fedora doesn't ship; mobile captures fall back to
+// Chromium with the iPhone 14 device descriptor (touch + UA + viewport).
+// Real iOS Safari verification still belongs on a physical device.
+//
+// Usage (from playground/, with `pnpm dev` running on :5173):
+//   node scripts/audit-screenshots.mjs before
+//   node scripts/audit-screenshots.mjs after
+//
+// Output: playground/.screenshots/audit/<before|after>/<viewport>__<scene>.png
+
+import { chromium, devices } from "@playwright/test";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+const MODE = process.argv[2] ?? "before";
+if (!["before", "after"].includes(MODE)) {
+  console.error(`mode must be "before" or "after", got: ${MODE}`);
+  process.exit(1);
+}
+
+const BASE = process.env.AUDIT_BASE_URL ?? "http://localhost:5173";
+const OUT_DIR = new URL(`../.screenshots/audit/${MODE}/`, import.meta.url).pathname;
+
+const SCENARIOS = [
+  { id: "convention-burst", strategy: "etd" },
+  { id: "skyscraper-sky-lobby", strategy: "look" },
+  { id: "space-elevator", strategy: "scan" },
+  { id: "airport-apm", strategy: "scan" },
+];
+
+const SCENES = [
+  {
+    name: "cold-start",
+    url: `${BASE}/`,
+    // No pause — capture the first paint, animations still settling.
+    skipPause: true,
+  },
+  ...SCENARIOS.map((s) => ({
+    name: `scenario__${s.id}`,
+    url: `${BASE}/?s=${s.id}&c=0&a=${s.strategy}`,
+  })),
+  {
+    name: "compare-default",
+    url: `${BASE}/?s=skyscraper-sky-lobby&c=1`,
+  },
+  {
+    name: "scenario-config-expanded",
+    url: `${BASE}/?s=skyscraper-sky-lobby&c=0&a=look`,
+    async setup(page) {
+      await page
+        .locator("#scenario-config-details > summary")
+        .click()
+        .catch(() => {});
+      await page.waitForTimeout(200);
+    },
+  },
+  {
+    name: "tweak-drawer-empty",
+    url: `${BASE}/?s=skyscraper-sky-lobby&c=0&a=look`,
+    async setup(page) {
+      await page
+        .locator("#tweak")
+        .click()
+        .catch(() => {});
+      await page.waitForTimeout(250);
+    },
+  },
+  {
+    name: "tweak-drawer-with-overrides",
+    // Permalink with explicit overrides so the drawer has values to show.
+    url: `${BASE}/?s=skyscraper-sky-lobby&c=0&a=look&o.speed=4&o.traffic=1.5`,
+    async setup(page) {
+      await page
+        .locator("#tweak")
+        .click()
+        .catch(() => {});
+      await page.waitForTimeout(250);
+    },
+  },
+  {
+    name: "scenario-picker-open",
+    url: `${BASE}/?s=skyscraper-sky-lobby&c=0&a=look`,
+    async setup(page) {
+      // The scenario picker is the cards strip at the top; capture its
+      // resting state plus a hover-ish look on the first non-active card.
+      await page
+        .locator("#scenario-cards .scenario-card")
+        .nth(1)
+        .hover()
+        .catch(() => {});
+      await page.waitForTimeout(150);
+    },
+  },
+];
+
+async function snap(context, scene, label) {
+  const page = await context.newPage();
+  await page.goto(scene.url, { waitUntil: "networkidle" });
+  if (!scene.skipPause) {
+    await page
+      .getByRole("button", { name: /^(pause|play)$/i })
+      .first()
+      .click()
+      .catch(() => {});
+    await page.waitForTimeout(400);
+  } else {
+    await page.waitForTimeout(250);
+  }
+  if (scene.setup) await scene.setup(page);
+  const path = join(OUT_DIR, `${label}__${scene.name}.png`);
+  await page.screenshot({ path, fullPage: true });
+  await page.close();
+  return path;
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+  const desktop = await browser.newContext({
+    viewport: { width: 1440, height: 900 },
+    deviceScaleFactor: 2,
+  });
+  const mobile = await browser.newContext({
+    ...devices["iPhone 14"],
+    viewport: { width: 375, height: 812 },
+  });
+
+  const captured = [];
+  try {
+    for (const scene of SCENES) {
+      captured.push(await snap(desktop, scene, "desktop-1440"));
+      captured.push(await snap(mobile, scene, "mobile-375"));
+    }
+  } finally {
+    await browser.close();
+  }
+  console.log(`Captured ${captured.length} → ${OUT_DIR}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/playground/scripts/audit-screenshots.mjs
+++ b/playground/scripts/audit-screenshots.mjs
@@ -102,22 +102,25 @@ const SCENES = [
 
 async function snap(context, scene, label) {
   const page = await context.newPage();
-  await page.goto(scene.url, { waitUntil: "networkidle" });
-  if (!scene.skipPause) {
-    await page
-      .getByRole("button", { name: /^(pause|play)$/i })
-      .first()
-      .click()
-      .catch(() => {});
-    await page.waitForTimeout(400);
-  } else {
-    await page.waitForTimeout(250);
+  try {
+    await page.goto(scene.url, { waitUntil: "networkidle" });
+    if (!scene.skipPause) {
+      await page
+        .getByRole("button", { name: /^(pause|play)$/i })
+        .first()
+        .click()
+        .catch(() => {});
+      await page.waitForTimeout(400);
+    } else {
+      await page.waitForTimeout(250);
+    }
+    if (scene.setup) await scene.setup(page);
+    const path = join(OUT_DIR, `${label}__${scene.name}.png`);
+    await page.screenshot({ path, fullPage: true });
+    return path;
+  } finally {
+    await page.close();
   }
-  if (scene.setup) await scene.setup(page);
-  const path = join(OUT_DIR, `${label}__${scene.name}.png`);
-  await page.screenshot({ path, fullPage: true });
-  await page.close();
-  return path;
 }
 
 async function main() {

--- a/playground/src/__tests__/layout.test.ts
+++ b/playground/src/__tests__/layout.test.ts
@@ -24,7 +24,7 @@ describe("scaleFor", () => {
     // t=0: lerp(a, b) = a
     expect(s.padX).toBeCloseTo(6, 5);
     expect(s.padTop).toBeCloseTo(22, 5);
-    expect(s.labelW).toBeCloseTo(52, 5);
+    expect(s.labelW).toBeCloseTo(62, 5);
     expect(s.figureGutterW).toBeCloseTo(40, 5);
     expect(s.carH).toBeCloseTo(32, 5);
   });
@@ -42,14 +42,14 @@ describe("scaleFor", () => {
     const s = scaleFor(610);
     // t = (610 - 320) / (900 - 320) = 290/580 = 0.5
     expect(s.padX).toBeCloseTo(10, 5); // lerp(6,14,0.5)
-    expect(s.labelW).toBeCloseTo(86, 5); // lerp(52,120,0.5)
+    expect(s.labelW).toBeCloseTo(91, 5); // lerp(62,120,0.5)
     expect(s.carH).toBeCloseTo(44, 5); // lerp(32,56,0.5)
   });
 
   it("width below 320 clamps to minimum values (t=0)", () => {
     const s = scaleFor(100);
     expect(s.padX).toBeCloseTo(6, 5);
-    expect(s.labelW).toBeCloseTo(52, 5);
+    expect(s.labelW).toBeCloseTo(62, 5);
   });
 
   it("width above 900 clamps to maximum values (t=1)", () => {

--- a/playground/src/features/scenario-picker/cards.ts
+++ b/playground/src/features/scenario-picker/cards.ts
@@ -38,6 +38,18 @@ export function renderScenarioCards(ui: ScenarioCardsUi): void {
     frag.appendChild(card);
   });
   ui.scenarioCards.replaceChildren(frag);
+  // The right-edge mask-image fade signals "scroll for more" on mobile.
+  // Clear it once the last card is reached so users get a stop-signal
+  // instead of an always-faded edge.
+  const SCROLL_SLOP = 2;
+  const sync = (): void => {
+    const exhausted =
+      ui.scenarioCards.scrollLeft + ui.scenarioCards.clientWidth >=
+      ui.scenarioCards.scrollWidth - SCROLL_SLOP;
+    ui.scenarioCards.classList.toggle("is-at-end", exhausted);
+  };
+  ui.scenarioCards.addEventListener("scroll", sync, { passive: true });
+  sync();
 }
 
 export function syncScenarioCards(ui: ScenarioCardsUi, scenarioId: string): void {

--- a/playground/src/features/scenario-picker/cards.ts
+++ b/playground/src/features/scenario-picker/cards.ts
@@ -16,7 +16,7 @@ const SCENARIO_CARD_CLS =
 const SCENARIO_KBD_CLS =
   "inline-flex items-center justify-center min-w-[15px] h-[15px] px-1 " +
   "text-[9.5px] font-semibold text-content-disabled bg-surface border border-stroke " +
-  "rounded-sm tabular-nums";
+  "rounded-sm tabular-nums max-md:hidden";
 
 /** Narrow interface — only the fields scenario cards need from UiHandles. */
 export interface ScenarioCardsUi {

--- a/playground/src/render/draw-tether.ts
+++ b/playground/src/render/draw-tether.ts
@@ -9,6 +9,7 @@ import {
 } from "./draw-tether-hud";
 import type { Scale } from "./layout";
 import { TARGET_FILL } from "./palette";
+import { truncate } from "./primitives";
 import { formatAltitudeShort, tetherDecadeTicks } from "./tether";
 import type { Snapshot, TetherMeta } from "../types";
 
@@ -287,7 +288,7 @@ function drawTetherStops(
     // Stop name + altitude on the left gutter.
     ctx.fillStyle = "rgba(220, 230, 245, 0.95)";
     ctx.textAlign = "right";
-    ctx.fillText(stop.name, labelLeft + labelW - 4, y - 1);
+    ctx.fillText(truncate(ctx, stop.name, labelW - 4), labelLeft + labelW - 4, y - 1);
     ctx.fillStyle = "rgba(160, 178, 210, 0.7)";
     ctx.font = `${(s.fontSmall - 0.5).toFixed(0)}px system-ui, -apple-system, "Segoe UI", sans-serif`;
     ctx.fillText(formatAltitudeShort(stop.y), labelLeft + labelW - 4, y + 10);

--- a/playground/src/render/layout.ts
+++ b/playground/src/render/layout.ts
@@ -49,7 +49,7 @@ export function scaleFor(width: number): Scale {
     // on the narrowest phones. Tether mode picks its own gutter width
     // inside `drawTetherScene`. `truncate()` clips anything that
     // spills over on ultra-long custom stop names.
-    labelW: lerp(52, 120),
+    labelW: lerp(62, 120),
     // Preferred gutter for rider figures. The gutter grows further
     // only when shafts hit their max; otherwise shafts claim slack.
     figureGutterW: lerp(40, 70),

--- a/playground/src/shell/boot.ts
+++ b/playground/src/shell/boot.ts
@@ -70,6 +70,16 @@ export async function boot(): Promise<void> {
       permalink.repositionB = scenario.defaultReposition;
     }
   }
+  // Cold-boot compare default on narrow portrait viewports: two stacked
+  // panes leave each sim cramped on a 375-wide phone. Shared links keep
+  // `c=` so a recipient still sees the sender's framing.
+  if (
+    !urlSearch.has("c") &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(max-width: 767px) and (orientation: portrait)").matches
+  ) {
+    permalink.compare = false;
+  }
   // Compact decoded overrides against the resolved scenario so a URL
   // that carries values matching the current default (possible if a
   // scenario default shifted between share-time and load-time) doesn't

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -881,6 +881,17 @@
     .tweak-panel-popover {
       width: calc(100vw - 16px);
     }
+    /* Soft right-edge fade hints at horizontally scrollable scenario
+     * cards on mobile. Desktop wraps the cards so no fade is needed. */
+    .scenario-cards-track {
+      -webkit-mask-image: linear-gradient(
+        to right,
+        black 0,
+        black calc(100% - 32px),
+        transparent 100%
+      );
+      mask-image: linear-gradient(to right, black 0, black calc(100% - 32px), transparent 100%);
+    }
   }
 
   /* ── Nav button (?) ─────────────────────────────────────────────────── */

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -896,8 +896,11 @@
       width: calc(100vw - 16px);
     }
     /* Soft right-edge fade hints at horizontally scrollable scenario
-     * cards on mobile. Desktop wraps the cards so no fade is needed. */
-    .scenario-cards-track {
+     * cards on mobile. Desktop wraps the cards so no fade is needed.
+     * `.is-at-end` is toggled by a scroll listener in cards.ts so the
+     * fade clears once the user has reached the last card — without
+     * this scope, the final card would stay perpetually half-faded. */
+    .scenario-cards-track:not(.is-at-end) {
       -webkit-mask-image: linear-gradient(
         to right,
         black 0,

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -870,6 +870,16 @@
       min-width: var(--touch-target);
       min-height: var(--touch-target);
     }
+    /* Reorder the wrapping bar so primary actions (play/reset/share)
+     * land on the first row at thumb level rather than wrapping below
+     * sliders. `margin-left: auto` is dropped here because the order
+     * already places the group; let flex distribute the row instead. */
+    .controls-bar-actions {
+      order: -1;
+      margin-left: 0;
+      width: 100%;
+      justify-content: flex-end;
+    }
     /* Phase block can hide on the narrowest viewports — the section
      * already collapses when no phases are installed, but on a phone
      * even the active label crowds out the controls. The dedicated

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -625,11 +625,13 @@
       border-color var(--transition-fast),
       box-shadow var(--transition-fast);
   }
-  button:hover {
-    background: linear-gradient(180deg, var(--bg-active) 0%, var(--bg-hover) 100%);
-    border-color: var(--border-strong);
-    transform: translateY(-1px);
-    box-shadow: var(--shadow-md);
+  @media (hover: hover) {
+    button:hover {
+      background: linear-gradient(180deg, var(--bg-active) 0%, var(--bg-hover) 100%);
+      border-color: var(--border-strong);
+      transform: translateY(-1px);
+      box-shadow: var(--shadow-md);
+    }
   }
   button:active {
     transform: translateY(0);
@@ -644,13 +646,15 @@
       color-mix(in srgb, var(--accent) 4%, transparent) 100%
     );
   }
-  #play:hover {
-    background: linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--accent) 20%, transparent) 0%,
-      color-mix(in srgb, var(--accent) 8%, transparent) 100%
-    );
-    border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+  @media (hover: hover) {
+    #play:hover {
+      background: linear-gradient(
+        180deg,
+        color-mix(in srgb, var(--accent) 20%, transparent) 0%,
+        color-mix(in srgb, var(--accent) 8%, transparent) 100%
+      );
+      border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+    }
   }
 
   /* ── Layout ─────────────────────────────────────────────────────────── */


### PR DESCRIPTION
UX audit of the main playground at 375 (iOS canonical) + 1440 (desktop), four lenses: mobile responsiveness, IA / wayfinding / content, visual design & typography, motion polish (a11y intentionally out of scope this round). Quest mode out of scope. Commits are grouped by lens so they can be reviewed independently and rolled back individually if needed.

## Caveats up front

- **No real iOS Safari.** Playwright's WebKit binary links against Ubuntu's libicu `.so.74`, which Fedora 43 doesn't ship (it has `.so.77`). Mobile captures fall back to Chromium with the iPhone 14 device descriptor (touch + UA + viewport). Verify on a real iPhone before merging if anything visual is in doubt.
- **No a11y bar** for this round (per scoping). WCAG / contrast / keyboard / ARIA were deliberately not measured. Locked-memory items (no React port, no auto-speed-change, etc.) were honored; no findings on those.
- Branch was cut off `main`, not stacked on the still-open #841. The docs/guide visibility fix from #841 is included here too — whichever lands first wins on conflict.

## Commits in this PR

| Lens | Commit | Findings addressed |
|---|---|---|
| Mobile responsiveness | `a4ec0be0` | M2, M4, M5, M6 |
| IA / wayfinding / content | `1130351e` | M8 (= #841), I5, I7 |
| Visual design | `aeccacc9` | M7 |
| Motion polish | `1991e4e7` | A2 |

## Findings, severity-tagged

### HIGH

- **M2 — mobile cold-start defaults to compare mode.** Two stacked panes on a 375 phone leave each half-viewport tall, useless for actual comparison. `boot.ts` now flips `permalink.compare` to `false` on cold-start when the URL omits `c=` and `matchMedia("(max-width: 767px) and (orientation: portrait)")` matches. Shared links keep their `c=` so the recipient sees the sender's framing.
- **M4 — skyscraper labels `Penthouse` / `Sky Lobby` truncating to `Penthou…` / `Sky Lob…`.** Bump `labelW` lerp baseline 52 → 62 px. Tests + mid-range expectations adjusted to match.
- **M5 — space-elevator `Ground Station` clipping on the left edge as `round Sta…`.** `draw-tether.ts` was calling raw `fillText`; wrap in `truncate(ctx, name, labelW - 4)` to match the building renderer (`draw-building.ts:144`).

### MEDIUM

- **M6 — scenario picker has `scrollbar-width: none` on mobile.** 4th scenario was completely invisible with zero scroll affordance. Added a `mask-image` linear-gradient fade on `.scenario-cards-track` inside the mobile breakpoint. The 4th card now visibly fades into the edge.
- **M7 — controls bar primary actions wrap to row 3 on mobile.** With `flex-wrap` + `margin-left: auto`, play / reset / share landed at the bottom-right of a three-row stack. Promoted `.controls-bar-actions` to `order: -1; width: 100%; justify-content: flex-end` inside the mobile media query. Desktop untouched.

### LOW

- **M8 — docs/guide nav anchors hidden on mobile** (was #841): `max-md:hidden` dropped from both.
- **I5 — `?` keyboard-shortcuts button shown on touch devices.** Now hidden below md; the global `?` key listener still works on a tablet with a physical keyboard.
- **I7 — kbd badge `[1][2][3][4]` on scenario tabs reads as ordinal IDs on touch.** Hidden below md.
- **A2 — global `button:hover` lift (`translateY(-1px)` + `box-shadow`) sticks after tap on touch.** Wrapped offending rules in `@media (hover: hover)`. Tailwind `hover:` variants are already touch-safe since Tailwind v3.

### Confirmed not bugs / no change

- **I4 — scenario-config code panel below canvas.** Already correctly wired: `wireScenarioConfig` reads `matchMedia("(min-width: 768px)")` and only opens the `<details>` on desktop.
- **V1 — metrics row 1-up stacked on mobile.** Intentional design; the label / value / delta / sparkline row spreads horizontally and reads well.
- **A1 — `prefers-reduced-motion: reduce`.** Already globally handled with `animation-duration: 0.01ms !important` + `transition-duration: 0.01ms !important` on `*`.
- **Controls-bar reservation height on mobile.** Initially flagged as HIGH — but the bar uses a ResizeObserver in `wire-ui.ts` to dynamically push `--controls-bar-h` onto `:root`, and `<main>` has `pb-[calc(var(--controls-bar-h)+12px+env(safe-area-inset-bottom))]`. Verified: the apparent canvas overlap in fullPage screenshots is just the sticky-bottom-bar position rendering at viewport-bottom of the initial scroll position. Real scroll behavior is correct.

## Tooling added

`playground/scripts/audit-screenshots.mjs` — Playwright capture script that snaps 10 scenes × 2 viewports (`mobile-375`, `desktop-1440`) for symmetric before/after diffing. Usage from `playground/` with `pnpm dev` running on :5173:

```
node scripts/audit-screenshots.mjs before
node scripts/audit-screenshots.mjs after
```

Output: `playground/.screenshots/audit/<before|after>/<viewport>__<scene>.png`. Captured baselines and after-pairs are NOT committed (they would bloat the repo); regenerate locally to compare.

## Test plan

- [ ] On a real iPhone (Safari) hit the deployed playground after merge: cold-start → confirm single pane (M2), header shows docs/guide (M8), play button is top-right of controls bar (M7), scenario tabs are unbadged (I7), `?` button gone (I5), scenario strip fades on the right (M6).
- [ ] Scroll through `?s=skyscraper-sky-lobby&c=0` and confirm `Penthouse` and `Sky Lobby` labels are unclipped on a 375 viewport (M4).
- [ ] Switch to `?s=space-elevator&c=0` and confirm `Ground Station` is visibly truncated with a right-edge ellipsis instead of left-clipped (M5).
- [ ] On desktop confirm the header, controls bar, and metric strip layouts are identical to pre-PR (no regression).
- [ ] Run `pnpm test` — expect 27 files / 353 tests, no failures.
- [ ] Tap any button on a phone and confirm it doesn't stay in the "lifted hover" state after the finger lifts (A2).