### PR TITLE
fix(lint): use assert_ne! for clippy 1.97 manual_assert_eq

### DIFF
--- a/crates/elevator-core/src/tests/api_surface_tests.rs
+++ b/crates/elevator-core/src/tests/api_surface_tests.rs
@@ -295,7 +295,7 @@ fn remove_stop_removes_from_stop_lookup() {
     let mut sim = Simulation::new(&config, scan()).unwrap();
 
     let stop_id = sim.stop_entity(StopId(2)).unwrap();
-    assert!(stop_id != EntityId::default());
+    assert_ne!(stop_id, EntityId::default());
 
     sim.remove_stop(stop_id).unwrap();
 


### PR DESCRIPTION
## Problem

clippy 1.97.0 added the `manual_assert_eq` lint, which fires on
`assert!(stop_id != EntityId::default())` in `api_surface_tests.rs` and fails
the CI `Check / Clippy` job (CI lints test targets). This blocks **all** open
PRs, not just this one.

The local pre-commit hook runs `cargo clippy -p elevator-core --all-features`
**without `--tests`**, so it never lints test modules — which is why this
slipped past local review to CI.

## Fix

One-line: `assert!(a != b)` → `assert_ne!(a, b)`. Verified the only occurrence
across the workspace via `cargo clippy --all-features --tests --benches`.

## Follow-up (not in this PR)

Add `--tests` (or `--all-targets`) to the pre-commit hook's clippy invocation so
this class of test-only lint is caught locally. Left out here to keep the
unblock minimal; it changes hook cost and warrants its own discussion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI Clippy failure by replacing a manual inequality assert with `assert_ne!` in `crates/elevator-core/src/tests/api_surface_tests.rs` to satisfy the new Clippy 1.97 `manual_assert_eq` lint.

<sup>Written for commit c3960af4742794b18adc71f372ddce703d429696. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/elevator-core/pull/919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

