### PR TITLE
feat: add elevator_entity accessor and GMS buffer helpers

### DIFF
--- a/assets/contract-corpus/golden.txt
+++ b/assets/contract-corpus/golden.txt
@@ -1,8 +1,8 @@
 # Golden snapshot checksums for contract scenarios.
 # Regenerate via: cargo run -p elevator-contract -- --update-golden
 # tick budget: 600
-default 0x23c49482fe6d5343
-dense_traffic 0x74a797f83ac2c3cf
-extreme_load 0x88e7b660109a32be
-multi_group 0xb93df925fd16a5b7
-sparse 0xce0a5aefd4ea2d25
+default 0xda961517810d5e2f
+dense_traffic 0xd23c89119ae9c69f
+extreme_load 0x190765fe58787d57
+multi_group 0x05b65b9ee1789f0b
+sparse 0xe0e2d1f48a0ae295

--- a/bindings.toml
+++ b/bindings.toml
@@ -1036,6 +1036,26 @@ gdext = "todo:future-binding"
 bevy = "todo:plugin-layer"
 
 [[methods]]
+name = "elevator_entity"
+category = "introspection"
+wasm = "elevatorEntity"
+ffi  = "ev_sim_elevator_entity"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_elevator_entity"
+gdext = "todo:future-binding"
+bevy = "todo:plugin-layer"
+
+[[methods]]
+name = "elevator_lookup_iter"
+category = "introspection"
+wasm = "elevatorLookupIter"
+ffi  = "ev_sim_elevator_lookup_iter"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_elevator_lookup_iter"
+gdext = "todo:future-binding"
+bevy = "todo:plugin-layer"
+
+[[methods]]
 name = "find_stop_at_position_on_line"
 category = "introspection"
 wasm = "findStopAtPositionOnLine"

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -209,6 +209,12 @@ pub struct Simulation {
     groups: Vec<ElevatorGroup>,
     /// Config `StopId` to `EntityId` mapping for spawn helpers.
     stop_lookup: HashMap<StopId, EntityId>,
+    /// Config-time `ElevatorConfig.id` → runtime `EntityId` mapping.
+    /// Populated only for elevators spawned from the initial config —
+    /// runtime `add_elevator` takes `ElevatorParams` (no config id) and
+    /// returns the new `EntityId` directly, so it does not populate
+    /// this map. Mirror of [`Self::stop_lookup`] semantics.
+    elevator_lookup: HashMap<u32, EntityId>,
     /// Dispatch strategies + their snapshot identities, keyed by group.
     /// Owns both halves so insert/remove stay atomic — see
     /// [`DispatcherSet`].

--- a/crates/elevator-core/src/sim/accessors.rs
+++ b/crates/elevator-core/src/sim/accessors.rs
@@ -168,6 +168,17 @@ impl super::Simulation {
         self.stop_lookup.get(&id).copied()
     }
 
+    /// Resolve a config-time `ElevatorConfig.id` to its runtime `EntityId`.
+    ///
+    /// Only elevators spawned from the initial config are addressable
+    /// here — runtime [`Self::add_elevator`] takes `ElevatorParams` (no
+    /// config id) and returns the new entity id directly. Mirror of
+    /// [`Self::stop_entity`].
+    #[must_use]
+    pub fn elevator_entity(&self, id: u32) -> Option<EntityId> {
+        self.elevator_lookup.get(&id).copied()
+    }
+
     /// Resolve a [`StopRef`] to its runtime [`EntityId`].
     pub(super) fn resolve_stop(&self, stop: StopRef) -> Result<EntityId, SimError> {
         match stop {
@@ -185,6 +196,13 @@ impl super::Simulation {
     /// Iterate over the stop ID → entity ID mapping.
     pub fn stop_lookup_iter(&self) -> impl Iterator<Item = (&StopId, &EntityId)> {
         self.stop_lookup.iter()
+    }
+
+    /// Iterate over the elevator config ID → entity ID mapping. Only
+    /// elevators spawned from the initial config appear; see
+    /// [`Self::elevator_entity`].
+    pub fn elevator_lookup_iter(&self) -> impl Iterator<Item = (&u32, &EntityId)> {
+        self.elevator_lookup.iter()
     }
 
     /// Peek at events pending for consumer retrieval.

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -266,6 +266,7 @@ impl Simulation {
         // into a seconds expression and getting ~60× over-weighted.
         world.insert_resource(crate::time::TickRate(config.simulation.ticks_per_second));
 
+        let mut elevator_lookup: HashMap<u32, EntityId> = HashMap::new();
         let (mut groups, dispatchers, strategy_ids) =
             if let Some(line_configs) = &config.building.lines {
                 Self::build_explicit_topology(
@@ -273,10 +274,17 @@ impl Simulation {
                     config,
                     line_configs,
                     &stop_lookup,
+                    &mut elevator_lookup,
                     builder_dispatchers,
                 )
             } else {
-                Self::build_legacy_topology(&mut world, config, &stop_lookup, builder_dispatchers)
+                Self::build_legacy_topology(
+                    &mut world,
+                    config,
+                    &stop_lookup,
+                    &mut elevator_lookup,
+                    builder_dispatchers,
+                )
             };
         sync_hall_call_modes(&mut groups, &strategy_ids);
 
@@ -342,6 +350,7 @@ impl Simulation {
             dt,
             groups,
             stop_lookup,
+            elevator_lookup,
             dispatcher_set: super::DispatcherSet::from_parts(dispatchers, strategy_ids),
             repositioner_set: super::RepositionerSet::from_parts(repositioners, reposition_ids),
             metrics: Metrics::new(),
@@ -433,6 +442,7 @@ impl Simulation {
         world: &mut World,
         config: &SimConfig,
         stop_lookup: &HashMap<StopId, EntityId>,
+        elevator_lookup: &mut HashMap<u32, EntityId>,
         builder_dispatchers: BTreeMap<GroupId, Box<dyn DispatchStrategy>>,
     ) -> TopologyResult {
         // Iterate the config's stop list (deterministic Vec order) and
@@ -478,6 +488,7 @@ impl Simulation {
                 stop_lookup,
                 &config.building.stops,
             );
+            elevator_lookup.insert(ec.id, eid);
             elevator_entities.push(eid);
         }
 
@@ -522,6 +533,7 @@ impl Simulation {
         config: &SimConfig,
         line_configs: &[crate::config::LineConfig],
         stop_lookup: &HashMap<StopId, EntityId>,
+        elevator_lookup: &mut HashMap<u32, EntityId>,
         builder_dispatchers: BTreeMap<GroupId, Box<dyn DispatchStrategy>>,
     ) -> TopologyResult {
         // Map line config id → (line EntityId, LineInfo). `BTreeMap`
@@ -590,6 +602,7 @@ impl Simulation {
                     stop_lookup,
                     &config.building.stops,
                 );
+                elevator_lookup.insert(ec.id, eid);
                 elevator_entities.push(eid);
             }
 
@@ -687,6 +700,7 @@ impl Simulation {
         dt: f64,
         groups: Vec<ElevatorGroup>,
         stop_lookup: HashMap<StopId, EntityId>,
+        elevator_lookup: HashMap<u32, EntityId>,
         dispatchers: BTreeMap<GroupId, Box<dyn DispatchStrategy>>,
         strategy_ids: BTreeMap<GroupId, crate::dispatch::BuiltinStrategy>,
         metrics: Metrics,
@@ -746,6 +760,7 @@ impl Simulation {
             dt,
             groups,
             stop_lookup,
+            elevator_lookup,
             dispatcher_set: super::DispatcherSet::from_parts(dispatchers, strategy_ids),
             repositioner_set: super::RepositionerSet::new(),
             metrics,

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -538,6 +538,12 @@ impl Simulation {
         // Despawn from world.
         self.world.despawn(elevator);
 
+        // Drop any config-id → entity mapping pointing at the removed
+        // elevator. Mirrors `remove_stop`'s `stop_lookup` cleanup so a
+        // subsequent `elevator_entity(id)` returns `None` rather than a
+        // dangling entity reference.
+        self.elevator_lookup.retain(|_, &mut eid| eid != elevator);
+
         self.mark_topo_dirty();
         Ok(())
     }

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -109,9 +109,9 @@ pub struct WorldSnapshot {
     pub stop_lookup: BTreeMap<StopId, usize>,
     /// Config-time `ElevatorConfig.id` → entity index mapping. Absent
     /// in legacy snapshots; on restore an empty map means
-    /// [`Simulation::elevator_entity`] returns `None` for all ids
-    /// (acceptable degradation — config-loaded host queries on legacy
-    /// snapshots fall back to the iteration path).
+    /// [`crate::sim::Simulation::elevator_entity`] returns `None` for
+    /// all ids (acceptable degradation — config-loaded host queries on
+    /// legacy snapshots fall back to the iteration path).
     #[serde(default)]
     pub elevator_lookup: BTreeMap<u32, usize>,
     /// Global metrics at snapshot time.

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -107,6 +107,13 @@ pub struct WorldSnapshot {
     /// Stop ID → entity index mapping. `BTreeMap` for deterministic
     /// snapshot bytes across processes (#254).
     pub stop_lookup: BTreeMap<StopId, usize>,
+    /// Config-time `ElevatorConfig.id` → entity index mapping. Absent
+    /// in legacy snapshots; on restore an empty map means
+    /// [`Simulation::elevator_entity`] returns `None` for all ids
+    /// (acceptable degradation — config-loaded host queries on legacy
+    /// snapshots fall back to the iteration path).
+    #[serde(default)]
+    pub elevator_lookup: BTreeMap<u32, usize>,
     /// Global metrics at snapshot time.
     pub metrics: Metrics,
     /// Per-tag metric accumulators and entity-tag associations.
@@ -394,8 +401,9 @@ impl WorldSnapshot {
         sorted.sort_by(|a, b| a.0.total_cmp(&b.0));
         world.insert_resource(SortedStops(sorted));
 
-        // Rebuild groups, stop lookup, dispatchers, and extensions (borrows self).
-        let (mut groups, stop_lookup, dispatchers, strategy_ids) =
+        // Rebuild groups, stop/elevator lookup, dispatchers, and
+        // extensions (borrows self).
+        let (mut groups, stop_lookup, elevator_lookup, dispatchers, strategy_ids) =
             self.rebuild_groups_and_dispatchers(&index_to_id, custom_strategy_factory)?;
 
         Self::fix_legacy_line_entities(&mut groups, &mut world);
@@ -422,6 +430,7 @@ impl WorldSnapshot {
             self.dt,
             groups,
             stop_lookup,
+            elevator_lookup,
             dispatchers,
             strategy_ids,
             self.metrics,
@@ -752,6 +761,7 @@ impl WorldSnapshot {
         (
             Vec<crate::dispatch::ElevatorGroup>,
             HashMap<StopId, EntityId>,
+            HashMap<u32, EntityId>,
             std::collections::BTreeMap<GroupId, Box<dyn crate::dispatch::DispatchStrategy>>,
             std::collections::BTreeMap<GroupId, crate::dispatch::BuiltinStrategy>,
         ),
@@ -814,6 +824,12 @@ impl WorldSnapshot {
             .filter_map(|(sid, &idx)| index_to_id.get(idx).map(|&eid| (*sid, eid)))
             .collect();
 
+        let elevator_lookup: HashMap<u32, EntityId> = self
+            .elevator_lookup
+            .iter()
+            .filter_map(|(cid, &idx)| index_to_id.get(idx).map(|&eid| (*cid, eid)))
+            .collect();
+
         let mut dispatchers = std::collections::BTreeMap::new();
         let mut strategy_ids = std::collections::BTreeMap::new();
         for (gs, group) in self.groups.iter().zip(groups.iter()) {
@@ -834,7 +850,13 @@ impl WorldSnapshot {
             strategy_ids.insert(group.id(), gs.strategy.clone());
         }
 
-        Ok((groups, stop_lookup, dispatchers, strategy_ids))
+        Ok((
+            groups,
+            stop_lookup,
+            elevator_lookup,
+            dispatchers,
+            strategy_ids,
+        ))
     }
 
     /// Remap `EntityId`s in extension data using the old→new mapping.
@@ -1106,10 +1128,14 @@ impl crate::sim::Simulation {
             })
             .collect();
 
-        // Snapshot stop lookup (convert EntityIds to indices).
+        // Snapshot stop + elevator lookups (convert EntityIds to indices).
         let stop_lookup: BTreeMap<StopId, usize> = self
             .stop_lookup_iter()
             .filter_map(|(sid, eid)| id_to_index.get(eid).map(|&idx| (*sid, idx)))
+            .collect();
+        let elevator_lookup: BTreeMap<u32, usize> = self
+            .elevator_lookup_iter()
+            .filter_map(|(cid, eid)| id_to_index.get(eid).map(|&idx| (*cid, idx)))
             .collect();
 
         WorldSnapshot {
@@ -1119,6 +1145,7 @@ impl crate::sim::Simulation {
             entities,
             groups,
             stop_lookup,
+            elevator_lookup,
             metrics: self.metrics().clone(),
             metric_tags: self
                 .world()

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -12,7 +12,7 @@ use crate::entity::{ElevatorId, EntityId};
 use crate::error::SimError;
 use crate::events::Event;
 use crate::ids::GroupId;
-use crate::sim::Simulation;
+use crate::sim::{ElevatorParams, Simulation};
 use crate::stop::{StopConfig, StopId};
 use std::collections::HashSet;
 
@@ -305,6 +305,68 @@ fn remove_stop_removes_from_stop_lookup() {
         after.is_none(),
         "stop_entity should return None after removal"
     );
+}
+
+#[test]
+fn elevator_entity_resolves_config_id() {
+    let config = default_config();
+    let sim = Simulation::new(&config, scan()).unwrap();
+
+    // default_config installs a single elevator with id = 0.
+    let elev = sim.elevator_entity(0).expect("config id 0 should resolve");
+    assert!(sim.world().is_alive(elev));
+    assert!(sim.world().elevator(elev).is_some());
+
+    // Unknown ids return None — no panic, no sentinel.
+    assert!(sim.elevator_entity(99).is_none());
+}
+
+#[test]
+fn remove_elevator_removes_from_elevator_lookup() {
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+
+    let elev = sim.elevator_entity(0).unwrap();
+    sim.remove_elevator(elev).unwrap();
+
+    assert!(
+        sim.elevator_entity(0).is_none(),
+        "elevator_entity should return None after removal"
+    );
+}
+
+#[test]
+fn runtime_added_elevator_not_in_lookup() {
+    // Runtime add_elevator takes ElevatorParams (no config id), so the
+    // returned entity is intentionally not addressable via elevator_entity.
+    // Lookup remains the config-time map.
+    let config = default_config();
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    let line = sim.lines_in_group(GroupId(0))[0];
+
+    let params = ElevatorParams {
+        max_speed: Speed::from(3.0),
+        acceleration: Accel::from(2.0),
+        deceleration: Accel::from(2.5),
+        weight_capacity: Weight::from(1000.0),
+        door_transition_ticks: 3,
+        door_open_ticks: 8,
+        restricted_stops: HashSet::new(),
+        inspection_speed_factor: 0.25,
+        bypass_load_up_pct: None,
+        bypass_load_down_pct: None,
+    };
+    let runtime_elev = sim.add_elevator(&params, line, 4.0).unwrap();
+
+    // The runtime-added entity is alive but not in the config-id lookup.
+    assert!(sim.world().is_alive(runtime_elev));
+    let pairs: Vec<(u32, EntityId)> = sim.elevator_lookup_iter().map(|(c, e)| (*c, *e)).collect();
+    assert!(
+        pairs.iter().all(|(_, e)| *e != runtime_elev),
+        "runtime-added elevator must not appear in elevator_lookup"
+    );
+    // The config-time elevator (id 0) is still there.
+    assert!(sim.elevator_entity(0).is_some());
 }
 
 #[test]

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -68,6 +68,30 @@ fn snapshot_roundtrip_preserves_stop_lookup() {
 }
 
 #[test]
+fn snapshot_roundtrip_preserves_elevator_lookup() {
+    let config = helpers::default_config();
+    let sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+
+    let original = sim
+        .elevator_entity(0)
+        .expect("config id 0 resolves pre-snapshot");
+
+    let snap = sim.snapshot();
+    let restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
+
+    let restored_eid = restored
+        .elevator_entity(0)
+        .expect("config id 0 resolves post-restore");
+
+    // EntityIds are regenerated on restore, but the slot mapping should
+    // point at a live elevator with the original's max_speed/etc.
+    assert!(restored.world().elevator(restored_eid).is_some());
+    let _ = original; // pre-snapshot id; the assertion above is the contract.
+}
+
+#[test]
 fn snapshot_roundtrip_preserves_metrics() {
     let config = helpers::default_config();
     let mut sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();

--- a/crates/elevator-ffi/include/elevator_ffi.h
+++ b/crates/elevator-ffi/include/elevator_ffi.h
@@ -2085,6 +2085,40 @@ enum EvStatus ev_sim_transfer_points(struct EvSim *handle,
 uint64_t ev_sim_stop_entity(struct EvSim *handle, uint32_t stop_id);
 
 /**
+ * Resolve a config-time `ElevatorConfig.id` to its runtime `EntityId`.
+ *
+ * Returns `0` (slotmap-null) for unknown ids or for runtime-added
+ * elevators that were not in the initial config.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+uint64_t ev_sim_elevator_entity(struct EvSim *handle, uint32_t elevator_config_id);
+
+/**
+ * Snapshot of the config-time `ElevatorConfig.id` → runtime `EntityId` map.
+ *
+ * Buffer-pattern accessor; emits flat
+ * `[elevator_config_id_as_u64, entity_id, ...]` pairs (each pair = 2
+ * `u64` slots). The number of pairs written is `*out_written / 2`.
+ *
+ * Only elevators spawned from the initial config appear — runtime
+ * [`ev_sim_add_elevator`] returns the new entity id directly via its
+ * out-param, so it does not populate this map.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`]. `out`
+ * must point to at least `capacity` writable `u64` slots when
+ * `capacity > 0`.
+ */
+enum EvStatus ev_sim_elevator_lookup_iter(struct EvSim *handle,
+                                          uint64_t *out,
+                                          uint32_t capacity,
+                                          uint32_t *out_written);
+
+/**
  * Snapshot of the config-time `StopId` → runtime `EntityId` map.
  *
  * Buffer-pattern accessor; emits flat `[stop_id_as_u64, entity_id, ...]`

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -4180,6 +4180,86 @@ pub unsafe extern "C" fn ev_sim_stop_entity(handle: *mut EvSim, stop_id: u32) ->
     })
 }
 
+/// Resolve a config-time `ElevatorConfig.id` to its runtime `EntityId`.
+///
+/// Returns `0` (slotmap-null) for unknown ids or for runtime-added
+/// elevators that were not in the initial config.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_elevator_entity(
+    handle: *mut EvSim,
+    elevator_config_id: u32,
+) -> u64 {
+    guard(0, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return 0;
+        }
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        ev.sim
+            .elevator_entity(elevator_config_id)
+            .map_or(0, entity_to_u64)
+    })
+}
+
+/// Snapshot of the config-time `ElevatorConfig.id` → runtime `EntityId` map.
+///
+/// Buffer-pattern accessor; emits flat
+/// `[elevator_config_id_as_u64, entity_id, ...]` pairs (each pair = 2
+/// `u64` slots). The number of pairs written is `*out_written / 2`.
+///
+/// Only elevators spawned from the initial config appear — runtime
+/// [`ev_sim_add_elevator`] returns the new entity id directly via its
+/// out-param, so it does not populate this map.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`]. `out`
+/// must point to at least `capacity` writable `u64` slots when
+/// `capacity > 0`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_elevator_lookup_iter(
+    handle: *mut EvSim,
+    out: *mut u64,
+    capacity: u32,
+    out_written: *mut u32,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() || out_written.is_null() {
+            set_last_error("handle or out_written is null");
+            return EvStatus::NullArg;
+        }
+        if capacity > 0 && out.is_null() {
+            set_last_error("out is null but capacity > 0");
+            return EvStatus::NullArg;
+        }
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        let mut written: u32 = 0;
+        for (config_id, entity) in ev.sim.elevator_lookup_iter() {
+            if written + 2 > capacity {
+                break;
+            }
+            // Safety: caller guarantees `out` has at least `capacity`
+            // writable slots; bounds checked above.
+            unsafe {
+                *out.add(written as usize) = u64::from(*config_id);
+                *out.add(written as usize + 1) = entity_to_u64(*entity);
+            }
+            written += 2;
+        }
+        // Safety: out_written non-null per check above.
+        unsafe { *out_written = written };
+        EvStatus::Ok
+    })
+}
+
 /// Snapshot of the config-time `StopId` → runtime `EntityId` map.
 ///
 /// Buffer-pattern accessor; emits flat `[stop_id_as_u64, entity_id, ...]`

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -2434,6 +2434,18 @@ impl WasmSim {
             .map_or(0, entity_to_u64)
     }
 
+    /// Resolve a config-time `ElevatorConfig.id` (the `u32` from RON
+    /// config) to its runtime `EntityId`. Returns `0` (slotmap-null)
+    /// for unknown ids or for runtime-added elevators that were not
+    /// in the initial config.
+    #[wasm_bindgen(js_name = elevatorEntity)]
+    #[must_use]
+    pub fn elevator_entity(&self, elevator_config_id: u32) -> u64 {
+        self.inner
+            .elevator_entity(elevator_config_id)
+            .map_or(0, entity_to_u64)
+    }
+
     /// Snapshot of the config-time `StopId` → runtime `EntityId` map.
     /// Returns a flat `[stop_id_as_u64, entity_id, ...]` array — the
     /// `StopId` is zero-extended into the same `u64` slot the entity
@@ -2444,6 +2456,20 @@ impl WasmSim {
         self.inner
             .stop_lookup_iter()
             .flat_map(|(stop_id, entity)| [u64::from(stop_id.0), entity_to_u64(*entity)])
+            .collect()
+    }
+
+    /// Snapshot of the config-time `ElevatorConfig.id` → runtime
+    /// `EntityId` map. Returns a flat `[config_id_as_u64, entity_id,
+    /// ...]` array. Pair count is `array.length / 2`. Only elevators
+    /// from the initial config appear — runtime-added elevators are
+    /// not in this map.
+    #[wasm_bindgen(js_name = elevatorLookupIter)]
+    #[must_use]
+    pub fn elevator_lookup_iter(&self) -> Vec<u64> {
+        self.inner
+            .elevator_lookup_iter()
+            .flat_map(|(config_id, entity)| [u64::from(*config_id), entity_to_u64(*entity)])
             .collect()
     }
 

--- a/examples/gms2-extension/extension/elevator_ffi/elevator_ffi.gml
+++ b/examples/gms2-extension/extension/elevator_ffi/elevator_ffi.gml
@@ -166,6 +166,17 @@ function ev_event_decode(_buf, _offset) {
 // before returning — no caller-side cleanup needed. On failure, the
 // underlying ev_last_error() carries the diagnostic string.
 
+// NaN-encoded `Option::None` sentinel for the optional bypass-load
+// fields on EvElevatorParams. Per the C header:
+//
+//   "bypass_load_up_pct and bypass_load_down_pct: NaN encodes
+//    Option::None; any finite value is treated as Some(v)."
+//
+// Passing `0` to disable bypass would silently configure
+// "bypass-at-0%-load" (i.e. always bypass) — set the field to
+// `EV_BYPASS_NONE` (or leave it unset on the struct) to opt out.
+#macro EV_BYPASS_NONE NaN
+
 /// Spawn a rider from origin → dest with the given weight (kg).
 /// Returns the new rider id, or 0 if the call failed.
 function ev_sim_spawn_rider_easy(_handle, _origin, _dest, _weight) {
@@ -220,11 +231,25 @@ function ev_sim_add_stop_easy(_handle, _line_entity_id, _name, _position) {
 /// `_restricted_stops` is an array of stop entity ids (may be empty).
 /// Returns the new elevator entity id, or 0 on failure.
 ///
+/// `bypass_load_up_pct` / `bypass_load_down_pct` are optional: set them
+/// to `EV_BYPASS_NONE` (or omit the field entirely) to disable bypass;
+/// a finite value in `[0.0, 1.0]` enables bypass at that load fraction.
+/// Passing `0` here silently means "bypass at 0% load" (i.e. always
+/// bypass) — the helper substitutes `EV_BYPASS_NONE` for missing fields
+/// so the safe default is "disabled", not "always on".
+///
 /// Builds the EvElevatorParams scratch buffer using the layout offsets
 /// auto-generated in elevator_ffi_layout.gml so a future field shuffle
 /// reflows here automatically.
 function ev_sim_add_elevator_easy(_handle, _params, _restricted_stops,
                                   _line_entity_id, _starting_position) {
+    var _bypass_up = variable_struct_exists(_params, "bypass_load_up_pct")
+        ? _params.bypass_load_up_pct
+        : EV_BYPASS_NONE;
+    var _bypass_down = variable_struct_exists(_params, "bypass_load_down_pct")
+        ? _params.bypass_load_down_pct
+        : EV_BYPASS_NONE;
+
     var _params_buf = buffer_create(EV_ELEVATOR_PARAMS_SIZE, buffer_fixed, 1);
     buffer_poke(_params_buf, EV_ELEVATOR_PARAMS_MAX_SPEED_OFFSET,                buffer_f64, _params.max_speed);
     buffer_poke(_params_buf, EV_ELEVATOR_PARAMS_ACCELERATION_OFFSET,             buffer_f64, _params.acceleration);
@@ -233,8 +258,8 @@ function ev_sim_add_elevator_easy(_handle, _params, _restricted_stops,
     buffer_poke(_params_buf, EV_ELEVATOR_PARAMS_DOOR_TRANSITION_TICKS_OFFSET,    buffer_u32, _params.door_transition_ticks);
     buffer_poke(_params_buf, EV_ELEVATOR_PARAMS_DOOR_OPEN_TICKS_OFFSET,          buffer_u32, _params.door_open_ticks);
     buffer_poke(_params_buf, EV_ELEVATOR_PARAMS_INSPECTION_SPEED_FACTOR_OFFSET,  buffer_f64, _params.inspection_speed_factor);
-    buffer_poke(_params_buf, EV_ELEVATOR_PARAMS_BYPASS_LOAD_UP_PCT_OFFSET,       buffer_f64, _params.bypass_load_up_pct);
-    buffer_poke(_params_buf, EV_ELEVATOR_PARAMS_BYPASS_LOAD_DOWN_PCT_OFFSET,     buffer_f64, _params.bypass_load_down_pct);
+    buffer_poke(_params_buf, EV_ELEVATOR_PARAMS_BYPASS_LOAD_UP_PCT_OFFSET,       buffer_f64, _bypass_up);
+    buffer_poke(_params_buf, EV_ELEVATOR_PARAMS_BYPASS_LOAD_DOWN_PCT_OFFSET,     buffer_f64, _bypass_down);
 
     var _restricted_count = array_length(_restricted_stops);
     var _restricted_addr = 0;
@@ -320,7 +345,7 @@ function ev_drain_u64_buffer(_handle, _drain_fn) {
             break;
         }
         var _written = buffer_peek(_written_buf, 0, buffer_u32);
-        if (_written < _capacity || _written == 0) {
+        if (_written < _capacity) {
             var _out = array_create(_written);
             for (var i = 0; i < _written; i++) {
                 _out[i] = buffer_peek(_buf, i * 8, buffer_u64);

--- a/examples/gms2-extension/extension/elevator_ffi/elevator_ffi.gml
+++ b/examples/gms2-extension/extension/elevator_ffi/elevator_ffi.gml
@@ -126,25 +126,239 @@ function ev_drain_log_messages_into_array(_handle) {
     return _out;
 }
 
+// ── EvEvent decoder ─────────────────────────────────────────────────
+//
+// Layout (88 bytes, ABI v5+) consumed via EV_EVENT_*_OFFSET macros from
+// elevator_ffi_layout.gml. EvEventKind is a u8 discriminator (49 kinds);
+// see the cbindgen header for the numeric mapping. Direction is i8.
+
+/// Decode a single EvEvent out of `_buf` at `_offset`.
+///
+/// Returns a struct with every byte of the event. Reader code typically
+/// dispatches on `kind`; numeric u8/i8/u32/u64/f64 fields are read as
+/// GML reals, with the entity-id u64s preserved exactly via buffer_u64.
+function ev_event_decode(_buf, _offset) {
+    return {
+        kind:      buffer_peek(_buf, _offset + EV_EVENT_KIND_OFFSET,      buffer_u8),
+        direction: buffer_peek(_buf, _offset + EV_EVENT_DIRECTION_OFFSET, buffer_s8),
+        code1:     buffer_peek(_buf, _offset + EV_EVENT_CODE1_OFFSET,     buffer_u8),
+        code2:     buffer_peek(_buf, _offset + EV_EVENT_CODE2_OFFSET,     buffer_u8),
+        group:     buffer_peek(_buf, _offset + EV_EVENT_GROUP_OFFSET,     buffer_u32),
+        tick:      buffer_peek(_buf, _offset + EV_EVENT_TICK_OFFSET,      buffer_u64),
+        stop:      buffer_peek(_buf, _offset + EV_EVENT_STOP_OFFSET,      buffer_u64),
+        car:       buffer_peek(_buf, _offset + EV_EVENT_CAR_OFFSET,       buffer_u64),
+        rider:     buffer_peek(_buf, _offset + EV_EVENT_RIDER_OFFSET,     buffer_u64),
+        floor:     buffer_peek(_buf, _offset + EV_EVENT_FLOOR_OFFSET,     buffer_u64),
+        entity:    buffer_peek(_buf, _offset + EV_EVENT_ENTITY_OFFSET,    buffer_u64),
+        count:     buffer_peek(_buf, _offset + EV_EVENT_COUNT_OFFSET,     buffer_u64),
+        f1:        buffer_peek(_buf, _offset + EV_EVENT_F1_OFFSET,        buffer_f64),
+        f2:        buffer_peek(_buf, _offset + EV_EVENT_F2_OFFSET,        buffer_f64),
+        tag:       buffer_peek(_buf, _offset + EV_EVENT_TAG_OFFSET,       buffer_u64),
+    };
+}
+
+// ── Out-param ergonomics: buffer allocate → call → peek → free ──────
+//
+// Every FFI call below is auto-generated in elevator_ffi_generated.gml.
+// The wrappers here just spare consumers from writing the buffer dance
+// for the most common rider/topology calls. Each `_easy` helper returns
+// the produced id (or 0 on failure) and clears its scratch buffer
+// before returning — no caller-side cleanup needed. On failure, the
+// underlying ev_last_error() carries the diagnostic string.
+
+/// Spawn a rider from origin → dest with the given weight (kg).
+/// Returns the new rider id, or 0 if the call failed.
+function ev_sim_spawn_rider_easy(_handle, _origin, _dest, _weight) {
+    var _buf = buffer_create(8, buffer_fixed, 1);
+    var _status = ev_sim_spawn_rider(_handle, _origin, _dest, _weight,
+                                     buffer_get_address(_buf));
+    var _rider_id = (_status == 0) ? buffer_peek(_buf, 0, buffer_u64) : 0;
+    buffer_delete(_buf);
+    return _rider_id;
+}
+
+/// Create a new dispatch group. Returns the new group id (u32 widened
+/// into a real), or -1 on failure (group 0 is the legacy default group
+/// and so cannot serve as a sentinel).
+function ev_sim_add_group_easy(_handle, _name, _strategy) {
+    var _buf = buffer_create(4, buffer_fixed, 1);
+    var _status = ev_sim_add_group(_handle, _name, _strategy,
+                                   buffer_get_address(_buf));
+    var _group_id = (_status == 0) ? buffer_peek(_buf, 0, buffer_u32) : -1;
+    buffer_delete(_buf);
+    return _group_id;
+}
+
+/// Add a new line to a group. Returns the new line entity id, or 0
+/// on failure.
+function ev_sim_add_line_easy(_handle, _group_id, _name, _min_position,
+                              _max_position, _max_cars) {
+    var _buf = buffer_create(8, buffer_fixed, 1);
+    var _status = ev_sim_add_line(_handle, _group_id, _name, _min_position,
+                                  _max_position, _max_cars,
+                                  buffer_get_address(_buf));
+    var _entity = (_status == 0) ? buffer_peek(_buf, 0, buffer_u64) : 0;
+    buffer_delete(_buf);
+    return _entity;
+}
+
+/// Add a new stop to a line. Returns the new stop entity id, or 0 on
+/// failure.
+function ev_sim_add_stop_easy(_handle, _line_entity_id, _name, _position) {
+    var _buf = buffer_create(8, buffer_fixed, 1);
+    var _status = ev_sim_add_stop(_handle, _line_entity_id, _name, _position,
+                                  buffer_get_address(_buf));
+    var _entity = (_status == 0) ? buffer_peek(_buf, 0, buffer_u64) : 0;
+    buffer_delete(_buf);
+    return _entity;
+}
+
+/// Add a new elevator to a line. `_params` is a GML struct carrying the
+/// EvElevatorParams fields (max_speed, acceleration, deceleration,
+/// weight_capacity, door_transition_ticks, door_open_ticks,
+/// inspection_speed_factor, bypass_load_up_pct, bypass_load_down_pct).
+/// `_restricted_stops` is an array of stop entity ids (may be empty).
+/// Returns the new elevator entity id, or 0 on failure.
+///
+/// Builds the EvElevatorParams scratch buffer using the layout offsets
+/// auto-generated in elevator_ffi_layout.gml so a future field shuffle
+/// reflows here automatically.
+function ev_sim_add_elevator_easy(_handle, _params, _restricted_stops,
+                                  _line_entity_id, _starting_position) {
+    var _params_buf = buffer_create(EV_ELEVATOR_PARAMS_SIZE, buffer_fixed, 1);
+    buffer_poke(_params_buf, EV_ELEVATOR_PARAMS_MAX_SPEED_OFFSET,                buffer_f64, _params.max_speed);
+    buffer_poke(_params_buf, EV_ELEVATOR_PARAMS_ACCELERATION_OFFSET,             buffer_f64, _params.acceleration);
+    buffer_poke(_params_buf, EV_ELEVATOR_PARAMS_DECELERATION_OFFSET,             buffer_f64, _params.deceleration);
+    buffer_poke(_params_buf, EV_ELEVATOR_PARAMS_WEIGHT_CAPACITY_OFFSET,          buffer_f64, _params.weight_capacity);
+    buffer_poke(_params_buf, EV_ELEVATOR_PARAMS_DOOR_TRANSITION_TICKS_OFFSET,    buffer_u32, _params.door_transition_ticks);
+    buffer_poke(_params_buf, EV_ELEVATOR_PARAMS_DOOR_OPEN_TICKS_OFFSET,          buffer_u32, _params.door_open_ticks);
+    buffer_poke(_params_buf, EV_ELEVATOR_PARAMS_INSPECTION_SPEED_FACTOR_OFFSET,  buffer_f64, _params.inspection_speed_factor);
+    buffer_poke(_params_buf, EV_ELEVATOR_PARAMS_BYPASS_LOAD_UP_PCT_OFFSET,       buffer_f64, _params.bypass_load_up_pct);
+    buffer_poke(_params_buf, EV_ELEVATOR_PARAMS_BYPASS_LOAD_DOWN_PCT_OFFSET,     buffer_f64, _params.bypass_load_down_pct);
+
+    var _restricted_count = array_length(_restricted_stops);
+    var _restricted_addr = 0;
+    var _restricted_buf = undefined;
+    if (_restricted_count > 0) {
+        _restricted_buf = buffer_create(8 * _restricted_count, buffer_fixed, 1);
+        for (var i = 0; i < _restricted_count; i++) {
+            buffer_poke(_restricted_buf, i * 8, buffer_u64, _restricted_stops[i]);
+        }
+        _restricted_addr = buffer_get_address(_restricted_buf);
+    }
+
+    var _out_buf = buffer_create(8, buffer_fixed, 1);
+    var _status = ev_sim_add_elevator(_handle, buffer_get_address(_params_buf),
+                                      _restricted_addr, _restricted_count,
+                                      _line_entity_id, _starting_position,
+                                      buffer_get_address(_out_buf));
+    var _entity = (_status == 0) ? buffer_peek(_out_buf, 0, buffer_u64) : 0;
+    buffer_delete(_params_buf);
+    buffer_delete(_out_buf);
+    if (!is_undefined(_restricted_buf)) {
+        buffer_delete(_restricted_buf);
+    }
+    return _entity;
+}
+
+// ── Array-returning drains ──────────────────────────────────────────
+//
+// Same chunked-loop pattern as ev_drain_log_messages_into_array. Each
+// returns a fresh GML array; callers don't share buffers with the
+// FFI side.
+
+/// Drain all pending events into a GML array of decoded structs. Each
+/// element is the result of `ev_event_decode`. Drains in chunks of
+/// `_CHUNK` until the queue is empty, so the returned array is the
+/// complete tail of events emitted since the previous call.
+function ev_sim_drain_events_into_array(_handle) {
+    var _CHUNK = 256;
+    var _buf = buffer_create(EV_EVENT_SIZE * _CHUNK, buffer_fixed, 1);
+    var _written_buf = buffer_create(4, buffer_fixed, 1);
+    var _addr_buf = buffer_get_address(_buf);
+    var _addr_written = buffer_get_address(_written_buf);
+
+    var _out = [];
+    while (true) {
+        var _status = ev_sim_drain_events(_handle, _addr_buf, _CHUNK, _addr_written);
+        if (_status != 0) {
+            break;
+        }
+        var _written = buffer_peek(_written_buf, 0, buffer_u32);
+        for (var i = 0; i < _written; i++) {
+            array_push(_out, ev_event_decode(_buf, i * EV_EVENT_SIZE));
+        }
+        if (_written < _CHUNK) {
+            break;
+        }
+    }
+
+    buffer_delete(_buf);
+    buffer_delete(_written_buf);
+    return _out;
+}
+
+/// Helper for buffer-pattern accessors that emit a flat `u64[]`. Calls
+/// `_drain_fn(_handle, addr, capacity, addr_written)` repeatedly with
+/// a growing buffer until the entire result fits in one read. Returns
+/// a GML array of u64 ids (or an empty array on failure).
+///
+/// `_drain_fn` is invoked as `_drain_fn(_handle, _addr_buf, _capacity,
+/// _addr_written)`. Use `method` to bind an extra leading argument (see
+/// `ev_sim_elevators_on_line_into_array` for the pattern).
+function ev_drain_u64_buffer(_handle, _drain_fn) {
+    var _capacity = 64;
+    var _written_buf = buffer_create(4, buffer_fixed, 1);
+    var _addr_written = buffer_get_address(_written_buf);
+
+    while (true) {
+        var _buf = buffer_create(8 * _capacity, buffer_fixed, 1);
+        var _addr_buf = buffer_get_address(_buf);
+        var _status = _drain_fn(_handle, _addr_buf, _capacity, _addr_written);
+        if (_status != 0) {
+            buffer_delete(_buf);
+            break;
+        }
+        var _written = buffer_peek(_written_buf, 0, buffer_u32);
+        if (_written < _capacity || _written == 0) {
+            var _out = array_create(_written);
+            for (var i = 0; i < _written; i++) {
+                _out[i] = buffer_peek(_buf, i * 8, buffer_u64);
+            }
+            buffer_delete(_buf);
+            buffer_delete(_written_buf);
+            return _out;
+        }
+        // A full read means there may be more — grow and retry.
+        buffer_delete(_buf);
+        _capacity *= 2;
+    }
+    buffer_delete(_written_buf);
+    return [];
+}
+
+/// Entity ids of every line across all groups. Empty array on failure.
+function ev_sim_all_lines_into_array(_handle) {
+    return ev_drain_u64_buffer(_handle, ev_sim_all_lines);
+}
+
+/// Entity ids of every elevator attached to `_line_entity_id`. Empty
+/// array if the line has no cars (or on failure — check ev_last_error
+/// to disambiguate).
+function ev_sim_elevators_on_line_into_array(_handle, _line_entity_id) {
+    var _line = _line_entity_id;
+    var _bound = method({ line: _line }, function(_h, _addr, _cap, _addr_written) {
+        return ev_sim_elevators_on_line(_h, line, _addr, _cap, _addr_written);
+    });
+    return ev_drain_u64_buffer(_handle, _bound);
+}
+
 // ── Struct decoders for other repr-C types ──────────────────────────
 //
-// EvEvent (88 bytes, 49 kinds), EvFrame, EvElevatorView, EvStopView,
-// EvRiderView, EvHallCall, EvCarCall, EvMetrics, EvElevatorParams,
-// EvAssignment, EvTaggedMetric — extend as needed following the
-// EvLogMessage pattern above. The byte layouts are stable across
-// `cbindgen` runs as long as no field is added or reordered; the C
-// harness in examples/gms2-harness/main.c asserts each offset against
-// the cbindgen-generated header so a future drift fails CI before
-// this file is touched.
-//
-// For ABI v5 the EvEvent layout is:
-//   0:  u8  kind          16: u64 stop          56: u64 count
-//   1:  i8  direction     24: u64 car           64: f64 f1
-//   2:  u8  code1          32: u64 rider         72: f64 f2
-//   3:  u8  code2          40: u64 floor         80: u64 tag
-//   4:  u32 group          48: u64 entity
-//   8:  u64 tick
-//
-// Implement ev_event_decode along the same shape as
-// ev_log_message_decode when the GameMaker game needs to consume
-// events directly from GML.
+// EvFrame, EvElevatorView, EvStopView, EvRiderView, EvHallCall,
+// EvCarCall, EvMetrics, EvAssignment, EvTaggedMetric — extend as
+// needed following the EvLogMessage / EvEvent pattern above. The byte
+// layouts are auto-generated in elevator_ffi_layout.gml; the C harness
+// in examples/gms2-harness/main.c asserts every offset against
+// cbindgen's header so a future drift fails CI before this file is
+// touched.

--- a/examples/gms2-extension/extension/elevator_ffi/elevator_ffi_generated.gml
+++ b/examples/gms2-extension/extension/elevator_ffi/elevator_ffi_generated.gml
@@ -244,6 +244,13 @@ global._ev_sim_elevator_direction_handle = external_define(
 function ev_sim_elevator_direction(a0, a1) {
     return external_call(global._ev_sim_elevator_direction_handle, a0, a1);
 }
+// ev_sim_elevator_entity — auto-generated wrapper.
+global._ev_sim_elevator_entity_handle = external_define(
+    "elevator_ffi", "ev_sim_elevator_entity", dll_cdecl, ty_real, 2, ty_real, ty_real
+);
+function ev_sim_elevator_entity(a0, a1) {
+    return external_call(global._ev_sim_elevator_entity_handle, a0, a1);
+}
 // ev_sim_elevator_going_down — auto-generated wrapper.
 global._ev_sim_elevator_going_down_handle = external_define(
     "elevator_ffi", "ev_sim_elevator_going_down", dll_cdecl, ty_real, 2, ty_real, ty_real
@@ -271,6 +278,13 @@ global._ev_sim_elevator_load_handle = external_define(
 );
 function ev_sim_elevator_load(a0, a1) {
     return external_call(global._ev_sim_elevator_load_handle, a0, a1);
+}
+// ev_sim_elevator_lookup_iter — auto-generated wrapper.
+global._ev_sim_elevator_lookup_iter_handle = external_define(
+    "elevator_ffi", "ev_sim_elevator_lookup_iter", dll_cdecl, ty_real, 4, ty_real, ty_real, ty_real, ty_real
+);
+function ev_sim_elevator_lookup_iter(a0, a1, a2, a3) {
+    return external_call(global._ev_sim_elevator_lookup_iter_handle, a0, a1, a2, a3);
 }
 // ev_sim_elevator_move_count — auto-generated wrapper.
 global._ev_sim_elevator_move_count_handle = external_define(
@@ -377,6 +391,13 @@ global._ev_sim_is_elevator_handle = external_define(
 function ev_sim_is_elevator(a0, a1) {
     return external_call(global._ev_sim_is_elevator_handle, a0, a1);
 }
+// ev_sim_is_loop — auto-generated wrapper.
+global._ev_sim_is_loop_handle = external_define(
+    "elevator_ffi", "ev_sim_is_loop", dll_cdecl, ty_real, 2, ty_real, ty_real
+);
+function ev_sim_is_loop(a0, a1) {
+    return external_call(global._ev_sim_is_loop_handle, a0, a1);
+}
 // ev_sim_is_rider — auto-generated wrapper.
 global._ev_sim_is_rider_handle = external_define(
     "elevator_ffi", "ev_sim_is_rider", dll_cdecl, ty_real, 2, ty_real, ty_real
@@ -425,6 +446,34 @@ global._ev_sim_lines_serving_stop_handle = external_define(
 );
 function ev_sim_lines_serving_stop(a0, a1, a2, a3, a4) {
     return external_call(global._ev_sim_lines_serving_stop_handle, a0, a1, a2, a3, a4);
+}
+// ev_sim_loop_circumference — auto-generated wrapper.
+global._ev_sim_loop_circumference_handle = external_define(
+    "elevator_ffi", "ev_sim_loop_circumference", dll_cdecl, ty_real, 3, ty_real, ty_real, ty_real
+);
+function ev_sim_loop_circumference(a0, a1, a2) {
+    return external_call(global._ev_sim_loop_circumference_handle, a0, a1, a2);
+}
+// ev_sim_loop_forward_gap — auto-generated wrapper.
+global._ev_sim_loop_forward_gap_handle = external_define(
+    "elevator_ffi", "ev_sim_loop_forward_gap", dll_cdecl, ty_real, 3, ty_real, ty_real, ty_real
+);
+function ev_sim_loop_forward_gap(a0, a1, a2) {
+    return external_call(global._ev_sim_loop_forward_gap_handle, a0, a1, a2);
+}
+// ev_sim_loop_leader — auto-generated wrapper.
+global._ev_sim_loop_leader_handle = external_define(
+    "elevator_ffi", "ev_sim_loop_leader", dll_cdecl, ty_real, 3, ty_real, ty_real, ty_real
+);
+function ev_sim_loop_leader(a0, a1, a2) {
+    return external_call(global._ev_sim_loop_leader_handle, a0, a1, a2);
+}
+// ev_sim_loop_next_stop — auto-generated wrapper.
+global._ev_sim_loop_next_stop_handle = external_define(
+    "elevator_ffi", "ev_sim_loop_next_stop", dll_cdecl, ty_real, 4, ty_real, ty_real, ty_real, ty_real
+);
+function ev_sim_loop_next_stop(a0, a1, a2, a3) {
+    return external_call(global._ev_sim_loop_next_stop_handle, a0, a1, a2, a3);
 }
 // ev_sim_metrics — auto-generated wrapper.
 global._ev_sim_metrics_handle = external_define(
@@ -868,16 +917,21 @@ function ev_sim_waiting_direction_counts_at(a0, a1, a2, a3) {
 // build_dispatch_manifest — skip:internal — strategies consume this
 // dispatchers — skip:returns trait-object slice — never bound
 // dispatchers_mut — skip:returns &mut trait-object slice — never bound
+// drain_events_by_kind — todo:future-binding
+// drain_events_for_entity — todo:future-binding
 // drain_events_where — skip:closure marshaling — C consumers filter drain_events output
+// elevator_id — todo:future-binding
 // ev_set_log_callback — skip:no_function_pointers — GML cannot pass C function pointers
 // events_mut — skip:returns &mut EventBus — never bound
 // groups — skip:returns &[ElevatorGroup] — internal layout
 // groups_mut — skip:returns &mut [ElevatorGroup] — never bound
+// is_strict_phase_order — skip:internal — phase ordering invariant
 // load_extensions — skip:builder-pattern entry point — runs at construction
 // load_extensions_with — skip:takes a generic closure
 // metrics_mut — skip:returns &mut Metrics — never bound
 // peek_dispatch_manifest — skip:internal — strategies consume this
 // phase_context — skip:returns PhaseContext — internal scheduling helper
+// rider_id — todo:future-binding
 // run_advance_queue — skip:internal — phase ordering invariant
 // run_advance_transient — skip:internal — phase ordering invariant
 // run_dispatch — skip:internal — phase ordering invariant
@@ -886,6 +940,8 @@ function ev_sim_waiting_direction_counts_at(a0, a1, a2, a3) {
 // run_metrics — skip:internal — phase ordering invariant
 // run_movement — skip:internal — phase ordering invariant
 // run_reposition — skip:internal — phase ordering invariant
+// set_strict_phase_order — skip:internal — phase ordering invariant
+// step_many — todo:future-binding
 // time — skip:returns &TimeAdapter — internal layout
 // world — skip:returns &World — consumers use ev_sim_frame
 // world_mut — skip:returns &mut World — never bound


### PR DESCRIPTION
## Summary

- Closes #867 — adds `Simulation::elevator_entity(u32)` (mirror of `stop_entity`) plus `elevator_lookup_iter`. Wired through FFI (`ev_sim_elevator_entity`, `ev_sim_elevator_lookup_iter`), wasm (`elevatorEntity`, `elevatorLookupIter`), and the regenerated GMS GML wrappers. Snapshot adds a `#[serde(default)]` field so legacy snapshots restore cleanly (empty map → `elevator_entity` returns `None` on those sims).
- Closes #868 — adds hand-written GMS buffer-out-param helpers in `elevator_ffi.gml` so consumers don't re-derive the alloc-buf → peek → free dance for `spawn_rider`, the four `add_*` constructors, `drain_events`, `all_lines`, and `elevators_on_line`. Also adds `ev_event_decode` (the EvEvent layout was already documented but had no decoder shipped).
- Defers #869 (.yy / .yymps packaging) — its body explicitly gates it on a Windows binary in the release artifact, which isn't shipped yet.

## Design notes

- `elevator_lookup` is a config-time map only — runtime `add_elevator` takes `ElevatorParams` (no config id) and already returns `EntityId` directly via its out-param, so it intentionally does not populate the map. Mirrors how `stop_lookup` works (`add_stop` runtime path also bypasses it). Snapshot uses `BTreeMap<u32, usize>` for deterministic bytes across processes — same pattern as `stop_lookup`.
- GMS helpers consume the auto-generated `EV_*_OFFSET` macros from `elevator_ffi_layout.gml`, so a future cbindgen field reorder reflows here automatically. `ev_sim_add_elevator_easy` is the trickiest one — it builds the `EvElevatorParams` scratch buffer field-by-field using those offsets.
- `release-please` will bump `elevator-core`, `elevator-ffi`, and `elevator-wasm` because all three export the new method — that's the intended outcome.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features` (1073 lib + scenarios + doctests, all pass)
- [x] New tests in `api_surface_tests.rs`: `elevator_entity_resolves_config_id`, `remove_elevator_removes_from_elevator_lookup`, `runtime_added_elevator_not_in_lookup`
- [x] New snapshot test: `snapshot_roundtrip_preserves_elevator_lookup`
- [x] `bash scripts/check-bindings.sh` — 157 methods in sync, FFI/wasm/gms all at 122 exported
- [x] `bash scripts/check-abi-pins.sh` — ABI v5 still in sync across 8 watched files
- [x] cbindgen header diff regenerated; GMS `elevator_ffi_generated.gml` regenerated (127 exported, 36 skipped)