### PR TITLE
chore: refresh Cargo.lock after elevator-core v20.16.0 bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "elevator-core"
-version = "20.15.0"
+version = "20.16.0"
 dependencies = [
  "criterion",
  "ordered-float",


### PR DESCRIPTION
## Summary

PR #861 (`chore: release main`) bumped `crates/elevator-core/Cargo.toml` to `20.16.0`, but the workflow step that refreshes `Cargo.lock` on the release branch crashed on the env-block `fromJSON` template error (now fixed in #863). The release PR merged with `Cargo.lock` still pinning `elevator-core` at `20.15.0`.

This blocks every subsequent non-release PR's pre-commit hook via the `cargo metadata --frozen` guard. `cargo update --workspace --offline` is the same one-line refresh the workflow would have run.

## Test plan

- [x] `cargo update --workspace --offline` touched only the `elevator-core` version line (1 insertion, 1 deletion)
- [x] Pre-commit hook passes (workspace check + tests + clippy + fmt + doc tests)
- [ ] No new release PR is opened by release-please on merge (this commit is a non-bumping `chore:` and only touches `Cargo.lock`, which is on the non-shipping-paths list — the workflow's shipping-changes guard should skip)