### PR TITLE
feat: add line_entity accessor and broaden GMS array helpers

### DIFF
--- a/assets/contract-corpus/golden.txt
+++ b/assets/contract-corpus/golden.txt
@@ -1,8 +1,8 @@
 # Golden snapshot checksums for contract scenarios.
 # Regenerate via: cargo run -p elevator-contract -- --update-golden
 # tick budget: 600
-default 0xda961517810d5e2f
-dense_traffic 0xd23c89119ae9c69f
-extreme_load 0x190765fe58787d57
-multi_group 0x05b65b9ee1789f0b
-sparse 0xe0e2d1f48a0ae295
+default 0x1a52e87b42fb4379
+dense_traffic 0xc50be9274d42a36b
+extreme_load 0x3226ff281b37f565
+multi_group 0xe29fe64c3f72c92b
+sparse 0xbc682f2d44fe841b

--- a/bindings.toml
+++ b/bindings.toml
@@ -1056,6 +1056,26 @@ gdext = "todo:future-binding"
 bevy = "todo:plugin-layer"
 
 [[methods]]
+name = "line_entity"
+category = "introspection"
+wasm = "lineEntity"
+ffi  = "ev_sim_line_entity"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_line_entity"
+gdext = "todo:future-binding"
+bevy = "todo:plugin-layer"
+
+[[methods]]
+name = "line_lookup_iter"
+category = "introspection"
+wasm = "lineLookupIter"
+ffi  = "ev_sim_line_lookup_iter"
+tui  = "skip:read-only v1 — interactive viewer does not expose mutators"
+gms  = "ev_sim_line_lookup_iter"
+gdext = "todo:future-binding"
+bevy = "todo:plugin-layer"
+
+[[methods]]
 name = "find_stop_at_position_on_line"
 category = "introspection"
 wasm = "findStopAtPositionOnLine"

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -215,6 +215,13 @@ pub struct Simulation {
     /// returns the new `EntityId` directly, so it does not populate
     /// this map. Mirror of [`Self::stop_lookup`] semantics.
     elevator_lookup: HashMap<u32, EntityId>,
+    /// Config-time `LineConfig.id` → runtime `EntityId` mapping.
+    /// Populated only for lines from an explicit `building.lines` block
+    /// in the config; legacy (flat-elevator-list) configs build a single
+    /// default line with no config id, so this stays empty for them.
+    /// Runtime `add_line` takes `LineParams` (no config id) and returns
+    /// the entity directly. Mirror of [`Self::stop_lookup`] semantics.
+    line_lookup: HashMap<u32, EntityId>,
     /// Dispatch strategies + their snapshot identities, keyed by group.
     /// Owns both halves so insert/remove stay atomic — see
     /// [`DispatcherSet`].

--- a/crates/elevator-core/src/sim/accessors.rs
+++ b/crates/elevator-core/src/sim/accessors.rs
@@ -179,6 +179,19 @@ impl super::Simulation {
         self.elevator_lookup.get(&id).copied()
     }
 
+    /// Resolve a config-time `LineConfig.id` to its runtime `EntityId`.
+    ///
+    /// Only lines from an explicit `building.lines` block are
+    /// addressable here. Legacy configs (flat elevator list, no
+    /// `lines` block) build a single default line with no config id,
+    /// so this returns `None` for every id on those sims. Runtime
+    /// [`Self::add_line`] takes `LineParams` (no config id) and
+    /// returns the new entity directly.
+    #[must_use]
+    pub fn line_entity(&self, id: u32) -> Option<EntityId> {
+        self.line_lookup.get(&id).copied()
+    }
+
     /// Resolve a [`StopRef`] to its runtime [`EntityId`].
     pub(super) fn resolve_stop(&self, stop: StopRef) -> Result<EntityId, SimError> {
         match stop {
@@ -203,6 +216,12 @@ impl super::Simulation {
     /// [`Self::elevator_entity`].
     pub fn elevator_lookup_iter(&self) -> impl Iterator<Item = (&u32, &EntityId)> {
         self.elevator_lookup.iter()
+    }
+
+    /// Iterate over the line config ID → entity ID mapping. Empty on
+    /// legacy configs; see [`Self::line_entity`].
+    pub fn line_lookup_iter(&self) -> impl Iterator<Item = (&u32, &EntityId)> {
+        self.line_lookup.iter()
     }
 
     /// Peek at events pending for consumer retrieval.

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -267,6 +267,7 @@ impl Simulation {
         world.insert_resource(crate::time::TickRate(config.simulation.ticks_per_second));
 
         let mut elevator_lookup: HashMap<u32, EntityId> = HashMap::new();
+        let mut line_lookup: HashMap<u32, EntityId> = HashMap::new();
         let (mut groups, dispatchers, strategy_ids) =
             if let Some(line_configs) = &config.building.lines {
                 Self::build_explicit_topology(
@@ -275,6 +276,7 @@ impl Simulation {
                     line_configs,
                     &stop_lookup,
                     &mut elevator_lookup,
+                    &mut line_lookup,
                     builder_dispatchers,
                 )
             } else {
@@ -351,6 +353,7 @@ impl Simulation {
             groups,
             stop_lookup,
             elevator_lookup,
+            line_lookup,
             dispatcher_set: super::DispatcherSet::from_parts(dispatchers, strategy_ids),
             repositioner_set: super::RepositionerSet::from_parts(repositioners, reposition_ids),
             metrics: Metrics::new(),
@@ -534,6 +537,7 @@ impl Simulation {
         line_configs: &[crate::config::LineConfig],
         stop_lookup: &HashMap<StopId, EntityId>,
         elevator_lookup: &mut HashMap<u32, EntityId>,
+        line_lookup: &mut HashMap<u32, EntityId>,
         builder_dispatchers: BTreeMap<GroupId, Box<dyn DispatchStrategy>>,
     ) -> TopologyResult {
         // Map line config id → (line EntityId, LineInfo). `BTreeMap`
@@ -607,6 +611,7 @@ impl Simulation {
             }
 
             let line_info = LineInfo::new(line_eid, elevator_entities, served_entities);
+            line_lookup.insert(lc.id, line_eid);
             line_map.insert(lc.id, (line_eid, line_info));
         }
 
@@ -701,6 +706,7 @@ impl Simulation {
         groups: Vec<ElevatorGroup>,
         stop_lookup: HashMap<StopId, EntityId>,
         elevator_lookup: HashMap<u32, EntityId>,
+        line_lookup: HashMap<u32, EntityId>,
         dispatchers: BTreeMap<GroupId, Box<dyn DispatchStrategy>>,
         strategy_ids: BTreeMap<GroupId, crate::dispatch::BuiltinStrategy>,
         metrics: Metrics,
@@ -761,6 +767,7 @@ impl Simulation {
             groups,
             stop_lookup,
             elevator_lookup,
+            line_lookup,
             dispatcher_set: super::DispatcherSet::from_parts(dispatchers, strategy_ids),
             repositioner_set: super::RepositionerSet::new(),
             metrics,

--- a/crates/elevator-core/src/sim/topology.rs
+++ b/crates/elevator-core/src/sim/topology.rs
@@ -477,6 +477,12 @@ impl Simulation {
         // Remove Line component from world.
         self.world.remove_line(line);
 
+        // Drop any config-id → entity mapping pointing at the removed
+        // line. Mirrors the stop/elevator lookup cleanup so a
+        // subsequent `line_entity(id)` returns `None` rather than a
+        // dangling entity reference.
+        self.line_lookup.retain(|_, &mut eid| eid != line);
+
         self.mark_topo_dirty();
         self.events.emit(Event::LineRemoved {
             line,

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -114,6 +114,13 @@ pub struct WorldSnapshot {
     /// legacy snapshots fall back to the iteration path).
     #[serde(default)]
     pub elevator_lookup: BTreeMap<u32, usize>,
+    /// Config-time `LineConfig.id` → entity index mapping. Absent in
+    /// legacy snapshots (and on legacy-topology sims that never had a
+    /// `building.lines` block); on restore an empty map means
+    /// [`crate::sim::Simulation::line_entity`] returns `None` for all
+    /// ids — same fall-back semantics as `elevator_lookup`.
+    #[serde(default)]
+    pub line_lookup: BTreeMap<u32, usize>,
     /// Global metrics at snapshot time.
     pub metrics: Metrics,
     /// Per-tag metric accumulators and entity-tag associations.
@@ -401,9 +408,9 @@ impl WorldSnapshot {
         sorted.sort_by(|a, b| a.0.total_cmp(&b.0));
         world.insert_resource(SortedStops(sorted));
 
-        // Rebuild groups, stop/elevator lookup, dispatchers, and
+        // Rebuild groups, stop/elevator/line lookup, dispatchers, and
         // extensions (borrows self).
-        let (mut groups, stop_lookup, elevator_lookup, dispatchers, strategy_ids) =
+        let (mut groups, stop_lookup, elevator_lookup, line_lookup, dispatchers, strategy_ids) =
             self.rebuild_groups_and_dispatchers(&index_to_id, custom_strategy_factory)?;
 
         Self::fix_legacy_line_entities(&mut groups, &mut world);
@@ -431,6 +438,7 @@ impl WorldSnapshot {
             groups,
             stop_lookup,
             elevator_lookup,
+            line_lookup,
             dispatchers,
             strategy_ids,
             self.metrics,
@@ -762,6 +770,7 @@ impl WorldSnapshot {
             Vec<crate::dispatch::ElevatorGroup>,
             HashMap<StopId, EntityId>,
             HashMap<u32, EntityId>,
+            HashMap<u32, EntityId>,
             std::collections::BTreeMap<GroupId, Box<dyn crate::dispatch::DispatchStrategy>>,
             std::collections::BTreeMap<GroupId, crate::dispatch::BuiltinStrategy>,
         ),
@@ -830,6 +839,12 @@ impl WorldSnapshot {
             .filter_map(|(cid, &idx)| index_to_id.get(idx).map(|&eid| (*cid, eid)))
             .collect();
 
+        let line_lookup: HashMap<u32, EntityId> = self
+            .line_lookup
+            .iter()
+            .filter_map(|(cid, &idx)| index_to_id.get(idx).map(|&eid| (*cid, eid)))
+            .collect();
+
         let mut dispatchers = std::collections::BTreeMap::new();
         let mut strategy_ids = std::collections::BTreeMap::new();
         for (gs, group) in self.groups.iter().zip(groups.iter()) {
@@ -854,6 +869,7 @@ impl WorldSnapshot {
             groups,
             stop_lookup,
             elevator_lookup,
+            line_lookup,
             dispatchers,
             strategy_ids,
         ))
@@ -1137,6 +1153,10 @@ impl crate::sim::Simulation {
             .elevator_lookup_iter()
             .filter_map(|(cid, eid)| id_to_index.get(eid).map(|&idx| (*cid, idx)))
             .collect();
+        let line_lookup: BTreeMap<u32, usize> = self
+            .line_lookup_iter()
+            .filter_map(|(cid, eid)| id_to_index.get(eid).map(|&idx| (*cid, idx)))
+            .collect();
 
         WorldSnapshot {
             version: SNAPSHOT_SCHEMA_VERSION,
@@ -1146,6 +1166,7 @@ impl crate::sim::Simulation {
             groups,
             stop_lookup,
             elevator_lookup,
+            line_lookup,
             metrics: self.metrics().clone(),
             metric_tags: self
                 .world()

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -336,6 +336,139 @@ fn remove_elevator_removes_from_elevator_lookup() {
 }
 
 #[test]
+fn legacy_config_has_empty_line_lookup() {
+    // Legacy config (no `building.lines` block) builds one default
+    // line without a config id, so line_entity always returns None.
+    let config = default_config();
+    let sim = Simulation::new(&config, scan()).unwrap();
+    assert!(sim.line_entity(0).is_none());
+    assert!(sim.line_entity(1).is_none());
+    assert_eq!(sim.line_lookup_iter().count(), 0);
+}
+
+#[test]
+fn explicit_topology_line_entity_resolves() {
+    use crate::components::Orientation;
+    use crate::config::{BuildingConfig, ElevatorConfig, LineConfig, SimConfig};
+    use crate::stop::StopConfig;
+
+    let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
+        building: BuildingConfig {
+            name: "LineEntityTest".into(),
+            stops: vec![
+                StopConfig {
+                    id: StopId(0),
+                    name: "G".into(),
+                    position: 0.0,
+                },
+                StopConfig {
+                    id: StopId(1),
+                    name: "T".into(),
+                    position: 10.0,
+                },
+            ],
+            lines: Some(vec![LineConfig {
+                id: 7,
+                name: "Main".into(),
+                serves: vec![StopId(0), StopId(1)],
+                elevators: vec![ElevatorConfig {
+                    id: 0,
+                    name: "E".into(),
+                    max_speed: Speed::from(2.0),
+                    acceleration: Accel::from(1.5),
+                    deceleration: Accel::from(2.0),
+                    weight_capacity: Weight::from(800.0),
+                    starting_stop: StopId(0),
+                    door_open_ticks: 10,
+                    door_transition_ticks: 5,
+                    restricted_stops: Vec::new(),
+                    #[cfg(feature = "energy")]
+                    energy_profile: None,
+                    service_mode: None,
+                    inspection_speed_factor: 0.25,
+                    bypass_load_up_pct: None,
+                    bypass_load_down_pct: None,
+                }],
+                orientation: Orientation::Vertical,
+                position: None,
+                min_position: None,
+                max_position: None,
+                kind: None,
+                max_cars: None,
+            }]),
+            groups: None,
+        },
+        elevators: vec![],
+        ..Default::default()
+    };
+
+    let sim = Simulation::new(&config, scan()).unwrap();
+    let line = sim.line_entity(7).expect("LineConfig.id 7 should resolve");
+    assert!(sim.world().line(line).is_some());
+    assert!(sim.line_entity(99).is_none());
+}
+
+#[test]
+fn remove_line_removes_from_line_lookup() {
+    use crate::components::Orientation;
+    use crate::config::{BuildingConfig, ElevatorConfig, LineConfig, SimConfig};
+    use crate::stop::StopConfig;
+
+    let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
+        building: BuildingConfig {
+            name: "LineRemovalTest".into(),
+            stops: vec![StopConfig {
+                id: StopId(0),
+                name: "G".into(),
+                position: 0.0,
+            }],
+            lines: Some(vec![LineConfig {
+                id: 42,
+                name: "Doomed".into(),
+                serves: vec![StopId(0)],
+                elevators: vec![ElevatorConfig {
+                    id: 0,
+                    name: "E".into(),
+                    max_speed: Speed::from(2.0),
+                    acceleration: Accel::from(1.5),
+                    deceleration: Accel::from(2.0),
+                    weight_capacity: Weight::from(800.0),
+                    starting_stop: StopId(0),
+                    door_open_ticks: 10,
+                    door_transition_ticks: 5,
+                    restricted_stops: Vec::new(),
+                    #[cfg(feature = "energy")]
+                    energy_profile: None,
+                    service_mode: None,
+                    inspection_speed_factor: 0.25,
+                    bypass_load_up_pct: None,
+                    bypass_load_down_pct: None,
+                }],
+                orientation: Orientation::Vertical,
+                position: None,
+                min_position: None,
+                max_position: None,
+                kind: None,
+                max_cars: None,
+            }]),
+            groups: None,
+        },
+        elevators: vec![],
+        ..Default::default()
+    };
+
+    let mut sim = Simulation::new(&config, scan()).unwrap();
+    let line = sim.line_entity(42).unwrap();
+    sim.remove_line(line).unwrap();
+    assert!(
+        sim.line_entity(42).is_none(),
+        "line_entity should return None after removal"
+    );
+}
+
+#[test]
 fn runtime_added_elevator_not_in_lookup() {
     // Runtime add_elevator takes ElevatorParams (no config id), so the
     // returned entity is intentionally not addressable via elevator_entity.

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -68,6 +68,71 @@ fn snapshot_roundtrip_preserves_stop_lookup() {
 }
 
 #[test]
+fn snapshot_roundtrip_preserves_line_lookup() {
+    use crate::components::Orientation;
+    use crate::components::{Accel, Speed, Weight};
+    use crate::config::{BuildingConfig, ElevatorConfig, LineConfig, SimConfig};
+    use crate::stop::StopConfig;
+
+    let config = SimConfig {
+        schema_version: crate::config::CURRENT_CONFIG_SCHEMA_VERSION,
+        building: BuildingConfig {
+            name: "LineLookupRoundtrip".into(),
+            stops: vec![StopConfig {
+                id: StopId(0),
+                name: "G".into(),
+                position: 0.0,
+            }],
+            lines: Some(vec![LineConfig {
+                id: 3,
+                name: "Main".into(),
+                serves: vec![StopId(0)],
+                elevators: vec![ElevatorConfig {
+                    id: 0,
+                    name: "E".into(),
+                    max_speed: Speed::from(2.0),
+                    acceleration: Accel::from(1.5),
+                    deceleration: Accel::from(2.0),
+                    weight_capacity: Weight::from(800.0),
+                    starting_stop: StopId(0),
+                    door_open_ticks: 10,
+                    door_transition_ticks: 5,
+                    restricted_stops: Vec::new(),
+                    #[cfg(feature = "energy")]
+                    energy_profile: None,
+                    service_mode: None,
+                    inspection_speed_factor: 0.25,
+                    bypass_load_up_pct: None,
+                    bypass_load_down_pct: None,
+                }],
+                orientation: Orientation::Vertical,
+                position: None,
+                min_position: None,
+                max_position: None,
+                kind: None,
+                max_cars: None,
+            }]),
+            groups: None,
+        },
+        elevators: vec![],
+        ..Default::default()
+    };
+
+    let sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
+    assert!(sim.line_entity(3).is_some());
+
+    let snap = sim.snapshot();
+    let restored = snap
+        .restore(crate::snapshot::RestoreOptions::default())
+        .unwrap();
+
+    let restored_line = restored
+        .line_entity(3)
+        .expect("LineConfig.id 3 resolves post-restore");
+    assert!(restored.world().line(restored_line).is_some());
+}
+
+#[test]
 fn snapshot_roundtrip_preserves_elevator_lookup() {
     let config = helpers::default_config();
     let sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();

--- a/crates/elevator-ffi/include/elevator_ffi.h
+++ b/crates/elevator-ffi/include/elevator_ffi.h
@@ -2097,6 +2097,42 @@ uint64_t ev_sim_stop_entity(struct EvSim *handle, uint32_t stop_id);
 uint64_t ev_sim_elevator_entity(struct EvSim *handle, uint32_t elevator_config_id);
 
 /**
+ * Resolve a config-time `LineConfig.id` to its runtime `EntityId`.
+ *
+ * Returns `0` (slotmap-null) for unknown ids. Legacy (flat-elevator-
+ * list) configs build a single default line with no config id, so
+ * this always returns `0` on those sims; the explicit-topology path
+ * (`building.lines` in the RON config) is where this is useful.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`].
+ */
+uint64_t ev_sim_line_entity(struct EvSim *handle, uint32_t line_config_id);
+
+/**
+ * Snapshot of the config-time `LineConfig.id` → runtime `EntityId` map.
+ *
+ * Buffer-pattern accessor; emits flat `[line_config_id_as_u64,
+ * entity_id, ...]` pairs (each pair = 2 `u64` slots). The number of
+ * pairs written is `*out_written / 2`.
+ *
+ * Empty on legacy-topology sims. Runtime [`ev_sim_add_line`] returns
+ * the new entity id directly via its out-param, so it does not
+ * populate this map either.
+ *
+ * # Safety
+ *
+ * `handle` must be a valid pointer returned by [`ev_sim_create`]. `out`
+ * must point to at least `capacity` writable `u64` slots when
+ * `capacity > 0`.
+ */
+enum EvStatus ev_sim_line_lookup_iter(struct EvSim *handle,
+                                      uint64_t *out,
+                                      uint32_t capacity,
+                                      uint32_t *out_written);
+
+/**
  * Snapshot of the config-time `ElevatorConfig.id` → runtime `EntityId` map.
  *
  * Buffer-pattern accessor; emits flat

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -4207,6 +4207,83 @@ pub unsafe extern "C" fn ev_sim_elevator_entity(
     })
 }
 
+/// Resolve a config-time `LineConfig.id` to its runtime `EntityId`.
+///
+/// Returns `0` (slotmap-null) for unknown ids. Legacy (flat-elevator-
+/// list) configs build a single default line with no config id, so
+/// this always returns `0` on those sims; the explicit-topology path
+/// (`building.lines` in the RON config) is where this is useful.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_line_entity(handle: *mut EvSim, line_config_id: u32) -> u64 {
+    guard(0, || {
+        clear_last_error();
+        if handle.is_null() {
+            set_last_error("handle is null");
+            return 0;
+        }
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        ev.sim.line_entity(line_config_id).map_or(0, entity_to_u64)
+    })
+}
+
+/// Snapshot of the config-time `LineConfig.id` → runtime `EntityId` map.
+///
+/// Buffer-pattern accessor; emits flat `[line_config_id_as_u64,
+/// entity_id, ...]` pairs (each pair = 2 `u64` slots). The number of
+/// pairs written is `*out_written / 2`.
+///
+/// Empty on legacy-topology sims. Runtime [`ev_sim_add_line`] returns
+/// the new entity id directly via its out-param, so it does not
+/// populate this map either.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by [`ev_sim_create`]. `out`
+/// must point to at least `capacity` writable `u64` slots when
+/// `capacity > 0`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ev_sim_line_lookup_iter(
+    handle: *mut EvSim,
+    out: *mut u64,
+    capacity: u32,
+    out_written: *mut u32,
+) -> EvStatus {
+    guard(EvStatus::Panic, || {
+        clear_last_error();
+        if handle.is_null() || out_written.is_null() {
+            set_last_error("handle or out_written is null");
+            return EvStatus::NullArg;
+        }
+        if capacity > 0 && out.is_null() {
+            set_last_error("out is null but capacity > 0");
+            return EvStatus::NullArg;
+        }
+        // Safety: validity guaranteed by caller.
+        let ev = unsafe { &*handle };
+        let mut written: u32 = 0;
+        for (config_id, entity) in ev.sim.line_lookup_iter() {
+            if written + 2 > capacity {
+                break;
+            }
+            // Safety: caller guarantees `out` has at least `capacity`
+            // writable slots; bounds checked above.
+            unsafe {
+                *out.add(written as usize) = u64::from(*config_id);
+                *out.add(written as usize + 1) = entity_to_u64(*entity);
+            }
+            written += 2;
+        }
+        // Safety: out_written non-null per check above.
+        unsafe { *out_written = written };
+        EvStatus::Ok
+    })
+}
+
 /// Snapshot of the config-time `ElevatorConfig.id` → runtime `EntityId` map.
 ///
 /// Buffer-pattern accessor; emits flat

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -2473,6 +2473,30 @@ impl WasmSim {
             .collect()
     }
 
+    /// Resolve a config-time `LineConfig.id` (`u32`) to its runtime
+    /// `EntityId`. Returns `0` (slotmap-null) for unknown ids; always
+    /// `0` on legacy-topology sims (no `building.lines` block).
+    #[wasm_bindgen(js_name = lineEntity)]
+    #[must_use]
+    pub fn line_entity(&self, line_config_id: u32) -> u64 {
+        self.inner
+            .line_entity(line_config_id)
+            .map_or(0, entity_to_u64)
+    }
+
+    /// Snapshot of the config-time `LineConfig.id` → runtime `EntityId`
+    /// map. Returns a flat `[config_id_as_u64, entity_id, ...]` array;
+    /// pair count is `array.length / 2`. Empty on legacy-topology sims
+    /// and for runtime-added lines.
+    #[wasm_bindgen(js_name = lineLookupIter)]
+    #[must_use]
+    pub fn line_lookup_iter(&self) -> Vec<u64> {
+        self.inner
+            .line_lookup_iter()
+            .flat_map(|(config_id, entity)| [u64::from(*config_id), entity_to_u64(*entity)])
+            .collect()
+    }
+
     /// Entity ids of every elevator currently repositioning (heading to
     /// a parking stop with no rider obligation).
     #[wasm_bindgen(js_name = iterRepositioningElevators)]

--- a/examples/gms2-extension/extension/elevator_ffi/elevator_ffi.gml
+++ b/examples/gms2-extension/extension/elevator_ffi/elevator_ffi.gml
@@ -378,6 +378,102 @@ function ev_sim_elevators_on_line_into_array(_handle, _line_entity_id) {
     return ev_drain_u64_buffer(_handle, _bound);
 }
 
+/// Entity ids of every elevator currently repositioning (heading to a
+/// parking stop with no rider obligation). Empty array on failure.
+function ev_sim_iter_repositioning_elevators_into_array(_handle) {
+    return ev_drain_u64_buffer(_handle, ev_sim_iter_repositioning_elevators);
+}
+
+/// Entity ids of every stop reachable by transfer from another line
+/// (i.e. served by more than one line). Empty array on failure.
+function ev_sim_transfer_points_into_array(_handle) {
+    return ev_drain_u64_buffer(_handle, ev_sim_transfer_points);
+}
+
+/// Stop entity ids in `_elevator`'s destination queue, in FIFO order.
+/// Empty array if the elevator has no destinations (or on failure).
+function ev_sim_destination_queue_into_array(_handle, _elevator_entity_id) {
+    var _elev = _elevator_entity_id;
+    var _bound = method({ elev: _elev }, function(_h, _addr, _cap, _addr_written) {
+        return ev_sim_destination_queue(_h, elev, _addr, _cap, _addr_written);
+    });
+    return ev_drain_u64_buffer(_handle, _bound);
+}
+
+/// Rider entity ids waiting at `_stop_entity_id`. Empty array if no
+/// riders are waiting (or on failure).
+function ev_sim_waiting_at_into_array(_handle, _stop_entity_id) {
+    var _stop = _stop_entity_id;
+    var _bound = method({ stop: _stop }, function(_h, _addr, _cap, _addr_written) {
+        return ev_sim_waiting_at(_h, stop, _addr, _cap, _addr_written);
+    });
+    return ev_drain_u64_buffer(_handle, _bound);
+}
+
+/// Rider entity ids settled / resident at `_stop_entity_id`.
+function ev_sim_residents_at_into_array(_handle, _stop_entity_id) {
+    var _stop = _stop_entity_id;
+    var _bound = method({ stop: _stop }, function(_h, _addr, _cap, _addr_written) {
+        return ev_sim_residents_at(_h, stop, _addr, _cap, _addr_written);
+    });
+    return ev_drain_u64_buffer(_handle, _bound);
+}
+
+/// Rider entity ids who abandoned their call at `_stop_entity_id`.
+function ev_sim_abandoned_at_into_array(_handle, _stop_entity_id) {
+    var _stop = _stop_entity_id;
+    var _bound = method({ stop: _stop }, function(_h, _addr, _cap, _addr_written) {
+        return ev_sim_abandoned_at(_h, stop, _addr, _cap, _addr_written);
+    });
+    return ev_drain_u64_buffer(_handle, _bound);
+}
+
+/// Entity ids of every line that serves `_stop_entity_id`.
+function ev_sim_lines_serving_stop_into_array(_handle, _stop_entity_id) {
+    var _stop = _stop_entity_id;
+    var _bound = method({ stop: _stop }, function(_h, _addr, _cap, _addr_written) {
+        return ev_sim_lines_serving_stop(_h, stop, _addr, _cap, _addr_written);
+    });
+    return ev_drain_u64_buffer(_handle, _bound);
+}
+
+/// Entity ids of every line in group `_group_id`.
+function ev_sim_lines_in_group_into_array(_handle, _group_id) {
+    var _gid = _group_id;
+    var _bound = method({ gid: _gid }, function(_h, _addr, _cap, _addr_written) {
+        return ev_sim_lines_in_group(_h, gid, _addr, _cap, _addr_written);
+    });
+    return ev_drain_u64_buffer(_handle, _bound);
+}
+
+/// Stop entity ids reachable from `_from_stop_entity_id` via the
+/// line-graph.
+function ev_sim_reachable_stops_from_into_array(_handle, _from_stop_entity_id) {
+    var _stop = _from_stop_entity_id;
+    var _bound = method({ stop: _stop }, function(_h, _addr, _cap, _addr_written) {
+        return ev_sim_reachable_stops_from(_h, stop, _addr, _cap, _addr_written);
+    });
+    return ev_drain_u64_buffer(_handle, _bound);
+}
+
+/// Stop entity ids served by `_line_entity_id`, in line-graph order.
+function ev_sim_stops_served_by_line_into_array(_handle, _line_entity_id) {
+    var _line = _line_entity_id;
+    var _bound = method({ line: _line }, function(_h, _addr, _cap, _addr_written) {
+        return ev_sim_stops_served_by_line(_h, line, _addr, _cap, _addr_written);
+    });
+    return ev_drain_u64_buffer(_handle, _bound);
+}
+
+/// Rider entity ids currently aboard `_elevator_entity_id`.
+function ev_sim_riders_on_into_array(_handle, _elevator_entity_id) {
+    var _elev = _elevator_entity_id;
+    var _bound = method({ elev: _elev }, function(_h, _addr, _cap, _addr_written) {
+        return ev_sim_riders_on(_h, elev, _addr, _cap, _addr_written);
+    });
+    return ev_drain_u64_buffer(_handle, _bound);
+}
+
 // ── Struct decoders for other repr-C types ──────────────────────────
 //
 // EvFrame, EvElevatorView, EvStopView, EvRiderView, EvHallCall,

--- a/examples/gms2-extension/extension/elevator_ffi/elevator_ffi_generated.gml
+++ b/examples/gms2-extension/extension/elevator_ffi/elevator_ffi_generated.gml
@@ -426,12 +426,26 @@ global._ev_sim_line_count_handle = external_define(
 function ev_sim_line_count(a0) {
     return external_call(global._ev_sim_line_count_handle, a0);
 }
+// ev_sim_line_entity — auto-generated wrapper.
+global._ev_sim_line_entity_handle = external_define(
+    "elevator_ffi", "ev_sim_line_entity", dll_cdecl, ty_real, 2, ty_real, ty_real
+);
+function ev_sim_line_entity(a0, a1) {
+    return external_call(global._ev_sim_line_entity_handle, a0, a1);
+}
 // ev_sim_line_for_elevator — auto-generated wrapper.
 global._ev_sim_line_for_elevator_handle = external_define(
     "elevator_ffi", "ev_sim_line_for_elevator", dll_cdecl, ty_real, 2, ty_real, ty_real
 );
 function ev_sim_line_for_elevator(a0, a1) {
     return external_call(global._ev_sim_line_for_elevator_handle, a0, a1);
+}
+// ev_sim_line_lookup_iter — auto-generated wrapper.
+global._ev_sim_line_lookup_iter_handle = external_define(
+    "elevator_ffi", "ev_sim_line_lookup_iter", dll_cdecl, ty_real, 4, ty_real, ty_real, ty_real, ty_real
+);
+function ev_sim_line_lookup_iter(a0, a1, a2, a3) {
+    return external_call(global._ev_sim_line_lookup_iter_handle, a0, a1, a2, a3);
 }
 // ev_sim_lines_in_group — auto-generated wrapper.
 global._ev_sim_lines_in_group_handle = external_define(


### PR DESCRIPTION
## Summary

Follow-up to PR #870, addressing the two top-tier findings from the post-merge audit.

- **Tier 1 from audit — closes the stops/elevators/lines symmetry.** Adds `Simulation::line_entity(u32)` and `line_lookup_iter()`, identical pattern to the just-shipped `elevator_entity`. `LineConfig.id` (`u32`) was previously unreachable as a runtime `EntityId` lookup — construction built a local `BTreeMap<u32, (EntityId, LineInfo)>` but discarded it. Now persisted on the Simulation, populated by the explicit-topology builder, cleaned up on `remove_line`, and snapshot-roundtrippable via a `#[serde(default)]` field. Empty on legacy-topology sims (no `building.lines` block) — the docstring + tests pin that down.
- **Tier 3 from audit — eleven more GMS `_into_array` helpers.** Every remaining single-id-per-slot u64[] buffer accessor on the FFI surface now has a `_into_array` GML wrapper, built on the existing `ev_drain_u64_buffer` grow-and-retry helper plus the `method()` pattern from `elevators_on_line_into_array`. Covers: `iter_repositioning_elevators`, `transfer_points`, `destination_queue`, `waiting_at`, `residents_at`, `abandoned_at`, `lines_serving_stop`, `lines_in_group`, `reachable_stops_from`, `stops_served_by_line`, `riders_on`.

## What's NOT in this PR

From the audit:
- **Tier 2 (typed `ElevatorConfigId` / `LineConfigId` newtypes).** Greptile flagged this as deferrable on #870; bundling it would touch every existing caller of `stop_entity` for symmetry. Worth its own PR.
- **Tier 4 (struct decoders for `EvElevatorView` / `EvRiderView` / `EvStopView` / `EvFrame` / etc).** Each decoder needs per-struct field-by-field work and the layout file shows 9 remaining structs without decoders. File's own comment says "extend as needed" — best landed incrementally as games hit them, matching the pattern of #868.
- **Scalar `_easy` helpers for non-buffer out-params** (e.g. `run_until_quiet`, `eta`, `loop_leader`, `rider_tag`). Lower value-add since the call already returns a single value via out-param; consumers can write the 4-line dance.

## Test plan

- [x] `cargo fmt --all`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --all-features`
- [x] `cargo test --workspace --all-features` — 1076 lib tests + scenarios + doctests pass
- [x] New tests: `legacy_config_has_empty_line_lookup`, `explicit_topology_line_entity_resolves`, `remove_line_removes_from_line_lookup`, `snapshot_roundtrip_preserves_line_lookup`
- [x] `bash scripts/check-bindings.sh` — 159 methods in sync; FFI/wasm/gms now at 124 exported (+2 from main)
- [x] `bash scripts/check-abi-pins.sh` — ABI v5 still in sync
- [x] `cargo run -p elevator-contract -- --update-golden` — regenerated golden checksums to absorb the new `line_lookup` snapshot field