### PR TITLE
fix(playground): add rel="noreferrer" to external GitHub links

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -449,6 +449,7 @@
             ><a
               class="text-content-tertiary max-md:hidden no-underline transition-colors hover:text-content"
               href="https://github.com/andymai/elevator-core"
+              rel="noreferrer"
               >elevator-core</a
             ><span class="text-content-tertiary max-md:hidden"> / </span
             ><span class="text-content">playground</span></span
@@ -462,6 +463,7 @@
           <a
             class="text-content-tertiary no-underline text-[13px] transition-colors hover:text-content inline-flex items-center gap-1.5"
             href="https://github.com/andymai/elevator-core"
+            rel="noreferrer"
             aria-label="elevator-core on GitHub"
             ><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
               <path


### PR DESCRIPTION
## Summary

Follow-up to #845 addressing Greptile's P2 finding: harden the H1 wordmark anchor and the "github" nav anchor so the repo can't read `document.referrer` when a user clicks through. Internal/relative links are unaffected.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 353 tests pass
- [ ] Visual check: github link still navigates correctly with no observable behavior change