### PR TITLE
ci(release-please): guard env-block fromJSON when no release PR is opened

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -111,7 +111,12 @@ jobs:
         if: steps.release.outputs.pr
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}
+          # Short-circuit: env-block expressions resolve at step-prep, not
+          # at step-run, so when `steps.release.outputs.pr` is empty
+          # (release-please opened no PR), `fromJSON('')` would crash the
+          # workflow before `if:` could skip the step. The `&& ... || ''`
+          # guard yields an empty string in that case; `if:` then skips.
+          PR_NUMBER: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).number || '' }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

Release Please has been failing on every push to `main` since #858 merged. The Cargo.lock refresh step uses `env: PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}` — but env-block expressions resolve at step-prep, not at step-run, so even though the step's `if: steps.release.outputs.pr` would skip it when no release PR is opened, the `fromJSON('')` call crashes the workflow template parser first:

```
##[error]The template is not valid. .github/workflows/release-please.yml (Line: 114, Col: 22):
Error reading JToken from JsonReader. Path '', line 0, position 0.
```

This fires whenever release-please runs on `main` without opening a new release PR — e.g. when the release PR itself was just merged (the push that produced this failure on #861), or when the shipping-changes guard skipped the action entirely (test-only commits, docs-only commits).

Short-circuit with `&& ... || ''` so `fromJSON` is never invoked on an empty string. The auto-approve and auto-merge steps a few lines below already work because their `fromJSON` is interpolated inside `run:` — those strings only resolve when the step actually executes.

## Test plan

- [x] YAML still parses (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [x] Pre-commit hook passes (workspace check, tests, clippy, fmt)
- [ ] Release Please workflow succeeds on this PR's merge to `main` (verifies the no-PR path)
- [ ] Next release-bumping PR opens a release PR successfully and refreshes Cargo.lock (verifies the with-PR path)