### PR TITLE
docs(core): enforce missing_docs + add events_loop example

### DIFF
--- a/crates/elevator-core/examples/events_loop.rs
+++ b/crates/elevator-core/examples/events_loop.rs
@@ -1,0 +1,86 @@
+//! Subscribe to the event stream and react to riders boarding and arriving.
+//!
+//! Every call to [`Simulation::step`] produces zero or more
+//! [`Event`](elevator_core::events::Event) records describing what happened
+//! during that tick. Drain them with [`Simulation::drain_events`] after each
+//! step (or batch a few first — events are buffered until drained).
+//!
+//! This example sets up a small three-stop building, spawns three riders, and
+//! pattern-matches over the event stream to print a short narrative. Run with:
+//!
+//! ```text
+//! cargo run --example events_loop -p elevator-core
+//! ```
+#![allow(clippy::unwrap_used, clippy::missing_docs_in_private_items)]
+
+use elevator_core::events::Event;
+use elevator_core::prelude::*;
+use elevator_core::stop::StopConfig;
+
+fn main() {
+    let mut sim = SimulationBuilder::demo()
+        .stops(vec![
+            StopConfig {
+                id: StopId(0),
+                name: "Lobby".into(),
+                position: 0.0,
+            },
+            StopConfig {
+                id: StopId(1),
+                name: "Mezzanine".into(),
+                position: 4.0,
+            },
+            StopConfig {
+                id: StopId(2),
+                name: "Rooftop".into(),
+                position: 8.0,
+            },
+        ])
+        .build()
+        .unwrap();
+
+    sim.spawn_rider(StopId(0), StopId(2), 75.0).unwrap();
+    sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
+    sim.spawn_rider(StopId(1), StopId(2), 65.0).unwrap();
+
+    let mut delivered = 0u32;
+
+    for _ in 0..2000 {
+        sim.step();
+
+        for event in sim.drain_events() {
+            match event {
+                Event::RiderBoarded {
+                    rider,
+                    elevator,
+                    tick,
+                    ..
+                } => {
+                    println!("[t={tick:>4}] rider {rider:?} boarded car {elevator:?}");
+                }
+                Event::RiderExited {
+                    rider, stop, tick, ..
+                } => {
+                    println!("[t={tick:>4}] rider {rider:?} exited at stop {stop:?}");
+                    delivered += 1;
+                }
+                Event::DoorOpened { elevator, tick, .. } => {
+                    println!("[t={tick:>4}] doors opened on car {elevator:?}");
+                }
+                _ => {}
+            }
+        }
+
+        if delivered == 3 {
+            break;
+        }
+    }
+
+    let m = sim.metrics();
+    println!(
+        "delivered={} avg_wait={:.1} avg_ride={:.1}",
+        m.total_delivered(),
+        m.avg_wait_time(),
+        m.avg_ride_time(),
+    );
+}

--- a/crates/elevator-core/examples/events_loop.rs
+++ b/crates/elevator-core/examples/events_loop.rs
@@ -71,7 +71,7 @@ fn main() {
             }
         }
 
-        if delivered == 3 {
+        if delivered >= 3 {
             break;
         }
     }

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -344,6 +344,7 @@
 
 #![forbid(unsafe_code)]
 #![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+#![deny(missing_docs)]
 
 /// Single source of truth for the host-binding wire/ABI version.
 ///


### PR DESCRIPTION
## Summary

Lock in a documentation floor on `elevator-core` and add a focused tutorial example for the event-stream consumption pattern.

- **`#![deny(missing_docs)]`** on `crates/elevator-core/src/lib.rs` — the crate already passes the lint clean across all features, so this is purely regression-prevention for the public API surface.
- **`examples/events_loop.rs`** — a short, tutorial-style example showing the typical pattern of draining the event stream after `Simulation::step` and pattern-matching `Event::RiderBoarded` / `Event::RiderExited` / `Event::DoorOpened`. Complements the existing `basic.rs`, `custom_dispatch.rs`, and `extensions.rs` examples.

This is the first PR in a small staged series targeting elevator-core API usability for external integrators (rustdoc → ergonomics → errors → mdBook). Subsequent PRs are non-breaking: ergonomic refactors land with `#[deprecated]` migrations, error surface cleanups rely on `#[non_exhaustive]` for additions.

No public API changes.

## Test plan

- [x] `cargo clippy -p elevator-core --all-features -- -D warnings` clean
- [x] `cargo check --workspace --all-features --all-targets` clean (all 10 crates)
- [x] `cargo test -p elevator-core --all-features` (1057 unit, 175 doctests)
- [x] `cargo run --example events_loop -p elevator-core` produces expected boarding/exit narration
- [x] Pre-commit hook passes (fmt, clippy, core tests, doctests, workspace check)