### PR TITLE
fix(playground): collapse bottom controls bar to one row on mobile

### DIFF
--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -896,6 +896,7 @@
     .controls-bar-actions {
       position: sticky;
       right: 0;
+      z-index: 1;
       margin-left: auto;
       padding-left: 12px;
       background: linear-gradient(to right, transparent, var(--bg-secondary) 12px);

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -854,9 +854,24 @@
   }
 
   @media (max-width: 767px) {
+    /* Single-row, horizontally scrolling bar — height stays at the 44 px
+     * touch-target floor instead of wrapping to multiple rows on phones. */
     .controls-bar-inner {
+      flex-wrap: nowrap;
+      overflow-x: auto;
+      overflow-y: hidden;
       padding: 4px 10px;
-      gap: 4px 6px;
+      gap: 4px 8px;
+      scrollbar-width: none;
+    }
+    .controls-bar-inner::-webkit-scrollbar {
+      display: none;
+    }
+    /* Secondary fields scroll under the sticky actions group on the right.
+     * `flex: 0 0 auto` prevents the flex container from squeezing them. */
+    .controls-bar-field,
+    .controls-bar-inner > .ctl-check {
+      flex: 0 0 auto;
     }
     .controls-bar-field input[type="range"] {
       width: 70px;
@@ -874,15 +889,16 @@
       min-width: var(--touch-target);
       min-height: var(--touch-target);
     }
-    /* Reorder the wrapping bar so primary actions (play/reset/share)
-     * land on the first row at thumb level rather than wrapping below
-     * sliders. `margin-left: auto` is dropped here because the order
-     * already places the group; let flex distribute the row instead. */
+    /* Pin primary actions to the right edge so play/reset/share remain in
+     * the thumb zone while the user scrolls horizontally through seed and
+     * the sliders. Solid background + left-edge fade hides scrolled content
+     * passing underneath. */
     .controls-bar-actions {
-      order: -1;
-      margin-left: 0;
-      width: 100%;
-      justify-content: flex-end;
+      position: sticky;
+      right: 0;
+      margin-left: auto;
+      padding-left: 12px;
+      background: linear-gradient(to right, transparent, var(--bg-secondary) 12px);
     }
     /* Phase block can hide on the narrowest viewports — the section
      * already collapses when no phases are installed, but on a phone


### PR DESCRIPTION
## Summary

The mobile bottom controls bar used to wrap onto three rows on phones — actions on top (full-width, 44px), then `compare + seed`, then the `speed + intensity` sliders. That added up to ~120–150 px of viewport (≈22% of an iPhone SE in portrait) just for chrome.

This switches the mobile inner to `flex-wrap: nowrap` + `overflow-x: auto` and pins `.controls-bar-actions` with `position: sticky; right: 0`, so:

- Bar height drops to **~53 px** on portrait phones (≈8% of viewport).
- Play / Reset / Share / Tweak stay in the thumb zone at the right edge — they don't scroll away.
- Seed, Compare, and the Speed / Intensity sliders scroll horizontally under a soft fade gradient at the actions' left edge.

Desktop layout is unchanged (rule lives in `@media (max-width: 767px)`).

### Measurements (Playwright, 2× DPR)

| Viewport         | Bar height (before)  | Bar height (after) |
| ---------------- | -------------------- | ------------------ |
| iPhone SE 375×667 | ~120-150 px (~22%)  | **53 px (7.9%)**   |
| iPhone 12 390×844 | ~120-150 px (~18%)  | **53 px (6.3%)**   |
| Pixel 7 412×915  | ~120-150 px (~16%)   | **53 px (5.8%)**   |

(Landscape ≥768 px keeps the existing desktop wrap behavior.)

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` — 353/353 pass
- [x] Visual: iPhone SE / iPhone 12 / Pixel 7 portrait — single 53 px row, actions pinned right, scroll reveals sliders
- [ ] Manual: pause/reset/share still tappable while scrolling secondary controls on a real device
- [ ] Manual: tweak-panel popover still opens correctly above the bar