### PR TITLE
fix(deps): restore playground security overrides under pnpm 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,11 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
         with:
-          version: 10
+          # Version comes from `packageManager`. A floating major here once
+          # drifted ahead of local pnpm, and the newer major stopped reading
+          # `pnpm.overrides` from package.json, silently dropping the
+          # security overrides on one side only.
+          package_json_file: playground/package.json
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,7 +57,11 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          # Version comes from `packageManager`. A floating major here once
+          # drifted ahead of local pnpm, and the newer major stopped reading
+          # `pnpm.overrides` from package.json, silently dropping the
+          # security overrides on one side only.
+          package_json_file: playground/package.json
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/playground/package.json
+++ b/playground/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "packageManager": "pnpm@11.9.0",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
@@ -55,10 +56,5 @@
   "dependencies": {
     "monaco-editor": "^0.55.1",
     "random-words": "^2.0.1"
-  },
-  "pnpm": {
-    "overrides": {
-      "dompurify": "^3.4.2"
-    }
   }
 }

--- a/playground/pnpm-lock.yaml
+++ b/playground/pnpm-lock.yaml
@@ -5,7 +5,11 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  dompurify: ^3.4.2
+  dompurify: ^3.4.13
+  fast-uri: ^3.1.5
+  js-yaml: ^4.3.1
+  brace-expansion: ^5.0.9
+  postcss: ^8.5.26
 
 importers:
 
@@ -1183,9 +1187,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1293,8 +1297,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  dompurify@3.4.2:
-    resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -1454,8 +1458,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1523,6 +1527,7 @@ packages:
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@6.0.2:
@@ -1624,8 +1629,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -1800,8 +1805,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1885,8 +1890,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -3102,7 +3107,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3128,7 +3133,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3201,7 +3206,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -3224,7 +3229,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  dompurify@3.4.2:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -3420,7 +3425,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -3558,7 +3563,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -3712,18 +3717,18 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.4.2
+      dompurify: 3.4.13
       marked: 14.0.0
 
   ms@2.1.3: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -3838,9 +3843,9 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss@8.5.15:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -4076,7 +4081,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.26
       rollup: 4.62.0
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/playground/pnpm-workspace.yaml
+++ b/playground/pnpm-workspace.yaml
@@ -1,0 +1,26 @@
+packages:
+  - .
+
+# Both ship prebuilt platform binaries via optionalDependencies; their install
+# scripts only re-verify what npm already fetched. Denying them keeps the
+# behaviour pnpm has had here all along, now stated explicitly.
+allowBuilds:
+  esbuild: false
+  unrs-resolver: false
+
+# pnpm 11 no longer reads the `pnpm` field from package.json; overrides live here.
+#
+# Every entry raises a transitive dependency past a published advisory. The
+# direct dependents already permit these ranges, so the overrides only pull the
+# floor up. Remove one once its dependent's own floor clears the advisory.
+overrides:
+  # monaco-editor pins dompurify below the sanitizer-bypass fixes.
+  dompurify: ^3.4.13
+  # ajv -> fast-uri: host confusion via backslash authority delimiter.
+  fast-uri: ^3.1.5
+  # cosmiconfig -> js-yaml: quadratic CPU consumption via merge keys / !!omap.
+  js-yaml: ^4.3.1
+  # minimatch -> brace-expansion: exponential-time expansion DoS.
+  brace-expansion: ^5.0.9
+  # vite -> postcss: sourceMappingURL path traversal.
+  postcss: ^8.5.26


### PR DESCRIPTION
Closes all 19 open Dependabot alerts. `pnpm audit` is clean for both prod and dev trees.

## Root cause

pnpm 11 no longer reads the `pnpm` field from `package.json`:

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm.
The following keys were ignored: "pnpm.overrides".
```

The playground carried a `dompurify: "^3.4.2"` override there. CI pinned `pnpm/action-setup` to a floating `version: 10`, which still honoured it, while local pnpm had moved to 11 and dropped it. The override existed, appeared to work on one side, and quietly stopped constraining anything on the other. Advisories piled up behind that split.

## Changes

- Overrides move to `playground/pnpm-workspace.yaml`, their supported home.
- `packageManager: "pnpm@11.9.0"` in `playground/package.json`; both workflows now resolve the version from it via `package_json_file:` instead of a floating major. Local and CI can no longer disagree about which settings are read.
- Every flagged transitive dependency is raised past its advisory. All five direct dependents already permitted these ranges, so the overrides only lift the floor.

| package | was | now | fixes | scope |
|---|---|---|---|---|
| dompurify | 3.4.2 | 3.4.13 | 10 alerts (XSS / sanitizer bypass) | runtime, via monaco-editor |
| fast-uri | 3.1.2 | 3.1.5 | 3 alerts (host confusion) | dev, via ajv |
| js-yaml | 4.1.1 | 4.3.1 | 3 alerts (quadratic CPU) | dev, via cosmiconfig |
| postcss | 8.5.15 | 8.5.26 | 2 alerts (sourceMappingURL traversal) | dev, via vite |
| brace-expansion | 5.0.5 | 5.0.9 | 1 alert (exponential expansion) | dev, via minimatch |

`allowBuilds` is now stated explicitly for `esbuild` and `unrs-resolver`. pnpm 11 prompts for these where 10 ignored them silently; both are denied, which is the behaviour the repo has had all along. They ship prebuilt platform binaries via `optionalDependencies`, so their install scripts only re-verify what was already fetched.

## Verification

- `pnpm audit` and `pnpm audit --prod`: no known vulnerabilities.
- 353 tests across 27 files pass; `tsc -b --noEmit` clean; eslint 0 errors; `vite build` succeeds.

Only `playground/` and `.github/` are touched, so no crate is bumped.

Note: `pnpm run knip` fails on unused exports in `src/features/quest/`. That is pre-existing and unrelated. knip runs in neither CI nor the pre-commit hook, so it is left for a separate change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores playground security overrides under `pnpm` 11 and pins `pnpm` via `packageManager` so CI and local resolve identically. Previously, `pnpm` 11 ignored `package.json` `pnpm.overrides` while CI on `pnpm` 10 honored them; now overrides live in `pnpm-workspace.yaml` and all flagged transitives are bumped past advisories.

- Move overrides to `playground/pnpm-workspace.yaml` and raise floors: `dompurify@^3.4.13`, `fast-uri@^3.1.5`, `js-yaml@^4.3.1`, `brace-expansion@^5.0.9`, `postcss@^8.5.26`.
- Pin `packageManager: "pnpm@11.9.0"` in `playground/package.json`; `pnpm/action-setup` now uses `package_json_file` to align CI with local.
- Declare `allowBuilds` for `esbuild` and `unrs-resolver` as false to match prior behavior (use prebuilt optional binaries).
- Validation: `pnpm audit` (prod and dev) clean; tests/tsc/eslint/build pass. Scope limited to `playground/` and `.github/`.

<sup>Written for commit c1b1aa9e1713e436fa67466530fa6a8ea33f9d72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/elevator-core/pull/943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

