### PR TITLE
feat!: introduce ElevatorConfigId and LineConfigId newtypes

### DIFF
--- a/crates/elevator-core/benches/common/mod.rs
+++ b/crates/elevator-core/benches/common/mod.rs
@@ -18,7 +18,7 @@ pub fn elevator_cfg(
     weight_capacity: f64,
 ) -> ElevatorConfig {
     ElevatorConfig {
-        id,
+        id: elevator_core::config::ElevatorConfigId(id),
         name: format!("E{id}"),
         max_speed: Speed::from(max_speed),
         acceleration: Accel::from(acceleration),

--- a/crates/elevator-core/benches/multi_line_bench.rs
+++ b/crates/elevator-core/benches/multi_line_bench.rs
@@ -81,7 +81,7 @@ fn multi_group_config(
 
             group_line_ids.push(line_id);
             lines.push(LineConfig {
-                id: line_id,
+                id: elevator_core::config::LineConfigId(line_id),
                 name: format!("L{line_id}"),
                 serves,
                 elevators,

--- a/crates/elevator-core/examples/dispatch_comparison.rs
+++ b/crates/elevator-core/examples/dispatch_comparison.rs
@@ -64,7 +64,7 @@ fn make_config() -> SimConfig {
 
     let elevators: Vec<ElevatorConfig> = (0..4)
         .map(|i| ElevatorConfig {
-            id: i,
+            id: elevator_core::config::ElevatorConfigId(i),
             name: format!("E{i}"),
             max_speed: Speed::from(2.5),
             acceleration: Accel::from(1.5),

--- a/crates/elevator-core/examples/scenario.rs
+++ b/crates/elevator-core/examples/scenario.rs
@@ -32,7 +32,7 @@ fn main() {
                 groups: None,
             },
             elevators: vec![ElevatorConfig {
-                id: 0,
+                id: elevator_core::config::ElevatorConfigId(0),
                 name: "E1".into(),
                 max_speed: Speed::from(2.0),
                 acceleration: Accel::from(1.5),

--- a/crates/elevator-core/examples/showcase.rs
+++ b/crates/elevator-core/examples/showcase.rs
@@ -389,7 +389,7 @@ fn part6_configuration() {
         },
         elevators: vec![
             ElevatorConfig {
-                id: 0,
+                id: elevator_core::config::ElevatorConfigId(0),
                 name: "Express A".into(),
                 max_speed: Speed::from(5.0),
                 acceleration: Accel::from(2.5),
@@ -409,7 +409,7 @@ fn part6_configuration() {
                 bypass_load_down_pct: None,
             },
             ElevatorConfig {
-                id: 1,
+                id: elevator_core::config::ElevatorConfigId(1),
                 name: "Express B".into(),
                 max_speed: Speed::from(5.0),
                 acceleration: Accel::from(2.5),

--- a/crates/elevator-core/src/builder.rs
+++ b/crates/elevator-core/src/builder.rs
@@ -70,7 +70,7 @@ impl SimulationBuilder {
     /// ```
     /// use elevator_core::prelude::*;
     /// use elevator_core::components::{Speed, Accel, Weight};
-    /// use elevator_core::config::ElevatorConfig;
+    /// use elevator_core::config::{ElevatorConfig, ElevatorConfigId};
     /// use elevator_core::stop::StopConfig;
     ///
     /// // An empty builder errors on build — you must configure it first.
@@ -83,7 +83,7 @@ impl SimulationBuilder {
     ///         StopConfig { id: StopId(1), name: "Top".into(), position: 10.0 },
     ///     ])
     ///     .elevator(ElevatorConfig {
-    ///         id: 0,
+    ///         id: ElevatorConfigId(0),
     ///         name: "Main".into(),
     ///         max_speed: Speed::from(2.0),
     ///         acceleration: Accel::from(1.5),
@@ -176,7 +176,7 @@ impl SimulationBuilder {
             },
         ];
         b.config.elevators = vec![ElevatorConfig {
-            id: 0,
+            id: crate::config::ElevatorConfigId(0),
             name: "Elevator 1".into(),
             max_speed: Speed::from(2.0),
             acceleration: Accel::from(1.5),

--- a/crates/elevator-core/src/config.rs
+++ b/crates/elevator-core/src/config.rs
@@ -16,6 +16,45 @@ use serde::{Deserialize, Serialize};
 /// for the full bump-trigger policy and migration playbook.
 pub const CURRENT_CONFIG_SCHEMA_VERSION: u32 = 1;
 
+/// Config-time numeric identifier for an [`ElevatorConfig`].
+///
+/// Unique within the config. Mapped to an
+/// [`EntityId`](crate::entity::EntityId) at construction time; resolve
+/// via [`Simulation::elevator_entity`](crate::sim::Simulation::elevator_entity).
+///
+/// Newtype mirrors [`StopId`]'s pattern so consumers can't accidentally
+/// pass an elevator id where a line/stop id was expected. RON
+/// deserializers unwrap newtype structs by default, so existing config
+/// files with bare `id: 0` continue to parse without changes.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+pub struct ElevatorConfigId(pub u32);
+
+impl std::fmt::Display for ElevatorConfigId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Config-time numeric identifier for a [`LineConfig`].
+///
+/// Unique within the config. Resolve via
+/// [`Simulation::line_entity`](crate::sim::Simulation::line_entity).
+/// Mirrors [`ElevatorConfigId`]'s pattern; same RON-compat note applies.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+pub struct LineConfigId(pub u32);
+
+impl std::fmt::Display for LineConfigId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 /// Top-level simulation configuration, loadable from RON.
 ///
 /// Validated at construction time by [`Simulation::new()`](crate::sim::Simulation::new)
@@ -95,8 +134,8 @@ pub struct ElevatorConfig {
     /// Numeric identifier for this elevator, unique within the config.
     ///
     /// Mapped to an [`EntityId`](crate::entity::EntityId) at construction
-    /// time; not used at runtime.
-    pub id: u32,
+    /// time; not used at runtime. See [`ElevatorConfigId`].
+    pub id: ElevatorConfigId,
     /// Human-readable elevator name, displayed in UIs and logs.
     pub name: String,
     /// Maximum travel speed in distance units per second.
@@ -213,7 +252,7 @@ impl Default for ElevatorConfig {
     /// id. Override if your config uses a different bottom-stop id.
     fn default() -> Self {
         Self {
-            id: 0,
+            id: ElevatorConfigId(0),
             name: "Elevator 1".into(),
             max_speed: Speed::from(2.0),
             acceleration: Accel::from(1.5),
@@ -306,8 +345,8 @@ impl Default for PassengerSpawnConfig {
 /// [`GroupConfig`] for dispatch purposes.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LineConfig {
-    /// Unique line identifier (within the config).
-    pub id: u32,
+    /// Unique line identifier (within the config). See [`LineConfigId`].
+    pub id: LineConfigId,
     /// Human-readable name.
     pub name: String,
     /// Stops served by this line (references [`StopConfig::id`]).

--- a/crates/elevator-core/src/sim.rs
+++ b/crates/elevator-core/src/sim.rs
@@ -214,14 +214,14 @@ pub struct Simulation {
     /// runtime `add_elevator` takes `ElevatorParams` (no config id) and
     /// returns the new `EntityId` directly, so it does not populate
     /// this map. Mirror of [`Self::stop_lookup`] semantics.
-    elevator_lookup: HashMap<u32, EntityId>,
+    elevator_lookup: HashMap<crate::config::ElevatorConfigId, EntityId>,
     /// Config-time `LineConfig.id` → runtime `EntityId` mapping.
     /// Populated only for lines from an explicit `building.lines` block
     /// in the config; legacy (flat-elevator-list) configs build a single
     /// default line with no config id, so this stays empty for them.
     /// Runtime `add_line` takes `LineParams` (no config id) and returns
     /// the entity directly. Mirror of [`Self::stop_lookup`] semantics.
-    line_lookup: HashMap<u32, EntityId>,
+    line_lookup: HashMap<crate::config::LineConfigId, EntityId>,
     /// Dispatch strategies + their snapshot identities, keyed by group.
     /// Owns both halves so insert/remove stay atomic — see
     /// [`DispatcherSet`].

--- a/crates/elevator-core/src/sim/accessors.rs
+++ b/crates/elevator-core/src/sim/accessors.rs
@@ -175,7 +175,7 @@ impl super::Simulation {
     /// config id) and returns the new entity id directly. Mirror of
     /// [`Self::stop_entity`].
     #[must_use]
-    pub fn elevator_entity(&self, id: u32) -> Option<EntityId> {
+    pub fn elevator_entity(&self, id: crate::config::ElevatorConfigId) -> Option<EntityId> {
         self.elevator_lookup.get(&id).copied()
     }
 
@@ -188,7 +188,7 @@ impl super::Simulation {
     /// [`Self::add_line`] takes `LineParams` (no config id) and
     /// returns the new entity directly.
     #[must_use]
-    pub fn line_entity(&self, id: u32) -> Option<EntityId> {
+    pub fn line_entity(&self, id: crate::config::LineConfigId) -> Option<EntityId> {
         self.line_lookup.get(&id).copied()
     }
 
@@ -214,13 +214,17 @@ impl super::Simulation {
     /// Iterate over the elevator config ID → entity ID mapping. Only
     /// elevators spawned from the initial config appear; see
     /// [`Self::elevator_entity`].
-    pub fn elevator_lookup_iter(&self) -> impl Iterator<Item = (&u32, &EntityId)> {
+    pub fn elevator_lookup_iter(
+        &self,
+    ) -> impl Iterator<Item = (&crate::config::ElevatorConfigId, &EntityId)> {
         self.elevator_lookup.iter()
     }
 
     /// Iterate over the line config ID → entity ID mapping. Empty on
     /// legacy configs; see [`Self::line_entity`].
-    pub fn line_lookup_iter(&self) -> impl Iterator<Item = (&u32, &EntityId)> {
+    pub fn line_lookup_iter(
+        &self,
+    ) -> impl Iterator<Item = (&crate::config::LineConfigId, &EntityId)> {
         self.line_lookup.iter()
     }
 

--- a/crates/elevator-core/src/sim/construction.rs
+++ b/crates/elevator-core/src/sim/construction.rs
@@ -266,8 +266,9 @@ impl Simulation {
         // into a seconds expression and getting ~60× over-weighted.
         world.insert_resource(crate::time::TickRate(config.simulation.ticks_per_second));
 
-        let mut elevator_lookup: HashMap<u32, EntityId> = HashMap::new();
-        let mut line_lookup: HashMap<u32, EntityId> = HashMap::new();
+        let mut elevator_lookup: HashMap<crate::config::ElevatorConfigId, EntityId> =
+            HashMap::new();
+        let mut line_lookup: HashMap<crate::config::LineConfigId, EntityId> = HashMap::new();
         let (mut groups, dispatchers, strategy_ids) =
             if let Some(line_configs) = &config.building.lines {
                 Self::build_explicit_topology(
@@ -445,7 +446,7 @@ impl Simulation {
         world: &mut World,
         config: &SimConfig,
         stop_lookup: &HashMap<StopId, EntityId>,
-        elevator_lookup: &mut HashMap<u32, EntityId>,
+        elevator_lookup: &mut HashMap<crate::config::ElevatorConfigId, EntityId>,
         builder_dispatchers: BTreeMap<GroupId, Box<dyn DispatchStrategy>>,
     ) -> TopologyResult {
         // Iterate the config's stop list (deterministic Vec order) and
@@ -536,8 +537,8 @@ impl Simulation {
         config: &SimConfig,
         line_configs: &[crate::config::LineConfig],
         stop_lookup: &HashMap<StopId, EntityId>,
-        elevator_lookup: &mut HashMap<u32, EntityId>,
-        line_lookup: &mut HashMap<u32, EntityId>,
+        elevator_lookup: &mut HashMap<crate::config::ElevatorConfigId, EntityId>,
+        line_lookup: &mut HashMap<crate::config::LineConfigId, EntityId>,
         builder_dispatchers: BTreeMap<GroupId, Box<dyn DispatchStrategy>>,
     ) -> TopologyResult {
         // Map line config id → (line EntityId, LineInfo). `BTreeMap`
@@ -612,7 +613,7 @@ impl Simulation {
 
             let line_info = LineInfo::new(line_eid, elevator_entities, served_entities);
             line_lookup.insert(lc.id, line_eid);
-            line_map.insert(lc.id, (line_eid, line_info));
+            line_map.insert(lc.id.0, (line_eid, line_info));
         }
 
         // Build groups from GroupConfigs, or auto-infer a single group.
@@ -705,8 +706,8 @@ impl Simulation {
         dt: f64,
         groups: Vec<ElevatorGroup>,
         stop_lookup: HashMap<StopId, EntityId>,
-        elevator_lookup: HashMap<u32, EntityId>,
-        line_lookup: HashMap<u32, EntityId>,
+        elevator_lookup: HashMap<crate::config::ElevatorConfigId, EntityId>,
+        line_lookup: HashMap<crate::config::LineConfigId, EntityId>,
         dispatchers: BTreeMap<GroupId, Box<dyn DispatchStrategy>>,
         strategy_ids: BTreeMap<GroupId, crate::dispatch::BuiltinStrategy>,
         metrics: Metrics,
@@ -1068,7 +1069,7 @@ impl Simulation {
 
         // Validate groups if present.
         if let Some(group_configs) = &building.groups {
-            let line_id_set: HashSet<u32> = line_configs.iter().map(|lc| lc.id).collect();
+            let line_id_set: HashSet<u32> = line_configs.iter().map(|lc| lc.id.0).collect();
 
             let mut seen_group_ids = HashSet::new();
             for gc in group_configs {
@@ -1097,7 +1098,7 @@ impl Simulation {
                 .flat_map(|g| g.lines.iter().copied())
                 .collect();
             for lc in line_configs {
-                if !referenced_line_ids.contains(&lc.id) {
+                if !referenced_line_ids.contains(&lc.id.0) {
                     return Err(SimError::InvalidConfig {
                         field: "building.lines",
                         reason: format!("line {} is not assigned to any group", lc.id),
@@ -1115,7 +1116,7 @@ impl Simulation {
                 let lines: Vec<&crate::config::LineConfig> = gc
                     .lines
                     .iter()
-                    .filter_map(|lid| line_configs.iter().find(|lc| lc.id == *lid))
+                    .filter_map(|lid| line_configs.iter().find(|lc| lc.id.0 == *lid))
                     .collect();
                 let any_loop = lines
                     .iter()

--- a/crates/elevator-core/src/snapshot.rs
+++ b/crates/elevator-core/src/snapshot.rs
@@ -769,8 +769,8 @@ impl WorldSnapshot {
         (
             Vec<crate::dispatch::ElevatorGroup>,
             HashMap<StopId, EntityId>,
-            HashMap<u32, EntityId>,
-            HashMap<u32, EntityId>,
+            HashMap<crate::config::ElevatorConfigId, EntityId>,
+            HashMap<crate::config::LineConfigId, EntityId>,
             std::collections::BTreeMap<GroupId, Box<dyn crate::dispatch::DispatchStrategy>>,
             std::collections::BTreeMap<GroupId, crate::dispatch::BuiltinStrategy>,
         ),
@@ -833,16 +833,24 @@ impl WorldSnapshot {
             .filter_map(|(sid, &idx)| index_to_id.get(idx).map(|&eid| (*sid, eid)))
             .collect();
 
-        let elevator_lookup: HashMap<u32, EntityId> = self
+        let elevator_lookup: HashMap<crate::config::ElevatorConfigId, EntityId> = self
             .elevator_lookup
             .iter()
-            .filter_map(|(cid, &idx)| index_to_id.get(idx).map(|&eid| (*cid, eid)))
+            .filter_map(|(cid, &idx)| {
+                index_to_id
+                    .get(idx)
+                    .map(|&eid| (crate::config::ElevatorConfigId(*cid), eid))
+            })
             .collect();
 
-        let line_lookup: HashMap<u32, EntityId> = self
+        let line_lookup: HashMap<crate::config::LineConfigId, EntityId> = self
             .line_lookup
             .iter()
-            .filter_map(|(cid, &idx)| index_to_id.get(idx).map(|&eid| (*cid, eid)))
+            .filter_map(|(cid, &idx)| {
+                index_to_id
+                    .get(idx)
+                    .map(|&eid| (crate::config::LineConfigId(*cid), eid))
+            })
             .collect();
 
         let mut dispatchers = std::collections::BTreeMap::new();
@@ -1151,11 +1159,11 @@ impl crate::sim::Simulation {
             .collect();
         let elevator_lookup: BTreeMap<u32, usize> = self
             .elevator_lookup_iter()
-            .filter_map(|(cid, eid)| id_to_index.get(eid).map(|&idx| (*cid, idx)))
+            .filter_map(|(cid, eid)| id_to_index.get(eid).map(|&idx| (cid.0, idx)))
             .collect();
         let line_lookup: BTreeMap<u32, usize> = self
             .line_lookup_iter()
-            .filter_map(|(cid, eid)| id_to_index.get(eid).map(|&idx| (*cid, idx)))
+            .filter_map(|(cid, eid)| id_to_index.get(eid).map(|&idx| (cid.0, idx)))
             .collect();
 
         WorldSnapshot {

--- a/crates/elevator-core/src/tests/adaptive_parking_tests.rs
+++ b/crates/elevator-core/src/tests/adaptive_parking_tests.rs
@@ -21,7 +21,7 @@ fn sim_with_idle_cars(cars: usize) -> Simulation {
     let mut cfg = default_config();
     for i in 1..cars {
         cfg.elevators.push(crate::config::ElevatorConfig {
-            id: i as u32,
+            id: crate::config::ElevatorConfigId(i as u32),
             name: format!("Car {i}"),
             max_speed: cfg.elevators[0].max_speed,
             acceleration: cfg.elevators[0].acceleration,

--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -313,12 +313,17 @@ fn elevator_entity_resolves_config_id() {
     let sim = Simulation::new(&config, scan()).unwrap();
 
     // default_config installs a single elevator with id = 0.
-    let elev = sim.elevator_entity(0).expect("config id 0 should resolve");
+    let elev = sim
+        .elevator_entity(crate::config::ElevatorConfigId(0))
+        .expect("config id 0 should resolve");
     assert!(sim.world().is_alive(elev));
     assert!(sim.world().elevator(elev).is_some());
 
     // Unknown ids return None — no panic, no sentinel.
-    assert!(sim.elevator_entity(99).is_none());
+    assert!(
+        sim.elevator_entity(crate::config::ElevatorConfigId(99))
+            .is_none()
+    );
 }
 
 #[test]
@@ -326,11 +331,14 @@ fn remove_elevator_removes_from_elevator_lookup() {
     let config = default_config();
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
-    let elev = sim.elevator_entity(0).unwrap();
+    let elev = sim
+        .elevator_entity(crate::config::ElevatorConfigId(0))
+        .unwrap();
     sim.remove_elevator(elev).unwrap();
 
     assert!(
-        sim.elevator_entity(0).is_none(),
+        sim.elevator_entity(crate::config::ElevatorConfigId(0))
+            .is_none(),
         "elevator_entity should return None after removal"
     );
 }
@@ -341,8 +349,8 @@ fn legacy_config_has_empty_line_lookup() {
     // line without a config id, so line_entity always returns None.
     let config = default_config();
     let sim = Simulation::new(&config, scan()).unwrap();
-    assert!(sim.line_entity(0).is_none());
-    assert!(sim.line_entity(1).is_none());
+    assert!(sim.line_entity(crate::config::LineConfigId(0)).is_none());
+    assert!(sim.line_entity(crate::config::LineConfigId(1)).is_none());
     assert_eq!(sim.line_lookup_iter().count(), 0);
 }
 
@@ -369,11 +377,11 @@ fn explicit_topology_line_entity_resolves() {
                 },
             ],
             lines: Some(vec![LineConfig {
-                id: 7,
+                id: crate::config::LineConfigId(7),
                 name: "Main".into(),
                 serves: vec![StopId(0), StopId(1)],
                 elevators: vec![ElevatorConfig {
-                    id: 0,
+                    id: crate::config::ElevatorConfigId(0),
                     name: "E".into(),
                     max_speed: Speed::from(2.0),
                     acceleration: Accel::from(1.5),
@@ -404,9 +412,11 @@ fn explicit_topology_line_entity_resolves() {
     };
 
     let sim = Simulation::new(&config, scan()).unwrap();
-    let line = sim.line_entity(7).expect("LineConfig.id 7 should resolve");
+    let line = sim
+        .line_entity(crate::config::LineConfigId(7))
+        .expect("LineConfig.id 7 should resolve");
     assert!(sim.world().line(line).is_some());
-    assert!(sim.line_entity(99).is_none());
+    assert!(sim.line_entity(crate::config::LineConfigId(99)).is_none());
 }
 
 #[test]
@@ -425,11 +435,11 @@ fn remove_line_removes_from_line_lookup() {
                 position: 0.0,
             }],
             lines: Some(vec![LineConfig {
-                id: 42,
+                id: crate::config::LineConfigId(42),
                 name: "Doomed".into(),
                 serves: vec![StopId(0)],
                 elevators: vec![ElevatorConfig {
-                    id: 0,
+                    id: crate::config::ElevatorConfigId(0),
                     name: "E".into(),
                     max_speed: Speed::from(2.0),
                     acceleration: Accel::from(1.5),
@@ -460,10 +470,10 @@ fn remove_line_removes_from_line_lookup() {
     };
 
     let mut sim = Simulation::new(&config, scan()).unwrap();
-    let line = sim.line_entity(42).unwrap();
+    let line = sim.line_entity(crate::config::LineConfigId(42)).unwrap();
     sim.remove_line(line).unwrap();
     assert!(
-        sim.line_entity(42).is_none(),
+        sim.line_entity(crate::config::LineConfigId(42)).is_none(),
         "line_entity should return None after removal"
     );
 }
@@ -493,13 +503,17 @@ fn runtime_added_elevator_not_in_lookup() {
 
     // The runtime-added entity is alive but not in the config-id lookup.
     assert!(sim.world().is_alive(runtime_elev));
-    let pairs: Vec<(u32, EntityId)> = sim.elevator_lookup_iter().map(|(c, e)| (*c, *e)).collect();
+    let pairs: Vec<(crate::config::ElevatorConfigId, EntityId)> =
+        sim.elevator_lookup_iter().map(|(c, e)| (*c, *e)).collect();
     assert!(
         pairs.iter().all(|(_, e)| *e != runtime_elev),
         "runtime-added elevator must not appear in elevator_lookup"
     );
     // The config-time elevator (id 0) is still there.
-    assert!(sim.elevator_entity(0).is_some());
+    assert!(
+        sim.elevator_entity(crate::config::ElevatorConfigId(0))
+            .is_some()
+    );
 }
 
 #[test]
@@ -1000,7 +1014,7 @@ fn iter_repositioning_elevators_returns_elevator_during_reposition() {
             },
         ])
         .elevator(crate::config::ElevatorConfig {
-            id: 0,
+            id: crate::config::ElevatorConfigId(0),
             name: "A".into(),
             max_speed: Speed::from(2.0),
             acceleration: Accel::from(1.5),
@@ -1065,7 +1079,7 @@ fn iter_repositioning_elevators_empty_after_reposition_completes() {
             },
         ])
         .elevator(crate::config::ElevatorConfig {
-            id: 0,
+            id: crate::config::ElevatorConfigId(0),
             name: "A".into(),
             max_speed: Speed::from(2.0),
             acceleration: Accel::from(1.5),
@@ -1300,7 +1314,7 @@ fn rider_builder_no_route_when_stops_not_in_same_group() {
             },
         ])
         .elevator(crate::config::ElevatorConfig {
-            id: 0,
+            id: crate::config::ElevatorConfigId(0),
             name: "E1".into(),
             max_speed: Speed::from(2.0),
             acceleration: Accel::from(1.5),

--- a/crates/elevator-core/src/tests/builder_tests.rs
+++ b/crates/elevator-core/src/tests/builder_tests.rs
@@ -51,7 +51,7 @@ fn from_config_produces_valid_sim() {
             groups: None,
         },
         elevators: vec![ElevatorConfig {
-            id: 0,
+            id: crate::config::ElevatorConfigId(0),
             name: "E1".into(),
             max_speed: Speed::from(3.0),
             acceleration: Accel::from(2.0),
@@ -112,7 +112,7 @@ fn builder_with_stops_and_elevators() {
             },
         ])
         .elevator(ElevatorConfig {
-            id: 1,
+            id: crate::config::ElevatorConfigId(1),
             name: "E2".into(),
             max_speed: Speed::from(2.0),
             acceleration: Accel::from(1.5),
@@ -198,11 +198,11 @@ fn from_config_honours_config_group_dispatch() {
                 },
             ],
             lines: Some(vec![LineConfig {
-                id: 1,
+                id: crate::config::LineConfigId(1),
                 name: "Main".into(),
                 serves: vec![StopId(0), StopId(1)],
                 elevators: vec![ElevatorConfig {
-                    id: 1,
+                    id: crate::config::ElevatorConfigId(1),
                     name: "E".into(),
                     max_speed: Speed::from(2.0),
                     acceleration: Accel::from(1.5),
@@ -287,11 +287,11 @@ fn from_config_dispatch_override_records_dispatcher_identity() {
                 },
             ],
             lines: Some(vec![LineConfig {
-                id: 1,
+                id: crate::config::LineConfigId(1),
                 name: "Main".into(),
                 serves: vec![StopId(0), StopId(1)],
                 elevators: vec![ElevatorConfig {
-                    id: 1,
+                    id: crate::config::ElevatorConfigId(1),
                     name: "E".into(),
                     max_speed: Speed::from(2.0),
                     acceleration: Accel::from(1.5),

--- a/crates/elevator-core/src/tests/config_tests.rs
+++ b/crates/elevator-core/src/tests/config_tests.rs
@@ -219,7 +219,7 @@ fn rejects_empty_line_serves() {
     use crate::config::LineConfig;
     let mut config = helpers::default_config();
     config.building.lines = Some(vec![LineConfig {
-        id: 0,
+        id: crate::config::LineConfigId(0),
         name: "Empty".into(),
         serves: vec![],
         elevators: config.elevators.clone(),

--- a/crates/elevator-core/src/tests/destination_dispatch_tests.rs
+++ b/crates/elevator-core/src/tests/destination_dispatch_tests.rs
@@ -40,7 +40,7 @@ fn single_car_config() -> SimConfig {
             groups: None,
         },
         elevators: vec![ElevatorConfig {
-            id: 0,
+            id: crate::config::ElevatorConfigId(0),
             name: "Solo".into(),
             max_speed: Speed::from(2.0),
             acceleration: Accel::from(1.5),
@@ -98,12 +98,12 @@ fn two_cars_same_group_config() -> SimConfig {
                 },
             ],
             lines: Some(vec![LineConfig {
-                id: 1,
+                id: crate::config::LineConfigId(1),
                 name: "Main".into(),
                 serves: vec![StopId(0), StopId(1), StopId(2), StopId(3)],
                 elevators: vec![
                     ElevatorConfig {
-                        id: 1,
+                        id: crate::config::ElevatorConfigId(1),
                         name: "A".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -123,7 +123,7 @@ fn two_cars_same_group_config() -> SimConfig {
                         bypass_load_down_pct: None,
                     },
                     ElevatorConfig {
-                        id: 2,
+                        id: crate::config::ElevatorConfigId(2),
                         name: "B".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -763,7 +763,7 @@ fn single_car_heavy_load_drains_within_tick_budget() {
             groups: None,
         },
         elevators: vec![ElevatorConfig {
-            id: 0,
+            id: crate::config::ElevatorConfigId(0),
             name: "Car 0".into(),
             max_speed: Speed::from(3.0),
             acceleration: Accel::from(1.5),

--- a/crates/elevator-core/src/tests/dispatch_commitment_tests.rs
+++ b/crates/elevator-core/src/tests/dispatch_commitment_tests.rs
@@ -23,7 +23,7 @@ fn second_idle_car_not_double_dispatched_to_same_stop() {
     let mut cfg = default_config();
     // Two cars, both starting at the lobby.
     cfg.elevators.push(crate::config::ElevatorConfig {
-        id: 1,
+        id: crate::config::ElevatorConfigId(1),
         name: "Car 2".into(),
         max_speed: cfg.elevators[0].max_speed,
         acceleration: cfg.elevators[0].acceleration,
@@ -88,7 +88,7 @@ fn second_idle_car_not_double_dispatched_to_same_stop() {
 fn committed_car_not_reassigned_mid_trip() {
     let mut cfg = default_config();
     cfg.elevators.push(crate::config::ElevatorConfig {
-        id: 1,
+        id: crate::config::ElevatorConfigId(1),
         name: "Car 2".into(),
         max_speed: cfg.elevators[0].max_speed,
         acceleration: cfg.elevators[0].acceleration,

--- a/crates/elevator-core/src/tests/dispatch_pruning_tests.rs
+++ b/crates/elevator-core/src/tests/dispatch_pruning_tests.rs
@@ -32,7 +32,7 @@ fn realistic_config() -> SimConfig {
 
     let elevators: Vec<ElevatorConfig> = (0..50u32)
         .map(|i| ElevatorConfig {
-            id: i,
+            id: crate::config::ElevatorConfigId(i),
             name: format!("E{i}"),
             max_speed: Speed::from(3.0),
             acceleration: Accel::from(1.5),

--- a/crates/elevator-core/src/tests/eta_tests.rs
+++ b/crates/elevator-core/src/tests/eta_tests.rs
@@ -217,7 +217,7 @@ fn best_eta_picks_min_across_elevators() {
     use crate::config::ElevatorConfig;
     let mut config = helpers::default_config();
     config.elevators.push(ElevatorConfig {
-        id: 1,
+        id: crate::config::ElevatorConfigId(1),
         name: "Alt".into(),
         max_speed: Speed::from(2.0),
         acceleration: Accel::from(1.5),

--- a/crates/elevator-core/src/tests/feature_tests.rs
+++ b/crates/elevator-core/src/tests/feature_tests.rs
@@ -883,7 +883,7 @@ fn weight_rejection_boundary() {
             groups: None,
         },
         elevators: vec![crate::config::ElevatorConfig {
-            id: 0,
+            id: crate::config::ElevatorConfigId(0),
             name: "E0".into(),
             max_speed: Speed::from(5.0),
             acceleration: Accel::from(3.0),
@@ -980,7 +980,7 @@ fn passing_floor_events_emitted() {
             groups: None,
         },
         elevators: vec![crate::config::ElevatorConfig {
-            id: 0,
+            id: crate::config::ElevatorConfigId(0),
             name: "E0".into(),
             max_speed: Speed::from(5.0),
             acceleration: Accel::from(2.0),

--- a/crates/elevator-core/src/tests/hall_call_tests.rs
+++ b/crates/elevator-core/src/tests/hall_call_tests.rs
@@ -443,14 +443,14 @@ fn pin_across_lines_is_rejected() {
         },
     ];
     let mk_elev = |id: u32, name: &str, start: StopId| ElevatorConfig {
-        id,
+        id: crate::config::ElevatorConfigId(id),
         name: name.into(),
         starting_stop: start,
         ..ElevatorConfig::default()
     };
     config.building.lines = Some(vec![
         LineConfig {
-            id: 1,
+            id: crate::config::LineConfigId(1),
             name: "Low".into(),
             serves: vec![StopId(0), StopId(1)],
             elevators: vec![mk_elev(1, "L1", StopId(0))],
@@ -462,7 +462,7 @@ fn pin_across_lines_is_rejected() {
             max_cars: None,
         },
         LineConfig {
-            id: 2,
+            id: crate::config::LineConfigId(2),
             name: "High".into(),
             serves: vec![StopId(1), StopId(2)],
             elevators: vec![mk_elev(2, "H1", StopId(1))],
@@ -668,7 +668,7 @@ fn group_config_wires_hall_call_mode_and_ack_latency() {
 
     let mut config = default_config();
     config.building.lines = Some(vec![LineConfig {
-        id: 1,
+        id: crate::config::LineConfigId(1),
         name: "Main".into(),
         serves: vec![StopId(0), StopId(1), StopId(2)],
         elevators: config.elevators.clone(),

--- a/crates/elevator-core/src/tests/helpers.rs
+++ b/crates/elevator-core/src/tests/helpers.rs
@@ -31,7 +31,7 @@ pub fn default_config() -> SimConfig {
             groups: None,
         },
         elevators: vec![ElevatorConfig {
-            id: 0,
+            id: crate::config::ElevatorConfigId(0),
             name: "Main".into(),
             max_speed: Speed::from(2.0),
             acceleration: Accel::from(1.5),
@@ -93,7 +93,7 @@ pub fn multi_floor_config(stops: usize, cars: usize) -> SimConfig {
         .collect();
     let elevators: Vec<ElevatorConfig> = (0..cars)
         .map(|i| ElevatorConfig {
-            id: i as u32,
+            id: crate::config::ElevatorConfigId(i as u32),
             name: format!("Car {i}"),
             max_speed: Speed::from(2.0),
             acceleration: Accel::from(1.5),

--- a/crates/elevator-core/src/tests/home_stop_tests.rs
+++ b/crates/elevator-core/src/tests/home_stop_tests.rs
@@ -345,14 +345,14 @@ fn two_line_config() -> SimConfig {
             ],
             lines: Some(vec![
                 LineConfig {
-                    id: 1,
+                    id: crate::config::LineConfigId(1),
                     name: "Low".into(),
                     serves: vec![StopId(0), StopId(1)],
                     elevators: vec![bare_elevator(1, "L1", StopId(0))],
                     ..Default::default()
                 },
                 LineConfig {
-                    id: 2,
+                    id: crate::config::LineConfigId(2),
                     name: "High".into(),
                     serves: vec![StopId(1), StopId(2)],
                     elevators: vec![bare_elevator(2, "H1", StopId(1))],
@@ -435,7 +435,7 @@ fn two_car_one_line_config() -> SimConfig {
 
 fn bare_elevator(id: u32, name: &str, starting: StopId) -> ElevatorConfig {
     ElevatorConfig {
-        id,
+        id: crate::config::ElevatorConfigId(id),
         name: name.into(),
         max_speed: Speed::from(2.0),
         acceleration: Accel::from(1.5),

--- a/crates/elevator-core/src/tests/invariants_tests.rs
+++ b/crates/elevator-core/src/tests/invariants_tests.rs
@@ -149,7 +149,7 @@ impl Workload {
             .collect();
         let elevators: Vec<ElevatorConfig> = (0..self.elevator_count)
             .map(|i| ElevatorConfig {
-                id: i,
+                id: crate::config::ElevatorConfigId(i),
                 name: format!("Car {i}"),
                 max_speed: Speed::from(3.0),
                 acceleration: Accel::from(1.5),

--- a/crates/elevator-core/src/tests/move_count_tests.rs
+++ b/crates/elevator-core/src/tests/move_count_tests.rs
@@ -35,7 +35,7 @@ fn two_elevator_config() -> SimConfig {
         },
         elevators: vec![
             ElevatorConfig {
-                id: 0,
+                id: crate::config::ElevatorConfigId(0),
                 name: "E1".into(),
                 max_speed: Speed::from(2.0),
                 acceleration: Accel::from(1.5),
@@ -55,7 +55,7 @@ fn two_elevator_config() -> SimConfig {
                 bypass_load_down_pct: None,
             },
             ElevatorConfig {
-                id: 1,
+                id: crate::config::ElevatorConfigId(1),
                 name: "E2".into(),
                 max_speed: Speed::from(2.0),
                 acceleration: Accel::from(1.5),

--- a/crates/elevator-core/src/tests/multi_elevator_tests.rs
+++ b/crates/elevator-core/src/tests/multi_elevator_tests.rs
@@ -34,7 +34,7 @@ fn two_elevator_config() -> SimConfig {
         },
         elevators: vec![
             ElevatorConfig {
-                id: 0,
+                id: crate::config::ElevatorConfigId(0),
                 name: "E1".into(),
                 max_speed: Speed::from(2.0),
                 acceleration: Accel::from(1.5),
@@ -54,7 +54,7 @@ fn two_elevator_config() -> SimConfig {
                 bypass_load_down_pct: None,
             },
             ElevatorConfig {
-                id: 1,
+                id: crate::config::ElevatorConfigId(1),
                 name: "E2".into(),
                 max_speed: Speed::from(2.0),
                 acceleration: Accel::from(1.5),

--- a/crates/elevator-core/src/tests/multi_line_tests.rs
+++ b/crates/elevator-core/src/tests/multi_line_tests.rs
@@ -48,11 +48,11 @@ fn two_group_config() -> SimConfig {
             ],
             lines: Some(vec![
                 LineConfig {
-                    id: 1,
+                    id: crate::config::LineConfigId(1),
                     name: "Low".into(),
                     serves: vec![StopId(0), StopId(1)],
                     elevators: vec![ElevatorConfig {
-                        id: 1,
+                        id: crate::config::ElevatorConfigId(1),
                         name: "L1".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -79,11 +79,11 @@ fn two_group_config() -> SimConfig {
                     max_cars: None,
                 },
                 LineConfig {
-                    id: 2,
+                    id: crate::config::LineConfigId(2),
                     name: "High".into(),
                     serves: vec![StopId(1), StopId(2)],
                     elevators: vec![ElevatorConfig {
-                        id: 2,
+                        id: crate::config::ElevatorConfigId(2),
                         name: "H1".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -162,11 +162,11 @@ fn overlapping_groups_config() -> SimConfig {
             ],
             lines: Some(vec![
                 LineConfig {
-                    id: 1,
+                    id: crate::config::LineConfigId(1),
                     name: "Express A".into(),
                     serves: vec![StopId(0), StopId(1)],
                     elevators: vec![ElevatorConfig {
-                        id: 1,
+                        id: crate::config::ElevatorConfigId(1),
                         name: "A1".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -193,11 +193,11 @@ fn overlapping_groups_config() -> SimConfig {
                     max_cars: None,
                 },
                 LineConfig {
-                    id: 2,
+                    id: crate::config::LineConfigId(2),
                     name: "Express B".into(),
                     serves: vec![StopId(0), StopId(1)],
                     elevators: vec![ElevatorConfig {
-                        id: 2,
+                        id: crate::config::ElevatorConfigId(2),
                         name: "B1".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -622,11 +622,11 @@ fn line_pinned_rider_boards_only_specified_line_elevator() {
             ],
             lines: Some(vec![
                 LineConfig {
-                    id: 1,
+                    id: crate::config::LineConfigId(1),
                     name: "Shaft A".into(),
                     serves: vec![StopId(0), StopId(1)],
                     elevators: vec![ElevatorConfig {
-                        id: 1,
+                        id: crate::config::ElevatorConfigId(1),
                         name: "A".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -653,11 +653,11 @@ fn line_pinned_rider_boards_only_specified_line_elevator() {
                     max_cars: None,
                 },
                 LineConfig {
-                    id: 2,
+                    id: crate::config::LineConfigId(2),
                     name: "Shaft B".into(),
                     serves: vec![StopId(0), StopId(1)],
                     elevators: vec![ElevatorConfig {
-                        id: 2,
+                        id: crate::config::ElevatorConfigId(2),
                         name: "B".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -2117,11 +2117,11 @@ fn reachable_stops_from_isolated_stop_returns_empty() {
                 },
             ],
             lines: Some(vec![LineConfig {
-                id: 1,
+                id: crate::config::LineConfigId(1),
                 name: "Main".into(),
                 serves: vec![StopId(0), StopId(1)],
                 elevators: vec![ElevatorConfig {
-                    id: 1,
+                    id: crate::config::ElevatorConfigId(1),
                     name: "E1".into(),
                     max_speed: Speed::from(2.0),
                     acceleration: Accel::from(1.5),
@@ -2271,11 +2271,11 @@ fn shortest_route_returns_none_for_unreachable_stop() {
             ],
             lines: Some(vec![
                 LineConfig {
-                    id: 1,
+                    id: crate::config::LineConfigId(1),
                     name: "Line A".into(),
                     serves: vec![StopId(0)],
                     elevators: vec![ElevatorConfig {
-                        id: 1,
+                        id: crate::config::ElevatorConfigId(1),
                         name: "E-A".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -2302,11 +2302,11 @@ fn shortest_route_returns_none_for_unreachable_stop() {
                     max_cars: None,
                 },
                 LineConfig {
-                    id: 2,
+                    id: crate::config::LineConfigId(2),
                     name: "Line B".into(),
                     serves: vec![StopId(1)],
                     elevators: vec![ElevatorConfig {
-                        id: 2,
+                        id: crate::config::ElevatorConfigId(2),
                         name: "E-B".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -2382,7 +2382,7 @@ fn duplicate_line_ids_fail_validation() {
     let mut config = two_group_config();
     // Make both lines have id 1.
     if let Some(lines) = config.building.lines.as_mut() {
-        lines[1].id = 1;
+        lines[1].id = crate::config::LineConfigId(1);
     }
 
     let result = Simulation::new(&config, ScanDispatch::new());
@@ -2482,7 +2482,7 @@ fn no_elevators_in_any_line_fails_validation() {
                 },
             ],
             lines: Some(vec![LineConfig {
-                id: 1,
+                id: crate::config::LineConfigId(1),
                 name: "Empty".into(),
                 serves: vec![StopId(0), StopId(1)],
                 elevators: vec![],
@@ -3030,11 +3030,11 @@ fn reassign_elevator_to_line_at_max_cars_returns_error() {
             ],
             lines: Some(vec![
                 LineConfig {
-                    id: 1,
+                    id: crate::config::LineConfigId(1),
                     name: "Low".into(),
                     serves: vec![StopId(0), StopId(1)],
                     elevators: vec![ElevatorConfig {
-                        id: 1,
+                        id: crate::config::ElevatorConfigId(1),
                         name: "L1".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -3061,11 +3061,11 @@ fn reassign_elevator_to_line_at_max_cars_returns_error() {
                     max_cars: None,
                 },
                 LineConfig {
-                    id: 2,
+                    id: crate::config::LineConfigId(2),
                     name: "High".into(),
                     serves: vec![StopId(1), StopId(2)],
                     elevators: vec![ElevatorConfig {
-                        id: 2,
+                        id: crate::config::ElevatorConfigId(2),
                         name: "H1".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -3196,12 +3196,12 @@ fn max_cars_exactly_met_at_config_time_succeeds() {
                 },
             ],
             lines: Some(vec![LineConfig {
-                id: 1,
+                id: crate::config::LineConfigId(1),
                 name: "Main".into(),
                 serves: vec![StopId(0), StopId(1)],
                 elevators: vec![
                     ElevatorConfig {
-                        id: 1,
+                        id: crate::config::ElevatorConfigId(1),
                         name: "E1".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -3221,7 +3221,7 @@ fn max_cars_exactly_met_at_config_time_succeeds() {
                         bypass_load_down_pct: None,
                     },
                     ElevatorConfig {
-                        id: 2,
+                        id: crate::config::ElevatorConfigId(2),
                         name: "E2".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -3287,12 +3287,12 @@ fn max_cars_exceeded_at_config_time_fails_validation() {
                 },
             ],
             lines: Some(vec![LineConfig {
-                id: 1,
+                id: crate::config::LineConfigId(1),
                 name: "Main".into(),
                 serves: vec![StopId(0), StopId(1)],
                 elevators: vec![
                     ElevatorConfig {
-                        id: 1,
+                        id: crate::config::ElevatorConfigId(1),
                         name: "E1".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -3312,7 +3312,7 @@ fn max_cars_exceeded_at_config_time_fails_validation() {
                         bypass_load_down_pct: None,
                     },
                     ElevatorConfig {
-                        id: 2,
+                        id: crate::config::ElevatorConfigId(2),
                         name: "E2".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -3384,11 +3384,11 @@ fn runtime_add_elevator_to_line_at_max_cars_returns_error() {
                 },
             ],
             lines: Some(vec![LineConfig {
-                id: 1,
+                id: crate::config::LineConfigId(1),
                 name: "Main".into(),
                 serves: vec![StopId(0), StopId(1)],
                 elevators: vec![ElevatorConfig {
-                    id: 1,
+                    id: crate::config::ElevatorConfigId(1),
                     name: "E1".into(),
                     max_speed: Speed::from(2.0),
                     acceleration: Accel::from(1.5),
@@ -3482,11 +3482,11 @@ fn three_group_config() -> SimConfig {
             ],
             lines: Some(vec![
                 LineConfig {
-                    id: 1,
+                    id: crate::config::LineConfigId(1),
                     name: "AB".into(),
                     serves: vec![StopId(0), StopId(1)],
                     elevators: vec![ElevatorConfig {
-                        id: 1,
+                        id: crate::config::ElevatorConfigId(1),
                         name: "E1".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -3513,11 +3513,11 @@ fn three_group_config() -> SimConfig {
                     max_cars: None,
                 },
                 LineConfig {
-                    id: 2,
+                    id: crate::config::LineConfigId(2),
                     name: "BC".into(),
                     serves: vec![StopId(1), StopId(2)],
                     elevators: vec![ElevatorConfig {
-                        id: 2,
+                        id: crate::config::ElevatorConfigId(2),
                         name: "E2".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -3544,11 +3544,11 @@ fn three_group_config() -> SimConfig {
                     max_cars: None,
                 },
                 LineConfig {
-                    id: 3,
+                    id: crate::config::LineConfigId(3),
                     name: "CD".into(),
                     serves: vec![StopId(2), StopId(3)],
                     elevators: vec![ElevatorConfig {
-                        id: 3,
+                        id: crate::config::ElevatorConfigId(3),
                         name: "E3".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -4077,11 +4077,11 @@ fn orphan_line_not_referenced_by_any_group_fails_validation() {
             ],
             lines: Some(vec![
                 LineConfig {
-                    id: 1,
+                    id: crate::config::LineConfigId(1),
                     name: "Main".into(),
                     serves: vec![StopId(0), StopId(1)],
                     elevators: vec![ElevatorConfig {
-                        id: 1,
+                        id: crate::config::ElevatorConfigId(1),
                         name: "E1".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -4108,11 +4108,11 @@ fn orphan_line_not_referenced_by_any_group_fails_validation() {
                     max_cars: None,
                 },
                 LineConfig {
-                    id: 2,
+                    id: crate::config::LineConfigId(2),
                     name: "Orphan".into(),
                     serves: vec![StopId(0), StopId(1)],
                     elevators: vec![ElevatorConfig {
-                        id: 2,
+                        id: crate::config::ElevatorConfigId(2),
                         name: "E2".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -4601,11 +4601,11 @@ fn dispatch_does_not_assign_car_to_stop_its_line_does_not_serve() {
             ],
             lines: Some(vec![
                 LineConfig {
-                    id: 1,
+                    id: crate::config::LineConfigId(1),
                     name: "A".into(),
                     serves: vec![StopId(0), StopId(1)],
                     elevators: vec![ElevatorConfig {
-                        id: 1,
+                        id: crate::config::ElevatorConfigId(1),
                         name: "carA".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -4630,11 +4630,11 @@ fn dispatch_does_not_assign_car_to_stop_its_line_does_not_serve() {
                     max_cars: None,
                 },
                 LineConfig {
-                    id: 2,
+                    id: crate::config::LineConfigId(2),
                     name: "B".into(),
                     serves: vec![StopId(2), StopId(3)],
                     elevators: vec![ElevatorConfig {
-                        id: 2,
+                        id: crate::config::ElevatorConfigId(2),
                         name: "carB".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -4765,11 +4765,11 @@ fn loading_resolves_co_located_stops_to_the_cars_own_line() {
             ],
             lines: Some(vec![
                 LineConfig {
-                    id: 1,
+                    id: crate::config::LineConfigId(1),
                     name: "A".into(),
                     serves: vec![StopId(0), StopId(1)],
                     elevators: vec![ElevatorConfig {
-                        id: 1,
+                        id: crate::config::ElevatorConfigId(1),
                         name: "carA".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -4794,11 +4794,11 @@ fn loading_resolves_co_located_stops_to_the_cars_own_line() {
                     max_cars: None,
                 },
                 LineConfig {
-                    id: 2,
+                    id: crate::config::LineConfigId(2),
                     name: "B".into(),
                     serves: vec![StopId(2), StopId(3)],
                     elevators: vec![ElevatorConfig {
-                        id: 2,
+                        id: crate::config::ElevatorConfigId(2),
                         name: "carB".into(),
                         max_speed: Speed::from(2.0),
                         acceleration: Accel::from(1.5),
@@ -4904,7 +4904,7 @@ fn two_car_loop_config() -> SimConfig {
     let line = config.building.lines.as_mut().unwrap();
     let template = line[0].elevators[0].clone();
     line[0].elevators.push(crate::config::ElevatorConfig {
-        id: 2,
+        id: crate::config::ElevatorConfigId(2),
         name: "L2".into(),
         starting_stop: StopId(2),
         ..template

--- a/crates/elevator-core/src/tests/proptest_tests.rs
+++ b/crates/elevator-core/src/tests/proptest_tests.rs
@@ -180,7 +180,7 @@ fn make_config(stop_count: u32, elevator_count: u32) -> SimConfig {
 
     let elevators: Vec<ElevatorConfig> = (0..elevator_count)
         .map(|i| ElevatorConfig {
-            id: i,
+            id: crate::config::ElevatorConfigId(i),
             name: format!("Elevator {i}"),
             max_speed: Speed::from(2.0),
             acceleration: Accel::from(1.0),
@@ -326,7 +326,7 @@ proptest! {
                 groups: None,
             },
             elevators: vec![ElevatorConfig {
-                id: 0,
+                id: crate::config::ElevatorConfigId(0),
                 name: "E0".into(),
                 max_speed: Speed::from(5.0),
                 acceleration: Accel::from(3.0),

--- a/crates/elevator-core/src/tests/reposition_tests.rs
+++ b/crates/elevator-core/src/tests/reposition_tests.rs
@@ -803,7 +803,7 @@ fn build_lobby_sim() -> crate::sim::Simulation {
             },
         ])
         .elevators(vec![ElevatorConfig {
-            id: 0,
+            id: crate::config::ElevatorConfigId(0),
             name: "A".into(),
             max_speed: Speed::from(2.0),
             acceleration: Accel::from(1.5),

--- a/crates/elevator-core/src/tests/reroute_tests.rs
+++ b/crates/elevator-core/src/tests/reroute_tests.rs
@@ -37,7 +37,7 @@ fn three_stop_config() -> SimConfig {
             groups: None,
         },
         elevators: vec![ElevatorConfig {
-            id: 0,
+            id: crate::config::ElevatorConfigId(0),
             name: "E0".into(),
             max_speed: Speed::from(5.0),
             acceleration: Accel::from(3.0),
@@ -149,7 +149,7 @@ fn disable_only_stop_causes_abandonment() {
             groups: None,
         },
         elevators: vec![ElevatorConfig {
-            id: 0,
+            id: crate::config::ElevatorConfigId(0),
             name: "E0".into(),
             max_speed: Speed::from(5.0),
             acceleration: Accel::from(3.0),
@@ -418,7 +418,7 @@ fn remove_only_destination_with_riding_passenger_returns_to_origin() {
             groups: None,
         },
         elevators: vec![ElevatorConfig {
-            id: 0,
+            id: crate::config::ElevatorConfigId(0),
             name: "E0".into(),
             max_speed: Speed::from(5.0),
             acceleration: Accel::from(3.0),
@@ -493,7 +493,7 @@ fn remove_stop_without_alternative_emits_stop_removed_not_no_alternative() {
             groups: None,
         },
         elevators: vec![ElevatorConfig {
-            id: 0,
+            id: crate::config::ElevatorConfigId(0),
             name: "E0".into(),
             max_speed: Speed::from(5.0),
             acceleration: Accel::from(3.0),

--- a/crates/elevator-core/src/tests/snapshot_tests.rs
+++ b/crates/elevator-core/src/tests/snapshot_tests.rs
@@ -84,11 +84,11 @@ fn snapshot_roundtrip_preserves_line_lookup() {
                 position: 0.0,
             }],
             lines: Some(vec![LineConfig {
-                id: 3,
+                id: crate::config::LineConfigId(3),
                 name: "Main".into(),
                 serves: vec![StopId(0)],
                 elevators: vec![ElevatorConfig {
-                    id: 0,
+                    id: crate::config::ElevatorConfigId(0),
                     name: "E".into(),
                     max_speed: Speed::from(2.0),
                     acceleration: Accel::from(1.5),
@@ -119,7 +119,7 @@ fn snapshot_roundtrip_preserves_line_lookup() {
     };
 
     let sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
-    assert!(sim.line_entity(3).is_some());
+    assert!(sim.line_entity(crate::config::LineConfigId(3)).is_some());
 
     let snap = sim.snapshot();
     let restored = snap
@@ -127,7 +127,7 @@ fn snapshot_roundtrip_preserves_line_lookup() {
         .unwrap();
 
     let restored_line = restored
-        .line_entity(3)
+        .line_entity(crate::config::LineConfigId(3))
         .expect("LineConfig.id 3 resolves post-restore");
     assert!(restored.world().line(restored_line).is_some());
 }
@@ -138,7 +138,7 @@ fn snapshot_roundtrip_preserves_elevator_lookup() {
     let sim = crate::sim::Simulation::new(&config, helpers::scan()).unwrap();
 
     let original = sim
-        .elevator_entity(0)
+        .elevator_entity(crate::config::ElevatorConfigId(0))
         .expect("config id 0 resolves pre-snapshot");
 
     let snap = sim.snapshot();
@@ -147,7 +147,7 @@ fn snapshot_roundtrip_preserves_elevator_lookup() {
         .unwrap();
 
     let restored_eid = restored
-        .elevator_entity(0)
+        .elevator_entity(crate::config::ElevatorConfigId(0))
         .expect("config id 0 resolves post-restore");
 
     // EntityIds are regenerated on restore, but the slot mapping should

--- a/crates/elevator-core/src/tests/traffic_detector_tests.rs
+++ b/crates/elevator-core/src/tests/traffic_detector_tests.rs
@@ -289,7 +289,7 @@ fn up_peak_detected_in_building_with_basement() {
             groups: None,
         },
         elevators: vec![ElevatorConfig {
-            id: 0,
+            id: crate::config::ElevatorConfigId(0),
             name: "Main".into(),
             max_speed: Speed::from(2.0),
             acceleration: Accel::from(1.5),

--- a/crates/elevator-core/tests/scenarios/common/mod.rs
+++ b/crates/elevator-core/tests/scenarios/common/mod.rs
@@ -53,7 +53,7 @@ pub fn canonical_building() -> SimConfig {
         .into_iter()
         .enumerate()
         .map(|(idx, start)| ElevatorConfig {
-            id: u32::try_from(idx).unwrap(),
+            id: elevator_core::config::ElevatorConfigId(u32::try_from(idx).unwrap()),
             name: format!("Car {}", char::from(b'A' + u8::try_from(idx).unwrap())),
             max_speed: Speed::from(4.0),
             acceleration: Accel::from(2.0),
@@ -88,7 +88,7 @@ pub fn canonical_building() -> SimConfig {
 #[must_use]
 pub fn twin_shaft_building() -> SimConfig {
     let car = |id: u32, name: &str| ElevatorConfig {
-        id,
+        id: elevator_core::config::ElevatorConfigId(id),
         name: name.into(),
         max_speed: Speed::from(2.0),
         acceleration: Accel::from(1.5),
@@ -101,7 +101,7 @@ pub fn twin_shaft_building() -> SimConfig {
     };
 
     let line = |id: u32, name: &str, car: ElevatorConfig| LineConfig {
-        id,
+        id: elevator_core::config::LineConfigId(id),
         name: name.into(),
         serves: vec![StopId(0), StopId(1), StopId(2)],
         elevators: vec![car],
@@ -184,7 +184,7 @@ pub fn compact_building() -> SimConfig {
             groups: None,
         },
         elevators: vec![ElevatorConfig {
-            id: 0,
+            id: elevator_core::config::ElevatorConfigId(0),
             name: "Only".into(),
             max_speed: Speed::from(2.0),
             acceleration: Accel::from(1.5),

--- a/crates/elevator-core/tests/scenarios/deterministic_replay.rs
+++ b/crates/elevator-core/tests/scenarios/deterministic_replay.rs
@@ -97,7 +97,7 @@ fn schedule() -> Vec<ScheduledSpawn> {
 /// assignments.
 fn build_sim() -> Simulation {
     let car = |id: u32, name: &str| ElevatorConfig {
-        id,
+        id: elevator_core::config::ElevatorConfigId(id),
         name: name.into(),
         max_speed: Speed::from(2.0),
         acceleration: Accel::from(1.5),

--- a/crates/elevator-core/tests/scenarios/penthouse_pickup.rs
+++ b/crates/elevator-core/tests/scenarios/penthouse_pickup.rs
@@ -30,7 +30,7 @@ fn multi_car_tower_config(stops: u32, door_open_ticks: u32, cars: u32) -> SimCon
         .collect();
     cfg.elevators = (0..cars)
         .map(|i| ElevatorConfig {
-            id: i,
+            id: elevator_core::config::ElevatorConfigId(i),
             name: format!("Car {}", char::from(b'A' + u8::try_from(i).unwrap())),
             max_speed: Speed::from(4.0),
             acceleration: Accel::from(2.0),

--- a/crates/elevator-core/tests/scenarios/single_call_single_car.rs
+++ b/crates/elevator-core/tests/scenarios/single_call_single_car.rs
@@ -36,7 +36,7 @@ fn three_car_sim_with<D: DispatchStrategy + 'static>(dispatch: D) -> Simulation 
         .into_iter()
         .enumerate()
         .map(|(idx, start)| ElevatorConfig {
-            id: u32::try_from(idx).unwrap(),
+            id: elevator_core::config::ElevatorConfigId(u32::try_from(idx).unwrap()),
             name: format!("Car {}", char::from(b'A' + u8::try_from(idx).unwrap())),
             max_speed: Speed::from(4.0),
             acceleration: Accel::from(2.0),
@@ -189,7 +189,7 @@ fn twin_shaft_sim() -> Simulation {
     use elevator_core::dispatch::BuiltinStrategy;
 
     let car = |id: u32, name: &str| ElevatorConfig {
-        id,
+        id: elevator_core::config::ElevatorConfigId(id),
         name: name.into(),
         max_speed: Speed::from(2.0),
         acceleration: Accel::from(1.5),
@@ -201,7 +201,7 @@ fn twin_shaft_sim() -> Simulation {
         ..ElevatorConfig::default()
     };
     let line = |id: u32, name: &str, car: ElevatorConfig| LineConfig {
-        id,
+        id: elevator_core::config::LineConfigId(id),
         name: name.into(),
         serves: vec![StopId(0), StopId(1)],
         elevators: vec![car],

--- a/crates/elevator-ffi/src/lib.rs
+++ b/crates/elevator-ffi/src/lib.rs
@@ -4202,7 +4202,7 @@ pub unsafe extern "C" fn ev_sim_elevator_entity(
         // Safety: validity guaranteed by caller.
         let ev = unsafe { &*handle };
         ev.sim
-            .elevator_entity(elevator_config_id)
+            .elevator_entity(elevator_core::config::ElevatorConfigId(elevator_config_id))
             .map_or(0, entity_to_u64)
     })
 }
@@ -4227,7 +4227,9 @@ pub unsafe extern "C" fn ev_sim_line_entity(handle: *mut EvSim, line_config_id: 
         }
         // Safety: validity guaranteed by caller.
         let ev = unsafe { &*handle };
-        ev.sim.line_entity(line_config_id).map_or(0, entity_to_u64)
+        ev.sim
+            .line_entity(elevator_core::config::LineConfigId(line_config_id))
+            .map_or(0, entity_to_u64)
     })
 }
 
@@ -4273,7 +4275,7 @@ pub unsafe extern "C" fn ev_sim_line_lookup_iter(
             // Safety: caller guarantees `out` has at least `capacity`
             // writable slots; bounds checked above.
             unsafe {
-                *out.add(written as usize) = u64::from(*config_id);
+                *out.add(written as usize) = u64::from(config_id.0);
                 *out.add(written as usize + 1) = entity_to_u64(*entity);
             }
             written += 2;
@@ -4326,7 +4328,7 @@ pub unsafe extern "C" fn ev_sim_elevator_lookup_iter(
             // Safety: caller guarantees `out` has at least `capacity`
             // writable slots; bounds checked above.
             unsafe {
-                *out.add(written as usize) = u64::from(*config_id);
+                *out.add(written as usize) = u64::from(config_id.0);
                 *out.add(written as usize + 1) = entity_to_u64(*entity);
             }
             written += 2;

--- a/crates/elevator-wasm/src/lib.rs
+++ b/crates/elevator-wasm/src/lib.rs
@@ -2442,7 +2442,7 @@ impl WasmSim {
     #[must_use]
     pub fn elevator_entity(&self, elevator_config_id: u32) -> u64 {
         self.inner
-            .elevator_entity(elevator_config_id)
+            .elevator_entity(elevator_core::config::ElevatorConfigId(elevator_config_id))
             .map_or(0, entity_to_u64)
     }
 
@@ -2469,7 +2469,7 @@ impl WasmSim {
     pub fn elevator_lookup_iter(&self) -> Vec<u64> {
         self.inner
             .elevator_lookup_iter()
-            .flat_map(|(config_id, entity)| [u64::from(*config_id), entity_to_u64(*entity)])
+            .flat_map(|(config_id, entity)| [u64::from(config_id.0), entity_to_u64(*entity)])
             .collect()
     }
 
@@ -2480,7 +2480,7 @@ impl WasmSim {
     #[must_use]
     pub fn line_entity(&self, line_config_id: u32) -> u64 {
         self.inner
-            .line_entity(line_config_id)
+            .line_entity(elevator_core::config::LineConfigId(line_config_id))
             .map_or(0, entity_to_u64)
     }
 
@@ -2493,7 +2493,7 @@ impl WasmSim {
     pub fn line_lookup_iter(&self) -> Vec<u64> {
         self.inner
             .line_lookup_iter()
-            .flat_map(|(config_id, entity)| [u64::from(*config_id), entity_to_u64(*entity)])
+            .flat_map(|(config_id, entity)| [u64::from(config_id.0), entity_to_u64(*entity)])
             .collect()
     }
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -77,7 +77,7 @@ SimConfig(
     ),
     elevators: [
         ElevatorConfig(
-            id: elevator_core::config::ElevatorConfigId(0),
+            id: 0,
             name: "Main",
             max_speed: 2.0,
             acceleration: 1.5,
@@ -157,7 +157,7 @@ SimConfig(
     ),
     elevators: [
         ElevatorConfig(
-            id: elevator_core::config::ElevatorConfigId(0),
+            id: 0,
             name: "Cage A",
             max_speed: 18.0,           // ~m/s, deep-shaft hoist class.
             acceleration: 1.5,

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -18,7 +18,7 @@ fn main() -> Result<(), SimError> {
         .stop(StopId(1), "Sky Lobby", 50.0)
         .stop(StopId(2), "Observation Deck", 100.0)
         .elevator(ElevatorConfig {
-            id: 0,
+            id: elevator_core::config::ElevatorConfigId(0),
             name: "Express A".into(),
             max_speed: 5.0.into(),
             acceleration: 2.0.into(),
@@ -77,7 +77,7 @@ SimConfig(
     ),
     elevators: [
         ElevatorConfig(
-            id: 0,
+            id: elevator_core::config::ElevatorConfigId(0),
             name: "Main",
             max_speed: 2.0,
             acceleration: 1.5,
@@ -157,7 +157,7 @@ SimConfig(
     ),
     elevators: [
         ElevatorConfig(
-            id: 0,
+            id: elevator_core::config::ElevatorConfigId(0),
             name: "Cage A",
             max_speed: 18.0,           // ~m/s, deep-shaft hoist class.
             acceleration: 1.5,

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -44,7 +44,7 @@ Override any `ElevatorConfig` field with struct-update syntax -- `ElevatorConfig
 
 | Field | Type | Description | Default |
 |---|---|---|---|
-| `id` | `u32` | Unique numeric ID within the config (mapped to `EntityId` at runtime) | -- |
+| `id` | `ElevatorConfigId` | Unique numeric ID within the config (mapped to `EntityId` at runtime) | -- |
 | `name` | `String` | Human-readable name for UIs and logs | -- |
 | `max_speed` | `Speed` | Maximum travel speed (distance units/second) | `2.0` |
 | `acceleration` | `Accel` | Acceleration rate | `1.5` |

--- a/docs/src/elevators.md
+++ b/docs/src/elevators.md
@@ -125,7 +125,7 @@ When constructing elevators, use `ElevatorConfig` to set initial parameters:
 #     .stop(StopId(0), "Ground", 0.0)
 #     .stop(StopId(1), "Top", 10.0)
     .elevator(ElevatorConfig {
-        id: 0,
+        id: elevator_core::config::ElevatorConfigId(0),
         name: "Express A".into(),
         max_speed: 5.0.into(),
         acceleration: 2.0.into(),

--- a/docs/src/stops-lines-groups.md
+++ b/docs/src/stops-lines-groups.md
@@ -37,8 +37,8 @@ For simple single-shaft buildings, you never need to think about lines. The buil
 SimulationBuilder::new()
     .stop(StopId(0), "Ground", 0.0)
     .stop(StopId(1), "Top", 10.0)
-    .elevator(ElevatorConfig { id: 0, ..Default::default() })
-    .elevator(ElevatorConfig { id: 1, ..Default::default() })
+    .elevator(ElevatorConfig { id: elevator_core::config::ElevatorConfigId(0), ..Default::default() })
+    .elevator(ElevatorConfig { id: elevator_core::config::ElevatorConfigId(1), ..Default::default() })
     .build()?;
 # Ok(())
 # }

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -28,7 +28,7 @@ struct ScheduledSpawn {
 
 fn car_config(id: u32, name: &str) -> ElevatorConfig {
     ElevatorConfig {
-        id,
+        id: elevator_core::config::ElevatorConfigId(id),
         name: name.into(),
         starting_stop: StopId(0),
         ..Default::default()


### PR DESCRIPTION
## Summary

Closes Tier 2 of the post-#870 audit and the final outstanding audit finding. Greptile flagged the raw `u32` on `Simulation::elevator_entity` / `line_entity` in #870 and #872 as inconsistent with the project's typed-ID convention (`StopId`, `ElevatorId`, `RiderId` are all newtypes). This brings the config-time identifier surface in line.

**Breaking** for Rust API users constructing configs programmatically. **Not breaking** for RON consumers, FFI/wasm/GMS callers, or snapshot bytes — see "What's NOT changing" below.

## What changes

- New `crate::config::ElevatorConfigId(pub u32)` and `LineConfigId(pub u32)` newtypes mirroring `StopId`'s shape.
- `ElevatorConfig.id` field type: `u32` → `ElevatorConfigId`.
- `LineConfig.id` field type: `u32` → `LineConfigId`.
- `Simulation::elevator_entity(ElevatorConfigId) -> Option<EntityId>` (was `u32`).
- `Simulation::line_entity(LineConfigId) -> Option<EntityId>` (was `u32`).
- `Simulation::elevator_lookup_iter()` and `line_lookup_iter()` now yield references to the newtypes.

Migration:

```rust
// before
ElevatorConfig { id: 0, ... }
sim.elevator_entity(0)

// after
ElevatorConfig { id: ElevatorConfigId(0), ... }
sim.elevator_entity(ElevatorConfigId(0))
```

## What's NOT changing

- **RON files**: both newtypes carry `#[serde(transparent)]`, so existing `assets/config/*.ron` with bare `id: 0` continue to deserialize. No RON file in this repo had to be touched.
- **FFI / wasm / GMS surface**: `ev_sim_elevator_entity(handle, u32)` and `ev_sim_line_entity(handle, u32)` still accept raw `u32`. The wrappers convert at the boundary (`elevator_core::config::ElevatorConfigId(elevator_config_id)`). C ABI, JS bindings, and the regenerated GML are byte-identical.
- **Snapshot format**: `WorldSnapshot::elevator_lookup` and `line_lookup` stay `BTreeMap<u32, usize>`. Conversion happens at the serialize/restore edges. Regenerated golden checksums produced **zero diff** in `assets/contract-corpus/golden.txt` — round-trip is bytewise stable.
- **`GroupConfig.id`**: deliberately left as `u32`. It's already converted to `GroupId` at the sim layer, so no asymmetry on the outward-facing surface.

## Implementation notes

The change touches ~42 files (mostly test fixtures constructing `ElevatorConfig`/`LineConfig` literals). The blast radius is exactly what's expected for a typed-ID refactor: every site that previously wrote `id: 0` for these structs now writes `id: ElevatorConfigId(0)`. Doc examples in `docs/src/*.md` and the public doctest on `SimulationBuilder::new` were updated alongside.

## Why `feat!:`

Per CLAUDE.md, this changes a public struct field type and a public method signature — that is breaking per semver. The `feat!:` convention triggers a major-version bump from release-please on the `elevator-core` crate (FFI / wasm / GMS surface ABI stays at v5, since their public surface is unchanged).

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --all-features`
- [x] `cargo test --workspace --all-features --tests` — 1077 lib tests + scenarios pass
- [x] `cargo test -p elevator-core --all-features --doc` — 179 doctests pass (4 in `docs/src/*.md` and one in `builder.rs` updated to use the new type)
- [x] `bash scripts/check-bindings.sh` — 159 methods in sync (no surface change)
- [x] `bash scripts/check-abi-pins.sh` — ABI v5 still in sync
- [x] `cargo run -p elevator-contract -- --update-golden` — **no diff** in golden.txt, confirms snapshot bytes are unchanged