### PR TITLE
fix(wasm): allow tsify's into_wasm_abi deprecation

### DIFF
--- a/crates/elevator-wasm/src/dto.rs
+++ b/crates/elevator-wasm/src/dto.rs
@@ -6,6 +6,15 @@
 //! re-exporting the raw type. This keeps the playground decoupled from the
 //! core's enum evolution.
 
+// tsify 0.5.7 blanket-deprecates into_wasm_abi alongside from_wasm_abi
+// (madonoharu/tsify#65). The leak it describes is in FromWasmABI, which
+// throws past destructors when *decoding* input; this crate declares no
+// from_wasm_abi impls, so that path does not exist here. Ts<T> is the
+// upstream replacement but would make every export return
+// Result<Ts<T>, JsError>, i.e. throw — which is exactly what the
+// discriminated-union results in result.rs exist to avoid.
+#![allow(deprecated)]
+
 use elevator_core::entity::EntityId;
 use elevator_core::events::Event;
 use elevator_core::prelude::Simulation;

--- a/crates/elevator-wasm/src/js_dispatch.rs
+++ b/crates/elevator-wasm/src/js_dispatch.rs
@@ -6,6 +6,15 @@
 //! returned number (or `null`/`undefined`) maps onto the trait's
 //! `Option<f64>` rank.
 
+// tsify 0.5.7 blanket-deprecates into_wasm_abi alongside from_wasm_abi
+// (madonoharu/tsify#65). The leak it describes is in FromWasmABI, which
+// throws past destructors when *decoding* input; this crate declares no
+// from_wasm_abi impls, so that path does not exist here. Ts<T> is the
+// upstream replacement but would make every export return
+// Result<Ts<T>, JsError>, i.e. throw — which is exactly what the
+// discriminated-union results in result.rs exist to avoid.
+#![allow(deprecated)]
+
 use elevator_core::dispatch::{BuiltinStrategy, DispatchStrategy, RankContext};
 use serde::Serialize;
 use slotmap::Key;

--- a/crates/elevator-wasm/src/result.rs
+++ b/crates/elevator-wasm/src/result.rs
@@ -37,6 +37,15 @@
 //! check is `r.kind === "ok"` which mirrors the ergonomics of
 //! `instance of Error` patterns elsewhere in the playground.
 
+// tsify 0.5.7 blanket-deprecates into_wasm_abi alongside from_wasm_abi
+// (madonoharu/tsify#65). The leak it describes is in FromWasmABI, which
+// throws past destructors when *decoding* input; this crate declares no
+// from_wasm_abi impls, so that path does not exist here. Ts<T> is the
+// upstream replacement but would make every export return
+// Result<Ts<T>, JsError>, i.e. throw — which is exactly what the
+// discriminated-union results in result.rs exist to avoid.
+#![allow(deprecated)]
+
 use serde::Serialize;
 use tsify::Tsify;
 

--- a/crates/elevator-wasm/src/world_view.rs
+++ b/crates/elevator-wasm/src/world_view.rs
@@ -14,6 +14,15 @@
 //! Game ticks at ~10 Hz call this once per frame; rendering ticks at 60 Hz
 //! interpolate from the cached value rather than rebuilding.
 
+// tsify 0.5.7 blanket-deprecates into_wasm_abi alongside from_wasm_abi
+// (madonoharu/tsify#65). The leak it describes is in FromWasmABI, which
+// throws past destructors when *decoding* input; this crate declares no
+// from_wasm_abi impls, so that path does not exist here. Ts<T> is the
+// upstream replacement but would make every export return
+// Result<Ts<T>, JsError>, i.e. throw — which is exactly what the
+// discriminated-union results in result.rs exist to avoid.
+#![allow(deprecated)]
+
 use elevator_core::components::CallDirection;
 use elevator_core::door::DoorState;
 use elevator_core::entity::{ElevatorId, EntityId};


### PR DESCRIPTION
Unblocks #948 (`tsify` 0.5.6 → 0.5.7), which fails `Check` with 27 copies of:

> use of deprecated constant: `into_wasm_abi`/`from_wasm_abi` are deprecated as they cause memory leaks

## Why an allow is the right call here

The leak in [madonoharu/tsify#65](https://github.com/madonoharu/tsify/issues/65) is in **`FromWasmABI`**: it calls `throw_str` when *decoding* input fails, which skips destructors and leaks. `into_wasm_abi` was swept into the same `#[deprecated]` even though the output path has no such failure mode. This crate declares `from_wasm_abi` **zero** times — all 27 sites are `into_wasm_abi` — so the bug being warned about cannot occur here.

The upstream replacement, `Ts<T>`, is fallible by construction: every export would become `Result<Ts<T>, JsError>`, which materializes on the JS side as a **thrown** `Error`. That is precisely what `result.rs` exists to avoid — its module docs spell out the `{ kind: "ok" | "err" }` discriminated unions so TS consumers get exhaustive `switch` narrowing instead of `try`/`catch`. Migrating would mean ~64 changed signatures and a frontend that now has to handle throws, to fix a leak on a path we do not use.

So the allow is scoped to the four modules that carry the attribute, each with the reasoning inline.

## Scope

Source only — no `Cargo.lock` change, so #948 remains the PR that actually takes the bump. `allow` (rather than `expect`) means it stays silent at the currently-locked 0.5.6 too.

## Verification

Against a local lock forced to `tsify` 0.5.8: `cargo clippy -p elevator-wasm --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean. Same commands clean at 0.5.6 with no unused-allow noise.

## Revisit when

`Ts<T>` grows an infallible constructor, or tsify narrows the deprecation to `from_wasm_abi`.

https://claude.ai/code/session_01MQidAeF7vzMhiX248ah5XL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows `tsify`’s blanket deprecation of `into_wasm_abi` without changing runtime behavior, unblocking the `tsify` 0.5.6 → 0.5.7 bump. Previously `Check` failed on these warnings; now the deprecation is allowed in four modules.

- Adds scoped `#![allow(deprecated)]` to `dto.rs`, `js_dispatch.rs`, `result.rs`, and `world_view.rs`.
- We do not implement `from_wasm_abi`; the leak cited in `madonoharu/tsify#65` is not reachable here.
- We intentionally avoid `Ts<T>` to keep `{ kind: "ok" | "err" }` results and avoid JS throws across ~64 exports.
- No `Cargo.lock` change; `#948` will carry the version bump. `cargo clippy -D warnings` is clean at `tsify` 0.5.6 and 0.5.8.

<sup>Written for commit 557b0a1ce479ad0736c562a9f3d35d881242bd6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/elevator-core/pull/949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

