### PR TITLE
ci(bench): pin nightly bench toolchain and key baseline on rustc version (#884)

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -29,11 +29,26 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned, NOT @stable. The criterion baseline is a frozen per-SHA
+      # measurement; comparing it against a run built by a newer stable
+      # rustc conflates compiler codegen drift with code changes, which
+      # is exactly how an unpinned @stable produced ~2 weeks of phantom
+      # +13–20% regressions (issue #884). Bump this deliberately when
+      # adopting a new toolchain — the baseline auto-re-establishes
+      # because the cache key below is keyed on `rustc --version`.
+      - uses: dtolnay/rust-toolchain@1.95.0
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: bench-criterion
           cache-targets: true
+
+      # Capture the exact compiler version into the env so the criterion
+      # baseline cache key can include it. Any toolchain change (the pin
+      # above, or even a patch release) then lands on a fresh key and the
+      # next nightly re-baselines instead of reporting compiler drift as
+      # a code regression.
+      - name: Record rustc version for the baseline cache key
+        run: echo "RUSTC_VER=$(rustc --version | tr ' ()' '___')" >> "$GITHUB_ENV"
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libudev-dev libasound2-dev libwayland-dev libxkbcommon-dev libvulkan-dev
@@ -53,14 +68,21 @@ jobs:
       # SHA's baseline so the new commit is compared against the prior
       # known-good measurement. The save step writes a fresh entry
       # under the new SHA, freezing it for subsequent nightlies.
+      #
+      # The key also carries `RUSTC_VER`, so the prefix-fallback only
+      # matches baselines built by the *same compiler*. A toolchain bump
+      # changes the prefix, every old baseline stops matching, and the
+      # next nightly re-establishes a clean baseline — instead of
+      # charging the compiler's codegen drift to the code as a phantom
+      # regression (issue #884).
       - name: Restore previous criterion baseline
         id: restore-baseline
         uses: actions/cache/restore@v4
         with:
           path: target/criterion
-          key: criterion-baseline-${{ github.ref_name }}-${{ github.sha }}
+          key: criterion-baseline-${{ github.ref_name }}-${{ env.RUSTC_VER }}-${{ github.sha }}
           restore-keys: |
-            criterion-baseline-${{ github.ref_name }}-
+            criterion-baseline-${{ github.ref_name }}-${{ env.RUSTC_VER }}-
 
       # Restore the previous nightly's regression-name list so the detect
       # step can gate issue-open on two-day persistence. Key is suffixed
@@ -137,7 +159,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: target/criterion
-          key: criterion-baseline-${{ github.ref_name }}-${{ github.sha }}
+          key: criterion-baseline-${{ github.ref_name }}-${{ env.RUSTC_VER }}-${{ github.sha }}
 
       # Save today's regression-name list under the per-run-id key so
       # tomorrow's prefix-fallback restore picks it up. Only the

--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -47,8 +47,11 @@ jobs:
       # above, or even a patch release) then lands on a fresh key and the
       # next nightly re-baselines instead of reporting compiler drift as
       # a code regression.
+      # Whitelist-sanitize to chars valid in a GitHub Actions cache key
+      # (commas in particular are rejected). A future rustc format change
+      # — channel suffix, date-delimiter tweak — can't then corrupt the key.
       - name: Record rustc version for the baseline cache key
-        run: echo "RUSTC_VER=$(rustc --version | tr ' ()' '___')" >> "$GITHUB_ENV"
+        run: echo "RUSTC_VER=$(rustc --version | sed 's/[^a-zA-Z0-9._-]/_/g')" >> "$GITHUB_ENV"
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libudev-dev libasound2-dev libwayland-dev libxkbcommon-dev libvulkan-dev


### PR DESCRIPTION
Closes #884 (and the dedup'd #887/#888/#889/#890/#891).

## TL;DR

The nightly "+13–20% regression" issues are a **false positive**. The elevator-core source did not regress — the bench harness's unpinned `@stable` toolchain was the cause.

## Evidence

A/B benchmarked **every** reported bench: current `main` vs a clean pre-window baseline (`f5a45584^`, before #859/#870/#872/#874), same local toolchain, 40–50 samples.

| Benchmark | CI-reported | Local main vs pre-window |
|---|---|---|
| `step/100_riders` | +13–17% | −0.06% (p=0.96) |
| `dispatch_comparison/scan_5e_10s` | +20% | −0.5% (p=0.33) |
| `dispatch_comparison/destination_5e_10s` | +15% | −0.1% (p=0.82) |
| `multi_group_step/multi_3g_2l_5e_20s` | +11% | **−4.4%** (improved) |
| `cross_group_routing/10_groups` | +6–7% | **−2.4%** (improved) |
| `dispatch/10e_50s` | +16% | +0.4% (p=0.89) |
| `query_riders/100_riders` | +8% | −2.8% (p=0.77) |

Also cleared the temporally-closest suspect #874 (`ElevatorConfigId`/`LineConfigId` newtypes) directly against its parent #872: zero-cost as expected.

## Root cause

`bench-nightly.yml` used `dtolnay/rust-toolchain@stable` (no pin, no `rust-toolchain.toml`). The criterion baseline is a frozen per-SHA measurement, so when a new stable rustc shipped (~05-23), every bench was rebuilt with newer codegen and compared against an old-compiler baseline — charging the compiler's codegen drift to the code. A same-toolchain A/B is blind to this (the compiler delta cancels), which is why it never showed up locally.

## Fix

- **Pin** the bench toolchain to `@1.95.0` so codegen is constant across nightlies — the harness now measures *code* changes, which is its job.
- **Key the criterion baseline cache on `rustc --version`** (restore / restore-keys / save). A deliberate toolchain bump now lands on a fresh cache prefix, so the next nightly re-establishes a clean baseline on the new compiler instead of reporting drift as a regression. Self-healing for all future bumps.

## Verification

- `python3 -c "yaml.safe_load(...)"` — workflow parses.
- `@1.95.0` is a supported `dtolnay/rust-toolchain` version ref; matches the current stable (`rustc 1.95.0`).
- No code change — `.github/` only, no crate path touched (no release-please bump).

Note: the unrelated macOS dylib packaging issue (#882) is left open with triage notes (needs a macOS GMS runtime to verify); the `_gms` arg-encoding crash (#883) is fixed in #892.