### PR TITLE
chore(workspace): include elevator-core in default-members

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "20.13.0"
+version = "20.15.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "cbindgen",
  "elevator-core",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-wasm"
-version = "0.24.0"
+version = "0.26.0"
 dependencies = [
  "elevator-core",
  "getrandom 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
     "crates/elevator-tui",
     "crates/elevator-wasm",
 ]
-default-members = ["crates/elevator-bevy"]
+default-members = ["crates/elevator-core", "crates/elevator-bevy"]
 
 [workspace.package]
 version = "1.0.0"


### PR DESCRIPTION
## Summary

- `default-members` listed only `crates/elevator-bevy`, so `cargo test` / `cargo build` without `-p` exercised only the Bevy binary. The library crate (which actually ships to crates.io and powers every host) was implicitly skipped.
- Extend `default-members` to include `crates/elevator-core` so a newcomer running `cargo test` hits the library's full test suite by default.
- Refresh `Cargo.lock` alongside to absorb the version bumps from the last several release-please PRs. Without this, the pre-commit `cargo metadata --frozen` guard rejected any new `Cargo.toml` edit on top of stale state — flagged as a separate process gap (release-please should regenerate `Cargo.lock` too).

## Test plan

- [x] `cargo metadata --no-deps` parses
- [x] Local pre-commit gate (fmt + clippy + 178 core tests + 8 doctests + workspace check) passes
- [ ] CI green