### PR TITLE
ci(bench): stratify the bench baseline by machine class

### DIFF
--- a/.github/scripts/detect-bench-regressions.py
+++ b/.github/scripts/detect-bench-regressions.py
@@ -1,34 +1,38 @@
 #!/usr/bin/env python3
-"""Detect bench regressions against a rolling median of the last N nightlies.
+"""Detect bench regressions against a rolling median of comparable nightlies.
 
-Detection deliberately does not use Criterion's own `change:` lines, which
-compare against a per-SHA-locked baseline. That pairing could not work:
-the baseline froze on the *first* nightly to measure a commit, so a
-genuine regression was visible for exactly one night (the nightly right
-after the new SHA landed, compared against the prior SHA) and that same
-night re-locked the baseline. Every later night compared the SHA against
-itself, where no code difference exists. Because the issue-open gate
-requires a bench to regress on two *consecutive* nightlies, it could only
-ever confirm noise — which does recur on same-SHA nights — and never a real
-regression. Issues #923/#924 are that failure mode.
+Baseline selection is machine-stratified. The `ubuntu-latest` pool cycles
+between a handful of distinct CPU SKUs, and the spread between them dwarfs
+the effect sizes worth alerting on: across 25 consecutive nightlies with no
+change to simulation code, whole-suite swings of -20% to +12% tracked which
+SKU the run landed on. A median taken over *all* recent nightlies therefore
+blends hardware, and a bench compared against it is measured mostly by which
+machine it drew rather than by its code.
 
-Here the baseline is instead the per-bench median of the last N nightly
-measurements, read from Criterion's machine-readable estimates.json rather
-than from its change lines. Two properties follow:
+The synthetic `calibration/fixed_workload` bench (benches/calibration_bench.rs,
+no elevator-core code) identifies the SKU: its reading is sharply quantized,
+clustering within 1% for repeat visits to the same machine class while classes
+sit 10-15% apart. Only prior nightlies whose calibration lands within
+MACHINE_TOL of tonight's are eligible as baseline samples, so the comparison is
+like-for-like hardware. Nights on a machine class with too little history are
+recorded but not gated, which is why HISTORY_LEN spans several weeks: a class
+seen occasionally still accumulates MIN_SAMPLES within the window.
 
-- A single unusually fast or slow runner moves the median by at most one
-  sample out of N, so the comparison point stays stable night to night.
-  That is what the per-SHA freeze was reaching for, without freezing.
-- A real regression stays above the median for several consecutive nights
-  after it lands (until enough post-regression samples accumulate to drag
-  the median up), so the two-day persistence gate can finally confirm one.
+Within a class the residual runner drift is divided out from each bench and
+clamped to damping-only: the adjustment may shrink a reported regression but
+never inflate one. Calibration is memory-bandwidth-bound while the sim benches
+are branch-bound, so the two diverge and an unclamped divide-out turns a small
+noise reading into a large one (#923/#924).
 
-Runner-speed variance is still divided out using the synthetic
-`calibration/fixed_workload` bench, computed the same way (tonight vs its
-own median). The adjustment is clamped to damping-only: it may shrink a
-reported regression but never inflate one, because calibration is
-memory-bandwidth-bound while the sim benches are branch-bound and the two
-diverge across runner instances.
+Detection deliberately does not use Criterion's own `change:` lines. Those
+compare against a per-SHA-locked baseline that froze on the first nightly to
+measure a commit, making a real regression visible for exactly one night and
+re-locking the baseline that same night. Since the issue-open gate requires a
+bench to regress on two consecutive nightlies, that pairing could only ever
+confirm same-SHA noise. The rolling median read from machine-readable
+estimates.json is what makes the persistence gate meaningful: it stays put
+night to night, so a real regression keeps clearing the threshold until enough
+post-regression samples accumulate to move it.
 
 Args:
     sys.argv[1]: path to append `regressed=`/`gate=` outputs to ($GITHUB_OUTPUT).
@@ -53,15 +57,26 @@ ISSUE_BODY = Path("regressions.txt")
 
 CALIBRATION_NAME = "calibration/fixed_workload"
 
-# Nightlies retained per bench. Seven keeps a week of history, so a single
-# outlier runner is outvoted while a real regression still takes over the
-# median within a week of landing.
-HISTORY_LEN = 7
+# Nightlies retained. Baseline samples are drawn only from those matching
+# tonight's machine class, so the window must span enough nights for an
+# infrequent class to reach MIN_SAMPLES. Three weeks covers a class seen on
+# roughly one night in five.
+HISTORY_LEN = 21
 
-# Below this many prior samples the median is not yet trustworthy, so the
-# bench is recorded but not gated. Applies per bench, so a newly added
-# bench warms up without suppressing detection on established ones.
+# Most recent same-class nightlies contributing to a bench's median. Capped
+# below HISTORY_LEN so a regression that lands is not held down indefinitely
+# by a long tail of pre-regression samples.
+BASELINE_SAMPLES = 7
+
+# Below this many comparable samples the median is not trustworthy, so the
+# bench is recorded but not gated. Applies per bench, so a newly added bench
+# warms up without suppressing detection on established ones.
 MIN_SAMPLES = 3
+
+# Relative calibration spread within which two nightlies count as the same
+# machine class. Repeat visits to one class hold within 1%; the nearest
+# distinct classes sit ~10% apart, so this separates them with wide margin.
+MACHINE_TOL = 0.03
 
 
 def read_today(root: str) -> dict[str, float]:
@@ -91,35 +106,88 @@ def read_today(root: str) -> dict[str, float]:
     return out
 
 
-def load_history(path: Path) -> dict[str, list[float]]:
+def _clean_nightly(raw: object) -> dict[str, float] | None:
+    if not isinstance(raw, dict):
+        return None
+    vals = {
+        name: float(v)
+        for name, v in raw.items()
+        if isinstance(name, str) and isinstance(v, (int, float)) and v > 0
+    }
+    return vals or None
+
+
+def load_history(path: Path) -> list[dict[str, float]]:
+    """Nightlies oldest-first, each a bench-name -> ns mapping.
+
+    Accepts the older per-bench-list layout by transposing it: samples were
+    appended once per nightly in a fixed order, so index k across benches
+    refers to one night. Rebuilding rather than discarding keeps an existing
+    cached history usable instead of forcing a multi-week warm-up.
+    """
     if not path.exists():
-        return {}
+        return []
     try:
         raw = json.loads(path.read_text())
     except (OSError, json.JSONDecodeError):
-        return {}
-    entries = raw.get("entries") if isinstance(raw, dict) else None
+        return []
+    if not isinstance(raw, dict):
+        return []
+
+    nightlies = raw.get("nightlies")
+    if isinstance(nightlies, list):
+        out = [n for n in (_clean_nightly(r) for r in nightlies) if n]
+        return out[-HISTORY_LEN:]
+
+    entries = raw.get("entries")
     if not isinstance(entries, dict):
-        return {}
-    clean: dict[str, list[float]] = {}
-    for name, samples in entries.items():
-        if isinstance(samples, list):
-            vals = [float(s) for s in samples if isinstance(s, (int, float)) and s > 0]
-            if vals:
-                clean[name] = vals[-HISTORY_LEN:]
-    return clean
+        return []
+    columns = {
+        name: [float(s) for s in samples if isinstance(s, (int, float)) and s > 0]
+        for name, samples in entries.items()
+        if isinstance(name, str) and isinstance(samples, list)
+    }
+    columns = {name: vals for name, vals in columns.items() if vals}
+    if not columns:
+        return []
+    # Right-align: a bench added part-way through has a shorter column, and
+    # its most recent sample belongs to the most recent night.
+    depth = max(len(v) for v in columns.values())
+    rebuilt: list[dict[str, float]] = []
+    for k in range(depth):
+        night: dict[str, float] = {}
+        for name, vals in columns.items():
+            idx = k - (depth - len(vals))
+            if idx >= 0:
+                night[name] = vals[idx]
+        if night:
+            rebuilt.append(night)
+    return rebuilt[-HISTORY_LEN:]
 
 
-def save_history(path: Path, history: dict[str, list[float]], today: dict[str, float]) -> None:
-    merged = {name: list(samples) for name, samples in history.items()}
-    for name, value in today.items():
-        merged.setdefault(name, []).append(value)
-        merged[name] = merged[name][-HISTORY_LEN:]
-    path.write_text(json.dumps({"version": 1, "entries": merged}, indent=1, sort_keys=True) + "\n")
+def save_history(path: Path, history: list[dict[str, float]], today: dict[str, float]) -> None:
+    merged = [*history, dict(today)][-HISTORY_LEN:]
+    path.write_text(json.dumps({"version": 2, "nightlies": merged}, indent=1) + "\n")
+
+
+def comparable(history: list[dict[str, float]], calib_today: float | None) -> list[dict[str, float]]:
+    """Prior nightlies measured on the same machine class as tonight.
+
+    Without a calibration reading the class is unknown, so every nightly stays
+    eligible — a wider baseline is better than none, and the caller warns.
+    """
+    if calib_today is None or calib_today <= 0:
+        return history
+    out = []
+    for night in history:
+        prior = night.get(CALIBRATION_NAME)
+        if prior and abs(prior / calib_today - 1.0) <= MACHINE_TOL:
+            out.append(night)
+    return out
 
 
 def adjust(change_pct: float, calib_pct: float | None) -> float:
-    """Divide the runner-speed factor out, clamped to damping-only.
+    """Divide the residual runner-speed factor out, clamped to damping-only.
 
     Without the clamp a faster-than-baseline runner amplifies rather than
     cancels: calibration -10.87% against a bench at +3% yields +15.6%, which
@@ -132,6 +200,10 @@ def adjust(change_pct: float, calib_pct: float | None) -> float:
         return change_pct
     adjusted = ((1.0 + change_pct / 100.0) / scale - 1.0) * 100.0
     return min(adjusted, change_pct)
+
+
+def samples_for(name: str, nights: list[dict[str, float]]) -> list[float]:
+    return [v for v in (night.get(name) for night in nights) if v][-BASELINE_SAMPLES:]
 
 
 def pct_above_median(value: float, samples: list[float]) -> float | None:
@@ -156,8 +228,8 @@ def block(name: str, today: float, samples: list[float], raw: float, adjusted: f
     note = "" if abs(adjusted - raw) < 0.005 else f"  (calibration-adjusted from {raw:+.2f}%)"
     return (
         f"{name}\n"
-        f"    median of last {len(samples)} nightlies: {fmt_ns(med)}\n"
-        f"    tonight:                       {fmt_ns(today)}\n"
+        f"    median of {len(samples)} comparable nightlies: {fmt_ns(med)}\n"
+        f"    tonight:                          {fmt_ns(today)}\n"
         f"    change: {adjusted:+.2f}%{note}\n\n"
     )
 
@@ -174,29 +246,30 @@ def main() -> int:
         sys.exit(f"detect-bench-regressions: no estimates found under {criterion_root}")
     history = load_history(history_path)
 
-    # Distinguish the two ways calibration can be unavailable: a warming-up
-    # history is expected and benign, a missing bench means calibration_bench
-    # did not produce a result this run and wants investigating.
-    calib = None
-    if CALIBRATION_NAME not in today:
+    calib_today = today.get(CALIBRATION_NAME)
+    if calib_today is None:
         print(
             f"warning: {CALIBRATION_NAME} produced no measurement this run — "
-            "runner-speed adjustment disabled, gating on raw change vs median. "
+            "machine class unknown, comparing against every retained nightly. "
             "This is not expected; check whether calibration_bench failed."
         )
-    else:
-        calib = pct_above_median(today[CALIBRATION_NAME], history.get(CALIBRATION_NAME, []))
-        if calib is None:
-            print(
-                f"warning: {CALIBRATION_NAME} has fewer than {MIN_SAMPLES} nightlies "
-                "of history — gating on raw change vs median until it warms up."
-            )
+    nights = comparable(history, calib_today)
+    print(
+        f"{len(nights)} of {len(history)} retained nightlies match tonight's machine class"
+        + (f" (calibration {fmt_ns(calib_today)})" if calib_today else "")
+    )
+
+    # Residual drift within the class. Stratification removes the between-SKU
+    # step; this catches whatever spread is left inside one class.
+    calib = None
+    if calib_today is not None:
+        calib = pct_above_median(calib_today, samples_for(CALIBRATION_NAME, nights))
 
     todays: dict[str, str] = {}
     for name, value in sorted(today.items()):
         if name == CALIBRATION_NAME:
             continue
-        samples = history.get(name, [])
+        samples = samples_for(name, nights)
         raw = pct_above_median(value, samples)
         if raw is None:
             continue

--- a/.github/scripts/detect-bench-regressions.py
+++ b/.github/scripts/detect-bench-regressions.py
@@ -120,10 +120,14 @@ def _clean_nightly(raw: object) -> dict[str, float] | None:
 def load_history(path: Path) -> list[dict[str, float]]:
     """Nightlies oldest-first, each a bench-name -> ns mapping.
 
-    Accepts the older per-bench-list layout by transposing it: samples were
-    appended once per nightly in a fixed order, so index k across benches
-    refers to one night. Rebuilding rather than discarding keeps an existing
-    cached history usable instead of forcing a multi-week warm-up.
+    Accepts the older per-bench-list layout by transposing it, which keeps a
+    cached history usable instead of forcing a multi-week warm-up. Only
+    columns holding a sample for every retained night are transposed: that
+    layout appended once per nightly per bench that reported, so a bench
+    missing from any night leaves a gap indistinguishable from a short tail.
+    Guessing where the gap falls would pair its samples with another night's
+    calibration and stratify on the wrong machine class, so short columns are
+    dropped and left to warm up.
     """
     if not path.exists():
         return []
@@ -150,19 +154,13 @@ def load_history(path: Path) -> list[dict[str, float]]:
     columns = {name: vals for name, vals in columns.items() if vals}
     if not columns:
         return []
-    # Right-align: a bench added part-way through has a shorter column, and
-    # its most recent sample belongs to the most recent night.
     depth = max(len(v) for v in columns.values())
-    rebuilt: list[dict[str, float]] = []
-    for k in range(depth):
-        night: dict[str, float] = {}
-        for name, vals in columns.items():
-            idx = k - (depth - len(vals))
-            if idx >= 0:
-                night[name] = vals[idx]
-        if night:
-            rebuilt.append(night)
-    return rebuilt[-HISTORY_LEN:]
+    aligned = {name: vals for name, vals in columns.items() if len(vals) == depth}
+    if CALIBRATION_NAME not in aligned:
+        # Without a calibration sample per night the machine class is unknown
+        # for every rebuilt night, which is the whole point of the history.
+        return []
+    return [{name: vals[k] for name, vals in aligned.items()} for k in range(depth)][-HISTORY_LEN:]
 
 
 def save_history(path: Path, history: list[dict[str, float]], today: dict[str, float]) -> None:

--- a/.github/scripts/detect-bench-regressions.py
+++ b/.github/scripts/detect-bench-regressions.py
@@ -120,14 +120,16 @@ def _clean_nightly(raw: object) -> dict[str, float] | None:
 def load_history(path: Path) -> list[dict[str, float]]:
     """Nightlies oldest-first, each a bench-name -> ns mapping.
 
-    Accepts the older per-bench-list layout by transposing it, which keeps a
-    cached history usable instead of forcing a multi-week warm-up. Only
-    columns holding a sample for every retained night are transposed: that
-    layout appended once per nightly per bench that reported, so a bench
-    missing from any night leaves a gap indistinguishable from a short tail.
-    Guessing where the gap falls would pair its samples with another night's
-    calibration and stratify on the wrong machine class, so short columns are
-    dropped and left to warm up.
+    A cached history in the older per-bench-column layout is discarded rather
+    than transposed. That layout appended one sample per nightly per bench
+    *that reported* and capped each column independently, so it records no
+    night identity: two columns can omit different nights and still hold
+    equal counts. Any reconstruction is therefore a guess, and a wrong one
+    pairs a bench with another night's calibration and stratifies it on the
+    wrong machine class — the failure this gate exists to remove, in a form
+    nothing downstream can detect. Warming up costs about a week and fails
+    safe: benches are recorded but not gated until enough same-class samples
+    accumulate.
     """
     if not path.exists():
         return []
@@ -143,24 +145,13 @@ def load_history(path: Path) -> list[dict[str, float]]:
         out = [n for n in (_clean_nightly(r) for r in nightlies) if n]
         return out[-HISTORY_LEN:]
 
-    entries = raw.get("entries")
-    if not isinstance(entries, dict):
-        return []
-    columns = {
-        name: [float(s) for s in samples if isinstance(s, (int, float)) and s > 0]
-        for name, samples in entries.items()
-        if isinstance(name, str) and isinstance(samples, list)
-    }
-    columns = {name: vals for name, vals in columns.items() if vals}
-    if not columns:
-        return []
-    depth = max(len(v) for v in columns.values())
-    aligned = {name: vals for name, vals in columns.items() if len(vals) == depth}
-    if CALIBRATION_NAME not in aligned:
-        # Without a calibration sample per night the machine class is unknown
-        # for every rebuilt night, which is the whole point of the history.
-        return []
-    return [{name: vals[k] for name, vals in aligned.items()} for k in range(depth)][-HISTORY_LEN:]
+    if isinstance(raw.get("entries"), dict):
+        print(
+            "note: cached history uses the per-bench-column layout, which does not "
+            "record which nightly each sample came from. Starting a fresh history — "
+            "benches are recorded but not gated until they warm up."
+        )
+    return []
 
 
 def save_history(path: Path, history: list[dict[str, float]], today: dict[str, float]) -> None:

--- a/.github/scripts/test_detect_bench_regressions.py
+++ b/.github/scripts/test_detect_bench_regressions.py
@@ -23,6 +23,8 @@ assert _spec and _spec.loader
 det = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(det)
 
+CAL = det.CALIBRATION_NAME
+
 
 def write_estimates(root: Path, means: dict[str, float]) -> None:
     """Lay out a target/criterion tree the way Criterion does."""
@@ -34,19 +36,34 @@ def write_estimates(root: Path, means: dict[str, float]) -> None:
         )
 
 
+def nights(count: int, **benches: float) -> list[dict[str, float]]:
+    """`count` identical nightlies, each holding the given bench means."""
+    return [dict(benches) for _ in range(count)]
+
+
+def column(history: list[dict[str, float]], name: str) -> list[float]:
+    return [n[name] for n in history if name in n]
+
+
 def run_detect(
     means: dict[str, float],
-    history: dict[str, list[float]] | None,
+    history: dict[str, list[float]] | list[dict[str, float]] | None,
     previous: list[str] | None,
     threshold: float = 5.0,
 ):
-    """Drive main(); return (regressed, gate, body, history_after)."""
+    """Drive main(); return (regressed, gate, body, history_after).
+
+    `history` accepts the current per-nightly list or the older per-bench
+    column layout, so the migration path stays covered by the same cases.
+    """
     with tempfile.TemporaryDirectory() as d:
         d = Path(d)
         root = d / "criterion"
         write_estimates(root, means)
         hist_path = d / "bench-history.json"
-        if history is not None:
+        if isinstance(history, list):
+            hist_path.write_text(json.dumps({"version": 2, "nightlies": history}))
+        elif history is not None:
             hist_path.write_text(json.dumps({"version": 1, "entries": history}))
         gh_out = d / "gh_output"
         gh_out.write_text("")
@@ -71,7 +88,7 @@ def run_detect(
         )
         body_path = d / "regressions.txt"
         body = body_path.read_text() if body_path.exists() else ""
-        after = json.loads(hist_path.read_text())["entries"]
+        after = json.loads(hist_path.read_text())["nightlies"]
         return out.get("regressed"), out.get("gate"), body, after
 
 
@@ -79,8 +96,8 @@ class MedianBaselineTest(unittest.TestCase):
     def test_regression_above_median_is_flagged(self):
         # Stable at 100, tonight 112 → +12% over median.
         regressed, gate, body, _ = run_detect(
-            {"dispatch/10e_50s": 112.0, det.CALIBRATION_NAME: 100.0},
-            history={"dispatch/10e_50s": [100.0] * 5, det.CALIBRATION_NAME: [100.0] * 5},
+            {"dispatch/10e_50s": 112.0, CAL: 100.0},
+            history=nights(5, **{"dispatch/10e_50s": 100.0, CAL: 100.0}),
             previous=["dispatch/10e_50s"],
         )
         self.assertEqual(regressed, "true")
@@ -88,64 +105,72 @@ class MedianBaselineTest(unittest.TestCase):
         self.assertIn("dispatch/10e_50s", body)
 
     def test_single_outlier_night_does_not_move_the_baseline(self):
-        # This is the property the per-SHA freeze was reaching for. One wild
-        # night in history must not become the comparison point.
-        history = [100.0, 100.0, 60.0, 100.0, 100.0]  # 60.0 is the outlier
+        # One wild night in history must not become the comparison point.
+        history = [
+            {"dispatch/10e_50s": v, CAL: 100.0} for v in (100.0, 100.0, 60.0, 100.0, 100.0)
+        ]
         regressed, _, _, _ = run_detect(
-            {"dispatch/10e_50s": 102.0, det.CALIBRATION_NAME: 100.0},
-            history={"dispatch/10e_50s": history, det.CALIBRATION_NAME: [100.0] * 5},
+            {"dispatch/10e_50s": 102.0, CAL: 100.0},
+            history=history,
             previous=["dispatch/10e_50s"],
         )
         # Median is 100, not 60 — tonight is +2%, under the gate.
         self.assertEqual(regressed, "false")
 
-    def test_uniform_runner_slowdown_cancels(self):
-        # Whole suite 12% slower including calibration → adjusted ~0.
+    def test_uniform_runner_slowdown_within_a_class_cancels(self):
+        # Whole suite 2% slower including calibration → adjusted ~0. The step
+        # stays inside MACHINE_TOL, so it is residual drift rather than a
+        # different machine class.
         means = {
-            "dispatch/10e_50s": 112.0,
-            "query_tuple/1000_entities": 112.0,
-            det.CALIBRATION_NAME: 112.0,
+            "dispatch/10e_50s": 102.0,
+            "query_tuple/1000_entities": 102.0,
+            CAL: 102.0,
         }
-        hist = {name: [100.0] * 5 for name in means}
-        regressed, _, body, _ = run_detect(means, history=hist, previous=list(means))
+        regressed, _, body, _ = run_detect(
+            means, history=nights(5, **{k: 100.0 for k in means}), previous=list(means)
+        )
         self.assertEqual(regressed, "false")
         self.assertEqual(body, "")
 
     def test_faster_runner_cannot_inflate(self):
-        # The #923/#924 shape: calibration 10.9% faster, benches 3% slower.
+        # The #923/#924 shape: calibration faster, benches 3% slower.
         # Damping-only holds them at +3%, below the gate.
         means = {
             "dispatch_comparison/etd_50e_200s": 103.0,
             "dispatch_comparison/rsr_50e_200s": 103.0,
-            det.CALIBRATION_NAME: 89.135,
+            CAL: 97.5,
         }
-        hist = {name: [100.0] * 5 for name in means}
-        regressed, _, body, _ = run_detect(means, history=hist, previous=list(means))
+        regressed, _, body, _ = run_detect(
+            means, history=nights(5, **{k: 100.0 for k in means}), previous=list(means)
+        )
         self.assertEqual(regressed, "false")
         self.assertEqual(body, "")
 
     def test_real_regression_survives_faster_runner(self):
-        # Calibration 5% faster but the bench is 20% slower — genuinely
+        # Calibration slightly faster but the bench is 20% slower — genuinely
         # diverges, so it must still be reported.
-        means = {"dispatch/10e_50s": 120.0, det.CALIBRATION_NAME: 95.0}
-        hist = {name: [100.0] * 5 for name in means}
-        regressed, _, body, _ = run_detect(means, history=hist, previous=["dispatch/10e_50s"])
+        means = {"dispatch/10e_50s": 120.0, CAL: 98.0}
+        regressed, _, body, _ = run_detect(
+            means,
+            history=nights(5, **{"dispatch/10e_50s": 100.0, CAL: 100.0}),
+            previous=["dispatch/10e_50s"],
+        )
         self.assertEqual(regressed, "true")
         self.assertIn("dispatch/10e_50s", body)
 
     def test_persistence_gate_requires_two_nights(self):
-        means = {"dispatch/10e_50s": 120.0, det.CALIBRATION_NAME: 100.0}
-        hist = {name: [100.0] * 5 for name in means}
-        regressed, gate, _, _ = run_detect(means, history=hist, previous=[])
+        means = {"dispatch/10e_50s": 120.0, CAL: 100.0}
+        regressed, gate, _, _ = run_detect(
+            means, history=nights(5, **{"dispatch/10e_50s": 100.0, CAL: 100.0}), previous=[]
+        )
         self.assertEqual(regressed, "false")
         self.assertEqual(gate, "two-day")
 
     def test_regression_persists_across_nights_so_gate_can_confirm(self):
-        # The property the per-SHA lock destroyed: after a regression lands,
-        # it stays above the rolling median on the following night too, so
-        # the two-day gate can actually confirm it.
-        hist = {"dispatch/10e_50s": [100.0] * 5, det.CALIBRATION_NAME: [100.0] * 5}
-        means = {"dispatch/10e_50s": 120.0, det.CALIBRATION_NAME: 100.0}
+        # After a regression lands it stays above the rolling median on the
+        # following night too, so the two-day gate can actually confirm it.
+        hist = nights(5, **{"dispatch/10e_50s": 100.0, CAL: 100.0})
+        means = {"dispatch/10e_50s": 120.0, CAL: 100.0}
         n1, _, _, after = run_detect(means, history=hist, previous=[])
         self.assertEqual(n1, "false")  # night one: flagged but unconfirmed
         n2, _, body, _ = run_detect(means, history=after, previous=["dispatch/10e_50s"])
@@ -153,22 +178,107 @@ class MedianBaselineTest(unittest.TestCase):
         self.assertIn("dispatch/10e_50s", body)
 
 
+class MachineStratificationTest(unittest.TestCase):
+    """The `ubuntu-latest` pool cycles between CPU SKUs 10-15% apart."""
+
+    def _mixed_pool(self):
+        # Five nightlies on the fast class, four on a class 15% slower.
+        return nights(5, **{"dispatch/10e_50s": 100.0, CAL: 100.0}) + nights(
+            4, **{"dispatch/10e_50s": 115.0, CAL: 115.0}
+        )
+
+    def test_slow_machine_is_compared_against_its_own_class(self):
+        # Tonight lands on the slow class and is normal *for that class*.
+        # Blending both classes would put the median at 100 and report +18%.
+        regressed, _, body, _ = run_detect(
+            {"dispatch/10e_50s": 118.0, CAL: 115.0},
+            history=self._mixed_pool(),
+            previous=["dispatch/10e_50s"],
+        )
+        self.assertEqual(regressed, "false")
+        self.assertEqual(body, "")
+
+    def test_regression_on_a_slow_machine_is_still_caught(self):
+        # Stratification must not blunt detection: same slow class, but the
+        # bench is 22% above where that class normally sits.
+        regressed, _, body, _ = run_detect(
+            {"dispatch/10e_50s": 140.0, CAL: 115.0},
+            history=self._mixed_pool(),
+            previous=["dispatch/10e_50s"],
+        )
+        self.assertEqual(regressed, "true")
+        self.assertIn("dispatch/10e_50s", body)
+
+    def test_fast_machine_does_not_read_as_an_improvement_then_regression(self):
+        # Tonight lands on the fast class and is normal for it.
+        regressed, _, _, _ = run_detect(
+            {"dispatch/10e_50s": 101.0, CAL: 100.0},
+            history=self._mixed_pool(),
+            previous=["dispatch/10e_50s"],
+        )
+        self.assertEqual(regressed, "false")
+
+    def test_unseen_machine_class_is_recorded_but_not_gated(self):
+        # Only one prior nightly on this class — below MIN_SAMPLES.
+        history = nights(6, **{"dispatch/10e_50s": 100.0, CAL: 100.0}) + nights(
+            1, **{"dispatch/10e_50s": 130.0, CAL: 130.0}
+        )
+        regressed, _, _, after = run_detect(
+            {"dispatch/10e_50s": 400.0, CAL: 130.0},
+            history=history,
+            previous=["dispatch/10e_50s"],
+        )
+        self.assertEqual(regressed, "false")
+        self.assertEqual(column(after, "dispatch/10e_50s")[-1], 400.0)
+
+    def test_within_tolerance_counts_as_the_same_class(self):
+        # Repeat visits to one SKU hold within ~1%, well inside MACHINE_TOL.
+        history = [
+            {"dispatch/10e_50s": 100.0, CAL: c} for c in (100.0, 100.5, 99.4, 100.8, 99.7)
+        ]
+        regressed, _, body, _ = run_detect(
+            {"dispatch/10e_50s": 120.0, CAL: 100.2},
+            history=history,
+            previous=["dispatch/10e_50s"],
+        )
+        self.assertEqual(regressed, "true")
+        self.assertIn("dispatch/10e_50s", body)
+
+    def test_comparable_keeps_everything_when_class_is_unknown(self):
+        history = nights(3, **{CAL: 100.0}) + nights(3, **{CAL: 130.0})
+        self.assertEqual(det.comparable(history, None), history)
+
+    def test_baseline_is_capped_at_baseline_samples(self):
+        # A long same-class tail must not hold a landed regression down: only
+        # the most recent BASELINE_SAMPLES contribute.
+        old = nights(det.BASELINE_SAMPLES + 3, **{"dispatch/10e_50s": 100.0, CAL: 100.0})
+        recent = nights(det.BASELINE_SAMPLES, **{"dispatch/10e_50s": 200.0, CAL: 100.0})
+        regressed, _, _, _ = run_detect(
+            {"dispatch/10e_50s": 205.0, CAL: 100.0},
+            history=old + recent,
+            previous=["dispatch/10e_50s"],
+        )
+        # Median of the last BASELINE_SAMPLES is 200, so tonight is +2.5%.
+        self.assertEqual(regressed, "false")
+
+
 class WarmupTest(unittest.TestCase):
     def test_no_history_records_but_does_not_gate(self):
-        means = {"dispatch/10e_50s": 500.0, det.CALIBRATION_NAME: 100.0}
+        means = {"dispatch/10e_50s": 500.0, CAL: 100.0}
         regressed, _, _, after = run_detect(means, history=None, previous=None)
         self.assertEqual(regressed, "false")
-        self.assertEqual(after["dispatch/10e_50s"], [500.0])
+        self.assertEqual(column(after, "dispatch/10e_50s"), [500.0])
 
     def test_below_min_samples_is_not_gated(self):
-        hist = {"dispatch/10e_50s": [100.0] * (det.MIN_SAMPLES - 1)}
-        means = {"dispatch/10e_50s": 500.0}
-        regressed, _, _, _ = run_detect(means, history=hist, previous=["dispatch/10e_50s"])
+        hist = nights(det.MIN_SAMPLES - 1, **{"dispatch/10e_50s": 100.0})
+        regressed, _, _, _ = run_detect(
+            {"dispatch/10e_50s": 500.0}, history=hist, previous=["dispatch/10e_50s"]
+        )
         self.assertEqual(regressed, "false")
 
     def test_new_bench_warms_up_without_muting_established_ones(self):
-        means = {"dispatch/10e_50s": 120.0, "brand/new": 100.0, det.CALIBRATION_NAME: 100.0}
-        hist = {"dispatch/10e_50s": [100.0] * 5, det.CALIBRATION_NAME: [100.0] * 5}
+        means = {"dispatch/10e_50s": 120.0, "brand/new": 100.0, CAL: 100.0}
+        hist = nights(5, **{"dispatch/10e_50s": 100.0, CAL: 100.0})
         regressed, _, body, _ = run_detect(means, history=hist, previous=list(means))
         self.assertEqual(regressed, "true")
         self.assertIn("dispatch/10e_50s", body)
@@ -177,38 +287,69 @@ class WarmupTest(unittest.TestCase):
 
 class HistoryFileTest(unittest.TestCase):
     def test_tonight_is_appended_after_detection(self):
-        hist = {"dispatch/10e_50s": [100.0] * 3, det.CALIBRATION_NAME: [100.0] * 3}
-        means = {"dispatch/10e_50s": 108.0, det.CALIBRATION_NAME: 100.0}
+        hist = nights(3, **{"dispatch/10e_50s": 100.0, CAL: 100.0})
+        means = {"dispatch/10e_50s": 108.0, CAL: 100.0}
         _, _, _, after = run_detect(means, history=hist, previous=None)
-        self.assertEqual(after["dispatch/10e_50s"], [100.0, 100.0, 100.0, 108.0])
+        self.assertEqual(column(after, "dispatch/10e_50s"), [100.0, 100.0, 100.0, 108.0])
 
     def test_history_is_capped(self):
-        hist = {"dispatch/10e_50s": [100.0] * (det.HISTORY_LEN + 4)}
-        means = {"dispatch/10e_50s": 100.0}
-        _, _, _, after = run_detect(means, history=hist, previous=None)
-        self.assertEqual(len(after["dispatch/10e_50s"]), det.HISTORY_LEN)
+        hist = nights(det.HISTORY_LEN + 4, **{"dispatch/10e_50s": 100.0, CAL: 100.0})
+        _, _, _, after = run_detect(
+            {"dispatch/10e_50s": 100.0, CAL: 100.0}, history=hist, previous=None
+        )
+        self.assertEqual(len(after), det.HISTORY_LEN)
+
+    def test_legacy_column_history_is_transposed_not_discarded(self):
+        # Columns were appended once per nightly, so index k lines up across
+        # benches. Rebuilding keeps a cached history usable.
+        legacy = {"dispatch/10e_50s": [100.0, 115.0, 100.0], CAL: [100.0, 115.0, 100.0]}
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "h.json"
+            p.write_text(json.dumps({"version": 1, "entries": legacy}))
+            got = det.load_history(p)
+        self.assertEqual(
+            got,
+            [
+                {"dispatch/10e_50s": 100.0, CAL: 100.0},
+                {"dispatch/10e_50s": 115.0, CAL: 115.0},
+                {"dispatch/10e_50s": 100.0, CAL: 100.0},
+            ],
+        )
+
+    def test_legacy_short_column_is_right_aligned(self):
+        # A bench added part-way through has a shorter column; its newest
+        # sample belongs to the newest night.
+        legacy = {"old/bench": [1.0, 2.0, 3.0], "new/bench": [9.0]}
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "h.json"
+            p.write_text(json.dumps({"version": 1, "entries": legacy}))
+            got = det.load_history(p)
+        self.assertEqual(got[-1], {"old/bench": 3.0, "new/bench": 9.0})
+        self.assertEqual(got[0], {"old/bench": 1.0})
 
     def test_corrupt_history_is_treated_as_empty(self):
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / "h.json"
             p.write_text("{not json")
-            self.assertEqual(det.load_history(p), {})
+            self.assertEqual(det.load_history(p), [])
 
     def test_missing_calibration_falls_back_to_raw(self):
         # calibration_bench produced nothing this run: detection must still
         # work, gating on the raw change vs median.
-        means = {"dispatch/10e_50s": 120.0}
-        hist = {"dispatch/10e_50s": [100.0] * 5}
-        regressed, _, body, _ = run_detect(means, history=hist, previous=["dispatch/10e_50s"])
+        hist = nights(5, **{"dispatch/10e_50s": 100.0})
+        regressed, _, body, _ = run_detect(
+            {"dispatch/10e_50s": 120.0}, history=hist, previous=["dispatch/10e_50s"]
+        )
         self.assertEqual(regressed, "true")
         self.assertIn("dispatch/10e_50s", body)
 
     def test_calibration_never_reported(self):
-        means = {det.CALIBRATION_NAME: 200.0}
-        hist = {det.CALIBRATION_NAME: [100.0] * 5}
-        regressed, _, body, _ = run_detect(means, history=hist, previous=[det.CALIBRATION_NAME])
+        hist = nights(5, **{CAL: 100.0})
+        regressed, _, body, _ = run_detect(
+            {CAL: 200.0}, history=hist, previous=[CAL]
+        )
         self.assertEqual(regressed, "false")
-        self.assertNotIn(det.CALIBRATION_NAME, body)
+        self.assertNotIn(CAL, body)
 
 
 class HelperMathTest(unittest.TestCase):
@@ -227,6 +368,12 @@ class HelperMathTest(unittest.TestCase):
     def test_pct_above_median_uses_median_not_mean(self):
         # Mean of this is 92, median is 100 — must use the median.
         self.assertAlmostEqual(det.pct_above_median(110.0, [100.0, 100.0, 60.0, 100.0]), 10.0)
+
+    def test_comparable_splits_on_machine_tol(self):
+        inside = 100.0 * (1 + det.MACHINE_TOL * 0.5)
+        outside = 100.0 * (1 + det.MACHINE_TOL * 2)
+        history = [{CAL: inside}, {CAL: outside}]
+        self.assertEqual(det.comparable(history, 100.0), [{CAL: inside}])
 
     def test_read_today_parses_criterion_layout(self):
         with tempfile.TemporaryDirectory() as d:

--- a/.github/scripts/test_detect_bench_regressions.py
+++ b/.github/scripts/test_detect_bench_regressions.py
@@ -316,16 +316,33 @@ class HistoryFileTest(unittest.TestCase):
             ],
         )
 
-    def test_legacy_short_column_is_right_aligned(self):
-        # A bench added part-way through has a shorter column; its newest
-        # sample belongs to the newest night.
-        legacy = {"old/bench": [1.0, 2.0, 3.0], "new/bench": [9.0]}
+    def test_legacy_short_column_is_dropped_not_guessed(self):
+        # A short column is ambiguous: the bench may have been added late or
+        # may have failed on an intermediate night. Guessing would pair its
+        # samples with another night's calibration and stratify on the wrong
+        # machine class, so it warms up instead.
+        legacy = {"old/bench": [1.0, 2.0, 3.0], "new/bench": [9.0], CAL: [10.0, 20.0, 30.0]}
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / "h.json"
             p.write_text(json.dumps({"version": 1, "entries": legacy}))
             got = det.load_history(p)
-        self.assertEqual(got[-1], {"old/bench": 3.0, "new/bench": 9.0})
-        self.assertEqual(got[0], {"old/bench": 1.0})
+        self.assertEqual(
+            got,
+            [
+                {"old/bench": 1.0, CAL: 10.0},
+                {"old/bench": 2.0, CAL: 20.0},
+                {"old/bench": 3.0, CAL: 30.0},
+            ],
+        )
+
+    def test_legacy_history_without_full_calibration_is_discarded(self):
+        # Every rebuilt night needs a calibration sample; without one the
+        # machine class is unknowable and the history has no value.
+        legacy = {"old/bench": [1.0, 2.0, 3.0], CAL: [10.0]}
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "h.json"
+            p.write_text(json.dumps({"version": 1, "entries": legacy}))
+            self.assertEqual(det.load_history(p), [])
 
     def test_corrupt_history_is_treated_as_empty(self):
         with tempfile.TemporaryDirectory() as d:

--- a/.github/scripts/test_detect_bench_regressions.py
+++ b/.github/scripts/test_detect_bench_regressions.py
@@ -53,8 +53,8 @@ def run_detect(
 ):
     """Drive main(); return (regressed, gate, body, history_after).
 
-    `history` accepts the current per-nightly list or the older per-bench
-    column layout, so the migration path stays covered by the same cases.
+    `history` accepts the current per-nightly list, or the older per-bench
+    column layout to cover the discard path.
     """
     with tempfile.TemporaryDirectory() as d:
         d = Path(d)
@@ -299,50 +299,27 @@ class HistoryFileTest(unittest.TestCase):
         )
         self.assertEqual(len(after), det.HISTORY_LEN)
 
-    def test_legacy_column_history_is_transposed_not_discarded(self):
-        # Columns were appended once per nightly, so index k lines up across
-        # benches. Rebuilding keeps a cached history usable.
+    def test_legacy_column_history_is_discarded(self):
+        # The column layout records no night identity, and two columns can
+        # omit different nights while holding equal counts, so equal length
+        # is not proof of alignment. Reconstructing would risk pairing a
+        # bench with another night's calibration.
         legacy = {"dispatch/10e_50s": [100.0, 115.0, 100.0], CAL: [100.0, 115.0, 100.0]}
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / "h.json"
             p.write_text(json.dumps({"version": 1, "entries": legacy}))
-            got = det.load_history(p)
-        self.assertEqual(
-            got,
-            [
-                {"dispatch/10e_50s": 100.0, CAL: 100.0},
-                {"dispatch/10e_50s": 115.0, CAL: 115.0},
-                {"dispatch/10e_50s": 100.0, CAL: 100.0},
-            ],
-        )
-
-    def test_legacy_short_column_is_dropped_not_guessed(self):
-        # A short column is ambiguous: the bench may have been added late or
-        # may have failed on an intermediate night. Guessing would pair its
-        # samples with another night's calibration and stratify on the wrong
-        # machine class, so it warms up instead.
-        legacy = {"old/bench": [1.0, 2.0, 3.0], "new/bench": [9.0], CAL: [10.0, 20.0, 30.0]}
-        with tempfile.TemporaryDirectory() as d:
-            p = Path(d) / "h.json"
-            p.write_text(json.dumps({"version": 1, "entries": legacy}))
-            got = det.load_history(p)
-        self.assertEqual(
-            got,
-            [
-                {"old/bench": 1.0, CAL: 10.0},
-                {"old/bench": 2.0, CAL: 20.0},
-                {"old/bench": 3.0, CAL: 30.0},
-            ],
-        )
-
-    def test_legacy_history_without_full_calibration_is_discarded(self):
-        # Every rebuilt night needs a calibration sample; without one the
-        # machine class is unknowable and the history has no value.
-        legacy = {"old/bench": [1.0, 2.0, 3.0], CAL: [10.0]}
-        with tempfile.TemporaryDirectory() as d:
-            p = Path(d) / "h.json"
-            p.write_text(json.dumps({"version": 1, "entries": legacy}))
             self.assertEqual(det.load_history(p), [])
+
+    def test_warm_up_after_discarding_legacy_history_does_not_gate(self):
+        # Failing safe: the night the new format lands, nothing is gated.
+        legacy = {"dispatch/10e_50s": [100.0] * 7, CAL: [100.0] * 7}
+        regressed, _, _, after = run_detect(
+            {"dispatch/10e_50s": 500.0, CAL: 100.0},
+            history=legacy,
+            previous=["dispatch/10e_50s"],
+        )
+        self.assertEqual(regressed, "false")
+        self.assertEqual(column(after, "dispatch/10e_50s"), [500.0])
 
     def test_corrupt_history_is_treated_as_empty(self):
         with tempfile.TemporaryDirectory() as d:

--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -29,9 +29,10 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v4
-      # Pinned, NOT @stable. The criterion baseline is a frozen per-SHA
-      # measurement; comparing it against a run built by a newer stable
-      # rustc conflates compiler codegen drift with code changes, which
+      # Pinned, NOT @stable. The comparison baseline is a rolling median of
+      # recent nightly measurements; comparing it against a run built by a
+      # newer stable rustc conflates compiler codegen drift with code changes,
+      # which
       # is exactly how an unpinned @stable produced ~2 weeks of phantom
       # +13–20% regressions (issue #884). Bump this deliberately when
       # adopting a new toolchain — the history auto-re-establishes
@@ -58,8 +59,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libudev-dev libasound2-dev libwayland-dev libxkbcommon-dev libvulkan-dev
 
       # Restore the rolling per-bench measurement history. The detect step
-      # compares tonight against the *median* of the last N nightlies rather
-      # than against a single frozen prior measurement.
+      # compares tonight against the *median* of recent nightlies that ran on
+      # the same machine class, rather than against a single frozen prior
+      # measurement. The `ubuntu-latest` pool cycles between CPU SKUs whose
+      # whole-suite spread (-20% to +12%) dwarfs any effect worth alerting on,
+      # so an unstratified median blends hardware and measures which machine
+      # the run drew rather than the code. Retention spans several weeks
+      # because only same-class nightlies are eligible as baseline samples.
       #
       # This replaces the per-SHA criterion baseline lock (#734). That lock
       # froze the comparison point at the first nightly to measure a commit,
@@ -132,12 +138,14 @@ jobs:
           cargo bench -p elevator-core --bench calibration_bench -- --save-baseline nightly 2>&1 | tee -a bench-output.log
 
       # Compare tonight's per-bench mean (read from Criterion's
-      # estimates.json, not its `change:` lines) against the median of the
-      # last N nightlies. A bench is reported when it exceeds that median by
-      # more than MIN_CHANGE_PCT after the calibration bench's runner-speed
-      # factor is divided out (#907/#908/#913/#914/#916), *and* it also
-      # appeared on the previous nightly's list (the recurrence-as-signal
-      # heuristic from #734).
+      # estimates.json, not its `change:` lines) against the median of recent
+      # nightlies on the same machine class. The calibration bench identifies
+      # the class: its reading is sharply quantized, holding within 1% across
+      # repeat visits to one SKU while classes sit 10-15% apart. A bench is
+      # reported when it exceeds that median by more than MIN_CHANGE_PCT after
+      # the residual within-class runner drift is divided out
+      # (#907/#908/#913/#914/#916), *and* it also appeared on the previous
+      # nightly's list (the recurrence-as-signal heuristic from #734).
       #
       # The median baseline is what makes that recurrence gate meaningful: it
       # stays put night to night, so a genuine regression keeps clearing the
@@ -146,9 +154,11 @@ jobs:
       # night the regression appeared, so the gate could only ever confirm
       # noise (#923/#924).
       #
-      # MIN_CHANGE_PCT stays at 5.0: calibration removes the uniform
-      # runner-speed component, so the residual this gate sees is genuine
-      # per-bench spread. Nudge to ~7-8 if residual noise still trips.
+      # MIN_CHANGE_PCT stays at 5.0. Backtesting the detector over 25
+      # consecutive nightlies with no simulation-code change showed raising it
+      # to 10.0 removed only one of five spurious filings while costing real
+      # sensitivity, so the threshold is not the useful lever here —
+      # stratification is.
       - name: Detect regressions
         id: detect
         env:


### PR DESCRIPTION
Closes #934. Closes #938.

## What was wrong

The nightly gate compared each bench against a rolling median taken over every recent nightly, regardless of which machine measured them. GitHub's `ubuntu-latest` pool cycles between a handful of CPU SKUs, and the spread between them dwarfs the effect sizes worth alerting on, so that median blended hardware. A bench was scored mostly by which machine it drew.

## Evidence

The 25 consecutive nightlies from 2026-07-16 to 08-09 are a natural control: the only commits in that window are dependency bumps and CI-only changes, so **every filing in it is a false positive by construction**. Replaying the detector over the published gh-pages series:

- The whole suite swung between **-20% and +12%**, tracking the SKU.
- 49 of 54 benches exceeded the 5% gate on pure noise at some point; `dynamic_topology/add_line` has a *median absolute* night-to-night deviation of 11%.
- The detector filed on **6 of 25 nights**. Both open regression issues are in that set.

The `calibration/fixed_workload` bench was already identifying the SKU without being read that way. Its measurement is sharply quantized rather than continuous:

| calibration reading | nights | spread within class |
|---|---|---|
| ~3.93e6 ns | 14 | < 1% |
| ~4.42e6 ns | 5 | < 0.3% |
| ~4.09-4.23e6 ns | 3 | |
| ~3.43-3.53e6 ns | 2 | |

Classes sit 10-15% apart while repeat visits to one class hold within 1%. On the two fastest nights (07-21, 08-07) *every* bench group dropped 15-22% together.

## What changed

Baseline samples are drawn only from prior nightlies whose calibration lands within `MACHINE_TOL` (3%) of tonight's, so the comparison is like-for-like hardware. Retention grows from 7 nightlies to 21 so an infrequently-seen class still reaches `MIN_SAMPLES`; a class without enough history is recorded but not gated. The median still uses at most `BASELINE_SAMPLES` (7) of the most recent same-class nights, so a landed regression is not held down indefinitely by a long pre-regression tail.

The within-class residual drift is still divided out and still clamped to damping-only, so the #923/#924 amplification shape stays impossible.

The history file moves to a per-nightly layout, since stratification needs to know which calibration reading each bench sample was measured alongside. A cached history in the old per-bench-column layout is **discarded rather than reconstructed**: that layout appended one sample per nightly per bench *that reported* and capped each column independently, so it records no night identity and two columns can omit different nights while holding equal counts. Any reconstruction is a guess, and a wrong one pairs a bench with another night's calibration - the exact failure this PR removes, in a form nothing downstream can detect. Discarding costs about a week of warm-up and fails safe, since nothing is gated until enough same-class samples accumulate.

`MIN_CHANGE_PCT` is unchanged at 5.0. Backtesting showed raising it to 10.0 removed only one of five spurious filings while costing real sensitivity, so the threshold is not the useful lever here.

## Validation

Backtested by driving the actual implementation night-by-night over the real series:

| | issues filed on 25 flat nights |
|---|---|
| before | 6 |
| after | 5 (4 of which are one episode, below) |

Sensitivity, injecting a step regression on 2026-08-01 and requiring a *new* filing naming that bench:

| step | quiet benches | mid | noisy |
|---|---|---|---|
| +6% | caught next night | caught next night | 1 of 3 caught |
| +8% | caught next night | caught next night | all caught |
| +10% and up | caught next night | caught next night | all caught |

Detector unit tests go from 20 to 33 cases, covering stratification, the `MACHINE_TOL` boundary, the warm-up path for an unseen class, the `BASELINE_SAMPLES` cap, and the legacy-history discard including the fail-safe warm-up night.

## Known remaining false positive

Four of the five surviving filings are one episode with a different cause. The `scaling_*` group sat ~14% low for the entire nine-night window of b6a71308 and returned to normal the night the SHA changed, **on the same machine class** - though that commit touched no Rust or Cargo file. Absolute timings therefore depend on build or environment state beyond the source. Stratifying by hardware cannot address that, so it is filed as #942 rather than papered over here.