### PR TITLE
fix(ci): pre-compile benches so cargo output doesn't pollute bench-output.log

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -120,6 +120,11 @@ jobs:
         id: bench
         run: |
           set -o pipefail
+          # Pre-compile all benches so cargo's "Updating/Downloading/Compiling"
+          # output doesn't land in bench-output.log (parsed by the publish step).
+          # On a cold build it otherwise pollutes the log and github-action-
+          # benchmark reports "No benchmark result was found".
+          cargo bench -p elevator-core --no-run
           cargo bench -p elevator-core --bench sim_bench         -- --save-baseline nightly 2>&1 | tee -a bench-output.log
           cargo bench -p elevator-core --bench scaling_bench     -- --save-baseline nightly 2>&1 | tee -a bench-output.log
           cargo bench -p elevator-core --bench dispatch_bench    -- --save-baseline nightly 2>&1 | tee -a bench-output.log


### PR DESCRIPTION
## Problem
The nightly benchmark job fails every run at **Publish bench history**:
> `No benchmark result was found in bench-output.log. Benchmark output was 'Updating crates.io index / Downloading crates / Downloaded ...'`

The `Run benchmarks` step pipes each bench through `2>&1 | tee -a bench-output.log`. On a cold build (no cargo build cache in this workflow), `cargo`'s *Updating/Downloading/Compiling* output is merged into the same log that `github-action-benchmark` parses, so it finds no benchmark data and fails.

This is **not** the gh-pages concurrency race (already handled by the existing `concurrency: pages` blocks) — it's log contamination.

## Fix
Add `cargo bench -p elevator-core --no-run` before the measured runs. Compilation output goes to that step instead, so the `tee -a` log captures only Criterion results.

One line + comment; no behavior change to the benchmarks or regression detection. Nightly run will confirm green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-compiles benches in nightly CI to keep cargo build output out of `bench-output.log`, so `github-action-benchmark` can parse results and publish history. Adds `cargo bench -p elevator-core --no-run` before measured runs; no benchmark behavior change.

<sup>Written for commit 255805e5e6edea9003c99ecab88fe3ce10813c88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/elevator-core/pull/921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

