### PR TITLE
chore: raise MSRV to 1.90 and adopt ordered-float 5.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,7 @@ jobs:
       # Pinned to the rust-version declared in the workspace Cargo.toml.
       # Only elevator-core commits to an MSRV; elevator-bevy depends on a
       # newer toolchain via bevy and is intentionally excluded.
-      - uses: dtolnay/rust-toolchain@1.88
+      - uses: dtolnay/rust-toolchain@1.90
       - uses: Swatinem/rust-cache@v2
 
       - name: Build elevator-core on MSRV

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4595,9 +4595,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "5.3.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+checksum = "8c7c9e0d9b23589f26070720bac724174bfec1083e82f7854cdd0267518343c0"
 dependencies = [
  "num-traits",
  "rand 0.8.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ version = "1.0.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/andymai/elevator-core"
-rust-version = "1.88"
+rust-version = "1.90"
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }


### PR DESCRIPTION
Replaces the closed Dependabot PR #951, which failed the MSRV check because ordered-float 5.5.0 requires rustc 1.90 (repo MSRV was 1.88).

Since raising the toolchain is acceptable, this bumps the workspace MSRV to 1.90 and adopts ordered-float 5.5 together:
- `Cargo.toml` `[workspace.package] rust-version` 1.88 to 1.90
- `ci.yml` MSRV job toolchain `@1.88` to `@1.90`
- `Cargo.lock` ordered-float 5.3.0 to 5.5.0

`cargo build -p elevator-core --all-features` passes locally on 1.90+.

https://claude.ai/code/session_01MwgwT1dJuYrDZanUVCYfMb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the workspace MSRV from 1.88 to 1.90 and updates `ordered-float` from 5.3.0 to 5.5.0, which requires rustc 1.90. Updates the CI MSRV job to match. `elevator-core` builds with all features on the new toolchain.

<sup>Written for commit c6fd20668bdffaffdf6ce4eda01fb2bf40e61b0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/elevator-core/pull/955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

