### PR TITLE
ci(bench): cancel runner-speed variance with a calibration bench

### DIFF
--- a/.github/scripts/filter-bench-regressions.py
+++ b/.github/scripts/filter-bench-regressions.py
@@ -12,6 +12,19 @@ bench names that regressed on the *previous* nightly. Only regressions that
 appear on two consecutive runs are treated as confirmed and surface in the
 issue-open output.
 
+To suppress *shared-runner-speed* variance (issues #907/#908/#913/#914/#916 —
+a uniform ~7-16% "regression" across every unrelated bench when a later
+nightly lands on a faster/slower `ubuntu-latest` instance), the script divides
+the runner-speed factor back out. The `calibration/fixed_workload` bench
+(benches/calibration_bench.rs) contains no elevator-core code, so its
+change% is a pure reading of this runner vs the baseline runner. Each real
+bench's change is adjusted by that factor before the magnitude gate:
+`adjusted = (1 + change/100) / (1 + calib/100) - 1`. A genuine per-bench
+regression diverges from calibration and survives; a whole-suite runner scale
+cancels. If the calibration reading is absent (the one-night warm-up right
+after this ships, before calibration has a prior baseline), the script falls
+back to raw change% so detection is never silently weakened.
+
 Args:
     sys.argv[1]: path to append `regressed=true|false` and `gate=two-day|
         single-run` outputs to ($GITHUB_OUTPUT). Callers can use the `gate`
@@ -32,16 +45,55 @@ import re
 import sys
 from pathlib import Path
 
+# Criterion prints negatives with a Unicode minus (U+2212), not ASCII '-', so
+# the sign class accepts both — otherwise a faster-runner calibration reading
+# (negative change) fails to parse and silently drops to the raw fallback.
+_SIGN = r"[+\-−]?"
 CHANGE_RE = re.compile(
-    r"change:\s*\["
-    r"([+\-]?\d+(?:\.\d+)?)%\s+"
-    r"([+\-]?\d+(?:\.\d+)?)%\s+"
-    r"([+\-]?\d+(?:\.\d+)?)%"
-    r"\]"
+    rf"change:\s*\["
+    rf"({_SIGN}\d+(?:\.\d+)?)%\s+"
+    rf"({_SIGN}\d+(?:\.\d+)?)%\s+"
+    rf"({_SIGN}\d+(?:\.\d+)?)%"
+    rf"\]"
 )
 
 CURRENT_LIST = Path("regressions-current.txt")
 ISSUE_BODY = Path("regressions.txt")
+
+# The synthetic runner-speed bench (benches/calibration_bench.rs). Its median
+# change% is the shared-runner speed factor we divide out. Excluded from the
+# reported/persisted regression set — it is instrumentation, not a finding.
+CALIBRATION_NAME = "calibration/fixed_workload"
+
+
+def _pct(raw: str) -> float:
+    """Parse a criterion percentage, normalizing its Unicode minus to ASCII."""
+    return float(raw.replace("−", "-"))
+
+
+def calibration_change(lines: list[str]) -> float | None:
+    """Median change% of the calibration bench, or None if it has no change
+    line yet (first nightly after this ships — no prior baseline to compare)."""
+    for i, line in enumerate(lines):
+        if CALIBRATION_NAME not in line:
+            continue
+        for follow in lines[i : i + 6]:
+            if "change:" in follow:
+                m = CHANGE_RE.search(follow)
+                if m:
+                    return _pct(m.group(2))
+    return None
+
+
+def adjust(change_pct: float, calib_pct: float | None) -> float:
+    """Divide the runner-speed factor out of a bench's change%. With no
+    calibration reading, pass the raw change through unchanged (fallback)."""
+    if calib_pct is None:
+        return change_pct
+    scale = 1.0 + calib_pct / 100.0
+    if scale <= 0.0:  # absurd reading — don't trust it, fall back to raw
+        return change_pct
+    return ((1.0 + change_pct / 100.0) / scale - 1.0) * 100.0
 
 
 def main() -> int:
@@ -52,17 +104,27 @@ def main() -> int:
 
     lines = bench_log.read_text().splitlines(keepends=True)
 
+    calib = calibration_change(lines)
+    if calib is None:
+        print(
+            "warning: no calibration/fixed_workload change reading in this run — "
+            "using raw change% (expected on the first nightly after the "
+            "calibration bench ships, before it has a prior baseline)."
+        )
+
     todays: dict[str, str] = {}
     for i, line in enumerate(lines):
         if "Performance has regressed." not in line:
             continue
         ctx = lines[max(0, i - 3) : i + 1]
+        name = ctx[0].strip() if ctx else f"unknown_{i}"
+        if CALIBRATION_NAME in name:
+            continue
         change_line = next((l for l in ctx if "change:" in l), None)
         if change_line:
             m = CHANGE_RE.search(change_line)
-            if m and abs(float(m.group(2))) < threshold:
+            if m and adjust(_pct(m.group(2)), calib) < threshold:
                 continue
-        name = ctx[0].strip() if ctx else f"unknown_{i}"
         todays[name] = "".join(ctx) + "\n"
 
     CURRENT_LIST.write_text("\n".join(sorted(todays)) + ("\n" if todays else ""))

--- a/.github/scripts/filter-bench-regressions.py
+++ b/.github/scripts/filter-bench-regressions.py
@@ -96,6 +96,31 @@ def adjust(change_pct: float, calib_pct: float | None) -> float:
     return ((1.0 + change_pct / 100.0) / scale - 1.0) * 100.0
 
 
+def regression_block(lines: list[str], verdict_idx: int) -> tuple[str, str]:
+    """Resolve the (bench_name, block) for a 'Performance has regressed.' line.
+
+    Criterion's summary block starts at an *unindented* line — the bench id,
+    sometimes with `time:` appended when the id is short — and the
+    time:/thrpt:/change:/verdict lines below it are indented. Scanning back to
+    the first unindented line is robust to how many stat lines criterion emits;
+    a fixed offset breaks when a `Throughput`-configured bench adds a `thrpt:`
+    line (greptile/cubic P2 on #920). The name is normalized to the bare
+    criterion id so it stays stable across nights for the persistence gate and
+    the calibration-skip substring match is reliable."""
+    start = verdict_idx
+    for j in range(verdict_idx - 1, max(-1, verdict_idx - 9), -1):
+        if lines[j].strip() and not lines[j][:1].isspace():
+            start = j
+            break
+    name = lines[start].strip()
+    if name.startswith("Benchmarking "):
+        name = name[len("Benchmarking ") :].rsplit(":", 1)[0]
+    for tail in ("time:", "thrpt:"):
+        name = name.split(tail, 1)[0]
+    name = name.strip() or f"unknown_{verdict_idx}"
+    return name, "".join(lines[start : verdict_idx + 1])
+
+
 def main() -> int:
     github_output = Path(sys.argv[1])
     threshold = float(sys.argv[2])
@@ -116,16 +141,15 @@ def main() -> int:
     for i, line in enumerate(lines):
         if "Performance has regressed." not in line:
             continue
-        ctx = lines[max(0, i - 3) : i + 1]
-        name = ctx[0].strip() if ctx else f"unknown_{i}"
+        name, block = regression_block(lines, i)
         if CALIBRATION_NAME in name:
             continue
-        change_line = next((l for l in ctx if "change:" in l), None)
+        change_line = next((l for l in block.splitlines() if "change:" in l), None)
         if change_line:
             m = CHANGE_RE.search(change_line)
             if m and adjust(_pct(m.group(2)), calib) < threshold:
                 continue
-        todays[name] = "".join(ctx) + "\n"
+        todays[name] = block + "\n"
 
     CURRENT_LIST.write_text("\n".join(sorted(todays)) + ("\n" if todays else ""))
 

--- a/.github/scripts/test_filter_bench_regressions.py
+++ b/.github/scripts/test_filter_bench_regressions.py
@@ -135,6 +135,37 @@ class CalibrationAdjustmentTest(unittest.TestCase):
         self.assertNotIn(flt.CALIBRATION_NAME, body)
 
 
+class NameExtractionTest(unittest.TestCase):
+    def test_throughput_line_does_not_shift_name(self):
+        # A Throughput-configured bench adds a `thrpt:` line — the name must
+        # still resolve, and a regressed calibration entry with a thrpt line
+        # must still be skipped (greptile/cubic P2).
+        block = (
+            f"{flt.CALIBRATION_NAME}\n"
+            "                        time:   [3.0 ms 3.1 ms 3.2 ms]\n"
+            "                        thrpt:  [1.0 elem/s 1.1 elem/s 1.2 elem/s]\n"
+            "                        change: [+11.0% +12.0% +13.0%] (p = 0.00 < 0.05)\n"
+            "                        Performance has regressed.\n\n"
+        )
+        regressed, _, body = run_filter(block, previous=[flt.CALIBRATION_NAME])
+        self.assertEqual(regressed, "false")
+        self.assertNotIn("time:", body)
+
+    def test_same_line_name_and_time(self):
+        # Criterion prints short ids as `<id>  time: [...]` on one line.
+        log = (
+            "query_riders/100_riders time:   [18.0 µs 18.4 µs 18.9 µs]\n"
+            "                        change: [+11.0% +12.0% +13.0%] (p = 0.00 < 0.05)\n"
+            "                        Performance has regressed.\n\n"
+        )
+        log += bench_block(flt.CALIBRATION_NAME, 0.0, False)
+        _, _, body = run_filter(log, previous=["query_riders/100_riders"])
+        self.assertIn("query_riders/100_riders", body)
+        # The persisted name must be the bare id, not the id+time string.
+        name, _ = flt.regression_block(log.splitlines(keepends=True), 2)
+        self.assertEqual(name, "query_riders/100_riders")
+
+
 class HelperMathTest(unittest.TestCase):
     def test_adjust_cancels_matching_scale(self):
         self.assertAlmostEqual(flt.adjust(12.0, 12.0), 0.0, places=6)

--- a/.github/scripts/test_filter_bench_regressions.py
+++ b/.github/scripts/test_filter_bench_regressions.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Unit tests for filter-bench-regressions.py.
+
+The regression math lives entirely in the filter, so this is the real
+correctness gate for the calibration-relative detection (issues
+#907/#908/#913/#914/#916). Run: python3 .github/scripts/test_filter_bench_regressions.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "filter_bench_regressions",
+    Path(__file__).with_name("filter-bench-regressions.py"),
+)
+assert _spec and _spec.loader
+flt = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(flt)
+
+
+def _fmt(v: float) -> str:
+    # Match criterion: ASCII '+' for positives, Unicode minus for negatives.
+    return f"+{v:.4f}" if v >= 0 else f"−{abs(v):.4f}"
+
+
+def bench_block(name: str, change_pct: float, regressed: bool) -> str:
+    verdict = (
+        "Performance has regressed." if regressed else "No change in performance."
+    )
+    lo, hi = change_pct - 1.0, change_pct + 1.0
+    return (
+        f"{name}\n"
+        f"                        time:   [10.0 µs 11.0 µs 12.0 µs]\n"
+        f"                        change: [{_fmt(lo)}% {_fmt(change_pct)}% {_fmt(hi)}%] (p = 0.00 < 0.05)\n"
+        f"                        {verdict}\n\n"
+    )
+
+
+def run_filter(log_text: str, previous: list[str] | None, threshold: float = 5.0):
+    """Drive main() over a synthetic log; return (regressed, gate, issue_body)."""
+    with tempfile.TemporaryDirectory() as d:
+        d = Path(d)
+        log = d / "bench-output.log"
+        log.write_text(log_text)
+        gh_out = d / "gh_output"
+        gh_out.write_text("")
+        argv = [str(gh_out), str(threshold), str(log)]
+        prev_path = None
+        if previous is not None:
+            prev_path = d / "regressions-previous.txt"
+            prev_path.write_text("\n".join(previous) + ("\n" if previous else ""))
+            argv.append(str(prev_path))
+
+        # main() writes regressions-current.txt / regressions.txt relative to
+        # cwd, so run it inside the temp dir.
+        import os
+
+        cwd = os.getcwd()
+        old_argv = flt.sys.argv
+        try:
+            os.chdir(d)
+            flt.sys.argv = ["filter", *argv]
+            flt.main()
+        finally:
+            os.chdir(cwd)
+            flt.sys.argv = old_argv
+
+        out = dict(
+            line.split("=", 1)
+            for line in gh_out.read_text().splitlines()
+            if "=" in line
+        )
+        body_path = d / "regressions.txt"
+        body = body_path.read_text() if body_path.exists() else ""
+        return out.get("regressed"), out.get("gate"), body
+
+
+class CalibrationAdjustmentTest(unittest.TestCase):
+    def test_uniform_runner_scale_is_cancelled(self):
+        # Every bench +12%, calibration also +12% → adjusted ≈ 0 → not a
+        # regression even though yesterday flagged the same names.
+        names = ["query_tuple/10000_entities", "dispatch/10e_50s"]
+        log = "".join(bench_block(n, 12.0, True) for n in names)
+        log += bench_block(flt.CALIBRATION_NAME, 12.0, True)
+        regressed, _, body = run_filter(log, previous=names)
+        self.assertEqual(regressed, "false")
+        self.assertEqual(body, "")
+
+    def test_real_single_bench_regression_survives(self):
+        # One bench +12%, calibration flat → adjusted ≈ +12% → confirmed.
+        log = bench_block("dispatch/10e_50s", 12.0, True)
+        log += bench_block("query_tuple/10000_entities", 0.2, False)
+        log += bench_block(flt.CALIBRATION_NAME, 0.0, False)
+        regressed, gate, body = run_filter(log, previous=["dispatch/10e_50s"])
+        self.assertEqual(regressed, "true")
+        self.assertEqual(gate, "two-day")
+        self.assertIn("dispatch/10e_50s", body)
+
+    def test_runner_faster_never_regresses(self):
+        # Benches +2%, calibration +10% → adjusted negative → filtered.
+        names = ["query_tuple/10000_entities"]
+        log = "".join(bench_block(n, 2.0, True) for n in names)
+        log += bench_block(flt.CALIBRATION_NAME, 10.0, False)
+        regressed, _, _ = run_filter(log, previous=names)
+        self.assertEqual(regressed, "false")
+
+    def test_negative_calibration_unicode_minus_parses(self):
+        # Runner slightly faster than baseline (calibration −4%, Unicode minus)
+        # while one bench genuinely regressed +9% → adjusted ≈ +13.5% survives.
+        log = bench_block("dispatch/10e_50s", 9.0, True)
+        log += bench_block(flt.CALIBRATION_NAME, -4.0, False)
+        regressed, _, body = run_filter(log, previous=["dispatch/10e_50s"])
+        self.assertEqual(flt.calibration_change(log.splitlines(keepends=True)), -4.0)
+        self.assertEqual(regressed, "true")
+        self.assertIn("dispatch/10e_50s", body)
+
+    def test_calibration_missing_falls_back_to_raw(self):
+        # No calibration line at all → raw change% gates (old behavior).
+        names = ["query_tuple/10000_entities"]
+        log = "".join(bench_block(n, 12.0, True) for n in names)
+        regressed, _, body = run_filter(log, previous=names)
+        self.assertEqual(regressed, "true")
+        self.assertIn("query_tuple/10000_entities", body)
+
+    def test_calibration_never_reported(self):
+        # Calibration flagged as regressed by criterion must not appear in the
+        # findings, and must not itself trip the gate.
+        log = bench_block(flt.CALIBRATION_NAME, 30.0, True)
+        regressed, _, body = run_filter(log, previous=[flt.CALIBRATION_NAME])
+        self.assertEqual(regressed, "false")
+        self.assertNotIn(flt.CALIBRATION_NAME, body)
+
+
+class HelperMathTest(unittest.TestCase):
+    def test_adjust_cancels_matching_scale(self):
+        self.assertAlmostEqual(flt.adjust(12.0, 12.0), 0.0, places=6)
+
+    def test_adjust_fallback_when_none(self):
+        self.assertEqual(flt.adjust(12.0, None), 12.0)
+
+    def test_adjust_absurd_scale_falls_back(self):
+        self.assertEqual(flt.adjust(12.0, -150.0), 12.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -125,15 +125,25 @@ jobs:
           cargo bench -p elevator-core --bench dispatch_bench    -- --save-baseline nightly 2>&1 | tee -a bench-output.log
           cargo bench -p elevator-core --bench multi_line_bench  -- --save-baseline nightly 2>&1 | tee -a bench-output.log
           cargo bench -p elevator-core --bench query_bench       -- --save-baseline nightly 2>&1 | tee -a bench-output.log
+          # Runner-speed calibration — no elevator-core code. The detect step
+          # divides its change% back out of every real bench to cancel the
+          # shared `ubuntu-latest` speed variance that otherwise reads as a
+          # uniform across-the-board regression (#907/#908/#913/#914/#916).
+          cargo bench -p elevator-core --bench calibration_bench -- --save-baseline nightly 2>&1 | tee -a bench-output.log
 
       # Criterion's "Performance has regressed." line fires on any
       # statistically significant change, irrespective of magnitude. On a
       # shared CI runner that produces false positives from sub-percent
       # drift and from micro-benches whose measurements are dominated by
       # timer jitter. The filter below keeps regressions whose median
-      # change exceeds MIN_CHANGE_PCT *and* whose bench name also appeared
-      # on the previous nightly's regression list — the documented
-      # recurrence-as-signal heuristic from #734.
+      # change — after dividing out the calibration bench's runner-speed
+      # factor (#907/#908/#913/#914/#916) — exceeds MIN_CHANGE_PCT *and*
+      # whose bench name also appeared on the previous nightly's regression
+      # list (the recurrence-as-signal heuristic from #734).
+      #
+      # MIN_CHANGE_PCT stays at 5.0: calibration removes the uniform
+      # runner-speed component, so the residual this gate sees is genuine
+      # per-bench spread. Nudge to ~7-8 if residual noise still trips.
       - name: Detect regressions
         id: detect
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ crates/*/proptest-regressions/
 .vscode/
 *.code-workspace
 *.log
+
+# Python bytecode cache (e.g. from running .github/scripts tests)
+__pycache__/
+*.pyc

--- a/crates/elevator-core/Cargo.toml
+++ b/crates/elevator-core/Cargo.toml
@@ -117,6 +117,10 @@ harness = false
 name = "query_bench"
 harness = false
 
+[[bench]]
+name = "calibration_bench"
+harness = false
+
 [[example]]
 name = "dispatch_comparison"
 required-features = ["traffic"]

--- a/crates/elevator-core/benches/calibration_bench.rs
+++ b/crates/elevator-core/benches/calibration_bench.rs
@@ -1,0 +1,66 @@
+#![allow(missing_docs, clippy::missing_docs_in_private_items)]
+
+//! Runner-speed calibration bench.
+//!
+//! This measures nothing about elevator-core. Its only job is to give the
+//! nightly regression filter a reading of how fast *this* CI runner is, so it
+//! can divide the shared-runner speed factor back out of the real benches.
+//!
+//! The nightly baseline is a single frozen per-SHA measurement; when a later
+//! nightly lands on a faster/slower instance of the `ubuntu-latest` pool
+//! (~10-20% spread) every real bench reads as a uniform regression. Because
+//! this workload contains no elevator-core code, a core change can never move
+//! it — so `real_change / calibration_change` cancels the runner component
+//! while leaving genuine per-bench regressions intact. See
+//! `.github/scripts/filter-bench-regressions.py` and issues #907/#908/#913/
+//! #914/#916.
+//!
+//! The workload walks a heap array sized to spill L1 so it tracks memory
+//! throughput as well as raw clock, approximating the `SoA` `World` iteration
+//! the query/dispatch benches are dominated by. Everything is fixed and
+//! `black_box`-fenced so the measurement is stable across runs and the
+//! optimizer can't fold it away.
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+
+const LEN: usize = 64 * 1024;
+const PASSES: usize = 64;
+
+fn seeded_buffer() -> Vec<u64> {
+    let mut buf = vec![0u64; LEN];
+    let mut x = 0x9E37_79B9_7F4A_7C15_u64;
+    for (i, slot) in buf.iter_mut().enumerate() {
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        *slot = x ^ (i as u64);
+    }
+    buf
+}
+
+fn calibration_workload(buf: &[u64]) -> u64 {
+    let mut acc = 0u64;
+    for _ in 0..PASSES {
+        for &v in buf {
+            acc = acc.wrapping_add(v).rotate_left(1) ^ v;
+        }
+    }
+    acc
+}
+
+fn bench_calibration(c: &mut Criterion) {
+    // Allocate + seed once, outside the timed loop, so the measurement is
+    // dominated by the memory walk (runner throughput) rather than allocator
+    // jitter.
+    let buf = seeded_buffer();
+    let mut group = c.benchmark_group("calibration");
+    group.bench_function("fixed_workload", |b| {
+        b.iter(|| black_box(calibration_workload(black_box(&buf))));
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_calibration);
+criterion_main!(benches);


### PR DESCRIPTION
## Problem

The nightly bench guard filed five false-positive regression issues
(#907, #908, #913, #914, #916) across 2026-06-25 → 07-06 with **zero commits
touching `crates/elevator-core/src` or `benches/`** in that window — every merge
was a dependency bump.

Root cause: the per-SHA criterion baseline is a **single frozen measurement**, so
a later nightly landing on a faster/slower `ubuntu-latest` instance reads as a
**uniform ~7–16% "regression" across every unrelated bench**. The `MIN_CHANGE_PCT=5.0`
gate sits below that ~10–20% runner-noise floor, and the two-day persistence gate
can't help because a bad baseline makes *every* subsequent night regress. PR #884
fixed *compiler* drift (pinned rustc); this is the orthogonal *runner* drift.

## Approach — calibration-relative detection

Add a synthetic `calibration/fixed_workload` bench (no elevator-core code — a fixed
memory walk that tracks only runner throughput) and divide its change% back out of
every real bench before the gate:

```
adjusted = (1 + change/100) / (1 + calib/100) - 1
```

A whole-suite runner scale cancels; a genuine per-bench regression diverges from
calibration and survives (a core change can't move the core-independent calibration
bench). If calibration has no reading yet — the one-night warm-up right after this
ships, before it has a prior baseline — the filter falls back to raw change% so
detection is never silently weakened.

Also widens `CHANGE_RE` to accept criterion's Unicode-minus so a faster-runner
(negative) calibration reading parses.

## Changes

- `crates/elevator-core/benches/calibration_bench.rs` — synthetic runner-speed bench.
- `crates/elevator-core/Cargo.toml` — `[[bench]]` entry (non-shipping).
- `.github/workflows/bench-nightly.yml` — run calibration + documented gate comments.
- `.github/scripts/filter-bench-regressions.py` — calibration adjustment + raw fallback.
- `.github/scripts/test_filter_bench_regressions.py` — 9 deterministic unittests.

## Verification

- `python3 .github/scripts/test_filter_bench_regressions.py` — 9 tests, all pass
  (uniform-scale cancels, single-bench regression survives, runner-faster filtered,
  calibration-missing falls back, calibration excluded from findings, Unicode-minus
  parses).
- `cargo bench -p elevator-core --bench calibration_bench` runs stably (~3.0 ms) and
  emits a parseable `change:` line on re-run.
- End-to-end only manifests on the GH Actions nightly. Shipped behind the unchanged
  persistence gate, so a filter bug can at worst fall back to today's behavior, never
  spuriously file. Expect a **one-night warm-up** (first post-merge nightly restores a
  pre-calibration baseline → raw fallback for that night; adjustment active from night 2).

## Notes

- Not implementing the heavier median-of-N-nightlies baseline freeze; calibration
  targets the observed signature with far less workflow state. Documented as fallback
  hardening if residual per-bench noise still trips after threshold tuning.
- Depends on #919 (clippy 1.97 lint) landing first for CI to go green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a synthetic `calibration/fixed_workload` bench and normalizes nightly Criterion change% against it to cancel shared runner-speed variance. Also hardens bench-name extraction by scanning to the first unindented id and stripping `Benchmarking …:`, `time:`, and `thrpt:` tails so calibration skipping and persistence stay stable.

- **Bug Fixes**
  - Adjust each bench using calibration before gating; adjusted = ((1 + change/100) / (1 + calib/100) - 1). Exclude calibration from findings; if it lacks a prior baseline, use raw change%.
  - Resolve names by backward scan to a stable id; handles `thrpt:` and short-id same-line formats, preventing skip/persist errors.
  - Parse Criterion’s Unicode minus; add deterministic tests (incl. `thrpt:` and short-id). Keep `MIN_CHANGE_PCT` at 5.0.

- **Migration**
  - No action needed.
  - Expect one warm-up night where raw change% is used; calibration-based adjustment activates from night two.

<sup>Written for commit 18121296ddb68250f2f972c1e4b8e9ef17525f88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/elevator-core/pull/920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

