### PR TITLE
ci: emit Check status for docs-only PRs to clear branch protection

### DIFF
--- a/.github/workflows/ci-docs-skip.yml
+++ b/.github/workflows/ci-docs-skip.yml
@@ -1,0 +1,58 @@
+name: CI
+
+# Mirror image of ci.yml's `paths-ignore`. When a PR or push touches
+# ONLY paths that ci.yml is configured to ignore, that workflow doesn't
+# fire — so the `Check` required status never appears, and branch
+# protection refuses the merge ("Waiting for status to be reported"
+# forever). The in-workflow comment at ci.yml:42-46 claiming
+# "branch-protection treats a SKIPPED required check as success" is
+# correct for job-level `if:` skips but NOT for workflow-level
+# `paths-ignore`; the latter never emits a status at all.
+#
+# This workflow fires for exactly those ignored paths and emits a
+# successful `Check` so the required-status gate clears. Both
+# workflows share `name: CI` and job name `Check`, producing the
+# identical status context "CI / Check" — branch protection sees one
+# required check; one of the two workflows fires per push/PR
+# depending on the touched paths.
+#
+# If a PR touches both docs AND code paths, both workflows fire (the
+# `paths` / `paths-ignore` filters each match independently). Both
+# pass → the gate clears. The duplicated status entry in the PR UI is
+# cosmetic.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'media/**'
+      - 'AI-DISCLOSURE.md'
+      - 'STABILITY.md'
+      - 'LICENSE*'
+      - '.research/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'media/**'
+      - 'AI-DISCLOSURE.md'
+      - 'STABILITY.md'
+      - 'LICENSE*'
+      - '.research/**'
+
+# Cancel superseded PR runs to mirror ci.yml's concurrency policy.
+concurrency:
+  group: ci-docs-skip-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Docs-only no-op
+        run: echo "Docs-only paths - no code change to validate. Check passes."

--- a/.github/workflows/ci-docs-skip.yml
+++ b/.github/workflows/ci-docs-skip.yml
@@ -12,14 +12,18 @@ name: CI
 # This workflow fires for exactly those ignored paths and emits a
 # successful `Check` so the required-status gate clears. Both
 # workflows share `name: CI` and job name `Check`, producing the
-# identical status context "CI / Check" — branch protection sees one
-# required check; one of the two workflows fires per push/PR
-# depending on the touched paths.
+# identical status context "CI / Check".
 #
-# If a PR touches both docs AND code paths, both workflows fire (the
-# `paths` / `paths-ignore` filters each match independently). Both
-# pass → the gate clears. The duplicated status entry in the PR UI is
-# cosmetic.
+# Mixed-PR safety (docs AND code paths touched simultaneously):
+# GitHub Actions emits a **check run** (Checks API), not a status
+# (legacy Status API). Branch protection requires every required
+# check run of the configured name to succeed — they are AND-ed, not
+# last-write-wins. So if a mixed PR fires both workflows and ci.yml's
+# real `Check` fails, this no-op's success cannot override it; the
+# gate stays blocked until the real check passes. (Last-write-wins
+# semantics apply only to the legacy commit-status API used by
+# third-party integrations, not by GitHub Actions.) The duplicate
+# status entry in the PR UI is cosmetic.
 
 on:
   push:


### PR DESCRIPTION
## Problem

`.github/workflows/ci.yml` declares workflow-level `paths-ignore` for `docs/**`, `media/**`, `AI-DISCLOSURE.md`, `STABILITY.md`, `LICENSE*`, and `.research/**`. Any PR touching only those paths skips the entire CI workflow — and branch protection on `main` requires the `Check` status context, which never appears.

Result: docs-only PRs sit forever as "Waiting for status to be reported" and need `gh pr merge --admin --squash` to land (most recently #850 on 2026-05-12).

The in-workflow comment at `ci.yml:42-46` claims "Branch-protection treats a SKIPPED required check as success" — that's true for job-level `if:` skips, but NOT for workflow-level `paths-ignore`. The latter never emits a status at all.

## Solution

Dual-workflow pattern. The new `.github/workflows/ci-docs-skip.yml`:

- Fires on **exactly** the paths `ci.yml` ignores (mirror image of its `paths-ignore`).
- Uses `name: CI` and job name `Check` — same as `ci.yml`, so the emitted status context "CI / Check" is identical from GitHub's perspective.
- Job body is a one-line `echo`; the whole workflow finishes in seconds.

Per push/PR, GitHub fires whichever workflow matches the changed paths:
- Docs-only PR → `ci-docs-skip.yml` fires, no-op `Check` succeeds → gate clears.
- Code-only PR → `ci.yml` fires, real `Check` runs → gate clears.
- Mixed PR (both docs and code) → both workflows fire; the duplicate "CI / Check" status entry in the UI is cosmetic, and both passing satisfies the gate either way.

## What this enables

- `#850`-style docs-only PRs land via normal auto-merge instead of needing `--admin --squash`.
- Removes the recurring admin-merge step from the PR workflow (see `project_docs_only_ci_block.md` for the prior incident report).

## Test plan

- [x] YAML syntax validated
- [x] Local pre-commit gate passes
- [ ] CI green (this PR isn't docs-only, so it exercises `ci.yml`, not the new workflow — the docs-skip path will be validated by the next docs-only PR)
- [ ] After merge, the next docs-only PR should auto-merge without admin override