### PR TITLE
docs(book): cover ElevatorId/RiderId, picking a host, events_loop example

### DIFF
--- a/docs/src/events-metrics.md
+++ b/docs/src/events-metrics.md
@@ -97,6 +97,8 @@ You can drain after every tick, every N ticks, or only when you need to -- event
 
 If you never drain, the buffer grows unbounded. In long-running simulations, drain at least periodically.
 
+The repository ships [`examples/events_loop.rs`](https://github.com/andymai/elevator-core/blob/main/crates/elevator-core/examples/events_loop.rs) as a focused tutorial showing this pattern end-to-end -- a 3-stop building, three riders, and a match arm over `RiderBoarded` / `RiderExited` / `DoorOpened` printing a short narrative.
+
 ## Event ordering guarantees
 
 - **Within a tick:** events fire in phase order (AdvanceTransient, Dispatch, Reposition, Movement, Doors, Loading, Metrics). Events from a later phase always appear later in the drained vec.

--- a/docs/src/stops-lines-groups.md
+++ b/docs/src/stops-lines-groups.md
@@ -88,13 +88,17 @@ Key invariants:
 
 ## Identity types
 
-The library uses three identity types. Knowing which to reach for saves confusion:
+The library uses five identity types. Knowing which to reach for saves confusion:
 
 | Type | Identifies | When you use it |
 |---|---|---|
 | `EntityId` | Any entity at runtime (stop, elevator, rider) | Event payloads, world lookups, dispatch decisions |
 | `StopId` | A stop in the config (e.g., `StopId(0)`) | Builder API, config files, `spawn_rider` |
 | `GroupId` | An elevator group (e.g., `GroupId(0)`) | Multi-group dispatch, group-specific hooks |
+| `ElevatorId` | A specific elevator entity | Public API surfaces that act on a car (`set_service_mode`, `push_destination`, manual control) |
+| `RiderId` | A specific rider entity | Public API surfaces that act on a rider (`despawn_rider`, `settle_rider`, `rider_tag`) |
+
+`ElevatorId` and `RiderId` are phantom-typed wrappers over `EntityId`. They exist to give the public API surface type safety -- `spawn_rider` returns a `RiderId`, not a bare `EntityId`, so you can't accidentally pass a stop id where a rider id is required. Internally, `World` and event payloads use the untyped `EntityId`.
 
 `StopId` is a config-level concept. When the simulation boots, each `StopId` is mapped to an `EntityId`. At runtime you work with `EntityId` everywhere. Convert when needed:
 

--- a/docs/src/stops-lines-groups.md
+++ b/docs/src/stops-lines-groups.md
@@ -96,7 +96,7 @@ The library uses five identity types. Knowing which to reach for saves confusion
 | `StopId` | A stop in the config (e.g., `StopId(0)`) | Builder API, config files, `spawn_rider` |
 | `GroupId` | An elevator group (e.g., `GroupId(0)`) | Multi-group dispatch, group-specific hooks |
 | `ElevatorId` | A specific elevator entity | Public API surfaces that act on a car (`set_service_mode`, `push_destination`, manual control) |
-| `RiderId` | A specific rider entity | Public API surfaces that act on a rider (`despawn_rider`, `settle_rider`, `rider_tag`) |
+| `RiderId` | A specific rider entity | Public API surfaces that act on a rider (`despawn_rider`, `settle_rider`, `set_rider_tag`) |
 
 `ElevatorId` and `RiderId` are phantom-typed wrappers over `EntityId`. They exist to give the public API surface type safety -- `spawn_rider` returns a `RiderId`, not a bare `EntityId`, so you can't accidentally pass a stop id where a rider id is required. Internally, `World` and event payloads use the untyped `EntityId`.
 

--- a/docs/src/using-the-bindings.md
+++ b/docs/src/using-the-bindings.md
@@ -11,6 +11,21 @@
 
 All bindings share the same simulation core: same physics, same dispatch, same event ordering. The split is purely about how the host language calls in. This chapter covers the contracts each binding exposes and the patterns consumers need to follow to use them safely.
 
+## Picking a host
+
+If you already know which language / engine you're building in, the table above is a one-step decision. The matrix below maps common starting points to the right binding when the choice isn't obvious:
+
+| You're building... | Use | Why |
+|---|---|---|
+| A Rust game with a renderer | [Bevy Integration](bevy-integration.md) or [Headless / macroquad / eframe](headless-non-bevy.md) | Direct Rust API, no binding layer; lowest friction. |
+| A browser playground or JS/TS frontend | `elevator-wasm` | TypeScript types auto-generated; no Rust toolchain on the consumer side. |
+| A Unity, .NET, or native C/C++ project | `elevator-ffi` | C ABI shared library plus generated `elevator_ffi.h`; P/Invoke or direct linking. |
+| A Godot game (GDScript or GDExtension) | `elevator-gdext` | Registers an `ElevatorSim` node; calls return Godot `Variant` dictionaries. |
+| A GameMaker Studio 2 game | GameMaker GML wrapper | Pre-generated GML scripts wrap `elevator-ffi` so the GMS project sees idiomatic functions. |
+| An analytics / batch / replay tool | Use `elevator-core` directly | The Rust crate is headless. The wasm and FFI surfaces exist for non-Rust consumers; reach for them only when language is the constraint. |
+
+Each binding is a thin translation layer — there's no behavioral difference between simulating in Rust vs. via wasm vs. via FFI given the same config and inputs. Pick by language ergonomics, not by feature set.
+
 ## Coverage and stability
 
 The set of `Simulation` methods exposed through each binding is enumerated in [`bindings.toml`](https://github.com/andymai/elevator-core/blob/main/bindings.toml) at the workspace root. CI verifies the file is in sync with `pub fn` declarations, so a new core method cannot ship without an explicit decision about whether it is bound and how.


### PR DESCRIPTION
## Summary

Final PR in the API-usability series. Three small mdBook gap-fills targeting external integrators:

- **Identity types** (`docs/src/stops-lines-groups.md`): the table listed only `EntityId` / `StopId` / `GroupId`, missing `ElevatorId` and `RiderId`. Integrators inspecting public `Simulation` signatures find these typed ids returned but no conceptual page documenting them. Add both rows and a short paragraph on the phantom-typed-wrapper rationale.
- **Picking a host** (`docs/src/using-the-bindings.md`): the page jumped from the audience table to per-host details with no orientation step. Add a decision matrix mapping common starting points (Rust game, browser, Unity, Godot, GameMaker, analytics tool) to the right binding, with a brief 'why' column.
- **Cross-link `events_loop` example** (`docs/src/events-metrics.md`): the 'Draining events' section had an inline code snippet but didn't point readers to the focused tutorial example added in #848.

Pairs with #848 (rustdoc floor + `events_loop`) and #849 (`StopConfig::linear` showcase + `# Example` doctests).

## Test plan

- [x] `scripts/lint-docs.sh --quick` clean (all 9 lint passes)
- [x] `mdbook build docs/` clean
- [x] Pre-commit hook passes