### PR TITLE
docs(core): showcase StopConfig::linear and add Examples to top-level methods

### DIFF
--- a/crates/elevator-core/examples/basic.rs
+++ b/crates/elevator-core/examples/basic.rs
@@ -6,23 +6,11 @@ use elevator_core::stop::StopConfig;
 
 fn main() {
     let mut sim = SimulationBuilder::demo()
-        .stops(vec![
-            StopConfig {
-                id: StopId(0),
-                name: "Ground".into(),
-                position: 0.0,
-            },
-            StopConfig {
-                id: StopId(1),
-                name: "Floor 2".into(),
-                position: 4.0,
-            },
-            StopConfig {
-                id: StopId(2),
-                name: "Floor 3".into(),
-                position: 8.0,
-            },
-        ])
+        .stops(StopConfig::linear(&[
+            ("Ground", 0.0),
+            ("Floor 2", 4.0),
+            ("Floor 3", 8.0),
+        ]))
         .build()
         .unwrap();
 

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -34,11 +34,11 @@
 //! use elevator_core::stop::StopConfig;
 //!
 //! let mut sim = SimulationBuilder::demo()
-//!     .stops(vec![
-//!         StopConfig { id: StopId(0), name: "Ground".into(), position: 0.0 },
-//!         StopConfig { id: StopId(1), name: "Floor 2".into(), position: 4.0 },
-//!         StopConfig { id: StopId(2), name: "Floor 3".into(), position: 8.0 },
-//!     ])
+//!     .stops(StopConfig::linear(&[
+//!         ("Ground", 0.0),
+//!         ("Floor 2", 4.0),
+//!         ("Floor 3", 8.0),
+//!     ]))
 //!     .build()
 //!     .unwrap();
 //!
@@ -50,6 +50,11 @@
 //!
 //! assert!(sim.metrics().total_delivered() > 0);
 //! ```
+//!
+//! Need hand-picked `StopId`s or non-sequential identifiers? Build the
+//! `Vec<StopConfig>` with struct literals instead — see
+//! [`StopConfig::linear`](stop::StopConfig::linear) for when each helper is
+//! appropriate.
 //!
 //! ## Crate layout
 //!

--- a/crates/elevator-core/src/lib.rs
+++ b/crates/elevator-core/src/lib.rs
@@ -52,9 +52,10 @@
 //! ```
 //!
 //! Need hand-picked `StopId`s or non-sequential identifiers? Build the
-//! `Vec<StopConfig>` with struct literals instead — see
-//! [`StopConfig::linear`](stop::StopConfig::linear) for when each helper is
-//! appropriate.
+//! `Vec<StopConfig>` with struct literals instead (`StopConfig { id:
+//! StopId(42), name: "Roof".into(), position: 120.0 }`). See
+//! [`StopConfig::linear`](stop::StopConfig::linear) for the constraints
+//! of the compact form.
 //!
 //! ## Crate layout
 //!

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -1249,6 +1249,17 @@ impl Simulation {
     /// caller-supplied `id`, preserving the prior API for registered
     /// custom factories. Mirrors the pattern applied to
     /// [`set_reposition`](Self::set_reposition) in #414.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use elevator_core::prelude::*;
+    /// use elevator_core::ids::GroupId;
+    ///
+    /// let mut sim = SimulationBuilder::demo().build().unwrap();
+    /// let strategy = BuiltinStrategy::Look.instantiate().unwrap();
+    /// sim.set_dispatch(GroupId(0), strategy, BuiltinStrategy::Look);
+    /// ```
     pub fn set_dispatch(
         &mut self,
         group: GroupId,
@@ -1294,6 +1305,18 @@ impl Simulation {
     /// strategies pay a memory cost equal to the largest historic
     /// window; if that matters, call `set_arrival_log_retention_ticks`
     /// explicitly after the swap.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use elevator_core::prelude::*;
+    /// use elevator_core::dispatch::BuiltinReposition;
+    /// use elevator_core::ids::GroupId;
+    ///
+    /// let mut sim = SimulationBuilder::demo().build().unwrap();
+    /// let strategy = BuiltinReposition::DemandWeighted.instantiate().unwrap();
+    /// sim.set_reposition(GroupId(0), strategy, BuiltinReposition::DemandWeighted);
+    /// ```
     pub fn set_reposition(
         &mut self,
         group: GroupId,

--- a/crates/elevator-core/src/sim/rider.rs
+++ b/crates/elevator-core/src/sim/rider.rs
@@ -70,6 +70,19 @@ impl super::Simulation {
     ///
     /// Returns [`SimError::NoRoute`] if no group serves both stops.
     /// Returns [`SimError::AmbiguousRoute`] if multiple groups serve both stops.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use elevator_core::prelude::*;
+    ///
+    /// let mut sim = SimulationBuilder::demo().build().unwrap();
+    /// let rider = sim.spawn_rider(StopId(0), StopId(1), 70.0).unwrap();
+    /// // `total_spawned` is incremented in the metrics phase of the next tick.
+    /// sim.step();
+    /// assert_eq!(sim.metrics().total_spawned(), 1);
+    /// # let _ = rider;
+    /// ```
     pub fn spawn_rider(
         &mut self,
         origin: impl Into<StopRef>,


### PR DESCRIPTION
## Summary

Continue the API-usability series with documentation-only changes that improve discoverability without touching the public surface.

- **Quick Start doctest + `examples/basic.rs`** now use `StopConfig::linear(&[("Ground", 0.0), ...])` instead of the verbose struct-literal form. The helper has existed for a while but the canonical entry points didn't showcase it. Adds a short note in the module docs pointing to the struct-literal form for cases that need hand-picked `StopId`s.
- **`# Example` sections** added to three high-traffic `Simulation` methods that had behavior docs but no copy-pasteable usage:
  - `Simulation::spawn_rider` — highlights that `total_spawned` increments in the metrics phase of the *next* tick (common gotcha for first-time integrators).
  - `Simulation::set_dispatch` — shows the typical `BuiltinStrategy::Look.instantiate()` pattern.
  - `Simulation::set_reposition` — same for `BuiltinReposition::DemandWeighted`.

178 doctests pass (3 net added; existing 175 unchanged). No API changes; pairs with #848.

## Test plan

- [x] `cargo test -p elevator-core --all-features --doc` — 178 passed
- [x] `cargo clippy -p elevator-core --all-features -- -D warnings` clean
- [x] `cargo run --example basic -p elevator-core` produces expected output
- [x] Pre-commit hook passes (fmt, clippy, core tests, doctests, workspace check)