### PR TITLE
fix(ci): publish bench history from Criterion JSON estimates

### DIFF
--- a/.github/scripts/criterion-to-bencher.py
+++ b/.github/scripts/criterion-to-bencher.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Convert Criterion's JSON estimates into libtest "bencher" lines.
+
+github-action-benchmark's `cargo` tool parses the libtest format
+(`test NAME ... bench: N ns/iter (+/- M)`), which Criterion never emits.
+Criterion's own `bench-output.log` is consumed by the regression detector
+in its native format, so we cannot change that. Instead we read the
+machine-readable estimates Criterion writes under target/criterion/ and
+emit a separate bencher-format file for the publish step.
+
+Names come from the directory path (reliable), not the log (where Criterion
+drops the name prefix in non-TTY runs). Values are nanoseconds.
+"""
+import glob
+import json
+import os
+import sys
+
+root = sys.argv[1] if len(sys.argv) > 1 else "target/criterion"
+lines = []
+for est in sorted(glob.glob(os.path.join(root, "**", "new", "estimates.json"), recursive=True)):
+    parts = est.split(os.sep)
+    ci = len(parts) - 1 - parts[::-1].index("criterion") if "criterion" in parts else 0
+    name = "/".join(parts[ci + 1:-2])
+    with open(est) as f:
+        data = json.load(f)
+    mean = data.get("mean", {}).get("point_estimate")
+    if mean is None:
+        continue
+    spread = (data.get("std_dev") or {}).get("point_estimate")
+    if spread is None:
+        spread = data.get("mean", {}).get("standard_error", 0.0)
+    lines.append(f"test {name} ... bench: {round(mean)} ns/iter (+/- {round(spread)})")
+
+if not lines:
+    sys.exit("criterion-to-bencher: no estimates found under " + root)
+sys.stdout.write("\n".join(lines) + "\n")

--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -235,11 +235,18 @@ jobs:
       # `tee -a` above) and pushes per-bench history to gh-pages/bench/. The
       # docs.yml workflow uses `keep_files: true` to preserve this directory
       # across docs deploys.
+      # github-action-benchmark's `cargo` parser wants libtest "bencher"
+      # lines, which Criterion never emits. Generate them from Criterion's
+      # JSON estimates so bench-output.log stays in its native format for
+      # the regression detector above.
+      - name: Convert Criterion results to bencher format
+        run: python3 .github/scripts/criterion-to-bencher.py > bench-bencher.txt
+
       - name: Publish bench history
         uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: 'cargo'
-          output-file-path: bench-output.log
+          output-file-path: bench-bencher.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           gh-pages-branch: gh-pages


### PR DESCRIPTION
## Problem
`Publish bench history` fails with `No benchmark result was found in bench-output.log`. `github-action-benchmark`'s `cargo` parser expects libtest bencher lines (`test NAME ... bench: N ns/iter (+/- M)`), but **Criterion never emits that format** — its `bench-output.log` uses `NAME time: [lo mid hi]`.

The log can't just be reformatted: the `Detect regressions` step parses Criterion's native output from the same file. And parsing the log for names is unreliable — Criterion drops the name prefix on many `time:` lines in non-TTY runs.

(My earlier PR #921 fixed a *different*, real bug — cargo build output polluting the log — which is why `Run benchmarks` now passes. This is the second, underlying bug.)

## Fix
Add `criterion-to-bencher.py`, which reads Criterion's machine-readable `target/criterion/*/new/estimates.json` (names from the dir path, values in ns) and emits bencher lines to `bench-bencher.txt`. Point the publish step at that file; `bench-output.log` is untouched for the detector.

## Verification
Ran the converter against the **real artifact** from the last failed run: **all 54 benchmarks convert and 100% match github-action-benchmark's exact cargo regex.** Values cross-check against the log (e.g. `dispatch/3e_10s` = 7476 ns ≈ the log's 7.6 µs). Final gh-pages publish will confirm on a dispatched run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI benchmark publishing by converting Criterion JSON estimates into libtest bencher lines for `benchmark-action/github-action-benchmark@v1`’s `cargo` parser. Leaves `bench-output.log` unchanged for regression detection, restoring bench history updates.

- **Bug Fixes**
  - Added `criterion-to-bencher.py` to read `target/criterion/**/new/estimates.json` and emit `test NAME ... bench: N ns/iter (+/- M)`.
  - Workflow now generates `bench-bencher.txt` and uses it as `output-file-path` for the publish step.
  - Prevents the “No benchmark result was found” failure; verified against real artifacts.

<sup>Written for commit 5618969b4821229181106f34038d0323d55a5e66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/elevator-core/pull/922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

