### PR TITLE
feat(playground): add Scenario source heading and grow the RON panel

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -700,14 +700,14 @@
 
     <section
       id="scenario-config"
-      class="scenario-config mx-5 mb-3 max-md:mx-3.5 max-md:mb-[calc(var(--controls-bar-h,52px)+12px+env(safe-area-inset-bottom))]"
-      aria-label="Active scenario configuration"
+      class="scenario-config mx-5 mb-8 max-md:mx-3.5 max-md:mb-[calc(var(--controls-bar-h,52px)+32px+env(safe-area-inset-bottom))]"
+      aria-labelledby="scenario-config-heading"
     >
+      <h2 id="scenario-config-heading" class="scenario-config-heading">Scenario source</h2>
       <details id="scenario-config-details" class="scenario-config-details">
         <summary class="scenario-config-summary">
           <span class="scenario-config-caret" aria-hidden="true">&#9656;</span>
           <span id="scenario-config-filename" class="scenario-config-filename">scenario.ron</span>
-          <span class="scenario-config-eyebrow">Active scenario config</span>
           <button
             id="scenario-config-copy"
             type="button"

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -1340,6 +1340,12 @@
 
   /* ── Scenario-config panel ──────────────────────────────────────────── */
 
+  .scenario-config-heading {
+    margin: 0 0 10px;
+    color: var(--text-primary);
+    font: 600 var(--text-base) / 1.25 var(--font-stack-sans);
+    letter-spacing: 0.01em;
+  }
   .scenario-config-details {
     background: linear-gradient(180deg, var(--bg-elevated), var(--bg-secondary));
     border: 1px solid var(--border-subtle);
@@ -1377,16 +1383,10 @@
     color: var(--text-primary);
     letter-spacing: 0;
   }
-  .scenario-config-eyebrow {
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--text-disabled);
-    margin-left: auto;
-  }
   .scenario-config-copy {
     display: inline-flex;
     align-items: center;
+    margin-left: auto;
     height: 22px;
     padding: 0 8px;
     background: var(--bg-active);
@@ -1407,7 +1407,7 @@
     border-color: var(--border-strong);
   }
   .scenario-config-body {
-    max-height: 360px;
+    max-height: 540px;
     overflow: auto;
     border-top: 1px solid var(--border-subtle);
     padding: 6px 0 4px;
@@ -1460,13 +1460,10 @@
   }
   @media (max-width: 767px) {
     .scenario-config-body {
-      max-height: 280px;
+      max-height: 420px;
     }
     .scenario-config-pre {
       font-size: 11.5px;
-    }
-    .scenario-config-eyebrow {
-      display: none;
     }
   }
 


### PR DESCRIPTION
## Summary

Three small, related quality-of-life changes to the scenario-config panel below the canvas:

1. **Adds a heading** — \`<h2>Scenario source</h2>\` sits above the collapsible \`<details>\` panel so the snippet has obvious purpose without having to open it.
2. **Taller body** — \`.scenario-config-body\` max-height **360 → 540 px** on desktop, **280 → 420 px** on mobile. A typical scenario fits without inner scroll.
3. **More bottom margin** — section bottom margin **12 → 32 px** (\`mb-3\` → \`mb-8\`); mobile bumps the visible portion of the safe-area + controls-bar calc from \`+12px\` to \`+32px\`.

The new heading subsumes the small "Active scenario config" eyebrow text that lived inside the summary row, so the eyebrow markup + CSS are removed. The Copy button takes over the eyebrow's \`margin-left: auto\` to stay right-aligned. \`aria-label\` on the section becomes \`aria-labelledby\` pointing at the new \`<h2>\`.

### Before / after (mobile, panel closed)

| Before | After |
| --- | --- |
| ![old](https://github.com/user-attachments/none-old) (no heading, panel collapsed, ~70 px tall, eyebrow inside summary) | "Scenario source" h2 visible above the panel — eyebrow gone, Copy button right-aligned |

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test --run\` — 353/353 pass
- [x] Visual (Playwright): desktop closed/open + mobile closed/open — heading renders, panel grows to new max-height, footer/controls-bar gap is 27–32 px
- [ ] Manual: confirm heading copy reads well at 1280 px and 375 px in a real browser
- [ ] Manual: collapsed panel still pleasant to use; Copy button still works