### PR TITLE
fix(playground): link elevator-core to repo, promote guide as canonical reference

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -446,7 +446,11 @@
           class="m-0 text-[13px] font-mono font-medium tracking-[0] inline-flex items-center gap-2.5 whitespace-nowrap min-w-0 before:content-[''] before:inline-block before:flex-none before:w-2 before:h-2 before:rounded-[2px] before:bg-accent max-md:text-[12px] max-md:gap-2"
         >
           <span class="truncate"
-            ><span class="text-content-tertiary max-md:hidden">elevator-core / </span
+            ><a
+              class="text-content-tertiary max-md:hidden no-underline transition-colors hover:text-content"
+              href="https://github.com/andymai/elevator-core"
+              >elevator-core</a
+            ><span class="text-content-tertiary max-md:hidden"> / </span
             ><span class="text-content">playground</span></span
           >
         </h1>
@@ -456,20 +460,34 @@
           aria-label="External links"
         >
           <a
-            class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content inline-flex items-center gap-1"
+            class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content inline-flex items-center gap-1.5"
             href="https://github.com/andymai/elevator-core"
-            aria-label="Star elevator-core on GitHub"
-            ><span aria-hidden="true">&#9733;</span><span class="max-md:hidden">star</span></a
+            aria-label="elevator-core on GitHub"
+            ><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+              <path
+                d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+              /></svg
+            ><span class="max-md:hidden">github</span></a
           >
           <a
-            class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content"
-            href="https://docs.rs/elevator-core"
-            >docs</a
-          >
-          <a
-            class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content"
+            class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content inline-flex items-center gap-1.5"
             href="../"
-            >guide</a
+            aria-label="elevator-core guide"
+            ><svg
+              width="13"
+              height="13"
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.4"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M8 4.5v9" />
+              <path d="M2 3h4.5A1.5 1.5 0 0 1 8 4.5v9a1 1 0 0 0-1-1H2V3Z" />
+              <path d="M14 3H9.5A1.5 1.5 0 0 0 8 4.5v9a1 1 0 0 1 1-1h5V3Z" /></svg
+            ><span class="max-md:hidden">guide</span></a
           >
           <button
             type="button"


### PR DESCRIPTION
## Summary

- "elevator-core" in the playground H1 now links to the GitHub repo. The `max-md:hidden` mobile breakpoint and the orange chip on the H1 are preserved — the link only appears at `md` and up.
- Header nav reworked: "star" → "github" with a real GitHub mark SVG; "guide" gains a matching open-book SVG. Both share `inline-flex items-center gap-1.5` and collapse to icon-only at `max-md`.
- Dropped the `docs.rs` nav link so the mdBook guide stands alone as the canonical reference for the project. The SEO fallback and JSON-LD `sameAs` block still list `docs.rs` for crawlers and no-JS visitors — that's a discoverability surface, not a canonicity claim.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 353 tests across 27 files pass
- [ ] Visual check: github + guide links each render icon + label on desktop, icon-only on mobile
- [ ] Visual check: clicking "elevator-core" in the H1 lands on the GitHub repo in a new tab/same tab as expected