### PR TITLE
ci(release-please): refresh Cargo.lock on the release PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -129,16 +129,21 @@ jobs:
             exit 0
           fi
 
-          # Attribute the commit to the App that owns the PR. Push
-          # uses the App token, which re-triggers CI on the PR
-          # (against the updated lock) but NOT this release-please
-          # workflow — its trigger is `push: branches: [main]`, and
-          # we're pushing to the PR branch, not main.
+          # Attribute the commit to the App that owns the PR. The
+          # default `actions/checkout` step set the credential helper
+          # to GITHUB_TOKEN; a bare `git push origin …` would inherit
+          # that and GitHub would silently suppress the CI re-trigger
+          # (anti-loop protection for pushes by GITHUB_TOKEN). Push
+          # explicitly via the App token URL so CI on the PR re-runs
+          # against the refreshed lock. This still does NOT re-trigger
+          # this release-please workflow — its trigger is
+          # `push: branches: [main]`, and we're pushing to the PR
+          # branch.
           git config user.name "release-kun[bot]"
           git config user.email "release-kun[bot]@users.noreply.github.com"
           git add Cargo.lock
           git commit -m "chore: refresh Cargo.lock for release"
-          git push origin "$pr_branch"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "HEAD:${pr_branch}"
 
       # Inline approve + auto-merge in the same workflow run that
       # opened the PR. Approval uses the default GITHUB_TOKEN

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -93,6 +93,53 @@ jobs:
           manifest-file: .release-please-manifest.json
           token: ${{ steps.app-token.outputs.token }}
 
+      # release-please-action only edits each tracked crate's
+      # `version = "..."` line in Cargo.toml; it never runs cargo, so
+      # the workspace Cargo.lock keeps the OLD versions. The next
+      # non-release PR then inherits the drift — its pre-commit hook's
+      # `cargo metadata --frozen` guard rejects any subsequent
+      # Cargo.toml edit until someone refreshes the lock manually.
+      # Refresh it here, on the release PR branch, so the lock lands
+      # together with the version bumps it describes. `--offline`
+      # forbids registry access — the only deltas are the workspace
+      # version lines, which don't need network resolution.
+      - name: Install Rust toolchain (for Cargo.lock refresh)
+        if: steps.release.outputs.pr
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Refresh Cargo.lock on release PR
+        if: steps.release.outputs.pr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          pr_branch=$(gh pr view "$PR_NUMBER" \
+            --repo "$REPO" \
+            --json headRefName --jq .headRefName)
+
+          git fetch origin "$pr_branch"
+          git checkout "$pr_branch"
+
+          cargo update --workspace --offline
+
+          if git diff --quiet Cargo.lock; then
+            echo "::notice::Cargo.lock is already in sync; no refresh needed."
+            exit 0
+          fi
+
+          # Attribute the commit to the App that owns the PR. Push
+          # uses the App token, which re-triggers CI on the PR
+          # (against the updated lock) but NOT this release-please
+          # workflow — its trigger is `push: branches: [main]`, and
+          # we're pushing to the PR branch, not main.
+          git config user.name "release-kun[bot]"
+          git config user.email "release-kun[bot]@users.noreply.github.com"
+          git add Cargo.lock
+          git commit -m "chore: refresh Cargo.lock for release"
+          git push origin "$pr_branch"
+
       # Inline approve + auto-merge in the same workflow run that
       # opened the PR. Approval uses the default GITHUB_TOKEN
       # (`github-actions[bot]` actor), which is distinct from the App

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "20.13.0"
+version = "20.15.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "cbindgen",
  "elevator-core",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-wasm"
-version = "0.24.0"
+version = "0.26.0"
 dependencies = [
  "elevator-core",
  "getrandom 0.4.2",


### PR DESCRIPTION
## Summary

After every `chore: release main` merge, `Cargo.lock` is left with the OLD crate versions while each `crates/<x>/Cargo.toml` carries the NEW ones. `release-please-action` v4 only edits version lines — it never runs cargo, so the lock never moves. The next non-release PR's pre-commit hook then fails on the `cargo metadata --frozen` guard until someone bundles a one-off lock refresh in their diff. This happened on every non-release PR for the past several release cycles (#855 / #856 / #857 all had to do it).

## What this does

- Adds a `dtolnay/rust-toolchain@stable` step in the release-please job (gated `if: steps.release.outputs.pr` — only fires when a PR was actually created).
- Adds a `Refresh Cargo.lock on release PR` step that:
  1. Looks up the release PR's branch name via `gh pr view`.
  2. Checks out that branch.
  3. Runs `cargo update --workspace --offline` — only the workspace version lines change; no network resolution needed.
  4. If the lock didn't change, exits quietly.
  5. Otherwise commits as `release-kun[bot]` and pushes to the PR branch via the App token.

The push re-triggers CI on the PR (so the updated lock is validated) but NOT this release-please workflow itself — its trigger is `push: branches: [main]`, and the refresh pushes to the PR branch, not main.

## Security review

All `${{ }}` interpolations in `run:` blocks are passed via `env:` and quoted as shell vars (`"$PR_NUMBER"`, `"$REPO"`) to neutralise injection. Only trusted runtime values (`github.repository`, `steps.release.outputs.pr.number`, `steps.app-token.outputs.token`) cross the boundary — no event-payload strings.

## Test plan

- [x] YAML syntax validated (`python3 -c 'import yaml; yaml.safe_load(open(...))'`)
- [x] Local pre-commit gate passes
- [ ] CI green
- [ ] Validated on the next real release PR