### PR TITLE
fix(gms): name macOS FFI proxy to match Mac_Runner dlopen (#882)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -369,7 +369,11 @@ jobs:
           cp -r examples/gms2-extension/* "$BUNDLE/"
           cp pickup/libelevator_ffi.so      "$BUNDLE/extension/elevator_ffi/"
           cp pickup/elevator_ffi.dll        "$BUNDLE/extension/elevator_ffi/"
-          cp pickup/libelevator_ffi.dylib   "$BUNDLE/extension/elevator_ffi/"
+          # macOS: the proxy name in elevator_ffi.yy is the bare `elevator_ffi`
+          # (no `lib` prefix, no `.dylib` suffix) because Mac_Runner dlopens the
+          # literal `@loader_path/elevator_ffi` (#882). The staged file has to
+          # match that proxy name, so drop the prefix/suffix on copy.
+          cp pickup/libelevator_ffi.dylib   "$BUNDLE/extension/elevator_ffi/elevator_ffi"
           # License compliance: the dual MIT/Apache notice ships with
           # every binary distribution.
           cp LICENSE LICENSE-MIT LICENSE-APACHE "$BUNDLE/"

--- a/examples/gms2-extension/README.md
+++ b/examples/gms2-extension/README.md
@@ -14,7 +14,7 @@ extension/elevator_ffi/
 ├── elevator_ffi_generated.gml       Auto-generated: external_define for every FFI fn
 ├── elevator_ffi_layout.gml          Auto-generated: #[repr(C)] field offsets
 ├── elevator_ffi.dll                 Windows binary (placed at release time / locally — see below)
-├── libelevator_ffi.dylib            macOS binary (   "   )
+├── elevator_ffi                     macOS binary — no lib prefix / no .dylib suffix (   "   )
 └── libelevator_ffi.so               Linux binary  (   "   )
 ```
 
@@ -102,7 +102,10 @@ cargo build -p elevator-ffi --release
 #    set CARGO_TARGET_DIR; adjust the source path accordingly.)
 cp target/release/libelevator_ffi.so \
    examples/gms2-extension/extension/elevator_ffi/    # Linux
-# or libelevator_ffi.dylib on macOS, elevator_ffi.dll on Windows
+# Windows: cp target/release/elevator_ffi.dll  examples/.../elevator_ffi/
+# macOS:   cp target/release/libelevator_ffi.dylib \
+#             examples/.../elevator_ffi/elevator_ffi   # note: no .dylib suffix —
+#          Mac_Runner dlopens the literal `@loader_path/elevator_ffi` (#882)
 
 # 3. Open a fresh GameMaker Studio 2 project and import the extension
 #    folder. From Asset Browser → right-click → Add → Existing Asset →
@@ -129,8 +132,10 @@ matrix). The harness includes static asserts on every
 ## Supported targets
 
 - **Windows x64 desktop**: `elevator_ffi.dll`
-- **macOS arm64 desktop**: `libelevator_ffi.dylib` (Intel Mac is a
-  follow-up — see PR 3's risk note)
+- **macOS arm64 desktop**: staged as `elevator_ffi` (built as
+  `libelevator_ffi.dylib`, renamed with no `lib` prefix / no `.dylib`
+  suffix to match the literal `dlopen` name — see #882). Intel Mac is a
+  follow-up — see PR 3's risk note.
 - **Ubuntu x64 desktop**: `libelevator_ffi.so`
 - **HTML5, mobile, consoles**: not supported. HTML5 needs
   [`elevator-wasm`](../../crates/elevator-wasm) with a different
@@ -150,8 +155,8 @@ Asset Browser instead of building it by hand. The manifest declares:
 - **Calling convention** `dll_cdecl` (default; on x64 ABI-equivalent
   to `dll_stdcall`).
 - **Per-platform binaries** via three `GMProxyFile` entries —
-  `elevator_ffi.dll` (Windows), `libelevator_ffi.dylib` (macOS),
-  `libelevator_ffi.so` (Linux). The `elevator_ffi.ext` zero-byte
+  `elevator_ffi.dll` (Windows), `elevator_ffi` (macOS — no prefix/suffix,
+  #882), `libelevator_ffi.so` (Linux). The `elevator_ffi.ext` zero-byte
   stub is the file the manifest's `filename` field points at; GMS
   picks the right per-platform `ProxyFile` at build time.
 - **Platform target mask** desktop x64 only (no HTML5, mobile, or

--- a/examples/gms2-extension/extension/elevator_ffi/.gitignore
+++ b/examples/gms2-extension/extension/elevator_ffi/.gitignore
@@ -1,3 +1,4 @@
 elevator_ffi.dll
+elevator_ffi
 libelevator_ffi.dylib
 libelevator_ffi.so

--- a/examples/gms2-extension/extension/elevator_ffi/elevator_ffi.yy
+++ b/examples/gms2-extension/extension/elevator_ffi/elevator_ffi.yy
@@ -15,7 +15,7 @@
   "copyToTargets":194,
   "description":"Native FFI bridge to elevator-core. Auto-generated manifest — see scripts/gen-gms-bindings.py.",
   "exportToGame":true,
-  "extensionVersion":"0.23.1",
+  "extensionVersion":"0.23.2",
   "files":[
     {
       "$GMExtensionFile":"v1",
@@ -30,7 +30,7 @@
       "name":"elevator_ffi.ext",
       "origname":"elevator_ffi.dll",
       "ProxyFiles":[
-        {"$GMProxyFile":"","%Name":"libelevator_ffi.dylib","name":"libelevator_ffi.dylib","resourceType":"GMProxyFile","resourceVersion":"2.0","TargetMask":1,},
+        {"$GMProxyFile":"","%Name":"elevator_ffi","name":"elevator_ffi","resourceType":"GMProxyFile","resourceVersion":"2.0","TargetMask":1,},
         {"$GMProxyFile":"","%Name":"libelevator_ffi.so","name":"libelevator_ffi.so","resourceType":"GMProxyFile","resourceVersion":"2.0","TargetMask":7,},
         {"$GMProxyFile":"","%Name":"elevator_ffi.dll","name":"elevator_ffi.dll","resourceType":"GMProxyFile","resourceVersion":"2.0","TargetMask":6,},
       ],

--- a/scripts/gen-gms-bindings.py
+++ b/scripts/gen-gms-bindings.py
@@ -387,7 +387,13 @@ def build_cdylib_file_entry() -> dict:
         "name": "elevator_ffi.ext",
         "origname": "elevator_ffi.dll",
         "ProxyFiles": [
-            build_proxy_file("libelevator_ffi.dylib", 1),
+            # macOS proxy is the bare symbol name with no `lib` prefix and
+            # no `.dylib` suffix: GameMaker's Mac_Runner calls
+            # dlopen("@loader_path/elevator_ffi", RTLD_NOW) with the literal
+            # extension name and no fallback — dyld does not auto-append
+            # `.dylib`, so the staged file must be named exactly
+            # `elevator_ffi` or `external_define` returns undefined (#882).
+            build_proxy_file("elevator_ffi", 1),
             build_proxy_file("libelevator_ffi.so", 7),
             build_proxy_file("elevator_ffi.dll", 6),
         ],


### PR DESCRIPTION
Fixes #882.

## Problem

GameMaker's `Mac_Runner` loads the extension binary with `dlopen("@loader_path/elevator_ffi", RTLD_NOW)` — the **literal** proxy name, no fallback. dyld does not auto-append `.dylib`, so a bundle that stages the binary as `libelevator_ffi.dylib` fails at runtime:

```
dlopen(@loader_path/elevator_ffi) failed ... '.../Contents/MacOS/elevator_ffi' (no such file)
```

`external_define` then returns `undefined` and `Open project in IDE → F5` breaks on macOS. @andymai verified by hand-staging that only a file named literally `elevator_ffi` (no `lib` prefix, no `.dylib` suffix) at `Contents/MacOS/` loads.

## Change (fix #1 from the issue)

- **`scripts/gen-gms-bindings.py`** — macOS `GMProxyFile` proxy name `libelevator_ffi.dylib` → bare `elevator_ffi`, with a comment recording the `dlopen`-literal constraint.
- **`elevator_ffi.yy`** — regenerated. Also picks up `extensionVersion` `0.23.1 → 0.23.2` (the committed manifest was stale relative to the crate version; this is a pure regeneration artifact).
- **`.github/workflows/release-please.yml`** — release-bundle staging renames the built dylib to `elevator_ffi` so the shipped file matches the proxy name.
- **`.gitignore`** — ignore the new local-build name `elevator_ffi`.
- **README** — extension tree, local-build recipe, supported-targets, and manifest sections updated to the macOS naming.

## Verification status

CI's `ffi-harness (macos-15)` job `dlopen`s the full file path directly, so it does **not** exercise the runner's literal-name resolution — the bug hides from CI and this fix can't be automatically verified there. What still needs on-device confirmation:

- [ ] Fresh IDE import of the extension folder on macOS, `F5`, and confirm `external_define` resolves (no `undefined`).
- [ ] Confirm GameMaker deploys the renamed proxy into `Contents/MacOS/` (the issue's open question — if the IDE still deploys to `Contents/Resources/`, the rename is necessary but not sufficient, and we escalate to fix #2/#3 in #882).

The rename is a prerequisite either way; it does not regress the Windows/Linux proxies (their `dlopen` names already carry the expected prefixes/suffixes).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Name the macOS GameMaker FFI proxy exactly `elevator_ffi` to match `Mac_Runner`’s literal `dlopen`, fixing `external_define` returning `undefined` on F5. Fixes #882.

- **Bug Fixes**
  - macOS `GMProxyFile` set to `elevator_ffi` in `scripts/gen-gms-bindings.py` (no `lib` prefix, no `.dylib` suffix).
  - Regenerated `elevator_ffi.yy` (proxy updated, `extensionVersion` to `0.23.2`).
  - Release workflow stages macOS binary as `elevator_ffi` (renames built `.dylib` on copy).
  - Updated README and `.gitignore`; Windows/Linux proxies unchanged.

- **Migration**
  - Local macOS builds: copy `libelevator_ffi.dylib` to `examples/gms2-extension/extension/elevator_ffi/elevator_ffi` (no suffix) before importing into GMS.

<sup>Written for commit 821465f92de420b5f10c4da5c551659875ff5146. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/elevator-core/pull/918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

