### PR TITLE
fix(deps): resolve crossbeam-epoch advisory, waive build-only quick-xml DoS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,9 +2365,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -10,7 +10,15 @@ version = 2
 yanked = "warn"
 # `unmaintained` defaults to "workspace" in v2; we want warnings, not failures.
 unmaintained = "workspace"
-ignore = []
+# quick-xml DoS advisories reachable only through wayland-scanner (a build-time
+# proc-macro that parses the fixed, trusted wayland-protocol XML shipped with the
+# crate — never attacker-controlled input). The fix lands in quick-xml >=0.41, but
+# wayland-scanner 0.31 pins ^0.39, so it is unreachable until wayland-rs bumps it.
+# Remove these once wayland-scanner ships a release using quick-xml >=0.41.
+ignore = [
+  "RUSTSEC-2026-0194",
+  "RUSTSEC-2026-0195",
+]
 
 [licenses]
 version = 2

--- a/deny.toml
+++ b/deny.toml
@@ -10,11 +10,16 @@ version = 2
 yanked = "warn"
 # `unmaintained` defaults to "workspace" in v2; we want warnings, not failures.
 unmaintained = "workspace"
-# quick-xml DoS advisories reachable only through wayland-scanner (a build-time
-# proc-macro that parses the fixed, trusted wayland-protocol XML shipped with the
-# crate — never attacker-controlled input). The fix lands in quick-xml >=0.41, but
-# wayland-scanner 0.31 pins ^0.39, so it is unreachable until wayland-rs bumps it.
-# Remove these once wayland-scanner ships a release using quick-xml >=0.41.
+# quick-xml DoS advisories (RUSTSEC-2026-0194/0195). Verified via
+# `cargo tree -i quick-xml`: its ONLY consumer is wayland-scanner, a BUILD-TIME
+# proc-macro that parses the fixed wayland-protocol XML shipped with the crate to
+# generate bindings at compile time. The runtime wayland protocol is binary, not
+# XML, so no runtime path parses compositor-/attacker-provided XML — the DoS
+# vectors are unreachable here.
+# This ignore is workspace-global: if `cargo tree -i quick-xml` ever reports a
+# consumer other than wayland-scanner, re-evaluate before trusting this waiver.
+# The fix lands in quick-xml >=0.41, but wayland-scanner 0.31 pins ^0.39, so it is
+# unreachable until wayland-rs bumps it. Remove once that release exists.
 ignore = [
   "RUSTSEC-2026-0194",
   "RUSTSEC-2026-0195",


### PR DESCRIPTION
## What
Clears the three RUSTSEC advisories failing the **Supply chain (cargo-deny)** check.

- **RUSTSEC-2026-0204** (crossbeam-epoch invalid pointer deref) — patched: `crossbeam-epoch` 0.9.18 → 0.9.20 via `cargo update`.
- **RUSTSEC-2026-0194 / -0195** (quick-xml quadratic-attr + namespace-exhaustion DoS) — waived with documented rationale in `deny.toml`.

## Why waive the quick-xml pair
`quick-xml` enters the tree **only** through `wayland-scanner` (a build-time proc-macro) which parses the fixed, trusted wayland-protocol XML shipped with the crate — never attacker-controlled input, so the DoS vectors are not reachable here. The fix lands in `quick-xml >= 0.41`, but `wayland-scanner` 0.31 pins `^0.39`; reaching 0.41 would require moving off winit/bevy 0.19. The ignore carries a removal trigger for when wayland-rs bumps quick-xml.

## Verification
- `cargo deny check advisories` → **advisories ok**
- `cargo check -p elevator-core` → clean (full bevy build validated by CI's wayland-equipped runners)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves failing cargo-deny advisories by bumping `crossbeam-epoch` and waiving build-only `quick-xml` DoS findings from `wayland-scanner`. The supply chain check now passes with no runtime exposure or functional changes.

- **Dependencies**
  - Update `crossbeam-epoch` 0.9.18 → 0.9.20 to fix RUSTSEC-2026-0204.
  - Add `deny.toml` ignores for RUSTSEC-2026-0194 and -0195 (impacting `quick-xml` only via `wayland-scanner` at build time; fixed in `quick-xml >=0.41`; remove when upstream bumps).

<sup>Written for commit 8cdf70499ed6e4bcb240e2b28f37b71420947704. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/elevator-core/pull/917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

