### PR TITLE
feat(elevator-core): opt-in strict substep phase-order guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "20.13.0"
+version = "20.15.0"
 dependencies = [
  "criterion",
  "ordered-float",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-ffi"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "cbindgen",
  "elevator-core",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-wasm"
-version = "0.24.0"
+version = "0.26.0"
 dependencies = [
  "elevator-core",
  "getrandom 0.4.2",

--- a/bindings.toml
+++ b/bindings.toml
@@ -231,6 +231,30 @@ gms  = "skip:internal — phase ordering invariant"
 gdext = "skip:internal — phase ordering invariant"
 bevy = "skip:internal — phase ordering invariant"
 
+# ─── Substep guard knobs ──────────────────────────────────────────────────
+# Tied to the internal substep API: only useful when a consumer drives the
+# run_* phases directly, which all hosts skip per the invariant above.
+
+[[methods]]
+name = "set_strict_phase_order"
+category = "internal"
+wasm = "skip:internal — phase ordering invariant"
+ffi  = "skip:internal — phase ordering invariant"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:internal — phase ordering invariant"
+gdext = "skip:internal — phase ordering invariant"
+bevy = "skip:internal — phase ordering invariant"
+
+[[methods]]
+name = "is_strict_phase_order"
+category = "internal"
+wasm = "skip:internal — phase ordering invariant"
+ffi  = "skip:internal — phase ordering invariant"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "skip:internal — phase ordering invariant"
+gdext = "skip:internal — phase ordering invariant"
+bevy = "skip:internal — phase ordering invariant"
+
 # ─── Modes (the original concern: \"emergency stop doesn't work\") ────────
 
 [[methods]]

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -250,6 +250,32 @@ pub struct Simulation {
     /// the substep loop owns the mutation through
     /// [`set_tick_in_progress`](Self::set_tick_in_progress).
     tick_in_progress: bool,
+    /// Opt-in phase-order check for the substep API. `Disabled` (the
+    /// default) skips all checks for backwards compatibility and zero
+    /// runtime cost. Hosts driving phases manually can flip this on
+    /// via [`set_strict_phase_order`](Self::set_strict_phase_order) to
+    /// fail fast on out-of-order `run_*` calls instead of seeing the
+    /// diffuse symptoms (riders boarding through closed doors,
+    /// movement before dispatch, transient states bleeding across
+    /// tick boundaries).
+    pub(crate) phase_check: PhaseCheckState,
+}
+
+/// State of the substep phase-order guard.
+///
+/// `Disabled` (the default) is a no-op: every `run_*` method
+/// short-circuits the check, so there is no runtime cost for hosts
+/// that don't opt in. `Expecting(phase)` enforces that the next
+/// `run_*` call matches `phase`; `AwaitingTick` requires
+/// [`Simulation::advance_tick`] before the next cycle begins.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PhaseCheckState {
+    /// Guard is off; substep calls are not validated.
+    Disabled,
+    /// Guard is on and the next allowed `run_*` is this phase.
+    Expecting(crate::hooks::Phase),
+    /// Metrics has run; `advance_tick()` must come before the next cycle.
+    AwaitingTick,
 }
 
 impl Simulation {

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -258,7 +258,7 @@ pub struct Simulation {
     /// diffuse symptoms (riders boarding through closed doors,
     /// movement before dispatch, transient states bleeding across
     /// tick boundaries).
-    pub(crate) phase_check: PhaseCheckState,
+    pub(crate) phase_check: PhaseCheck,
 }
 
 /// State of the substep phase-order guard.
@@ -269,7 +269,7 @@ pub struct Simulation {
 /// `run_*` call matches `phase`; `AwaitingTick` requires
 /// [`Simulation::advance_tick`] before the next cycle begins.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum PhaseCheckState {
+pub(crate) enum PhaseCheck {
     /// Guard is off; substep calls are not validated.
     Disabled,
     /// Guard is on and the next allowed `run_*` is this phase.

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -353,6 +353,7 @@ impl Simulation {
             topo_graph: Mutex::new(TopologyGraph::new()),
             rider_index: RiderIndex::default(),
             tick_in_progress: false,
+            phase_check: super::PhaseCheckState::Disabled,
         })
     }
 
@@ -756,6 +757,7 @@ impl Simulation {
             topo_graph: Mutex::new(TopologyGraph::new()),
             rider_index,
             tick_in_progress: false,
+            phase_check: super::PhaseCheckState::Disabled,
         }
     }
 

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -353,7 +353,7 @@ impl Simulation {
             topo_graph: Mutex::new(TopologyGraph::new()),
             rider_index: RiderIndex::default(),
             tick_in_progress: false,
-            phase_check: super::PhaseCheckState::Disabled,
+            phase_check: super::PhaseCheck::Disabled,
         })
     }
 
@@ -757,7 +757,7 @@ impl Simulation {
             topo_graph: Mutex::new(TopologyGraph::new()),
             rider_index,
             tick_in_progress: false,
-            phase_check: super::PhaseCheckState::Disabled,
+            phase_check: super::PhaseCheck::Disabled,
         }
     }
 

--- a/crates/elevator-core/src/sim/substep.rs
+++ b/crates/elevator-core/src/sim/substep.rs
@@ -9,7 +9,7 @@ use crate::events::EventBus;
 use crate::hooks::Phase;
 use crate::ids::GroupId;
 use crate::metrics::Metrics;
-use crate::sim::PhaseCheckState;
+use crate::sim::PhaseCheck;
 use crate::systems::PhaseContext;
 use std::collections::BTreeMap;
 
@@ -86,9 +86,9 @@ impl super::Simulation {
     /// ```
     pub const fn set_strict_phase_order(&mut self, enabled: bool) {
         self.phase_check = if enabled {
-            PhaseCheckState::Expecting(Phase::AdvanceTransient)
+            PhaseCheck::Expecting(Phase::AdvanceTransient)
         } else {
-            PhaseCheckState::Disabled
+            PhaseCheck::Disabled
         };
     }
 
@@ -97,7 +97,7 @@ impl super::Simulation {
     /// debug overlays.
     #[must_use]
     pub const fn is_strict_phase_order(&self) -> bool {
-        !matches!(self.phase_check, PhaseCheckState::Disabled)
+        !matches!(self.phase_check, PhaseCheck::Disabled)
     }
 
     /// Validate that `current` is the next-expected phase, then advance
@@ -113,8 +113,8 @@ impl super::Simulation {
     #[allow(clippy::panic)]
     fn check_and_advance_phase(&mut self, current: Phase, next: Option<Phase>) {
         match self.phase_check {
-            PhaseCheckState::Disabled => {}
-            PhaseCheckState::Expecting(expected) => {
+            PhaseCheck::Disabled => {}
+            PhaseCheck::Expecting(expected) => {
                 assert_eq!(
                     expected, current,
                     "substep phase order violated: expected {expected}, called {current}.\n\
@@ -122,10 +122,9 @@ impl super::Simulation {
                      advance_queue → movement → doors → loading → metrics, then advance_tick() \
                      before the next cycle. See Simulation::set_strict_phase_order.",
                 );
-                self.phase_check =
-                    next.map_or(PhaseCheckState::AwaitingTick, PhaseCheckState::Expecting);
+                self.phase_check = next.map_or(PhaseCheck::AwaitingTick, PhaseCheck::Expecting);
             }
-            PhaseCheckState::AwaitingTick => {
+            PhaseCheck::AwaitingTick => {
                 panic!(
                     "substep phase order violated: called {current} but the previous tick's \
                      metrics phase has run — advance_tick() must run before the next cycle. \
@@ -387,25 +386,46 @@ impl super::Simulation {
     ///
     /// Call after running all desired phases. Events emitted during this tick
     /// are moved to the output buffer and available via `drain_events()`.
+    //
+    // `clippy::panic` is workspace-denied, but the two `Expecting(...)`
+    // arms below describe distinct guard violations that don't fit a
+    // single `assert_eq!`: the start-of-cycle case has no value to
+    // compare against, and the mid-cycle case panics whenever the
+    // expected phase is anything other than AdvanceTransient — which is
+    // already handled by the other arm. Tailored `panic!` messages
+    // surface the failure context; allow is scoped to this function.
+    #[allow(clippy::panic)]
     pub fn advance_tick(&mut self) {
         // Reset the substep guard to the start of the next cycle. With
-        // strict mode on, calling advance_tick from Expecting(X != AdvanceTransient)
-        // means the host skipped at least one phase — fail loud rather
-        // than silently bumping the tick counter on a half-stepped cycle.
+        // strict mode on, `advance_tick()` is only valid after
+        // `run_metrics()` (the `AwaitingTick` state). Any `Expecting(...)`
+        // means the host stopped short — either mid-cycle after some
+        // run_*'s, or at the start of a cycle with zero run_*'s. Both
+        // would silently bump the tick counter on a half-stepped (or
+        // empty) cycle, so reject both.
         match self.phase_check {
-            PhaseCheckState::Disabled => {}
-            PhaseCheckState::AwaitingTick => {
-                self.phase_check = PhaseCheckState::Expecting(Phase::AdvanceTransient);
+            PhaseCheck::Disabled => {}
+            PhaseCheck::AwaitingTick => {
+                self.phase_check = PhaseCheck::Expecting(Phase::AdvanceTransient);
             }
-            PhaseCheckState::Expecting(phase) => {
-                assert_eq!(
-                    phase,
-                    Phase::AdvanceTransient,
+            PhaseCheck::Expecting(Phase::AdvanceTransient) => {
+                // Zero phases ran since the last advance_tick (or since
+                // enabling strict mode). Reject to keep the
+                // documented invariant "advance_tick only fires after
+                // run_metrics" honest.
+                panic!(
+                    "advance_tick() called with zero phases run this cycle. \
+                     Strict mode requires the full canonical phase sequence \
+                     per tick: advance_transient → dispatch → reposition → \
+                     advance_queue → movement → doors → loading → metrics, \
+                     then advance_tick(). See Simulation::set_strict_phase_order.",
+                );
+            }
+            PhaseCheck::Expecting(phase) => {
+                panic!(
                     "advance_tick() called mid-tick: expected to be entering phase {phase} but the \
                      metrics phase has not run yet. See Simulation::set_strict_phase_order.",
                 );
-                // Already at the start of a cycle (no phases run since
-                // last advance_tick) — harmless idempotent reset.
             }
         }
         self.pending_output.extend(self.events.drain());

--- a/crates/elevator-core/src/sim/substep.rs
+++ b/crates/elevator-core/src/sim/substep.rs
@@ -9,6 +9,7 @@ use crate::events::EventBus;
 use crate::hooks::Phase;
 use crate::ids::GroupId;
 use crate::metrics::Metrics;
+use crate::sim::PhaseCheckState;
 use crate::systems::PhaseContext;
 use std::collections::BTreeMap;
 
@@ -56,6 +57,84 @@ impl super::Simulation {
         }
     }
 
+    /// Enable or disable strict substep phase-order validation.
+    ///
+    /// When enabled, each `run_*` substep method panics if called out
+    /// of the canonical 8-phase order, and `advance_tick()` panics if
+    /// called before `run_metrics()` has run. Default off — opt in
+    /// during host development to fail fast on accidental out-of-order
+    /// calls instead of debugging the downstream symptoms (riders
+    /// boarding through closed doors, movement before dispatch,
+    /// transient rider states bleeding across tick boundaries).
+    ///
+    /// `step()` and `step_many()` always satisfy the order, so flipping
+    /// this on in production code that drives the sim via `step()` is
+    /// safe (and zero overhead — a single branch per phase).
+    ///
+    /// # Canonical order
+    ///
+    /// Each tick: `run_advance_transient` → `run_dispatch` →
+    /// `run_reposition` → `run_advance_queue` → `run_movement` →
+    /// `run_doors` → `run_loading` → `run_metrics` → `advance_tick`.
+    ///
+    /// ```
+    /// use elevator_core::prelude::*;
+    ///
+    /// let mut sim = SimulationBuilder::demo().build().unwrap();
+    /// sim.set_strict_phase_order(true);
+    /// sim.step(); // canonical order — passes the check.
+    /// ```
+    pub const fn set_strict_phase_order(&mut self, enabled: bool) {
+        self.phase_check = if enabled {
+            PhaseCheckState::Expecting(Phase::AdvanceTransient)
+        } else {
+            PhaseCheckState::Disabled
+        };
+    }
+
+    /// Whether strict substep phase-order validation is currently
+    /// enabled. Useful for hosts that want to surface the setting in
+    /// debug overlays.
+    #[must_use]
+    pub const fn is_strict_phase_order(&self) -> bool {
+        !matches!(self.phase_check, PhaseCheckState::Disabled)
+    }
+
+    /// Validate that `current` is the next-expected phase, then advance
+    /// the expectation to `next`. No-op when the guard is disabled.
+    /// `next == None` means "tick complete, await `advance_tick`".
+    //
+    // `clippy::panic` is workspace-denied, but the AwaitingTick arm is
+    // unrepresentable as an `assert_eq!` against `current` — there is no
+    // single "expected phase" to compare against (the only allowed next
+    // action is `advance_tick`, not a phase). A direct `panic!` with a
+    // tailored message is the right shape for the AwaitingTick arm; the
+    // allow is scoped to this helper only.
+    #[allow(clippy::panic)]
+    fn check_and_advance_phase(&mut self, current: Phase, next: Option<Phase>) {
+        match self.phase_check {
+            PhaseCheckState::Disabled => {}
+            PhaseCheckState::Expecting(expected) => {
+                assert_eq!(
+                    expected, current,
+                    "substep phase order violated: expected {expected}, called {current}.\n\
+                     Canonical order each tick: advance_transient → dispatch → reposition → \
+                     advance_queue → movement → doors → loading → metrics, then advance_tick() \
+                     before the next cycle. See Simulation::set_strict_phase_order.",
+                );
+                self.phase_check =
+                    next.map_or(PhaseCheckState::AwaitingTick, PhaseCheckState::Expecting);
+            }
+            PhaseCheckState::AwaitingTick => {
+                panic!(
+                    "substep phase order violated: called {current} but the previous tick's \
+                     metrics phase has run — advance_tick() must run before the next cycle. \
+                     See Simulation::set_strict_phase_order.",
+                );
+            }
+        }
+    }
+
     /// Run only the `advance_transient` phase (with hooks).
     ///
     /// # Phase ordering
@@ -76,6 +155,7 @@ impl super::Simulation {
     /// elevators to move before dispatch, or transient states to persist
     /// across tick boundaries.
     pub fn run_advance_transient(&mut self) {
+        self.check_and_advance_phase(Phase::AdvanceTransient, Some(Phase::Dispatch));
         self.set_tick_in_progress(true);
         self.sync_world_tick();
         self.hooks
@@ -101,6 +181,7 @@ impl super::Simulation {
 
     /// Run only the dispatch phase (with hooks).
     pub fn run_dispatch(&mut self) {
+        self.check_and_advance_phase(Phase::Dispatch, Some(Phase::Reposition));
         self.sync_world_tick();
         self.hooks.run_before(Phase::Dispatch, &mut self.world);
         for group in &self.groups {
@@ -126,6 +207,7 @@ impl super::Simulation {
 
     /// Run only the movement phase (with hooks).
     pub fn run_movement(&mut self) {
+        self.check_and_advance_phase(Phase::Movement, Some(Phase::Doors));
         self.hooks.run_before(Phase::Movement, &mut self.world);
         for group in &self.groups {
             self.hooks
@@ -149,6 +231,7 @@ impl super::Simulation {
 
     /// Run only the doors phase (with hooks).
     pub fn run_doors(&mut self) {
+        self.check_and_advance_phase(Phase::Doors, Some(Phase::Loading));
         self.hooks.run_before(Phase::Doors, &mut self.world);
         for group in &self.groups {
             self.hooks
@@ -172,6 +255,7 @@ impl super::Simulation {
 
     /// Run only the loading phase (with hooks).
     pub fn run_loading(&mut self) {
+        self.check_and_advance_phase(Phase::Loading, Some(Phase::Metrics));
         self.hooks.run_before(Phase::Loading, &mut self.world);
         for group in &self.groups {
             self.hooks
@@ -200,6 +284,7 @@ impl super::Simulation {
     /// [`DestinationQueue`](crate::components::DestinationQueue). Runs
     /// between Reposition and Movement.
     pub fn run_advance_queue(&mut self) {
+        self.check_and_advance_phase(Phase::AdvanceQueue, Some(Phase::Movement));
         self.hooks.run_before(Phase::AdvanceQueue, &mut self.world);
         for group in &self.groups {
             self.hooks
@@ -229,6 +314,7 @@ impl super::Simulation {
     /// repositioner — this differs from other phases where per-group hooks
     /// fire unconditionally.
     pub fn run_reposition(&mut self) {
+        self.check_and_advance_phase(Phase::Reposition, Some(Phase::AdvanceQueue));
         self.sync_world_tick();
         self.hooks.run_before(Phase::Reposition, &mut self.world);
         if !self.repositioner_set.is_empty() {
@@ -273,6 +359,8 @@ impl super::Simulation {
 
     /// Run only the metrics phase (with hooks).
     pub fn run_metrics(&mut self) {
+        // None → AwaitingTick: advance_tick() must come before the next cycle.
+        self.check_and_advance_phase(Phase::Metrics, None);
         self.hooks.run_before(Phase::Metrics, &mut self.world);
         for group in &self.groups {
             self.hooks
@@ -300,6 +388,26 @@ impl super::Simulation {
     /// Call after running all desired phases. Events emitted during this tick
     /// are moved to the output buffer and available via `drain_events()`.
     pub fn advance_tick(&mut self) {
+        // Reset the substep guard to the start of the next cycle. With
+        // strict mode on, calling advance_tick from Expecting(X != AdvanceTransient)
+        // means the host skipped at least one phase — fail loud rather
+        // than silently bumping the tick counter on a half-stepped cycle.
+        match self.phase_check {
+            PhaseCheckState::Disabled => {}
+            PhaseCheckState::AwaitingTick => {
+                self.phase_check = PhaseCheckState::Expecting(Phase::AdvanceTransient);
+            }
+            PhaseCheckState::Expecting(phase) => {
+                assert_eq!(
+                    phase,
+                    Phase::AdvanceTransient,
+                    "advance_tick() called mid-tick: expected to be entering phase {phase} but the \
+                     metrics phase has not run yet. See Simulation::set_strict_phase_order.",
+                );
+                // Already at the start of a cycle (no phases run since
+                // last advance_tick) — harmless idempotent reset.
+            }
+        }
         self.pending_output.extend(self.events.drain());
         self.tick += 1;
         self.set_tick_in_progress(false);

--- a/crates/elevator-core/src/sim/substep.rs
+++ b/crates/elevator-core/src/sim/substep.rs
@@ -85,10 +85,16 @@ impl super::Simulation {
     /// sim.step(); // canonical order — passes the check.
     /// ```
     pub const fn set_strict_phase_order(&mut self, enabled: bool) {
-        self.phase_check = if enabled {
-            PhaseCheck::Expecting(Phase::AdvanceTransient)
-        } else {
-            PhaseCheck::Disabled
+        // Idempotent on a redundant enable: if the guard is already
+        // on, preserve the existing mid-cycle / AwaitingTick state so
+        // a `set_strict_phase_order(true)` call between `run_metrics`
+        // and `advance_tick` doesn't silently erase the
+        // advance_tick-required marker (which would let the consumer
+        // skip the tick-counter increment and event flush).
+        self.phase_check = match (enabled, self.phase_check) {
+            (true, PhaseCheck::Disabled) => PhaseCheck::Expecting(Phase::AdvanceTransient),
+            (true, current) => current,
+            (false, _) => PhaseCheck::Disabled,
         };
     }
 

--- a/crates/elevator-core/src/tests/substep_tests.rs
+++ b/crates/elevator-core/src/tests/substep_tests.rs
@@ -219,6 +219,60 @@ fn strict_phase_order_rejects_zero_phase_advance_tick() {
 }
 
 #[test]
+#[should_panic(expected = "advance_tick()")]
+fn strict_phase_order_redundant_enable_preserves_awaiting_tick() {
+    // Greptile #859 finding: a second `set_strict_phase_order(true)`
+    // mid-cycle used to unconditionally reset to
+    // Expecting(AdvanceTransient), silently erasing the AwaitingTick
+    // marker after `run_metrics()`. That would let the consumer call
+    // `run_advance_transient()` without `advance_tick()` between
+    // ticks — skipping the tick-counter increment and event flush.
+    //
+    // The setter is now idempotent on `enabled == true`: redundant
+    // enable preserves the existing state, so the AwaitingTick
+    // requirement survives and the next `run_advance_transient()`
+    // panics as expected.
+    let mut sim = crate::sim::Simulation::new(&default_config(), scan()).unwrap();
+    sim.set_strict_phase_order(true);
+    sim.run_advance_transient();
+    sim.run_dispatch();
+    sim.run_reposition();
+    sim.run_advance_queue();
+    sim.run_movement();
+    sim.run_doors();
+    sim.run_loading();
+    sim.run_metrics();
+    // Redundant enable — must NOT reset the AwaitingTick state.
+    sim.set_strict_phase_order(true);
+    // Without advance_tick(), this should still panic.
+    sim.run_advance_transient();
+}
+
+#[test]
+fn strict_phase_order_toggle_off_then_on_resets_to_start_of_cycle() {
+    // Toggling off then on IS a reset — the consumer explicitly
+    // disabled and re-enabled, which should land at the start of a
+    // fresh cycle regardless of where mid-cycle they were.
+    let mut sim = crate::sim::Simulation::new(&default_config(), scan()).unwrap();
+    sim.set_strict_phase_order(true);
+    sim.run_advance_transient();
+    sim.run_dispatch();
+    // Disable mid-cycle, then re-enable. State is now
+    // Expecting(AdvanceTransient) so a fresh canonical cycle works.
+    sim.set_strict_phase_order(false);
+    sim.set_strict_phase_order(true);
+    sim.run_advance_transient();
+    sim.run_dispatch();
+    sim.run_reposition();
+    sim.run_advance_queue();
+    sim.run_movement();
+    sim.run_doors();
+    sim.run_loading();
+    sim.run_metrics();
+    sim.advance_tick();
+}
+
+#[test]
 #[should_panic(expected = "advance_tick() called with zero phases")]
 fn strict_phase_order_rejects_back_to_back_advance_tick() {
     // After a complete canonical cycle plus advance_tick(), a second

--- a/crates/elevator-core/src/tests/substep_tests.rs
+++ b/crates/elevator-core/src/tests/substep_tests.rs
@@ -101,3 +101,108 @@ fn events_mut_allows_custom_emission() {
             .any(|e| matches!(e, Event::ElevatorDeparted { tick: 999, .. }))
     );
 }
+
+// ── Strict phase-order guard ───────────────────────────────────────
+
+#[test]
+fn strict_phase_order_default_off() {
+    let sim = crate::sim::Simulation::new(&default_config(), scan()).unwrap();
+    assert!(!sim.is_strict_phase_order());
+}
+
+#[test]
+fn strict_phase_order_step_passes_check() {
+    // step() walks the canonical order, so strict mode is a no-op
+    // from the consumer's perspective — never panics.
+    let mut sim = crate::sim::Simulation::new(&default_config(), scan()).unwrap();
+    sim.set_strict_phase_order(true);
+    assert!(sim.is_strict_phase_order());
+    for _ in 0..50 {
+        sim.step();
+    }
+}
+
+#[test]
+fn strict_phase_order_full_substep_cycle_passes() {
+    // Every public substep method in canonical order, with strict on.
+    let mut sim = crate::sim::Simulation::new(&default_config(), scan()).unwrap();
+    sim.set_strict_phase_order(true);
+    for _ in 0..10 {
+        sim.run_advance_transient();
+        sim.run_dispatch();
+        sim.run_reposition();
+        sim.run_advance_queue();
+        sim.run_movement();
+        sim.run_doors();
+        sim.run_loading();
+        sim.run_metrics();
+        sim.advance_tick();
+    }
+    assert_eq!(sim.current_tick(), 10);
+}
+
+#[test]
+fn strict_phase_order_can_be_toggled_off() {
+    // Toggling off restores the pre-existing tolerant behaviour, so
+    // hosts that skip phases (e.g. the original
+    // `per_phase_methods_equivalent_to_step` test) still work after
+    // experimenting with strict mode.
+    let mut sim = crate::sim::Simulation::new(&default_config(), scan()).unwrap();
+    sim.set_strict_phase_order(true);
+    sim.set_strict_phase_order(false);
+    // This call skips run_reposition + run_advance_queue and would
+    // panic if strict were still on.
+    sim.run_advance_transient();
+    sim.run_dispatch();
+    sim.run_movement();
+}
+
+#[test]
+#[should_panic(expected = "substep phase order violated")]
+fn strict_phase_order_rejects_out_of_order_call() {
+    let mut sim = crate::sim::Simulation::new(&default_config(), scan()).unwrap();
+    sim.set_strict_phase_order(true);
+    // Skip straight to dispatch without advance_transient — should panic.
+    sim.run_dispatch();
+}
+
+#[test]
+#[should_panic(expected = "substep phase order violated")]
+fn strict_phase_order_rejects_skipped_phase() {
+    let mut sim = crate::sim::Simulation::new(&default_config(), scan()).unwrap();
+    sim.set_strict_phase_order(true);
+    sim.run_advance_transient();
+    // Skip dispatch + reposition + advance_queue — straight to movement.
+    sim.run_movement();
+}
+
+#[test]
+#[should_panic(expected = "advance_tick() must run before the next cycle")]
+fn strict_phase_order_rejects_run_before_advance_tick() {
+    // Complete one full cycle, then start the next without
+    // advance_tick(). The AwaitingTick state should reject it.
+    let mut sim = crate::sim::Simulation::new(&default_config(), scan()).unwrap();
+    sim.set_strict_phase_order(true);
+    sim.run_advance_transient();
+    sim.run_dispatch();
+    sim.run_reposition();
+    sim.run_advance_queue();
+    sim.run_movement();
+    sim.run_doors();
+    sim.run_loading();
+    sim.run_metrics();
+    // Missing advance_tick() here — next call must panic.
+    sim.run_advance_transient();
+}
+
+#[test]
+#[should_panic(expected = "advance_tick() called mid-tick")]
+fn strict_phase_order_rejects_premature_advance_tick() {
+    // advance_tick() called before run_metrics — should panic in strict mode.
+    let mut sim = crate::sim::Simulation::new(&default_config(), scan()).unwrap();
+    sim.set_strict_phase_order(true);
+    sim.run_advance_transient();
+    sim.run_dispatch();
+    // Skip the rest — advance_tick should reject.
+    sim.advance_tick();
+}

--- a/crates/elevator-core/src/tests/substep_tests.rs
+++ b/crates/elevator-core/src/tests/substep_tests.rs
@@ -206,3 +206,33 @@ fn strict_phase_order_rejects_premature_advance_tick() {
     // Skip the rest — advance_tick should reject.
     sim.advance_tick();
 }
+
+#[test]
+#[should_panic(expected = "advance_tick() called with zero phases")]
+fn strict_phase_order_rejects_zero_phase_advance_tick() {
+    // advance_tick() right after enabling strict mode, with no run_*
+    // calls in this cycle. Without this guard, the tick counter
+    // would silently bump on an empty cycle.
+    let mut sim = crate::sim::Simulation::new(&default_config(), scan()).unwrap();
+    sim.set_strict_phase_order(true);
+    sim.advance_tick();
+}
+
+#[test]
+#[should_panic(expected = "advance_tick() called with zero phases")]
+fn strict_phase_order_rejects_back_to_back_advance_tick() {
+    // After a complete canonical cycle plus advance_tick(), a second
+    // advance_tick() with no intervening run_*'s is also zero-phase.
+    let mut sim = crate::sim::Simulation::new(&default_config(), scan()).unwrap();
+    sim.set_strict_phase_order(true);
+    sim.run_advance_transient();
+    sim.run_dispatch();
+    sim.run_reposition();
+    sim.run_advance_queue();
+    sim.run_movement();
+    sim.run_doors();
+    sim.run_loading();
+    sim.run_metrics();
+    sim.advance_tick(); // first one is fine
+    sim.advance_tick(); // second one with no run_*'s — should panic
+}


### PR DESCRIPTION
## Problem

`Simulation`'s substep API (`run_advance_transient`, `run_dispatch`, …, `run_metrics`, `advance_tick`) documents a canonical 8-phase order each tick but doesn't enforce it. Out-of-order calls produce diffuse symptoms — riders boarding through closed doors, movement before dispatch, transient rider states bleeding across tick boundaries — that are painful to debug. The substep methods are already marked `skip:internal — phase ordering invariant` for every host in `bindings.toml` precisely because of this fragility.

## Solution

Opt-in `set_strict_phase_order(bool)` that:

- When **enabled**, asserts each `run_*` call is the next-expected phase, and that `advance_tick()` only fires after `run_metrics()` (no half-stepped ticks).
- When **disabled** (the default), every check short-circuits — single branch per call, zero behavioural change for existing consumers.
- `step()` and `step_many()` honour the canonical order, so strict mode is safe to leave on in production code that drives the sim through `step()`.

```rust
let mut sim = SimulationBuilder::demo().build()?;
sim.set_strict_phase_order(true);
sim.step();      // passes
sim.run_doors(); // panics — `advance_transient` was expected
```

## Implementation

- New private enum `PhaseCheckState { Disabled | Expecting(Phase) | AwaitingTick }` on `Simulation`.
- Each public `run_*` method calls a private `check_and_advance_phase` helper that validates the current phase and advances the expectation.
- The private `run_energy()` phase is intentionally outside the guard — `step()` interleaves it between Loading and Metrics, and exposing it to consumers would be a separate API decision (currently it's `fn`, not `pub fn`).
- `advance_tick()` resets the state machine to the start of the next cycle and asserts no half-stepped tick.

## bindings.toml

Both `set_strict_phase_order` and `is_strict_phase_order` are marked `skip:internal — phase ordering invariant` for every host, matching the substep methods they govern. Exposing them across the FFI boundary would be a host-by-host decision; for now they're internal guards for Rust-level consumers (TUI, contract harness, integration tests).

## Tests

8 new tests in `substep_tests.rs`:
- Default is off
- `step()` always passes the check
- Full canonical substep cycle passes
- Toggle-off restores tolerant behaviour
- Out-of-order call panics
- Skipped phase panics
- Missing `advance_tick` between cycles panics
- Premature `advance_tick` (before metrics) panics

All 179 doctests and 1065 unit tests still pass.

## Release impact

`feat:` → minor bump on `elevator-core`. Non-breaking — default off.

`Cargo.lock` is refreshed alongside to absorb the version bumps from the last several release-please PRs (same drift situation as #855 / #856 / #857 / #858; #858 is the systemic fix).

## Test plan

- [x] `cargo test -p elevator-core --all-features` → 1065 + 179 passing
- [x] `cargo clippy -p elevator-core --all-features --all-targets -- -D warnings`
- [x] `bash scripts/check-bindings.sh`
- [x] Local pre-commit gate passes
- [ ] CI green