### PR TITLE
fix(playground): collapse tweak panel to a single column

### DIFF
--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -284,8 +284,8 @@
 
   .tweak-panel {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(290px, 1fr));
-    gap: 10px 18px;
+    grid-template-columns: 1fr;
+    gap: 10px;
     padding: 12px 20px 14px;
     font-variant-numeric: tabular-nums;
   }


### PR DESCRIPTION
## Summary

The Tweak panel (cogs button in the bottom controls bar) was overflowing on desktop — "default 1000.0" / "default 7.0" labels floated past the popover's right edge, and the left column's row content got clipped behind the right column.

### Root cause

`.tweak-panel` used `grid-template-columns: repeat(auto-fit, minmax(290px, 1fr))`. At the popover's `min(680px, …)` max width that fits two columns at ~311px each. But each row needs ~447px minimum:

| element | min width |
|---|---|
| label (e.g. "Max speed m/s") | ~85px |
| stepper with 6-char value ("1000.0") | ~121px |
| track | 90px (min) |
| "default 1000.0" inline label | ~95px |
| 4 × 10px column gaps + 16px row padding | ~56px |
| **total** | **~447px** |

So every row overflowed its grid cell by ~120px — that's the artifact in the screenshot.

### Fix

Single column. The popover holds only four settings, so a vertical stack stays compact and each row gets ~640px to comfortably fit all of label, stepper, track, default text, and the (override-only) Reset button.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 353/353 pass
- [ ] **Manual**: open the Tweak panel (cogs icon in the bottom controls bar). All four rows (Cars, Max speed, Capacity, Door cycle) stack vertically; every "default X" label sits inside the popover; the orange track and Reset button (when overridden) align cleanly.
- [ ] **Manual**: nudge each row's stepper to override; confirm the Reset button appears in-row without re-introducing overflow.
- [ ] **Manual (mobile)**: panel still pops above the controls bar without horizontal overflow.