### PR TITLE
ci(bench): clamp calibration adjustment to damping-only

### DIFF
--- a/.github/scripts/filter-bench-regressions.py
+++ b/.github/scripts/filter-bench-regressions.py
@@ -19,7 +19,8 @@ the runner-speed factor back out. The `calibration/fixed_workload` bench
 (benches/calibration_bench.rs) contains no elevator-core code, so its
 change% is a pure reading of this runner vs the baseline runner. Each real
 bench's change is adjusted by that factor before the magnitude gate:
-`adjusted = min((1 + change/100) / (1 + calib/100) - 1, change)`. A genuine
+`adjusted = min(((1 + change/100) / (1 + calib/100) - 1) * 100, change)`, with
+both sides of the `min` in percentage units. A genuine
 per-bench regression diverges from calibration and survives; a whole-suite
 runner scale cancels. If the calibration reading is absent (the one-night
 warm-up right after this ships, before calibration has a prior baseline), the

--- a/.github/scripts/filter-bench-regressions.py
+++ b/.github/scripts/filter-bench-regressions.py
@@ -19,11 +19,15 @@ the runner-speed factor back out. The `calibration/fixed_workload` bench
 (benches/calibration_bench.rs) contains no elevator-core code, so its
 change% is a pure reading of this runner vs the baseline runner. Each real
 bench's change is adjusted by that factor before the magnitude gate:
-`adjusted = (1 + change/100) / (1 + calib/100) - 1`. A genuine per-bench
-regression diverges from calibration and survives; a whole-suite runner scale
-cancels. If the calibration reading is absent (the one-night warm-up right
-after this ships, before calibration has a prior baseline), the script falls
-back to raw change% so detection is never silently weakened.
+`adjusted = min((1 + change/100) / (1 + calib/100) - 1, change)`. A genuine
+per-bench regression diverges from calibration and survives; a whole-suite
+runner scale cancels. If the calibration reading is absent (the one-night
+warm-up right after this ships, before calibration has a prior baseline), the
+script falls back to raw change% so detection is never silently weakened.
+
+The `min(..., change)` clamp makes the adjustment damping-only — see `adjust()`
+for why an unclamped divide-out amplified +3% into +15.6% and produced the
+false positives in #923/#924.
 
 Args:
     sys.argv[1]: path to append `regressed=true|false` and `gate=two-day|
@@ -87,13 +91,27 @@ def calibration_change(lines: list[str]) -> float | None:
 
 def adjust(change_pct: float, calib_pct: float | None) -> float:
     """Divide the runner-speed factor out of a bench's change%. With no
-    calibration reading, pass the raw change through unchanged (fallback)."""
+    calibration reading, pass the raw change through unchanged (fallback).
+
+    The result is clamped to never exceed the raw change: calibration may only
+    *shrink* a reported regression, never inflate one. Without the clamp a
+    faster-than-baseline runner amplifies instead of cancelling — on run
+    29680411190 calibration read −10.87% while four `dispatch_comparison/
+    *_50e_200s` benches read +3%, and `(1.03)/(0.8913)−1 = +15.6%` cleared the
+    5% gate (issues #923/#924). The divide-out assumes runner speed is a single
+    scalar every bench shares; it isn't, because the calibration walk is
+    memory-bandwidth-bound while the dispatch benches are branch-bound, so the
+    two diverge across runner instances. Damping-only keeps the whole-suite
+    cancellation this was built for while making that divergence unable to
+    manufacture a regression.
+    """
     if calib_pct is None:
         return change_pct
     scale = 1.0 + calib_pct / 100.0
     if scale <= 0.0:  # absurd reading — don't trust it, fall back to raw
         return change_pct
-    return ((1.0 + change_pct / 100.0) / scale - 1.0) * 100.0
+    adjusted = ((1.0 + change_pct / 100.0) / scale - 1.0) * 100.0
+    return min(adjusted, change_pct)
 
 
 def regression_block(lines: list[str], verdict_idx: int) -> tuple[str, str]:

--- a/.github/scripts/test_filter_bench_regressions.py
+++ b/.github/scripts/test_filter_bench_regressions.py
@@ -110,7 +110,9 @@ class CalibrationAdjustmentTest(unittest.TestCase):
 
     def test_negative_calibration_unicode_minus_parses(self):
         # Runner slightly faster than baseline (calibration −4%, Unicode minus)
-        # while one bench genuinely regressed +9% → adjusted ≈ +13.5% survives.
+        # while one bench genuinely regressed +9%. The damping clamp holds the
+        # adjusted value at the raw +9% rather than inflating it to +13.5%; it
+        # still clears the 5% gate, so the finding survives either way.
         log = bench_block("dispatch/10e_50s", 9.0, True)
         log += bench_block(flt.CALIBRATION_NAME, -4.0, False)
         regressed, _, body = run_filter(log, previous=["dispatch/10e_50s"])
@@ -175,6 +177,33 @@ class HelperMathTest(unittest.TestCase):
 
     def test_adjust_absurd_scale_falls_back(self):
         self.assertEqual(flt.adjust(12.0, -150.0), 12.0)
+
+    def test_adjust_never_exceeds_raw_change(self):
+        # Faster runner (negative calibration) must not inflate a small
+        # positive change. Unclamped this is (1.03)/(0.89135)-1 = +15.6%.
+        self.assertAlmostEqual(flt.adjust(3.0, -10.865), 3.0, places=6)
+
+    def test_adjust_still_damps_when_calibration_slower(self):
+        # The original purpose is preserved: a slower runner still cancels.
+        self.assertLess(flt.adjust(12.0, 10.0), 12.0)
+
+
+class DampingRegressionTest(unittest.TestCase):
+    def test_issue_923_924_shape_is_not_flagged(self):
+        # The exact shape that produced #923/#924: runner ~11% faster on
+        # calibration, four benches ~+3%, flagged both nights by the
+        # persistence gate. Damping-only holds them at +3% → below the gate.
+        names = [
+            "dispatch_comparison/etd_50e_200s",
+            "dispatch_comparison/nearest_car_50e_200s",
+            "dispatch_comparison/rsr_50e_200s",
+            "dispatch_comparison/scan_50e_200s",
+        ]
+        log = "".join(bench_block(n, 3.0, True) for n in names)
+        log += bench_block(flt.CALIBRATION_NAME, -10.865, False)
+        regressed, _, body = run_filter(log, previous=names)
+        self.assertEqual(regressed, "false")
+        self.assertEqual(body, "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes the false-positive class behind #923 and #924.

## The bug

The calibration divide-out from #920 assumes runner speed is a single scalar shared by every bench, so dividing one synthetic bench's change% out of the others cancels the shared component. That assumption breaks when the calibration bench and the real bench respond differently to a change of runner instance.

`calibration/fixed_workload` is a fixed 64Ki x u64 sequential walk — memory-bandwidth-bound and L2-resident. `dispatch_comparison/*_50e_200s` is branch-heavy over a much larger working set. On a runner whose memory subsystem is disproportionately fast, calibration swings much harder than the benches it is correcting, and the division *inflates* the result instead of cancelling it.

On nightly run 29680411190:

| | median change |
|---|---|
| `calibration/fixed_workload` | **-10.87%** |
| `dispatch_comparison/etd_50e_200s` | +3.04% |
| `dispatch_comparison/nearest_car_50e_200s` | +3.37% |
| `dispatch_comparison/rsr_50e_200s` | +4.16% |
| `dispatch_comparison/scan_50e_200s` | +3.41% |

```
(1 + 0.0304) / (1 - 0.1087) - 1 = +15.6%
```

Every one of them cleared the 5% gate on a +3% raw reading, two nights running, and the persistence gate filed an issue.

## The fix

Clamp the adjustment so it can only ever *shrink* a reported regression:

```python
adjusted = ((1.0 + change_pct / 100.0) / scale - 1.0) * 100.0
return min(adjusted, change_pct)
```

A whole-suite runner slowdown still cancels exactly as before (that path only ever reduces the value, so the clamp is inert). Calibration divergence can no longer manufacture a regression that the raw measurement does not support.

## Verification

Replaying the real `bench-output.log` from run 29680411190 through both versions, with the previous night's regression list supplied so the two-day gate applies:

```
old: regressed=true      <- filed #924
new: regressed=false
```

Tests: 14 pass (`python3 .github/scripts/test_filter_bench_regressions.py`), including a new case built from the exact #923/#924 shape and a `min`-boundary case asserting `adjust(3.0, -10.865) == 3.0`.

## Not fixed here

The deeper issue is that the persistence gate and the per-SHA baseline lock are mutually incompatible: a real regression is visible on exactly one night (the first nightly after a new SHA lands), and that same night re-locks the baseline, so every later night is a same-SHA self-comparison. Since the gate requires two consecutive nightlies, it can only ever confirm noise. Follow-up PR replaces the gate with a median-of-N-nightlies baseline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp the CI bench calibration adjustment to damping-only so it can only reduce a reported regression, preventing inflated results. This stops false positives when calibration diverges from real benches (e.g., #923, #924).

- **Bug Fixes**
  - Change `adjust()` to cap the adjusted value at the raw `change%` (damping-only), and document the formula with both sides of the clamp in percent units.
  - Preserve whole-suite runner cancellation and fallback behavior when calibration is missing or absurd.
  - Add targeted tests for the #923/#924 shape, the clamp boundary, and the slower-runner damping case; all tests pass.

<sup>Written for commit a1dea43c31c5e34bc8b3ec6ba7ea23d6280afb82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/elevator-core/pull/931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

